### PR TITLE
M5 — executor binary (polling, dispatch, claim, reap, review-policy gate)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,10 @@ ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
 
 # MCP server
-AGENT_MCP_URL=http://localhost:3002/mcp
-MCP_SERVER_PORT=3002
+# URL the executor bakes into each agent's mcp-config.json. Spawned CLIs
+# connect here for tools. Must be reachable from wherever CLIs spawn.
+BEEVIBE_MCP_SERVER_URL=http://localhost:3000/
+MCP_SERVER_PORT=3000
 
 # Executor
 WORKSPACE_ROOT=/tmp/beevibe-workspaces

--- a/migrations/1777500000000_fix-task-dispatch-index.sql
+++ b/migrations/1777500000000_fix-task-dispatch-index.sql
@@ -1,0 +1,19 @@
+-- Replace the alphabetical priority DESC index with a semantic CASE ordering
+-- matching the executor's dispatch query. Alphabetical `priority DESC` on a
+-- TEXT column orders low > high > critical — the opposite of intent.
+--
+-- The new index also covers status IN ('assigned', 'revision') so revision
+-- tasks (re-queued after human feedback) share the dispatch path.
+
+DROP INDEX IF EXISTS idx_task_dispatch;
+
+CREATE INDEX idx_task_dispatch ON task (
+  (CASE priority
+     WHEN 'critical' THEN 4
+     WHEN 'high'     THEN 3
+     WHEN 'medium'   THEN 2
+     WHEN 'low'      THEN 1
+     ELSE 0
+   END) DESC,
+  created_at ASC
+) WHERE status IN ('assigned', 'revision');

--- a/migrations/1777700000000_add-task-needs-revision-status.sql
+++ b/migrations/1777700000000_add-task-needs-revision-status.sql
@@ -1,0 +1,43 @@
+-- Split `revision` into two states to preserve semantic clarity between
+-- "re-work is queued" and "re-work is currently running":
+--
+--   needs_revision  (new)  — human requested re-work; waiting for dispatch.
+--                            This is what listAssignable + claimById match.
+--   revision        (was "queue state"; now "running state")
+--                          — re-work is currently executing. Set by claimById
+--                            as the post-claim status for a `needs_revision`
+--                            task. Dispatch reads this to pass priorSessionId
+--                            (→ --resume on the Claude CLI).
+--
+-- Atomic claim continues to rely on the row's status transition: claim
+-- changes needs_revision → revision, so the row no longer matches
+-- listAssignable's predicate and cannot be double-claimed.
+
+ALTER TABLE task DROP CONSTRAINT IF EXISTS task_status_check;
+ALTER TABLE task ADD CONSTRAINT task_status_check
+  CHECK (status IN (
+    'pending',
+    'assigned',
+    'in_progress',
+    'needs_revision',
+    'revision',
+    'review',
+    'blocked',
+    'done',
+    'failed',
+    'cancelled'
+  ));
+
+-- Dispatch index predicate must follow listAssignable / claimById.
+DROP INDEX IF EXISTS idx_task_dispatch;
+
+CREATE INDEX idx_task_dispatch ON task (
+  (CASE priority
+     WHEN 'critical' THEN 4
+     WHEN 'high'     THEN 3
+     WHEN 'medium'   THEN 2
+     WHEN 'low'      THEN 1
+     ELSE 0
+   END) DESC,
+  created_at ASC
+) WHERE status IN ('assigned', 'needs_revision');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,39 +9,39 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "default": "./dist/index.js"
     },
     "./adapters/postgres": {
       "types": "./dist/adapters/postgres/index.d.ts",
-      "import": "./dist/adapters/postgres/index.js"
+      "default": "./dist/adapters/postgres/index.js"
     },
     "./adapters/claude-code": {
       "types": "./dist/adapters/claude-code/index.d.ts",
-      "import": "./dist/adapters/claude-code/index.js"
+      "default": "./dist/adapters/claude-code/index.js"
     },
     "./adapters/local-workspace": {
       "types": "./dist/adapters/local-workspace/index.d.ts",
-      "import": "./dist/adapters/local-workspace/index.js"
+      "default": "./dist/adapters/local-workspace/index.js"
     },
     "./adapters/openai": {
       "types": "./dist/adapters/openai/index.d.ts",
-      "import": "./dist/adapters/openai/index.js"
+      "default": "./dist/adapters/openai/index.js"
     },
     "./adapters/anthropic": {
       "types": "./dist/adapters/anthropic/index.d.ts",
-      "import": "./dist/adapters/anthropic/index.js"
+      "default": "./dist/adapters/anthropic/index.js"
     },
     "./adapters/runtime-registry": {
       "types": "./dist/adapters/runtime-registry.d.ts",
-      "import": "./dist/adapters/runtime-registry.js"
+      "default": "./dist/adapters/runtime-registry.js"
     },
     "./services/agent-session": {
       "types": "./dist/services/agent-session.d.ts",
-      "import": "./dist/services/agent-session.js"
+      "default": "./dist/services/agent-session.js"
     },
     "./services/memory": {
       "types": "./dist/services/memory/index.d.ts",
-      "import": "./dist/services/memory/index.js"
+      "default": "./dist/services/memory/index.js"
     }
   },
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,38 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./adapters/postgres": {
+      "types": "./dist/adapters/postgres/index.d.ts",
+      "import": "./dist/adapters/postgres/index.js"
+    },
+    "./adapters/claude-code": {
+      "types": "./dist/adapters/claude-code/index.d.ts",
+      "import": "./dist/adapters/claude-code/index.js"
+    },
+    "./adapters/local-workspace": {
+      "types": "./dist/adapters/local-workspace/index.d.ts",
+      "import": "./dist/adapters/local-workspace/index.js"
+    },
+    "./adapters/openai": {
+      "types": "./dist/adapters/openai/index.d.ts",
+      "import": "./dist/adapters/openai/index.js"
+    },
+    "./adapters/anthropic": {
+      "types": "./dist/adapters/anthropic/index.d.ts",
+      "import": "./dist/adapters/anthropic/index.js"
+    },
+    "./adapters/runtime-registry": {
+      "types": "./dist/adapters/runtime-registry.d.ts",
+      "import": "./dist/adapters/runtime-registry.js"
+    },
+    "./services/agent-session": {
+      "types": "./dist/services/agent-session.d.ts",
+      "import": "./dist/services/agent-session.js"
+    },
+    "./services/memory": {
+      "types": "./dist/services/memory/index.d.ts",
+      "import": "./dist/services/memory/index.js"
     }
   },
   "scripts": {

--- a/packages/core/src/adapters/claude-code/runtime.test.ts
+++ b/packages/core/src/adapters/claude-code/runtime.test.ts
@@ -41,7 +41,6 @@ function mockRunCli(result: CliProcessResult = MOCK_OK): void {
 function ctx(overrides: Partial<RuntimeContext> = {}): RuntimeContext {
   return {
     intent: "do a thing",
-    urgency: "normal",
     workspace: { path: "/tmp/beevibe-test-ws" },
     system_prompt_append: "",
     ...overrides,
@@ -94,6 +93,27 @@ describe("ClaudeCodeRuntime.execute", () => {
     await new ClaudeCodeRuntime().execute(ctx());
     expect(lastOptions!.args).not.toContain("--model");
     expect(lastOptions!.args).not.toContain("--max-turns");
+  });
+
+  it("passes context.model + context.max_turns (per-agent override wins over constructor)", async () => {
+    mockRunCli();
+    await new ClaudeCodeRuntime({ model: "ctor-default", maxTurns: 99 }).execute(
+      ctx({ model: "claude-haiku-4-5", max_turns: 7 }),
+    );
+    // Context wins.
+    const modelIdx = lastOptions!.args!.indexOf("--model");
+    expect(lastOptions!.args![modelIdx + 1]).toBe("claude-haiku-4-5");
+    const turnsIdx = lastOptions!.args!.indexOf("--max-turns");
+    expect(lastOptions!.args![turnsIdx + 1]).toBe("7");
+  });
+
+  it("falls back to constructor config when context.model / context.max_turns are unset", async () => {
+    mockRunCli();
+    await new ClaudeCodeRuntime({ model: "fallback", maxTurns: 3 }).execute(ctx());
+    const modelIdx = lastOptions!.args!.indexOf("--model");
+    expect(lastOptions!.args![modelIdx + 1]).toBe("fallback");
+    const turnsIdx = lastOptions!.args!.indexOf("--max-turns");
+    expect(lastOptions!.args![turnsIdx + 1]).toBe("3");
   });
 
   it("passes --resume when context.resume_session_id is set", async () => {

--- a/packages/core/src/adapters/claude-code/runtime.ts
+++ b/packages/core/src/adapters/claude-code/runtime.ts
@@ -65,8 +65,10 @@ export class ClaudeCodeRuntime implements AgentRuntime {
       "--mcp-config",
       mcpConfigPath,
     ];
-    if (this.config.model) args.push("--model", this.config.model);
-    if (this.config.maxTurns) args.push("--max-turns", String(this.config.maxTurns));
+    const model = context.model ?? this.config.model;
+    if (model) args.push("--model", model);
+    const maxTurns = context.max_turns ?? this.config.maxTurns;
+    if (maxTurns) args.push("--max-turns", String(maxTurns));
     if (context.resume_session_id) args.push("--resume", context.resume_session_id);
     if (context.system_prompt_append.length > 0) {
       args.push("--append-system-prompt", context.system_prompt_append);

--- a/packages/core/src/adapters/claude-code/smoke.test.ts
+++ b/packages/core/src/adapters/claude-code/smoke.test.ts
@@ -38,7 +38,6 @@ describe.skipIf(!RUN)("ClaudeCodeRuntime (smoke)", () => {
       const runtime = new ClaudeCodeRuntime({ maxTurns: 1 });
       const result = await runtime.execute({
         intent: "Reply with the literal word 'ok' and nothing else.",
-        urgency: "low",
         workspace: { path: workspacePath },
         system_prompt_append: "",
       });

--- a/packages/core/src/adapters/local-workspace/manager.test.ts
+++ b/packages/core/src/adapters/local-workspace/manager.test.ts
@@ -1,8 +1,34 @@
-import { existsSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Agent } from "../../domain/agent.js";
 import { LocalWorkspaceManager } from "./manager.js";
+
+const MCP_URL = "http://mcp.example/";
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: "agent_abc",
+    name: "Test Agent",
+    owner_id: "person_owner",
+    hierarchy_level: "ic",
+    api_key: "bv_a_testkey123",
+    runtime_config: { type: "claude-code", model: "claude-opus-4-7" },
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
 
 describe("LocalWorkspaceManager", () => {
   let workspaceRoot: string;
@@ -10,7 +36,7 @@ describe("LocalWorkspaceManager", () => {
 
   beforeEach(() => {
     workspaceRoot = mkdtempSync(join(tmpdir(), "beevibe-ws-test-"));
-    manager = new LocalWorkspaceManager({ workspaceRoot });
+    manager = new LocalWorkspaceManager({ workspaceRoot, mcpServerUrl: MCP_URL });
   });
 
   afterEach(() => {
@@ -18,7 +44,7 @@ describe("LocalWorkspaceManager", () => {
   });
 
   it("ensureWorkspace creates the agent dir under workspaceRoot", async () => {
-    const ws = await manager.ensureWorkspace({ agent_id: "agent_abc" });
+    const ws = await manager.ensureWorkspace({ agent: makeAgent({ id: "agent_abc" }) });
     expect(ws.path).toBe(join(workspaceRoot, "agent_abc"));
     expect(existsSync(ws.path)).toBe(true);
     expect(statSync(ws.path).isDirectory()).toBe(true);
@@ -27,47 +53,49 @@ describe("LocalWorkspaceManager", () => {
   it.skipIf(process.platform === "win32")(
     "dir is created with 0o700 (user-only) permissions",
     async () => {
-      const ws = await manager.ensureWorkspace({ agent_id: "agent_perms" });
+      const ws = await manager.ensureWorkspace({ agent: makeAgent({ id: "agent_perms" }) });
       const mode = statSync(ws.path).mode & 0o777;
       expect(mode).toBe(0o700);
     },
   );
 
   it("ensureWorkspace is idempotent: second call returns same path, doesn't error", async () => {
-    const ws1 = await manager.ensureWorkspace({ agent_id: "agent_idem" });
-    const ws2 = await manager.ensureWorkspace({ agent_id: "agent_idem" });
+    const ws1 = await manager.ensureWorkspace({ agent: makeAgent({ id: "agent_idem" }) });
+    const ws2 = await manager.ensureWorkspace({ agent: makeAgent({ id: "agent_idem" }) });
     expect(ws2.path).toBe(ws1.path);
   });
 
   it("ensureWorkspace preserves existing files inside the dir (persistence)", async () => {
-    const ws = await manager.ensureWorkspace({ agent_id: "agent_persist" });
+    const ws = await manager.ensureWorkspace({ agent: makeAgent({ id: "agent_persist" }) });
     writeFileSync(join(ws.path, "notes.md"), "# notes\n");
     writeFileSync(join(ws.path, "cloned-repo.txt"), "repo data");
 
-    // Second call should NOT wipe the dir
-    await manager.ensureWorkspace({ agent_id: "agent_persist" });
+    await manager.ensureWorkspace({ agent: makeAgent({ id: "agent_persist" }) });
 
     const files = readdirSync(ws.path).sort();
-    expect(files).toEqual(["cloned-repo.txt", "notes.md"]);
+    // mcp-config.json was written on first ensure; preserved along with the user-created files.
+    expect(files).toEqual(["cloned-repo.txt", "mcp-config.json", "notes.md"]);
   });
 
   it("recursive mkdir creates missing parent dirs", async () => {
     const deepRoot = join(workspaceRoot, "nested", "deeper");
-    const deepManager = new LocalWorkspaceManager({ workspaceRoot: deepRoot });
-    const ws = await deepManager.ensureWorkspace({ agent_id: "agent_deep" });
+    const deepManager = new LocalWorkspaceManager({
+      workspaceRoot: deepRoot,
+      mcpServerUrl: MCP_URL,
+    });
+    const ws = await deepManager.ensureWorkspace({ agent: makeAgent({ id: "agent_deep" }) });
     expect(existsSync(ws.path)).toBe(true);
     expect(ws.path).toBe(join(deepRoot, "agent_deep"));
   });
 
   it("defaults workspaceRoot to ~/.beevibe/workspaces when not provided", () => {
-    const m = new LocalWorkspaceManager();
-    // Inspecting private field via cast — acceptable for a sanity test
+    const m = new LocalWorkspaceManager({ mcpServerUrl: MCP_URL });
     const root = (m as unknown as { root: string }).root;
     expect(root).toMatch(/\/\.beevibe\/workspaces$/);
   });
 
   it("removeWorkspace deletes the dir and all contents", async () => {
-    const ws = await manager.ensureWorkspace({ agent_id: "agent_rm" });
+    const ws = await manager.ensureWorkspace({ agent: makeAgent({ id: "agent_rm" }) });
     writeFileSync(join(ws.path, "file.txt"), "x");
     await manager.removeWorkspace(ws);
     expect(existsSync(ws.path)).toBe(false);
@@ -80,12 +108,88 @@ describe("LocalWorkspaceManager", () => {
   });
 
   it("different agents get isolated dirs", async () => {
-    const a = await manager.ensureWorkspace({ agent_id: "agent_a" });
-    const b = await manager.ensureWorkspace({ agent_id: "agent_b" });
+    const a = await manager.ensureWorkspace({ agent: makeAgent({ id: "agent_a" }) });
+    const b = await manager.ensureWorkspace({ agent: makeAgent({ id: "agent_b" }) });
     expect(a.path).not.toBe(b.path);
 
     writeFileSync(join(a.path, "a-only.txt"), "a");
     expect(existsSync(join(a.path, "a-only.txt"))).toBe(true);
     expect(existsSync(join(b.path, "a-only.txt"))).toBe(false);
+  });
+
+  describe("mcp-config.json writeback", () => {
+    it("first ensureWorkspace writes mcp-config.json with Bearer token + session-id placeholder", async () => {
+      const ws = await manager.ensureWorkspace({
+        agent: makeAgent({ id: "agent_cfg", api_key: "bv_a_XyZ" }),
+      });
+      const configPath = join(ws.path, "mcp-config.json");
+      expect(existsSync(configPath)).toBe(true);
+
+      const parsed = JSON.parse(readFileSync(configPath, "utf-8"));
+      expect(parsed.mcpServers.beevibe.type).toBe("http");
+      expect(parsed.mcpServers.beevibe.url).toBe(MCP_URL);
+      expect(parsed.mcpServers.beevibe.headers.Authorization).toBe("Bearer bv_a_XyZ");
+      expect(parsed.mcpServers.beevibe.headers["X-Beevibe-Session"]).toBe(
+        "${BEEVIBE_SESSION_ID}",
+      );
+    });
+
+    it.skipIf(process.platform === "win32")(
+      "mcp-config.json is written with mode 0o600 (file contains secrets)",
+      async () => {
+        const ws = await manager.ensureWorkspace({ agent: makeAgent({ id: "agent_mode" }) });
+        const mode = statSync(join(ws.path, "mcp-config.json")).mode & 0o777;
+        expect(mode).toBe(0o600);
+      },
+    );
+
+    it("second ensureWorkspace does NOT rewrite the config file (file-exists check)", async () => {
+      const ws = await manager.ensureWorkspace({ agent: makeAgent({ id: "agent_noredo" }) });
+      const configPath = join(ws.path, "mcp-config.json");
+      const firstMtime = statSync(configPath).mtimeMs;
+
+      // Tiny wait to ensure mtime resolution would catch a rewrite
+      await new Promise((r) => setTimeout(r, 10));
+      await manager.ensureWorkspace({ agent: makeAgent({ id: "agent_noredo" }) });
+
+      const secondMtime = statSync(configPath).mtimeMs;
+      expect(secondMtime).toBe(firstMtime);
+    });
+
+    it("ensureWorkspace re-creates the config after it's deleted (self-heals)", async () => {
+      const ws = await manager.ensureWorkspace({ agent: makeAgent({ id: "agent_heal" }) });
+      const configPath = join(ws.path, "mcp-config.json");
+      unlinkSync(configPath);
+      expect(existsSync(configPath)).toBe(false);
+
+      await manager.ensureWorkspace({ agent: makeAgent({ id: "agent_heal" }) });
+      expect(existsSync(configPath)).toBe(true);
+    });
+
+    it("new instance with different mcpServerUrl does NOT auto-refresh a stale file (documented limitation)", async () => {
+      await manager.ensureWorkspace({ agent: makeAgent({ id: "agent_stale" }) });
+      const configPath = join(workspaceRoot, "agent_stale", "mcp-config.json");
+      const original = readFileSync(configPath, "utf-8");
+
+      const different = new LocalWorkspaceManager({
+        workspaceRoot,
+        mcpServerUrl: "http://different.example/",
+      });
+      await different.ensureWorkspace({ agent: makeAgent({ id: "agent_stale" }) });
+
+      // File persists unchanged — operator must rm to force refresh.
+      const after = readFileSync(configPath, "utf-8");
+      expect(after).toBe(original);
+      expect(after).toContain(MCP_URL);
+      expect(after).not.toContain("different.example");
+    });
+
+    it("throws when agent has no api_key", async () => {
+      await expect(
+        manager.ensureWorkspace({
+          agent: makeAgent({ id: "agent_nokey", api_key: undefined }),
+        }),
+      ).rejects.toThrow(/api_key is missing/);
+    });
   });
 });

--- a/packages/core/src/adapters/local-workspace/manager.ts
+++ b/packages/core/src/adapters/local-workspace/manager.ts
@@ -1,6 +1,7 @@
-import { mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import type { Agent } from "../../domain/agent.js";
 import type { Workspace } from "../../ports/runtime.js";
 import type { WorkspaceManager } from "../../ports/workspace.js";
 
@@ -8,35 +9,86 @@ import type { WorkspaceManager } from "../../ports/workspace.js";
  * Filesystem-backed WorkspaceManager.
  *
  * Provisions `<workspaceRoot>/<agent_id>/` as the agent's persistent
- * sandbox. Default root is `~/.beevibe/workspaces`. Directories are
- * created with mode 0o700 because they will contain cloned repos and
- * their credentials (`.git/config`, possibly GitHub tokens).
+ * sandbox AND writes `mcp-config.json` into it on first encounter. The
+ * config contains the agent's bv_a_ API key + an `${BEEVIBE_SESSION_ID}`
+ * placeholder that Claude CLI interpolates per-spawn.
  *
- * The adapter does nothing more than mkdir + rm — all git operations
- * are the agent's responsibility.
+ * Default root is `~/.beevibe/workspaces`. Directories are created with
+ * mode 0o700 because they contain cloned repos and their credentials;
+ * `mcp-config.json` is written with mode 0o600 because it contains an
+ * unredacted bearer token.
+ *
+ * Idempotency comes from `existsSync` on the config file — no in-memory
+ * state. After API key rotation or `mcpServerUrl` change, the existing
+ * file persists until an operator deletes it (or the whole workspace).
+ * Key rotation is deliberate and infrequent; the cost of this simplicity
+ * is that operators must `rm` the file to force re-provisioning.
  */
 export interface LocalWorkspaceManagerConfig {
   /** Defaults to `~/.beevibe/workspaces`. */
   workspaceRoot?: string;
+  /**
+   * MCP server URL baked into each agent's `mcp-config.json`. Required:
+   * the file cannot be written without it. Typically sourced from
+   * `BEEVIBE_MCP_SERVER_URL` via the executor/MCP-server bootstrap.
+   */
+  mcpServerUrl: string;
 }
 
 export class LocalWorkspaceManager implements WorkspaceManager {
   private readonly root: string;
 
-  constructor(config: LocalWorkspaceManagerConfig = {}) {
+  constructor(private config: LocalWorkspaceManagerConfig) {
     this.root = config.workspaceRoot ?? join(homedir(), ".beevibe", "workspaces");
   }
 
-  async ensureWorkspace(opts: { agent_id: string }): Promise<Workspace> {
-    const path = join(this.root, opts.agent_id);
+  async ensureWorkspace({ agent }: { agent: Agent }): Promise<Workspace> {
+    const path = join(this.root, agent.id);
     // recursive: true creates parent dirs and is a no-op if the dir exists.
     // mode 0o700 applies only when the dir is created; existing dirs keep
     // their current permissions, which is the right semantic (idempotent).
     mkdirSync(path, { recursive: true, mode: 0o700 });
+
+    const configPath = join(path, "mcp-config.json");
+    if (!existsSync(configPath)) {
+      if (!agent.api_key) {
+        throw new Error(
+          `Cannot write mcp-config.json for agent ${agent.id}: agent.api_key is missing`,
+        );
+      }
+      writeFileSync(configPath, buildMcpConfig(agent.api_key, this.config.mcpServerUrl), {
+        mode: 0o600,
+      });
+    }
+
     return { path };
   }
 
   async removeWorkspace(workspace: Workspace): Promise<void> {
     rmSync(workspace.path, { recursive: true, force: true });
   }
+}
+
+function buildMcpConfig(apiKey: string, mcpServerUrl: string): string {
+  return (
+    JSON.stringify(
+      {
+        mcpServers: {
+          beevibe: {
+            type: "http",
+            url: mcpServerUrl,
+            headers: {
+              Authorization: `Bearer ${apiKey}`,
+              // Literal placeholder — Claude CLI interpolates from process env
+              // at config parse time; AgentSession sets BEEVIBE_SESSION_ID on
+              // the spawned subprocess env. Verified via runtime probe.
+              "X-Beevibe-Session": "${BEEVIBE_SESSION_ID}",
+            },
+          },
+        },
+      },
+      null,
+      2,
+    ) + "\n"
+  );
 }

--- a/packages/core/src/adapters/postgres/task-repo.test.ts
+++ b/packages/core/src/adapters/postgres/task-repo.test.ts
@@ -199,6 +199,108 @@ describe("PostgresTaskRepository", () => {
     expect(child.parent_task_id).toBe(parent.id);
   });
 
+  describe("listAssignable + claimById (M5.0 dispatch API)", () => {
+    it("listAssignable orders critical > high > medium > low then by created_at ASC", async () => {
+      const low = await tasks.create(
+        newTask({ status: "assigned", priority: "low", assignee_id: assigneeAgentId }),
+      );
+      await new Promise((r) => setTimeout(r, 5));
+      const critical = await tasks.create(
+        newTask({ status: "assigned", priority: "critical", assignee_id: assigneeAgentId }),
+      );
+      await new Promise((r) => setTimeout(r, 5));
+      const high = await tasks.create(
+        newTask({ status: "assigned", priority: "high", assignee_id: assigneeAgentId }),
+      );
+      await new Promise((r) => setTimeout(r, 5));
+      const medium = await tasks.create(
+        newTask({ status: "assigned", priority: "medium", assignee_id: assigneeAgentId }),
+      );
+
+      const list = await tasks.listAssignable();
+      expect(list.map((t) => t.id)).toEqual([critical.id, high.id, medium.id, low.id]);
+    });
+
+    it("listAssignable uses created_at ASC to break ties within the same priority (FIFO)", async () => {
+      const first = await tasks.create(
+        newTask({ status: "assigned", priority: "high", assignee_id: assigneeAgentId }),
+      );
+      await new Promise((r) => setTimeout(r, 5));
+      const second = await tasks.create(
+        newTask({ status: "assigned", priority: "high", assignee_id: assigneeAgentId }),
+      );
+
+      const list = await tasks.listAssignable();
+      expect(list.map((t) => t.id)).toEqual([first.id, second.id]);
+    });
+
+    it("listAssignable includes both assigned and revision status", async () => {
+      const assigned = await tasks.create(
+        newTask({ status: "assigned", assignee_id: assigneeAgentId }),
+      );
+      const revision = await tasks.create(
+        newTask({ status: "revision", assignee_id: assigneeAgentId }),
+      );
+      const list = await tasks.listAssignable();
+      const ids = list.map((t) => t.id).sort();
+      expect(ids).toEqual([assigned.id, revision.id].sort());
+    });
+
+    it("listAssignable excludes pending/in_progress/done/failed/cancelled", async () => {
+      await tasks.create(newTask({ status: "pending", assignee_id: assigneeAgentId }));
+      await tasks.create(newTask({ status: "in_progress", assignee_id: assigneeAgentId }));
+      await tasks.create(newTask({ status: "done", assignee_id: assigneeAgentId }));
+      await tasks.create(newTask({ status: "failed", assignee_id: assigneeAgentId }));
+      await tasks.create(newTask({ status: "cancelled", assignee_id: assigneeAgentId }));
+      const list = await tasks.listAssignable();
+      expect(list).toHaveLength(0);
+    });
+
+    it("listAssignable excludes tasks with null assignee_id", async () => {
+      await tasks.create(newTask({ status: "assigned" })); // no assignee
+      const list = await tasks.listAssignable();
+      expect(list).toHaveLength(0);
+    });
+
+    it("claimById transitions assigned → in_progress and returns the row", async () => {
+      const t = await tasks.create(
+        newTask({ status: "assigned", assignee_id: assigneeAgentId }),
+      );
+      const claimed = await tasks.claimById(t.id);
+      expect(claimed?.id).toBe(t.id);
+      expect(claimed?.status).toBe("in_progress");
+      const reread = await tasks.findById(t.id);
+      expect(reread?.status).toBe("in_progress");
+    });
+
+    it("claimById also accepts revision → in_progress", async () => {
+      const t = await tasks.create(
+        newTask({ status: "revision", assignee_id: assigneeAgentId }),
+      );
+      const claimed = await tasks.claimById(t.id);
+      expect(claimed?.status).toBe("in_progress");
+    });
+
+    it("claimById returns undefined when the row is no longer assigned/revision (race loser)", async () => {
+      const t = await tasks.create(
+        newTask({ status: "assigned", assignee_id: assigneeAgentId }),
+      );
+      const first = await tasks.claimById(t.id);
+      expect(first?.status).toBe("in_progress");
+      const second = await tasks.claimById(t.id);
+      expect(second).toBeUndefined();
+    });
+
+    it("two concurrent claimById calls on the same task yield exactly one winner", async () => {
+      const t = await tasks.create(
+        newTask({ status: "assigned", assignee_id: assigneeAgentId }),
+      );
+      const [a, b] = await Promise.all([tasks.claimById(t.id), tasks.claimById(t.id)]);
+      const winners = [a, b].filter((r) => r !== undefined);
+      expect(winners).toHaveLength(1);
+    });
+  });
+
   it("delete removes the row", async () => {
     const t = await tasks.create(newTask());
     await tasks.delete(t.id);

--- a/packages/core/src/adapters/postgres/task-repo.test.ts
+++ b/packages/core/src/adapters/postgres/task-repo.test.ts
@@ -118,12 +118,17 @@ describe("PostgresTaskRepository", () => {
     expect(got.map((t) => t.id)).toEqual([mine.id]);
   });
 
-  it("listReviewQueue returns only review/revision, priority desc then updated_at asc", async () => {
-    const a = await tasks.create(newTask({ status: "review", priority: "high" }));
-    const b = await tasks.create(newTask({ status: "revision", priority: "critical" }));
+  it("listReviewQueue returns only review, priority desc then updated_at asc", async () => {
+    const high = await tasks.create(newTask({ status: "review", priority: "high" }));
+    const critical = await tasks.create(newTask({ status: "review", priority: "critical" }));
+    // needs_revision (queued for re-work) and revision (actively running
+    // re-work) are NOT in the human review queue — those are executor-side
+    // states now, not awaiting-human-decision states.
+    await tasks.create(newTask({ status: "needs_revision", priority: "critical" }));
+    await tasks.create(newTask({ status: "revision", priority: "critical" }));
     await tasks.create(newTask({ status: "done" }));
     const queue = await tasks.listReviewQueue();
-    expect(queue.map((t) => t.id)).toEqual([b.id, a.id]);
+    expect(queue.map((t) => t.id)).toEqual([critical.id, high.id]);
   });
 
   it("countChildrenNotComplete counts sub-tasks in non-terminal states", async () => {
@@ -234,21 +239,25 @@ describe("PostgresTaskRepository", () => {
       expect(list.map((t) => t.id)).toEqual([first.id, second.id]);
     });
 
-    it("listAssignable includes both assigned and revision status", async () => {
+    it("listAssignable includes both assigned and needs_revision status", async () => {
       const assigned = await tasks.create(
         newTask({ status: "assigned", assignee_id: assigneeAgentId }),
       );
-      const revision = await tasks.create(
-        newTask({ status: "revision", assignee_id: assigneeAgentId }),
+      const needsRevision = await tasks.create(
+        newTask({ status: "needs_revision", assignee_id: assigneeAgentId }),
       );
       const list = await tasks.listAssignable();
       const ids = list.map((t) => t.id).sort();
-      expect(ids).toEqual([assigned.id, revision.id].sort());
+      expect(ids).toEqual([assigned.id, needsRevision.id].sort());
     });
 
-    it("listAssignable excludes pending/in_progress/done/failed/cancelled", async () => {
+    it("listAssignable excludes running states (in_progress, revision) and terminal states", async () => {
       await tasks.create(newTask({ status: "pending", assignee_id: assigneeAgentId }));
       await tasks.create(newTask({ status: "in_progress", assignee_id: assigneeAgentId }));
+      // `revision` is a running state (actively re-working) — must NOT appear
+      // in the assignable queue, or a worker would re-claim it mid-run.
+      await tasks.create(newTask({ status: "revision", assignee_id: assigneeAgentId }));
+      await tasks.create(newTask({ status: "review", assignee_id: assigneeAgentId }));
       await tasks.create(newTask({ status: "done", assignee_id: assigneeAgentId }));
       await tasks.create(newTask({ status: "failed", assignee_id: assigneeAgentId }));
       await tasks.create(newTask({ status: "cancelled", assignee_id: assigneeAgentId }));
@@ -273,15 +282,17 @@ describe("PostgresTaskRepository", () => {
       expect(reread?.status).toBe("in_progress");
     });
 
-    it("claimById also accepts revision → in_progress", async () => {
+    it("claimById transitions needs_revision → revision (re-work running state)", async () => {
       const t = await tasks.create(
-        newTask({ status: "revision", assignee_id: assigneeAgentId }),
+        newTask({ status: "needs_revision", assignee_id: assigneeAgentId }),
       );
       const claimed = await tasks.claimById(t.id);
-      expect(claimed?.status).toBe("in_progress");
+      expect(claimed?.status).toBe("revision");
+      const reread = await tasks.findById(t.id);
+      expect(reread?.status).toBe("revision");
     });
 
-    it("claimById returns undefined when the row is no longer assigned/revision (race loser)", async () => {
+    it("claimById returns undefined when the row is no longer in a queue state (race loser)", async () => {
       const t = await tasks.create(
         newTask({ status: "assigned", assignee_id: assigneeAgentId }),
       );
@@ -298,6 +309,16 @@ describe("PostgresTaskRepository", () => {
       const [a, b] = await Promise.all([tasks.claimById(t.id), tasks.claimById(t.id)]);
       const winners = [a, b].filter((r) => r !== undefined);
       expect(winners).toHaveLength(1);
+    });
+
+    it("two concurrent claimById on a needs_revision task yield exactly one winner (revision path too)", async () => {
+      const t = await tasks.create(
+        newTask({ status: "needs_revision", assignee_id: assigneeAgentId }),
+      );
+      const [a, b] = await Promise.all([tasks.claimById(t.id), tasks.claimById(t.id)]);
+      const winners = [a, b].filter((r) => r !== undefined);
+      expect(winners).toHaveLength(1);
+      expect(winners[0]?.status).toBe("revision");
     });
   });
 

--- a/packages/core/src/adapters/postgres/task-repo.ts
+++ b/packages/core/src/adapters/postgres/task-repo.ts
@@ -73,10 +73,13 @@ export class PostgresTaskRepository implements TaskRepository {
   }
 
   async listAssignable(): Promise<Task[]> {
-    // Matches idx_task_dispatch expression index (migrations/..._fix-task-dispatch-index.sql).
+    // Matches idx_task_dispatch (migrations/..._add-task-needs-revision-status.sql).
+    // The queue states are `assigned` (first dispatch) and `needs_revision`
+    // (re-work requested). Tasks in `in_progress` / `revision` are currently
+    // running, not assignable.
     const { rows } = await this.pool.query<TaskRow>(
       `SELECT * FROM task
-        WHERE status IN ('assigned', 'revision')
+        WHERE status IN ('assigned', 'needs_revision')
           AND assignee_id IS NOT NULL
         ORDER BY
           (CASE priority
@@ -93,11 +96,19 @@ export class PostgresTaskRepository implements TaskRepository {
 
   async claimById(taskId: string): Promise<Task | undefined> {
     // Row-level MVCC atomic: under concurrent executors, one UPDATE wins and
-    // others see the row already at status='in_progress' and match nothing.
+    // the other sees the row with a status no longer in the WHERE predicate
+    // and returns empty. The CASE preserves the semantic distinction between
+    // fresh work (assigned → in_progress) and re-work (needs_revision →
+    // revision). Dispatch reads post-claim status=="revision" to decide on
+    // priorSessionId (--resume).
     const { rows } = await this.pool.query<TaskRow>(
       `UPDATE task
-          SET status = 'in_progress', updated_at = NOW()
-        WHERE id = $1 AND status IN ('assigned', 'revision')
+          SET status = CASE
+                         WHEN status = 'assigned'       THEN 'in_progress'
+                         WHEN status = 'needs_revision' THEN 'revision'
+                       END,
+              updated_at = NOW()
+        WHERE id = $1 AND status IN ('assigned', 'needs_revision')
         RETURNING *`,
       [taskId],
     );
@@ -105,12 +116,13 @@ export class PostgresTaskRepository implements TaskRepository {
   }
 
   async listReviewQueue(): Promise<Task[]> {
-    // Semantic priority ordering: critical > high > medium > low (not alphabetical).
-    // The dispatch partial index (M5 concern) will get a matching expression index
-    // when the executor's dispatch query is written.
+    // Tasks awaiting a human review decision. `review` is the only state
+    // where a reviewer action is needed — `needs_revision` means the human
+    // already decided "re-work" and the executor will pick it up;
+    // `revision` means the agent is actively re-working.
     const { rows } = await this.pool.query<TaskRow>(
       `SELECT * FROM task
-        WHERE status IN ('review', 'revision')
+        WHERE status = 'review'
         ORDER BY
           CASE priority
             WHEN 'critical' THEN 4

--- a/packages/core/src/adapters/postgres/task-repo.ts
+++ b/packages/core/src/adapters/postgres/task-repo.ts
@@ -72,6 +72,38 @@ export class PostgresTaskRepository implements TaskRepository {
     return rows.map(rowToTask);
   }
 
+  async listAssignable(): Promise<Task[]> {
+    // Matches idx_task_dispatch expression index (migrations/..._fix-task-dispatch-index.sql).
+    const { rows } = await this.pool.query<TaskRow>(
+      `SELECT * FROM task
+        WHERE status IN ('assigned', 'revision')
+          AND assignee_id IS NOT NULL
+        ORDER BY
+          (CASE priority
+             WHEN 'critical' THEN 4
+             WHEN 'high'     THEN 3
+             WHEN 'medium'   THEN 2
+             WHEN 'low'      THEN 1
+             ELSE 0
+           END) DESC,
+          created_at ASC`,
+    );
+    return rows.map(rowToTask);
+  }
+
+  async claimById(taskId: string): Promise<Task | undefined> {
+    // Row-level MVCC atomic: under concurrent executors, one UPDATE wins and
+    // others see the row already at status='in_progress' and match nothing.
+    const { rows } = await this.pool.query<TaskRow>(
+      `UPDATE task
+          SET status = 'in_progress', updated_at = NOW()
+        WHERE id = $1 AND status IN ('assigned', 'revision')
+        RETURNING *`,
+      [taskId],
+    );
+    return rows[0] ? rowToTask(rows[0]) : undefined;
+  }
+
   async listReviewQueue(): Promise<Task[]> {
     // Semantic priority ordering: critical > high > medium > low (not alphabetical).
     // The dispatch partial index (M5 concern) will get a matching expression index

--- a/packages/core/src/adapters/runtime-registry.test.ts
+++ b/packages/core/src/adapters/runtime-registry.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { createDefaultRuntimeRegistry } from "./runtime-registry.js";
+
+describe("createDefaultRuntimeRegistry", () => {
+  it("registers claude-code", () => {
+    const registry = createDefaultRuntimeRegistry();
+    expect(registry["claude-code"]).toBeDefined();
+    expect(registry["claude-code"]!.type).toBe("claude-code");
+  });
+
+  it("every registry value's .type matches its registry key (sanity check against typos)", () => {
+    const registry = createDefaultRuntimeRegistry();
+    for (const [key, runtime] of Object.entries(registry)) {
+      expect(runtime.type).toBe(key);
+    }
+  });
+
+  it("returns a fresh registry on each call (no shared mutable state across composition roots)", () => {
+    const a = createDefaultRuntimeRegistry();
+    const b = createDefaultRuntimeRegistry();
+    // Different object identity — consumers can mutate one without affecting the other.
+    expect(a).not.toBe(b);
+  });
+});

--- a/packages/core/src/adapters/runtime-registry.ts
+++ b/packages/core/src/adapters/runtime-registry.ts
@@ -1,0 +1,22 @@
+import type { RuntimeRegistry } from "../ports/runtime.js";
+import { ClaudeCodeRuntime } from "./claude-code/runtime.js";
+
+/**
+ * Default registry with all production runtimes wired.
+ *
+ * Used by both the executor (M5) and the MCP server (M6) composition roots —
+ * mesh tool handlers in M6 spawn CLIs via `AgentSession`, which needs the same
+ * registry. Centralizing here avoids the executor-vs-mcp-server duplication
+ * that a bootstrap-literal would require. Adding a new runtime (codex, amp,
+ * etc.) is a one-line change + one new adapter file; both composition roots
+ * pick it up automatically.
+ *
+ * Runtime instances are shared across all dispatches for the same
+ * `agent.runtime_config.type` — they are stateless (each `execute()` spawns
+ * a fresh subprocess), so a single instance serves all agents of that type.
+ */
+export function createDefaultRuntimeRegistry(): RuntimeRegistry {
+  return {
+    "claude-code": new ClaudeCodeRuntime({}),
+  };
+}

--- a/packages/core/src/domain/agent.ts
+++ b/packages/core/src/domain/agent.ts
@@ -6,7 +6,14 @@ export type ReviewPolicy = "require_human" | "auto_done";
 
 export interface RuntimeConfig {
   type: "claude-code";
-  model: string;
+  /**
+   * Model alias passed to the CLI via `--model`. Optional: when unset, the
+   * CLI uses its own default. Claude Code CLI accepts short aliases (`opus`,
+   * `sonnet`, `haiku`) that resolve dynamically to the latest version, or
+   * full API model names (`claude-opus-4-7`, etc.) pinned to a specific
+   * release.
+   */
+  model?: string;
   max_turns?: number;
   timeout_ms?: number;
   system_prompt_addition?: string;
@@ -14,7 +21,7 @@ export interface RuntimeConfig {
 
 export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
   type: "claude-code",
-  model: "claude-opus-4-7",
+  model: "opus",
 };
 
 export interface Agent {

--- a/packages/core/src/domain/task.ts
+++ b/packages/core/src/domain/task.ts
@@ -2,8 +2,9 @@ export type TaskStatus =
   | "pending"
   | "assigned"
   | "in_progress"
-  | "review"
+  | "needs_revision"
   | "revision"
+  | "review"
   | "blocked"
   | "done"
   | "failed"
@@ -13,8 +14,9 @@ export const TASK_STATUSES: readonly TaskStatus[] = [
   "pending",
   "assigned",
   "in_progress",
-  "review",
+  "needs_revision",
   "revision",
+  "review",
   "blocked",
   "done",
   "failed",

--- a/packages/core/src/ports/runtime.ts
+++ b/packages/core/src/ports/runtime.ts
@@ -45,11 +45,22 @@ export interface RuntimeContext {
   /** What the agent should do — prompt text (task description, mesh message, etc.). */
   intent: string;
 
-  /** Urgency hint passed through to the runtime (may influence scheduling). */
-  urgency: "low" | "normal" | "high" | "critical";
-
   /** Agent's sandbox. Runtime sets cwd to `workspace.path`. */
   workspace: Workspace;
+
+  /**
+   * Per-agent model override. AgentSession passes `agent.runtime_config.model`
+   * here so each spawn uses the model configured for that agent (e.g. one
+   * executor can serve claude-opus-4-7 agents and claude-haiku-4-5 agents
+   * concurrently). Adapter falls back to its constructor config when unset.
+   */
+  model?: string;
+
+  /**
+   * Per-agent turn cap. AgentSession passes `agent.runtime_config.max_turns`
+   * here. Adapter falls back to constructor config when unset.
+   */
+  max_turns?: number;
 
   /**
    * Content appended to Claude Code's baseline system prompt via
@@ -145,3 +156,10 @@ export interface RuntimeHealth {
   latency_ms?: number;
   error?: string;
 }
+
+/**
+ * Shared registry type — maps `agent.runtime_config.type` to its runtime
+ * instance. Both the executor (M5) and the MCP server (M6) compose an
+ * `AgentRuntime` per dispatch by looking up the agent's declared type.
+ */
+export type RuntimeRegistry = Record<string, AgentRuntime>;

--- a/packages/core/src/ports/task-repo.ts
+++ b/packages/core/src/ports/task-repo.ts
@@ -21,6 +21,21 @@ export interface TaskRepository {
 
   listByAssignee(assigneeId: string): Promise<Task[]>;
 
+  /**
+   * All assignable tasks — `status IN ('assigned','revision')` with a non-null
+   * assignee — ordered by semantic priority DESC (critical > high > medium > low)
+   * then created_at ASC. Cheap read, index-backed. No limit arg: capacity
+   * gating in the worker bounds throughput naturally.
+   */
+  listAssignable(): Promise<Task[]>;
+
+  /**
+   * Atomically transition one task from `assigned`/`revision` → `in_progress`.
+   * Returns `undefined` if the row's status changed since `listAssignable`
+   * (race loser under multiple concurrent executors).
+   */
+  claimById(taskId: string): Promise<Task | undefined>;
+
   /** Tasks awaiting human decision: status ∈ {review, revision}. */
   listReviewQueue(): Promise<Task[]>;
 

--- a/packages/core/src/ports/task-repo.ts
+++ b/packages/core/src/ports/task-repo.ts
@@ -22,15 +22,20 @@ export interface TaskRepository {
   listByAssignee(assigneeId: string): Promise<Task[]>;
 
   /**
-   * All assignable tasks — `status IN ('assigned','revision')` with a non-null
-   * assignee — ordered by semantic priority DESC (critical > high > medium > low)
-   * then created_at ASC. Cheap read, index-backed. No limit arg: capacity
-   * gating in the worker bounds throughput naturally.
+   * All assignable tasks — `status IN ('assigned','needs_revision')` with a
+   * non-null assignee — ordered by semantic priority DESC (critical > high >
+   * medium > low) then created_at ASC. Cheap read, index-backed. No limit
+   * arg: capacity gating in the worker bounds throughput naturally.
    */
   listAssignable(): Promise<Task[]>;
 
   /**
-   * Atomically transition one task from `assigned`/`revision` → `in_progress`.
+   * Atomically transition one task out of its queue status into the matching
+   * running status:
+   *   - `assigned`       → `in_progress`  (fresh work)
+   *   - `needs_revision` → `revision`     (re-work; dispatch reads this to
+   *                                        pass priorSessionId for --resume)
+   *
    * Returns `undefined` if the row's status changed since `listAssignable`
    * (race loser under multiple concurrent executors).
    */

--- a/packages/core/src/ports/workspace.ts
+++ b/packages/core/src/ports/workspace.ts
@@ -1,24 +1,32 @@
+import type { Agent } from "../domain/agent.js";
 import type { Workspace } from "./runtime.js";
 
 /**
  * Per-agent workspace provisioner.
  *
  * The platform's entire filesystem responsibility for agent execution:
- * give the agent a directory it owns, and remove it when the agent is
- * deleted. Cloning repos, creating git worktrees for parallel tasks,
- * committing, and opening PRs are all the agent's responsibility.
+ * give the agent a directory it owns, remove it when the agent is deleted,
+ * and make sure the `mcp-config.json` the spawned CLI needs is on disk.
+ * Cloning repos, creating git worktrees for parallel tasks, committing, and
+ * opening PRs are all the agent's responsibility.
  *
  * Scope: per-AGENT, not per-task. The workspace persists across tasks so
  * repo clones and cached state accumulate naturally. Revision sessions
  * re-enter the same dir and see their prior state.
+ *
+ * Why the port takes `agent` (not just `agent_id`): adapters may need to
+ * write agent-scoped artifacts into the dir (e.g. `LocalWorkspaceManager`
+ * writes a `mcp-config.json` containing the agent's bv_a_ API key).
+ * Requiring the caller to provide the resolved Agent keeps adapters
+ * independent of the AgentRepository.
  */
 export interface WorkspaceManager {
   /**
-   * Ensure a workspace directory exists for the given agent and return it.
-   * Idempotent: calling twice for the same agent_id is a no-op; existing
-   * files inside are preserved.
+   * Ensure `agent`'s workspace dir exists and its expected artifacts
+   * (e.g. `mcp-config.json`) are on disk. Idempotent: calling twice for
+   * the same agent is safe; existing files inside are preserved.
    */
-  ensureWorkspace(opts: { agent_id: string }): Promise<Workspace>;
+  ensureWorkspace(opts: { agent: Agent }): Promise<Workspace>;
 
   /**
    * Remove a workspace and everything inside it. Called when an agent is

--- a/packages/core/src/services/agent-session.test.ts
+++ b/packages/core/src/services/agent-session.test.ts
@@ -118,7 +118,6 @@ describe("AgentSession.run", () => {
     const out = await service.run({
       agentId: "agent_1",
       intent: "Reply with 'ok'.",
-      urgency: "normal",
       workspace: WORKSPACE,
       taskId: "task_1",
     });
@@ -161,7 +160,6 @@ describe("AgentSession.run", () => {
     await service.run({
       agentId: "agent_1",
       intent: "x",
-      urgency: "normal",
       workspace: WORKSPACE,
     });
 
@@ -188,7 +186,6 @@ describe("AgentSession.run", () => {
     const out = await service.run({
       agentId: "agent_1",
       intent: "x",
-      urgency: "normal",
       workspace: WORKSPACE,
     });
     expect(out.status).toBe("cancelled");
@@ -207,8 +204,7 @@ describe("AgentSession.run", () => {
       service.run({
         agentId: "agent_1",
         intent: "x",
-        urgency: "normal",
-        workspace: WORKSPACE,
+          workspace: WORKSPACE,
       }),
     ).rejects.toThrow(/spawn ENOENT/);
 
@@ -217,6 +213,31 @@ describe("AgentSession.run", () => {
       .mock.calls.find((c) => (c[1] as { status?: string }).status === "failed");
     expect(failPatch).toBeDefined();
     expect(failPatch![1].error).toContain("spawn ENOENT");
+  });
+
+  it("passes agent.runtime_config.model + max_turns into RuntimeContext (per-agent override)", async () => {
+    vi.mocked(agentRepo.findById).mockResolvedValue(
+      makeAgent({
+        runtime_config: {
+          type: "claude-code",
+          model: "claude-haiku-4-5",
+          max_turns: 7,
+        },
+      }),
+    );
+    vi.mocked(sessionRepo.create).mockImplementation(async (i) => makeSession(i.id));
+    vi.mocked(memoryAgent.prepareBriefing).mockResolvedValue("");
+    vi.mocked(runtime.execute).mockResolvedValue(makeRuntimeResult());
+    vi.mocked(sessionRepo.update).mockImplementation(async (id) => makeSession(id));
+
+    await service.run({
+      agentId: "agent_1",
+      intent: "x",
+      workspace: WORKSPACE,
+    });
+    const ctx = vi.mocked(runtime.execute).mock.calls[0]![0];
+    expect(ctx.model).toBe("claude-haiku-4-5");
+    expect(ctx.max_turns).toBe(7);
   });
 
   it("passes BEEVIBE_SESSION_ID via RuntimeContext.env (agent id rides on the bv_ token, not env)", async () => {
@@ -233,7 +254,6 @@ describe("AgentSession.run", () => {
     await service.run({
       agentId: "agent_1",
       intent: "x",
-      urgency: "normal",
       workspace: WORKSPACE,
     });
 
@@ -254,7 +274,6 @@ describe("AgentSession.run", () => {
     await service.run({
       agentId: "agent_1",
       intent: "x",
-      urgency: "normal",
       workspace: WORKSPACE,
       priorSessionId: "sess_prev",
     });
@@ -278,7 +297,6 @@ describe("AgentSession.run", () => {
     await service.run({
       agentId: "agent_1",
       intent: "x",
-      urgency: "normal",
       workspace: WORKSPACE,
     });
     // Yield to microtask queue so the void-awaited promotion fires
@@ -292,8 +310,7 @@ describe("AgentSession.run", () => {
       service.run({
         agentId: "agent_missing",
         intent: "x",
-        urgency: "normal",
-        workspace: WORKSPACE,
+          workspace: WORKSPACE,
       }),
     ).rejects.toThrow(/agent not found/);
   });
@@ -308,7 +325,6 @@ describe("AgentSession.run", () => {
     await service.run({
       agentId: "agent_1",
       intent: "x",
-      urgency: "normal",
       workspace: WORKSPACE,
     });
     expect(vi.mocked(sessionRepo.create).mock.calls[0]![0].type).toBe("chat");
@@ -317,7 +333,6 @@ describe("AgentSession.run", () => {
     await service.run({
       agentId: "agent_1",
       intent: "y",
-      urgency: "normal",
       workspace: WORKSPACE,
       taskId: "task_xyz",
     });

--- a/packages/core/src/services/agent-session.ts
+++ b/packages/core/src/services/agent-session.ts
@@ -20,7 +20,6 @@ export interface AgentSessionDeps {
 export interface AgentSessionRunInput {
   agentId: string;
   intent: string;
-  urgency: "low" | "normal" | "high" | "critical";
   workspace: Workspace;
   /** Task this session is working on. Required for `type="task"` sessions. */
   taskId?: string;
@@ -82,9 +81,13 @@ export class AgentSession {
     try {
       result = await this.deps.runtime.execute({
         intent: input.intent,
-        urgency: input.urgency,
         workspace: input.workspace,
         system_prompt_append,
+        // Per-agent runtime config flows here. ClaudeCodeRuntime reads these
+        // on the execute() call with constructor fallback, so one executor
+        // process can serve agents configured for different models.
+        model: agent.runtime_config.model,
+        max_turns: agent.runtime_config.max_turns,
         // Session-scoped env — inherited by stdio MCP server subprocesses.
         // Agent identity rides on the bv_ OAuth token in the MCP config,
         // not here (would risk divergence).

--- a/packages/core/src/services/memory/index.ts
+++ b/packages/core/src/services/memory/index.ts
@@ -1,0 +1,11 @@
+export { CoreMemory } from "./core-memory.js";
+export type { CoreMemoryDeps, CoreMemoryOperation } from "./core-memory.js";
+
+export { FactStore } from "./fact-store.js";
+export type { FactStoreDeps } from "./fact-store.js";
+
+export { FactPromoter } from "./fact-promoter.js";
+export type { FactPromoterDeps, PromotionResult } from "./fact-promoter.js";
+
+export { createMemoryAgent } from "./memory-agent.js";
+export type { MemoryAgent, MemoryAgentDeps } from "./memory-agent.js";

--- a/packages/core/src/services/task-service.test.ts
+++ b/packages/core/src/services/task-service.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Agent, ReviewPolicy } from "../domain/agent.js";
 import type { Task, TaskStatus } from "../domain/task.js";
 import type { WorkProduct } from "../domain/work-product.js";
+import type { AgentRepository } from "../ports/agent-repo.js";
 import type { TaskRepository } from "../ports/task-repo.js";
 import type { WorkProductRepository } from "../ports/work-product-repo.js";
 import {
@@ -35,8 +37,22 @@ function makeWorkProduct(overrides: Partial<WorkProduct> = {}): WorkProduct {
   };
 }
 
+function makeAgent(review_policy?: ReviewPolicy): Agent {
+  return {
+    id: "agent_1",
+    name: "A",
+    owner_id: "person_1",
+    hierarchy_level: "ic",
+    runtime_config: { type: "claude-code" },
+    review_policy,
+    created_at: new Date(),
+    updated_at: new Date(),
+  };
+}
+
 let taskRepo: TaskRepository;
 let workProductRepo: WorkProductRepository;
+let agentRepo: AgentRepository;
 let service: TaskService;
 
 beforeEach(() => {
@@ -44,6 +60,8 @@ beforeEach(() => {
     findById: vi.fn(),
     list: vi.fn(),
     listByAssignee: vi.fn(),
+    listAssignable: vi.fn(),
+    claimById: vi.fn(),
     listReviewQueue: vi.fn(),
     countChildrenNotComplete: vi.fn(),
     create: vi.fn(),
@@ -60,7 +78,19 @@ beforeEach(() => {
     create: vi.fn(),
     delete: vi.fn(),
   };
-  service = new TaskService({ taskRepo, workProductRepo });
+  agentRepo = {
+    findById: vi.fn(),
+    findByApiKey: vi.fn(),
+    findByOwnerId: vi.fn(),
+    findTopLevelForOwner: vi.fn(),
+    findSubordinates: vi.fn(),
+    findPeers: vi.fn(),
+    findByLevel: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+  service = new TaskService({ taskRepo, workProductRepo, agentRepo });
 });
 
 describe("TaskService.updateProgress", () => {
@@ -85,6 +115,90 @@ describe("TaskService.updateProgress", () => {
     await expect(
       service.updateProgress("task_x", "in_progress", "x"),
     ).rejects.toBeInstanceOf(TaskNotFoundError);
+  });
+
+  describe("review_policy gating", () => {
+    it("agent.review_policy='require_human' + status='done' → transitions to 'review'", async () => {
+      vi.mocked(taskRepo.findById).mockResolvedValue(
+        makeTask({ assignee_id: "agent_1" }),
+      );
+      vi.mocked(agentRepo.findById).mockResolvedValue(makeAgent("require_human"));
+      vi.mocked(taskRepo.updateProgress).mockImplementation(async (id, status, summary) =>
+        makeTask({ id, status, result_summary: summary }),
+      );
+
+      const out = await service.updateProgress("task_1", "done", "finished it");
+      expect(out.status).toBe("review");
+      // Critical: the REPO is called with "review", not "done" — the gate
+      // rewrites the status before persisting.
+      expect(taskRepo.updateProgress).toHaveBeenCalledWith("task_1", "review", "finished it");
+    });
+
+    it("agent.review_policy='auto_done' + status='done' → passes through as 'done'", async () => {
+      vi.mocked(taskRepo.findById).mockResolvedValue(
+        makeTask({ assignee_id: "agent_1" }),
+      );
+      vi.mocked(agentRepo.findById).mockResolvedValue(makeAgent("auto_done"));
+      vi.mocked(taskRepo.updateProgress).mockImplementation(async (id, status, summary) =>
+        makeTask({ id, status, result_summary: summary }),
+      );
+
+      const out = await service.updateProgress("task_1", "done", "finished it");
+      expect(out.status).toBe("done");
+      expect(taskRepo.updateProgress).toHaveBeenCalledWith("task_1", "done", "finished it");
+    });
+
+    it("agent.review_policy=undefined + status='done' → passes through as 'done' (default is auto_done)", async () => {
+      vi.mocked(taskRepo.findById).mockResolvedValue(
+        makeTask({ assignee_id: "agent_1" }),
+      );
+      vi.mocked(agentRepo.findById).mockResolvedValue(makeAgent(undefined));
+      vi.mocked(taskRepo.updateProgress).mockImplementation(async (id, status, summary) =>
+        makeTask({ id, status, result_summary: summary }),
+      );
+
+      const out = await service.updateProgress("task_1", "done", "finished it");
+      expect(out.status).toBe("done");
+    });
+
+    it("agent.review_policy='require_human' + status='failed' → NOT gated (failed stays failed)", async () => {
+      vi.mocked(taskRepo.findById).mockResolvedValue(
+        makeTask({ assignee_id: "agent_1" }),
+      );
+      vi.mocked(agentRepo.findById).mockResolvedValue(makeAgent("require_human"));
+      vi.mocked(taskRepo.updateProgress).mockImplementation(async (id, status, summary) =>
+        makeTask({ id, status, result_summary: summary }),
+      );
+
+      const out = await service.updateProgress("task_1", "failed", "it broke");
+      expect(out.status).toBe("failed");
+    });
+
+    it("agent.review_policy='require_human' + status='blocked' → NOT gated", async () => {
+      vi.mocked(taskRepo.findById).mockResolvedValue(
+        makeTask({ assignee_id: "agent_1" }),
+      );
+      vi.mocked(agentRepo.findById).mockResolvedValue(makeAgent("require_human"));
+      vi.mocked(taskRepo.updateProgress).mockImplementation(async (id, status, summary) =>
+        makeTask({ id, status, result_summary: summary }),
+      );
+
+      const out = await service.updateProgress("task_1", "blocked", "waiting on x");
+      expect(out.status).toBe("blocked");
+    });
+
+    it("task has no assignee_id → skips policy lookup, passes status through", async () => {
+      vi.mocked(taskRepo.findById).mockResolvedValue(
+        makeTask({ assignee_id: undefined }),
+      );
+      vi.mocked(taskRepo.updateProgress).mockImplementation(async (id, status, summary) =>
+        makeTask({ id, status, result_summary: summary }),
+      );
+
+      await service.updateProgress("task_1", "done", "finished");
+      expect(agentRepo.findById).not.toHaveBeenCalled();
+      expect(taskRepo.updateProgress).toHaveBeenCalledWith("task_1", "done", "finished");
+    });
   });
 });
 

--- a/packages/core/src/services/task-service.test.ts
+++ b/packages/core/src/services/task-service.test.ts
@@ -114,7 +114,7 @@ describe("TaskService.approveTask", () => {
   it.each([
     ["approve", "done"],
     ["reject", "cancelled"],
-    ["revise", "revision"],
+    ["revise", "needs_revision"],
   ] as const)(
     "transitions review → %s via %s",
     async (action, expectedStatus) => {
@@ -131,13 +131,20 @@ describe("TaskService.approveTask", () => {
     },
   );
 
-  it("allows approving from 'revision' too", async () => {
-    vi.mocked(taskRepo.findById).mockResolvedValue(makeTask({ status: "revision" }));
+  it("allows approving from 'needs_revision' too (reviewer changes mind before executor picks up re-work)", async () => {
+    vi.mocked(taskRepo.findById).mockResolvedValue(makeTask({ status: "needs_revision" }));
     vi.mocked(taskRepo.update).mockImplementation(async (id, patch) =>
-      makeTask({ id, ...patch, status: patch.status ?? "revision" }),
+      makeTask({ id, ...patch, status: patch.status ?? "needs_revision" }),
     );
     const out = await service.approveTask("task_1", "approve");
     expect(out.status).toBe("done");
+  });
+
+  it("rejects approval from 'revision' (actively running re-work — can't approve mid-run)", async () => {
+    vi.mocked(taskRepo.findById).mockResolvedValue(makeTask({ status: "revision" }));
+    await expect(
+      service.approveTask("task_1", "approve"),
+    ).rejects.toBeInstanceOf(InvalidTaskTransitionError);
   });
 
   it("rejects approval from an invalid status", async () => {

--- a/packages/core/src/services/task-service.ts
+++ b/packages/core/src/services/task-service.ts
@@ -26,11 +26,18 @@ export class InvalidTaskTransitionError extends Error {
 const APPROVAL_TRANSITIONS: Record<"approve" | "reject" | "revise", TaskStatus> = {
   approve: "done",
   reject: "cancelled",
-  revise: "revision",
+  // "revise" queues the task for re-work; the executor's claim will then
+  // transition needs_revision → revision (running as re-work).
+  revise: "needs_revision",
 };
 
-/** Statuses from which an approval action is legal. */
-const APPROVABLE_FROM: readonly TaskStatus[] = ["review", "revision"];
+/**
+ * Statuses from which an approval action is legal. `review` is the natural
+ * case (agent finished, waiting for human). `needs_revision` lets a reviewer
+ * change their mind about a re-work request before the executor picks it
+ * up — not allowed once the task is actively re-running (`revision`).
+ */
+const APPROVABLE_FROM: readonly TaskStatus[] = ["review", "needs_revision"];
 
 /** Cancellation from these requires `force: true`. */
 const TERMINAL_STATUSES: readonly TaskStatus[] = ["done", "cancelled"];
@@ -92,7 +99,8 @@ export class TaskService {
 
   /**
    * Approve / reject / revise a task awaiting review. Valid only when the
-   * task is currently in `review` or `revision`.
+   * task is currently in `review` or `needs_revision` (latter lets a
+   * reviewer undo a re-work request before the executor claims it).
    */
   async approveTask(
     taskId: string,

--- a/packages/core/src/services/task-service.ts
+++ b/packages/core/src/services/task-service.ts
@@ -1,5 +1,6 @@
 import type { Task, TaskStatus } from "../domain/task.js";
 import type { WorkProduct } from "../domain/work-product.js";
+import type { AgentRepository } from "../ports/agent-repo.js";
 import type {
   NewWorkProduct,
   WorkProductRepository,
@@ -48,6 +49,8 @@ const COMPLETE_STATUSES: readonly TaskStatus[] = ["done", "cancelled", "failed"]
 export interface TaskServiceDeps {
   taskRepo: TaskRepository;
   workProductRepo: WorkProductRepository;
+  /** Looked up on `updateProgress` to apply the agent's `review_policy`. */
+  agentRepo: AgentRepository;
 }
 
 /**
@@ -71,14 +74,32 @@ export interface TaskServiceDeps {
 export class TaskService {
   constructor(private deps: TaskServiceDeps) {}
 
-  /** Update progress — used by the `update_progress` MCP tool (M6). */
+  /**
+   * Update progress — used by the `update_progress` MCP tool (M6).
+   *
+   * Applies the agent's `review_policy` as a gate: when the agent declares
+   * `done` and its policy is `require_human`, the task is transitioned to
+   * `review` instead so a human can sign off before it's truly closed.
+   * Undefined policy and `auto_done` both pass `done` through. Other
+   * statuses (`failed`, `blocked`, etc.) are never gated — those aren't
+   * "I'm finished" claims and don't need review.
+   */
   async updateProgress(
     taskId: string,
     status: TaskStatus,
     summary: string,
   ): Promise<Task> {
-    await this.requireTask(taskId);
-    return this.deps.taskRepo.updateProgress(taskId, status, summary);
+    const task = await this.requireTask(taskId);
+
+    let finalStatus = status;
+    if (status === "done" && task.assignee_id) {
+      const agent = await this.deps.agentRepo.findById(task.assignee_id);
+      if (agent?.review_policy === "require_human") {
+        finalStatus = "review";
+      }
+    }
+
+    return this.deps.taskRepo.updateProgress(taskId, finalStatus, summary);
   }
 
   /** Mark blocked (set blocker agent + reason). Used by the `report_blocker` mesh tool (M6). */

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -19,5 +19,9 @@
   },
   "dependencies": {
     "@beevibe/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.11.10",
+    "dotenv": "^17.4.2"
   }
 }

--- a/packages/executor/src/bootstrap.ts
+++ b/packages/executor/src/bootstrap.ts
@@ -1,0 +1,111 @@
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import {
+  PostgresAgentRepository,
+  PostgresCoreMemoryRepository,
+  PostgresMemoryFactRepository,
+  PostgresPersonRepository,
+  PostgresSessionRepository,
+  PostgresTaskRepository,
+  PostgresWorkProductRepository,
+  createPool,
+} from "@beevibe/core/adapters/postgres";
+import { LocalWorkspaceManager } from "@beevibe/core/adapters/local-workspace";
+import { OpenAIEmbeddingService } from "@beevibe/core/adapters/openai";
+import { AnthropicLlmProvider } from "@beevibe/core/adapters/anthropic";
+import { createDefaultRuntimeRegistry } from "@beevibe/core/adapters/runtime-registry";
+import {
+  CoreMemory,
+  FactPromoter,
+  FactStore,
+  createMemoryAgent,
+} from "@beevibe/core/services/memory";
+import { createTaskDispatcher } from "./dispatch.js";
+import { TaskExecutionWorker } from "./worker.js";
+
+export interface BootstrapConfig {
+  databaseUrl: string;
+  mcpServerUrl: string;
+  openaiApiKey: string;
+  anthropicApiKey: string;
+  /** Default `~/.beevibe/workspaces`. */
+  workspaceRoot?: string;
+  /** Default 30_000ms. */
+  pollIntervalMs?: number;
+}
+
+export interface BootstrapResult {
+  worker: TaskExecutionWorker;
+  pool: Pool;
+  shutdown: () => Promise<void>;
+}
+
+/**
+ * Composition root for the executor process. Wires pool → repos → adapters →
+ * M3 services → per-agent `MemoryAgent` factory → runtime registry →
+ * dispatcher → worker. Returns the assembled worker plus a `shutdown`
+ * function that stops the poll loop and drains the pool.
+ *
+ * The MCP server (M6) will do the same wiring in its own bootstrap — it
+ * imports the same factories and adapters from `@beevibe/core`, so adding a
+ * new runtime (codex, amp, etc.) is one line in the shared
+ * `createDefaultRuntimeRegistry` and both composition roots pick it up.
+ *
+ * No `claudeCommand` / `claudeModel` here: per-agent model flows from
+ * `agent.runtime_config.model` through `RuntimeContext.model` at run time.
+ * Anything the CLI binary itself needs comes from its own PATH resolution.
+ */
+export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> {
+  const pool = createPool({ connectionString: cfg.databaseUrl });
+
+  // Repositories
+  const agentRepo = new PostgresAgentRepository(pool);
+  const taskRepo = new PostgresTaskRepository(pool);
+  const sessionRepo = new PostgresSessionRepository(pool);
+  const coreMemoryRepo = new PostgresCoreMemoryRepository(pool);
+  const memoryFactRepo = new PostgresMemoryFactRepository(pool);
+  // Held to force adapter instantiation — exercised by E2E flows.
+  void new PostgresPersonRepository(pool);
+  void new PostgresWorkProductRepository(pool);
+
+  // External-service adapters
+  const embed = new OpenAIEmbeddingService({ apiKey: cfg.openaiApiKey });
+  const llm = new AnthropicLlmProvider({ apiKey: cfg.anthropicApiKey });
+
+  // Workspace + runtime (shared with M6 via the factory)
+  const workspaceManager = new LocalWorkspaceManager({
+    workspaceRoot: cfg.workspaceRoot,
+    mcpServerUrl: cfg.mcpServerUrl,
+  });
+  const runtimeRegistry = createDefaultRuntimeRegistry();
+
+  // Memory services
+  const coreMemory = new CoreMemory({ repo: coreMemoryRepo });
+  const factStore = new FactStore({ repo: memoryFactRepo, embed, llm });
+  const promoter = new FactPromoter({ llm });
+
+  const makeMemoryAgent = (agentId: string) =>
+    createMemoryAgent({ agentId, coreMemory, factStore, promoter, embed });
+
+  // Dispatcher + worker
+  const dispatchTask = createTaskDispatcher({
+    agentRepo,
+    sessionRepo,
+    runtimeRegistry,
+    makeMemoryAgent,
+  });
+  const worker = new TaskExecutionWorker({
+    agentRepo,
+    taskRepo,
+    sessionRepo,
+    workspaceManager,
+    dispatchTask,
+    pollIntervalMs: cfg.pollIntervalMs,
+  });
+
+  const shutdown = async () => {
+    await worker.stop();
+    await pool.end();
+  };
+
+  return { worker, pool, shutdown };
+}

--- a/packages/executor/src/bootstrap.ts
+++ b/packages/executor/src/bootstrap.ts
@@ -3,10 +3,8 @@ import {
   PostgresAgentRepository,
   PostgresCoreMemoryRepository,
   PostgresMemoryFactRepository,
-  PostgresPersonRepository,
   PostgresSessionRepository,
   PostgresTaskRepository,
-  PostgresWorkProductRepository,
   createPool,
 } from "@beevibe/core/adapters/postgres";
 import { LocalWorkspaceManager } from "@beevibe/core/adapters/local-workspace";
@@ -57,15 +55,13 @@ export interface BootstrapResult {
 export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> {
   const pool = createPool({ connectionString: cfg.databaseUrl });
 
-  // Repositories
+  // Repositories (only the ones the executor actually drives; person + work-
+  // product are managed by M6's MCP server and M8's web API respectively).
   const agentRepo = new PostgresAgentRepository(pool);
   const taskRepo = new PostgresTaskRepository(pool);
   const sessionRepo = new PostgresSessionRepository(pool);
   const coreMemoryRepo = new PostgresCoreMemoryRepository(pool);
   const memoryFactRepo = new PostgresMemoryFactRepository(pool);
-  // Held to force adapter instantiation — exercised by E2E flows.
-  void new PostgresPersonRepository(pool);
-  void new PostgresWorkProductRepository(pool);
 
   // External-service adapters
   const embed = new OpenAIEmbeddingService({ apiKey: cfg.openaiApiKey });

--- a/packages/executor/src/dispatch.test.ts
+++ b/packages/executor/src/dispatch.test.ts
@@ -204,7 +204,7 @@ describe("createTaskDispatcher", () => {
     expect(arg.intent).toBe("just a title");
   });
 
-  it("revision task: looks up latest prior session and passes priorSessionId", async () => {
+  it("task in `revision` (post-claim re-work): looks up latest prior session and passes priorSessionId", async () => {
     vi.mocked(sessionRepo.findLatestForTask).mockResolvedValue({
       id: "sess_prior",
       agent_id: "agent_test",
@@ -233,7 +233,7 @@ describe("createTaskDispatcher", () => {
     expect(arg.priorSessionId).toBe("sess_prior");
   });
 
-  it("non-revision task: does NOT call findLatestForTask + priorSessionId is undefined", async () => {
+  it("fresh (in_progress) task: does NOT call findLatestForTask + priorSessionId is undefined", async () => {
     const registry: RuntimeRegistry = { "claude-code": fakeRuntime };
     const dispatch = createTaskDispatcher({
       agentRepo,
@@ -244,7 +244,9 @@ describe("createTaskDispatcher", () => {
         onTaskComplete: vi.fn(),
       }) as unknown as MemoryAgent),
     });
-    await dispatch(makeTask({ status: "assigned" }), makeAgent(), WORKSPACE, SIGNAL);
+    // Post-claim status for fresh work is `in_progress`; dispatch must not
+    // trigger the --resume path for this.
+    await dispatch(makeTask({ status: "in_progress" }), makeAgent(), WORKSPACE, SIGNAL);
     expect(sessionRepo.findLatestForTask).not.toHaveBeenCalled();
     const arg = runSpy.mock.calls[0]![0] as Parameters<AgentSession["run"]>[0];
     expect(arg.priorSessionId).toBeUndefined();

--- a/packages/executor/src/dispatch.test.ts
+++ b/packages/executor/src/dispatch.test.ts
@@ -1,0 +1,252 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  AgentRuntime,
+  RuntimeRegistry,
+  Session,
+  SessionRepository,
+  Task,
+  Workspace,
+} from "@beevibe/core";
+import type { MemoryAgent } from "@beevibe/core/services/memory";
+import { AgentSession } from "@beevibe/core/services/agent-session";
+import { createTaskDispatcher } from "./dispatch.js";
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: "agent_test",
+    name: "Agent",
+    owner_id: "person_owner",
+    hierarchy_level: "ic",
+    api_key: "bv_a_k",
+    runtime_config: { type: "claude-code" },
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "task_test",
+    title: "Do a thing",
+    status: "assigned",
+    priority: "medium",
+    creator_id: "person_owner",
+    creator_type: "person",
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
+const WORKSPACE: Workspace = { path: "/tmp/ws" };
+const SIGNAL = new AbortController().signal;
+
+let agentRepo: AgentRepository;
+let sessionRepo: SessionRepository;
+let fakeRuntime: AgentRuntime;
+let runSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  agentRepo = {
+    findById: vi.fn(),
+    findByApiKey: vi.fn(),
+    findByOwnerId: vi.fn(),
+    findTopLevelForOwner: vi.fn(),
+    findSubordinates: vi.fn(),
+    findPeers: vi.fn(),
+    findByLevel: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+  sessionRepo = {
+    findById: vi.fn(),
+    findLatestForTask: vi.fn(),
+    listForTask: vi.fn(),
+    listForAgent: vi.fn(),
+    countRunningByAgent: vi.fn(),
+    listRunningWithPid: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  };
+  fakeRuntime = {
+    type: "claude-code",
+    execute: vi.fn(),
+    healthCheck: vi.fn(),
+    shutdown: vi.fn(),
+  };
+  // Intercept AgentSession.run so the dispatcher tests don't actually walk the
+  // 6-step pipeline — we only care that run() gets called with the right args.
+  runSpy = vi
+    .spyOn(AgentSession.prototype, "run")
+    .mockResolvedValue({
+      id: "sess_1",
+      agent_id: "agent_test",
+      type: "task",
+      status: "succeeded",
+      intent: "x",
+      created_at: new Date(),
+    } as unknown as Session);
+});
+
+describe("createTaskDispatcher", () => {
+  it("resolves runtime via registry keyed by agent.runtime_config.type", async () => {
+    const codexRuntime = { ...fakeRuntime, type: "codex" } as AgentRuntime;
+    const registry: RuntimeRegistry = {
+      "claude-code": fakeRuntime,
+      codex: codexRuntime,
+    };
+    const makeMemoryAgent = vi.fn(() => ({
+      prepareBriefing: vi.fn(),
+      onTaskComplete: vi.fn(),
+    }) as unknown as MemoryAgent);
+
+    const dispatch = createTaskDispatcher({
+      agentRepo,
+      sessionRepo,
+      runtimeRegistry: registry,
+      makeMemoryAgent,
+    });
+
+    const agent = makeAgent({ runtime_config: { type: "codex" } });
+    await dispatch(makeTask(), agent, WORKSPACE, SIGNAL);
+
+    // AgentSession ctor saw the codex runtime.
+    // The spy was set on AgentSession.prototype.run, so we can introspect via
+    // the `this` the call was made on.
+    const sessionInstance = runSpy.mock.instances[0] as AgentSession;
+    expect(
+      (sessionInstance as unknown as { deps: { runtime: AgentRuntime } }).deps.runtime,
+    ).toBe(codexRuntime);
+  });
+
+  it("throws 'Unsupported runtime: X' when agent's runtime type is not registered", async () => {
+    const registry: RuntimeRegistry = { "claude-code": fakeRuntime };
+    const dispatch = createTaskDispatcher({
+      agentRepo,
+      sessionRepo,
+      runtimeRegistry: registry,
+      makeMemoryAgent: vi.fn(),
+    });
+    const agent = makeAgent({ runtime_config: { type: "unknown-runtime" } });
+    await expect(dispatch(makeTask(), agent, WORKSPACE, SIGNAL)).rejects.toThrow(
+      /Unsupported runtime: unknown-runtime/,
+    );
+  });
+
+  it("builds MemoryAgent with agent.id", async () => {
+    const registry: RuntimeRegistry = { "claude-code": fakeRuntime };
+    const makeMemoryAgent = vi.fn(() => ({
+      prepareBriefing: vi.fn(),
+      onTaskComplete: vi.fn(),
+    }) as unknown as MemoryAgent);
+    const dispatch = createTaskDispatcher({
+      agentRepo,
+      sessionRepo,
+      runtimeRegistry: registry,
+      makeMemoryAgent,
+    });
+    await dispatch(makeTask(), makeAgent({ id: "agent_XYZ" }), WORKSPACE, SIGNAL);
+    expect(makeMemoryAgent).toHaveBeenCalledWith("agent_XYZ");
+  });
+
+  it("calls AgentSession.run with { agentId, taskId, intent (title+description), workspace, abortSignal }", async () => {
+    const registry: RuntimeRegistry = { "claude-code": fakeRuntime };
+    const dispatch = createTaskDispatcher({
+      agentRepo,
+      sessionRepo,
+      runtimeRegistry: registry,
+      makeMemoryAgent: vi.fn(() => ({
+        prepareBriefing: vi.fn(),
+        onTaskComplete: vi.fn(),
+      }) as unknown as MemoryAgent),
+    });
+
+    const agent = makeAgent({ id: "agent_run" });
+    const task = makeTask({
+      id: "task_run",
+      title: "Fix auth",
+      description: "Find and fix the login bug.",
+    });
+    await dispatch(task, agent, WORKSPACE, SIGNAL);
+
+    const arg = runSpy.mock.calls[0]![0] as Parameters<AgentSession["run"]>[0];
+    expect(arg.agentId).toBe("agent_run");
+    expect(arg.taskId).toBe("task_run");
+    expect(arg.intent).toBe("Fix auth\n\nFind and fix the login bug.");
+    expect(arg.workspace).toBe(WORKSPACE);
+    expect(arg.abortSignal).toBe(SIGNAL);
+    // No urgency field — M5.0 dropped it.
+    expect(arg).not.toHaveProperty("urgency");
+  });
+
+  it("intent is just the title when description is missing", async () => {
+    const registry: RuntimeRegistry = { "claude-code": fakeRuntime };
+    const dispatch = createTaskDispatcher({
+      agentRepo,
+      sessionRepo,
+      runtimeRegistry: registry,
+      makeMemoryAgent: vi.fn(() => ({
+        prepareBriefing: vi.fn(),
+        onTaskComplete: vi.fn(),
+      }) as unknown as MemoryAgent),
+    });
+    await dispatch(
+      makeTask({ title: "just a title", description: undefined }),
+      makeAgent(),
+      WORKSPACE,
+      SIGNAL,
+    );
+    const arg = runSpy.mock.calls[0]![0] as Parameters<AgentSession["run"]>[0];
+    expect(arg.intent).toBe("just a title");
+  });
+
+  it("revision task: looks up latest prior session and passes priorSessionId", async () => {
+    vi.mocked(sessionRepo.findLatestForTask).mockResolvedValue({
+      id: "sess_prior",
+      agent_id: "agent_test",
+      type: "task",
+      status: "failed",
+      intent: "x",
+      created_at: new Date(),
+    } as unknown as Session);
+
+    const registry: RuntimeRegistry = { "claude-code": fakeRuntime };
+    const dispatch = createTaskDispatcher({
+      agentRepo,
+      sessionRepo,
+      runtimeRegistry: registry,
+      makeMemoryAgent: vi.fn(() => ({
+        prepareBriefing: vi.fn(),
+        onTaskComplete: vi.fn(),
+      }) as unknown as MemoryAgent),
+    });
+
+    const task = makeTask({ id: "task_rev", status: "revision" });
+    await dispatch(task, makeAgent(), WORKSPACE, SIGNAL);
+
+    expect(sessionRepo.findLatestForTask).toHaveBeenCalledWith("task_rev");
+    const arg = runSpy.mock.calls[0]![0] as Parameters<AgentSession["run"]>[0];
+    expect(arg.priorSessionId).toBe("sess_prior");
+  });
+
+  it("non-revision task: does NOT call findLatestForTask + priorSessionId is undefined", async () => {
+    const registry: RuntimeRegistry = { "claude-code": fakeRuntime };
+    const dispatch = createTaskDispatcher({
+      agentRepo,
+      sessionRepo,
+      runtimeRegistry: registry,
+      makeMemoryAgent: vi.fn(() => ({
+        prepareBriefing: vi.fn(),
+        onTaskComplete: vi.fn(),
+      }) as unknown as MemoryAgent),
+    });
+    await dispatch(makeTask({ status: "assigned" }), makeAgent(), WORKSPACE, SIGNAL);
+    expect(sessionRepo.findLatestForTask).not.toHaveBeenCalled();
+    const arg = runSpy.mock.calls[0]![0] as Parameters<AgentSession["run"]>[0];
+    expect(arg.priorSessionId).toBeUndefined();
+  });
+});

--- a/packages/executor/src/dispatch.ts
+++ b/packages/executor/src/dispatch.ts
@@ -1,0 +1,88 @@
+import type {
+  Agent,
+  AgentRepository,
+  RuntimeRegistry,
+  Session,
+  SessionRepository,
+  Task,
+  Workspace,
+} from "@beevibe/core";
+import { AgentSession } from "@beevibe/core/services/agent-session";
+import type { MemoryAgent } from "@beevibe/core/services/memory";
+
+/** Factory for a per-agent `MemoryAgent`, closing over the shared memory services. */
+export type MakeMemoryAgent = (agentId: string) => MemoryAgent;
+
+export interface DispatchDeps {
+  agentRepo: AgentRepository;
+  sessionRepo: SessionRepository;
+  /**
+   * Keyed by `agent.runtime_config.type`. Built via
+   * `createDefaultRuntimeRegistry` in bootstrap; tests inject a fake map.
+   */
+  runtimeRegistry: RuntimeRegistry;
+  makeMemoryAgent: MakeMemoryAgent;
+}
+
+/**
+ * Dispatch function the worker calls per claimed task.
+ *
+ * Agent is passed in (the worker already fetched it for the capacity check +
+ * workspace provisioning), avoiding a redundant `findById`. AgentSession will
+ * re-fetch internally for `runtime_config.system_prompt_addition` — accepted
+ * cost for PK-indexed lookups.
+ */
+export type TaskDispatcher = (
+  task: Task,
+  agent: Agent,
+  workspace: Workspace,
+  abortSignal: AbortSignal,
+) => Promise<Session>;
+
+/**
+ * Build the per-task dispatcher closed over shared deps.
+ *
+ * Flow:
+ *   1. Resolve runtime from `runtimeRegistry[agent.runtime_config.type]`.
+ *      Throws `Unsupported runtime: <type>` if not registered.
+ *   2. Build a per-agent `MemoryAgent` (agentId baked in).
+ *   3. Construct `AgentSession` with the resolved runtime + memory agent.
+ *   4. For revision tasks, look up the latest prior session so AgentSession
+ *      can issue `--resume` to continue the conversation.
+ *   5. Call `agentSession.run({...})`. All session-row lifecycle, briefing,
+ *      runtime spawn, and post-session promotion happen inside.
+ */
+export function createTaskDispatcher(deps: DispatchDeps): TaskDispatcher {
+  return async (task, agent, workspace, abortSignal) => {
+    const runtime = deps.runtimeRegistry[agent.runtime_config.type];
+    if (!runtime) {
+      throw new Error(`Unsupported runtime: ${agent.runtime_config.type}`);
+    }
+
+    const memoryAgent = deps.makeMemoryAgent(agent.id);
+    const agentSession = new AgentSession({
+      agentRepo: deps.agentRepo,
+      sessionRepo: deps.sessionRepo,
+      runtime,
+      memoryAgent,
+    });
+
+    const priorSessionId =
+      task.status === "revision"
+        ? (await deps.sessionRepo.findLatestForTask(task.id))?.id
+        : undefined;
+
+    return agentSession.run({
+      agentId: agent.id,
+      taskId: task.id,
+      intent: composeIntent(task),
+      workspace,
+      priorSessionId,
+      abortSignal,
+    });
+  };
+}
+
+function composeIntent(task: Task): string {
+  return task.description ? `${task.title}\n\n${task.description}` : task.title;
+}

--- a/packages/executor/src/main.ts
+++ b/packages/executor/src/main.ts
@@ -1,3 +1,59 @@
-// @beevibe/executor — task polling loop and session dispatch.
-// Populated M5. Spawns CLI agent subprocesses via core AgentSession.
-export {};
+#!/usr/bin/env node
+import { config as loadEnv } from "dotenv";
+import { bootstrap } from "./bootstrap.js";
+
+const REQUIRED_ENV = [
+  "DATABASE_URL",
+  "BEEVIBE_MCP_SERVER_URL",
+  "OPENAI_API_KEY",
+  "ANTHROPIC_API_KEY",
+] as const;
+
+async function main(): Promise<void> {
+  // Load .env from CWD (production: env provided by orchestrator;
+  // local dev: repo-root .env).
+  loadEnv();
+
+  const missing = REQUIRED_ENV.filter((k) => !process.env[k]);
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required env vars: ${missing.join(", ")}. See .env.example for the full set.`,
+    );
+  }
+
+  const { worker, shutdown } = await bootstrap({
+    databaseUrl: process.env.DATABASE_URL!,
+    mcpServerUrl: process.env.BEEVIBE_MCP_SERVER_URL!,
+    openaiApiKey: process.env.OPENAI_API_KEY!,
+    anthropicApiKey: process.env.ANTHROPIC_API_KEY!,
+    workspaceRoot: process.env.WORKSPACE_ROOT,
+    pollIntervalMs: process.env.POLL_INTERVAL_MS
+      ? Number(process.env.POLL_INTERVAL_MS)
+      : undefined,
+  });
+
+  await worker.start();
+  console.error("[executor] ready");
+
+  const stop = async (signal: string): Promise<void> => {
+    console.error(`[executor] ${signal} received, shutting down`);
+    try {
+      await shutdown();
+    } catch (err) {
+      console.error("[executor] shutdown error:", err);
+    }
+    process.exit(0);
+  };
+
+  process.on("SIGINT", () => {
+    void stop("SIGINT");
+  });
+  process.on("SIGTERM", () => {
+    void stop("SIGTERM");
+  });
+}
+
+main().catch((err: unknown) => {
+  console.error("[executor] fatal:", err);
+  process.exit(1);
+});

--- a/packages/executor/src/test-helpers.ts
+++ b/packages/executor/src/test-helpers.ts
@@ -1,0 +1,32 @@
+import { config as loadEnv } from "dotenv";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createPool, type Pool } from "@beevibe/core/adapters/postgres";
+
+const here = dirname(fileURLToPath(import.meta.url));
+loadEnv({ path: resolve(here, "../../../.env") });
+
+const ALL_TABLES = [
+  "memory_fact",
+  "work_product",
+  "core_memory_block",
+  "session",
+  "task",
+  "agent",
+  "person",
+];
+
+export function createTestPool(): Pool {
+  const url = process.env.DATABASE_URL_TEST;
+  if (!url) {
+    throw new Error(
+      "DATABASE_URL_TEST env var is required for integration tests. " +
+        "Set it in .env or export it before running vitest.",
+    );
+  }
+  return createPool({ connectionString: url, max: 4 });
+}
+
+export async function truncateAll(pool: Pool): Promise<void> {
+  await pool.query(`TRUNCATE ${ALL_TABLES.join(", ")} RESTART IDENTITY CASCADE`);
+}

--- a/packages/executor/src/worker.test.ts
+++ b/packages/executor/src/worker.test.ts
@@ -1,0 +1,413 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import {
+  PostgresAgentRepository,
+  PostgresPersonRepository,
+  PostgresSessionRepository,
+  PostgresTaskRepository,
+} from "@beevibe/core/adapters/postgres";
+import { LocalWorkspaceManager } from "@beevibe/core/adapters/local-workspace";
+import type { Agent, Task, Workspace } from "@beevibe/core";
+import {
+  DEFAULT_RUNTIME_CONFIG,
+  agentId,
+  personId,
+  sessionId,
+  taskId,
+} from "@beevibe/core";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createTestPool, truncateAll } from "./test-helpers.js";
+import {
+  DEFAULT_POLL_MS,
+  DEFAULT_TASK_CAP,
+  TaskExecutionWorker,
+  isProcessAlive,
+} from "./worker.js";
+
+describe("isProcessAlive", () => {
+  it("returns false for invalid pids", () => {
+    expect(isProcessAlive(null)).toBe(false);
+    expect(isProcessAlive(undefined)).toBe(false);
+    expect(isProcessAlive(0)).toBe(false);
+    expect(isProcessAlive(-1)).toBe(false);
+    expect(isProcessAlive(1.5)).toBe(false);
+  });
+
+  it("returns true for the current process pid", () => {
+    expect(isProcessAlive(process.pid)).toBe(true);
+  });
+
+  it("returns false for a non-existent pid", () => {
+    // 99_999_999 is well above typical pid_max; effectively guaranteed to not exist.
+    expect(isProcessAlive(99_999_999)).toBe(false);
+  });
+});
+
+describe("TaskExecutionWorker", () => {
+  let pool: Pool;
+  let agents: PostgresAgentRepository;
+  let tasks: PostgresTaskRepository;
+  let sessions: PostgresSessionRepository;
+  let persons: PostgresPersonRepository;
+  let workspaceRoot: string;
+  let workspaceManager: LocalWorkspaceManager;
+  let ownerPersonId: string;
+
+  beforeAll(() => {
+    pool = createTestPool();
+    agents = new PostgresAgentRepository(pool);
+    tasks = new PostgresTaskRepository(pool);
+    sessions = new PostgresSessionRepository(pool);
+    persons = new PostgresPersonRepository(pool);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await truncateAll(pool);
+    const owner = await persons.create({ id: personId(), name: "Worker Owner" });
+    ownerPersonId = owner.id;
+    workspaceRoot = mkdtempSync(join(tmpdir(), "beevibe-worker-test-"));
+    workspaceManager = new LocalWorkspaceManager({
+      workspaceRoot,
+      mcpServerUrl: "http://mcp.test.invalid/",
+    });
+  });
+
+  afterEach(() => {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+  });
+
+  async function seedAgent(overrides: Partial<Agent> = {}): Promise<Agent> {
+    return agents.create({
+      id: agentId(),
+      name: "Agent",
+      owner_id: ownerPersonId,
+      hierarchy_level: "ic",
+      api_key: `bv_a_test_${Math.random().toString(36).slice(2, 10)}`,
+      runtime_config: DEFAULT_RUNTIME_CONFIG,
+      ...overrides,
+    });
+  }
+
+  async function seedTask(
+    assigneeAgentId: string,
+    overrides: Partial<Task> = {},
+  ): Promise<Task> {
+    return tasks.create({
+      id: taskId(),
+      title: "Do X",
+      priority: "medium",
+      creator_id: ownerPersonId,
+      creator_type: "person",
+      status: "assigned",
+      assignee_id: assigneeAgentId,
+      ...overrides,
+    });
+  }
+
+  function makeWorker(dispatchTask = vi.fn().mockResolvedValue(undefined)): {
+    worker: TaskExecutionWorker;
+    dispatchTask: ReturnType<typeof vi.fn>;
+  } {
+    const worker = new TaskExecutionWorker({
+      agentRepo: agents,
+      taskRepo: tasks,
+      sessionRepo: sessions,
+      workspaceManager,
+      dispatchTask,
+      pollIntervalMs: 60_000, // disable auto-polling in tests; we call poll() manually
+    });
+    return { worker, dispatchTask };
+  }
+
+  it("empty queue: dispatchTask is not called", async () => {
+    const { worker, dispatchTask } = makeWorker();
+    await worker.start();
+    await worker.stop();
+    expect(dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("one assigned task: gets claimed and dispatched; task transitions to in_progress", async () => {
+    const agent = await seedAgent();
+    const task = await seedTask(agent.id);
+    const { worker, dispatchTask } = makeWorker();
+    await worker.start();
+    await worker.stop();
+
+    expect(dispatchTask).toHaveBeenCalledTimes(1);
+    const [dispatchedTask, dispatchedAgent, dispatchedWorkspace] = dispatchTask.mock.calls[0]!;
+    expect((dispatchedTask as Task).id).toBe(task.id);
+    expect((dispatchedAgent as Agent).id).toBe(agent.id);
+    expect((dispatchedWorkspace as Workspace).path).toBe(join(workspaceRoot, agent.id));
+
+    const reread = await tasks.findById(task.id);
+    expect(reread?.status).toBe("in_progress");
+  });
+
+  it("picks higher-priority tasks first within a single poll", async () => {
+    const a1 = await seedAgent();
+    const a2 = await seedAgent();
+    const a3 = await seedAgent();
+    const low = await seedTask(a1.id, { priority: "low" });
+    const critical = await seedTask(a2.id, { priority: "critical" });
+    const high = await seedTask(a3.id, { priority: "high" });
+
+    const { worker, dispatchTask } = makeWorker();
+    await worker.start();
+    await worker.stop();
+
+    expect(dispatchTask).toHaveBeenCalledTimes(3);
+    const dispatchedIds = dispatchTask.mock.calls.map((c) => (c[0] as Task).id);
+    expect(dispatchedIds).toEqual([critical.id, high.id, low.id]);
+  });
+
+  it("respects per-agent capacity (default 1): two tasks for same agent → only one dispatched", async () => {
+    const agent = await seedAgent();
+    const first = await seedTask(agent.id);
+    await seedTask(agent.id);
+
+    const { worker, dispatchTask } = makeWorker();
+    await worker.start();
+    await worker.stop();
+
+    expect(dispatchTask).toHaveBeenCalledTimes(1);
+    const dispatchedId = (dispatchTask.mock.calls[0]![0] as Task).id;
+    expect(dispatchedId).toBe(first.id);
+  });
+
+  it("agent.max_task_sessions=2: two tasks for same agent → both dispatched in one poll", async () => {
+    const agent = await seedAgent({ max_task_sessions: 2 });
+    await seedTask(agent.id);
+    await seedTask(agent.id);
+
+    const { worker, dispatchTask } = makeWorker();
+    await worker.start();
+    await worker.stop();
+
+    expect(dispatchTask).toHaveBeenCalledTimes(2);
+  });
+
+  it("two concurrent workers: each claim is disjoint (no double-claim)", async () => {
+    const a1 = await seedAgent();
+    const a2 = await seedAgent();
+    await seedTask(a1.id);
+    await seedTask(a2.id);
+
+    // Dispatch stubs that just record and return — don't hold anything open.
+    const dispatchA = vi.fn().mockResolvedValue(undefined);
+    const dispatchB = vi.fn().mockResolvedValue(undefined);
+    const workerA = new TaskExecutionWorker({
+      agentRepo: agents,
+      taskRepo: tasks,
+      sessionRepo: sessions,
+      workspaceManager,
+      dispatchTask: dispatchA,
+      pollIntervalMs: 60_000,
+    });
+    const workerB = new TaskExecutionWorker({
+      agentRepo: agents,
+      taskRepo: tasks,
+      sessionRepo: sessions,
+      workspaceManager,
+      dispatchTask: dispatchB,
+      pollIntervalMs: 60_000,
+    });
+    await Promise.all([workerA.start(), workerB.start()]);
+    await Promise.all([workerA.stop(), workerB.stop()]);
+
+    const total = dispatchA.mock.calls.length + dispatchB.mock.calls.length;
+    expect(total).toBe(2);
+    const allIds = [...dispatchA.mock.calls, ...dispatchB.mock.calls].map(
+      (c) => (c[0] as Task).id,
+    );
+    expect(new Set(allIds).size).toBe(2); // no duplicates
+  });
+
+  it("reaps orphaned sessions: dead pid → session=failed + task re-queued", async () => {
+    const agent = await seedAgent();
+    // Task has no assignee so the SAME poll's dispatch phase doesn't re-claim
+    // it after reap re-queues it (listAssignable filters assignee_id IS NOT NULL).
+    // This isolates the reap assertion.
+    const task = await tasks.create({
+      id: taskId(),
+      title: "orphaned",
+      priority: "medium",
+      creator_id: ownerPersonId,
+      creator_type: "person",
+      status: "in_progress",
+    });
+    const deadPid = 99_999_999;
+    const sess = await sessions.create({
+      id: sessionId(),
+      agent_id: agent.id,
+      task_id: task.id,
+      type: "task",
+      intent: "x",
+      process_pid: deadPid,
+      process_group_id: deadPid,
+      status: "running",
+      started_at: new Date(),
+    });
+
+    const { worker } = makeWorker();
+    await worker.start();
+    await worker.stop();
+
+    const reread = await sessions.findById(sess.id);
+    expect(reread?.status).toBe("failed");
+    expect(reread?.error).toBe("process_lost");
+    const rereadTask = await tasks.findById(task.id);
+    expect(rereadTask?.status).toBe("assigned");
+  });
+
+  it("reap skips live sessions", async () => {
+    const agent = await seedAgent();
+    const task = await seedTask(agent.id, { status: "in_progress" });
+    // Use the current process pid — guaranteed alive.
+    const sess = await sessions.create({
+      id: sessionId(),
+      agent_id: agent.id,
+      task_id: task.id,
+      type: "task",
+      intent: "x",
+      process_pid: process.pid,
+      process_group_id: process.pid,
+      status: "running",
+      started_at: new Date(),
+    });
+
+    const { worker } = makeWorker();
+    await worker.start();
+    await worker.stop();
+
+    const reread = await sessions.findById(sess.id);
+    expect(reread?.status).toBe("running");
+  });
+
+  it("cancelTask aborts an in-flight controller and returns true", async () => {
+    const agent = await seedAgent();
+    const task = await seedTask(agent.id);
+
+    // Dispatch that never resolves until aborted, so the inFlight entry is live
+    // when we call cancelTask().
+    let abortedFromSignal = false;
+    const dispatchTask = vi
+      .fn<
+        (task: Task, agent: Agent, ws: Workspace, signal: AbortSignal) => Promise<void>
+      >()
+      .mockImplementation(
+        (_task, _agent, _ws, signal) =>
+          new Promise((resolve) => {
+            signal.addEventListener("abort", () => {
+              abortedFromSignal = true;
+              resolve();
+            });
+          }),
+      );
+
+    const worker = new TaskExecutionWorker({
+      agentRepo: agents,
+      taskRepo: tasks,
+      sessionRepo: sessions,
+      workspaceManager,
+      dispatchTask,
+      pollIntervalMs: 60_000,
+    });
+    await worker.start();
+    // dispatched; cancel it
+    const aborted = await worker.cancelTask(task.id);
+    expect(aborted).toBe(true);
+    // Let the signal-handled promise settle before stopping.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(abortedFromSignal).toBe(true);
+    await worker.stop();
+  });
+
+  it("cancelTask returns false when task is not in flight", async () => {
+    const { worker } = makeWorker();
+    await worker.start();
+    const aborted = await worker.cancelTask("task_nonexistent");
+    expect(aborted).toBe(false);
+    await worker.stop();
+  });
+
+  it("stop() aborts in-flight controllers", async () => {
+    const agent = await seedAgent();
+    await seedTask(agent.id);
+    let abortedFromSignal = false;
+    const dispatchTask = vi
+      .fn<
+        (task: Task, agent: Agent, ws: Workspace, signal: AbortSignal) => Promise<void>
+      >()
+      .mockImplementation(
+        (_task, _agent, _ws, signal) =>
+          new Promise((resolve) => {
+            signal.addEventListener("abort", () => {
+              abortedFromSignal = true;
+              resolve();
+            });
+          }),
+      );
+    const worker = new TaskExecutionWorker({
+      agentRepo: agents,
+      taskRepo: tasks,
+      sessionRepo: sessions,
+      workspaceManager,
+      dispatchTask,
+      pollIntervalMs: 60_000,
+    });
+    await worker.start();
+    await worker.stop();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(abortedFromSignal).toBe(true);
+  });
+
+  it("revision-status tasks are also picked up", async () => {
+    const agent = await seedAgent();
+    const task = await seedTask(agent.id, { status: "revision" });
+    const { worker, dispatchTask } = makeWorker();
+    await worker.start();
+    await worker.stop();
+    expect(dispatchTask).toHaveBeenCalledTimes(1);
+    expect((dispatchTask.mock.calls[0]![0] as Task).id).toBe(task.id);
+  });
+
+  it("default poll interval is 30_000ms when not configured", async () => {
+    vi.useFakeTimers();
+    try {
+      const pollSpy = vi.fn<() => Promise<void>>();
+      // Reach into private via subclass to count timer firings explicitly.
+      class SpyWorker extends TaskExecutionWorker {
+        override async poll(): Promise<void> {
+          pollSpy();
+          return super.poll();
+        }
+      }
+      const worker = new SpyWorker({
+        agentRepo: agents,
+        taskRepo: tasks,
+        sessionRepo: sessions,
+        workspaceManager,
+        dispatchTask: vi.fn().mockResolvedValue(undefined),
+      });
+      // start() runs one immediate poll (awaited) then schedules the interval.
+      await worker.start();
+      expect(pollSpy).toHaveBeenCalledTimes(1);
+      // Advance one full default interval → one more poll.
+      await vi.advanceTimersByTimeAsync(DEFAULT_POLL_MS);
+      expect(pollSpy).toHaveBeenCalledTimes(2);
+      await worker.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("capacity defaults to DEFAULT_TASK_CAP when agent.max_task_sessions is undefined", () => {
+    expect(DEFAULT_TASK_CAP).toBe(1);
+  });
+});

--- a/packages/executor/src/worker.test.ts
+++ b/packages/executor/src/worker.test.ts
@@ -367,14 +367,52 @@ describe("TaskExecutionWorker", () => {
     expect(abortedFromSignal).toBe(true);
   });
 
-  it("revision-status tasks are also picked up", async () => {
+  it("needs_revision tasks are picked up and claimed into revision state", async () => {
     const agent = await seedAgent();
-    const task = await seedTask(agent.id, { status: "revision" });
+    const task = await seedTask(agent.id, { status: "needs_revision" });
     const { worker, dispatchTask } = makeWorker();
     await worker.start();
     await worker.stop();
     expect(dispatchTask).toHaveBeenCalledTimes(1);
-    expect((dispatchTask.mock.calls[0]![0] as Task).id).toBe(task.id);
+    const dispatched = dispatchTask.mock.calls[0]![0] as Task;
+    expect(dispatched.id).toBe(task.id);
+    // Post-claim status signals dispatch to set priorSessionId for --resume.
+    expect(dispatched.status).toBe("revision");
+  });
+
+  it("reap of a dead session whose task is in `revision` resets task to `needs_revision` (not `assigned`)", async () => {
+    const agent = await seedAgent();
+    // Task in running re-work state, no assignee so dispatch doesn't reclaim
+    // in the same poll (mirrors the trick used by the assigned-reap test).
+    const task = await tasks.create({
+      id: taskId(),
+      title: "orphaned revision",
+      priority: "medium",
+      creator_id: ownerPersonId,
+      creator_type: "person",
+      status: "revision",
+    });
+    const deadPid = 99_999_999;
+    const sess = await sessions.create({
+      id: sessionId(),
+      agent_id: agent.id,
+      task_id: task.id,
+      type: "task",
+      intent: "x",
+      process_pid: deadPid,
+      process_group_id: deadPid,
+      status: "running",
+      started_at: new Date(),
+    });
+
+    const { worker } = makeWorker();
+    await worker.start();
+    await worker.stop();
+
+    const rereadSession = await sessions.findById(sess.id);
+    expect(rereadSession?.status).toBe("failed");
+    const rereadTask = await tasks.findById(task.id);
+    expect(rereadTask?.status).toBe("needs_revision");
   });
 
   it("default poll interval is 30_000ms when not configured", async () => {

--- a/packages/executor/src/worker.ts
+++ b/packages/executor/src/worker.ts
@@ -136,16 +136,30 @@ export class TaskExecutionWorker {
       if (isProcessAlive(session.process_pid)) continue;
 
       // CLI process is gone. Mark session failed; re-queue the task (if any)
-      // so the next poll picks it up again. Crash recovery only — this is
-      // different from the M6 post-dispatch retry, which handles the agent
-      // exiting cleanly without calling update_progress.
+      // back to the matching queue status so the next poll picks it up
+      // again. Crash recovery only — this is different from the M6
+      // post-dispatch retry, which handles the agent exiting cleanly
+      // without calling update_progress.
       await this.config.sessionRepo.update(session.id, {
         status: "failed",
         error: "process_lost",
         completed_at: new Date(),
       });
       if (session.task_id) {
-        await this.config.taskRepo.update(session.task_id, { status: "assigned" });
+        // Mirror the claim transition: in_progress → assigned,
+        // revision → needs_revision. Anything else (e.g., already done or
+        // cancelled) we leave alone — reap shouldn't overwrite a terminal
+        // state set by the agent or an operator.
+        const current = await this.config.taskRepo.findById(session.task_id);
+        const next =
+          current?.status === "in_progress"
+            ? "assigned"
+            : current?.status === "revision"
+            ? "needs_revision"
+            : undefined;
+        if (next) {
+          await this.config.taskRepo.update(session.task_id, { status: next });
+        }
       }
     }
   }
@@ -176,15 +190,12 @@ export class TaskExecutionWorker {
       this.inFlight.set(task.id, ac);
       runningByAgent.set(agent.id, (runningByAgent.get(agent.id) ?? 0) + 1);
 
-      // Pre-claim task (status=assigned|revision) goes to dispatch — the
-      // post-claim row has status=in_progress, erasing the revision signal
-      // dispatch uses to decide whether to set priorSessionId for --resume.
-      // `claimed` is only useful as proof the row was in fact transitioned.
-      void claimed;
-
       // Fire-and-forget. The promise chain always cleans up inFlight.
+      // Dispatch receives the post-claim row: status=in_progress for fresh
+      // work, status=revision for re-work. Dispatch checks task.status ===
+      // "revision" to decide on priorSessionId (--resume).
       void Promise.resolve()
-        .then(() => this.config.dispatchTask(task, agent, workspace, ac.signal))
+        .then(() => this.config.dispatchTask(claimed, agent, workspace, ac.signal))
         .catch((err: unknown) =>
           this.onError(err instanceof Error ? err : new Error(String(err))),
         )

--- a/packages/executor/src/worker.ts
+++ b/packages/executor/src/worker.ts
@@ -4,6 +4,7 @@ import type {
   SessionRepository,
   Task,
   TaskRepository,
+  TaskStatus,
   Workspace,
   WorkspaceManager,
 } from "@beevibe/core";
@@ -146,17 +147,15 @@ export class TaskExecutionWorker {
         completed_at: new Date(),
       });
       if (session.task_id) {
-        // Mirror the claim transition: in_progress → assigned,
-        // revision → needs_revision. Anything else (e.g., already done or
-        // cancelled) we leave alone — reap shouldn't overwrite a terminal
-        // state set by the agent or an operator.
+        // Mirror the claim transition. Anything else (done, cancelled, …)
+        // we leave alone — reap shouldn't overwrite a terminal state set
+        // by the agent or an operator.
+        const REAP_REQUEUE: Partial<Record<TaskStatus, TaskStatus>> = {
+          in_progress: "assigned",
+          revision: "needs_revision",
+        };
         const current = await this.config.taskRepo.findById(session.task_id);
-        const next =
-          current?.status === "in_progress"
-            ? "assigned"
-            : current?.status === "revision"
-            ? "needs_revision"
-            : undefined;
+        const next = current && REAP_REQUEUE[current.status];
         if (next) {
           await this.config.taskRepo.update(session.task_id, { status: next });
         }
@@ -190,10 +189,7 @@ export class TaskExecutionWorker {
       this.inFlight.set(task.id, ac);
       runningByAgent.set(agent.id, (runningByAgent.get(agent.id) ?? 0) + 1);
 
-      // Fire-and-forget. The promise chain always cleans up inFlight.
-      // Dispatch receives the post-claim row: status=in_progress for fresh
-      // work, status=revision for re-work. Dispatch checks task.status ===
-      // "revision" to decide on priorSessionId (--resume).
+      // Fire-and-forget. `.finally` always clears inFlight.
       void Promise.resolve()
         .then(() => this.config.dispatchTask(claimed, agent, workspace, ac.signal))
         .catch((err: unknown) =>
@@ -209,13 +205,11 @@ export class TaskExecutionWorker {
     agent: Agent,
     runningByAgent: Map<string, number>,
   ): Promise<boolean> {
-    if (!runningByAgent.has(agent.id)) {
-      runningByAgent.set(
-        agent.id,
-        await this.config.sessionRepo.countRunningByAgent(agent.id, ["task"]),
-      );
+    let current = runningByAgent.get(agent.id);
+    if (current === undefined) {
+      current = await this.config.sessionRepo.countRunningByAgent(agent.id, ["task"]);
+      runningByAgent.set(agent.id, current);
     }
-    const current = runningByAgent.get(agent.id)!;
     const cap = agent.max_task_sessions ?? DEFAULT_TASK_CAP;
     return current < cap;
   }

--- a/packages/executor/src/worker.ts
+++ b/packages/executor/src/worker.ts
@@ -176,9 +176,15 @@ export class TaskExecutionWorker {
       this.inFlight.set(task.id, ac);
       runningByAgent.set(agent.id, (runningByAgent.get(agent.id) ?? 0) + 1);
 
+      // Pre-claim task (status=assigned|revision) goes to dispatch — the
+      // post-claim row has status=in_progress, erasing the revision signal
+      // dispatch uses to decide whether to set priorSessionId for --resume.
+      // `claimed` is only useful as proof the row was in fact transitioned.
+      void claimed;
+
       // Fire-and-forget. The promise chain always cleans up inFlight.
       void Promise.resolve()
-        .then(() => this.config.dispatchTask(claimed, agent, workspace, ac.signal))
+        .then(() => this.config.dispatchTask(task, agent, workspace, ac.signal))
         .catch((err: unknown) =>
           this.onError(err instanceof Error ? err : new Error(String(err))),
         )

--- a/packages/executor/src/worker.ts
+++ b/packages/executor/src/worker.ts
@@ -1,0 +1,225 @@
+import type {
+  Agent,
+  AgentRepository,
+  SessionRepository,
+  Task,
+  TaskRepository,
+  Workspace,
+  WorkspaceManager,
+} from "@beevibe/core";
+
+/**
+ * Default per-agent cap on concurrent task sessions. Matches the old repo's
+ * `SessionManager.canAcceptSession` default (intentcore-platform).
+ */
+export const DEFAULT_TASK_CAP = 1;
+
+/**
+ * Default poll interval. Matches the old repo's `POLL_INTERVAL_MS`.
+ * Production deployments override via `BootstrapConfig.pollIntervalMs`.
+ */
+export const DEFAULT_POLL_MS = 30_000;
+
+/**
+ * Fire-and-forget dispatch callback the worker hands claimed tasks to.
+ * Implementations build the per-task `AgentSession` + `MemoryAgent` and call
+ * `agentSession.run(...)`. The resolved value is ignored; rejections are
+ * caught by the worker and surfaced via `onError`.
+ */
+export type DispatchFn = (
+  task: Task,
+  agent: Agent,
+  workspace: Workspace,
+  abortSignal: AbortSignal,
+) => Promise<unknown>;
+
+export interface TaskExecutionWorkerConfig {
+  agentRepo: AgentRepository;
+  taskRepo: TaskRepository;
+  sessionRepo: SessionRepository;
+  workspaceManager: WorkspaceManager;
+  dispatchTask: DispatchFn;
+  /** Default `DEFAULT_POLL_MS` (30s). */
+  pollIntervalMs?: number;
+  /**
+   * Called when a dispatched task rejects. Default: `console.error`. Does not
+   * stop the poll loop — the worker keeps running after errors.
+   */
+  onError?: (err: Error) => void;
+}
+
+/**
+ * Poll-claim-dispatch-reap loop for the executor.
+ *
+ * One poll cycle:
+ *   1. Reap — detect orphaned sessions whose CLI process died (via
+ *      `isProcessAlive`) and mark them failed; re-queue the parent task.
+ *   2. Dispatch — list all assignable tasks, for each: check per-agent
+ *      capacity (DB running count + poll-local pending), atomically claim
+ *      via `TaskRepository.claimById`, provision the workspace, hand off to
+ *      `dispatchTask` (fire-and-forget).
+ *
+ * All session-row bookkeeping (create/update), briefing composition, runtime
+ * spawn, and post-session promotion live inside `AgentSession` (M3). The
+ * worker doesn't touch any of that.
+ */
+export class TaskExecutionWorker {
+  private running = false;
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private inFlight = new Map<string, AbortController>();
+  private readonly pollIntervalMs: number;
+  private readonly onError: (err: Error) => void;
+
+  constructor(private readonly config: TaskExecutionWorkerConfig) {
+    this.pollIntervalMs = config.pollIntervalMs ?? DEFAULT_POLL_MS;
+    this.onError =
+      config.onError ?? ((err) => console.error("[worker] dispatch error:", err));
+  }
+
+  /**
+   * Begin polling. Fires an immediate first poll, then every `pollIntervalMs`.
+   */
+  async start(): Promise<void> {
+    if (this.running) return;
+    this.running = true;
+    await this.poll();
+    this.pollTimer = setInterval(() => {
+      void this.poll().catch(this.onError);
+    }, this.pollIntervalMs);
+  }
+
+  /**
+   * Stop the poll loop and abort any in-flight dispatches. Does NOT wait for
+   * the aborted tasks to settle — callers that need to drain should do so
+   * after calling stop().
+   */
+  async stop(): Promise<void> {
+    this.running = false;
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+    for (const controller of this.inFlight.values()) {
+      controller.abort();
+    }
+    this.inFlight.clear();
+  }
+
+  /** One complete poll cycle: reap → dispatch. Public for testing. */
+  async poll(): Promise<void> {
+    if (!this.running) return;
+    await this.reapOrphanedSessions();
+    await this.dispatchReady();
+  }
+
+  /**
+   * Cancel an in-flight task by aborting its controller. Returns true if the
+   * task was in-flight and got aborted, false otherwise. Does NOT update the
+   * task or session row — the dispatched `AgentSession.run` sees the abort
+   * signal and writes a `cancelled` session status; task status transitions
+   * are M6's concern (via `update_progress` or post-dispatch check).
+   */
+  async cancelTask(taskId: string): Promise<boolean> {
+    const controller = this.inFlight.get(taskId);
+    if (!controller) return false;
+    controller.abort();
+    this.inFlight.delete(taskId);
+    return true;
+  }
+
+  private async reapOrphanedSessions(): Promise<void> {
+    const sessions = await this.config.sessionRepo.listRunningWithPid();
+    for (const session of sessions) {
+      // Skip sessions this worker is actively managing — aborts go through
+      // `cancelTask`, not reap.
+      if (session.task_id && this.inFlight.has(session.task_id)) continue;
+      if (isProcessAlive(session.process_pid)) continue;
+
+      // CLI process is gone. Mark session failed; re-queue the task (if any)
+      // so the next poll picks it up again. Crash recovery only — this is
+      // different from the M6 post-dispatch retry, which handles the agent
+      // exiting cleanly without calling update_progress.
+      await this.config.sessionRepo.update(session.id, {
+        status: "failed",
+        error: "process_lost",
+        completed_at: new Date(),
+      });
+      if (session.task_id) {
+        await this.config.taskRepo.update(session.task_id, { status: "assigned" });
+      }
+    }
+  }
+
+  private async dispatchReady(): Promise<void> {
+    const candidates = await this.config.taskRepo.listAssignable();
+    // Poll-scoped: seeded lazily from DB on first access per agent, incremented
+    // on dispatch. Single map avoids the double-count race a separate "pending"
+    // map would have when a DB INSERT commits between iterations.
+    const runningByAgent = new Map<string, number>();
+
+    for (const task of candidates) {
+      if (!this.running) break;
+      if (this.inFlight.has(task.id)) continue;
+
+      const agentId = task.assignee_id;
+      if (!agentId) continue;
+      const agent = await this.config.agentRepo.findById(agentId);
+      if (!agent) continue;
+
+      if (!(await this.hasTaskCapacity(agent, runningByAgent))) continue;
+
+      const claimed = await this.config.taskRepo.claimById(task.id);
+      if (!claimed) continue; // race loser — another executor won the claim
+
+      const workspace = await this.config.workspaceManager.ensureWorkspace({ agent });
+      const ac = new AbortController();
+      this.inFlight.set(task.id, ac);
+      runningByAgent.set(agent.id, (runningByAgent.get(agent.id) ?? 0) + 1);
+
+      // Fire-and-forget. The promise chain always cleans up inFlight.
+      void Promise.resolve()
+        .then(() => this.config.dispatchTask(claimed, agent, workspace, ac.signal))
+        .catch((err: unknown) =>
+          this.onError(err instanceof Error ? err : new Error(String(err))),
+        )
+        .finally(() => {
+          this.inFlight.delete(task.id);
+        });
+    }
+  }
+
+  private async hasTaskCapacity(
+    agent: Agent,
+    runningByAgent: Map<string, number>,
+  ): Promise<boolean> {
+    if (!runningByAgent.has(agent.id)) {
+      runningByAgent.set(
+        agent.id,
+        await this.config.sessionRepo.countRunningByAgent(agent.id, ["task"]),
+      );
+    }
+    const current = runningByAgent.get(agent.id)!;
+    const cap = agent.max_task_sessions ?? DEFAULT_TASK_CAP;
+    return current < cap;
+  }
+}
+
+/**
+ * Check whether a process is still alive via signal 0.
+ * Ported from intentcore-platform `task-execution-worker.ts`.
+ *
+ * Returns true if the process exists (or exists but is in another uid, which
+ * surfaces as EPERM — treated as alive to avoid spurious reaps).
+ * Returns false for invalid pids and for ESRCH ("no such process").
+ */
+export function isProcessAlive(pid: number | null | undefined): boolean {
+  if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === "EPERM") return true;
+    return false;
+  }
+}

--- a/packages/executor/tsconfig.json
+++ b/packages/executor/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "node_modules", "**/*.test.ts", "**/test-helpers.ts"]
 }

--- a/packages/executor/vitest.config.ts
+++ b/packages/executor/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: false,
+    include: ["src/**/*.test.ts"],
+    testTimeout: 30_000,
+    // Worker tests share the beevibe_test DB with core tests when both run.
+    // Single fork + file parallelism disabled keeps TRUNCATE + query from
+    // interleaving.
+    pool: "forks",
+    poolOptions: {
+      forks: { singleFork: true },
+    },
+    fileParallelism: false,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,13 @@ importers:
       '@beevibe/core':
         specifier: workspace:*
         version: link:../core
+    devDependencies:
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.20.0
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
 
   packages/mcp-server:
     dependencies:

--- a/scripts/m3-e2e.ts
+++ b/scripts/m3-e2e.ts
@@ -189,7 +189,6 @@ async function main(): Promise<void> {
     const result = await session.run({
       agentId: agent.id,
       intent: "Reply with the single word 'ok'.",
-      urgency: "low",
       workspace: { path: workspacePath },
     });
     console.log(

--- a/scripts/m5-e2e.ts
+++ b/scripts/m5-e2e.ts
@@ -1,7 +1,7 @@
 /**
  * M5 end-to-end smoke for the executor binary. Exercises the full
- * poll → claim → dispatch → session-completion pipeline against live
- * infrastructure.
+ * poll → claim → dispatch → session-completion pipeline plus six
+ * targeted scenarios that catch integration behavior unit tests can't.
  *
  * Requires:
  * - `RUN_M5_E2E=1`
@@ -13,25 +13,19 @@
  * Usage:
  *   RUN_M5_E2E=1 pnpm tsx scripts/m5-e2e.ts
  *
- * What it does:
- *   1. Truncate test DB.
- *   2. Create a person + IC agent via provisionAgent.
- *   3. Create an assigned task for the agent with a trivial prompt.
- *   4. Boot the executor (mcpServerUrl points at localhost:0 — unreachable;
- *      the prompt needs no tools so the session still completes).
- *   5. worker.start() and poll the DB until the task transitions and the
- *      session reaches a terminal state (up to ~90s).
- *   6. Assert:
- *      - Task went assigned → in_progress (claimed by the worker).
- *      - Session row exists, status=succeeded, cli_session_id non-empty,
- *        usage.input_tokens > 0, exit_code=0.
- *      - mcp-config.json was written with mode 0o600 and correct contents
- *        (Bearer token + ${BEEVIBE_SESSION_ID} placeholder + url).
- *   7. worker.stop() + shutdown() + cleanup workspace.
+ * Scenarios:
+ *   0. Happy path — 1 agent, trivial task, full plumbing.
+ *   A. Cancel mid-flight — long-running task, cancelTask aborts CLI.
+ *   B. Orphan reap — session in DB with dead PID → failed + task re-queued.
+ *   C. Revision resume — second session resumes first via --resume
+ *      (same cli_session_id, distinct beevibe rows, prior_session_id linked).
+ *   D. Priority ordering — critical > medium > low dispatched in that order.
+ *   E. Per-agent capacity — max_task_sessions=1 serializes 2 tasks for one agent.
+ *   F. Multi-agent parallel — 2 agents each get a task; sessions overlap in time.
  *
- * Explicitly deferred to M6 E2E: task.status='done' (needs update_progress
- * tool), work_product rows (needs create_work_product tool),
- * memory_fact.source_session_ids assertions (needs save_memory tool).
+ * Deferred to M6 E2E: task.status='done' (update_progress tool),
+ * work_product rows (create_work_product tool), memory_fact.source_session_ids
+ * content (save_memory tool).
  */
 
 import { config as loadEnv } from "dotenv";
@@ -44,7 +38,13 @@ const here = dirname(fileURLToPath(import.meta.url));
 loadEnv({ path: resolve(here, "../.env") });
 
 import { bootstrap } from "../packages/executor/src/bootstrap.js";
-import { agentId, personId, taskId } from "../packages/core/src/domain/ids.js";
+import { isProcessAlive } from "../packages/executor/src/worker.js";
+import {
+  agentId as makeAgentId,
+  personId as makePersonId,
+  sessionId as makeSessionId,
+  taskId as makeTaskId,
+} from "../packages/core/src/domain/ids.js";
 import { DEFAULT_RUNTIME_CONFIG } from "../packages/core/src/domain/agent.js";
 import { provisionAgent } from "../packages/core/src/auth/provision.js";
 import { PostgresAgentRepository } from "../packages/core/src/adapters/postgres/agent-repo.js";
@@ -52,7 +52,9 @@ import { PostgresCoreMemoryRepository } from "../packages/core/src/adapters/post
 import { PostgresPersonRepository } from "../packages/core/src/adapters/postgres/person-repo.js";
 import { PostgresSessionRepository } from "../packages/core/src/adapters/postgres/session-repo.js";
 import { PostgresTaskRepository } from "../packages/core/src/adapters/postgres/task-repo.js";
-import { createPool } from "../packages/core/src/adapters/postgres/client.js";
+import { createPool, type Pool } from "../packages/core/src/adapters/postgres/client.js";
+import type { Session } from "../packages/core/src/domain/session.js";
+import type { Task, TaskPriority } from "../packages/core/src/domain/task.js";
 
 const TABLES = [
   "memory_fact",
@@ -64,153 +66,208 @@ const TABLES = [
   "person",
 ];
 
-const TASK_TRANSITION_DEADLINE_MS = 10_000;
-const SESSION_SUCCESS_DEADLINE_MS = 90_000;
+const TRIVIAL_PROMPT = "Reply with the single word 'ok'.";
+const LONG_PROMPT =
+  "Use the Bash tool to run `sleep 20`. Then reply with just the word 'done'.";
 
-function step(n: number, title: string): void {
-  console.log(`\n━━━ ${n}. ${title}`);
+const MCP_URL_UNREACHABLE = "http://localhost:0/";
+
+const TASK_TRANSITION_DEADLINE_MS = 10_000;
+const SESSION_TERMINAL_DEADLINE_MS = 90_000;
+const PID_POPULATED_DEADLINE_MS = 30_000;
+
+// ───────────────────────── helpers ─────────────────────────
+
+function log(msg: string): void {
+  console.log(msg);
 }
 
 function assert(cond: unknown, msg: string): asserts cond {
   if (!cond) {
-    console.error(`ASSERTION FAILED: ${msg}`);
+    console.error(`    ✗ ${msg}`);
     process.exit(1);
   }
 }
 
-async function wait(ms: number): Promise<void> {
+async function sleep(ms: number): Promise<void> {
   await new Promise((r) => setTimeout(r, ms));
 }
 
-async function main(): Promise<void> {
-  if (process.env.RUN_M5_E2E !== "1") {
-    console.log("Set RUN_M5_E2E=1 to run this script.");
-    process.exit(0);
+async function resetDb(pool: Pool): Promise<void> {
+  await pool.query(`TRUNCATE ${TABLES.join(", ")} RESTART IDENTITY CASCADE`);
+}
+
+/**
+ * Poll the task until its status matches the predicate or the deadline hits.
+ */
+async function waitForTask(
+  tasks: PostgresTaskRepository,
+  id: string,
+  deadlineMs: number,
+  pred: (t: Task) => boolean,
+  tag: string,
+): Promise<Task> {
+  const end = Date.now() + deadlineMs;
+  while (Date.now() < end) {
+    const t = await tasks.findById(id);
+    if (t && pred(t)) return t;
+    await sleep(500);
   }
+  const current = await tasks.findById(id);
+  throw new Error(`task ${id} never satisfied predicate "${tag}" (last status=${current?.status})`);
+}
 
-  const dbUrl = process.env.DATABASE_URL_TEST;
-  assert(dbUrl, "DATABASE_URL_TEST must be set");
-  assert(process.env.OPENAI_API_KEY, "OPENAI_API_KEY must be set");
-  assert(process.env.ANTHROPIC_API_KEY, "ANTHROPIC_API_KEY must be set");
+/**
+ * Poll for a session row matching the predicate (latest for task).
+ */
+async function waitForSession(
+  sessions: PostgresSessionRepository,
+  taskId: string,
+  deadlineMs: number,
+  pred: (s: Session) => boolean,
+  tag: string,
+): Promise<Session> {
+  const end = Date.now() + deadlineMs;
+  while (Date.now() < end) {
+    const s = await sessions.findLatestForTask(taskId);
+    if (s && pred(s)) return s;
+    await sleep(500);
+  }
+  const current = await sessions.findLatestForTask(taskId);
+  throw new Error(
+    `session for task ${taskId} never satisfied predicate "${tag}" (last status=${current?.status})`,
+  );
+}
 
-  const pool = createPool({ connectionString: dbUrl, max: 4 });
-  const workspaceRoot = mkdtempSync(join(tmpdir(), "beevibe-m5-e2e-"));
+type Deps = {
+  pool: Pool;
+  persons: PostgresPersonRepository;
+  agents: PostgresAgentRepository;
+  coreMemoryRepo: PostgresCoreMemoryRepository;
+  tasks: PostgresTaskRepository;
+  sessions: PostgresSessionRepository;
+  workspaceRoot: string;
+};
 
+type Scenario = (deps: Deps) => Promise<void>;
+
+async function scenario(name: string, fn: Scenario, deps: Deps): Promise<void> {
+  log(`\n═══ ${name} ═══`);
+  const startedAt = Date.now();
+  await resetDb(deps.pool);
+  await fn(deps);
+  const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
+  log(`  ✓ ${name}  (${elapsed}s)`);
+}
+
+async function bootExecutor(
+  deps: Deps,
+  opts: { pollIntervalMs?: number; start?: boolean } = {},
+): Promise<{
+  worker: Awaited<ReturnType<typeof bootstrap>>["worker"];
+  shutdown: () => Promise<void>;
+}> {
+  const { worker, shutdown } = await bootstrap({
+    databaseUrl: process.env.DATABASE_URL_TEST!,
+    mcpServerUrl: MCP_URL_UNREACHABLE,
+    openaiApiKey: process.env.OPENAI_API_KEY!,
+    anthropicApiKey: process.env.ANTHROPIC_API_KEY!,
+    workspaceRoot: deps.workspaceRoot,
+    pollIntervalMs: opts.pollIntervalMs ?? 2_000,
+  });
+  if (opts.start !== false) await worker.start();
+  return { worker, shutdown };
+}
+
+async function seedOwnerAndAgent(
+  deps: Deps,
+  agentName: string,
+  agentOverrides: Parameters<PostgresAgentRepository["create"]>[0] extends infer A
+    ? Partial<Omit<A, "id" | "owner_id">>
+    : never = {} as never,
+): Promise<{
+  ownerId: string;
+  agentRecord: Awaited<ReturnType<typeof provisionAgent>>["agent"];
+  apiKey: string;
+}> {
+  const owner = await deps.persons.create({ id: makePersonId(), name: `${agentName}-owner` });
+  const { agent, apiKey } = await provisionAgent(
+    { agentRepo: deps.agents, coreMemoryRepo: deps.coreMemoryRepo },
+    {
+      id: makeAgentId(),
+      name: agentName,
+      owner_id: owner.id,
+      hierarchy_level: "ic",
+      runtime_config: DEFAULT_RUNTIME_CONFIG,
+      ...agentOverrides,
+    },
+  );
+  return { ownerId: owner.id, agentRecord: agent, apiKey };
+}
+
+async function seedTask(
+  deps: Deps,
+  opts: {
+    ownerId: string;
+    agentId: string;
+    title?: string;
+    priority?: TaskPriority;
+  },
+): Promise<Task> {
+  return deps.tasks.create({
+    id: makeTaskId(),
+    title: opts.title ?? TRIVIAL_PROMPT,
+    priority: opts.priority ?? "medium",
+    status: "assigned",
+    assignee_id: opts.agentId,
+    creator_id: opts.ownerId,
+    creator_type: "person",
+  });
+}
+
+// ───────────────────────── scenarios ─────────────────────────
+
+const happyPath: Scenario = async (deps) => {
+  const { ownerId, agentRecord, apiKey } = await seedOwnerAndAgent(deps, "happy-agent");
+  const task = await seedTask(deps, { ownerId, agentId: agentRecord.id });
+  log(`  agent=${agentRecord.id}  task=${task.id}`);
+
+  const { worker, shutdown } = await bootExecutor(deps);
   try {
-    step(1, "Truncate test DB");
-    await pool.query(`TRUNCATE ${TABLES.join(", ")} RESTART IDENTITY CASCADE`);
-
-    step(2, "Create person + IC agent via provisionAgent");
-    const persons = new PostgresPersonRepository(pool);
-    const agents = new PostgresAgentRepository(pool);
-    const coreMemoryRepo = new PostgresCoreMemoryRepository(pool);
-    const tasks = new PostgresTaskRepository(pool);
-    const sessions = new PostgresSessionRepository(pool);
-
-    const owner = await persons.create({ id: personId(), name: "M5 Owner" });
-    const { agent, apiKey } = await provisionAgent(
-      { agentRepo: agents, coreMemoryRepo },
-      {
-        id: agentId(),
-        name: "M5 IC",
-        owner_id: owner.id,
-        hierarchy_level: "ic",
-        runtime_config: DEFAULT_RUNTIME_CONFIG,
-      },
+    await waitForTask(
+      deps.tasks,
+      task.id,
+      TASK_TRANSITION_DEADLINE_MS,
+      (t) => t.status === "in_progress" || t.status === "done",
+      "assigned→in_progress",
     );
-    console.log(`   agent ${agent.id}, api_key ${apiKey.slice(0, 10)}…`);
-    assert(apiKey.startsWith("bv_a_"), "agent key should have bv_a_ prefix");
+    const session = await waitForSession(
+      deps.sessions,
+      task.id,
+      SESSION_TERMINAL_DEADLINE_MS,
+      (s) => s.status === "succeeded" || s.status === "failed",
+      "terminal",
+    );
+    log(`  session=${session.id} status=${session.status} cli_session=${session.cli_session_id}`);
+    assert(session.status === "succeeded", `session ended with status=${session.status}`);
+    assert(session.cli_session_id, "cli_session_id missing");
+    assert(
+      session.usage?.input_tokens && session.usage.input_tokens > 0,
+      "usage.input_tokens not recorded",
+    );
+    assert(session.exit_code === 0, `exit_code=${session.exit_code}`);
 
-    step(3, "Seed assigned task for the agent");
-    const createdTask = await tasks.create({
-      id: taskId(),
-      title: "Reply with the single word 'ok'.",
-      priority: "medium",
-      status: "assigned",
-      assignee_id: agent.id,
-      creator_id: owner.id,
-      creator_type: "person",
-    });
-    console.log(`   task ${createdTask.id}`);
-
-    step(4, "Boot executor");
-    // Unreachable MCP URL is intentional: the trivial prompt needs no tools.
-    // M6 E2E will hit a real MCP server.
-    const { worker, shutdown } = await bootstrap({
-      databaseUrl: dbUrl,
-      mcpServerUrl: "http://localhost:0/",
-      openaiApiKey: process.env.OPENAI_API_KEY!,
-      anthropicApiKey: process.env.ANTHROPIC_API_KEY!,
-      workspaceRoot,
-      pollIntervalMs: 2_000, // tight loop for E2E responsiveness
-    });
-
-    step(5, "worker.start()");
-    await worker.start();
-
-    try {
-      step(6, "Wait for claim transition (task: assigned → in_progress)");
-      const transitionStart = Date.now();
-      let inProgress = false;
-      while (Date.now() - transitionStart < TASK_TRANSITION_DEADLINE_MS) {
-        const t = await tasks.findById(createdTask.id);
-        if (t?.status === "in_progress" || t?.status === "done") {
-          inProgress = true;
-          break;
-        }
-        await wait(500);
-      }
-      assert(
-        inProgress,
-        `task did not transition to in_progress within ${TASK_TRANSITION_DEADLINE_MS}ms`,
-      );
-
-      step(7, "Wait for a succeeded session row on the task");
-      const sessionStart = Date.now();
-      let finalSession = null as Awaited<ReturnType<typeof sessions.findLatestForTask>>;
-      while (Date.now() - sessionStart < SESSION_SUCCESS_DEADLINE_MS) {
-        const s = await sessions.findLatestForTask(createdTask.id);
-        if (s && (s.status === "succeeded" || s.status === "failed")) {
-          finalSession = s;
-          break;
-        }
-        await wait(1_000);
-      }
-      assert(
-        finalSession,
-        `no terminal session row appeared within ${SESSION_SUCCESS_DEADLINE_MS}ms`,
-      );
-      console.log(
-        `   session ${finalSession.id} → status=${finalSession.status}, cli_session=${finalSession.cli_session_id}`,
-      );
-      assert(
-        finalSession.status === "succeeded",
-        `session ended with status=${finalSession.status} (expected succeeded)`,
-      );
-      assert(finalSession.cli_session_id, "cli_session_id missing");
-      assert(
-        finalSession.usage?.input_tokens && finalSession.usage.input_tokens > 0,
-        "usage.input_tokens not recorded",
-      );
-      assert(
-        finalSession.exit_code === 0,
-        `exit_code=${finalSession.exit_code} (expected 0)`,
-      );
-    } finally {
-      step(8, "worker.stop() + shutdown()");
-      await shutdown();
-    }
-
-    step(9, "Assert mcp-config.json on disk has correct contents + mode");
-    const configPath = join(workspaceRoot, agent.id, "mcp-config.json");
-    const mode = statSync(configPath).mode & 0o777;
+    const configPath = join(deps.workspaceRoot, agentRecord.id, "mcp-config.json");
     if (process.platform !== "win32") {
-      assert(mode === 0o600, `mcp-config.json mode=${mode.toString(8)} (expected 600)`);
+      assert(
+        (statSync(configPath).mode & 0o777) === 0o600,
+        `mcp-config.json mode must be 0600`,
+      );
     }
     const parsed = JSON.parse(readFileSync(configPath, "utf-8"));
     assert(
-      parsed.mcpServers.beevibe.url === "http://localhost:0/",
-      `unexpected mcpServerUrl in config: ${parsed.mcpServers.beevibe.url}`,
+      parsed.mcpServers.beevibe.url === MCP_URL_UNREACHABLE,
+      `mcpServerUrl mismatch: ${parsed.mcpServers.beevibe.url}`,
     );
     assert(
       parsed.mcpServers.beevibe.headers.Authorization === `Bearer ${apiKey}`,
@@ -218,14 +275,360 @@ async function main(): Promise<void> {
     );
     assert(
       parsed.mcpServers.beevibe.headers["X-Beevibe-Session"] === "${BEEVIBE_SESSION_ID}",
-      "X-Beevibe-Session placeholder missing or wrong",
+      "X-Beevibe-Session placeholder missing",
+    );
+  } finally {
+    await shutdown();
+  }
+};
+
+const cancelMidFlight: Scenario = async (deps) => {
+  const { ownerId, agentRecord } = await seedOwnerAndAgent(deps, "cancel-agent");
+  const task = await seedTask(deps, {
+    ownerId,
+    agentId: agentRecord.id,
+    title: LONG_PROMPT,
+  });
+  log(`  agent=${agentRecord.id}  task=${task.id}  (long-running prompt: sleep 20)`);
+
+  const { worker, shutdown } = await bootExecutor(deps);
+  try {
+    // Wait for the CLI subprocess to spawn + onSpawn callback to persist pid.
+    const spawned = await waitForSession(
+      deps.sessions,
+      task.id,
+      PID_POPULATED_DEADLINE_MS,
+      (s) => s.process_pid !== undefined && s.process_pid !== null,
+      "process_pid populated",
+    );
+    log(`  session=${spawned.id} pid=${spawned.process_pid}`);
+    assert(isProcessAlive(spawned.process_pid), "CLI should be alive before cancel");
+
+    // Fire cancel.
+    const aborted = await worker.cancelTask(task.id);
+    assert(aborted, "cancelTask should return true for in-flight task");
+
+    // Session transitions to cancelled once AbortController chain propagates.
+    const final = await waitForSession(
+      deps.sessions,
+      task.id,
+      30_000,
+      (s) => s.status === "cancelled" || s.status === "failed",
+      "terminal after cancel",
+    );
+    log(`  post-cancel session status=${final.status}`);
+    assert(final.status === "cancelled", `expected cancelled, got ${final.status}`);
+
+    // PID should be dead (SIGTERM/KILL via spawn.ts).
+    await sleep(1_000);
+    assert(
+      !isProcessAlive(final.process_pid),
+      `CLI pid ${final.process_pid} still alive after cancel`,
+    );
+  } finally {
+    await shutdown();
+  }
+};
+
+const orphanReap: Scenario = async (deps) => {
+  const { ownerId, agentRecord } = await seedOwnerAndAgent(deps, "orphan-agent");
+  const task = await seedTask(deps, { ownerId, agentId: agentRecord.id });
+  // Pre-create an orphaned session row with a fake dead PID. This represents
+  // the state after an executor crash: session=running, PID points to a
+  // process that no longer exists. Real-CLI-death variant is racy because
+  // AgentSession would write the terminal state before reap sees it.
+  const orphan = await deps.sessions.create({
+    id: makeSessionId(),
+    agent_id: agentRecord.id,
+    task_id: task.id,
+    type: "task",
+    intent: TRIVIAL_PROMPT,
+    process_pid: 99_999_999,
+    process_group_id: 99_999_999,
+    status: "running",
+    started_at: new Date(),
+  });
+  await deps.tasks.update(task.id, { status: "in_progress" });
+  log(`  orphan session=${orphan.id} with fake dead pid=99_999_999`);
+
+  const { worker, shutdown } = await bootExecutor(deps);
+  try {
+    // start() ran one poll immediately → reap detected the orphan.
+    const reread = await deps.sessions.findById(orphan.id);
+    assert(reread?.status === "failed", `expected failed, got ${reread?.status}`);
+    assert(reread?.error === "process_lost", `expected process_lost error, got ${reread?.error}`);
+    log(`  orphan reaped → status=${reread?.status} error=${reread?.error}`);
+
+    // Task re-queued, then re-dispatched. Wait for the FOLLOWING session to succeed.
+    const followup = await waitForSession(
+      deps.sessions,
+      task.id,
+      SESSION_TERMINAL_DEADLINE_MS,
+      (s) => s.id !== orphan.id && (s.status === "succeeded" || s.status === "failed"),
+      "re-dispatched session terminal",
+    );
+    log(`  re-dispatched session=${followup.id} status=${followup.status}`);
+    assert(
+      followup.status === "succeeded",
+      `re-dispatched session ended with status=${followup.status}`,
+    );
+  } finally {
+    await shutdown();
+  }
+};
+
+const revisionResume: Scenario = async (deps) => {
+  const { ownerId, agentRecord } = await seedOwnerAndAgent(deps, "revision-agent");
+  const task = await seedTask(deps, { ownerId, agentId: agentRecord.id });
+  log(`  agent=${agentRecord.id}  task=${task.id}`);
+
+  const { worker, shutdown } = await bootExecutor(deps);
+  try {
+    // First run.
+    const first = await waitForSession(
+      deps.sessions,
+      task.id,
+      SESSION_TERMINAL_DEADLINE_MS,
+      (s) => s.status === "succeeded" || s.status === "failed",
+      "first session terminal",
+    );
+    assert(first.status === "succeeded", `first session status=${first.status}`);
+    assert(first.cli_session_id, "first cli_session_id missing");
+    log(`  first session=${first.id} cli=${first.cli_session_id}`);
+
+    // Mark task back to revision; next poll re-dispatches.
+    await deps.tasks.update(task.id, { status: "revision" });
+
+    const second = await waitForSession(
+      deps.sessions,
+      task.id,
+      SESSION_TERMINAL_DEADLINE_MS,
+      (s) => s.id !== first.id && (s.status === "succeeded" || s.status === "failed"),
+      "second session terminal",
+    );
+    assert(second.status === "succeeded", `second session status=${second.status}`);
+    log(`  second session=${second.id} cli=${second.cli_session_id}`);
+
+    // Core assertions: CLI session was resumed (same id), DB rows are
+    // distinct, and prior_session_id links them.
+    assert(second.id !== first.id, "second session must be a new beevibe row");
+    assert(
+      second.cli_session_id === first.cli_session_id,
+      `cli_session_id changed: first=${first.cli_session_id} second=${second.cli_session_id} (expected same — --resume keeps same ID)`,
+    );
+    assert(
+      second.prior_session_id === first.id,
+      `prior_session_id mismatch: expected ${first.id}, got ${second.prior_session_id}`,
+    );
+  } finally {
+    await shutdown();
+  }
+};
+
+const priorityOrdering: Scenario = async (deps) => {
+  // Three different agents so cap=1 doesn't serialize dispatch. Observe
+  // claim order via task.updated_at: claimById sets `updated_at = NOW()` and
+  // the worker for-loop awaits each claim sequentially, so these timestamps
+  // reflect dispatch order (unlike session.started_at, which is set after
+  // an awaited DB lookup inside AgentSession.run and races between parallel
+  // dispatches).
+  const a1 = await seedOwnerAndAgent(deps, "p-low-agent");
+  const a2 = await seedOwnerAndAgent(deps, "p-critical-agent");
+  const a3 = await seedOwnerAndAgent(deps, "p-medium-agent");
+  const low = await seedTask(deps, {
+    ownerId: a1.ownerId,
+    agentId: a1.agentRecord.id,
+    priority: "low",
+  });
+  const critical = await seedTask(deps, {
+    ownerId: a2.ownerId,
+    agentId: a2.agentRecord.id,
+    priority: "critical",
+  });
+  const medium = await seedTask(deps, {
+    ownerId: a3.ownerId,
+    agentId: a3.agentRecord.id,
+    priority: "medium",
+  });
+  log(`  tasks seeded: critical=${critical.id} medium=${medium.id} low=${low.id}`);
+
+  const { worker, shutdown } = await bootExecutor(deps);
+  try {
+    // Wait for all three claims to land (task status → in_progress).
+    const claimedCritical = await waitForTask(
+      deps.tasks,
+      critical.id,
+      TASK_TRANSITION_DEADLINE_MS,
+      (t) => t.status === "in_progress",
+      "critical claimed",
+    );
+    const claimedMedium = await waitForTask(
+      deps.tasks,
+      medium.id,
+      TASK_TRANSITION_DEADLINE_MS,
+      (t) => t.status === "in_progress",
+      "medium claimed",
+    );
+    const claimedLow = await waitForTask(
+      deps.tasks,
+      low.id,
+      TASK_TRANSITION_DEADLINE_MS,
+      (t) => t.status === "in_progress",
+      "low claimed",
+    );
+    log(
+      `  claimed_at (updated_at): critical=${claimedCritical.updated_at.toISOString()} medium=${claimedMedium.updated_at.toISOString()} low=${claimedLow.updated_at.toISOString()}`,
+    );
+    assert(
+      claimedCritical.updated_at.getTime() <= claimedMedium.updated_at.getTime(),
+      `critical should be claimed before medium`,
+    );
+    assert(
+      claimedMedium.updated_at.getTime() <= claimedLow.updated_at.getTime(),
+      `medium should be claimed before low`,
     );
 
-    console.log("\n✓ M5 E2E complete");
+    // Wait for all three to reach terminal state so we clean shutdown without
+    // leaving child claude processes behind.
+    for (const [name, id] of [
+      ["critical", critical.id],
+      ["medium", medium.id],
+      ["low", low.id],
+    ] as const) {
+      const s = await waitForSession(
+        deps.sessions,
+        id,
+        SESSION_TERMINAL_DEADLINE_MS,
+        (s) => s.status === "succeeded" || s.status === "failed",
+        `${name} terminal`,
+      );
+      assert(s.status === "succeeded", `${name} session status=${s.status}`);
+    }
+  } finally {
+    await shutdown();
+  }
+};
+
+const perAgentCapacity: Scenario = async (deps) => {
+  // Same agent, cap=1 (default). Two tasks seeded; second must wait for first.
+  const { ownerId, agentRecord } = await seedOwnerAndAgent(deps, "cap-agent");
+  const t1 = await seedTask(deps, { ownerId, agentId: agentRecord.id, title: TRIVIAL_PROMPT });
+  const t2 = await seedTask(deps, { ownerId, agentId: agentRecord.id, title: TRIVIAL_PROMPT });
+  log(`  agent=${agentRecord.id}  tasks=[${t1.id}, ${t2.id}]`);
+
+  const { worker, shutdown } = await bootExecutor(deps);
+  try {
+    const s1 = await waitForSession(
+      deps.sessions,
+      t1.id,
+      SESSION_TERMINAL_DEADLINE_MS,
+      (s) => s.status === "succeeded" || s.status === "failed",
+      "task1 terminal",
+    );
+    const s2 = await waitForSession(
+      deps.sessions,
+      t2.id,
+      SESSION_TERMINAL_DEADLINE_MS,
+      (s) => s.status === "succeeded" || s.status === "failed",
+      "task2 terminal",
+    );
+    assert(s1.status === "succeeded" && s2.status === "succeeded", "both sessions should succeed");
+    log(`  t1 started=${s1.started_at?.toISOString()} completed=${s1.completed_at?.toISOString()}`);
+    log(`  t2 started=${s2.started_at?.toISOString()} completed=${s2.completed_at?.toISOString()}`);
+
+    // Capacity gate should have serialized: t2.started_at >= t1.completed_at.
+    assert(s1.completed_at, "session 1 missing completed_at");
+    assert(
+      s2.started_at!.getTime() >= s1.completed_at!.getTime(),
+      `capacity gate did NOT serialize: t2.started_at (${s2.started_at?.toISOString()}) before t1.completed_at (${s1.completed_at?.toISOString()})`,
+    );
+  } finally {
+    await shutdown();
+  }
+};
+
+const multiAgentParallel: Scenario = async (deps) => {
+  // Two distinct agents → cap gate never blocks. Both sessions should run
+  // simultaneously, so their time intervals overlap.
+  const a1 = await seedOwnerAndAgent(deps, "par-agent-1");
+  const a2 = await seedOwnerAndAgent(deps, "par-agent-2");
+  const t1 = await seedTask(deps, { ownerId: a1.ownerId, agentId: a1.agentRecord.id });
+  const t2 = await seedTask(deps, { ownerId: a2.ownerId, agentId: a2.agentRecord.id });
+  log(`  agents=[${a1.agentRecord.id}, ${a2.agentRecord.id}]  tasks=[${t1.id}, ${t2.id}]`);
+
+  const { worker, shutdown } = await bootExecutor(deps);
+  try {
+    const s1 = await waitForSession(
+      deps.sessions,
+      t1.id,
+      SESSION_TERMINAL_DEADLINE_MS,
+      (s) => s.status === "succeeded" || s.status === "failed",
+      "task1 terminal",
+    );
+    const s2 = await waitForSession(
+      deps.sessions,
+      t2.id,
+      SESSION_TERMINAL_DEADLINE_MS,
+      (s) => s.status === "succeeded" || s.status === "failed",
+      "task2 terminal",
+    );
+    assert(s1.status === "succeeded" && s2.status === "succeeded", "both sessions should succeed");
+    log(`  t1 [${s1.started_at?.toISOString()}, ${s1.completed_at?.toISOString()}]`);
+    log(`  t2 [${s2.started_at?.toISOString()}, ${s2.completed_at?.toISOString()}]`);
+
+    assert(s1.completed_at && s2.completed_at, "both sessions must have completed_at");
+    // Intervals overlap: each starts before the other ends.
+    const overlap =
+      s1.started_at!.getTime() < s2.completed_at!.getTime() &&
+      s2.started_at!.getTime() < s1.completed_at!.getTime();
+    assert(
+      overlap,
+      `sessions did not overlap in time — dispatch was serialized instead of parallel`,
+    );
+  } finally {
+    await shutdown();
+  }
+};
+
+// ───────────────────────── entry ─────────────────────────
+
+async function main(): Promise<void> {
+  if (process.env.RUN_M5_E2E !== "1") {
+    console.log("Set RUN_M5_E2E=1 to run this script.");
+    process.exit(0);
+  }
+  const dbUrl = process.env.DATABASE_URL_TEST;
+  assert(dbUrl, "DATABASE_URL_TEST must be set");
+  assert(process.env.OPENAI_API_KEY, "OPENAI_API_KEY must be set");
+  assert(process.env.ANTHROPIC_API_KEY, "ANTHROPIC_API_KEY must be set");
+
+  const pool = createPool({ connectionString: dbUrl, max: 4 });
+  const workspaceRoot = mkdtempSync(join(tmpdir(), "beevibe-m5-e2e-"));
+  const deps: Deps = {
+    pool,
+    persons: new PostgresPersonRepository(pool),
+    agents: new PostgresAgentRepository(pool),
+    coreMemoryRepo: new PostgresCoreMemoryRepository(pool),
+    tasks: new PostgresTaskRepository(pool),
+    sessions: new PostgresSessionRepository(pool),
+    workspaceRoot,
+  };
+
+  const overall = Date.now();
+  try {
+    await scenario("0. happy path", happyPath, deps);
+    await scenario("A. cancel mid-flight", cancelMidFlight, deps);
+    await scenario("B. orphan reap", orphanReap, deps);
+    await scenario("C. revision resume", revisionResume, deps);
+    await scenario("D. priority ordering", priorityOrdering, deps);
+    await scenario("E. per-agent capacity", perAgentCapacity, deps);
+    await scenario("F. multi-agent parallel", multiAgentParallel, deps);
   } finally {
     rmSync(workspaceRoot, { recursive: true, force: true });
     await pool.end();
   }
+  const totalSec = ((Date.now() - overall) / 1000).toFixed(1);
+  log(`\n✓ M5 E2E complete (all 7 scenarios, ${totalSec}s total)`);
 }
 
 main().catch((err: unknown) => {

--- a/scripts/m5-e2e.ts
+++ b/scripts/m5-e2e.ts
@@ -396,8 +396,9 @@ const revisionResume: Scenario = async (deps) => {
     assert(first.cli_session_id, "first cli_session_id missing");
     log(`  first session=${first.id} cli=${first.cli_session_id}`);
 
-    // Mark task back to revision; next poll re-dispatches.
-    await deps.tasks.update(task.id, { status: "revision" });
+    // Queue task for re-work. Worker's next poll picks it up; claimById
+    // transitions needs_revision → revision before dispatching.
+    await deps.tasks.update(task.id, { status: "needs_revision" });
 
     const second = await waitForSession(
       deps.sessions,
@@ -408,6 +409,15 @@ const revisionResume: Scenario = async (deps) => {
     );
     assert(second.status === "succeeded", `second session status=${second.status}`);
     log(`  second session=${second.id} cli=${second.cli_session_id}`);
+
+    // Verify task reached status="revision" during re-work dispatch — this
+    // is the semantic distinction the needs_revision ↔ revision split
+    // preserves.
+    const taskDuringOrAfterRework = await deps.tasks.findById(task.id);
+    assert(
+      taskDuringOrAfterRework?.status === "revision",
+      `task.status during re-work should be "revision", got "${taskDuringOrAfterRework?.status}"`,
+    );
 
     // Core assertions: CLI session was resumed (same id), DB rows are
     // distinct, and prior_session_id links them.

--- a/scripts/m5-e2e.ts
+++ b/scripts/m5-e2e.ts
@@ -1,0 +1,234 @@
+/**
+ * M5 end-to-end smoke for the executor binary. Exercises the full
+ * poll → claim → dispatch → session-completion pipeline against live
+ * infrastructure.
+ *
+ * Requires:
+ * - `RUN_M5_E2E=1`
+ * - `DATABASE_URL_TEST` — pgvector-enabled Postgres (M0 schema + all migrations)
+ * - `OPENAI_API_KEY` — embeddings for briefing retrieval
+ * - `ANTHROPIC_API_KEY` — memory LLM (FactPromoter, FactStore merge)
+ * - `claude` CLI on PATH (M2 runtime dependency)
+ *
+ * Usage:
+ *   RUN_M5_E2E=1 pnpm tsx scripts/m5-e2e.ts
+ *
+ * What it does:
+ *   1. Truncate test DB.
+ *   2. Create a person + IC agent via provisionAgent.
+ *   3. Create an assigned task for the agent with a trivial prompt.
+ *   4. Boot the executor (mcpServerUrl points at localhost:0 — unreachable;
+ *      the prompt needs no tools so the session still completes).
+ *   5. worker.start() and poll the DB until the task transitions and the
+ *      session reaches a terminal state (up to ~90s).
+ *   6. Assert:
+ *      - Task went assigned → in_progress (claimed by the worker).
+ *      - Session row exists, status=succeeded, cli_session_id non-empty,
+ *        usage.input_tokens > 0, exit_code=0.
+ *      - mcp-config.json was written with mode 0o600 and correct contents
+ *        (Bearer token + ${BEEVIBE_SESSION_ID} placeholder + url).
+ *   7. worker.stop() + shutdown() + cleanup workspace.
+ *
+ * Explicitly deferred to M6 E2E: task.status='done' (needs update_progress
+ * tool), work_product rows (needs create_work_product tool),
+ * memory_fact.source_session_ids assertions (needs save_memory tool).
+ */
+
+import { config as loadEnv } from "dotenv";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+loadEnv({ path: resolve(here, "../.env") });
+
+import { bootstrap } from "../packages/executor/src/bootstrap.js";
+import { agentId, personId, taskId } from "../packages/core/src/domain/ids.js";
+import { DEFAULT_RUNTIME_CONFIG } from "../packages/core/src/domain/agent.js";
+import { provisionAgent } from "../packages/core/src/auth/provision.js";
+import { PostgresAgentRepository } from "../packages/core/src/adapters/postgres/agent-repo.js";
+import { PostgresCoreMemoryRepository } from "../packages/core/src/adapters/postgres/core-memory-repo.js";
+import { PostgresPersonRepository } from "../packages/core/src/adapters/postgres/person-repo.js";
+import { PostgresSessionRepository } from "../packages/core/src/adapters/postgres/session-repo.js";
+import { PostgresTaskRepository } from "../packages/core/src/adapters/postgres/task-repo.js";
+import { createPool } from "../packages/core/src/adapters/postgres/client.js";
+
+const TABLES = [
+  "memory_fact",
+  "work_product",
+  "core_memory_block",
+  "session",
+  "task",
+  "agent",
+  "person",
+];
+
+const TASK_TRANSITION_DEADLINE_MS = 10_000;
+const SESSION_SUCCESS_DEADLINE_MS = 90_000;
+
+function step(n: number, title: string): void {
+  console.log(`\n━━━ ${n}. ${title}`);
+}
+
+function assert(cond: unknown, msg: string): asserts cond {
+  if (!cond) {
+    console.error(`ASSERTION FAILED: ${msg}`);
+    process.exit(1);
+  }
+}
+
+async function wait(ms: number): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+async function main(): Promise<void> {
+  if (process.env.RUN_M5_E2E !== "1") {
+    console.log("Set RUN_M5_E2E=1 to run this script.");
+    process.exit(0);
+  }
+
+  const dbUrl = process.env.DATABASE_URL_TEST;
+  assert(dbUrl, "DATABASE_URL_TEST must be set");
+  assert(process.env.OPENAI_API_KEY, "OPENAI_API_KEY must be set");
+  assert(process.env.ANTHROPIC_API_KEY, "ANTHROPIC_API_KEY must be set");
+
+  const pool = createPool({ connectionString: dbUrl, max: 4 });
+  const workspaceRoot = mkdtempSync(join(tmpdir(), "beevibe-m5-e2e-"));
+
+  try {
+    step(1, "Truncate test DB");
+    await pool.query(`TRUNCATE ${TABLES.join(", ")} RESTART IDENTITY CASCADE`);
+
+    step(2, "Create person + IC agent via provisionAgent");
+    const persons = new PostgresPersonRepository(pool);
+    const agents = new PostgresAgentRepository(pool);
+    const coreMemoryRepo = new PostgresCoreMemoryRepository(pool);
+    const tasks = new PostgresTaskRepository(pool);
+    const sessions = new PostgresSessionRepository(pool);
+
+    const owner = await persons.create({ id: personId(), name: "M5 Owner" });
+    const { agent, apiKey } = await provisionAgent(
+      { agentRepo: agents, coreMemoryRepo },
+      {
+        id: agentId(),
+        name: "M5 IC",
+        owner_id: owner.id,
+        hierarchy_level: "ic",
+        runtime_config: DEFAULT_RUNTIME_CONFIG,
+      },
+    );
+    console.log(`   agent ${agent.id}, api_key ${apiKey.slice(0, 10)}…`);
+    assert(apiKey.startsWith("bv_a_"), "agent key should have bv_a_ prefix");
+
+    step(3, "Seed assigned task for the agent");
+    const createdTask = await tasks.create({
+      id: taskId(),
+      title: "Reply with the single word 'ok'.",
+      priority: "medium",
+      status: "assigned",
+      assignee_id: agent.id,
+      creator_id: owner.id,
+      creator_type: "person",
+    });
+    console.log(`   task ${createdTask.id}`);
+
+    step(4, "Boot executor");
+    // Unreachable MCP URL is intentional: the trivial prompt needs no tools.
+    // M6 E2E will hit a real MCP server.
+    const { worker, shutdown } = await bootstrap({
+      databaseUrl: dbUrl,
+      mcpServerUrl: "http://localhost:0/",
+      openaiApiKey: process.env.OPENAI_API_KEY!,
+      anthropicApiKey: process.env.ANTHROPIC_API_KEY!,
+      workspaceRoot,
+      pollIntervalMs: 2_000, // tight loop for E2E responsiveness
+    });
+
+    step(5, "worker.start()");
+    await worker.start();
+
+    try {
+      step(6, "Wait for claim transition (task: assigned → in_progress)");
+      const transitionStart = Date.now();
+      let inProgress = false;
+      while (Date.now() - transitionStart < TASK_TRANSITION_DEADLINE_MS) {
+        const t = await tasks.findById(createdTask.id);
+        if (t?.status === "in_progress" || t?.status === "done") {
+          inProgress = true;
+          break;
+        }
+        await wait(500);
+      }
+      assert(
+        inProgress,
+        `task did not transition to in_progress within ${TASK_TRANSITION_DEADLINE_MS}ms`,
+      );
+
+      step(7, "Wait for a succeeded session row on the task");
+      const sessionStart = Date.now();
+      let finalSession = null as Awaited<ReturnType<typeof sessions.findLatestForTask>>;
+      while (Date.now() - sessionStart < SESSION_SUCCESS_DEADLINE_MS) {
+        const s = await sessions.findLatestForTask(createdTask.id);
+        if (s && (s.status === "succeeded" || s.status === "failed")) {
+          finalSession = s;
+          break;
+        }
+        await wait(1_000);
+      }
+      assert(
+        finalSession,
+        `no terminal session row appeared within ${SESSION_SUCCESS_DEADLINE_MS}ms`,
+      );
+      console.log(
+        `   session ${finalSession.id} → status=${finalSession.status}, cli_session=${finalSession.cli_session_id}`,
+      );
+      assert(
+        finalSession.status === "succeeded",
+        `session ended with status=${finalSession.status} (expected succeeded)`,
+      );
+      assert(finalSession.cli_session_id, "cli_session_id missing");
+      assert(
+        finalSession.usage?.input_tokens && finalSession.usage.input_tokens > 0,
+        "usage.input_tokens not recorded",
+      );
+      assert(
+        finalSession.exit_code === 0,
+        `exit_code=${finalSession.exit_code} (expected 0)`,
+      );
+    } finally {
+      step(8, "worker.stop() + shutdown()");
+      await shutdown();
+    }
+
+    step(9, "Assert mcp-config.json on disk has correct contents + mode");
+    const configPath = join(workspaceRoot, agent.id, "mcp-config.json");
+    const mode = statSync(configPath).mode & 0o777;
+    if (process.platform !== "win32") {
+      assert(mode === 0o600, `mcp-config.json mode=${mode.toString(8)} (expected 600)`);
+    }
+    const parsed = JSON.parse(readFileSync(configPath, "utf-8"));
+    assert(
+      parsed.mcpServers.beevibe.url === "http://localhost:0/",
+      `unexpected mcpServerUrl in config: ${parsed.mcpServers.beevibe.url}`,
+    );
+    assert(
+      parsed.mcpServers.beevibe.headers.Authorization === `Bearer ${apiKey}`,
+      "Authorization header mismatch",
+    );
+    assert(
+      parsed.mcpServers.beevibe.headers["X-Beevibe-Session"] === "${BEEVIBE_SESSION_ID}",
+      "X-Beevibe-Session placeholder missing or wrong",
+    );
+
+    console.log("\n✓ M5 E2E complete");
+  } finally {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+    await pool.end();
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error("\n✗ M5 E2E failed:", err);
+  process.exit(1);
+});

--- a/scripts/m5-e2e.ts
+++ b/scripts/m5-e2e.ts
@@ -1,31 +1,13 @@
 /**
- * M5 end-to-end smoke for the executor binary. Exercises the full
- * poll → claim → dispatch → session-completion pipeline plus six
- * targeted scenarios that catch integration behavior unit tests can't.
+ * M5 end-to-end smoke for the executor binary.
  *
- * Requires:
- * - `RUN_M5_E2E=1`
- * - `DATABASE_URL_TEST` — pgvector-enabled Postgres (M0 schema + all migrations)
- * - `OPENAI_API_KEY` — embeddings for briefing retrieval
- * - `ANTHROPIC_API_KEY` — memory LLM (FactPromoter, FactStore merge)
- * - `claude` CLI on PATH (M2 runtime dependency)
+ * Gated by `RUN_M5_E2E=1`. Requires `DATABASE_URL_TEST`, `OPENAI_API_KEY`,
+ * `ANTHROPIC_API_KEY`, and `claude` on PATH.
  *
- * Usage:
  *   RUN_M5_E2E=1 pnpm tsx scripts/m5-e2e.ts
  *
- * Scenarios:
- *   0. Happy path — 1 agent, trivial task, full plumbing.
- *   A. Cancel mid-flight — long-running task, cancelTask aborts CLI.
- *   B. Orphan reap — session in DB with dead PID → failed + task re-queued.
- *   C. Revision resume — second session resumes first via --resume
- *      (same cli_session_id, distinct beevibe rows, prior_session_id linked).
- *   D. Priority ordering — critical > medium > low dispatched in that order.
- *   E. Per-agent capacity — max_task_sessions=1 serializes 2 tasks for one agent.
- *   F. Multi-agent parallel — 2 agents each get a task; sessions overlap in time.
- *
- * Deferred to M6 E2E: task.status='done' (update_progress tool),
- * work_product rows (create_work_product tool), memory_fact.source_session_ids
- * content (save_memory tool).
+ * Seven scenarios: happy path, cancel mid-flight, orphan reap, revision
+ * resume, priority ordering, per-agent capacity, multi-agent parallel.
  */
 
 import { config as loadEnv } from "dotenv";

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,7 @@
       "dependsOn": ["^build"]
     },
     "test": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build", "^test"]
     },
     "dev": {
       "persistent": true,


### PR DESCRIPTION
## Summary

- **New `@beevibe/executor` binary**: task polling loop, atomic claim, per-agent capacity check, orphan reap, fire-and-forget dispatch via M3's `AgentSession`. Graceful SIGTERM/SIGINT. Composable bootstrap wires core repos + M3 services + runtime registry.
- **Task state clarity**: `revision` status split into `needs_revision` (queued for re-work) and `revision` (actively running re-work). Preserves the "why is this running" signal through the dispatch pipeline without schema gymnastics.
- **Review-policy gate**: `TaskService.updateProgress` now applies `agent.review_policy` — agent-declared `done` becomes `review` when the agent has `require_human`. Agents can only author end states (`done`/`failed`/`blocked`); humans/system own `review`/`needs_revision`/`cancelled`.
- **WorkspaceManager extended**: now owns both the workspace dir AND the per-agent `mcp-config.json` (file-existence idempotent, no in-memory state). M6's MCP server will reuse the same adapter for mesh spawns.
- **Runtime registry**: shared factory `createDefaultRuntimeRegistry()` in core, consumed by executor now and M6 MCP server later.
- **Per-call runtime config**: `RuntimeContext.model` / `max_turns` flow from `agent.runtime_config` per spawn, so one executor can serve agents with different models. Fixed latent bug where `ClaudeCodeRuntime` hardcoded model from constructor.

## Commits (9, grouped by milestone)

| # | Commit | Scope |
| --- | --- | --- |
| M5.0 | `0b98415` | core+runtime plumbing: per-call model, listAssignable/claimById, urgency removal, runtime-registry factory, dispatch index |
| M5.1 | `5d59428` | `WorkspaceManager` port + adapter extended to provision `mcp-config.json` (file-exists idempotent) |
| M5.2 | `bc5118e` | `TaskExecutionWorker` (poll/claim/reap + per-agent capacity) |
| M5.3 | `9f27029` | `dispatch.ts` thin wrapper around `AgentSession.run` + runtime registry lookup |
| M5.4 | `3a28881` | `bootstrap.ts` + `main.ts` (composition root, SIGTERM/SIGINT handlers) |
| M5.5 | `48e167f` | `scripts/m5-e2e.ts` (happy-path E2E) |
| — | `e8a3626` | expand M5 E2E with 6 scenarios (cancel / reap / revision / priority / capacity / parallel) + fix revision-dispatch bug |
| — | `759ad35` | split `revision → needs_revision` (queue) + `revision` (running) across core + executor + task-service + tests |
| — | `65b3f47` | `review_policy` gate in `TaskService.updateProgress` |

## Test plan

- [x] `pnpm -w build` — all 3 packages compile
- [x] `pnpm -w typecheck` — strict TS across all packages
- [x] `pnpm -w lint` — ESLint clean
- [x] `pnpm -w test` — 25 executor tests + 28 task-service tests (+6 new for policy) + 284+ other core tests
- [x] **M3 E2E regression** — `RUN_M3_E2E=1 pnpm tsx scripts/m3-e2e.ts` green (no regression from the core changes)
- [x] **M5 E2E** — `RUN_M5_E2E=1 pnpm tsx scripts/m5-e2e.ts` green, all 7 scenarios, ~25-45s total depending on run:
  - Happy path — full plumbing + config-file assertions
  - A. Cancel mid-flight — AbortController → SIGTERM → CLI terminates, session=cancelled
  - B. Orphan reap — dead-PID session reaped, task re-dispatched
  - C. Revision resume — `--resume` honored (same `cli_session_id`, distinct beevibe rows, `prior_session_id` linked); task goes `needs_revision → revision` via claim
  - D. Priority ordering — critical > medium > low observed via `task.updated_at`
  - E. Per-agent capacity — `max_task_sessions=1` serializes 2 tasks (t2.started_at > t1.completed_at)
  - F. Multi-agent parallel — time intervals overlap (simultaneous dispatch)
- [x] Two migrations applied cleanly against `DATABASE_URL_TEST`: `fix-task-dispatch-index.sql` (M5.0) + `add-task-needs-revision-status.sql` (status split)

## Runtime verification

- [x] `claude` CLI's env-var interpolation in mcp-config headers verified via runtime probe (documented in plan; covered in scenarios 0/A/C/F)
- [x] `claude --resume <sid>` confirmed to keep the same `cli_session_id` per official docs + E2E scenario C
- [x] `opus` model alias accepted by installed Claude Code CLI v2.1.118 (pins M5.1 default config to a working value)

## Related

- Closes #5
- Comment posted on #6 documenting M6-facing deltas: [comment link](https://github.com/beevibe-ai/beevibe/issues/6#issuecomment-4310504371)
  - `update_progress` tool should enum-constrain to `"done" | "failed" | "blocked"`
  - M6 handler must delegate to `TaskService.updateProgress` (applies `review_policy` gate)
  - M6 bootstrap needs to wire `agentRepo` into `TaskServiceDeps`
  - `approveTask("revise")` now targets `needs_revision` (was `revision`)
- Plan file snapshot attached as comment on #5 for execution reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)