### PR TITLE
M8 — design mocks for the web frontend

### DIFF
--- a/mocks/agent-detail.html
+++ b/mocks/agent-detail.html
@@ -1,0 +1,607 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>beevibe — agent detail · ic-agent-1</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+  <script>
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.classList.add('dark');
+    }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+  <style>
+    :root {
+      --background: 0 0% 100%;
+      --foreground: 240 10% 4%;
+      --card: 240 5% 98%;
+      --card-foreground: 240 10% 4%;
+      --primary: 48 96% 53%;
+      --primary-foreground: 240 10% 4%;
+      --secondary: 240 5% 96%;
+      --secondary-foreground: 240 6% 10%;
+      --muted: 240 5% 96%;
+      --muted-foreground: 240 4% 46%;
+      --border: 240 6% 90%;
+      --input: 240 6% 90%;
+      --ring: 47 96% 47%;
+      --radius: 0.375rem;
+
+      --status-pending:   240 4% 46%;
+      --status-running:   217 91% 60%;
+      --status-review:    38 92% 50%;
+      --status-blocked:   25 95% 53%;
+      --status-done:      160 84% 39%;
+      --status-failed:    0 84% 60%;
+
+      --hier-ic:   240 4% 46%;
+      --hier-team: 262 83% 58%;
+      --hier-org:  38 92% 50%;
+    }
+    .dark {
+      --background: 240 10% 4%;
+      --foreground: 0 0% 98%;
+      --card: 240 6% 10%;
+      --card-foreground: 0 0% 98%;
+      --primary: 48 96% 53%;
+      --primary-foreground: 240 10% 4%;
+      --secondary: 240 4% 16%;
+      --secondary-foreground: 0 0% 98%;
+      --muted: 240 4% 16%;
+      --muted-foreground: 240 5% 65%;
+      --border: 240 4% 16%;
+      --input: 240 4% 16%;
+      --ring: 48 96% 53%;
+    }
+
+    body {
+      font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
+      font-feature-settings: 'cv11', 'ss01';
+      background-color: hsl(var(--background));
+      color: hsl(var(--foreground));
+      -webkit-font-smoothing: antialiased;
+    }
+    .font-mono { font-family: 'JetBrains Mono', ui-monospace, 'Menlo', monospace; }
+
+    @keyframes pulse-breathe {
+      0%, 100% { opacity: 1; transform: scale(1); }
+      50%      { opacity: 0.55; transform: scale(0.92); }
+    }
+    .pulse-dot { animation: pulse-breathe 2s ease-in-out infinite; }
+
+    @keyframes spin-slow { to { transform: rotate(360deg); } }
+    .spin-slow { animation: spin-slow 2.5s linear infinite; }
+
+    @media (prefers-reduced-motion: reduce) {
+      .pulse-dot, .spin-slow { animation: none; }
+    }
+
+    button:focus-visible, a:focus-visible {
+      outline: 2px solid hsl(var(--ring));
+      outline-offset: 2px;
+      border-radius: var(--radius);
+    }
+
+    /* core memory block ring — visualizes char_limit fill */
+    .ring-track {
+      stroke: hsl(var(--border));
+    }
+    .ring-fill {
+      stroke: hsl(var(--primary));
+      stroke-linecap: round;
+      transform: rotate(-90deg);
+      transform-origin: center;
+    }
+    .ring-fill-warn { stroke: hsl(var(--status-review)); }
+  </style>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+            mono: ['JetBrains Mono', 'ui-monospace', 'Menlo', 'monospace'],
+          },
+          colors: {
+            border: 'hsl(var(--border))',
+            input: 'hsl(var(--input))',
+            ring: 'hsl(var(--ring))',
+            background: 'hsl(var(--background))',
+            foreground: 'hsl(var(--foreground))',
+            primary: { DEFAULT: 'hsl(var(--primary))', foreground: 'hsl(var(--primary-foreground))' },
+            secondary: { DEFAULT: 'hsl(var(--secondary))', foreground: 'hsl(var(--secondary-foreground))' },
+            muted: { DEFAULT: 'hsl(var(--muted))', foreground: 'hsl(var(--muted-foreground))' },
+            card: { DEFAULT: 'hsl(var(--card))', foreground: 'hsl(var(--card-foreground))' },
+            status: {
+              pending:   'hsl(var(--status-pending))',
+              running:   'hsl(var(--status-running))',
+              review:    'hsl(var(--status-review))',
+              blocked:   'hsl(var(--status-blocked))',
+              done:      'hsl(var(--status-done))',
+              failed:    'hsl(var(--status-failed))',
+            },
+            hier: {
+              ic:   'hsl(var(--hier-ic))',
+              team: 'hsl(var(--hier-team))',
+              org:  'hsl(var(--hier-org))',
+            },
+          },
+          borderRadius: {
+            DEFAULT: 'var(--radius)',
+            md: 'var(--radius)',
+            lg: 'calc(var(--radius) + 2px)',
+            xl: 'calc(var(--radius) + 6px)',
+          },
+        },
+      },
+    };
+  </script>
+</head>
+<body class="min-h-screen">
+  <div class="flex min-h-screen">
+
+    <!-- Sidebar (Agents active) -->
+    <aside class="w-[220px] shrink-0 bg-card flex flex-col">
+      <div class="h-14 flex items-center gap-2.5 px-4">
+        <div class="h-6 w-6 rounded bg-primary flex items-center justify-center">
+          <span class="text-primary-foreground text-sm font-bold leading-none">b</span>
+        </div>
+        <span class="font-semibold tracking-tight">beevibe</span>
+      </div>
+      <nav class="flex-1 p-2 space-y-0.5 text-sm">
+        <a href="home.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="home" class="h-4 w-4"></i>
+          <span>Home</span>
+        </a>
+        <a href="tasks-list.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="list-checks" class="h-4 w-4"></i>
+          <span>Tasks</span>
+        </a>
+        <a href="agents-list.html" class="flex items-center gap-3 px-3 py-2 rounded bg-secondary text-foreground font-medium">
+          <i data-lucide="circle-dot" class="h-4 w-4"></i>
+          <span>Agents</span>
+        </a>
+        <a href="threads.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="message-square" class="h-4 w-4"></i>
+          <span>Threads</span>
+        </a>
+        <a href="memory.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="sparkles" class="h-4 w-4"></i>
+          <span>Memory</span>
+        </a>
+      </nav>
+
+      <div class="p-3">
+        <div class="flex items-center gap-1">
+          <button class="flex-1 min-w-0 flex items-center gap-2 px-2 py-1.5 rounded hover:bg-secondary cursor-pointer transition-colors text-left">
+            <div class="h-7 w-7 rounded-full bg-secondary border border-border flex items-center justify-center text-xs font-medium shrink-0">W</div>
+            <div class="flex-1 min-w-0">
+              <div class="text-sm font-medium truncate leading-tight">Weijia</div>
+              <div class="text-[10px] text-muted-foreground flex items-center gap-1 leading-tight mt-0.5">
+                <span class="pulse-dot inline-block h-1 w-1 rounded-full bg-status-running"></span>
+                live
+              </div>
+            </div>
+            <i data-lucide="chevrons-up-down" class="h-3.5 w-3.5 text-muted-foreground shrink-0"></i>
+          </button>
+          <button id="theme-toggle" class="h-8 w-8 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary cursor-pointer transition-colors shrink-0" title="Toggle theme">
+            <i data-lucide="sun" class="h-4 w-4 hidden dark:block"></i>
+            <i data-lucide="moon" class="h-4 w-4 block dark:hidden"></i>
+          </button>
+        </div>
+      </div>
+    </aside>
+
+    <!-- Main — DETAIL density (max-w-5xl, space-y-5) -->
+    <main class="flex-1 min-w-0 flex flex-col">
+      <div class="flex-1 overflow-auto">
+        <div class="max-w-5xl mx-auto pt-8 pb-12 px-6">
+
+          <!-- Breadcrumb -->
+          <div class="text-xs text-muted-foreground mb-4 flex items-center gap-1.5">
+            <a href="agents-list.html" class="hover:text-foreground transition-colors">Agents</a>
+            <i data-lucide="chevron-right" class="h-3 w-3"></i>
+            <a href="#" class="hover:text-foreground transition-colors">team-alpha</a>
+            <i data-lucide="chevron-right" class="h-3 w-3"></i>
+            <span class="text-foreground font-mono">ic-agent-1</span>
+          </div>
+
+          <!-- Header zone — identity, hierarchy, depth at a glance -->
+          <header class="mb-6">
+            <div class="flex items-start gap-4">
+              <div class="relative shrink-0">
+                <div class="h-14 w-14 rounded-full bg-hier-ic/10 flex items-center justify-center text-hier-ic text-xl font-semibold">
+                  <i data-lucide="key-round" class="h-6 w-6"></i>
+                </div>
+                <span class="absolute bottom-0 right-0 h-3.5 w-3.5 rounded-full bg-status-running border-2 border-background pulse-dot"></span>
+              </div>
+              <div class="flex-1 min-w-0">
+                <div class="flex items-center gap-2 mb-1">
+                  <h1 class="font-mono text-xl font-semibold leading-tight">ic-agent-1</h1>
+                  <span class="inline-flex items-center h-5 px-2 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic">ic</span>
+                  <span class="inline-flex items-center gap-1 h-5 px-2 rounded text-[10px] text-status-running bg-status-running/10">
+                    <i data-lucide="loader-2" class="spin-slow h-3 w-3"></i>1 running
+                  </span>
+                </div>
+                <div class="text-sm text-muted-foreground">
+                  reports to <a href="#" class="text-foreground hover:underline font-mono">team-alpha</a>
+                  <span class="text-border mx-1.5">·</span>
+                  specialty: <span class="text-foreground">auth flows, OAuth, session security</span>
+                </div>
+              </div>
+              <button class="inline-flex items-center gap-1.5 h-8 px-3 rounded text-xs font-medium hover:bg-secondary cursor-pointer transition-colors text-muted-foreground hover:text-foreground shrink-0">
+                <i data-lucide="settings-2" class="h-3.5 w-3.5"></i>
+                Configure
+              </button>
+            </div>
+
+            <!-- Depth metrics row — proves accumulation is real -->
+            <div class="grid grid-cols-4 gap-x-8 mt-6 pt-6 border-t border-border">
+              <div>
+                <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Sessions</div>
+                <div class="flex items-baseline gap-1.5">
+                  <span class="text-2xl font-semibold tabular-nums leading-none">47</span>
+                  <span class="text-xs text-status-done">+3 this week</span>
+                </div>
+              </div>
+              <div>
+                <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Facts learned</div>
+                <div class="flex items-baseline gap-1.5">
+                  <span class="text-2xl font-semibold tabular-nums leading-none">23</span>
+                  <span class="text-xs text-muted-foreground">in memory</span>
+                </div>
+              </div>
+              <div>
+                <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Merge events</div>
+                <div class="flex items-baseline gap-1.5">
+                  <span class="text-2xl font-semibold tabular-nums leading-none">8</span>
+                  <span class="text-xs text-muted-foreground">consolidated</span>
+                </div>
+              </div>
+              <div>
+                <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Promoted up</div>
+                <div class="flex items-baseline gap-1.5">
+                  <span class="text-2xl font-semibold tabular-nums leading-none">4</span>
+                  <span class="text-xs text-muted-foreground">to team / org</span>
+                </div>
+              </div>
+            </div>
+          </header>
+
+          <!-- Two-column layout: main content + right rail -->
+          <div class="grid grid-cols-3 gap-6">
+
+            <!-- LEFT — main content -->
+            <div class="col-span-2 space-y-5">
+
+              <!-- Core memory blocks — bounded persona/domain/constraints. Agent edits these via update_core_memory. -->
+              <section>
+                <div class="flex items-baseline justify-between mb-3">
+                  <h2 class="text-sm font-semibold">Core memory blocks</h2>
+                  <span class="text-[10px] text-muted-foreground">3 blocks · agent-edited via <span class="font-mono">update_core_memory</span></span>
+                </div>
+
+                <div class="space-y-3">
+                  <!-- persona block -->
+                  <div class="rounded-lg border border-border bg-card p-4">
+                    <div class="flex items-start gap-3">
+                      <!-- Char limit ring -->
+                      <div class="shrink-0">
+                        <svg class="h-12 w-12" viewBox="0 0 36 36">
+                          <circle class="ring-track" cx="18" cy="18" r="14" fill="none" stroke-width="2.5" />
+                          <circle class="ring-fill" cx="18" cy="18" r="14" fill="none" stroke-width="2.5"
+                                  stroke-dasharray="62 88" />
+                        </svg>
+                      </div>
+                      <div class="flex-1 min-w-0">
+                        <div class="flex items-center gap-2 mb-1.5">
+                          <span class="font-mono text-xs font-medium">persona</span>
+                          <span class="text-[10px] text-muted-foreground">1,376 / 2,000 chars</span>
+                          <button class="ml-auto h-5 w-5 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors">
+                            <i data-lucide="pencil" class="h-3 w-3"></i>
+                          </button>
+                        </div>
+                        <p class="text-sm text-foreground/85 leading-relaxed">
+                          You are a senior engineer specialized in authentication flows. You think in terms of trust boundaries: who is asserting identity, who is verifying, what tokens are crossing which network edges, what's signed vs encrypted. You prefer OAuth 2.1 over implicit-grant patterns; you treat session storage as a security primitive, not a convenience.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- domain block -->
+                  <div class="rounded-lg border border-border bg-card p-4">
+                    <div class="flex items-start gap-3">
+                      <div class="shrink-0">
+                        <svg class="h-12 w-12" viewBox="0 0 36 36">
+                          <circle class="ring-track" cx="18" cy="18" r="14" fill="none" stroke-width="2.5" />
+                          <circle class="ring-fill" cx="18" cy="18" r="14" fill="none" stroke-width="2.5"
+                                  stroke-dasharray="76 88" />
+                        </svg>
+                      </div>
+                      <div class="flex-1 min-w-0">
+                        <div class="flex items-center gap-2 mb-1.5">
+                          <span class="font-mono text-xs font-medium">domain</span>
+                          <span class="text-[10px] text-muted-foreground">1,728 / 2,000 chars</span>
+                          <button class="ml-auto h-5 w-5 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors">
+                            <i data-lucide="pencil" class="h-3 w-3"></i>
+                          </button>
+                        </div>
+                        <p class="text-sm text-foreground/85 leading-relaxed">
+                          Auth surface for this codebase: <span class="font-mono text-xs">bv_a_</span> agent keys + <span class="font-mono text-xs">bv_u_</span> user keys, both resolved via <span class="font-mono text-xs">lookupApiKey</span>. MCP server speaks OAuth 2.1 to Claude Code CLI. User-driven sessions bind via <span class="font-mono text-xs">Mcp-Session-Id</span> header (server-assigned, client auto-echoes). Agent-driven sessions bind via <span class="font-mono text-xs">X-Beevibe-Session</span>. Token rotation deferred to M14.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- constraints block — near limit, warn color on ring -->
+                  <div class="rounded-lg border border-border bg-card p-4">
+                    <div class="flex items-start gap-3">
+                      <div class="shrink-0">
+                        <svg class="h-12 w-12" viewBox="0 0 36 36">
+                          <circle class="ring-track" cx="18" cy="18" r="14" fill="none" stroke-width="2.5" />
+                          <circle class="ring-fill ring-fill-warn" cx="18" cy="18" r="14" fill="none" stroke-width="2.5"
+                                  stroke-dasharray="82 88" />
+                        </svg>
+                      </div>
+                      <div class="flex-1 min-w-0">
+                        <div class="flex items-center gap-2 mb-1.5">
+                          <span class="font-mono text-xs font-medium">constraints</span>
+                          <span class="text-[10px] text-status-review">1,860 / 2,000 chars · approaching limit</span>
+                          <button class="ml-auto h-5 w-5 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors">
+                            <i data-lucide="pencil" class="h-3 w-3"></i>
+                          </button>
+                        </div>
+                        <p class="text-sm text-foreground/85 leading-relaxed">
+                          Never log full bearer tokens — log first-8-chars with hash suffix. Never store refresh tokens in <span class="font-mono text-xs">localStorage</span> — HttpOnly cookie or KMS only. Never accept <span class="font-mono text-xs">none</span> as a JWT alg. When unsure about a cross-tree mesh ask, escalate to <span class="font-mono text-xs">team-alpha</span> rather than guessing.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <!-- Facts — only this agent's facts. No global pool view exists anywhere in the UI. -->
+              <section>
+                <div class="flex items-baseline justify-between mb-3">
+                  <h2 class="text-sm font-semibold">What this agent has learned</h2>
+                  <a href="memory.html?agent=ic-agent-1" class="text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1">
+                    All 23 facts <i data-lucide="arrow-right" class="h-3 w-3"></i>
+                  </a>
+                </div>
+
+                <div class="space-y-2">
+                  <!-- A merged fact — proof of accumulation -->
+                  <div class="rounded-lg border border-border bg-card p-3.5 hover:border-ring/40 transition-colors cursor-pointer">
+                    <div class="flex items-start gap-3">
+                      <div class="shrink-0 mt-0.5">
+                        <i data-lucide="git-merge" class="h-3.5 w-3.5 text-status-running" title="Merged from prior facts"></i>
+                      </div>
+                      <div class="flex-1 min-w-0">
+                        <p class="text-sm leading-relaxed">
+                          Claude Code spawns subprocesses; the executor must reap them with <span class="font-mono text-xs">process_group_id</span>, not just <span class="font-mono text-xs">process_pid</span>, or orphaned children accumulate over long runs.
+                        </p>
+                        <div class="flex items-center gap-2 mt-2 text-[10px]">
+                          <span class="inline-flex items-center h-4 px-1.5 rounded font-medium bg-hier-ic/15 text-hier-ic">ic</span>
+                          <span class="inline-flex items-center h-4 px-1.5 rounded text-status-failed/80 bg-status-failed/10 font-medium">gotcha</span>
+                          <span class="text-muted-foreground font-mono">merged · 4 sessions · 3d ago</span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="rounded-lg border border-border bg-card p-3.5 hover:border-ring/40 transition-colors cursor-pointer">
+                    <div class="flex items-start gap-3">
+                      <div class="shrink-0 mt-0.5">
+                        <i data-lucide="circle" class="h-3.5 w-3.5 text-muted-foreground"></i>
+                      </div>
+                      <div class="flex-1 min-w-0">
+                        <p class="text-sm leading-relaxed">
+                          When binding bv_u_ to MCP, the server-assigned <span class="font-mono text-xs">Mcp-Session-Id</span> must be cached in-memory keyed to the session row id — Claude Code CLI auto-echoes the header on every subsequent request per spec 2025-11-25.
+                        </p>
+                        <div class="flex items-center gap-2 mt-2 text-[10px]">
+                          <span class="inline-flex items-center h-4 px-1.5 rounded font-medium bg-hier-ic/15 text-hier-ic">ic</span>
+                          <span class="inline-flex items-center h-4 px-1.5 rounded text-status-running bg-status-running/10 font-medium">decision</span>
+                          <span class="text-muted-foreground font-mono">1 session · 2d ago</span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- A promoted fact — proof of curated commons -->
+                  <div class="rounded-lg border border-border bg-card p-3.5 hover:border-ring/40 transition-colors cursor-pointer">
+                    <div class="flex items-start gap-3">
+                      <div class="shrink-0 mt-0.5">
+                        <i data-lucide="trending-up" class="h-3.5 w-3.5 text-hier-team" title="Promoted to team scope"></i>
+                      </div>
+                      <div class="flex-1 min-w-0">
+                        <p class="text-sm leading-relaxed">
+                          Postgres NOTIFY payload is capped at 8KB. Keep payloads to id, status, and timestamps; clients refetch full rows via HTTP after the event.
+                        </p>
+                        <div class="flex items-center gap-2 mt-2 text-[10px]">
+                          <span class="inline-flex items-center h-4 px-1.5 rounded font-medium bg-hier-team/10 text-hier-team">team</span>
+                          <span class="inline-flex items-center h-4 px-1.5 rounded text-status-running bg-status-running/10 font-medium">decision</span>
+                          <span class="text-muted-foreground font-mono">promoted from ic · 3 sessions · 4d ago</span>
+                          <a href="promotions.html" class="text-muted-foreground hover:text-foreground underline transition-colors">why?</a>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="rounded-lg border border-border bg-card p-3.5 hover:border-ring/40 transition-colors cursor-pointer">
+                    <div class="flex items-start gap-3">
+                      <div class="shrink-0 mt-0.5">
+                        <i data-lucide="git-merge" class="h-3.5 w-3.5 text-status-running"></i>
+                      </div>
+                      <div class="flex-1 min-w-0">
+                        <p class="text-sm leading-relaxed">
+                          OAuth 2.1 strict mode rejects implicit grant entirely. For Claude Code CLI integration, use authorization-code-with-PKCE; bv_ keys exchange for short-lived bearer tokens via the token endpoint.
+                        </p>
+                        <div class="flex items-center gap-2 mt-2 text-[10px]">
+                          <span class="inline-flex items-center h-4 px-1.5 rounded font-medium bg-hier-ic/15 text-hier-ic">ic</span>
+                          <span class="inline-flex items-center h-4 px-1.5 rounded text-hier-team bg-hier-team/10 font-medium">pattern</span>
+                          <span class="text-muted-foreground font-mono">merged · 2 sessions · 5d ago</span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="rounded-lg border border-border bg-card p-3.5 hover:border-ring/40 transition-colors cursor-pointer">
+                    <div class="flex items-start gap-3">
+                      <div class="shrink-0 mt-0.5">
+                        <i data-lucide="circle" class="h-3.5 w-3.5 text-muted-foreground"></i>
+                      </div>
+                      <div class="flex-1 min-w-0">
+                        <p class="text-sm leading-relaxed">
+                          When the OAuth provider config drift (e.g., redirect URI changed in their dashboard, not ours), the failure surfaces as a 400 from <span class="font-mono text-xs">/token</span>, not a redirect failure. Log the upstream response body, not just status.
+                        </p>
+                        <div class="flex items-center gap-2 mt-2 text-[10px]">
+                          <span class="inline-flex items-center h-4 px-1.5 rounded font-medium bg-hier-ic/15 text-hier-ic">ic</span>
+                          <span class="inline-flex items-center h-4 px-1.5 rounded text-status-failed/80 bg-status-failed/10 font-medium">gotcha</span>
+                          <span class="text-muted-foreground font-mono">1 session · 6d ago</span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="rounded-lg border border-border bg-card p-3.5 hover:border-ring/40 transition-colors cursor-pointer">
+                    <div class="flex items-start gap-3">
+                      <div class="shrink-0 mt-0.5">
+                        <i data-lucide="circle" class="h-3.5 w-3.5 text-muted-foreground"></i>
+                      </div>
+                      <div class="flex-1 min-w-0">
+                        <p class="text-sm leading-relaxed">
+                          Prefer Argon2id over bcrypt for new password hashes — Argon2 has tunable memory cost that resists GPU attack better; bcrypt's 72-byte input limit is a footgun for long passphrases.
+                        </p>
+                        <div class="flex items-center gap-2 mt-2 text-[10px]">
+                          <span class="inline-flex items-center h-4 px-1.5 rounded font-medium bg-hier-ic/15 text-hier-ic">ic</span>
+                          <span class="inline-flex items-center h-4 px-1.5 rounded text-status-running bg-status-running/10 font-medium">preference</span>
+                          <span class="text-muted-foreground font-mono">1 session · 1w ago</span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+            </div>
+
+            <!-- RIGHT RAIL — themes, recent sessions, mesh hint -->
+            <aside class="col-span-1 space-y-5">
+
+              <!-- Themes derived from facts -->
+              <section>
+                <h3 class="text-[10px] uppercase tracking-wider text-muted-foreground mb-3">What this agent knows about</h3>
+                <div class="flex flex-wrap gap-1.5">
+                  <span class="inline-flex items-center h-6 px-2 rounded text-xs bg-secondary text-foreground/85">OAuth 2.1</span>
+                  <span class="inline-flex items-center h-6 px-2 rounded text-xs bg-secondary text-foreground/85">JWT</span>
+                  <span class="inline-flex items-center h-6 px-2 rounded text-xs bg-secondary text-foreground/85">session storage</span>
+                  <span class="inline-flex items-center h-6 px-2 rounded text-xs bg-secondary text-foreground/85">PKCE</span>
+                  <span class="inline-flex items-center h-6 px-2 rounded text-xs bg-secondary text-foreground/85">bv_ keys</span>
+                  <span class="inline-flex items-center h-6 px-2 rounded text-xs bg-secondary text-foreground/85">MCP auth</span>
+                  <span class="inline-flex items-center h-6 px-2 rounded text-xs bg-secondary text-foreground/85">password hashing</span>
+                  <span class="inline-flex items-center h-6 px-2 rounded text-xs bg-secondary text-foreground/85">CSRF</span>
+                </div>
+              </section>
+
+              <!-- Recent sessions -->
+              <section>
+                <div class="flex items-baseline justify-between mb-3">
+                  <h3 class="text-[10px] uppercase tracking-wider text-muted-foreground">Recent sessions</h3>
+                  <a href="#" class="text-[10px] text-muted-foreground hover:text-foreground transition-colors">All</a>
+                </div>
+                <ul class="space-y-1">
+                  <li>
+                    <a href="session-detail.html" class="flex items-center gap-2 px-2 py-2 -mx-2 rounded hover:bg-secondary/40 transition-colors">
+                      <i data-lucide="loader-2" class="spin-slow h-3 w-3 text-status-running shrink-0"></i>
+                      <span class="text-xs flex-1 truncate">running OAuth flow integration</span>
+                      <span class="text-[10px] text-muted-foreground tabular-nums">2m</span>
+                    </a>
+                  </li>
+                  <li>
+                    <a href="#" class="flex items-center gap-2 px-2 py-2 -mx-2 rounded hover:bg-secondary/40 transition-colors">
+                      <i data-lucide="check-circle-2" class="h-3 w-3 text-status-done shrink-0"></i>
+                      <span class="text-xs flex-1 truncate">add MCP session-id round-trip</span>
+                      <span class="text-[10px] text-muted-foreground tabular-nums">2h</span>
+                    </a>
+                  </li>
+                  <li>
+                    <a href="#" class="flex items-center gap-2 px-2 py-2 -mx-2 rounded hover:bg-secondary/40 transition-colors">
+                      <i data-lucide="alert-circle" class="h-3 w-3 text-status-review shrink-0"></i>
+                      <span class="text-xs flex-1 truncate">audit token rotation policy</span>
+                      <span class="text-[10px] text-muted-foreground tabular-nums">1d</span>
+                    </a>
+                  </li>
+                  <li>
+                    <a href="#" class="flex items-center gap-2 px-2 py-2 -mx-2 rounded hover:bg-secondary/40 transition-colors">
+                      <i data-lucide="check-circle-2" class="h-3 w-3 text-status-done shrink-0"></i>
+                      <span class="text-xs flex-1 truncate">migrate password hashing to argon2id</span>
+                      <span class="text-[10px] text-muted-foreground tabular-nums">3d</span>
+                    </a>
+                  </li>
+                </ul>
+              </section>
+
+              <!-- Mesh hint — what this agent ASKS others when it doesn't know -->
+              <section>
+                <div class="flex items-baseline justify-between mb-3">
+                  <h3 class="text-[10px] uppercase tracking-wider text-muted-foreground">When it doesn't know</h3>
+                  <a href="mesh.html" class="text-[10px] text-muted-foreground hover:text-foreground transition-colors">Mesh →</a>
+                </div>
+                <div class="rounded-lg bg-secondary/40 p-3 text-xs leading-relaxed">
+                  <p class="text-muted-foreground">Outgoing asks last 7d:</p>
+                  <ul class="mt-2 space-y-1.5">
+                    <li class="flex items-baseline gap-2">
+                      <i data-lucide="arrow-up-right" class="h-3 w-3 text-muted-foreground shrink-0 self-center"></i>
+                      <span class="font-mono text-foreground">db-agent</span>
+                      <span class="text-muted-foreground flex-1 truncate">— schema for refresh-token storage?</span>
+                      <span class="text-[10px] text-muted-foreground tabular-nums">3</span>
+                    </li>
+                    <li class="flex items-baseline gap-2">
+                      <i data-lucide="arrow-up-right" class="h-3 w-3 text-muted-foreground shrink-0 self-center"></i>
+                      <span class="font-mono text-foreground">team-alpha</span>
+                      <span class="text-muted-foreground flex-1 truncate">— escalate token rotation</span>
+                      <span class="text-[10px] text-muted-foreground tabular-nums">1</span>
+                    </li>
+                  </ul>
+                </div>
+              </section>
+
+            </aside>
+          </div>
+
+          <!-- Quiet footer — full id, parent, identity primitives -->
+          <div class="mt-10 pt-6 border-t border-border text-xs text-muted-foreground flex flex-wrap items-center gap-x-4 gap-y-2">
+            <button class="inline-flex items-center gap-1.5 hover:text-foreground transition-colors">
+              <i data-lucide="hash" class="h-3 w-3"></i>
+              <span class="font-mono">ag_4f8a2c91b7</span>
+              <i data-lucide="copy" class="h-3 w-3"></i>
+            </button>
+            <span class="text-border">·</span>
+            <span>created Apr 8, 2026</span>
+            <span class="text-border">·</span>
+            <span>parent <a href="#" class="text-foreground/70 hover:text-foreground font-mono">team-alpha</a></span>
+            <span class="text-border">·</span>
+            <span>runtime <span class="font-mono">claude-opus-4-7</span></span>
+            <span class="text-border">·</span>
+            <span>review policy <span class="font-mono">require_human</span></span>
+          </div>
+
+        </div>
+      </div>
+    </main>
+  </div>
+
+  <script>
+    lucide.createIcons();
+    document.getElementById('theme-toggle').addEventListener('click', () => {
+      document.documentElement.classList.toggle('dark');
+      lucide.createIcons();
+    });
+  </script>
+</body>
+</html>

--- a/mocks/agents-list.html
+++ b/mocks/agents-list.html
@@ -1,0 +1,453 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>beevibe — agents org chart mock</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+  <script>
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.classList.add('dark');
+    }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+  <style>
+    :root {
+      --background: 0 0% 100%;
+      --foreground: 240 10% 4%;
+      --card: 240 5% 98%;
+      --card-foreground: 240 10% 4%;
+      --primary: 48 96% 53%;
+      --primary-foreground: 240 10% 4%;
+      --secondary: 240 5% 96%;
+      --secondary-foreground: 240 6% 10%;
+      --muted: 240 5% 96%;
+      --muted-foreground: 240 4% 46%;
+      --border: 240 6% 90%;
+      --input: 240 6% 90%;
+      --ring: 47 96% 47%;
+      --radius: 0.375rem;
+
+      --status-pending:   240 4% 46%;
+      --status-running:   217 91% 60%;
+      --status-review:    38 92% 50%;
+      --status-blocked:   25 95% 53%;
+      --status-done:      160 84% 39%;
+      --status-failed:    0 84% 60%;
+
+      --hier-ic:   240 4% 46%;
+      --hier-team: 262 83% 58%;
+      --hier-org:  38 92% 50%;
+    }
+    .dark {
+      --background: 240 10% 4%;
+      --foreground: 0 0% 98%;
+      --card: 240 6% 10%;
+      --card-foreground: 0 0% 98%;
+      --primary: 48 96% 53%;
+      --primary-foreground: 240 10% 4%;
+      --secondary: 240 4% 16%;
+      --secondary-foreground: 0 0% 98%;
+      --muted: 240 4% 16%;
+      --muted-foreground: 240 5% 65%;
+      --border: 240 4% 16%;
+      --input: 240 4% 16%;
+      --ring: 48 96% 53%;
+    }
+
+    body {
+      font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
+      font-feature-settings: 'cv11', 'ss01';
+      background-color: hsl(var(--background));
+      color: hsl(var(--foreground));
+      -webkit-font-smoothing: antialiased;
+    }
+    .font-mono { font-family: 'JetBrains Mono', ui-monospace, 'Menlo', monospace; }
+
+    @keyframes pulse-breathe {
+      0%, 100% { opacity: 1; transform: scale(1); }
+      50%      { opacity: 0.55; transform: scale(0.92); }
+    }
+    .pulse-dot { animation: pulse-breathe 2s ease-in-out infinite; }
+
+    @keyframes spin-slow { to { transform: rotate(360deg); } }
+    .spin-slow { animation: spin-slow 2.5s linear infinite; }
+
+    @media (prefers-reduced-motion: reduce) {
+      .pulse-dot, .spin-slow { animation: none; }
+    }
+
+    button:focus-visible, a:focus-visible {
+      outline: 2px solid hsl(var(--ring));
+      outline-offset: 2px;
+      border-radius: var(--radius);
+    }
+
+    /* Org chart canvas — fixed size, scrollable horizontally if narrow viewport. */
+    .chart-canvas {
+      position: relative;
+      width: 1016px;
+      height: 580px;
+      margin: 0 auto;
+    }
+
+    /* Agent cards positioned absolutely. Multica/Paperclip layout: 200×100 boxes. */
+    .agent-card {
+      position: absolute;
+      width: 200px;
+      height: 100px;
+      background: hsl(var(--card));
+      border: 1px solid hsl(var(--border));
+      border-radius: calc(var(--radius) + 2px);
+      box-shadow: 0 1px 2px rgb(0 0 0 / 0.04);
+      transition: border-color 150ms ease-out, box-shadow 150ms ease-out, transform 150ms ease-out;
+      overflow: hidden;
+    }
+    .agent-card:hover {
+      border-color: hsl(var(--ring));
+      box-shadow: 0 4px 12px -2px rgb(0 0 0 / 0.10);
+      transform: translateY(-1px);
+    }
+
+    /* Status indicator dot on avatar. */
+    .avatar-dot {
+      position: absolute;
+      bottom: -2px;
+      right: -2px;
+      width: 12px;
+      height: 12px;
+      border-radius: 9999px;
+      border: 2px solid hsl(var(--card));
+    }
+  </style>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+            mono: ['JetBrains Mono', 'ui-monospace', 'Menlo', 'monospace'],
+          },
+          colors: {
+            border: 'hsl(var(--border))',
+            input: 'hsl(var(--input))',
+            ring: 'hsl(var(--ring))',
+            background: 'hsl(var(--background))',
+            foreground: 'hsl(var(--foreground))',
+            primary: { DEFAULT: 'hsl(var(--primary))', foreground: 'hsl(var(--primary-foreground))' },
+            secondary: { DEFAULT: 'hsl(var(--secondary))', foreground: 'hsl(var(--secondary-foreground))' },
+            muted: { DEFAULT: 'hsl(var(--muted))', foreground: 'hsl(var(--muted-foreground))' },
+            card: { DEFAULT: 'hsl(var(--card))', foreground: 'hsl(var(--card-foreground))' },
+            status: {
+              pending:   'hsl(var(--status-pending))',
+              running:   'hsl(var(--status-running))',
+              review:    'hsl(var(--status-review))',
+              blocked:   'hsl(var(--status-blocked))',
+              done:      'hsl(var(--status-done))',
+              failed:    'hsl(var(--status-failed))',
+            },
+            hier: {
+              ic:   'hsl(var(--hier-ic))',
+              team: 'hsl(var(--hier-team))',
+              org:  'hsl(var(--hier-org))',
+            },
+          },
+          borderRadius: {
+            DEFAULT: 'var(--radius)',
+            md: 'var(--radius)',
+            lg: 'calc(var(--radius) + 2px)',
+            xl: 'calc(var(--radius) + 6px)',
+          },
+        },
+      },
+    };
+  </script>
+</head>
+<body class="min-h-screen">
+  <div class="flex min-h-screen">
+
+    <!-- Sidebar (Agents active) -->
+    <aside class="w-[220px] shrink-0 bg-card flex flex-col">
+      <div class="h-14 flex items-center gap-2.5 px-4">
+        <div class="h-6 w-6 rounded bg-primary flex items-center justify-center">
+          <span class="text-primary-foreground text-sm font-bold leading-none">b</span>
+        </div>
+        <span class="font-semibold tracking-tight">beevibe</span>
+      </div>
+      <nav class="flex-1 p-2 space-y-0.5 text-sm">
+        <a href="#" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="home" class="h-4 w-4"></i>
+          <span>Home</span>
+        </a>
+        <a href="tasks-list.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="list-checks" class="h-4 w-4"></i>
+          <span>Tasks</span>
+        </a>
+        <a href="#" class="flex items-center gap-3 px-3 py-2 rounded bg-secondary text-foreground font-medium">
+          <i data-lucide="circle-dot" class="h-4 w-4"></i>
+          <span>Agents</span>
+        </a>
+        <a href="threads.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="message-square" class="h-4 w-4"></i>
+          <span>Threads</span>
+        </a>
+        <a href="memory.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="sparkles" class="h-4 w-4"></i>
+          <span>Memory</span>
+        </a>
+      </nav>
+
+      <div class="p-3">
+        <div class="flex items-center gap-1">
+          <button class="flex-1 min-w-0 flex items-center gap-2 px-2 py-1.5 rounded hover:bg-secondary cursor-pointer transition-colors text-left">
+            <div class="h-7 w-7 rounded-full bg-secondary border border-border flex items-center justify-center text-xs font-medium shrink-0">W</div>
+            <div class="flex-1 min-w-0">
+              <div class="text-sm font-medium truncate leading-tight">Weijia</div>
+              <div class="text-[10px] text-muted-foreground flex items-center gap-1 leading-tight mt-0.5">
+                <span class="pulse-dot inline-block h-1 w-1 rounded-full bg-status-running"></span>
+                live
+              </div>
+            </div>
+            <i data-lucide="chevrons-up-down" class="h-3.5 w-3.5 text-muted-foreground shrink-0"></i>
+          </button>
+          <button id="theme-toggle" class="h-8 w-8 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary cursor-pointer transition-colors shrink-0" title="Toggle theme">
+            <i data-lucide="sun" class="h-4 w-4 hidden dark:block"></i>
+            <i data-lucide="moon" class="h-4 w-4 block dark:hidden"></i>
+          </button>
+        </div>
+      </div>
+    </aside>
+
+    <!-- Main -->
+    <main class="flex-1 min-w-0 flex flex-col">
+      <div class="flex-1 overflow-auto">
+        <div class="pt-8 pb-12 px-6">
+
+          <!-- Lead line + new agent CTA -->
+          <div class="max-w-5xl mx-auto flex items-end justify-between gap-6 mb-8">
+            <div class="text-base text-muted-foreground">
+              <span class="text-foreground font-medium">7 agents</span> in your org
+              — <span class="text-hier-ic font-medium">4 ic</span>, <span class="text-hier-team font-medium">2 team</span>, <span class="text-hier-org font-medium">1 org</span>.
+              <span class="text-foreground">4 active</span> right now.
+            </div>
+            <button class="inline-flex items-center gap-2 h-8 px-3 rounded bg-primary text-primary-foreground text-xs font-medium hover:opacity-90 active:scale-[0.98] transition-all duration-150 cursor-pointer shrink-0">
+              <i data-lucide="plus" class="h-3.5 w-3.5"></i>
+              New agent
+            </button>
+          </div>
+
+          <!-- Org chart canvas. Layout positions computed offline:
+               root-org: (408, 60) · team-alpha: (292, 240) · team-data: (756, 240)
+               ic-agent-1: (60, 420) · ic-agent-2: (292, 420) · ic-agent-3: (524, 420) · db-agent: (756, 420)
+               Cards 200×100, gap_x 32, gap_y 80, padding 60. -->
+          <div class="overflow-x-auto -mx-6 px-6">
+            <div class="chart-canvas">
+
+              <!-- SVG edge layer (behind cards) -->
+              <svg class="absolute inset-0 w-full h-full pointer-events-none" viewBox="0 0 1016 580" preserveAspectRatio="xMidYMid meet">
+                <!-- root-org → team-alpha   (508,160) → (392,240), midY=200 -->
+                <path d="M 508 160 L 508 200 L 392 200 L 392 240" fill="none" stroke="hsl(var(--border))" stroke-width="1.5" />
+                <!-- root-org → team-data    (508,160) → (856,240), midY=200 -->
+                <path d="M 508 160 L 508 200 L 856 200 L 856 240" fill="none" stroke="hsl(var(--border))" stroke-width="1.5" />
+                <!-- team-alpha → ic-agent-1 (392,340) → (160,420), midY=380 -->
+                <path d="M 392 340 L 392 380 L 160 380 L 160 420" fill="none" stroke="hsl(var(--border))" stroke-width="1.5" />
+                <!-- team-alpha → ic-agent-2 (392,340) → (392,420), straight vertical -->
+                <path d="M 392 340 L 392 420" fill="none" stroke="hsl(var(--border))" stroke-width="1.5" />
+                <!-- team-alpha → ic-agent-3 (392,340) → (624,420), midY=380 -->
+                <path d="M 392 340 L 392 380 L 624 380 L 624 420" fill="none" stroke="hsl(var(--border))" stroke-width="1.5" />
+                <!-- team-data → db-agent    (856,340) → (856,420), straight vertical -->
+                <path d="M 856 340 L 856 420" fill="none" stroke="hsl(var(--border))" stroke-width="1.5" />
+              </svg>
+
+              <!-- ── ROOT-ORG card at (408, 60) ── -->
+              <a href="#" class="agent-card cursor-pointer block" style="left: 408px; top: 60px;">
+                <div class="flex items-start gap-3 p-3.5">
+                  <div class="relative shrink-0">
+                    <div class="h-9 w-9 rounded-full bg-hier-org/10 flex items-center justify-center text-hier-org text-sm font-semibold">
+                      <i data-lucide="building-2" class="h-4 w-4"></i>
+                    </div>
+                    <span class="avatar-dot bg-status-pending"></span>
+                  </div>
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-center justify-between gap-1.5">
+                      <span class="font-mono font-medium text-sm truncate">root-org</span>
+                      <span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium border border-hier-org text-hier-org shrink-0">org</span>
+                    </div>
+                    <div class="text-xs text-muted-foreground mt-0.5">2 children · idle</div>
+                    <div class="text-[10px] text-muted-foreground mt-2">last active 5d ago</div>
+                  </div>
+                </div>
+              </a>
+
+              <!-- ── TEAM-ALPHA card at (292, 240) ── -->
+              <a href="#" class="agent-card cursor-pointer block" style="left: 292px; top: 240px;">
+                <div class="flex items-start gap-3 p-3.5">
+                  <div class="relative shrink-0">
+                    <div class="h-9 w-9 rounded-full bg-hier-team/10 flex items-center justify-center text-hier-team text-sm font-semibold">
+                      <i data-lucide="users" class="h-4 w-4"></i>
+                    </div>
+                    <span class="avatar-dot bg-status-running"></span>
+                  </div>
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-center justify-between gap-1.5">
+                      <span class="font-mono font-medium text-sm truncate">team-alpha</span>
+                      <span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium bg-hier-team/10 text-hier-team shrink-0">team</span>
+                    </div>
+                    <div class="text-xs text-muted-foreground mt-0.5">3 children</div>
+                    <div class="flex items-center gap-3 text-xs mt-2">
+                      <span class="text-status-running inline-flex items-center gap-1">
+                        <i data-lucide="loader-2" class="spin-slow h-3 w-3"></i>1
+                      </span>
+                      <span class="text-[10px] text-muted-foreground ml-auto">7h ago</span>
+                    </div>
+                  </div>
+                </div>
+              </a>
+
+              <!-- ── TEAM-DATA card at (756, 240) ── -->
+              <a href="#" class="agent-card cursor-pointer block" style="left: 756px; top: 240px;">
+                <div class="flex items-start gap-3 p-3.5">
+                  <div class="relative shrink-0">
+                    <div class="h-9 w-9 rounded-full bg-hier-team/10 flex items-center justify-center text-hier-team text-sm font-semibold">
+                      <i data-lucide="users" class="h-4 w-4"></i>
+                    </div>
+                    <span class="avatar-dot bg-status-pending"></span>
+                  </div>
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-center justify-between gap-1.5">
+                      <span class="font-mono font-medium text-sm truncate">team-data</span>
+                      <span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium bg-hier-team/10 text-hier-team shrink-0">team</span>
+                    </div>
+                    <div class="text-xs text-muted-foreground mt-0.5">1 child · idle</div>
+                    <div class="text-[10px] text-muted-foreground mt-2">last active 1d ago</div>
+                  </div>
+                </div>
+              </a>
+
+              <!-- ── IC-AGENT-1 at (60, 420) ── -->
+              <a href="#" class="agent-card cursor-pointer block" style="left: 60px; top: 420px;">
+                <div class="flex items-start gap-3 p-3.5">
+                  <div class="relative shrink-0">
+                    <div class="h-9 w-9 rounded-full bg-hier-ic/10 flex items-center justify-center text-hier-ic text-sm font-semibold">1</div>
+                    <span class="avatar-dot bg-status-running"></span>
+                  </div>
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-center justify-between gap-1.5">
+                      <span class="font-mono font-medium text-sm truncate">ic-agent-1</span>
+                      <span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic shrink-0">ic</span>
+                    </div>
+                    <div class="text-xs text-muted-foreground mt-0.5 truncate">running OAuth flow</div>
+                    <div class="flex items-center gap-3 text-xs mt-2">
+                      <span class="text-status-running inline-flex items-center gap-1">
+                        <i data-lucide="loader-2" class="spin-slow h-3 w-3"></i>1
+                      </span>
+                      <span class="text-status-review inline-flex items-center gap-1">
+                        <i data-lucide="alert-circle" class="h-3 w-3"></i>3
+                      </span>
+                      <span class="text-[10px] text-muted-foreground ml-auto">2m</span>
+                    </div>
+                  </div>
+                </div>
+              </a>
+
+              <!-- ── IC-AGENT-2 at (292, 420) ── -->
+              <a href="#" class="agent-card cursor-pointer block" style="left: 292px; top: 420px;">
+                <div class="flex items-start gap-3 p-3.5">
+                  <div class="relative shrink-0">
+                    <div class="h-9 w-9 rounded-full bg-hier-ic/10 flex items-center justify-center text-hier-ic text-sm font-semibold">2</div>
+                    <span class="avatar-dot bg-status-running"></span>
+                  </div>
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-center justify-between gap-1.5">
+                      <span class="font-mono font-medium text-sm truncate">ic-agent-2</span>
+                      <span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic shrink-0">ic</span>
+                    </div>
+                    <div class="text-xs text-muted-foreground mt-0.5 truncate">migrating logging to pino</div>
+                    <div class="flex items-center gap-3 text-xs mt-2">
+                      <span class="text-status-running inline-flex items-center gap-1">
+                        <i data-lucide="loader-2" class="spin-slow h-3 w-3"></i>1
+                      </span>
+                      <span class="text-status-blocked inline-flex items-center gap-1">
+                        <i data-lucide="ban" class="h-3 w-3"></i>1
+                      </span>
+                      <span class="text-[10px] text-muted-foreground ml-auto">30m</span>
+                    </div>
+                  </div>
+                </div>
+              </a>
+
+              <!-- ── IC-AGENT-3 at (524, 420) ── -->
+              <a href="#" class="agent-card cursor-pointer block" style="left: 524px; top: 420px;">
+                <div class="flex items-start gap-3 p-3.5">
+                  <div class="relative shrink-0">
+                    <div class="h-9 w-9 rounded-full bg-hier-ic/10 flex items-center justify-center text-hier-ic text-sm font-semibold">3</div>
+                    <span class="avatar-dot bg-status-running"></span>
+                  </div>
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-center justify-between gap-1.5">
+                      <span class="font-mono font-medium text-sm truncate">ic-agent-3</span>
+                      <span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic shrink-0">ic</span>
+                    </div>
+                    <div class="text-xs text-muted-foreground mt-0.5 truncate">refactoring task repo</div>
+                    <div class="flex items-center gap-3 text-xs mt-2">
+                      <span class="text-status-running inline-flex items-center gap-1">
+                        <i data-lucide="loader-2" class="spin-slow h-3 w-3"></i>1
+                      </span>
+                      <span class="text-[10px] text-muted-foreground ml-auto">4m</span>
+                    </div>
+                  </div>
+                </div>
+              </a>
+
+              <!-- ── DB-AGENT at (756, 420) ── -->
+              <a href="#" class="agent-card cursor-pointer block" style="left: 756px; top: 420px;">
+                <div class="flex items-start gap-3 p-3.5">
+                  <div class="relative shrink-0">
+                    <div class="h-9 w-9 rounded-full bg-hier-ic/10 flex items-center justify-center text-hier-ic text-sm font-semibold">
+                      <i data-lucide="database" class="h-4 w-4"></i>
+                    </div>
+                    <span class="avatar-dot bg-status-review"></span>
+                  </div>
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-center justify-between gap-1.5">
+                      <span class="font-mono font-medium text-sm truncate">db-agent</span>
+                      <span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic shrink-0">ic</span>
+                    </div>
+                    <div class="text-xs text-muted-foreground mt-0.5 truncate">2 tasks awaiting review</div>
+                    <div class="flex items-center gap-3 text-xs mt-2">
+                      <span class="text-status-review inline-flex items-center gap-1">
+                        <i data-lucide="alert-circle" class="h-3 w-3"></i>2
+                      </span>
+                      <span class="text-[10px] text-muted-foreground ml-auto">11h</span>
+                    </div>
+                  </div>
+                </div>
+              </a>
+
+            </div>
+          </div>
+
+          <!-- Foot note -->
+          <div class="max-w-5xl mx-auto mt-8 text-xs text-muted-foreground flex items-center gap-3">
+            <span class="font-mono">mock</span>
+            <span class="text-border">·</span>
+            <span>SVG orthogonal connectors + absolute-positioned cards (Multica/Paperclip pattern). Layout positions precomputed; in real app a layout function recomputes on agent add/remove. Status dot on avatar indicates current activity.</span>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+
+  <script>
+    lucide.createIcons();
+    document.getElementById('theme-toggle').addEventListener('click', () => {
+      document.documentElement.classList.toggle('dark');
+      lucide.createIcons();
+    });
+  </script>
+</body>
+</html>

--- a/mocks/agents-list.html
+++ b/mocks/agents-list.html
@@ -431,6 +431,121 @@
             </div>
           </div>
 
+          <!-- Specialization depth panel — proves the org chart isn't just structural.
+               Each agent's accumulation is observable. mem0 / Multica / Mastra dashboards have no equivalent. -->
+          <div class="max-w-5xl mx-auto mt-10">
+            <div class="flex items-baseline justify-between mb-3">
+              <h2 class="text-[10px] uppercase tracking-wider text-muted-foreground">Specialization depth · per agent</h2>
+              <a href="memory.html" class="text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1">
+                Browse all facts <i data-lucide="arrow-right" class="h-3 w-3"></i>
+              </a>
+            </div>
+            <div class="rounded-lg border border-border bg-card overflow-hidden">
+              <table class="w-full text-sm">
+                <colgroup>
+                  <col />
+                  <col style="width: 80px" />
+                  <col style="width: 100px" />
+                  <col style="width: 100px" />
+                  <col style="width: 100px" />
+                  <col style="width: 60px" />
+                </colgroup>
+                <thead>
+                  <tr class="bg-secondary/40 text-[10px] uppercase tracking-wider text-muted-foreground">
+                    <th class="text-left px-4 py-2 font-medium">Agent</th>
+                    <th class="text-left px-3 py-2 font-medium">Tier</th>
+                    <th class="text-right px-3 py-2 font-medium">Sessions</th>
+                    <th class="text-right px-3 py-2 font-medium">Facts</th>
+                    <th class="text-right px-3 py-2 font-medium">Merges</th>
+                    <th class="text-right px-3 py-2 font-medium"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr class="border-t border-border hover:bg-secondary/30 transition-colors">
+                    <td class="px-4 py-2.5">
+                      <a href="agent-detail.html" class="font-mono text-foreground hover:underline">ic-agent-1</a>
+                      <span class="text-xs text-muted-foreground ml-2">auth · OAuth</span>
+                    </td>
+                    <td class="px-3 py-2.5"><span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic">ic</span></td>
+                    <td class="px-3 py-2.5 text-right tabular-nums">47</td>
+                    <td class="px-3 py-2.5 text-right tabular-nums">23</td>
+                    <td class="px-3 py-2.5 text-right tabular-nums">8</td>
+                    <td class="px-3 py-2.5 text-right text-[10px] text-status-done">+3 this wk</td>
+                  </tr>
+                  <tr class="border-t border-border hover:bg-secondary/30 transition-colors">
+                    <td class="px-4 py-2.5">
+                      <a href="#" class="font-mono text-foreground hover:underline">ic-agent-2</a>
+                      <span class="text-xs text-muted-foreground ml-2">infra · logging</span>
+                    </td>
+                    <td class="px-3 py-2.5"><span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic">ic</span></td>
+                    <td class="px-3 py-2.5 text-right tabular-nums">31</td>
+                    <td class="px-3 py-2.5 text-right tabular-nums">14</td>
+                    <td class="px-3 py-2.5 text-right tabular-nums">4</td>
+                    <td class="px-3 py-2.5 text-right text-[10px] text-muted-foreground">+1</td>
+                  </tr>
+                  <tr class="border-t border-border hover:bg-secondary/30 transition-colors">
+                    <td class="px-4 py-2.5">
+                      <a href="#" class="font-mono text-foreground hover:underline">ic-agent-3</a>
+                      <span class="text-xs text-muted-foreground ml-2">infra · refactor</span>
+                    </td>
+                    <td class="px-3 py-2.5"><span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic">ic</span></td>
+                    <td class="px-3 py-2.5 text-right tabular-nums">23</td>
+                    <td class="px-3 py-2.5 text-right tabular-nums">11</td>
+                    <td class="px-3 py-2.5 text-right tabular-nums">2</td>
+                    <td class="px-3 py-2.5 text-right text-[10px] text-status-done">+2</td>
+                  </tr>
+                  <tr class="border-t border-border hover:bg-secondary/30 transition-colors">
+                    <td class="px-4 py-2.5">
+                      <a href="#" class="font-mono text-foreground hover:underline">db-agent</a>
+                      <span class="text-xs text-muted-foreground ml-2">data · migrations</span>
+                    </td>
+                    <td class="px-3 py-2.5"><span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic">ic</span></td>
+                    <td class="px-3 py-2.5 text-right tabular-nums">19</td>
+                    <td class="px-3 py-2.5 text-right tabular-nums">17</td>
+                    <td class="px-3 py-2.5 text-right tabular-nums">5</td>
+                    <td class="px-3 py-2.5 text-right text-[10px] text-muted-foreground">—</td>
+                  </tr>
+                  <tr class="border-t border-border hover:bg-secondary/30 transition-colors">
+                    <td class="px-4 py-2.5">
+                      <a href="#" class="font-mono text-foreground hover:underline">team-alpha</a>
+                      <span class="text-xs text-muted-foreground ml-2">coordinator</span>
+                    </td>
+                    <td class="px-3 py-2.5"><span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium bg-hier-team/10 text-hier-team">team</span></td>
+                    <td class="px-3 py-2.5 text-right tabular-nums">8</td>
+                    <td class="px-3 py-2.5 text-right tabular-nums">9</td>
+                    <td class="px-3 py-2.5 text-right tabular-nums">2</td>
+                    <td class="px-3 py-2.5 text-right text-[10px] text-muted-foreground">+1</td>
+                  </tr>
+                  <tr class="border-t border-border hover:bg-secondary/30 transition-colors">
+                    <td class="px-4 py-2.5">
+                      <a href="#" class="font-mono text-foreground hover:underline">team-data</a>
+                      <span class="text-xs text-muted-foreground ml-2">coordinator</span>
+                    </td>
+                    <td class="px-3 py-2.5"><span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium bg-hier-team/10 text-hier-team">team</span></td>
+                    <td class="px-3 py-2.5 text-right tabular-nums">4</td>
+                    <td class="px-3 py-2.5 text-right tabular-nums">3</td>
+                    <td class="px-3 py-2.5 text-right tabular-nums">0</td>
+                    <td class="px-3 py-2.5 text-right text-[10px] text-muted-foreground">—</td>
+                  </tr>
+                  <tr class="border-t border-border hover:bg-secondary/30 transition-colors">
+                    <td class="px-4 py-2.5">
+                      <a href="#" class="font-mono text-foreground hover:underline">root-org</a>
+                      <span class="text-xs text-muted-foreground ml-2">strategy</span>
+                    </td>
+                    <td class="px-3 py-2.5"><span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium border border-hier-org text-hier-org">org</span></td>
+                    <td class="px-3 py-2.5 text-right tabular-nums">2</td>
+                    <td class="px-3 py-2.5 text-right tabular-nums">4</td>
+                    <td class="px-3 py-2.5 text-right tabular-nums">1</td>
+                    <td class="px-3 py-2.5 text-right text-[10px] text-muted-foreground">—</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <p class="mt-2.5 text-[10px] text-muted-foreground">
+              Each agent's depth is bounded — no agent's facts dilute another's. Promoted facts (visible to wider scopes) preserve their originating agent_id. <a href="promotions.html" class="text-foreground/70 hover:text-foreground hover:underline transition-colors">14 promotions in last 30d →</a>
+            </p>
+          </div>
+
           <!-- Foot note -->
           <div class="max-w-5xl mx-auto mt-8 text-xs text-muted-foreground flex items-center gap-3">
             <span class="font-mono">mock</span>

--- a/mocks/home.html
+++ b/mocks/home.html
@@ -1,0 +1,448 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>beevibe — home / fleet stats</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+  <script>
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.classList.add('dark');
+    }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+  <style>
+    :root {
+      --background: 0 0% 100%;
+      --foreground: 240 10% 4%;
+      --card: 240 5% 98%;
+      --card-foreground: 240 10% 4%;
+      --primary: 48 96% 53%;
+      --primary-foreground: 240 10% 4%;
+      --secondary: 240 5% 96%;
+      --secondary-foreground: 240 6% 10%;
+      --muted: 240 5% 96%;
+      --muted-foreground: 240 4% 46%;
+      --border: 240 6% 90%;
+      --input: 240 6% 90%;
+      --ring: 47 96% 47%;
+      --radius: 0.375rem;
+
+      --status-pending:   240 4% 46%;
+      --status-running:   217 91% 60%;
+      --status-review:    38 92% 50%;
+      --status-blocked:   25 95% 53%;
+      --status-done:      160 84% 39%;
+      --status-failed:    0 84% 60%;
+
+      --hier-ic:   240 4% 46%;
+      --hier-team: 262 83% 58%;
+      --hier-org:  38 92% 50%;
+    }
+    .dark {
+      --background: 240 10% 4%;
+      --foreground: 0 0% 98%;
+      --card: 240 6% 10%;
+      --card-foreground: 0 0% 98%;
+      --primary: 48 96% 53%;
+      --primary-foreground: 240 10% 4%;
+      --secondary: 240 4% 16%;
+      --secondary-foreground: 0 0% 98%;
+      --muted: 240 4% 16%;
+      --muted-foreground: 240 5% 65%;
+      --border: 240 4% 16%;
+      --input: 240 4% 16%;
+      --ring: 48 96% 53%;
+    }
+
+    body {
+      font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
+      font-feature-settings: 'cv11', 'ss01';
+      background-color: hsl(var(--background));
+      color: hsl(var(--foreground));
+      -webkit-font-smoothing: antialiased;
+    }
+    .font-mono { font-family: 'JetBrains Mono', ui-monospace, 'Menlo', monospace; }
+
+    @keyframes pulse-breathe {
+      0%, 100% { opacity: 1; transform: scale(1); }
+      50%      { opacity: 0.55; transform: scale(0.92); }
+    }
+    .pulse-dot { animation: pulse-breathe 2s ease-in-out infinite; }
+
+    @media (prefers-reduced-motion: reduce) {
+      .pulse-dot { animation: none; }
+    }
+
+    button:focus-visible, a:focus-visible {
+      outline: 2px solid hsl(var(--ring));
+      outline-offset: 2px;
+      border-radius: var(--radius);
+    }
+  </style>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+            mono: ['JetBrains Mono', 'ui-monospace', 'Menlo', 'monospace'],
+          },
+          colors: {
+            border: 'hsl(var(--border))',
+            input: 'hsl(var(--input))',
+            ring: 'hsl(var(--ring))',
+            background: 'hsl(var(--background))',
+            foreground: 'hsl(var(--foreground))',
+            primary: { DEFAULT: 'hsl(var(--primary))', foreground: 'hsl(var(--primary-foreground))' },
+            secondary: { DEFAULT: 'hsl(var(--secondary))', foreground: 'hsl(var(--secondary-foreground))' },
+            muted: { DEFAULT: 'hsl(var(--muted))', foreground: 'hsl(var(--muted-foreground))' },
+            card: { DEFAULT: 'hsl(var(--card))', foreground: 'hsl(var(--card-foreground))' },
+            status: {
+              pending:   'hsl(var(--status-pending))',
+              running:   'hsl(var(--status-running))',
+              review:    'hsl(var(--status-review))',
+              blocked:   'hsl(var(--status-blocked))',
+              done:      'hsl(var(--status-done))',
+              failed:    'hsl(var(--status-failed))',
+            },
+            hier: {
+              ic:   'hsl(var(--hier-ic))',
+              team: 'hsl(var(--hier-team))',
+              org:  'hsl(var(--hier-org))',
+            },
+          },
+          borderRadius: {
+            DEFAULT: 'var(--radius)',
+            md: 'var(--radius)',
+            lg: 'calc(var(--radius) + 2px)',
+            xl: 'calc(var(--radius) + 6px)',
+          },
+        },
+      },
+    };
+  </script>
+</head>
+<body class="min-h-screen">
+  <div class="flex min-h-screen">
+
+    <!-- Sidebar (Home active) -->
+    <aside class="w-[220px] shrink-0 bg-card flex flex-col">
+      <div class="h-14 flex items-center gap-2.5 px-4">
+        <div class="h-6 w-6 rounded bg-primary flex items-center justify-center">
+          <span class="text-primary-foreground text-sm font-bold leading-none">b</span>
+        </div>
+        <span class="font-semibold tracking-tight">beevibe</span>
+      </div>
+      <nav class="flex-1 p-2 space-y-0.5 text-sm">
+        <a href="#" class="flex items-center gap-3 px-3 py-2 rounded bg-secondary text-foreground font-medium">
+          <i data-lucide="home" class="h-4 w-4"></i>
+          <span>Home</span>
+        </a>
+        <a href="tasks-list.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="list-checks" class="h-4 w-4"></i>
+          <span>Tasks</span>
+        </a>
+        <a href="agents-list.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="circle-dot" class="h-4 w-4"></i>
+          <span>Agents</span>
+        </a>
+        <a href="threads.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="message-square" class="h-4 w-4"></i>
+          <span>Threads</span>
+        </a>
+        <a href="memory.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="sparkles" class="h-4 w-4"></i>
+          <span>Memory</span>
+        </a>
+      </nav>
+
+      <div class="p-3">
+        <div class="flex items-center gap-1">
+          <button class="flex-1 min-w-0 flex items-center gap-2 px-2 py-1.5 rounded hover:bg-secondary cursor-pointer transition-colors text-left">
+            <div class="h-7 w-7 rounded-full bg-secondary border border-border flex items-center justify-center text-xs font-medium shrink-0">W</div>
+            <div class="flex-1 min-w-0">
+              <div class="text-sm font-medium truncate leading-tight">Weijia</div>
+              <div class="text-[10px] text-muted-foreground flex items-center gap-1 leading-tight mt-0.5">
+                <span class="pulse-dot inline-block h-1 w-1 rounded-full" style="background: hsl(217 91% 60%);"></span>
+                live
+              </div>
+            </div>
+            <i data-lucide="chevrons-up-down" class="h-3.5 w-3.5 text-muted-foreground shrink-0"></i>
+          </button>
+          <button id="theme-toggle" class="h-8 w-8 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary cursor-pointer transition-colors shrink-0" title="Toggle theme">
+            <i data-lucide="sun" class="h-4 w-4 hidden dark:block"></i>
+            <i data-lucide="moon" class="h-4 w-4 block dark:hidden"></i>
+          </button>
+        </div>
+      </div>
+    </aside>
+
+    <!-- Main — LIST density (max-w-6xl, pt-8) -->
+    <main class="flex-1 min-w-0 flex flex-col">
+      <div class="flex-1 overflow-auto">
+        <div class="max-w-6xl mx-auto pt-8 pb-12 px-6">
+
+          <!-- Lead line — date + fleet health -->
+          <div class="mb-10 text-sm text-muted-foreground flex items-center gap-3">
+            <span class="text-foreground font-medium">Sunday, April 26</span>
+            <span class="text-border">·</span>
+            <span class="inline-flex items-center gap-1.5">
+              <span class="h-1.5 w-1.5 rounded-full bg-status-done"></span>
+              fleet healthy
+            </span>
+            <span class="text-border">·</span>
+            <span>last activity <span class="text-foreground tabular-nums">30s ago</span></span>
+          </div>
+
+          <!-- KPI ROW — 4 columns. Typography-only, no borders, no boxes. -->
+          <div class="grid grid-cols-4 gap-x-10 mb-14">
+
+            <!-- Active sessions -->
+            <a href="threads.html" class="group block">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-1.5">Active sessions</div>
+              <div class="flex items-baseline gap-2">
+                <span class="pulse-dot inline-block h-2 w-2 rounded-full bg-status-running self-center"></span>
+                <span class="text-3xl font-semibold tabular-nums leading-none">3</span>
+                <span class="text-sm text-muted-foreground">running</span>
+              </div>
+              <div class="mt-2 text-xs text-muted-foreground">
+                4m oldest · 18m avg
+              </div>
+              <!-- mini sparkline: concurrent sessions over last 24h -->
+              <svg viewBox="0 0 120 24" class="mt-2 w-full h-6 text-status-running">
+                <path d="M0 20 L10 18 L20 18 L30 14 L40 14 L50 10 L60 10 L70 12 L80 8 L90 6 L100 4 L110 4 L120 6"
+                      fill="none" stroke="currentColor" stroke-width="1.5" />
+                <circle cx="120" cy="6" r="2" fill="currentColor" />
+              </svg>
+            </a>
+
+            <!-- Awaiting review -->
+            <a href="tasks-list.html" class="group block">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-1.5">Awaiting your review</div>
+              <div class="flex items-baseline gap-2">
+                <span class="text-3xl font-semibold tabular-nums leading-none text-status-review">7</span>
+                <span class="text-sm text-muted-foreground">tasks</span>
+              </div>
+              <div class="mt-2 text-xs text-muted-foreground">
+                oldest 1d · <span class="text-status-review">3 high priority</span>
+              </div>
+              <svg viewBox="0 0 120 24" class="mt-2 w-full h-6 text-status-review">
+                <path d="M0 20 L10 18 L20 16 L30 14 L40 16 L50 12 L60 10 L70 8 L80 8 L90 6 L100 6 L110 4 L120 4"
+                      fill="none" stroke="currentColor" stroke-width="1.5" />
+                <circle cx="120" cy="4" r="2" fill="currentColor" />
+              </svg>
+            </a>
+
+            <!-- Today's spend -->
+            <a href="#" class="group block">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-1.5">Today's spend</div>
+              <div class="flex items-baseline gap-2">
+                <span class="text-3xl font-semibold tabular-nums leading-none">$4.21</span>
+              </div>
+              <div class="mt-2 text-xs text-muted-foreground">
+                <span class="text-status-failed">+$0.42</span> vs yesterday
+              </div>
+              <svg viewBox="0 0 120 24" class="mt-2 w-full h-6" style="color: hsl(var(--primary));">
+                <path d="M0 20 L10 18 L20 16 L30 16 L40 14 L50 12 L60 10 L70 10 L80 8 L90 6 L100 6 L110 4 L120 4"
+                      fill="none" stroke="currentColor" stroke-width="1.5" />
+                <circle cx="120" cy="4" r="2" fill="currentColor" />
+              </svg>
+            </a>
+
+            <!-- Completed today -->
+            <a href="tasks-list.html" class="group block">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-1.5">Completed today</div>
+              <div class="flex items-baseline gap-2">
+                <span class="text-3xl font-semibold tabular-nums leading-none text-status-done">12</span>
+                <span class="text-sm text-muted-foreground">tasks</span>
+              </div>
+              <div class="mt-2 text-xs text-muted-foreground">
+                <span class="text-status-done">+3</span> vs yesterday · 1 failed
+              </div>
+              <!-- bar sparkline: completions per day last 7d -->
+              <svg viewBox="0 0 120 24" class="mt-2 w-full h-6 text-status-done">
+                <rect x="2"   y="14" width="13" height="10" rx="1" fill="currentColor" opacity="0.3" />
+                <rect x="19"  y="10" width="13" height="14" rx="1" fill="currentColor" opacity="0.3" />
+                <rect x="36"  y="6"  width="13" height="18" rx="1" fill="currentColor" opacity="0.4" />
+                <rect x="53"  y="12" width="13" height="12" rx="1" fill="currentColor" opacity="0.3" />
+                <rect x="70"  y="8"  width="13" height="16" rx="1" fill="currentColor" opacity="0.4" />
+                <rect x="87"  y="4"  width="13" height="20" rx="1" fill="currentColor" opacity="0.5" />
+                <rect x="104" y="6"  width="13" height="18" rx="1" fill="currentColor" />
+              </svg>
+            </a>
+          </div>
+
+          <!-- BREAKDOWN ROW — Tasks by status (full-width stacked bar) + Fleet (compact) -->
+          <div class="grid grid-cols-3 gap-x-10 mb-14">
+
+            <!-- Tasks by status — spans 2 cols -->
+            <div class="col-span-2">
+              <div class="flex items-baseline justify-between mb-3">
+                <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Tasks by status</div>
+                <div class="text-xs text-muted-foreground"><span class="text-foreground tabular-nums">47</span> total</div>
+              </div>
+              <!-- Single horizontal stacked bar -->
+              <div class="flex h-2 rounded-full overflow-hidden mb-3">
+                <div class="bg-status-pending"  style="width: 17.0%;" title="pending 8"></div>
+                <div class="bg-status-pending"  style="width: 10.6%; opacity: 0.6" title="assigned 5"></div>
+                <div class="bg-status-running"  style="width: 6.4%;"  title="in_progress 3"></div>
+                <div class="bg-status-running"  style="width: 4.3%; opacity: 0.7" title="revision 2"></div>
+                <div class="bg-status-review"   style="width: 14.9%;" title="review 7"></div>
+                <div class="bg-status-blocked"  style="width: 4.3%;"  title="blocked 2"></div>
+                <div class="bg-status-done"     style="width: 29.8%;" title="done 14"></div>
+                <div class="bg-status-failed"   style="width: 6.4%;"  title="failed 3"></div>
+                <div class="bg-status-pending"  style="width: 6.4%; opacity: 0.4" title="cancelled 3"></div>
+              </div>
+              <!-- Legend — 2 columns -->
+              <div class="grid grid-cols-2 gap-x-6 gap-y-1.5 text-xs">
+                <div class="flex items-center gap-2"><span class="h-1.5 w-1.5 rounded-full bg-status-review"></span><span class="text-muted-foreground flex-1">Review</span><span class="font-mono tabular-nums">7</span></div>
+                <div class="flex items-center gap-2"><span class="h-1.5 w-1.5 rounded-full bg-status-done"></span><span class="text-muted-foreground flex-1">Done</span><span class="font-mono tabular-nums">14</span></div>
+                <div class="flex items-center gap-2"><span class="h-1.5 w-1.5 rounded-full bg-status-blocked"></span><span class="text-muted-foreground flex-1">Blocked</span><span class="font-mono tabular-nums">2</span></div>
+                <div class="flex items-center gap-2"><span class="h-1.5 w-1.5 rounded-full bg-status-failed"></span><span class="text-muted-foreground flex-1">Failed</span><span class="font-mono tabular-nums">3</span></div>
+                <div class="flex items-center gap-2"><span class="h-1.5 w-1.5 rounded-full bg-status-running"></span><span class="text-muted-foreground flex-1">In progress / revision</span><span class="font-mono tabular-nums">5</span></div>
+                <div class="flex items-center gap-2"><span class="h-1.5 w-1.5 rounded-full bg-status-pending"></span><span class="text-muted-foreground flex-1">Pending / assigned / cancelled</span><span class="font-mono tabular-nums">16</span></div>
+              </div>
+            </div>
+
+            <!-- Fleet -->
+            <div>
+              <div class="flex items-baseline justify-between mb-3">
+                <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Fleet</div>
+                <div class="text-xs text-muted-foreground"><span class="text-foreground tabular-nums">7</span> agents</div>
+              </div>
+              <!-- Hierarchy bars -->
+              <div class="space-y-2 text-xs">
+                <div class="flex items-center gap-2">
+                  <span class="text-muted-foreground w-10 text-right">org</span>
+                  <div class="flex-1 h-1.5 bg-secondary rounded-full overflow-hidden">
+                    <div class="h-full bg-hier-org" style="width: 14.3%;"></div>
+                  </div>
+                  <span class="font-mono tabular-nums w-4 text-right">1</span>
+                </div>
+                <div class="flex items-center gap-2">
+                  <span class="text-muted-foreground w-10 text-right">team</span>
+                  <div class="flex-1 h-1.5 bg-secondary rounded-full overflow-hidden">
+                    <div class="h-full bg-hier-team" style="width: 28.6%;"></div>
+                  </div>
+                  <span class="font-mono tabular-nums w-4 text-right">2</span>
+                </div>
+                <div class="flex items-center gap-2">
+                  <span class="text-muted-foreground w-10 text-right">ic</span>
+                  <div class="flex-1 h-1.5 bg-secondary rounded-full overflow-hidden">
+                    <div class="h-full bg-hier-ic" style="width: 57.1%;"></div>
+                  </div>
+                  <span class="font-mono tabular-nums w-4 text-right">4</span>
+                </div>
+              </div>
+              <div class="mt-4 text-xs text-muted-foreground flex items-center gap-2">
+                <span class="pulse-dot inline-block h-1.5 w-1.5 rounded-full bg-status-running"></span>
+                <span><span class="text-foreground tabular-nums">4</span> active</span>
+                <span class="text-border">·</span>
+                <span><span class="text-foreground tabular-nums">3</span> idle</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- TREND ROW — last 7 days, sessions completed per day. Full-width chart. -->
+          <div class="mb-14">
+            <div class="flex items-baseline justify-between mb-3">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Sessions completed · last 7 days</div>
+              <div class="text-xs text-muted-foreground"><span class="text-foreground tabular-nums">142</span> total · <span class="text-status-done">+12%</span> vs prior 7d</div>
+            </div>
+            <!-- SVG bar chart: 7 days, value 0-30 -->
+            <svg viewBox="0 0 700 140" class="w-full h-32">
+              <!-- baseline -->
+              <line x1="40" y1="120" x2="700" y2="120" stroke="hsl(var(--border))" stroke-width="1" />
+              <!-- subtle gridlines -->
+              <line x1="40" y1="80"  x2="700" y2="80"  stroke="hsl(var(--border))" stroke-width="1" stroke-dasharray="2 4" opacity="0.5" />
+              <line x1="40" y1="40"  x2="700" y2="40"  stroke="hsl(var(--border))" stroke-width="1" stroke-dasharray="2 4" opacity="0.5" />
+              <!-- y axis labels -->
+              <text x="32" y="124" text-anchor="end" font-size="10" fill="hsl(var(--muted-foreground))" font-family="JetBrains Mono">0</text>
+              <text x="32" y="84"  text-anchor="end" font-size="10" fill="hsl(var(--muted-foreground))" font-family="JetBrains Mono">15</text>
+              <text x="32" y="44"  text-anchor="end" font-size="10" fill="hsl(var(--muted-foreground))" font-family="JetBrains Mono">30</text>
+
+              <!-- 7 bars (Mon-Sun). Width 64, gap 30 starting at x=60. Heights map count → pixels (max 30 = 80px tall). -->
+              <g fill="hsl(var(--muted-foreground) / 0.3)">
+                <rect x="60"  y="64" width="64" height="56" rx="2" /> <!-- Mon: 21 -->
+                <rect x="154" y="48" width="64" height="72" rx="2" /> <!-- Tue: 27 -->
+                <rect x="248" y="56" width="64" height="64" rx="2" /> <!-- Wed: 24 -->
+                <rect x="342" y="72" width="64" height="48" rx="2" /> <!-- Thu: 18 -->
+                <rect x="436" y="40" width="64" height="80" rx="2" /> <!-- Fri: 30 -->
+                <rect x="530" y="56" width="64" height="64" rx="2" /> <!-- Sat: 24 -->
+              </g>
+              <!-- Today (Sun) — highlighted -->
+              <rect x="624" y="56" width="64" height="64" rx="2" fill="hsl(var(--primary))" />
+
+              <!-- Day labels -->
+              <g font-size="11" fill="hsl(var(--muted-foreground))" text-anchor="middle">
+                <text x="92"  y="135">Mon</text>
+                <text x="186" y="135">Tue</text>
+                <text x="280" y="135">Wed</text>
+                <text x="374" y="135">Thu</text>
+                <text x="468" y="135">Fri</text>
+                <text x="562" y="135">Sat</text>
+                <text x="656" y="135" fill="hsl(var(--foreground))" font-weight="600">Sun</text>
+              </g>
+              <!-- Value labels on bars -->
+              <g font-size="10" font-family="JetBrains Mono" fill="hsl(var(--muted-foreground))" text-anchor="middle">
+                <text x="92"  y="58">21</text>
+                <text x="186" y="42">27</text>
+                <text x="280" y="50">24</text>
+                <text x="374" y="66">18</text>
+                <text x="468" y="34">30</text>
+                <text x="562" y="50">24</text>
+                <text x="656" y="50" fill="hsl(var(--foreground))" font-weight="600">24</text>
+              </g>
+            </svg>
+          </div>
+
+          <!-- ATTENTION — small section showing things that need a look -->
+          <div>
+            <div class="flex items-baseline justify-between mb-3">
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground">Needs a look</div>
+              <a href="tasks-list.html" class="text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1">View all <i data-lucide="arrow-right" class="h-3 w-3"></i></a>
+            </div>
+            <ul class="space-y-1">
+              <li>
+                <a href="#" class="flex items-center gap-3 px-2 py-2 -mx-2 rounded hover:bg-secondary/40 cursor-pointer transition-colors">
+                  <i data-lucide="ban" class="h-4 w-4 text-status-blocked shrink-0"></i>
+                  <span class="text-sm flex-1 truncate">OAuth provider configuration · blocked 3h, awaiting decision</span>
+                  <span class="text-xs text-muted-foreground tabular-nums">3h</span>
+                </a>
+              </li>
+              <li>
+                <a href="#" class="flex items-center gap-3 px-2 py-2 -mx-2 rounded hover:bg-secondary/40 cursor-pointer transition-colors">
+                  <i data-lucide="x-circle" class="h-4 w-4 text-status-failed shrink-0"></i>
+                  <span class="text-sm flex-1 truncate">Backfill memory_fact embeddings · failed by ic-agent-2</span>
+                  <span class="text-xs text-muted-foreground tabular-nums">20h</span>
+                </a>
+              </li>
+              <li>
+                <a href="#" class="flex items-center gap-3 px-2 py-2 -mx-2 rounded hover:bg-secondary/40 cursor-pointer transition-colors">
+                  <i data-lucide="alert-circle" class="h-4 w-4 text-status-review shrink-0"></i>
+                  <span class="text-sm flex-1 truncate">Audit task dispatch index · in review 1d</span>
+                  <span class="text-xs text-muted-foreground tabular-nums">1d</span>
+                </a>
+              </li>
+            </ul>
+          </div>
+
+        </div>
+      </div>
+    </main>
+  </div>
+
+  <script>
+    lucide.createIcons();
+    document.getElementById('theme-toggle').addEventListener('click', () => {
+      document.documentElement.classList.toggle('dark');
+      lucide.createIcons();
+    });
+  </script>
+</body>
+</html>

--- a/mocks/memory.html
+++ b/mocks/memory.html
@@ -248,6 +248,44 @@
       <div class="flex-1 overflow-auto">
         <div class="max-w-6xl mx-auto pt-8 pb-6 px-6">
 
+          <!-- Memory sub-nav tabs -->
+          <div class="flex items-center gap-1 mb-5 -mt-2 text-sm">
+            <a href="#" class="px-3 py-1.5 rounded bg-secondary text-foreground font-medium">All facts</a>
+            <a href="promotions.html" class="px-3 py-1.5 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors">Promotions</a>
+            <a href="#" class="px-3 py-1.5 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors">Merges</a>
+            <a href="#" class="px-3 py-1.5 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors">Conflicts</a>
+          </div>
+
+          <!-- Scope tabs — Mine/Team/Org. The architectural opinion made literal: no global pool view exists.
+               This UI lets you filter by visibility radius, not by "see everything." -->
+          <div class="flex items-center gap-1.5 mb-4 text-xs">
+            <span class="text-muted-foreground mr-1">View:</span>
+            <button class="inline-flex items-center gap-1.5 h-7 px-2.5 rounded bg-secondary text-foreground font-medium">
+              <i data-lucide="layers" class="h-3 w-3"></i>
+              <span>All scopes</span>
+              <span class="font-mono tabular-nums text-muted-foreground">47</span>
+            </button>
+            <button class="inline-flex items-center gap-1.5 h-7 px-2.5 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors">
+              <span class="inline-flex items-center h-4 px-1 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic">ic</span>
+              <span>Mine</span>
+              <span class="font-mono tabular-nums">23</span>
+            </button>
+            <button class="inline-flex items-center gap-1.5 h-7 px-2.5 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors">
+              <span class="inline-flex items-center h-4 px-1 rounded text-[10px] font-medium bg-hier-team/10 text-hier-team">team</span>
+              <span>Team</span>
+              <span class="font-mono tabular-nums">18</span>
+            </button>
+            <button class="inline-flex items-center gap-1.5 h-7 px-2.5 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors">
+              <span class="inline-flex items-center h-4 px-1 rounded text-[10px] font-medium border border-hier-org text-hier-org">org</span>
+              <span>Org</span>
+              <span class="font-mono tabular-nums">6</span>
+            </button>
+            <span class="ml-auto inline-flex items-center gap-1.5 text-muted-foreground">
+              <i data-lucide="info" class="h-3 w-3"></i>
+              <span>retrieved at brief-time per agent · no global pool view</span>
+            </span>
+          </div>
+
           <!-- Search + filter row, single line. Mem0 puts these together; we follow. -->
           <div class="flex items-center gap-2 mb-3">
             <div class="relative flex-1 max-w-lg">

--- a/mocks/memory.html
+++ b/mocks/memory.html
@@ -1,0 +1,556 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>beevibe — memory mock</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+  <script>
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.classList.add('dark');
+    }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+  <style>
+    :root {
+      --background: 0 0% 100%;
+      --foreground: 240 10% 4%;
+      --card: 240 5% 98%;
+      --card-foreground: 240 10% 4%;
+      --primary: 48 96% 53%;
+      --primary-foreground: 240 10% 4%;
+      --secondary: 240 5% 96%;
+      --secondary-foreground: 240 6% 10%;
+      --muted: 240 5% 96%;
+      --muted-foreground: 240 4% 46%;
+      --border: 240 6% 90%;
+      --input: 240 6% 90%;
+      --ring: 47 96% 47%;
+      --radius: 0.375rem;
+
+      --hier-ic:   240 4% 46%;
+      --hier-team: 262 83% 58%;
+      --hier-org:  38 92% 50%;
+
+      --type-belief-bg:     240 5% 90%;
+      --type-belief-fg:     240 6% 25%;
+      --type-pattern-bg:    217 91% 92%;
+      --type-pattern-fg:    217 91% 38%;
+      --type-gotcha-bg:     25 95% 90%;
+      --type-gotcha-fg:     25 95% 35%;
+      --type-preference-bg: 262 83% 92%;
+      --type-preference-fg: 262 83% 42%;
+      --type-decision-bg:   160 60% 88%;
+      --type-decision-fg:   160 84% 25%;
+    }
+    .dark {
+      --background: 240 10% 4%;
+      --foreground: 0 0% 98%;
+      --card: 240 6% 10%;
+      --card-foreground: 0 0% 98%;
+      --primary: 48 96% 53%;
+      --primary-foreground: 240 10% 4%;
+      --secondary: 240 4% 16%;
+      --secondary-foreground: 0 0% 98%;
+      --muted: 240 4% 16%;
+      --muted-foreground: 240 5% 65%;
+      --border: 240 4% 16%;
+      --input: 240 4% 16%;
+      --ring: 48 96% 53%;
+
+      --type-belief-bg:     240 4% 18%;
+      --type-belief-fg:     240 5% 75%;
+      --type-pattern-bg:    217 60% 22%;
+      --type-pattern-fg:    217 91% 75%;
+      --type-gotcha-bg:     25 60% 22%;
+      --type-gotcha-fg:     25 95% 70%;
+      --type-preference-bg: 262 50% 24%;
+      --type-preference-fg: 262 80% 80%;
+      --type-decision-bg:   160 50% 18%;
+      --type-decision-fg:   160 70% 65%;
+    }
+
+    body {
+      font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
+      font-feature-settings: 'cv11', 'ss01';
+      background-color: hsl(var(--background));
+      color: hsl(var(--foreground));
+      -webkit-font-smoothing: antialiased;
+    }
+    .font-mono { font-family: 'JetBrains Mono', ui-monospace, 'Menlo', monospace; }
+
+    @keyframes pulse-breathe {
+      0%, 100% { opacity: 1; transform: scale(1); }
+      50%      { opacity: 0.55; transform: scale(0.92); }
+    }
+    .pulse-dot { animation: pulse-breathe 2s ease-in-out infinite; }
+
+    @media (prefers-reduced-motion: reduce) {
+      .pulse-dot { animation: none; }
+    }
+
+    button:focus-visible, a:focus-visible, input:focus-visible {
+      outline: 2px solid hsl(var(--ring));
+      outline-offset: 2px;
+      border-radius: var(--radius);
+    }
+
+    /* Notion-style soft tag (kept from prior iteration) */
+    .tag {
+      display: inline-flex;
+      align-items: center;
+      height: 20px;
+      padding: 0 8px;
+      border-radius: 4px;
+      font-size: 11px;
+      font-weight: 500;
+      letter-spacing: 0.01em;
+      white-space: nowrap;
+    }
+    .tag-belief     { background: hsl(var(--type-belief-bg));     color: hsl(var(--type-belief-fg)); }
+    .tag-pattern    { background: hsl(var(--type-pattern-bg));    color: hsl(var(--type-pattern-fg)); }
+    .tag-gotcha     { background: hsl(var(--type-gotcha-bg));     color: hsl(var(--type-gotcha-fg)); }
+    .tag-preference { background: hsl(var(--type-preference-bg)); color: hsl(var(--type-preference-fg)); }
+    .tag-decision   { background: hsl(var(--type-decision-bg));   color: hsl(var(--type-decision-fg)); }
+
+    /* Table content truncation */
+    .clamp-2 {
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+
+    /* Custom checkbox to match design tokens */
+    .ck {
+      appearance: none;
+      width: 14px;
+      height: 14px;
+      border: 1.5px solid hsl(var(--muted-foreground) / 0.6);
+      border-radius: 3px;
+      cursor: pointer;
+      position: relative;
+      transition: all 150ms;
+    }
+    .ck:hover { border-color: hsl(var(--foreground)); }
+    .ck:checked {
+      background: hsl(var(--primary));
+      border-color: hsl(var(--primary));
+    }
+    .ck:checked::after {
+      content: '';
+      position: absolute;
+      left: 3px;
+      top: 0px;
+      width: 4px;
+      height: 8px;
+      border: solid hsl(var(--primary-foreground));
+      border-width: 0 2px 2px 0;
+      transform: rotate(45deg);
+    }
+  </style>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+            mono: ['JetBrains Mono', 'ui-monospace', 'Menlo', 'monospace'],
+          },
+          colors: {
+            border: 'hsl(var(--border))',
+            input: 'hsl(var(--input))',
+            ring: 'hsl(var(--ring))',
+            background: 'hsl(var(--background))',
+            foreground: 'hsl(var(--foreground))',
+            primary: { DEFAULT: 'hsl(var(--primary))', foreground: 'hsl(var(--primary-foreground))' },
+            secondary: { DEFAULT: 'hsl(var(--secondary))', foreground: 'hsl(var(--secondary-foreground))' },
+            muted: { DEFAULT: 'hsl(var(--muted))', foreground: 'hsl(var(--muted-foreground))' },
+            card: { DEFAULT: 'hsl(var(--card))', foreground: 'hsl(var(--card-foreground))' },
+            hier: {
+              ic:   'hsl(var(--hier-ic))',
+              team: 'hsl(var(--hier-team))',
+              org:  'hsl(var(--hier-org))',
+            },
+          },
+          borderRadius: {
+            DEFAULT: 'var(--radius)',
+            md: 'var(--radius)',
+            lg: 'calc(var(--radius) + 2px)',
+            xl: 'calc(var(--radius) + 6px)',
+          },
+        },
+      },
+    };
+  </script>
+</head>
+<body class="min-h-screen">
+  <div class="flex min-h-screen">
+
+    <!-- Sidebar (Memory active) -->
+    <aside class="w-[220px] shrink-0 bg-card flex flex-col">
+      <div class="h-14 flex items-center gap-2.5 px-4">
+        <div class="h-6 w-6 rounded bg-primary flex items-center justify-center">
+          <span class="text-primary-foreground text-sm font-bold leading-none">b</span>
+        </div>
+        <span class="font-semibold tracking-tight">beevibe</span>
+      </div>
+      <nav class="flex-1 p-2 space-y-0.5 text-sm">
+        <a href="#" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="home" class="h-4 w-4"></i>
+          <span>Home</span>
+        </a>
+        <a href="tasks-list.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="list-checks" class="h-4 w-4"></i>
+          <span>Tasks</span>
+        </a>
+        <a href="agents-list.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="circle-dot" class="h-4 w-4"></i>
+          <span>Agents</span>
+        </a>
+        <a href="threads.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="message-square" class="h-4 w-4"></i>
+          <span>Threads</span>
+        </a>
+        <a href="#" class="flex items-center gap-3 px-3 py-2 rounded bg-secondary text-foreground font-medium">
+          <i data-lucide="sparkles" class="h-4 w-4"></i>
+          <span>Memory</span>
+        </a>
+      </nav>
+
+      <div class="p-3">
+        <div class="flex items-center gap-1">
+          <button class="flex-1 min-w-0 flex items-center gap-2 px-2 py-1.5 rounded hover:bg-secondary cursor-pointer transition-colors text-left">
+            <div class="h-7 w-7 rounded-full bg-secondary border border-border flex items-center justify-center text-xs font-medium shrink-0">W</div>
+            <div class="flex-1 min-w-0">
+              <div class="text-sm font-medium truncate leading-tight">Weijia</div>
+              <div class="text-[10px] text-muted-foreground flex items-center gap-1 leading-tight mt-0.5">
+                <span class="pulse-dot inline-block h-1 w-1 rounded-full" style="background: hsl(217 91% 60%);"></span>
+                live
+              </div>
+            </div>
+            <i data-lucide="chevrons-up-down" class="h-3.5 w-3.5 text-muted-foreground shrink-0"></i>
+          </button>
+          <button id="theme-toggle" class="h-8 w-8 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary cursor-pointer transition-colors shrink-0" title="Toggle theme">
+            <i data-lucide="sun" class="h-4 w-4 hidden dark:block"></i>
+            <i data-lucide="moon" class="h-4 w-4 block dark:hidden"></i>
+          </button>
+        </div>
+      </div>
+    </aside>
+
+    <!-- Main — LIST mode tokens (max-w-6xl, pt-8, pb-6) -->
+    <main class="flex-1 min-w-0 flex flex-col">
+      <div class="flex-1 overflow-auto">
+        <div class="max-w-6xl mx-auto pt-8 pb-6 px-6">
+
+          <!-- Search + filter row, single line. Mem0 puts these together; we follow. -->
+          <div class="flex items-center gap-2 mb-3">
+            <div class="relative flex-1 max-w-lg">
+              <i data-lucide="search" class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground"></i>
+              <input
+                type="text"
+                placeholder='Search memory — semantic + keyword'
+                class="w-full h-9 pl-10 pr-3 text-sm rounded-md bg-secondary placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 transition-shadow"
+              />
+            </div>
+            <button class="inline-flex items-center gap-1.5 h-9 px-3 text-xs rounded-md hover:bg-secondary cursor-pointer transition-colors text-muted-foreground">
+              <span>Type: any</span>
+              <i data-lucide="chevron-down" class="h-3 w-3"></i>
+            </button>
+            <button class="inline-flex items-center gap-1.5 h-9 px-3 text-xs rounded-md hover:bg-secondary cursor-pointer transition-colors text-muted-foreground">
+              <span>Scope: any</span>
+              <i data-lucide="chevron-down" class="h-3 w-3"></i>
+            </button>
+            <button class="inline-flex items-center gap-1.5 h-9 px-3 text-xs rounded-md hover:bg-secondary cursor-pointer transition-colors text-muted-foreground">
+              <span>Agent: any</span>
+              <i data-lucide="chevron-down" class="h-3 w-3"></i>
+            </button>
+          </div>
+
+          <!-- Bulk action bar (would slide in when rows are selected) -->
+          <div id="bulk-bar" class="hidden mb-3 flex items-center gap-3 px-3 py-2 rounded-md bg-secondary text-sm">
+            <span><span id="bulk-count">0</span> selected</span>
+            <button class="text-muted-foreground hover:text-foreground transition-colors">Promote scope</button>
+            <button class="text-muted-foreground hover:text-foreground transition-colors">Export</button>
+            <button class="text-muted-foreground hover:text-destructive transition-colors">Delete</button>
+            <button id="bulk-cancel" class="ml-auto text-muted-foreground hover:text-foreground transition-colors">
+              Cancel
+            </button>
+          </div>
+
+          <!-- Result count + sort -->
+          <div class="flex items-center justify-between mb-2 text-xs text-muted-foreground">
+            <span><span class="text-foreground tabular-nums">47</span> facts</span>
+            <button class="inline-flex items-center gap-1.5 hover:text-foreground transition-colors">
+              <i data-lucide="arrow-up-down" class="h-3 w-3"></i>
+              <span>Sort: recently learned</span>
+              <i data-lucide="chevron-down" class="h-3 w-3"></i>
+            </button>
+          </div>
+
+          <!-- Table.
+               Columns: [✓] Memory · Type · Scope · Agent · Created · ⋯
+               Mem0 pattern: header row tinted bg, body rows hover bg, no inter-row borders. -->
+          <div class="overflow-hidden rounded-md">
+            <table class="w-full text-sm">
+              <colgroup>
+                <col style="width: 40px" />
+                <col />
+                <col style="width: 110px" />
+                <col style="width: 80px" />
+                <col style="width: 140px" />
+                <col style="width: 100px" />
+                <col style="width: 40px" />
+              </colgroup>
+              <thead>
+                <tr class="bg-secondary/60 text-xs uppercase tracking-wider text-muted-foreground">
+                  <th class="text-left px-3 py-2.5 font-medium">
+                    <input type="checkbox" class="ck" id="select-all" />
+                  </th>
+                  <th class="text-left px-3 py-2.5 font-medium">
+                    <span class="inline-flex items-center gap-1.5"><i data-lucide="book-text" class="h-3.5 w-3.5"></i>Memory</span>
+                  </th>
+                  <th class="text-left px-3 py-2.5 font-medium">
+                    <span class="inline-flex items-center gap-1.5"><i data-lucide="tags" class="h-3.5 w-3.5"></i>Type</span>
+                  </th>
+                  <th class="text-left px-3 py-2.5 font-medium">
+                    <span class="inline-flex items-center gap-1.5"><i data-lucide="layers" class="h-3.5 w-3.5"></i>Scope</span>
+                  </th>
+                  <th class="text-left px-3 py-2.5 font-medium">
+                    <span class="inline-flex items-center gap-1.5"><i data-lucide="bot" class="h-3.5 w-3.5"></i>Agent</span>
+                  </th>
+                  <th class="text-left px-3 py-2.5 font-medium">
+                    <span class="inline-flex items-center gap-1.5"><i data-lucide="clock" class="h-3.5 w-3.5"></i>Created</span>
+                  </th>
+                  <th class="text-left px-3 py-2.5 font-medium"></th>
+                </tr>
+              </thead>
+              <tbody>
+
+                <!-- Each row: checkbox + content (clamp-2) + tag + chip + agent + created + kebab. -->
+                <tr class="hover:bg-secondary/30 transition-colors">
+                  <td class="px-3 py-3 align-top"><input type="checkbox" class="ck row-ck" /></td>
+                  <td class="px-3 py-3">
+                    <a href="#" class="block clamp-2 font-medium hover:underline cursor-pointer">
+                      Postgres NOTIFY payload is capped at 8KB. Keep payloads to id, status, and timestamps; clients refetch full rows via HTTP after the event.
+                    </a>
+                    <div class="mt-1 text-[10px] text-muted-foreground font-mono">3 sessions</div>
+                  </td>
+                  <td class="px-3 py-3 align-middle"><span class="tag tag-decision">decision</span></td>
+                  <td class="px-3 py-3 align-middle"><span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium bg-hier-team/10 text-hier-team">team</span></td>
+                  <td class="px-3 py-3 align-middle font-mono text-xs">team-alpha</td>
+                  <td class="px-3 py-3 align-middle text-xs text-muted-foreground tabular-nums">2d ago</td>
+                  <td class="px-3 py-3 align-middle">
+                    <button class="h-6 w-6 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary cursor-pointer transition-colors">
+                      <i data-lucide="more-horizontal" class="h-3.5 w-3.5"></i>
+                    </button>
+                  </td>
+                </tr>
+
+                <tr class="hover:bg-secondary/30 transition-colors">
+                  <td class="px-3 py-3 align-top"><input type="checkbox" class="ck row-ck" /></td>
+                  <td class="px-3 py-3">
+                    <a href="#" class="block clamp-2 font-medium hover:underline cursor-pointer">
+                      Claude Code spawns subprocesses; the executor must reap them with process_group_id, not just process_pid, or orphaned children accumulate over long runs.
+                    </a>
+                    <div class="mt-1 text-[10px] text-muted-foreground font-mono">2 sessions</div>
+                  </td>
+                  <td class="px-3 py-3 align-middle"><span class="tag tag-gotcha">gotcha</span></td>
+                  <td class="px-3 py-3 align-middle"><span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic">ic</span></td>
+                  <td class="px-3 py-3 align-middle font-mono text-xs">ic-agent-1</td>
+                  <td class="px-3 py-3 align-middle text-xs text-muted-foreground tabular-nums">3d ago</td>
+                  <td class="px-3 py-3 align-middle">
+                    <button class="h-6 w-6 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary cursor-pointer transition-colors">
+                      <i data-lucide="more-horizontal" class="h-3.5 w-3.5"></i>
+                    </button>
+                  </td>
+                </tr>
+
+                <tr class="hover:bg-secondary/30 transition-colors">
+                  <td class="px-3 py-3 align-top"><input type="checkbox" class="ck row-ck" /></td>
+                  <td class="px-3 py-3">
+                    <a href="#" class="block clamp-2 font-medium hover:underline cursor-pointer">
+                      All inter-agent communication flows through the task queue, not direct calls. Async dispatch via task assignment is the only mesh primitive — no synchronous agent-to-agent RPC.
+                    </a>
+                    <div class="mt-1 text-[10px] text-muted-foreground font-mono">8 sessions</div>
+                  </td>
+                  <td class="px-3 py-3 align-middle"><span class="tag tag-pattern">pattern</span></td>
+                  <td class="px-3 py-3 align-middle"><span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium border border-hier-org text-hier-org">org</span></td>
+                  <td class="px-3 py-3 align-middle font-mono text-xs">root-org</td>
+                  <td class="px-3 py-3 align-middle text-xs text-muted-foreground tabular-nums">1w ago</td>
+                  <td class="px-3 py-3 align-middle">
+                    <button class="h-6 w-6 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary cursor-pointer transition-colors">
+                      <i data-lucide="more-horizontal" class="h-3.5 w-3.5"></i>
+                    </button>
+                  </td>
+                </tr>
+
+                <tr class="hover:bg-secondary/30 transition-colors">
+                  <td class="px-3 py-3 align-top"><input type="checkbox" class="ck row-ck" /></td>
+                  <td class="px-3 py-3">
+                    <a href="#" class="block clamp-2 font-medium hover:underline cursor-pointer">
+                      For dense list views, prefer Inter over IBM Plex Sans — better metrics at 12–14px and matches the operator-tool aesthetic the rest of our stack uses.
+                    </a>
+                    <div class="mt-1 text-[10px] text-muted-foreground font-mono">1 session</div>
+                  </td>
+                  <td class="px-3 py-3 align-middle"><span class="tag tag-preference">preference</span></td>
+                  <td class="px-3 py-3 align-middle"><span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium bg-hier-team/10 text-hier-team">team</span></td>
+                  <td class="px-3 py-3 align-middle font-mono text-xs">team-alpha</td>
+                  <td class="px-3 py-3 align-middle text-xs text-muted-foreground tabular-nums">4d ago</td>
+                  <td class="px-3 py-3 align-middle">
+                    <button class="h-6 w-6 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary cursor-pointer transition-colors">
+                      <i data-lucide="more-horizontal" class="h-3.5 w-3.5"></i>
+                    </button>
+                  </td>
+                </tr>
+
+                <tr class="hover:bg-secondary/30 transition-colors">
+                  <td class="px-3 py-3 align-top"><input type="checkbox" class="ck row-ck" /></td>
+                  <td class="px-3 py-3">
+                    <a href="#" class="block clamp-2 font-medium hover:underline cursor-pointer">
+                      pgvector cosine similarity outperforms L2 distance for memory_fact retrieval — embeddings cluster better in angular space when content lengths vary widely.
+                    </a>
+                    <div class="mt-1 text-[10px] text-muted-foreground font-mono">2 sessions</div>
+                  </td>
+                  <td class="px-3 py-3 align-middle"><span class="tag tag-belief">belief</span></td>
+                  <td class="px-3 py-3 align-middle"><span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic">ic</span></td>
+                  <td class="px-3 py-3 align-middle font-mono text-xs">db-agent</td>
+                  <td class="px-3 py-3 align-middle text-xs text-muted-foreground tabular-nums">5d ago</td>
+                  <td class="px-3 py-3 align-middle">
+                    <button class="h-6 w-6 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary cursor-pointer transition-colors">
+                      <i data-lucide="more-horizontal" class="h-3.5 w-3.5"></i>
+                    </button>
+                  </td>
+                </tr>
+
+                <tr class="hover:bg-secondary/30 transition-colors">
+                  <td class="px-3 py-3 align-top"><input type="checkbox" class="ck row-ck" /></td>
+                  <td class="px-3 py-3">
+                    <a href="#" class="block clamp-2 font-medium hover:underline cursor-pointer">
+                      M8 deploys self-hosted, not Vercel, so SSE survives long connections without serverless timeout workarounds. Single Next.js process; long-lived pg client for LISTEN.
+                    </a>
+                    <div class="mt-1 text-[10px] text-muted-foreground font-mono">5 sessions</div>
+                  </td>
+                  <td class="px-3 py-3 align-middle"><span class="tag tag-decision">decision</span></td>
+                  <td class="px-3 py-3 align-middle"><span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium border border-hier-org text-hier-org">org</span></td>
+                  <td class="px-3 py-3 align-middle font-mono text-xs">root-org</td>
+                  <td class="px-3 py-3 align-middle text-xs text-muted-foreground tabular-nums">1w ago</td>
+                  <td class="px-3 py-3 align-middle">
+                    <button class="h-6 w-6 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary cursor-pointer transition-colors">
+                      <i data-lucide="more-horizontal" class="h-3.5 w-3.5"></i>
+                    </button>
+                  </td>
+                </tr>
+
+                <tr class="hover:bg-secondary/30 transition-colors">
+                  <td class="px-3 py-3 align-top"><input type="checkbox" class="ck row-ck" /></td>
+                  <td class="px-3 py-3">
+                    <a href="#" class="block clamp-2 font-medium hover:underline cursor-pointer">
+                      When a task is rejected back to revision, the agent re-uses the same prior_session_id chain — context flows forward, not backward. Reviewer notes attach to the new session's intent.
+                    </a>
+                    <div class="mt-1 text-[10px] text-muted-foreground font-mono">4 sessions</div>
+                  </td>
+                  <td class="px-3 py-3 align-middle"><span class="tag tag-pattern">pattern</span></td>
+                  <td class="px-3 py-3 align-middle"><span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic">ic</span></td>
+                  <td class="px-3 py-3 align-middle font-mono text-xs">ic-agent-2</td>
+                  <td class="px-3 py-3 align-middle text-xs text-muted-foreground tabular-nums">2w ago</td>
+                  <td class="px-3 py-3 align-middle">
+                    <button class="h-6 w-6 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary cursor-pointer transition-colors">
+                      <i data-lucide="more-horizontal" class="h-3.5 w-3.5"></i>
+                    </button>
+                  </td>
+                </tr>
+
+                <tr class="hover:bg-secondary/30 transition-colors">
+                  <td class="px-3 py-3 align-top"><input type="checkbox" class="ck row-ck" /></td>
+                  <td class="px-3 py-3">
+                    <a href="#" class="block clamp-2 font-medium hover:underline cursor-pointer">
+                      Tailwind prefers-color-scheme with class-based dark mode requires a small inline script to set the .dark class before paint, otherwise flicker happens between SSR and client hydration.
+                    </a>
+                    <div class="mt-1 text-[10px] text-muted-foreground font-mono">1 session</div>
+                  </td>
+                  <td class="px-3 py-3 align-middle"><span class="tag tag-gotcha">gotcha</span></td>
+                  <td class="px-3 py-3 align-middle"><span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic">ic</span></td>
+                  <td class="px-3 py-3 align-middle font-mono text-xs">ic-agent-3</td>
+                  <td class="px-3 py-3 align-middle text-xs text-muted-foreground tabular-nums">2w ago</td>
+                  <td class="px-3 py-3 align-middle">
+                    <button class="h-6 w-6 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary cursor-pointer transition-colors">
+                      <i data-lucide="more-horizontal" class="h-3.5 w-3.5"></i>
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Pagination -->
+          <div class="mt-4 flex items-center justify-between text-xs text-muted-foreground">
+            <span>Showing <span class="text-foreground">1–8</span> of <span class="text-foreground">47</span></span>
+            <div class="flex items-center gap-1">
+              <button class="h-7 w-7 rounded inline-flex items-center justify-center hover:bg-secondary cursor-pointer transition-colors disabled:opacity-30 disabled:cursor-not-allowed" disabled>
+                <i data-lucide="chevron-left" class="h-3.5 w-3.5"></i>
+              </button>
+              <button class="h-7 min-w-7 px-2 rounded text-foreground bg-secondary font-medium cursor-pointer">1</button>
+              <button class="h-7 min-w-7 px-2 rounded hover:bg-secondary cursor-pointer transition-colors">2</button>
+              <button class="h-7 min-w-7 px-2 rounded hover:bg-secondary cursor-pointer transition-colors">3</button>
+              <button class="h-7 min-w-7 px-2 rounded hover:bg-secondary cursor-pointer transition-colors">4</button>
+              <button class="h-7 min-w-7 px-2 rounded hover:bg-secondary cursor-pointer transition-colors">5</button>
+              <button class="h-7 w-7 rounded inline-flex items-center justify-center hover:bg-secondary cursor-pointer transition-colors">
+                <i data-lucide="chevron-right" class="h-3.5 w-3.5"></i>
+              </button>
+            </div>
+          </div>
+
+          <!-- Foot note -->
+          <div class="mt-10 text-xs text-muted-foreground">
+            mock · Mem0 OpenMemory pattern: table view, bulk-selectable rows, type/scope/agent columns. Click a row for full content + source sessions.
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+
+  <script>
+    lucide.createIcons();
+    document.getElementById('theme-toggle').addEventListener('click', () => {
+      document.documentElement.classList.toggle('dark');
+      lucide.createIcons();
+    });
+
+    // Bulk selection
+    const rowCks = document.querySelectorAll('.row-ck');
+    const selectAll = document.getElementById('select-all');
+    const bulkBar = document.getElementById('bulk-bar');
+    const bulkCount = document.getElementById('bulk-count');
+    const bulkCancel = document.getElementById('bulk-cancel');
+
+    function updateBulk() {
+      const checked = Array.from(rowCks).filter(c => c.checked).length;
+      if (checked > 0) {
+        bulkBar.classList.remove('hidden');
+        bulkBar.classList.add('flex');
+        bulkCount.textContent = checked;
+      } else {
+        bulkBar.classList.add('hidden');
+        bulkBar.classList.remove('flex');
+      }
+      selectAll.checked = checked === rowCks.length;
+      selectAll.indeterminate = checked > 0 && checked < rowCks.length;
+    }
+    rowCks.forEach(c => c.addEventListener('change', updateBulk));
+    selectAll.addEventListener('change', () => {
+      rowCks.forEach(c => { c.checked = selectAll.checked; });
+      updateBulk();
+    });
+    bulkCancel.addEventListener('click', () => {
+      rowCks.forEach(c => { c.checked = false; });
+      updateBulk();
+    });
+  </script>
+</body>
+</html>

--- a/mocks/mesh.html
+++ b/mocks/mesh.html
@@ -1,0 +1,628 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>beevibe — mesh · agent-to-agent asks</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+  <script>
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.classList.add('dark');
+    }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+  <style>
+    :root {
+      --background: 0 0% 100%;
+      --foreground: 240 10% 4%;
+      --card: 240 5% 98%;
+      --card-foreground: 240 10% 4%;
+      --primary: 48 96% 53%;
+      --primary-foreground: 240 10% 4%;
+      --secondary: 240 5% 96%;
+      --secondary-foreground: 240 6% 10%;
+      --muted: 240 5% 96%;
+      --muted-foreground: 240 4% 46%;
+      --border: 240 6% 90%;
+      --input: 240 6% 90%;
+      --ring: 47 96% 47%;
+      --radius: 0.375rem;
+
+      --status-pending:   240 4% 46%;
+      --status-running:   217 91% 60%;
+      --status-review:    38 92% 50%;
+      --status-blocked:   25 95% 53%;
+      --status-done:      160 84% 39%;
+      --status-failed:    0 84% 60%;
+
+      --hier-ic:   240 4% 46%;
+      --hier-team: 262 83% 58%;
+      --hier-org:  38 92% 50%;
+    }
+    .dark {
+      --background: 240 10% 4%;
+      --foreground: 0 0% 98%;
+      --card: 240 6% 10%;
+      --card-foreground: 0 0% 98%;
+      --primary: 48 96% 53%;
+      --primary-foreground: 240 10% 4%;
+      --secondary: 240 4% 16%;
+      --secondary-foreground: 0 0% 98%;
+      --muted: 240 4% 16%;
+      --muted-foreground: 240 5% 65%;
+      --border: 240 4% 16%;
+      --input: 240 4% 16%;
+      --ring: 48 96% 53%;
+    }
+
+    body {
+      font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
+      font-feature-settings: 'cv11', 'ss01';
+      background-color: hsl(var(--background));
+      color: hsl(var(--foreground));
+      -webkit-font-smoothing: antialiased;
+    }
+    .font-mono { font-family: 'JetBrains Mono', ui-monospace, 'Menlo', monospace; }
+
+    @keyframes pulse-breathe {
+      0%, 100% { opacity: 1; transform: scale(1); }
+      50%      { opacity: 0.55; transform: scale(0.92); }
+    }
+    .pulse-dot { animation: pulse-breathe 2s ease-in-out infinite; }
+
+    @keyframes spin-slow { to { transform: rotate(360deg); } }
+    .spin-slow { animation: spin-slow 2.5s linear infinite; }
+
+    /* Animated dashed edge to show in-flight ask */
+    @keyframes dash-flow {
+      to { stroke-dashoffset: -16; }
+    }
+    .ask-edge-live {
+      stroke-dasharray: 4 4;
+      animation: dash-flow 1.2s linear infinite;
+    }
+
+    /* Pulse ring for active node */
+    @keyframes node-pulse {
+      0%   { opacity: 0.6; transform: scale(1); }
+      100% { opacity: 0;   transform: scale(1.8); }
+    }
+    .node-ring { animation: node-pulse 1.8s ease-out infinite; transform-origin: center; transform-box: fill-box; }
+
+    @media (prefers-reduced-motion: reduce) {
+      .pulse-dot, .spin-slow, .ask-edge-live, .node-ring { animation: none; }
+    }
+
+    button:focus-visible, a:focus-visible {
+      outline: 2px solid hsl(var(--ring));
+      outline-offset: 2px;
+      border-radius: var(--radius);
+    }
+  </style>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+            mono: ['JetBrains Mono', 'ui-monospace', 'Menlo', 'monospace'],
+          },
+          colors: {
+            border: 'hsl(var(--border))',
+            input: 'hsl(var(--input))',
+            ring: 'hsl(var(--ring))',
+            background: 'hsl(var(--background))',
+            foreground: 'hsl(var(--foreground))',
+            primary: { DEFAULT: 'hsl(var(--primary))', foreground: 'hsl(var(--primary-foreground))' },
+            secondary: { DEFAULT: 'hsl(var(--secondary))', foreground: 'hsl(var(--secondary-foreground))' },
+            muted: { DEFAULT: 'hsl(var(--muted))', foreground: 'hsl(var(--muted-foreground))' },
+            card: { DEFAULT: 'hsl(var(--card))', foreground: 'hsl(var(--card-foreground))' },
+            status: {
+              pending:   'hsl(var(--status-pending))',
+              running:   'hsl(var(--status-running))',
+              review:    'hsl(var(--status-review))',
+              blocked:   'hsl(var(--status-blocked))',
+              done:      'hsl(var(--status-done))',
+              failed:    'hsl(var(--status-failed))',
+            },
+            hier: {
+              ic:   'hsl(var(--hier-ic))',
+              team: 'hsl(var(--hier-team))',
+              org:  'hsl(var(--hier-org))',
+            },
+          },
+          borderRadius: {
+            DEFAULT: 'var(--radius)',
+            md: 'var(--radius)',
+            lg: 'calc(var(--radius) + 2px)',
+            xl: 'calc(var(--radius) + 6px)',
+          },
+        },
+      },
+    };
+  </script>
+</head>
+<body class="min-h-screen">
+  <div class="flex min-h-screen">
+
+    <!-- Sidebar (Threads active — mesh is conceptually conversations between agents) -->
+    <aside class="w-[220px] shrink-0 bg-card flex flex-col">
+      <div class="h-14 flex items-center gap-2.5 px-4">
+        <div class="h-6 w-6 rounded bg-primary flex items-center justify-center">
+          <span class="text-primary-foreground text-sm font-bold leading-none">b</span>
+        </div>
+        <span class="font-semibold tracking-tight">beevibe</span>
+      </div>
+      <nav class="flex-1 p-2 space-y-0.5 text-sm">
+        <a href="home.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="home" class="h-4 w-4"></i>
+          <span>Home</span>
+        </a>
+        <a href="tasks-list.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="list-checks" class="h-4 w-4"></i>
+          <span>Tasks</span>
+        </a>
+        <a href="agents-list.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="circle-dot" class="h-4 w-4"></i>
+          <span>Agents</span>
+        </a>
+        <a href="threads.html" class="flex items-center gap-3 px-3 py-2 rounded bg-secondary text-foreground font-medium">
+          <i data-lucide="message-square" class="h-4 w-4"></i>
+          <span>Threads</span>
+        </a>
+        <a href="memory.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="sparkles" class="h-4 w-4"></i>
+          <span>Memory</span>
+        </a>
+      </nav>
+
+      <div class="p-3">
+        <div class="flex items-center gap-1">
+          <button class="flex-1 min-w-0 flex items-center gap-2 px-2 py-1.5 rounded hover:bg-secondary cursor-pointer transition-colors text-left">
+            <div class="h-7 w-7 rounded-full bg-secondary border border-border flex items-center justify-center text-xs font-medium shrink-0">W</div>
+            <div class="flex-1 min-w-0">
+              <div class="text-sm font-medium truncate leading-tight">Weijia</div>
+              <div class="text-[10px] text-muted-foreground flex items-center gap-1 leading-tight mt-0.5">
+                <span class="pulse-dot inline-block h-1 w-1 rounded-full bg-status-running"></span>
+                live
+              </div>
+            </div>
+            <i data-lucide="chevrons-up-down" class="h-3.5 w-3.5 text-muted-foreground shrink-0"></i>
+          </button>
+          <button id="theme-toggle" class="h-8 w-8 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary cursor-pointer transition-colors shrink-0" title="Toggle theme">
+            <i data-lucide="sun" class="h-4 w-4 hidden dark:block"></i>
+            <i data-lucide="moon" class="h-4 w-4 block dark:hidden"></i>
+          </button>
+        </div>
+      </div>
+    </aside>
+
+    <!-- Main — CANVAS density (max-w-5xl for content; graph can overflow) -->
+    <main class="flex-1 min-w-0 flex flex-col">
+      <div class="flex-1 overflow-auto">
+        <div class="max-w-5xl mx-auto pt-8 pb-12 px-6">
+
+          <!-- Tabs row (Mesh sub-section of Threads) -->
+          <div class="flex items-center gap-1 mb-6 -mt-2 text-sm">
+            <a href="threads.html" class="px-3 py-1.5 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors">Channels</a>
+            <a href="#" class="px-3 py-1.5 rounded bg-secondary text-foreground font-medium">Mesh</a>
+            <a href="#" class="px-3 py-1.5 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors">DMs</a>
+          </div>
+
+          <!-- Lead line -->
+          <div class="mb-6 flex items-baseline justify-between gap-6">
+            <div>
+              <h1 class="text-base font-semibold mb-1">Mesh activity</h1>
+              <p class="text-sm text-muted-foreground max-w-2xl leading-relaxed">
+                Agents ask each other when their bounded context isn't enough. Each ask is a session — caller's intent, target's response, with provenance. <span class="font-mono text-foreground">ChainBudget</span> caps depth and total tokens per chain to prevent runaway loops.
+              </p>
+            </div>
+            <div class="text-xs text-muted-foreground shrink-0 text-right">
+              <div><span class="text-foreground tabular-nums">23</span> asks · last 24h</div>
+              <div class="mt-1">
+                <span class="pulse-dot inline-block h-1.5 w-1.5 rounded-full bg-status-running"></span>
+                <span class="text-status-running font-medium">2 in flight</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Two-pane: feed (left) + graph (right). On wide screens side-by-side; on narrow stacks. -->
+          <div class="grid grid-cols-5 gap-6">
+
+            <!-- LEFT: activity feed -->
+            <section class="col-span-3">
+              <div class="flex items-center justify-between mb-3">
+                <h2 class="text-[10px] uppercase tracking-wider text-muted-foreground">Recent asks</h2>
+                <div class="flex items-center gap-1 text-xs">
+                  <button class="px-2 py-1 rounded bg-secondary text-foreground font-medium">All</button>
+                  <button class="px-2 py-1 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors">ask</button>
+                  <button class="px-2 py-1 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors">negotiate</button>
+                  <button class="px-2 py-1 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors">blocker</button>
+                </div>
+              </div>
+
+              <div class="space-y-1">
+
+                <!-- Live in-flight ask -->
+                <a href="#" class="block rounded-lg border border-status-running/40 bg-status-running/5 p-3 hover:border-ring transition-colors cursor-pointer">
+                  <div class="flex items-center gap-2 mb-2 text-xs">
+                    <span class="font-mono text-foreground">ic-agent-1</span>
+                    <i data-lucide="arrow-right" class="h-3 w-3 text-status-running"></i>
+                    <span class="font-mono text-foreground">db-agent</span>
+                    <span class="ml-auto inline-flex items-center gap-1 h-5 px-2 rounded text-[10px] font-medium bg-status-running/10 text-status-running">
+                      <i data-lucide="loader-2" class="spin-slow h-3 w-3"></i>
+                      in flight · 4s
+                    </span>
+                  </div>
+                  <p class="text-sm leading-relaxed text-foreground/85 mb-2">
+                    What's the schema for refresh-token storage? Need a column that can hold the encrypted blob plus rotation metadata, with a unique index by user_id.
+                  </p>
+                  <div class="flex items-center gap-3 text-[10px] text-muted-foreground font-mono">
+                    <span class="inline-flex items-center gap-1">
+                      <i data-lucide="link" class="h-3 w-3"></i>
+                      type: ask
+                    </span>
+                    <span class="text-border">·</span>
+                    <span>chain depth 1/4</span>
+                    <span class="text-border">·</span>
+                    <span>session sess_a8c2 · from <a href="#" class="hover:text-foreground transition-colors">T-1029</a></span>
+                  </div>
+                </a>
+
+                <!-- Live in-flight ask 2 -->
+                <a href="#" class="block rounded-lg border border-status-running/40 bg-status-running/5 p-3 hover:border-ring transition-colors cursor-pointer">
+                  <div class="flex items-center gap-2 mb-2 text-xs">
+                    <span class="font-mono text-foreground">ic-agent-3</span>
+                    <i data-lucide="arrow-right" class="h-3 w-3 text-status-running"></i>
+                    <span class="font-mono text-foreground">team-alpha</span>
+                    <span class="ml-auto inline-flex items-center gap-1 h-5 px-2 rounded text-[10px] font-medium bg-status-running/10 text-status-running">
+                      <i data-lucide="loader-2" class="spin-slow h-3 w-3"></i>
+                      in flight · 11s
+                    </span>
+                  </div>
+                  <p class="text-sm leading-relaxed text-foreground/85 mb-2">
+                    Should the task-repo refactor preserve the existing index <span class="font-mono text-xs">idx_task_dispatch</span> verbatim, or rebuild as a partial index? Performance budget for dispatch query is 5ms p95.
+                  </p>
+                  <div class="flex items-center gap-3 text-[10px] text-muted-foreground font-mono">
+                    <span class="inline-flex items-center gap-1">
+                      <i data-lucide="git-pull-request" class="h-3 w-3"></i>
+                      type: negotiate
+                    </span>
+                    <span class="text-border">·</span>
+                    <span>chain depth 1/4</span>
+                    <span class="text-border">·</span>
+                    <span>session sess_b4f1 · from <a href="#" class="hover:text-foreground transition-colors">T-1031</a></span>
+                  </div>
+                </a>
+
+                <!-- Completed ask -->
+                <a href="#" class="block rounded-lg border border-border bg-card p-3 hover:border-ring/40 transition-colors cursor-pointer">
+                  <div class="flex items-center gap-2 mb-2 text-xs">
+                    <span class="font-mono text-foreground">ic-agent-1</span>
+                    <i data-lucide="arrow-right" class="h-3 w-3 text-muted-foreground"></i>
+                    <span class="font-mono text-foreground">db-agent</span>
+                    <span class="ml-auto inline-flex items-center gap-1 h-5 px-2 rounded text-[10px] font-medium bg-status-done/10 text-status-done">
+                      <i data-lucide="check" class="h-3 w-3"></i>
+                      8s
+                    </span>
+                  </div>
+                  <p class="text-sm leading-relaxed text-foreground/85">
+                    Is the new auth path safe given how we're handling token refresh? Walking through: PKCE verifier, /token exchange, then writing the encrypted refresh blob.
+                  </p>
+                  <div class="mt-2 rounded bg-secondary/40 p-2 text-xs leading-relaxed">
+                    <span class="text-muted-foreground">db-agent →</span>
+                    <span class="text-foreground/85">Refresh blob fine in `refresh_token` table — but you need <span class="font-mono">FOR UPDATE SKIP LOCKED</span> on read for the rotation flow, or two concurrent rotations race the increment. Patch in db_helpers.ts:142.</span>
+                  </div>
+                  <div class="flex items-center gap-3 mt-2 text-[10px] text-muted-foreground font-mono">
+                    <span class="inline-flex items-center gap-1"><i data-lucide="link" class="h-3 w-3"></i>type: ask</span>
+                    <span class="text-border">·</span>
+                    <span>chain depth 1/4</span>
+                    <span class="text-border">·</span>
+                    <span>session sess_3a8c · 18m ago</span>
+                  </div>
+                </a>
+
+                <!-- Completed ask -->
+                <a href="#" class="block rounded-lg border border-border bg-card p-3 hover:border-ring/40 transition-colors cursor-pointer">
+                  <div class="flex items-center gap-2 mb-2 text-xs">
+                    <span class="font-mono text-foreground">ic-agent-2</span>
+                    <i data-lucide="arrow-right" class="h-3 w-3 text-muted-foreground"></i>
+                    <span class="font-mono text-foreground">ic-agent-3</span>
+                    <span class="ml-auto inline-flex items-center gap-1 h-5 px-2 rounded text-[10px] font-medium bg-status-done/10 text-status-done">
+                      <i data-lucide="check" class="h-3 w-3"></i>
+                      4s
+                    </span>
+                  </div>
+                  <p class="text-sm leading-relaxed text-foreground/85">
+                    Did you already migrate the logger to pino, or am I about to step on your work?
+                  </p>
+                  <div class="mt-2 rounded bg-secondary/40 p-2 text-xs leading-relaxed">
+                    <span class="text-muted-foreground">ic-agent-3 →</span>
+                    <span class="text-foreground/85">Task-repo logger only — <span class="font-mono">packages/core/src/adapters/postgres/task-repo.ts</span>. Yours is greenfield.</span>
+                  </div>
+                  <div class="flex items-center gap-3 mt-2 text-[10px] text-muted-foreground font-mono">
+                    <span class="inline-flex items-center gap-1"><i data-lucide="link" class="h-3 w-3"></i>type: ask</span>
+                    <span class="text-border">·</span>
+                    <span>chain depth 1/4</span>
+                    <span class="text-border">·</span>
+                    <span>session sess_5d12 · 47m ago</span>
+                  </div>
+                </a>
+
+                <!-- Blocker -->
+                <a href="#" class="block rounded-lg border border-status-blocked/40 bg-status-blocked/5 p-3 hover:border-ring transition-colors cursor-pointer">
+                  <div class="flex items-center gap-2 mb-2 text-xs">
+                    <span class="font-mono text-foreground">ic-agent-2</span>
+                    <i data-lucide="arrow-up" class="h-3 w-3 text-status-blocked"></i>
+                    <span class="font-mono text-foreground">team-alpha</span>
+                    <span class="ml-auto inline-flex items-center gap-1 h-5 px-2 rounded text-[10px] font-medium bg-status-blocked/10 text-status-blocked">
+                      <i data-lucide="ban" class="h-3 w-3"></i>
+                      blocker · 3h
+                    </span>
+                  </div>
+                  <p class="text-sm leading-relaxed text-foreground/85">
+                    OAuth provider config drifted between env vars and Auth0 dashboard. Need a human decision: roll forward with new redirect URI (breaks staging) or roll back the Auth0 change.
+                  </p>
+                  <div class="flex items-center gap-3 mt-2 text-[10px] text-muted-foreground font-mono">
+                    <span class="inline-flex items-center gap-1"><i data-lucide="alert-triangle" class="h-3 w-3"></i>type: report_blocker</span>
+                    <span class="text-border">·</span>
+                    <span>chain depth 1/4</span>
+                    <span class="text-border">·</span>
+                    <span>awaiting <a href="task-detail.html" class="hover:text-foreground transition-colors">T-1014</a> review</span>
+                  </div>
+                </a>
+
+                <!-- Multi-hop ask: team-alpha → ic-agent-1, then -> db-agent. Chain depth 2. -->
+                <a href="#" class="block rounded-lg border border-border bg-card p-3 hover:border-ring/40 transition-colors cursor-pointer">
+                  <div class="flex items-center gap-2 mb-2 text-xs">
+                    <span class="font-mono text-foreground">team-alpha</span>
+                    <i data-lucide="arrow-right" class="h-3 w-3 text-muted-foreground"></i>
+                    <span class="font-mono text-foreground">ic-agent-1</span>
+                    <span class="text-muted-foreground/60">→</span>
+                    <span class="font-mono text-muted-foreground">db-agent</span>
+                    <span class="ml-auto inline-flex items-center gap-1 h-5 px-2 rounded text-[10px] font-medium bg-status-done/10 text-status-done">
+                      <i data-lucide="check" class="h-3 w-3"></i>
+                      24s
+                    </span>
+                  </div>
+                  <p class="text-sm leading-relaxed text-foreground/85">
+                    Is the OAuth refresh-token rotation production-safe? (ic-agent-1 sub-asked db-agent about lock semantics before answering.)
+                  </p>
+                  <div class="flex items-center gap-3 mt-2 text-[10px] text-muted-foreground font-mono">
+                    <span class="inline-flex items-center gap-1"><i data-lucide="link" class="h-3 w-3"></i>type: ask</span>
+                    <span class="text-border">·</span>
+                    <span class="text-status-review">chain depth 2/4</span>
+                    <span class="text-border">·</span>
+                    <span>session sess_8c4a · 2h ago</span>
+                  </div>
+                </a>
+
+                <!-- Older ask -->
+                <a href="#" class="block rounded-lg border border-border bg-card p-3 hover:border-ring/40 transition-colors cursor-pointer">
+                  <div class="flex items-center gap-2 mb-2 text-xs">
+                    <span class="font-mono text-foreground">db-agent</span>
+                    <i data-lucide="arrow-right" class="h-3 w-3 text-muted-foreground"></i>
+                    <span class="font-mono text-foreground">root-org</span>
+                    <span class="ml-auto inline-flex items-center gap-1 h-5 px-2 rounded text-[10px] font-medium bg-status-done/10 text-status-done">
+                      <i data-lucide="check" class="h-3 w-3"></i>
+                      6s
+                    </span>
+                  </div>
+                  <p class="text-sm leading-relaxed text-foreground/85">
+                    Should new migrations include explicit Down sections, or is auto-generated reverse acceptable?
+                  </p>
+                  <div class="mt-2 rounded bg-secondary/40 p-2 text-xs leading-relaxed">
+                    <span class="text-muted-foreground">root-org →</span>
+                    <span class="text-foreground/85">Always explicit Down. Auto-generated reverses miss CHECK constraints and partial-index drops.</span>
+                  </div>
+                  <div class="flex items-center gap-3 mt-2 text-[10px] text-muted-foreground font-mono">
+                    <span class="inline-flex items-center gap-1"><i data-lucide="link" class="h-3 w-3"></i>type: ask</span>
+                    <span class="text-border">·</span>
+                    <span>chain depth 1/4</span>
+                    <span class="text-border">·</span>
+                    <span>session sess_4f9a · 6h ago</span>
+                  </div>
+                </a>
+
+              </div>
+
+              <div class="mt-4 text-center">
+                <button class="inline-flex items-center gap-1.5 h-8 px-3 rounded text-xs font-medium hover:bg-secondary cursor-pointer transition-colors text-muted-foreground hover:text-foreground">
+                  Load 16 older asks
+                </button>
+              </div>
+            </section>
+
+            <!-- RIGHT: graph -->
+            <section class="col-span-2">
+              <div class="flex items-center justify-between mb-3">
+                <h2 class="text-[10px] uppercase tracking-wider text-muted-foreground">Live graph · last 24h</h2>
+                <div class="text-[10px] text-muted-foreground">
+                  <span class="text-foreground tabular-nums">23</span> edges
+                </div>
+              </div>
+
+              <!-- SVG graph: orthogonal force-direct-style layout, hand-positioned for the mock.
+                   Layout (viewBox 320 × 480): root-org at top, two team agents below, four ICs at bottom. -->
+              <div class="rounded-lg border border-border bg-card overflow-hidden">
+                <svg viewBox="0 0 320 480" class="w-full h-[480px]">
+                  <defs>
+                    <!-- arrowhead -->
+                    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+                      <path d="M 0 0 L 10 5 L 0 10 z" fill="hsl(var(--muted-foreground))" />
+                    </marker>
+                    <marker id="arr-live" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+                      <path d="M 0 0 L 10 5 L 0 10 z" fill="hsl(var(--status-running))" />
+                    </marker>
+                    <marker id="arr-blocked" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+                      <path d="M 0 0 L 10 5 L 0 10 z" fill="hsl(var(--status-blocked))" />
+                    </marker>
+                  </defs>
+
+                  <!-- ── Edges (drawn first, behind nodes) ── -->
+
+                  <!-- ic-agent-1 → db-agent : LIVE -->
+                  <path d="M 80 380 Q 100 280, 240 380" fill="none"
+                        stroke="hsl(var(--status-running))" stroke-width="1.5" class="ask-edge-live"
+                        marker-end="url(#arr-live)" />
+                  <text x="138" y="290" font-size="9" fill="hsl(var(--status-running))" font-family="JetBrains Mono">ask · 4s</text>
+
+                  <!-- ic-agent-3 → team-alpha : LIVE (negotiate) -->
+                  <path d="M 200 380 Q 180 280, 120 200" fill="none"
+                        stroke="hsl(var(--status-running))" stroke-width="1.5" class="ask-edge-live"
+                        marker-end="url(#arr-live)" />
+                  <text x="146" y="280" font-size="9" fill="hsl(var(--status-running))" font-family="JetBrains Mono">negotiate</text>
+
+                  <!-- ic-agent-2 → team-alpha : BLOCKER, escalation upward -->
+                  <path d="M 140 380 Q 130 290, 120 200" fill="none"
+                        stroke="hsl(var(--status-blocked))" stroke-width="1.5" stroke-dasharray="2 3"
+                        marker-end="url(#arr-blocked)" />
+                  <text x="60" y="290" font-size="9" fill="hsl(var(--status-blocked))" font-family="JetBrains Mono">blocker</text>
+
+                  <!-- ic-agent-1 → db-agent : completed -->
+                  <path d="M 80 380 Q 160 410, 240 380" fill="none"
+                        stroke="hsl(var(--muted-foreground))" stroke-width="1" stroke-opacity="0.5"
+                        marker-end="url(#arr)" />
+
+                  <!-- ic-agent-2 → ic-agent-3 : completed -->
+                  <path d="M 140 360 L 200 360" fill="none"
+                        stroke="hsl(var(--muted-foreground))" stroke-width="1" stroke-opacity="0.5"
+                        marker-end="url(#arr)" />
+
+                  <!-- team-alpha → ic-agent-1 : completed (from multi-hop ask) -->
+                  <path d="M 105 220 L 80 360" fill="none"
+                        stroke="hsl(var(--muted-foreground))" stroke-width="1" stroke-opacity="0.4"
+                        marker-end="url(#arr)" />
+
+                  <!-- db-agent → root-org : completed -->
+                  <path d="M 240 365 Q 200 220, 160 100" fill="none"
+                        stroke="hsl(var(--muted-foreground))" stroke-width="1" stroke-opacity="0.4"
+                        marker-end="url(#arr)" />
+
+                  <!-- ── Nodes ── -->
+
+                  <!-- root-org at (160, 80) — org tier -->
+                  <circle cx="160" cy="80" r="22" fill="hsl(var(--card))" stroke="hsl(var(--hier-org))" stroke-width="1.5" />
+                  <text x="160" y="85" text-anchor="middle" font-size="10" font-weight="600" fill="hsl(var(--foreground))" font-family="JetBrains Mono">root-org</text>
+                  <text x="160" y="116" text-anchor="middle" font-size="9" fill="hsl(var(--hier-org))">org</text>
+
+                  <!-- team-alpha at (105, 200) — team tier, ACTIVE -->
+                  <g>
+                    <circle class="node-ring" cx="105" cy="200" r="20" fill="hsl(var(--status-running))" fill-opacity="0.25" />
+                    <circle cx="105" cy="200" r="20" fill="hsl(var(--card))" stroke="hsl(var(--hier-team))" stroke-width="1.5" />
+                    <text x="105" y="205" text-anchor="middle" font-size="9" font-weight="600" fill="hsl(var(--foreground))" font-family="JetBrains Mono">team-alpha</text>
+                    <text x="105" y="234" text-anchor="middle" font-size="9" fill="hsl(var(--hier-team))">team</text>
+                  </g>
+
+                  <!-- team-data at (240, 200) — team tier, idle -->
+                  <circle cx="240" cy="200" r="20" fill="hsl(var(--card))" stroke="hsl(var(--hier-team))" stroke-width="1.5" />
+                  <text x="240" y="205" text-anchor="middle" font-size="9" font-weight="600" fill="hsl(var(--foreground))" font-family="JetBrains Mono">team-data</text>
+                  <text x="240" y="234" text-anchor="middle" font-size="9" fill="hsl(var(--hier-team))">team</text>
+
+                  <!-- ic-agent-1 at (60, 380) — ic, ACTIVE -->
+                  <g>
+                    <circle class="node-ring" cx="60" cy="380" r="18" fill="hsl(var(--status-running))" fill-opacity="0.25" />
+                    <circle cx="60" cy="380" r="18" fill="hsl(var(--card))" stroke="hsl(var(--hier-ic))" stroke-width="1.5" />
+                    <text x="60" y="384" text-anchor="middle" font-size="9" font-weight="600" fill="hsl(var(--foreground))" font-family="JetBrains Mono">ic-1</text>
+                    <text x="60" y="412" text-anchor="middle" font-size="8" fill="hsl(var(--hier-ic))">auth</text>
+                  </g>
+
+                  <!-- ic-agent-2 at (140, 380) — ic, BLOCKED -->
+                  <circle cx="140" cy="380" r="18" fill="hsl(var(--card))" stroke="hsl(var(--status-blocked))" stroke-width="1.5" />
+                  <text x="140" y="384" text-anchor="middle" font-size="9" font-weight="600" fill="hsl(var(--foreground))" font-family="JetBrains Mono">ic-2</text>
+                  <text x="140" y="412" text-anchor="middle" font-size="8" fill="hsl(var(--status-blocked))">blocked</text>
+
+                  <!-- ic-agent-3 at (220, 380) — ic, ACTIVE -->
+                  <g>
+                    <circle class="node-ring" cx="220" cy="380" r="18" fill="hsl(var(--status-running))" fill-opacity="0.25" />
+                    <circle cx="220" cy="380" r="18" fill="hsl(var(--card))" stroke="hsl(var(--hier-ic))" stroke-width="1.5" />
+                    <text x="220" y="384" text-anchor="middle" font-size="9" font-weight="600" fill="hsl(var(--foreground))" font-family="JetBrains Mono">ic-3</text>
+                    <text x="220" y="412" text-anchor="middle" font-size="8" fill="hsl(var(--hier-ic))">infra</text>
+                  </g>
+
+                  <!-- db-agent at (270, 380) — ic, idle -->
+                  <circle cx="270" cy="380" r="18" fill="hsl(var(--card))" stroke="hsl(var(--hier-ic))" stroke-width="1.5" />
+                  <text x="270" y="384" text-anchor="middle" font-size="9" font-weight="600" fill="hsl(var(--foreground))" font-family="JetBrains Mono">db</text>
+                  <text x="270" y="412" text-anchor="middle" font-size="8" fill="hsl(var(--hier-ic))">data</text>
+
+                </svg>
+
+                <!-- Legend -->
+                <div class="px-3 py-2.5 border-t border-border text-[10px] text-muted-foreground flex flex-wrap items-center gap-x-4 gap-y-1.5">
+                  <span class="inline-flex items-center gap-1.5">
+                    <svg width="14" height="6"><line x1="0" y1="3" x2="14" y2="3" stroke="hsl(var(--status-running))" stroke-width="1.5" stroke-dasharray="3 2" /></svg>
+                    <span>in-flight ask</span>
+                  </span>
+                  <span class="inline-flex items-center gap-1.5">
+                    <svg width="14" height="6"><line x1="0" y1="3" x2="14" y2="3" stroke="hsl(var(--status-blocked))" stroke-width="1.5" stroke-dasharray="2 2" /></svg>
+                    <span>blocker / escalation</span>
+                  </span>
+                  <span class="inline-flex items-center gap-1.5">
+                    <svg width="14" height="6"><line x1="0" y1="3" x2="14" y2="3" stroke="hsl(var(--muted-foreground))" stroke-width="1" opacity="0.5" /></svg>
+                    <span>completed</span>
+                  </span>
+                </div>
+              </div>
+
+              <!-- Chain budget summary -->
+              <div class="mt-5 rounded-lg border border-border bg-card p-3.5">
+                <div class="flex items-baseline justify-between mb-2.5">
+                  <span class="text-[10px] uppercase tracking-wider text-muted-foreground">Chain budget · last 24h</span>
+                </div>
+                <div class="space-y-2 text-xs">
+                  <div class="flex items-center gap-2">
+                    <span class="text-muted-foreground w-20 shrink-0">Avg depth</span>
+                    <div class="flex-1 h-1.5 bg-secondary rounded-full overflow-hidden">
+                      <div class="h-full bg-status-done" style="width: 32%;"></div>
+                    </div>
+                    <span class="font-mono tabular-nums text-foreground w-12 text-right">1.3 / 4</span>
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <span class="text-muted-foreground w-20 shrink-0">Max depth</span>
+                    <div class="flex-1 h-1.5 bg-secondary rounded-full overflow-hidden">
+                      <div class="h-full bg-status-review" style="width: 50%;"></div>
+                    </div>
+                    <span class="font-mono tabular-nums text-foreground w-12 text-right">2 / 4</span>
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <span class="text-muted-foreground w-20 shrink-0">Tokens used</span>
+                    <div class="flex-1 h-1.5 bg-secondary rounded-full overflow-hidden">
+                      <div class="h-full" style="width: 18%; background: hsl(var(--primary));"></div>
+                    </div>
+                    <span class="font-mono tabular-nums text-foreground w-12 text-right">8.2k / 50k</span>
+                  </div>
+                </div>
+                <div class="mt-3 text-[10px] text-muted-foreground leading-relaxed">
+                  No chain has reached the depth cap or token cap. <span class="text-foreground/80">ChainBudget</span> would terminate at depth 4 or 50k tokens, whichever first.
+                </div>
+              </div>
+            </section>
+
+          </div>
+
+          <!-- Foot note -->
+          <div class="mt-10 text-xs text-muted-foreground flex items-start gap-2 max-w-2xl">
+            <i data-lucide="info" class="h-3.5 w-3.5 shrink-0 mt-0.5"></i>
+            <span>
+              <span class="text-foreground/80">Each ask is a session.</span> Caller and target agents stay bounded — neither dumps its memory into a shared pool. The target answers from its own context; the caller incorporates the answer into its work. <span class="font-mono">ChainBudget</span> caps depth and total tokens to prevent runaway asks.
+            </span>
+          </div>
+
+        </div>
+      </div>
+    </main>
+  </div>
+
+  <script>
+    lucide.createIcons();
+    document.getElementById('theme-toggle').addEventListener('click', () => {
+      document.documentElement.classList.toggle('dark');
+      lucide.createIcons();
+    });
+  </script>
+</body>
+</html>

--- a/mocks/promotions.html
+++ b/mocks/promotions.html
@@ -1,0 +1,565 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>beevibe — promotions · curated commons</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+  <script>
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.classList.add('dark');
+    }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+  <style>
+    :root {
+      --background: 0 0% 100%;
+      --foreground: 240 10% 4%;
+      --card: 240 5% 98%;
+      --card-foreground: 240 10% 4%;
+      --primary: 48 96% 53%;
+      --primary-foreground: 240 10% 4%;
+      --secondary: 240 5% 96%;
+      --secondary-foreground: 240 6% 10%;
+      --muted: 240 5% 96%;
+      --muted-foreground: 240 4% 46%;
+      --border: 240 6% 90%;
+      --input: 240 6% 90%;
+      --ring: 47 96% 47%;
+      --radius: 0.375rem;
+
+      --status-pending:   240 4% 46%;
+      --status-running:   217 91% 60%;
+      --status-review:    38 92% 50%;
+      --status-blocked:   25 95% 53%;
+      --status-done:      160 84% 39%;
+      --status-failed:    0 84% 60%;
+
+      --hier-ic:   240 4% 46%;
+      --hier-team: 262 83% 58%;
+      --hier-org:  38 92% 50%;
+    }
+    .dark {
+      --background: 240 10% 4%;
+      --foreground: 0 0% 98%;
+      --card: 240 6% 10%;
+      --card-foreground: 0 0% 98%;
+      --primary: 48 96% 53%;
+      --primary-foreground: 240 10% 4%;
+      --secondary: 240 4% 16%;
+      --secondary-foreground: 0 0% 98%;
+      --muted: 240 4% 16%;
+      --muted-foreground: 240 5% 65%;
+      --border: 240 4% 16%;
+      --input: 240 4% 16%;
+      --ring: 48 96% 53%;
+    }
+
+    body {
+      font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
+      font-feature-settings: 'cv11', 'ss01';
+      background-color: hsl(var(--background));
+      color: hsl(var(--foreground));
+      -webkit-font-smoothing: antialiased;
+    }
+    .font-mono { font-family: 'JetBrains Mono', ui-monospace, 'Menlo', monospace; }
+
+    @keyframes pulse-breathe {
+      0%, 100% { opacity: 1; transform: scale(1); }
+      50%      { opacity: 0.55; transform: scale(0.92); }
+    }
+    .pulse-dot { animation: pulse-breathe 2s ease-in-out infinite; }
+
+    @media (prefers-reduced-motion: reduce) {
+      .pulse-dot { animation: none; }
+    }
+
+    button:focus-visible, a:focus-visible {
+      outline: 2px solid hsl(var(--ring));
+      outline-offset: 2px;
+      border-radius: var(--radius);
+    }
+
+    /* Timeline rail */
+    .timeline-rail {
+      position: relative;
+    }
+    .timeline-rail::before {
+      content: '';
+      position: absolute;
+      left: 11px;
+      top: 8px;
+      bottom: 8px;
+      width: 1px;
+      background: hsl(var(--border));
+    }
+    .timeline-dot {
+      position: relative;
+      z-index: 1;
+    }
+  </style>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+            mono: ['JetBrains Mono', 'ui-monospace', 'Menlo', 'monospace'],
+          },
+          colors: {
+            border: 'hsl(var(--border))',
+            input: 'hsl(var(--input))',
+            ring: 'hsl(var(--ring))',
+            background: 'hsl(var(--background))',
+            foreground: 'hsl(var(--foreground))',
+            primary: { DEFAULT: 'hsl(var(--primary))', foreground: 'hsl(var(--primary-foreground))' },
+            secondary: { DEFAULT: 'hsl(var(--secondary))', foreground: 'hsl(var(--secondary-foreground))' },
+            muted: { DEFAULT: 'hsl(var(--muted))', foreground: 'hsl(var(--muted-foreground))' },
+            card: { DEFAULT: 'hsl(var(--card))', foreground: 'hsl(var(--card-foreground))' },
+            status: {
+              pending:   'hsl(var(--status-pending))',
+              running:   'hsl(var(--status-running))',
+              review:    'hsl(var(--status-review))',
+              blocked:   'hsl(var(--status-blocked))',
+              done:      'hsl(var(--status-done))',
+              failed:    'hsl(var(--status-failed))',
+            },
+            hier: {
+              ic:   'hsl(var(--hier-ic))',
+              team: 'hsl(var(--hier-team))',
+              org:  'hsl(var(--hier-org))',
+            },
+          },
+          borderRadius: {
+            DEFAULT: 'var(--radius)',
+            md: 'var(--radius)',
+            lg: 'calc(var(--radius) + 2px)',
+            xl: 'calc(var(--radius) + 6px)',
+          },
+        },
+      },
+    };
+  </script>
+</head>
+<body class="min-h-screen">
+  <div class="flex min-h-screen">
+
+    <!-- Sidebar (Memory active — promotions is a memory sub-page) -->
+    <aside class="w-[220px] shrink-0 bg-card flex flex-col">
+      <div class="h-14 flex items-center gap-2.5 px-4">
+        <div class="h-6 w-6 rounded bg-primary flex items-center justify-center">
+          <span class="text-primary-foreground text-sm font-bold leading-none">b</span>
+        </div>
+        <span class="font-semibold tracking-tight">beevibe</span>
+      </div>
+      <nav class="flex-1 p-2 space-y-0.5 text-sm">
+        <a href="home.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="home" class="h-4 w-4"></i>
+          <span>Home</span>
+        </a>
+        <a href="tasks-list.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="list-checks" class="h-4 w-4"></i>
+          <span>Tasks</span>
+        </a>
+        <a href="agents-list.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="circle-dot" class="h-4 w-4"></i>
+          <span>Agents</span>
+        </a>
+        <a href="threads.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="message-square" class="h-4 w-4"></i>
+          <span>Threads</span>
+        </a>
+        <a href="memory.html" class="flex items-center gap-3 px-3 py-2 rounded bg-secondary text-foreground font-medium">
+          <i data-lucide="sparkles" class="h-4 w-4"></i>
+          <span>Memory</span>
+        </a>
+      </nav>
+
+      <div class="p-3">
+        <div class="flex items-center gap-1">
+          <button class="flex-1 min-w-0 flex items-center gap-2 px-2 py-1.5 rounded hover:bg-secondary cursor-pointer transition-colors text-left">
+            <div class="h-7 w-7 rounded-full bg-secondary border border-border flex items-center justify-center text-xs font-medium shrink-0">W</div>
+            <div class="flex-1 min-w-0">
+              <div class="text-sm font-medium truncate leading-tight">Weijia</div>
+              <div class="text-[10px] text-muted-foreground flex items-center gap-1 leading-tight mt-0.5">
+                <span class="pulse-dot inline-block h-1 w-1 rounded-full bg-status-running"></span>
+                live
+              </div>
+            </div>
+            <i data-lucide="chevrons-up-down" class="h-3.5 w-3.5 text-muted-foreground shrink-0"></i>
+          </button>
+          <button id="theme-toggle" class="h-8 w-8 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary cursor-pointer transition-colors shrink-0" title="Toggle theme">
+            <i data-lucide="sun" class="h-4 w-4 hidden dark:block"></i>
+            <i data-lucide="moon" class="h-4 w-4 block dark:hidden"></i>
+          </button>
+        </div>
+      </div>
+    </aside>
+
+    <!-- Main — LIST density (max-w-6xl) -->
+    <main class="flex-1 min-w-0 flex flex-col">
+      <div class="flex-1 overflow-auto">
+        <div class="max-w-6xl mx-auto pt-8 pb-12 px-6">
+
+          <!-- Memory sub-nav tabs -->
+          <div class="flex items-center gap-1 mb-6 -mt-2 text-sm">
+            <a href="memory.html" class="px-3 py-1.5 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors">All facts</a>
+            <a href="#" class="px-3 py-1.5 rounded bg-secondary text-foreground font-medium">Promotions</a>
+            <a href="#" class="px-3 py-1.5 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors">Merges</a>
+            <a href="#" class="px-3 py-1.5 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors">Conflicts</a>
+          </div>
+
+          <!-- Lead line -->
+          <div class="mb-6 flex items-baseline justify-between gap-6">
+            <div>
+              <h1 class="text-base font-semibold mb-1">Promotions</h1>
+              <p class="text-sm text-muted-foreground max-w-2xl leading-relaxed">
+                When the same observation reappears across sessions, <span class="font-mono text-foreground">FactPromoter</span> evaluates whether it has earned a wider scope. Each event below is the LLM's per-fact decision with its stated reason. The default is to keep facts narrow.
+              </p>
+            </div>
+            <div class="text-xs text-muted-foreground shrink-0 text-right">
+              <div><span class="text-foreground tabular-nums">14</span> promotions · last 30d</div>
+              <div class="mt-1"><span class="text-status-done tabular-nums">+3</span> this week</div>
+            </div>
+          </div>
+
+          <!-- Scope-transition filter -->
+          <div class="flex items-center gap-2 mb-4 text-xs">
+            <span class="text-muted-foreground">Filter:</span>
+            <button class="inline-flex items-center gap-1.5 h-7 px-2.5 rounded bg-secondary text-foreground font-medium">
+              <span>All</span>
+              <span class="font-mono tabular-nums text-muted-foreground">14</span>
+            </button>
+            <button class="inline-flex items-center gap-1.5 h-7 px-2.5 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors">
+              <span class="inline-flex items-center h-4 px-1 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic">ic</span>
+              <i data-lucide="arrow-right" class="h-3 w-3"></i>
+              <span class="inline-flex items-center h-4 px-1 rounded text-[10px] font-medium bg-hier-team/10 text-hier-team">team</span>
+              <span class="font-mono tabular-nums">11</span>
+            </button>
+            <button class="inline-flex items-center gap-1.5 h-7 px-2.5 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors">
+              <span class="inline-flex items-center h-4 px-1 rounded text-[10px] font-medium bg-hier-team/10 text-hier-team">team</span>
+              <i data-lucide="arrow-right" class="h-3 w-3"></i>
+              <span class="inline-flex items-center h-4 px-1 rounded text-[10px] font-medium border border-hier-org text-hier-org">org</span>
+              <span class="font-mono tabular-nums">3</span>
+            </button>
+            <span class="ml-auto text-muted-foreground inline-flex items-center gap-1 cursor-pointer hover:text-foreground transition-colors">
+              <i data-lucide="arrow-up-down" class="h-3 w-3"></i>
+              <span>Newest</span>
+            </span>
+          </div>
+
+          <!-- Timeline list. LIST mode: py-2.5 rows, abuts. -->
+          <div class="timeline-rail pl-7">
+
+            <!-- ── Most recent — fresh ic→team this morning ── -->
+            <div class="relative py-4 border-b border-border">
+              <div class="timeline-dot absolute -left-7 top-5 h-6 w-6 rounded-full bg-background border-2 border-hier-team flex items-center justify-center">
+                <i data-lucide="trending-up" class="h-3 w-3 text-hier-team"></i>
+              </div>
+              <div class="flex items-start justify-between gap-4 mb-2">
+                <div class="flex items-center gap-2 text-xs">
+                  <span class="inline-flex items-center h-5 px-1.5 rounded font-medium bg-hier-ic/15 text-hier-ic">ic</span>
+                  <i data-lucide="arrow-right" class="h-3 w-3 text-muted-foreground"></i>
+                  <span class="inline-flex items-center h-5 px-1.5 rounded font-medium bg-hier-team/10 text-hier-team">team</span>
+                  <span class="text-border">·</span>
+                  <span class="text-muted-foreground">originated by <a href="agent-detail.html" class="font-mono text-foreground hover:underline">ic-agent-1</a></span>
+                </div>
+                <span class="text-xs text-muted-foreground tabular-nums shrink-0">2h ago</span>
+              </div>
+              <p class="text-sm leading-relaxed mb-2">
+                Postgres NOTIFY payload is capped at 8KB. Keep payloads to id, status, and timestamps; clients refetch full rows via HTTP after the event.
+              </p>
+              <div class="rounded-lg bg-secondary/50 p-3 mb-2">
+                <div class="flex items-start gap-2 text-xs">
+                  <i data-lucide="brain-circuit" class="h-3.5 w-3.5 text-primary shrink-0 mt-0.5"></i>
+                  <div class="text-muted-foreground leading-relaxed">
+                    <span class="text-foreground font-medium">FactPromoter:</span>
+                    "Observation surfaced independently in 3 sessions across 2 different agents (ic-agent-1, ic-agent-2). The constraint is a Postgres-level fact, not domain-specific to auth or to any single agent's work — it generalizes across the team's infrastructure work. Promote to team."
+                  </div>
+                </div>
+              </div>
+              <div class="flex items-center gap-3 text-[10px] text-muted-foreground font-mono">
+                <span class="inline-flex items-center gap-1">
+                  <i data-lucide="hash" class="h-3 w-3"></i>
+                  fact_8c4b2af19e
+                </span>
+                <span class="text-border">·</span>
+                <span>source sessions:</span>
+                <a href="session-detail.html" class="hover:text-foreground transition-colors">sess_3a8c</a>
+                <a href="#" class="hover:text-foreground transition-colors">sess_5d12</a>
+                <a href="#" class="hover:text-foreground transition-colors">sess_9e7b</a>
+              </div>
+            </div>
+
+            <!-- ── team→org rare event ── -->
+            <div class="relative py-4 border-b border-border">
+              <div class="timeline-dot absolute -left-7 top-5 h-6 w-6 rounded-full bg-background border-2 border-hier-org flex items-center justify-center">
+                <i data-lucide="trending-up" class="h-3 w-3 text-hier-org"></i>
+              </div>
+              <div class="flex items-start justify-between gap-4 mb-2">
+                <div class="flex items-center gap-2 text-xs">
+                  <span class="inline-flex items-center h-5 px-1.5 rounded font-medium bg-hier-team/10 text-hier-team">team</span>
+                  <i data-lucide="arrow-right" class="h-3 w-3 text-muted-foreground"></i>
+                  <span class="inline-flex items-center h-5 px-1.5 rounded font-medium border border-hier-org text-hier-org">org</span>
+                  <span class="text-border">·</span>
+                  <span class="text-muted-foreground">originated by <a href="#" class="font-mono text-foreground hover:underline">team-alpha</a></span>
+                </div>
+                <span class="text-xs text-muted-foreground tabular-nums shrink-0">11h ago</span>
+              </div>
+              <p class="text-sm leading-relaxed mb-2">
+                All inter-agent communication flows through the task queue and mesh tools, not direct calls. Async dispatch via task assignment + synchronous mesh ask are the only two primitives — no out-of-band agent-to-agent RPC.
+              </p>
+              <div class="rounded-lg bg-secondary/50 p-3 mb-2">
+                <div class="flex items-start gap-2 text-xs">
+                  <i data-lucide="brain-circuit" class="h-3.5 w-3.5 text-primary shrink-0 mt-0.5"></i>
+                  <div class="text-muted-foreground leading-relaxed">
+                    <span class="text-foreground font-medium">FactPromoter:</span>
+                    "This is a foundational architectural invariant of the runtime, not a team-specific pattern. team-data has independently arrived at the same constraint in their work. Cross-team applicability and architectural-tier importance both warrant org scope."
+                  </div>
+                </div>
+              </div>
+              <div class="flex items-center gap-3 text-[10px] text-muted-foreground font-mono">
+                <span class="inline-flex items-center gap-1">
+                  <i data-lucide="hash" class="h-3 w-3"></i>
+                  fact_2e9a4f8c3d
+                </span>
+                <span class="text-border">·</span>
+                <span>source sessions:</span>
+                <a href="#" class="hover:text-foreground transition-colors">sess_1f4a</a>
+                <a href="#" class="hover:text-foreground transition-colors">sess_8b2c</a>
+                <a href="#" class="hover:text-foreground transition-colors">sess_4d9e</a>
+                <a href="#" class="hover:text-foreground transition-colors">sess_7c1a</a>
+                <span class="text-muted-foreground/60">+4 more</span>
+              </div>
+            </div>
+
+            <!-- ── ic→team yesterday ── -->
+            <div class="relative py-4 border-b border-border">
+              <div class="timeline-dot absolute -left-7 top-5 h-6 w-6 rounded-full bg-background border-2 border-hier-team flex items-center justify-center">
+                <i data-lucide="trending-up" class="h-3 w-3 text-hier-team"></i>
+              </div>
+              <div class="flex items-start justify-between gap-4 mb-2">
+                <div class="flex items-center gap-2 text-xs">
+                  <span class="inline-flex items-center h-5 px-1.5 rounded font-medium bg-hier-ic/15 text-hier-ic">ic</span>
+                  <i data-lucide="arrow-right" class="h-3 w-3 text-muted-foreground"></i>
+                  <span class="inline-flex items-center h-5 px-1.5 rounded font-medium bg-hier-team/10 text-hier-team">team</span>
+                  <span class="text-border">·</span>
+                  <span class="text-muted-foreground">originated by <a href="#" class="font-mono text-foreground hover:underline">ic-agent-2</a></span>
+                </div>
+                <span class="text-xs text-muted-foreground tabular-nums shrink-0">1d ago</span>
+              </div>
+              <p class="text-sm leading-relaxed mb-2">
+                When a task is rejected back to revision, the agent re-uses the same prior_session_id chain — context flows forward, not backward. Reviewer notes attach to the new session's intent, not to the rejected session.
+              </p>
+              <div class="rounded-lg bg-secondary/50 p-3 mb-2">
+                <div class="flex items-start gap-2 text-xs">
+                  <i data-lucide="brain-circuit" class="h-3.5 w-3.5 text-primary shrink-0 mt-0.5"></i>
+                  <div class="text-muted-foreground leading-relaxed">
+                    <span class="text-foreground font-medium">FactPromoter:</span>
+                    "Pattern about the revision flow that any IC agent in team-alpha could plausibly hit. Generalizes across the team's task work; not specific to one agent's domain. Promote to team."
+                  </div>
+                </div>
+              </div>
+              <div class="flex items-center gap-3 text-[10px] text-muted-foreground font-mono">
+                <span class="inline-flex items-center gap-1">
+                  <i data-lucide="hash" class="h-3 w-3"></i>
+                  fact_6d3b8e2a91
+                </span>
+                <span class="text-border">·</span>
+                <span>source sessions:</span>
+                <a href="#" class="hover:text-foreground transition-colors">sess_2a9f</a>
+                <a href="#" class="hover:text-foreground transition-colors">sess_6e3b</a>
+              </div>
+            </div>
+
+            <!-- ── A REJECTED candidate — showing the editorial gate is real ── -->
+            <div class="relative py-4 border-b border-border opacity-70">
+              <div class="timeline-dot absolute -left-7 top-5 h-6 w-6 rounded-full bg-background border-2 border-border flex items-center justify-center">
+                <i data-lucide="x" class="h-3 w-3 text-muted-foreground"></i>
+              </div>
+              <div class="flex items-start justify-between gap-4 mb-2">
+                <div class="flex items-center gap-2 text-xs">
+                  <span class="inline-flex items-center h-5 px-1.5 rounded font-medium bg-hier-ic/15 text-hier-ic">ic</span>
+                  <span class="text-border">·</span>
+                  <span class="text-muted-foreground italic">candidate rejected — kept narrow</span>
+                  <span class="text-border">·</span>
+                  <span class="text-muted-foreground">in <a href="#" class="font-mono text-foreground hover:underline">db-agent</a></span>
+                </div>
+                <span class="text-xs text-muted-foreground tabular-nums shrink-0">2d ago</span>
+              </div>
+              <p class="text-sm leading-relaxed mb-2">
+                pgvector cosine similarity outperforms L2 distance for memory_fact retrieval — embeddings cluster better in angular space when content lengths vary widely.
+              </p>
+              <div class="rounded-lg bg-secondary/50 p-3 mb-2">
+                <div class="flex items-start gap-2 text-xs">
+                  <i data-lucide="brain-circuit" class="h-3.5 w-3.5 text-muted-foreground shrink-0 mt-0.5"></i>
+                  <div class="text-muted-foreground leading-relaxed">
+                    <span class="text-foreground/80 font-medium">FactPromoter:</span>
+                    "Domain-specific to retrieval-quality work; only one agent has surfaced it; team-alpha's auth/UI focus is unrelated. Keep narrow at ic. Re-evaluate if a second agent independently rediscovers."
+                  </div>
+                </div>
+              </div>
+              <div class="flex items-center gap-3 text-[10px] text-muted-foreground font-mono">
+                <span class="inline-flex items-center gap-1">
+                  <i data-lucide="hash" class="h-3 w-3"></i>
+                  fact_9a7e5c1b4d
+                </span>
+                <span class="text-border">·</span>
+                <span>source sessions:</span>
+                <a href="#" class="hover:text-foreground transition-colors">sess_3c8b</a>
+              </div>
+            </div>
+
+            <!-- ── Older ic→team ── -->
+            <div class="relative py-4 border-b border-border">
+              <div class="timeline-dot absolute -left-7 top-5 h-6 w-6 rounded-full bg-background border-2 border-hier-team flex items-center justify-center">
+                <i data-lucide="trending-up" class="h-3 w-3 text-hier-team"></i>
+              </div>
+              <div class="flex items-start justify-between gap-4 mb-2">
+                <div class="flex items-center gap-2 text-xs">
+                  <span class="inline-flex items-center h-5 px-1.5 rounded font-medium bg-hier-ic/15 text-hier-ic">ic</span>
+                  <i data-lucide="arrow-right" class="h-3 w-3 text-muted-foreground"></i>
+                  <span class="inline-flex items-center h-5 px-1.5 rounded font-medium bg-hier-team/10 text-hier-team">team</span>
+                  <span class="text-border">·</span>
+                  <span class="text-muted-foreground">originated by <a href="agent-detail.html" class="font-mono text-foreground hover:underline">ic-agent-1</a></span>
+                </div>
+                <span class="text-xs text-muted-foreground tabular-nums shrink-0">3d ago</span>
+              </div>
+              <p class="text-sm leading-relaxed mb-2">
+                For dense list views, prefer Inter over IBM Plex Sans — better metrics at 12–14px and matches the operator-tool aesthetic the rest of our stack uses.
+              </p>
+              <div class="rounded-lg bg-secondary/50 p-3 mb-2">
+                <div class="flex items-start gap-2 text-xs">
+                  <i data-lucide="brain-circuit" class="h-3.5 w-3.5 text-primary shrink-0 mt-0.5"></i>
+                  <div class="text-muted-foreground leading-relaxed">
+                    <span class="text-foreground font-medium">FactPromoter:</span>
+                    "Typography choice that affects all of team-alpha's UI work. Promote to team — but err: if team-data ever does UI work, will need re-evaluation for org. Note: ic-agent-3 has independently used Inter in their UI work; confirms generalization within team."
+                  </div>
+                </div>
+              </div>
+              <div class="flex items-center gap-3 text-[10px] text-muted-foreground font-mono">
+                <span class="inline-flex items-center gap-1">
+                  <i data-lucide="hash" class="h-3 w-3"></i>
+                  fact_1c9b3e7a82
+                </span>
+                <span class="text-border">·</span>
+                <span>source sessions:</span>
+                <a href="#" class="hover:text-foreground transition-colors">sess_8a4f</a>
+              </div>
+            </div>
+
+            <!-- ── ic→team older ── -->
+            <div class="relative py-4 border-b border-border">
+              <div class="timeline-dot absolute -left-7 top-5 h-6 w-6 rounded-full bg-background border-2 border-hier-team flex items-center justify-center">
+                <i data-lucide="trending-up" class="h-3 w-3 text-hier-team"></i>
+              </div>
+              <div class="flex items-start justify-between gap-4 mb-2">
+                <div class="flex items-center gap-2 text-xs">
+                  <span class="inline-flex items-center h-5 px-1.5 rounded font-medium bg-hier-ic/15 text-hier-ic">ic</span>
+                  <i data-lucide="arrow-right" class="h-3 w-3 text-muted-foreground"></i>
+                  <span class="inline-flex items-center h-5 px-1.5 rounded font-medium bg-hier-team/10 text-hier-team">team</span>
+                  <span class="text-border">·</span>
+                  <span class="text-muted-foreground">originated by <a href="#" class="font-mono text-foreground hover:underline">ic-agent-3</a></span>
+                </div>
+                <span class="text-xs text-muted-foreground tabular-nums shrink-0">5d ago</span>
+              </div>
+              <p class="text-sm leading-relaxed mb-2">
+                M8 deploys self-hosted, not Vercel, so SSE survives long connections without serverless timeout workarounds. Single Next.js process; long-lived pg client for LISTEN.
+              </p>
+              <div class="rounded-lg bg-secondary/50 p-3 mb-2">
+                <div class="flex items-start gap-2 text-xs">
+                  <i data-lucide="brain-circuit" class="h-3.5 w-3.5 text-primary shrink-0 mt-0.5"></i>
+                  <div class="text-muted-foreground leading-relaxed">
+                    <span class="text-foreground font-medium">FactPromoter:</span>
+                    "Deployment-target decision binding all team-alpha frontend work. Promote to team. Subsequently observed in 4 more sessions — strong cross-agent corroboration."
+                  </div>
+                </div>
+              </div>
+              <div class="flex items-center gap-3 text-[10px] text-muted-foreground font-mono">
+                <span class="inline-flex items-center gap-1">
+                  <i data-lucide="hash" class="h-3 w-3"></i>
+                  fact_4e8b2c9f1a
+                </span>
+                <span class="text-border">·</span>
+                <span>source sessions:</span>
+                <a href="#" class="hover:text-foreground transition-colors">sess_2b9c</a>
+                <a href="#" class="hover:text-foreground transition-colors">sess_7d4a</a>
+                <a href="#" class="hover:text-foreground transition-colors">sess_5f8e</a>
+                <span class="text-muted-foreground/60">+2 more</span>
+              </div>
+            </div>
+
+            <!-- ── ic→team older ── -->
+            <div class="relative py-4 border-b border-border">
+              <div class="timeline-dot absolute -left-7 top-5 h-6 w-6 rounded-full bg-background border-2 border-hier-team flex items-center justify-center">
+                <i data-lucide="trending-up" class="h-3 w-3 text-hier-team"></i>
+              </div>
+              <div class="flex items-start justify-between gap-4 mb-2">
+                <div class="flex items-center gap-2 text-xs">
+                  <span class="inline-flex items-center h-5 px-1.5 rounded font-medium bg-hier-ic/15 text-hier-ic">ic</span>
+                  <i data-lucide="arrow-right" class="h-3 w-3 text-muted-foreground"></i>
+                  <span class="inline-flex items-center h-5 px-1.5 rounded font-medium bg-hier-team/10 text-hier-team">team</span>
+                  <span class="text-border">·</span>
+                  <span class="text-muted-foreground">originated by <a href="#" class="font-mono text-foreground hover:underline">db-agent</a></span>
+                </div>
+                <span class="text-xs text-muted-foreground tabular-nums shrink-0">1w ago</span>
+              </div>
+              <p class="text-sm leading-relaxed mb-2">
+                Drizzle migrations need explicit Down sections for production safety — never rely on auto-generated reverses; they often miss CHECK constraints and index drops.
+              </p>
+              <div class="rounded-lg bg-secondary/50 p-3 mb-2">
+                <div class="flex items-start gap-2 text-xs">
+                  <i data-lucide="brain-circuit" class="h-3.5 w-3.5 text-primary shrink-0 mt-0.5"></i>
+                  <div class="text-muted-foreground leading-relaxed">
+                    <span class="text-foreground font-medium">FactPromoter:</span>
+                    "Migration-safety constraint that all team-data work follows. Promote to team. Likely org-tier eventually if team-alpha encounters it during their schema work."
+                  </div>
+                </div>
+              </div>
+              <div class="flex items-center gap-3 text-[10px] text-muted-foreground font-mono">
+                <span class="inline-flex items-center gap-1">
+                  <i data-lucide="hash" class="h-3 w-3"></i>
+                  fact_7a2c4d8b1e
+                </span>
+                <span class="text-border">·</span>
+                <span>source sessions:</span>
+                <a href="#" class="hover:text-foreground transition-colors">sess_9e1c</a>
+                <a href="#" class="hover:text-foreground transition-colors">sess_4b8a</a>
+                <a href="#" class="hover:text-foreground transition-colors">sess_2f5d</a>
+              </div>
+            </div>
+
+          </div>
+
+          <!-- Foot note + load more -->
+          <div class="mt-6 text-center">
+            <button class="inline-flex items-center gap-1.5 h-8 px-3 rounded text-xs font-medium hover:bg-secondary cursor-pointer transition-colors text-muted-foreground hover:text-foreground">
+              Load 7 older promotions
+            </button>
+          </div>
+
+          <div class="mt-10 text-xs text-muted-foreground flex items-start gap-2 max-w-2xl">
+            <i data-lucide="info" class="h-3.5 w-3.5 shrink-0 mt-0.5"></i>
+            <span>
+              <span class="text-foreground/80">No flat pool exists.</span> Every fact, at every scope, is attributed to its originating agent (<span class="font-mono">memory_fact.agent_id</span> is non-null). Promotion changes <em>visibility radius</em>, not authorship. The org agent reads org-scope facts at brief-time and can override the synthesized view via its own core memory.
+            </span>
+          </div>
+
+        </div>
+      </div>
+    </main>
+  </div>
+
+  <script>
+    lucide.createIcons();
+    document.getElementById('theme-toggle').addEventListener('click', () => {
+      document.documentElement.classList.toggle('dark');
+      lucide.createIcons();
+    });
+  </script>
+</body>
+</html>

--- a/mocks/session-detail.html
+++ b/mocks/session-detail.html
@@ -1,0 +1,596 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>beevibe — session sess_3a8c · ic-agent-1</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+  <script>
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.classList.add('dark');
+    }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+  <style>
+    :root {
+      --background: 0 0% 100%;
+      --foreground: 240 10% 4%;
+      --card: 240 5% 98%;
+      --card-foreground: 240 10% 4%;
+      --primary: 48 96% 53%;
+      --primary-foreground: 240 10% 4%;
+      --secondary: 240 5% 96%;
+      --secondary-foreground: 240 6% 10%;
+      --muted: 240 5% 96%;
+      --muted-foreground: 240 4% 46%;
+      --border: 240 6% 90%;
+      --input: 240 6% 90%;
+      --ring: 47 96% 47%;
+      --radius: 0.375rem;
+
+      --status-pending:   240 4% 46%;
+      --status-running:   217 91% 60%;
+      --status-review:    38 92% 50%;
+      --status-blocked:   25 95% 53%;
+      --status-done:      160 84% 39%;
+      --status-failed:    0 84% 60%;
+
+      --hier-ic:   240 4% 46%;
+      --hier-team: 262 83% 58%;
+      --hier-org:  38 92% 50%;
+    }
+    .dark {
+      --background: 240 10% 4%;
+      --foreground: 0 0% 98%;
+      --card: 240 6% 10%;
+      --card-foreground: 0 0% 98%;
+      --primary: 48 96% 53%;
+      --primary-foreground: 240 10% 4%;
+      --secondary: 240 4% 16%;
+      --secondary-foreground: 0 0% 98%;
+      --muted: 240 4% 16%;
+      --muted-foreground: 240 5% 65%;
+      --border: 240 4% 16%;
+      --input: 240 4% 16%;
+      --ring: 48 96% 53%;
+    }
+
+    body {
+      font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
+      font-feature-settings: 'cv11', 'ss01';
+      background-color: hsl(var(--background));
+      color: hsl(var(--foreground));
+      -webkit-font-smoothing: antialiased;
+    }
+    .font-mono { font-family: 'JetBrains Mono', ui-monospace, 'Menlo', monospace; }
+
+    @keyframes pulse-breathe {
+      0%, 100% { opacity: 1; transform: scale(1); }
+      50%      { opacity: 0.55; transform: scale(0.92); }
+    }
+    .pulse-dot { animation: pulse-breathe 2s ease-in-out infinite; }
+
+    @keyframes spin-slow { to { transform: rotate(360deg); } }
+    .spin-slow { animation: spin-slow 2.5s linear infinite; }
+
+    @media (prefers-reduced-motion: reduce) {
+      .pulse-dot, .spin-slow { animation: none; }
+    }
+
+    button:focus-visible, a:focus-visible {
+      outline: 2px solid hsl(var(--ring));
+      outline-offset: 2px;
+      border-radius: var(--radius);
+    }
+
+    /* Transcript timeline rail */
+    .timeline-rail {
+      position: relative;
+    }
+    .timeline-rail::before {
+      content: '';
+      position: absolute;
+      left: 13px;
+      top: 8px;
+      bottom: 8px;
+      width: 1px;
+      background: hsl(var(--border));
+    }
+
+    /* Message bubble for agent transcript turns */
+    .turn-agent {
+      background: hsl(var(--secondary) / 0.4);
+    }
+    .turn-tool {
+      background: hsl(var(--card));
+      border: 1px dashed hsl(var(--border));
+    }
+  </style>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+            mono: ['JetBrains Mono', 'ui-monospace', 'Menlo', 'monospace'],
+          },
+          colors: {
+            border: 'hsl(var(--border))',
+            input: 'hsl(var(--input))',
+            ring: 'hsl(var(--ring))',
+            background: 'hsl(var(--background))',
+            foreground: 'hsl(var(--foreground))',
+            primary: { DEFAULT: 'hsl(var(--primary))', foreground: 'hsl(var(--primary-foreground))' },
+            secondary: { DEFAULT: 'hsl(var(--secondary))', foreground: 'hsl(var(--secondary-foreground))' },
+            muted: { DEFAULT: 'hsl(var(--muted))', foreground: 'hsl(var(--muted-foreground))' },
+            card: { DEFAULT: 'hsl(var(--card))', foreground: 'hsl(var(--card-foreground))' },
+            status: {
+              pending:   'hsl(var(--status-pending))',
+              running:   'hsl(var(--status-running))',
+              review:    'hsl(var(--status-review))',
+              blocked:   'hsl(var(--status-blocked))',
+              done:      'hsl(var(--status-done))',
+              failed:    'hsl(var(--status-failed))',
+            },
+            hier: {
+              ic:   'hsl(var(--hier-ic))',
+              team: 'hsl(var(--hier-team))',
+              org:  'hsl(var(--hier-org))',
+            },
+          },
+          borderRadius: {
+            DEFAULT: 'var(--radius)',
+            md: 'var(--radius)',
+            lg: 'calc(var(--radius) + 2px)',
+            xl: 'calc(var(--radius) + 6px)',
+          },
+        },
+      },
+    };
+  </script>
+</head>
+<body class="min-h-screen">
+  <div class="flex min-h-screen">
+
+    <!-- Sidebar (Tasks active — session is a sub-page of a task) -->
+    <aside class="w-[220px] shrink-0 bg-card flex flex-col">
+      <div class="h-14 flex items-center gap-2.5 px-4">
+        <div class="h-6 w-6 rounded bg-primary flex items-center justify-center">
+          <span class="text-primary-foreground text-sm font-bold leading-none">b</span>
+        </div>
+        <span class="font-semibold tracking-tight">beevibe</span>
+      </div>
+      <nav class="flex-1 p-2 space-y-0.5 text-sm">
+        <a href="home.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="home" class="h-4 w-4"></i>
+          <span>Home</span>
+        </a>
+        <a href="tasks-list.html" class="flex items-center gap-3 px-3 py-2 rounded bg-secondary text-foreground font-medium">
+          <i data-lucide="list-checks" class="h-4 w-4"></i>
+          <span>Tasks</span>
+        </a>
+        <a href="agents-list.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="circle-dot" class="h-4 w-4"></i>
+          <span>Agents</span>
+        </a>
+        <a href="threads.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="message-square" class="h-4 w-4"></i>
+          <span>Threads</span>
+        </a>
+        <a href="memory.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="sparkles" class="h-4 w-4"></i>
+          <span>Memory</span>
+        </a>
+      </nav>
+
+      <div class="p-3">
+        <div class="flex items-center gap-1">
+          <button class="flex-1 min-w-0 flex items-center gap-2 px-2 py-1.5 rounded hover:bg-secondary cursor-pointer transition-colors text-left">
+            <div class="h-7 w-7 rounded-full bg-secondary border border-border flex items-center justify-center text-xs font-medium shrink-0">W</div>
+            <div class="flex-1 min-w-0">
+              <div class="text-sm font-medium truncate leading-tight">Weijia</div>
+              <div class="text-[10px] text-muted-foreground flex items-center gap-1 leading-tight mt-0.5">
+                <span class="pulse-dot inline-block h-1 w-1 rounded-full bg-status-running"></span>
+                live
+              </div>
+            </div>
+            <i data-lucide="chevrons-up-down" class="h-3.5 w-3.5 text-muted-foreground shrink-0"></i>
+          </button>
+          <button id="theme-toggle" class="h-8 w-8 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary cursor-pointer transition-colors shrink-0" title="Toggle theme">
+            <i data-lucide="sun" class="h-4 w-4 hidden dark:block"></i>
+            <i data-lucide="moon" class="h-4 w-4 block dark:hidden"></i>
+          </button>
+        </div>
+      </div>
+    </aside>
+
+    <!-- Main — DETAIL density (max-w-5xl, space-y-5) -->
+    <main class="flex-1 min-w-0 flex flex-col">
+      <div class="flex-1 overflow-auto">
+        <div class="max-w-5xl mx-auto pt-8 pb-12 px-6">
+
+          <!-- Breadcrumb -->
+          <div class="text-xs text-muted-foreground mb-4 flex items-center gap-1.5">
+            <a href="tasks-list.html" class="hover:text-foreground transition-colors">Tasks</a>
+            <i data-lucide="chevron-right" class="h-3 w-3"></i>
+            <a href="task-detail.html" class="hover:text-foreground transition-colors">T-1014 · OAuth provider configuration</a>
+            <i data-lucide="chevron-right" class="h-3 w-3"></i>
+            <span class="text-foreground font-mono">sess_3a8c</span>
+          </div>
+
+          <!-- Header -->
+          <header class="mb-6">
+            <div class="flex items-start gap-3">
+              <div class="h-10 w-10 rounded-full bg-status-done/10 flex items-center justify-center text-status-done shrink-0">
+                <i data-lucide="check" class="h-5 w-5"></i>
+              </div>
+              <div class="flex-1 min-w-0">
+                <div class="flex items-center gap-2 mb-1">
+                  <h1 class="text-base font-semibold leading-tight">Wire OAuth refresh-token rotation</h1>
+                  <span class="inline-flex items-center h-5 px-2 rounded text-[10px] font-medium bg-status-done/10 text-status-done">succeeded</span>
+                </div>
+                <div class="text-sm text-muted-foreground flex items-center gap-2">
+                  <a href="agent-detail.html" class="font-mono text-foreground hover:underline">ic-agent-1</a>
+                  <span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic">ic</span>
+                  <span class="text-border">·</span>
+                  <span>type <span class="font-mono text-foreground">task</span></span>
+                  <span class="text-border">·</span>
+                  <span>started 18m ago, ran 2m 14s</span>
+                </div>
+              </div>
+              <div class="flex items-center gap-1 shrink-0">
+                <button class="inline-flex items-center gap-1.5 h-8 px-3 rounded text-xs font-medium hover:bg-secondary cursor-pointer transition-colors text-muted-foreground hover:text-foreground">
+                  <i data-lucide="repeat" class="h-3.5 w-3.5"></i>
+                  Re-run
+                </button>
+                <button class="h-8 w-8 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary cursor-pointer transition-colors">
+                  <i data-lucide="download" class="h-4 w-4"></i>
+                </button>
+              </div>
+            </div>
+          </header>
+
+          <!-- BRIEFING COMPOSER — show what went INTO this session's system prompt.
+               This is the surface mem0/Letta dashboards do NOT have. -->
+          <section class="rounded-lg border border-border bg-card overflow-hidden mb-5">
+            <button class="w-full flex items-center justify-between px-4 py-3 hover:bg-secondary/40 transition-colors text-left cursor-pointer">
+              <div class="flex items-center gap-2.5">
+                <i data-lucide="layers" class="h-4 w-4 text-primary"></i>
+                <span class="text-sm font-semibold">Briefing</span>
+                <span class="text-xs text-muted-foreground">— what this session was told before it started</span>
+              </div>
+              <div class="flex items-center gap-3 text-xs text-muted-foreground">
+                <span class="font-mono tabular-nums">3 blocks · 5 facts · 2,847 tokens</span>
+                <i data-lucide="chevron-up" class="h-4 w-4"></i>
+              </div>
+            </button>
+
+            <div class="border-t border-border p-4 space-y-4">
+
+              <!-- Core blocks pulled in -->
+              <div>
+                <div class="flex items-center gap-2 mb-2 text-xs">
+                  <i data-lucide="square-stack" class="h-3.5 w-3.5 text-muted-foreground"></i>
+                  <span class="font-medium text-foreground">Core memory blocks</span>
+                  <span class="text-muted-foreground">— bounded persona/domain/constraints, agent-edited</span>
+                </div>
+                <div class="space-y-1.5 ml-5 text-xs">
+                  <div class="flex items-center gap-2 text-muted-foreground">
+                    <span class="font-mono text-foreground">persona</span>
+                    <span class="text-border">·</span>
+                    <span class="tabular-nums">1,376 chars</span>
+                    <span class="text-foreground/70 italic truncate">"You are a senior engineer specialized in authentication flows…"</span>
+                  </div>
+                  <div class="flex items-center gap-2 text-muted-foreground">
+                    <span class="font-mono text-foreground">domain</span>
+                    <span class="text-border">·</span>
+                    <span class="tabular-nums">1,728 chars</span>
+                    <span class="text-foreground/70 italic truncate">"Auth surface for this codebase: bv_a_ agent keys + bv_u_ user keys…"</span>
+                  </div>
+                  <div class="flex items-center gap-2 text-muted-foreground">
+                    <span class="font-mono text-foreground">constraints</span>
+                    <span class="text-border">·</span>
+                    <span class="tabular-nums">1,860 chars</span>
+                    <span class="text-foreground/70 italic truncate">"Never log full bearer tokens — log first-8-chars with hash suffix…"</span>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Retrieved facts. Each shows scope chip — proves bounded retrieval. -->
+              <div>
+                <div class="flex items-center gap-2 mb-2 text-xs">
+                  <i data-lucide="search" class="h-3.5 w-3.5 text-muted-foreground"></i>
+                  <span class="font-medium text-foreground">Retrieved facts</span>
+                  <span class="text-muted-foreground">— top-5 by cosine similarity to task intent · scope ≤ ic</span>
+                </div>
+                <div class="space-y-2 ml-5">
+                  <div class="text-xs flex items-start gap-2">
+                    <span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic shrink-0 mt-0.5">ic</span>
+                    <span class="text-foreground/85 leading-relaxed">OAuth 2.1 strict mode rejects implicit grant entirely. For Claude Code CLI integration, use authorization-code-with-PKCE; bv_ keys exchange for short-lived bearer tokens via the token endpoint.</span>
+                    <span class="text-muted-foreground tabular-nums shrink-0">0.91</span>
+                  </div>
+                  <div class="text-xs flex items-start gap-2">
+                    <span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium bg-hier-team/10 text-hier-team shrink-0 mt-0.5">team</span>
+                    <span class="text-foreground/85 leading-relaxed">Postgres NOTIFY payload is capped at 8KB. Keep payloads to id, status, and timestamps; clients refetch full rows via HTTP after the event.</span>
+                    <span class="text-muted-foreground tabular-nums shrink-0">0.87</span>
+                  </div>
+                  <div class="text-xs flex items-start gap-2">
+                    <span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic shrink-0 mt-0.5">ic</span>
+                    <span class="text-foreground/85 leading-relaxed">When the OAuth provider config drift, the failure surfaces as a 400 from /token, not a redirect failure. Log the upstream response body, not just status.</span>
+                    <span class="text-muted-foreground tabular-nums shrink-0">0.85</span>
+                  </div>
+                  <div class="text-xs flex items-start gap-2">
+                    <span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium border border-hier-org text-hier-org shrink-0 mt-0.5">org</span>
+                    <span class="text-foreground/85 leading-relaxed">All inter-agent communication flows through the task queue and mesh tools, not direct calls. Async dispatch + synchronous mesh ask are the only two primitives.</span>
+                    <span class="text-muted-foreground tabular-nums shrink-0">0.82</span>
+                  </div>
+                  <div class="text-xs flex items-start gap-2">
+                    <span class="inline-flex items-center h-4 px-1.5 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic shrink-0 mt-0.5">ic</span>
+                    <span class="text-foreground/85 leading-relaxed">Prefer Argon2id over bcrypt for new password hashes — Argon2 has tunable memory cost that resists GPU attack better.</span>
+                    <span class="text-muted-foreground tabular-nums shrink-0">0.78</span>
+                  </div>
+                </div>
+                <div class="mt-2 ml-5 text-[10px] text-muted-foreground italic">
+                  Only this agent's own facts + facts promoted to scopes it can read (team-alpha, root-org). No global pool.
+                </div>
+              </div>
+
+              <!-- CLI args -->
+              <div>
+                <div class="flex items-center gap-2 mb-2 text-xs">
+                  <i data-lucide="terminal" class="h-3.5 w-3.5 text-muted-foreground"></i>
+                  <span class="font-medium text-foreground">Runtime invocation</span>
+                </div>
+                <pre class="ml-5 text-[11px] font-mono text-muted-foreground leading-relaxed whitespace-pre-wrap">claude code --model claude-opus-4-7 \
+  --append-system-prompt &lt;briefing above&gt; \
+  --max-turns 12 \
+  --mcp-config ~/.beevibe/workspaces/ic-agent-1/mcp-config.json</pre>
+              </div>
+
+            </div>
+          </section>
+
+          <!-- TRANSCRIPT — agent turns + tool calls + cross-agent asks inline -->
+          <section class="space-y-4">
+            <div class="flex items-baseline justify-between">
+              <h2 class="text-sm font-semibold">Transcript</h2>
+              <span class="text-xs text-muted-foreground">12 turns · 2 mesh asks</span>
+            </div>
+
+            <!-- intent (the task description) -->
+            <div class="rounded-lg p-4 turn-tool">
+              <div class="flex items-center gap-2 mb-2 text-xs">
+                <i data-lucide="target" class="h-3.5 w-3.5 text-primary"></i>
+                <span class="font-medium">Intent</span>
+                <span class="text-muted-foreground">— from task <a href="task-detail.html" class="text-foreground hover:underline">T-1014</a></span>
+              </div>
+              <p class="text-sm leading-relaxed">
+                Wire OAuth refresh-token rotation end-to-end. Token table exists; we need: (1) the rotation endpoint, (2) the encryption-at-rest layer, (3) update the auth middleware to swap on near-expiry. Production-safe with concurrent-rotation handling.
+              </p>
+            </div>
+
+            <!-- Turn 1: agent thinks -->
+            <div class="rounded-lg p-4 turn-agent">
+              <div class="flex items-center gap-2 mb-2 text-xs">
+                <span class="font-mono text-foreground font-medium">ic-agent-1</span>
+                <span class="text-muted-foreground">turn 1 · 4s</span>
+              </div>
+              <p class="text-sm leading-relaxed text-foreground/85">
+                Reading the existing token table schema and middleware. The encryption layer needs a KMS-backed key — let me check whether the project has one configured before assuming.
+              </p>
+            </div>
+
+            <!-- Tool call: read file -->
+            <div class="rounded-lg p-3 turn-tool">
+              <div class="flex items-center gap-2 text-xs font-mono">
+                <i data-lucide="wrench" class="h-3.5 w-3.5 text-muted-foreground"></i>
+                <span class="text-muted-foreground">Read</span>
+                <span class="text-foreground">packages/core/src/auth/api-key.ts</span>
+                <span class="text-muted-foreground ml-auto">280 lines</span>
+              </div>
+            </div>
+
+            <!-- Turn 2: agent decides to ask db-agent -->
+            <div class="rounded-lg p-4 turn-agent">
+              <div class="flex items-center gap-2 mb-2 text-xs">
+                <span class="font-mono text-foreground font-medium">ic-agent-1</span>
+                <span class="text-muted-foreground">turn 4 · 31s</span>
+              </div>
+              <p class="text-sm leading-relaxed text-foreground/85">
+                Schema for storing the rotation state isn't obvious from this codebase — the existing token table doesn't have rotation columns yet. Asking db-agent how they'd shape the schema, since they own data-layer decisions for team-data.
+              </p>
+            </div>
+
+            <!-- INLINE ASK THREAD — proves mesh is real, not just diagram -->
+            <div class="rounded-lg border border-status-running/30 bg-status-running/5 p-4">
+              <div class="flex items-center gap-2 mb-3 text-xs">
+                <i data-lucide="link" class="h-3.5 w-3.5 text-status-running"></i>
+                <span class="font-medium">Mesh ask</span>
+                <span class="font-mono text-foreground">ic-agent-1</span>
+                <i data-lucide="arrow-right" class="h-3 w-3 text-muted-foreground"></i>
+                <span class="font-mono text-foreground">db-agent</span>
+                <span class="ml-auto inline-flex items-center gap-1 h-5 px-2 rounded text-[10px] font-medium bg-status-done/10 text-status-done">
+                  <i data-lucide="check" class="h-3 w-3"></i>
+                  resolved · 8s
+                </span>
+              </div>
+
+              <div class="space-y-2.5 pl-1">
+                <!-- request -->
+                <div class="flex items-start gap-2">
+                  <i data-lucide="arrow-up-right" class="h-3 w-3 text-muted-foreground mt-1.5 shrink-0"></i>
+                  <div class="flex-1">
+                    <p class="text-sm leading-relaxed text-foreground/85">
+                      Schema for refresh-token storage? Need a column for the encrypted blob plus rotation metadata (last_rotated_at, rotation_count) with a unique index by user_id. Concurrent rotation has to be safe.
+                    </p>
+                  </div>
+                </div>
+                <!-- response -->
+                <div class="flex items-start gap-2">
+                  <i data-lucide="arrow-down-right" class="h-3 w-3 text-muted-foreground mt-1.5 shrink-0"></i>
+                  <div class="flex-1">
+                    <div class="text-[10px] text-muted-foreground mb-1">
+                      <span class="font-mono text-foreground">db-agent</span>
+                      <span> · answered from its own bounded memory</span>
+                    </div>
+                    <p class="text-sm leading-relaxed text-foreground/85">
+                      Add <span class="font-mono text-xs">refresh_token</span> table — columns: <span class="font-mono text-xs">id, user_id (UQ), encrypted_blob BYTEA, last_rotated_at TIMESTAMPTZ, rotation_count INT</span>. Read with <span class="font-mono text-xs">FOR UPDATE SKIP LOCKED</span> in the rotation flow, or two concurrent rotations race the increment. Migration template at <span class="font-mono text-xs">migrations/_template_with_partial_index.sql</span>.
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div class="mt-3 flex items-center gap-3 text-[10px] text-muted-foreground font-mono">
+                <span>chain depth 1/4</span>
+                <span class="text-border">·</span>
+                <span>session sess_a4f9 spawned for db-agent</span>
+                <span class="text-border">·</span>
+                <span>1,128 tokens used of chain budget</span>
+              </div>
+            </div>
+
+            <!-- Turn 5: agent integrates the answer -->
+            <div class="rounded-lg p-4 turn-agent">
+              <div class="flex items-center gap-2 mb-2 text-xs">
+                <span class="font-mono text-foreground font-medium">ic-agent-1</span>
+                <span class="text-muted-foreground">turn 5 · 47s</span>
+              </div>
+              <p class="text-sm leading-relaxed text-foreground/85">
+                Got it. Writing the migration with that schema, plus the rotation endpoint that uses <span class="font-mono text-xs">SELECT … FOR UPDATE SKIP LOCKED</span> on read. Encryption layer will pull the KMS key id from <span class="font-mono text-xs">BV_ROTATION_KMS_KEY</span> env var — failing closed if absent.
+              </p>
+            </div>
+
+            <!-- Tool call: write -->
+            <div class="rounded-lg p-3 turn-tool">
+              <div class="flex items-center gap-2 text-xs font-mono">
+                <i data-lucide="wrench" class="h-3.5 w-3.5 text-muted-foreground"></i>
+                <span class="text-muted-foreground">Write</span>
+                <span class="text-foreground">migrations/1777800000000_refresh_token_rotation.sql</span>
+                <span class="text-status-done ml-auto">+42</span>
+              </div>
+            </div>
+
+            <!-- Tool call: write 2 -->
+            <div class="rounded-lg p-3 turn-tool">
+              <div class="flex items-center gap-2 text-xs font-mono">
+                <i data-lucide="wrench" class="h-3.5 w-3.5 text-muted-foreground"></i>
+                <span class="text-muted-foreground">Edit</span>
+                <span class="text-foreground">packages/core/src/auth/refresh-rotation.ts</span>
+                <span class="text-status-done ml-auto">+118</span>
+              </div>
+            </div>
+
+            <!-- Turn 8: agent decides to ask team-alpha for safety review -->
+            <div class="rounded-lg p-4 turn-agent">
+              <div class="flex items-center gap-2 mb-2 text-xs">
+                <span class="font-mono text-foreground font-medium">ic-agent-1</span>
+                <span class="text-muted-foreground">turn 8 · 1m 23s</span>
+              </div>
+              <p class="text-sm leading-relaxed text-foreground/85">
+                Implementation in place. Before I claim done, asking team-alpha to sanity-check the rotation flow — this is production-critical and my constraints block say "escalate when unsure on cross-tree mesh."
+              </p>
+            </div>
+
+            <!-- INLINE ASK THREAD 2 -->
+            <div class="rounded-lg border border-border bg-card p-4">
+              <div class="flex items-center gap-2 mb-3 text-xs">
+                <i data-lucide="link" class="h-3.5 w-3.5 text-muted-foreground"></i>
+                <span class="font-medium">Mesh ask</span>
+                <span class="font-mono text-foreground">ic-agent-1</span>
+                <i data-lucide="arrow-up" class="h-3 w-3 text-muted-foreground"></i>
+                <span class="font-mono text-foreground">team-alpha</span>
+                <span class="ml-auto inline-flex items-center gap-1 h-5 px-2 rounded text-[10px] font-medium bg-status-done/10 text-status-done">
+                  <i data-lucide="check" class="h-3 w-3"></i>
+                  resolved · 14s
+                </span>
+              </div>
+
+              <div class="space-y-2.5 pl-1">
+                <div class="flex items-start gap-2">
+                  <i data-lucide="arrow-up-right" class="h-3 w-3 text-muted-foreground mt-1.5 shrink-0"></i>
+                  <div class="flex-1">
+                    <p class="text-sm leading-relaxed text-foreground/85">
+                      Sanity check the OAuth refresh-token rotation: KMS-backed encryption, FOR UPDATE SKIP LOCKED on read, increment-on-rotate, fails closed if KMS key missing. Sound for prod?
+                    </p>
+                  </div>
+                </div>
+                <div class="flex items-start gap-2">
+                  <i data-lucide="arrow-down-right" class="h-3 w-3 text-muted-foreground mt-1.5 shrink-0"></i>
+                  <div class="flex-1">
+                    <div class="text-[10px] text-muted-foreground mb-1">
+                      <span class="font-mono text-foreground">team-alpha</span>
+                      <span> · approved with one note</span>
+                    </div>
+                    <p class="text-sm leading-relaxed text-foreground/85">
+                      Sound. Add a metric on <span class="font-mono text-xs">rotation_count</span> per user — anomalous spikes are how we'll catch a stolen-token replay. Open a follow-up task; not blocking this one.
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div class="mt-3 flex items-center gap-3 text-[10px] text-muted-foreground font-mono">
+                <span>chain depth 1/4</span>
+                <span class="text-border">·</span>
+                <span>session sess_b8c3 spawned for team-alpha</span>
+              </div>
+            </div>
+
+            <!-- Final turn: update_progress -->
+            <div class="rounded-lg p-3 turn-tool">
+              <div class="flex items-center gap-2 text-xs font-mono">
+                <i data-lucide="wrench" class="h-3.5 w-3.5 text-status-done"></i>
+                <span class="text-muted-foreground">update_progress</span>
+                <span class="text-foreground">status='done'</span>
+                <span class="text-muted-foreground">summary='OAuth refresh rotation wired with KMS encryption, FOR UPDATE SKIP LOCKED, fails closed.'</span>
+              </div>
+            </div>
+
+            <!-- Result -->
+            <div class="rounded-lg border border-status-done/30 bg-status-done/5 p-4">
+              <div class="flex items-center gap-2 mb-2 text-xs">
+                <i data-lucide="check-circle-2" class="h-4 w-4 text-status-done"></i>
+                <span class="font-semibold">Result</span>
+                <span class="ml-auto text-muted-foreground">exit 0 · 2m 14s · 12 turns · 8.4k tokens</span>
+              </div>
+              <p class="text-sm leading-relaxed text-foreground/85">
+                OAuth refresh rotation wired end-to-end. Migration <span class="font-mono text-xs">1777800000000_refresh_token_rotation</span> creates the table; <span class="font-mono text-xs">refresh-rotation.ts</span> implements the rotation flow with FOR UPDATE SKIP LOCKED and KMS-backed encryption. Fails closed if <span class="font-mono text-xs">BV_ROTATION_KMS_KEY</span> is missing. Opened follow-up task for the rotation_count anomaly metric per team-alpha's note.
+              </p>
+            </div>
+
+          </section>
+
+          <!-- Quiet footer — provenance + chain ledger -->
+          <div class="mt-10 pt-6 border-t border-border text-xs text-muted-foreground flex flex-wrap items-center gap-x-4 gap-y-2">
+            <button class="inline-flex items-center gap-1.5 hover:text-foreground transition-colors">
+              <i data-lucide="hash" class="h-3 w-3"></i>
+              <span class="font-mono">sess_3a8c2f9b1e</span>
+              <i data-lucide="copy" class="h-3 w-3"></i>
+            </button>
+            <span class="text-border">·</span>
+            <span>started Apr 28 2026 09:42 UTC</span>
+            <span class="text-border">·</span>
+            <span>worktree <span class="font-mono">~/.beevibe/workspaces/ic-agent-1/beevibe-T-1014</span></span>
+            <span class="text-border">·</span>
+            <span>cli session <span class="font-mono">cli_8e2a4c</span></span>
+            <span class="text-border">·</span>
+            <span>1 work product → <a href="task-detail.html" class="text-foreground/70 hover:text-foreground">PR #29</a></span>
+          </div>
+
+        </div>
+      </div>
+    </main>
+  </div>
+
+  <script>
+    lucide.createIcons();
+    document.getElementById('theme-toggle').addEventListener('click', () => {
+      document.documentElement.classList.toggle('dark');
+      lucide.createIcons();
+    });
+  </script>
+</body>
+</html>

--- a/mocks/showcase.html
+++ b/mocks/showcase.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>beevibe — your AI agents and your teammates in one workspace</title>
+  <title>Beevibe — your AI agents and your teammates in one workspace</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
@@ -185,9 +185,9 @@
     <div class="max-w-6xl mx-auto px-6 h-14 flex items-center justify-between">
       <a href="#" class="flex items-center gap-2.5">
         <div class="h-6 w-6 rounded bg-primary flex items-center justify-center">
-          <span class="text-primary-foreground text-sm font-bold leading-none">b</span>
+          <span class="text-primary-foreground text-sm font-bold leading-none">B</span>
         </div>
-        <span class="font-semibold tracking-tight">beevibe</span>
+        <span class="font-semibold tracking-tight">Beevibe</span>
       </a>
       <nav class="hidden md:flex items-center gap-6 text-sm text-muted-foreground">
         <a href="#promise" class="hover:text-foreground transition-colors">How it works</a>
@@ -224,7 +224,7 @@
           Your AI agents and your teammates, working in <span class="bg-primary text-primary-foreground px-1.5 -mx-0.5 rounded-sm">the same workspace</span>.
         </h1>
         <p class="text-lg text-muted-foreground leading-relaxed max-w-2xl">
-          Every agent has its own memory and specialty. When one needs help, it asks another agent — or escalates to a human. Nothing gets pooled, and every fact keeps its source.
+          Each agent keeps its own memory and asks the others when it needs help.
         </p>
         <div class="mt-7 flex flex-wrap items-center gap-3">
           <a href="home.html" class="inline-flex items-center gap-2 h-10 px-4 rounded bg-primary text-primary-foreground text-sm font-semibold hover:opacity-90 active:scale-[0.98] transition-all duration-150">
@@ -307,7 +307,7 @@
               <div class="text-[10px] uppercase tracking-wider text-primary mb-0.5">bounded specialists</div>
               <div class="text-sm font-semibold">Each agent keeps its own context</div>
             </div>
-            <span class="text-[10px] text-muted-foreground font-mono">beevibe</span>
+            <span class="text-[10px] text-muted-foreground font-mono">Beevibe</span>
           </div>
 
           <div class="p-5">
@@ -408,14 +408,94 @@
 
   <!-- THE PROBLEM — felt-pain framing right after the hero, before how-it-works -->
   <section class="border-b border-border bg-secondary/30">
-    <div class="max-w-5xl mx-auto px-6 py-20">
+    <div class="max-w-6xl mx-auto px-6 py-20">
       <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-3">The problem</div>
-      <h2 class="text-3xl md:text-4xl font-bold tracking-tight leading-[1.15] mb-5 max-w-3xl">
+      <h2 class="text-3xl md:text-4xl font-bold tracking-tight leading-[1.15] mb-4 max-w-3xl">
         End the silos between every person and every AI agent on your team.
       </h2>
-      <p class="text-lg text-muted-foreground leading-relaxed max-w-3xl">
-        Today, everyone works with AI in their own private chat. Context dies in those chats. The teammate next to you can't see what your agent learned, your agent can't ask theirs, and every new session starts from zero.
+      <p class="text-base text-muted-foreground leading-relaxed max-w-2xl mb-10">
+        Today, everyone works with AI in their own private chat. Nothing crosses between them.
       </p>
+
+      <!-- Three private chats — same insight learned three separate times -->
+      <div class="grid md:grid-cols-3 gap-4">
+
+        <!-- Chat 1: Sarah · Claude Code -->
+        <div class="rounded-lg border border-border bg-card overflow-hidden flex flex-col">
+          <div class="px-4 py-2.5 border-b border-border flex items-center gap-2 bg-secondary/40">
+            <div class="h-5 w-5 rounded-full bg-hier-team/20 flex items-center justify-center text-[9px] font-semibold text-hier-team">S</div>
+            <span class="text-xs font-medium">Sarah</span>
+            <span class="text-[10px] text-muted-foreground font-mono ml-auto">Claude Code</span>
+          </div>
+          <div class="p-4 space-y-2.5 text-xs flex-1">
+            <div>
+              <div class="text-[10px] text-muted-foreground mb-0.5">Sarah</div>
+              <div class="text-foreground/85">Best way to rotate refresh tokens safely?</div>
+            </div>
+            <div>
+              <div class="text-[10px] text-muted-foreground mb-0.5">Claude</div>
+              <div class="text-foreground/70">Use <span class="font-mono">FOR UPDATE SKIP LOCKED</span> on the rotation flow to avoid races on concurrent refreshes.</div>
+            </div>
+          </div>
+          <div class="px-4 py-2 border-t border-border bg-status-failed/5 flex items-center gap-1.5 text-[10px] text-status-failed">
+            <i data-lucide="x-circle" class="h-3 w-3"></i>
+            session ended · context lost
+          </div>
+        </div>
+
+        <!-- Chat 2: Marcus · Cursor -->
+        <div class="rounded-lg border border-border bg-card overflow-hidden flex flex-col">
+          <div class="px-4 py-2.5 border-b border-border flex items-center gap-2 bg-secondary/40">
+            <div class="h-5 w-5 rounded-full bg-status-running/20 flex items-center justify-center text-[9px] font-semibold text-status-running">M</div>
+            <span class="text-xs font-medium">Marcus</span>
+            <span class="text-[10px] text-muted-foreground font-mono ml-auto">Cursor</span>
+          </div>
+          <div class="p-4 space-y-2.5 text-xs flex-1">
+            <div>
+              <div class="text-[10px] text-muted-foreground mb-0.5">Marcus</div>
+              <div class="text-foreground/85">How do we prevent rotation races on refresh tokens?</div>
+            </div>
+            <div>
+              <div class="text-[10px] text-muted-foreground mb-0.5">Cursor</div>
+              <div class="text-foreground/70">Lock the row with <span class="font-mono">FOR UPDATE SKIP LOCKED</span> during rotation. Concurrent calls won't double-rotate.</div>
+            </div>
+          </div>
+          <div class="px-4 py-2 border-t border-border bg-status-failed/5 flex items-center gap-1.5 text-[10px] text-status-failed">
+            <i data-lucide="x-circle" class="h-3 w-3"></i>
+            session ended · context lost
+          </div>
+        </div>
+
+        <!-- Chat 3: Priya · Codex -->
+        <div class="rounded-lg border border-border bg-card overflow-hidden flex flex-col">
+          <div class="px-4 py-2.5 border-b border-border flex items-center gap-2 bg-secondary/40">
+            <div class="h-5 w-5 rounded-full bg-status-review/20 flex items-center justify-center text-[9px] font-semibold text-status-review">P</div>
+            <span class="text-xs font-medium">Priya</span>
+            <span class="text-[10px] text-muted-foreground font-mono ml-auto">Codex</span>
+          </div>
+          <div class="p-4 space-y-2.5 text-xs flex-1">
+            <div>
+              <div class="text-[10px] text-muted-foreground mb-0.5">Priya</div>
+              <div class="text-foreground/85">Refresh token concurrency — what pattern?</div>
+            </div>
+            <div>
+              <div class="text-[10px] text-muted-foreground mb-0.5">Codex</div>
+              <div class="text-foreground/70"><span class="font-mono">FOR UPDATE SKIP LOCKED</span> on the rotation row, then issue the new token. Avoids the race.</div>
+            </div>
+          </div>
+          <div class="px-4 py-2 border-t border-border bg-status-failed/5 flex items-center gap-1.5 text-[10px] text-status-failed">
+            <i data-lucide="x-circle" class="h-3 w-3"></i>
+            session ended · context lost
+          </div>
+        </div>
+
+      </div>
+
+      <p class="mt-6 text-sm text-center max-w-2xl mx-auto">
+        <span class="font-medium text-foreground">Same answer learned three times.</span>
+        <span class="text-muted-foreground">Then forgotten three times.</span>
+      </p>
+
     </div>
   </section>
 
@@ -426,7 +506,7 @@
         <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">How it works</div>
         <h2 class="text-2xl font-bold tracking-tight mb-3">Three things that make a hybrid team actually work.</h2>
         <p class="text-muted-foreground leading-relaxed">
-          beevibe is the open-source platform where humans and AI agents share one workspace. Drop in via MCP — works with Claude Code, Cursor, Codex, and any tool that speaks the protocol.
+          Beevibe is the open-source platform where humans and AI agents share one workspace. Drop in via MCP — works with Claude Code, Cursor, Codex, and any tool that speaks the protocol.
         </p>
       </div>
 
@@ -455,9 +535,29 @@
           </div>
           <h3 class="text-base font-semibold mb-2">Humans review, redirect, hand off</h3>
           <p class="text-sm text-muted-foreground leading-relaxed mb-3">
-            People and agents share one workspace. Agents send work for review; humans approve, request revision, or reassign. Blockers escalate up the chain to the right teammate — agent or human. The whole loop is visible to everyone who needs to see it.
+            Agents send work for review. You approve, revise, or reassign — blockers escalate to the right teammate.
           </p>
-          <code class="block text-[11px] font-mono text-muted-foreground bg-secondary/50 rounded px-2 py-1.5 mb-3">task.review_policy = 'require_human'</code>
+          <!-- Inline review-card mini-mockup -->
+          <div class="rounded-md border border-border bg-secondary/30 p-3 mb-3">
+            <div class="flex items-center gap-1.5 mb-2 text-[10px]">
+              <i data-lucide="clipboard-check" class="h-3 w-3 text-primary"></i>
+              <span class="text-muted-foreground">by</span>
+              <span class="font-mono text-foreground">ic-agent-2</span>
+              <span class="ml-auto inline-flex items-center h-4 px-1.5 rounded text-[9px] font-medium bg-status-review/15 text-status-review">review</span>
+            </div>
+            <div class="text-xs font-medium text-foreground/90 mb-2.5 leading-snug">Add refresh-token rotation logic</div>
+            <div class="flex gap-1.5">
+              <button class="flex-1 inline-flex items-center justify-center gap-1 h-6 rounded text-[10px] font-medium bg-status-done/15 text-status-done hover:bg-status-done/25 transition-colors">
+                <i data-lucide="check" class="h-3 w-3"></i> Approve
+              </button>
+              <button class="flex-1 inline-flex items-center justify-center gap-1 h-6 rounded text-[10px] font-medium bg-secondary text-muted-foreground hover:text-foreground transition-colors">
+                <i data-lucide="rotate-ccw" class="h-3 w-3"></i> Revise
+              </button>
+              <button class="inline-flex items-center justify-center h-6 w-6 rounded bg-secondary text-muted-foreground hover:text-foreground transition-colors" title="Reassign">
+                <i data-lucide="user-plus" class="h-3 w-3"></i>
+              </button>
+            </div>
+          </div>
           <a href="task-detail.html" class="text-xs font-medium text-foreground hover:underline inline-flex items-center gap-1">
             See a review flow
             <i data-lucide="arrow-right" class="h-3 w-3"></i>
@@ -620,10 +720,7 @@
     <div class="max-w-6xl mx-auto px-6 py-20">
       <div class="max-w-2xl mb-8">
         <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Where this fits</div>
-        <h2 class="text-2xl font-bold tracking-tight mb-3">One workspace. Drops in alongside the agents your team already uses.</h2>
-        <p class="text-muted-foreground leading-relaxed">
-          beevibe is the shared workspace where humans and agents coordinate. Agents connect to it from whatever runtime they live in — Claude Code, Cursor, Codex, anything that speaks MCP — and start collaborating with each other and with the humans on the team.
-        </p>
+        <h2 class="text-2xl font-bold tracking-tight mb-3">Drops in alongside Claude Code, Cursor, Codex — anything that speaks MCP.</h2>
       </div>
 
       <div class="grid md:grid-cols-2 gap-4">
@@ -659,9 +756,9 @@ claude mcp add beevibe http://localhost:3002</pre>
     <div class="max-w-6xl mx-auto px-6 py-20">
       <div class="max-w-2xl mb-10">
         <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Compared to</div>
-        <h2 class="text-2xl font-bold tracking-tight mb-3">How beevibe differs from Multica and Paperclip.</h2>
+        <h2 class="text-2xl font-bold tracking-tight mb-3">How Beevibe differs from Multica and Paperclip.</h2>
         <p class="text-muted-foreground leading-relaxed">
-          Multica ships team task-tracking with agents as routing targets. Paperclip ships solo company simulation with agents as scheduled workers. beevibe ships a hybrid team where each agent is a persistent specialist that grows expertise over time and asks other agents when it needs help.
+          Multica ships team task-tracking with agents as routing targets. Paperclip ships solo company simulation with agents as scheduled workers. Beevibe ships a hybrid team where each agent is a persistent specialist that grows expertise over time and asks other agents when it needs help.
         </p>
       </div>
 
@@ -672,7 +769,7 @@ claude mcp add beevibe http://localhost:3002</pre>
               <th class="text-left px-4 py-3 font-medium">Axis</th>
               <th class="text-left px-4 py-3 font-medium">Multica</th>
               <th class="text-left px-4 py-3 font-medium">Paperclip</th>
-              <th class="text-left px-4 py-3 font-medium bg-primary/10">beevibe</th>
+              <th class="text-left px-4 py-3 font-medium bg-primary/10">Beevibe</th>
             </tr>
           </thead>
           <tbody>
@@ -723,18 +820,59 @@ claude mcp add beevibe http://localhost:3002</pre>
         </table>
       </div>
 
-      <!-- Differentiation callout — the thesis the table is making -->
-      <div class="mt-8 rounded-lg border-l-4 border-primary bg-primary/5 px-5 py-4">
-        <div class="flex items-start gap-3">
-          <i data-lucide="quote" class="h-5 w-5 text-primary shrink-0 mt-0.5"></i>
-          <div class="text-sm leading-relaxed">
-            <span class="font-semibold text-foreground">The key difference.</span>
-            <span class="text-muted-foreground"> Multica and Paperclip agents are stateless: they pick up a task, run a skill or script, and forget. </span>
-            <span class="text-foreground">beevibe agents remember.</span>
-            <span class="text-muted-foreground"> Each one has its own memory that grows every session — repeated facts get merged instead of duplicated, so expertise actually compounds.</span>
+      <!-- Differentiation visual — memory depth across sessions -->
+      <div class="mt-8 grid md:grid-cols-3 gap-4">
+
+        <div class="rounded-lg border border-border bg-card p-5">
+          <div class="flex items-center gap-2 mb-3">
+            <span class="text-sm font-semibold">Multica</span>
+            <span class="ml-auto inline-flex items-center h-5 px-2 rounded text-[10px] font-medium bg-muted text-muted-foreground">stateless</span>
           </div>
+          <svg viewBox="0 0 180 60" class="w-full h-14 mb-3" preserveAspectRatio="none">
+            <line x1="0" y1="56" x2="180" y2="56" stroke="hsl(var(--border))" stroke-width="0.5"/>
+            <rect x="10"  y="50" width="20" height="6" fill="hsl(var(--muted-foreground) / 0.35)" />
+            <rect x="40"  y="50" width="20" height="6" fill="hsl(var(--muted-foreground) / 0.35)" />
+            <rect x="70"  y="50" width="20" height="6" fill="hsl(var(--muted-foreground) / 0.35)" />
+            <rect x="100" y="50" width="20" height="6" fill="hsl(var(--muted-foreground) / 0.35)" />
+            <rect x="130" y="50" width="20" height="6" fill="hsl(var(--muted-foreground) / 0.35)" />
+          </svg>
+          <p class="text-xs text-muted-foreground leading-snug">Each session pulls from the static skill library. Nothing learned persists.</p>
         </div>
+
+        <div class="rounded-lg border border-border bg-card p-5">
+          <div class="flex items-center gap-2 mb-3">
+            <span class="text-sm font-semibold">Paperclip</span>
+            <span class="ml-auto inline-flex items-center h-5 px-2 rounded text-[10px] font-medium bg-muted text-muted-foreground">stateless</span>
+          </div>
+          <svg viewBox="0 0 180 60" class="w-full h-14 mb-3" preserveAspectRatio="none">
+            <line x1="0" y1="56" x2="180" y2="56" stroke="hsl(var(--border))" stroke-width="0.5"/>
+            <rect x="10"  y="50" width="20" height="6" fill="hsl(var(--muted-foreground) / 0.35)" />
+            <rect x="40"  y="50" width="20" height="6" fill="hsl(var(--muted-foreground) / 0.35)" />
+            <rect x="70"  y="50" width="20" height="6" fill="hsl(var(--muted-foreground) / 0.35)" />
+            <rect x="100" y="50" width="20" height="6" fill="hsl(var(--muted-foreground) / 0.35)" />
+            <rect x="130" y="50" width="20" height="6" fill="hsl(var(--muted-foreground) / 0.35)" />
+          </svg>
+          <p class="text-xs text-muted-foreground leading-snug">Each heartbeat runs the plugin script. Forgets between runs.</p>
+        </div>
+
+        <div class="rounded-lg border-2 border-primary/40 bg-card p-5">
+          <div class="flex items-center gap-2 mb-3">
+            <span class="text-sm font-semibold">Beevibe</span>
+            <span class="ml-auto inline-flex items-center h-5 px-2 rounded text-[10px] font-medium bg-primary/15 text-primary">remembers</span>
+          </div>
+          <svg viewBox="0 0 180 60" class="w-full h-14 mb-3" preserveAspectRatio="none">
+            <line x1="0" y1="56" x2="180" y2="56" stroke="hsl(var(--border))" stroke-width="0.5"/>
+            <rect x="10"  y="48" width="20" height="8"  fill="hsl(var(--primary) / 0.5)" />
+            <rect x="40"  y="40" width="20" height="16" fill="hsl(var(--primary) / 0.6)" />
+            <rect x="70"  y="30" width="20" height="26" fill="hsl(var(--primary) / 0.7)" />
+            <rect x="100" y="18" width="20" height="38" fill="hsl(var(--primary) / 0.85)" />
+            <rect x="130" y="6"  width="20" height="50" fill="hsl(var(--primary))" />
+          </svg>
+          <p class="text-xs text-foreground leading-snug">Each session merges new facts into the agent's own memory. Expertise compounds.</p>
+        </div>
+
       </div>
+      <p class="mt-3 text-[10px] text-muted-foreground text-center font-mono uppercase tracking-wider">memory depth · 5 sessions →</p>
     </div>
   </section>
 
@@ -746,7 +884,7 @@ claude mcp add beevibe http://localhost:3002</pre>
         They start <span class="bg-primary text-primary-foreground px-1.5 -mx-0.5 rounded-sm">working together</span>.
       </h2>
       <p class="text-muted-foreground leading-relaxed mb-7">
-        beevibe is the open-source runtime that connects the AI tools your team already uses. Agents ask each other, escalate to humans, and share work — every person and every agent in one workspace.
+        Beevibe is the open-source runtime that connects the AI tools your team already uses. Agents ask each other, escalate to humans, and share work — every person and every agent in one workspace.
       </p>
       <div class="flex flex-wrap items-center justify-center gap-3">
         <a href="#" class="inline-flex items-center gap-2 h-10 px-5 rounded bg-primary text-primary-foreground text-sm font-semibold hover:opacity-90 active:scale-[0.98] transition-all duration-150">
@@ -765,9 +903,9 @@ claude mcp add beevibe http://localhost:3002</pre>
     <div class="max-w-6xl mx-auto px-6 py-8 flex flex-wrap items-center justify-between gap-4 text-xs text-muted-foreground">
       <div class="flex items-center gap-2">
         <div class="h-5 w-5 rounded bg-primary flex items-center justify-center">
-          <span class="text-primary-foreground text-xs font-bold leading-none">b</span>
+          <span class="text-primary-foreground text-xs font-bold leading-none">B</span>
         </div>
-        <span>beevibe · MIT licensed · self-hosted</span>
+        <span>Beevibe · MIT licensed · self-hosted</span>
       </div>
       <div class="flex items-center gap-5">
         <a href="#" class="hover:text-foreground transition-colors">Docs</a>

--- a/mocks/showcase.html
+++ b/mocks/showcase.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>beevibe — where context flows between every person and every agent</title>
+  <title>beevibe — your AI agents and your teammates in one workspace</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
@@ -221,10 +221,10 @@
           <span>Open source · self-host or hosted</span>
         </div>
         <h1 class="text-4xl md:text-5xl font-bold tracking-tight leading-[1.1] mb-5">
-          Where context flows between every person and every <span class="bg-primary text-primary-foreground px-1.5 -mx-0.5 rounded-sm">agent on your team</span>.
+          Your AI agents and your teammates, working in <span class="bg-primary text-primary-foreground px-1.5 -mx-0.5 rounded-sm">the same workspace</span>.
         </h1>
         <p class="text-lg text-muted-foreground leading-relaxed max-w-2xl">
-          beevibe coordinates work across people and AI agents in one shared workspace. Each agent stays in its own context; when it needs another specialist's input, it asks. Humans approve, redirect, or hand off. Context flows at the crossings — every ask, every handoff, every review, with provenance preserved — so nothing gets lost between sessions, between agents, or between people.
+          Every agent has its own memory and specialty. When one needs help, it asks another agent — or escalates to a human. Nothing gets pooled, and every fact keeps its source.
         </p>
         <div class="mt-7 flex flex-wrap items-center gap-3">
           <a href="home.html" class="inline-flex items-center gap-2 h-10 px-4 rounded bg-primary text-primary-foreground text-sm font-semibold hover:opacity-90 active:scale-[0.98] transition-all duration-150">
@@ -293,9 +293,9 @@
             </svg>
 
             <ul class="mt-4 space-y-1.5 text-xs text-muted-foreground">
-              <li class="flex items-start gap-2"><i data-lucide="x" class="h-3.5 w-3.5 text-status-failed shrink-0 mt-0.5"></i>No specialization — every agent inherits everyone's notes.</li>
-              <li class="flex items-start gap-2"><i data-lucide="x" class="h-3.5 w-3.5 text-status-failed shrink-0 mt-0.5"></i>No provenance — facts arrive sourceless once written.</li>
-              <li class="flex items-start gap-2"><i data-lucide="x" class="h-3.5 w-3.5 text-status-failed shrink-0 mt-0.5"></i>Context window dilutes — depth competes with everyone else's domain.</li>
+              <li class="flex items-start gap-2"><i data-lucide="x" class="h-3.5 w-3.5 text-status-failed shrink-0 mt-0.5"></i>Every agent reads everyone else's notes. Nobody specializes.</li>
+              <li class="flex items-start gap-2"><i data-lucide="x" class="h-3.5 w-3.5 text-status-failed shrink-0 mt-0.5"></i>Facts arrive without a source once they're in the pool.</li>
+              <li class="flex items-start gap-2"><i data-lucide="x" class="h-3.5 w-3.5 text-status-failed shrink-0 mt-0.5"></i>Each agent's context fills with other people's domains, leaving less room for its own.</li>
             </ul>
           </div>
         </div>
@@ -388,10 +388,10 @@
             </svg>
 
             <ul class="mt-4 space-y-1.5 text-xs text-muted-foreground">
-              <li class="flex items-start gap-2"><i data-lucide="check" class="h-3.5 w-3.5 text-status-done shrink-0 mt-0.5"></i><span><span class="text-foreground">Specialization compounds.</span> Each agent's depth doesn't dilute into a global pool.</span></li>
-              <li class="flex items-start gap-2"><i data-lucide="check" class="h-3.5 w-3.5 text-status-done shrink-0 mt-0.5"></i><span><span class="text-foreground">Provenance preserved.</span> Every fact carries its originating agent — even after promotion.</span></li>
-              <li class="flex items-start gap-2"><i data-lucide="check" class="h-3.5 w-3.5 text-status-done shrink-0 mt-0.5"></i><span><span class="text-foreground">Curated commons.</span> Facts earn wider scope through editorial judgment, not auto-pooling.</span></li>
-              <li class="flex items-start gap-2"><i data-lucide="check" class="h-3.5 w-3.5 text-status-done shrink-0 mt-0.5"></i><span><span class="text-foreground">Mesh asks for the rest.</span> When an agent doesn't know, it asks the specialist who does.</span></li>
+              <li class="flex items-start gap-2"><i data-lucide="check" class="h-3.5 w-3.5 text-status-done shrink-0 mt-0.5"></i><span><span class="text-foreground">Specialization compounds.</span> Each agent goes deeper in its own area instead of skimming everyone's.</span></li>
+              <li class="flex items-start gap-2"><i data-lucide="check" class="h-3.5 w-3.5 text-status-done shrink-0 mt-0.5"></i><span><span class="text-foreground">Source preserved.</span> Every fact remembers which agent wrote it — even after promotion.</span></li>
+              <li class="flex items-start gap-2"><i data-lucide="check" class="h-3.5 w-3.5 text-status-done shrink-0 mt-0.5"></i><span><span class="text-foreground">Curated shared pool.</span> Facts spread only when a promoter decides they should — not automatically.</span></li>
+              <li class="flex items-start gap-2"><i data-lucide="check" class="h-3.5 w-3.5 text-status-done shrink-0 mt-0.5"></i><span><span class="text-foreground">Agents fill the gaps.</span> When an agent doesn't know something, it asks the specialist who does.</span></li>
             </ul>
           </div>
         </div>
@@ -400,7 +400,7 @@
 
       <!-- Tiny caption under the animation -->
       <p class="mt-4 text-xs text-muted-foreground text-center">
-        Same logical event sequence in both panels — fact written, second agent observes a similar one, merge / promotion, mesh ask. Watch what each architecture does with it.
+        Both panels show the same sequence: a fact is written, a similar one shows up, it gets merged or promoted, then another agent asks about it. Watch how each architecture handles it.
       </p>
 
     </div>
@@ -414,7 +414,7 @@
         End the silos between every person and every AI agent on your team.
       </h2>
       <p class="text-lg text-muted-foreground leading-relaxed max-w-3xl">
-        Today, everyone works with AI in their own private chat. beevibe brings humans and their agents into a shared workspace where context, decisions, and work-in-progress are visible to whoever needs them — and where agents can ask other agents when their own context isn't enough.
+        Today, everyone works with AI in their own private chat. Context dies in those chats. The teammate next to you can't see what your agent learned, your agent can't ask theirs, and every new session starts from zero.
       </p>
     </div>
   </section>
@@ -426,7 +426,7 @@
         <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">How it works</div>
         <h2 class="text-2xl font-bold tracking-tight mb-3">Three things that make a hybrid team actually work.</h2>
         <p class="text-muted-foreground leading-relaxed">
-          beevibe is the open-source platform for organizations where humans and AI agents work together in one workspace. Drop in via MCP — works with Claude Code, Cursor, Codex, and any tool that speaks the protocol.
+          beevibe is the open-source platform where humans and AI agents share one workspace. Drop in via MCP — works with Claude Code, Cursor, Codex, and any tool that speaks the protocol.
         </p>
       </div>
 
@@ -439,7 +439,7 @@
           </div>
           <h3 class="text-base font-semibold mb-2">Agents ask each other</h3>
           <p class="text-sm text-muted-foreground leading-relaxed mb-3">
-            When one specialist needs another's input, it asks. <span class="font-mono text-xs">ask</span>, <span class="font-mono text-xs">negotiate</span>, <span class="font-mono text-xs">report_blocker</span> are first-class operations between agents, with chain-budget guards against runaway loops. Each target answers from its own context — no merging into one chatbot.
+            When one specialist needs another's input, it asks. <span class="font-mono text-xs">ask</span>, <span class="font-mono text-xs">negotiate</span>, and <span class="font-mono text-xs">report_blocker</span> are built-in commands, with chain-budget guards against runaway loops. The agent you ask answers from its own memory — not from a merged super-bot.
           </p>
           <code class="block text-[11px] font-mono text-muted-foreground bg-secondary/50 rounded px-2 py-1.5 mb-3">ask(target_agent_id, question)</code>
           <a href="mesh.html" class="text-xs font-medium text-foreground hover:underline inline-flex items-center gap-1">
@@ -469,9 +469,9 @@
           <div class="h-9 w-9 rounded-full bg-hier-ic/10 flex items-center justify-center text-hier-ic mb-4">
             <i data-lucide="workflow" class="h-5 w-5"></i>
           </div>
-          <h3 class="text-base font-semibold mb-2">Context crosses at the seams</h3>
+          <h3 class="text-base font-semibold mb-2">Context travels with the work</h3>
           <p class="text-sm text-muted-foreground leading-relaxed mb-3">
-            Every ask, handoff, and review carries the right slice of context to where it's needed — with provenance preserved. No shared pool, no universal knowledge graph. Agents stay bounded and specialized; nothing gets lost between them.
+            Every ask, handoff, and review hands over only the context it needs — and records who said what. No shared pool. No universal knowledge graph. Agents stay specialized, and nothing gets lost between them.
           </p>
           <code class="block text-[11px] font-mono text-muted-foreground bg-secondary/50 rounded px-2 py-1.5 mb-3">memory_fact.agent_id NOT NULL</code>
           <a href="agent-detail.html" class="text-xs font-medium text-foreground hover:underline inline-flex items-center gap-1">
@@ -503,7 +503,7 @@
             <div class="text-xs font-mono text-muted-foreground mb-2">001 · DEPTH</div>
             <h3 class="text-xl font-semibold mb-3">An agent gets visibly sharper.</h3>
             <p class="text-sm text-muted-foreground leading-relaxed mb-4">
-              Open <span class="font-mono text-foreground">agent_codebase</span> — 5 facts. Run a Claude Code session against your repo. Open again — 8 facts, 2 tagged "merged from prior" with the LLM-merged content visible. Depth accrues, observable. No "Claude with a costume."
+              Open <span class="font-mono text-foreground">agent_codebase</span>: 5 facts. Run a Claude Code session against your repo. Open it again: 8 facts, 2 of them merged from earlier ones. The agent is actually learning — not Claude in a costume.
             </p>
             <a href="agent-detail.html" class="text-sm font-medium text-foreground hover:underline inline-flex items-center gap-1">
               Open an agent's memory
@@ -564,7 +564,7 @@
             <div class="text-xs font-mono text-muted-foreground mb-2">002 · COMMONS</div>
             <h3 class="text-xl font-semibold mb-3">A fact earns promotion.</h3>
             <p class="text-sm text-muted-foreground leading-relaxed mb-4">
-              When the same observation reappears across sessions, the editorial promoter decides per-fact whether it's earned wider visibility — with a stated reason for the decision. The commons is curated, not pooled. Provenance is preserved through the promotion.
+              When the same fact shows up across sessions, a promoter decides whether the rest of the team should see it — with a written reason. The shared pool is curated, not automatic, and the original agent stays attached.
             </p>
             <a href="promotions.html" class="text-sm font-medium text-foreground hover:underline inline-flex items-center gap-1">
               Read the promotion log
@@ -579,7 +579,7 @@
             <div class="text-xs font-mono text-muted-foreground mb-2">003 · MESH</div>
             <h3 class="text-xl font-semibold mb-3">Agents ask each other live.</h3>
             <p class="text-sm text-muted-foreground leading-relaxed mb-4">
-              A session in <span class="font-mono text-foreground">ic-agent-1</span> calls <span class="font-mono text-foreground">ask(db-agent, …)</span>. The mesh activity feed surfaces the request and response in real time; <span class="font-mono text-foreground">db-agent</span> answers from <em>its own</em> bounded memory. Bounded specialists collaborating, not merging.
+              A session in <span class="font-mono text-foreground">ic-agent-1</span> calls <span class="font-mono text-foreground">ask(db-agent, …)</span>. The mesh activity feed shows the request and response in real time; <span class="font-mono text-foreground">db-agent</span> answers from <em>its own</em> memory. Specialists collaborating, not merging.
             </p>
             <a href="mesh.html" class="text-sm font-medium text-foreground hover:underline inline-flex items-center gap-1">
               Open the mesh view
@@ -729,9 +729,9 @@ claude mcp add beevibe http://localhost:3002</pre>
           <i data-lucide="quote" class="h-5 w-5 text-primary shrink-0 mt-0.5"></i>
           <div class="text-sm leading-relaxed">
             <span class="font-semibold text-foreground">The key difference.</span>
-            <span class="text-muted-foreground"> Multica and Paperclip agents are largely one-off — assignment targets that pull from a shared static skills library or run a heartbeat-triggered script. </span>
-            <span class="text-foreground">beevibe agents are persistent specialists.</span>
-            <span class="text-muted-foreground"> Each agent has its own bounded memory that grows session over session via merge-on-similarity. Same observation rediscovered → consolidated, not duplicated. Their expertise compounds; their identity persists; their collaborations form the team's actual shape.</span>
+            <span class="text-muted-foreground"> Multica and Paperclip agents are stateless: they pick up a task, run a skill or script, and forget. </span>
+            <span class="text-foreground">beevibe agents remember.</span>
+            <span class="text-muted-foreground"> Each one has its own memory that grows every session — repeated facts get merged instead of duplicated, so expertise actually compounds.</span>
           </div>
         </div>
       </div>
@@ -746,7 +746,7 @@ claude mcp add beevibe http://localhost:3002</pre>
         They start <span class="bg-primary text-primary-foreground px-1.5 -mx-0.5 rounded-sm">working together</span>.
       </h2>
       <p class="text-muted-foreground leading-relaxed mb-7">
-        beevibe is the open-source runtime that turns scattered, single-user AI tools into a coordinated team. Agents ask each other, escalate to humans, share work products, and stay in sync across sessions. Every person on your team and every agent they spawn — one shared workspace.
+        beevibe is the open-source runtime that connects the AI tools your team already uses. Agents ask each other, escalate to humans, and share work — every person and every agent in one workspace.
       </p>
       <div class="flex flex-wrap items-center justify-center gap-3">
         <a href="#" class="inline-flex items-center gap-2 h-10 px-5 rounded bg-primary text-primary-foreground text-sm font-semibold hover:opacity-90 active:scale-[0.98] transition-all duration-150">

--- a/mocks/showcase.html
+++ b/mocks/showcase.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>beevibe — bounded specialists, curated commons, mesh asks</title>
+  <title>beevibe — where context flows between every person and every agent</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
@@ -218,21 +218,21 @@
       <div class="max-w-3xl mb-12">
         <div class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-secondary text-xs text-muted-foreground mb-5">
           <span class="h-1.5 w-1.5 rounded-full bg-primary"></span>
-          <span>Open source · MIT · self-host or hosted</span>
+          <span>Open source · self-host or hosted</span>
         </div>
         <h1 class="text-4xl md:text-5xl font-bold tracking-tight leading-[1.1] mb-5">
-          The agent runtime with the right opinion about <span class="bg-primary text-primary-foreground px-1.5 -mx-0.5 rounded-sm">multi-agent shape</span>.
+          Where context flows between every person and every <span class="bg-primary text-primary-foreground px-1.5 -mx-0.5 rounded-sm">agent on your team</span>.
         </h1>
         <p class="text-lg text-muted-foreground leading-relaxed max-w-2xl">
-          Bounded domain-expert agents that accumulate real depth, share what genuinely generalizes through a curated commons, and ask each other for the rest. Drop into your stack and your agents start composing like a team — not averaging into one mediocre brain.
+          beevibe coordinates work across people and AI agents in one shared workspace. Each agent stays in its own context; when it needs another specialist's input, it asks. Humans approve, redirect, or hand off. Context flows at the crossings — every ask, every handoff, every review, with provenance preserved — so nothing gets lost between sessions, between agents, or between people.
         </p>
         <div class="mt-7 flex flex-wrap items-center gap-3">
-          <a href="#" class="inline-flex items-center gap-2 h-10 px-4 rounded bg-primary text-primary-foreground text-sm font-semibold hover:opacity-90 active:scale-[0.98] transition-all duration-150">
-            <i data-lucide="terminal" class="h-4 w-4"></i>
-            <span class="font-mono">npm i @beevibe/core</span>
+          <a href="home.html" class="inline-flex items-center gap-2 h-10 px-4 rounded bg-primary text-primary-foreground text-sm font-semibold hover:opacity-90 active:scale-[0.98] transition-all duration-150">
+            <i data-lucide="layout-dashboard" class="h-4 w-4"></i>
+            Open the workspace
           </a>
           <a href="#moments" class="inline-flex items-center gap-1.5 h-10 px-4 rounded text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors">
-            See the three magic moments
+            See it in action
             <i data-lucide="arrow-right" class="h-4 w-4"></i>
           </a>
         </div>
@@ -406,60 +406,63 @@
     </div>
   </section>
 
-  <!-- THE THREE PROMISES -->
+  <!-- THREE THINGS THAT MAKE A HYBRID TEAM WORK -->
   <section id="promise" class="border-b border-border">
     <div class="max-w-6xl mx-auto px-6 py-20">
       <div class="max-w-2xl mb-12">
         <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">How it works</div>
-        <h2 class="text-2xl font-bold tracking-tight mb-3">Three architectural commitments. Verifiable in your terminal.</h2>
+        <h2 class="text-2xl font-bold tracking-tight mb-3">Three things that make a hybrid team actually work.</h2>
         <p class="text-muted-foreground leading-relaxed">
-          beevibe is not a chat product. It's an opinionated runtime for multi-agent systems — open source, MIT-licensed, drop-in for any MCP-speaking agent (Claude Code, Cursor, Codex, whatever ships next).
+          beevibe is the open-source platform for organizations where humans and AI agents work together in one workspace. Drop in via MCP — works with Claude Code, Cursor, Codex, and any tool that speaks the protocol.
         </p>
       </div>
 
       <div class="grid md:grid-cols-3 gap-6">
 
-        <div class="rounded-lg border border-border bg-card p-5">
-          <div class="h-9 w-9 rounded-full bg-hier-ic/10 flex items-center justify-center text-hier-ic mb-4">
-            <i data-lucide="square-stack" class="h-5 w-5"></i>
-          </div>
-          <h3 class="text-base font-semibold mb-2">Bounded specialists</h3>
-          <p class="text-sm text-muted-foreground leading-relaxed mb-3">
-            Each agent has its own bounded core memory and fact store. Sessions accumulate depth via merge-on-similarity — the same observation hit twice consolidates, doesn't duplicate. No global pool exists anywhere in the runtime.
-          </p>
-          <code class="block text-[11px] font-mono text-muted-foreground bg-secondary/50 rounded px-2 py-1.5 mb-3">memory_fact.agent_id NOT NULL</code>
-          <a href="agent-detail.html" class="text-xs font-medium text-foreground hover:underline inline-flex items-center gap-1">
-            See an agent's memory
-            <i data-lucide="arrow-right" class="h-3 w-3"></i>
-          </a>
-        </div>
-
-        <div class="rounded-lg border border-border bg-card p-5">
-          <div class="h-9 w-9 rounded-full bg-hier-team/10 flex items-center justify-center text-hier-team mb-4">
-            <i data-lucide="trending-up" class="h-5 w-5"></i>
-          </div>
-          <h3 class="text-base font-semibold mb-2">Curated commons</h3>
-          <p class="text-sm text-muted-foreground leading-relaxed mb-3">
-            Facts earn wider scope through an editorial promoter — an LLM classifier that decides per-fact whether <span class="font-mono text-xs">ic → team</span> or <span class="font-mono text-xs">team → org</span> movement is warranted, with a stated reason. Default is to keep narrow.
-          </p>
-          <code class="block text-[11px] font-mono text-muted-foreground bg-secondary/50 rounded px-2 py-1.5 mb-3">FactPromoter.evaluate(fact)</code>
-          <a href="promotions.html" class="text-xs font-medium text-foreground hover:underline inline-flex items-center gap-1">
-            Read promotion log
-            <i data-lucide="arrow-right" class="h-3 w-3"></i>
-          </a>
-        </div>
-
+        <!-- Pillar 1 — Agents ask each other -->
         <div class="rounded-lg border border-border bg-card p-5">
           <div class="h-9 w-9 rounded-full bg-status-running/10 flex items-center justify-center text-status-running mb-4">
             <i data-lucide="link" class="h-5 w-5"></i>
           </div>
-          <h3 class="text-base font-semibold mb-2">Mesh asks</h3>
+          <h3 class="text-base font-semibold mb-2">Agents ask each other</h3>
           <p class="text-sm text-muted-foreground leading-relaxed mb-3">
-            When a specialist doesn't know, it asks. <span class="font-mono text-xs">ask</span>, <span class="font-mono text-xs">negotiate</span>, <span class="font-mono text-xs">report_blocker</span> are first-class tools with chain-budget guards against runaway loops. The target answers from <em>its own bounded memory</em>.
+            When one specialist needs another's input, it asks. <span class="font-mono text-xs">ask</span>, <span class="font-mono text-xs">negotiate</span>, <span class="font-mono text-xs">report_blocker</span> are first-class operations between agents, with chain-budget guards against runaway loops. Each target answers from its own context — no merging into one chatbot.
           </p>
           <code class="block text-[11px] font-mono text-muted-foreground bg-secondary/50 rounded px-2 py-1.5 mb-3">ask(target_agent_id, question)</code>
           <a href="mesh.html" class="text-xs font-medium text-foreground hover:underline inline-flex items-center gap-1">
             See the live mesh
+            <i data-lucide="arrow-right" class="h-3 w-3"></i>
+          </a>
+        </div>
+
+        <!-- Pillar 2 — Humans steer, review, hand off -->
+        <div class="rounded-lg border border-border bg-card p-5">
+          <div class="h-9 w-9 rounded-full bg-primary/15 flex items-center justify-center text-primary mb-4">
+            <i data-lucide="user-check" class="h-5 w-5"></i>
+          </div>
+          <h3 class="text-base font-semibold mb-2">Humans review, redirect, hand off</h3>
+          <p class="text-sm text-muted-foreground leading-relaxed mb-3">
+            People and agents share one workspace. Agents send work for review; humans approve, request revision, or reassign. Blockers escalate up the chain to the right teammate — agent or human. The whole loop is visible to everyone who needs to see it.
+          </p>
+          <code class="block text-[11px] font-mono text-muted-foreground bg-secondary/50 rounded px-2 py-1.5 mb-3">task.review_policy = 'require_human'</code>
+          <a href="task-detail.html" class="text-xs font-medium text-foreground hover:underline inline-flex items-center gap-1">
+            See a review flow
+            <i data-lucide="arrow-right" class="h-3 w-3"></i>
+          </a>
+        </div>
+
+        <!-- Pillar 3 — Context crosses, doesn't pool -->
+        <div class="rounded-lg border border-border bg-card p-5">
+          <div class="h-9 w-9 rounded-full bg-hier-ic/10 flex items-center justify-center text-hier-ic mb-4">
+            <i data-lucide="workflow" class="h-5 w-5"></i>
+          </div>
+          <h3 class="text-base font-semibold mb-2">Context crosses at the seams</h3>
+          <p class="text-sm text-muted-foreground leading-relaxed mb-3">
+            Every ask, handoff, and review carries the right slice of context to where it's needed — with provenance preserved. No shared pool, no universal knowledge graph. Agents stay bounded and specialized; nothing gets lost between them.
+          </p>
+          <code class="block text-[11px] font-mono text-muted-foreground bg-secondary/50 rounded px-2 py-1.5 mb-3">memory_fact.agent_id NOT NULL</code>
+          <a href="agent-detail.html" class="text-xs font-medium text-foreground hover:underline inline-flex items-center gap-1">
+            See an agent's context
             <i data-lucide="arrow-right" class="h-3 w-3"></i>
           </a>
         </div>
@@ -604,9 +607,9 @@
     <div class="max-w-6xl mx-auto px-6 py-20">
       <div class="max-w-2xl mb-8">
         <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Where this fits</div>
-        <h2 class="text-2xl font-bold tracking-tight mb-3">Library-shaped. Drop-in. Self-host or hosted.</h2>
+        <h2 class="text-2xl font-bold tracking-tight mb-3">One workspace. Drops in alongside the agents your team already uses.</h2>
         <p class="text-muted-foreground leading-relaxed">
-          beevibe is not an app users open. It's the opinionated cognition layer that sits under your agent stack, exposed via MCP for any tool that speaks it.
+          beevibe is the shared workspace where humans and agents coordinate. Agents connect to it from whatever runtime they live in — Claude Code, Cursor, Codex, anything that speaks MCP — and start collaborating with each other and with the humans on the team.
         </p>
       </div>
 
@@ -643,7 +646,10 @@ claude mcp add beevibe http://localhost:3002</pre>
     <div class="max-w-6xl mx-auto px-6 py-20">
       <div class="max-w-2xl mb-8">
         <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Compared to</div>
-        <h2 class="text-2xl font-bold tracking-tight mb-3">Where the architectural opinion lives.</h2>
+        <h2 class="text-2xl font-bold tracking-tight mb-3">How beevibe differs from the field.</h2>
+        <p class="text-muted-foreground leading-relaxed mt-3">
+          mem0 ships memory. Multica ships task tracking. Mastra ships an agent framework. None of them ship the workspace where humans and their agents coordinate as one team.
+        </p>
       </div>
 
       <div class="rounded-lg border border-border bg-card overflow-hidden">
@@ -702,9 +708,9 @@ claude mcp add beevibe http://localhost:3002</pre>
   <!-- CTA -->
   <section>
     <div class="max-w-3xl mx-auto px-6 py-20 text-center">
-      <h2 class="text-2xl md:text-3xl font-bold tracking-tight mb-4">Try it in five minutes.</h2>
+      <h2 class="text-2xl md:text-3xl font-bold tracking-tight mb-4">Bring your team into one workspace.</h2>
       <p class="text-muted-foreground leading-relaxed mb-7">
-        Run the runtime locally, point Claude Code at the MCP server, work in your repo for a session. Open the dashboard. Watch your agent get visibly sharper.
+        Spin up the workspace locally, invite your teammates, and point each person's agents at it via MCP. Watch context start flowing where it needs to — across asks, handoffs, and reviews — without dissolving into one shared brain.
       </p>
       <div class="flex flex-wrap items-center justify-center gap-3">
         <a href="#" class="inline-flex items-center gap-2 h-10 px-5 rounded bg-primary text-primary-foreground text-sm font-semibold hover:opacity-90 active:scale-[0.98] transition-all duration-150">
@@ -712,7 +718,7 @@ claude mcp add beevibe http://localhost:3002</pre>
           Quickstart
         </a>
         <a href="home.html" class="inline-flex items-center gap-1.5 h-10 px-5 rounded text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors">
-          Open the dashboard
+          Open the workspace
           <i data-lucide="arrow-right" class="h-4 w-4"></i>
         </a>
       </div>

--- a/mocks/showcase.html
+++ b/mocks/showcase.html
@@ -1,0 +1,746 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>beevibe — bounded specialists, curated commons, mesh asks</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+  <script>
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.classList.add('dark');
+    }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+  <style>
+    :root {
+      --background: 0 0% 100%;
+      --foreground: 240 10% 4%;
+      --card: 240 5% 98%;
+      --card-foreground: 240 10% 4%;
+      --primary: 48 96% 53%;
+      --primary-foreground: 240 10% 4%;
+      --secondary: 240 5% 96%;
+      --secondary-foreground: 240 6% 10%;
+      --muted: 240 5% 96%;
+      --muted-foreground: 240 4% 46%;
+      --border: 240 6% 90%;
+      --input: 240 6% 90%;
+      --ring: 47 96% 47%;
+      --radius: 0.375rem;
+
+      --status-pending:   240 4% 46%;
+      --status-running:   217 91% 60%;
+      --status-review:    38 92% 50%;
+      --status-blocked:   25 95% 53%;
+      --status-done:      160 84% 39%;
+      --status-failed:    0 84% 60%;
+
+      --hier-ic:   240 4% 46%;
+      --hier-team: 262 83% 58%;
+      --hier-org:  38 92% 50%;
+    }
+    .dark {
+      --background: 240 10% 4%;
+      --foreground: 0 0% 98%;
+      --card: 240 6% 10%;
+      --card-foreground: 0 0% 98%;
+      --primary: 48 96% 53%;
+      --primary-foreground: 240 10% 4%;
+      --secondary: 240 4% 16%;
+      --secondary-foreground: 0 0% 98%;
+      --muted: 240 4% 16%;
+      --muted-foreground: 240 5% 65%;
+      --border: 240 4% 16%;
+      --input: 240 4% 16%;
+      --ring: 48 96% 53%;
+    }
+
+    body {
+      font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
+      font-feature-settings: 'cv11', 'ss01';
+      background-color: hsl(var(--background));
+      color: hsl(var(--foreground));
+      -webkit-font-smoothing: antialiased;
+    }
+    .font-mono { font-family: 'JetBrains Mono', ui-monospace, 'Menlo', monospace; }
+
+    button:focus-visible, a:focus-visible {
+      outline: 2px solid hsl(var(--ring));
+      outline-offset: 2px;
+      border-radius: var(--radius);
+    }
+
+    /* ── HERO ANIMATION ────────────────────────────────────────────────
+       8-second cycle, repeats. Both panels show the same logical event
+       sequence so the viewer reads them as comparable.
+       0.0s: a fact appears in agent A
+       1.5s: a similar fact appears in agent B
+       3.0s: merge / promotion event
+       4.5s: ask between A and B
+       6.0s: response
+       7.5s: cycle reset (fade out)
+    ─────────────────────────────────────────────────────────────────── */
+
+    @keyframes fact-flat {
+      0%, 4%   { opacity: 0; transform: translateY(-8px); }
+      6%, 90%  { opacity: 1; transform: translateY(0); }
+      100%     { opacity: 0; transform: translateY(0); }
+    }
+    @keyframes fact-flat-2 {
+      0%, 22%  { opacity: 0; transform: translateY(-8px); }
+      24%, 90% { opacity: 1; transform: translateY(0); }
+      100%     { opacity: 0; transform: translateY(0); }
+    }
+
+    @keyframes fact-bounded-a {
+      0%, 4%   { opacity: 0; transform: translateY(-4px); }
+      6%, 90%  { opacity: 1; transform: translateY(0); }
+      100%     { opacity: 0; transform: translateY(0); }
+    }
+    @keyframes fact-bounded-b {
+      0%, 22%  { opacity: 0; transform: translateY(-4px); }
+      24%, 90% { opacity: 1; transform: translateY(0); }
+      100%     { opacity: 0; transform: translateY(0); }
+    }
+
+    @keyframes promotion-bubble {
+      0%, 36%   { opacity: 0; transform: translateY(8px) scale(0.95); }
+      40%, 86%  { opacity: 1; transform: translateY(0) scale(1); }
+      100%      { opacity: 0; transform: translateY(0) scale(1); }
+    }
+
+    @keyframes ask-edge {
+      0%, 50%   { opacity: 0; }
+      55%, 86%  { opacity: 1; }
+      100%      { opacity: 0; }
+    }
+    @keyframes ask-dash {
+      to { stroke-dashoffset: -16; }
+    }
+
+    .anim-flat-1   { animation: fact-flat   8s ease-out infinite; }
+    .anim-flat-2   { animation: fact-flat-2 8s ease-out infinite; }
+    .anim-bound-a  { animation: fact-bounded-a 8s ease-out infinite; }
+    .anim-bound-b  { animation: fact-bounded-b 8s ease-out infinite; }
+    .anim-promo    { animation: promotion-bubble 8s ease-out infinite; }
+    .anim-ask      { animation: ask-edge 8s ease-out infinite; }
+    .anim-ask-line { stroke-dasharray: 4 4; animation: ask-dash 1s linear infinite, ask-edge 8s ease-out infinite; }
+
+    @media (prefers-reduced-motion: reduce) {
+      .anim-flat-1, .anim-flat-2, .anim-bound-a, .anim-bound-b,
+      .anim-promo, .anim-ask, .anim-ask-line { animation: none; opacity: 1; }
+    }
+  </style>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+            mono: ['JetBrains Mono', 'ui-monospace', 'Menlo', 'monospace'],
+          },
+          colors: {
+            border: 'hsl(var(--border))',
+            input: 'hsl(var(--input))',
+            ring: 'hsl(var(--ring))',
+            background: 'hsl(var(--background))',
+            foreground: 'hsl(var(--foreground))',
+            primary: { DEFAULT: 'hsl(var(--primary))', foreground: 'hsl(var(--primary-foreground))' },
+            secondary: { DEFAULT: 'hsl(var(--secondary))', foreground: 'hsl(var(--secondary-foreground))' },
+            muted: { DEFAULT: 'hsl(var(--muted))', foreground: 'hsl(var(--muted-foreground))' },
+            card: { DEFAULT: 'hsl(var(--card))', foreground: 'hsl(var(--card-foreground))' },
+            status: {
+              pending:   'hsl(var(--status-pending))',
+              running:   'hsl(var(--status-running))',
+              review:    'hsl(var(--status-review))',
+              blocked:   'hsl(var(--status-blocked))',
+              done:      'hsl(var(--status-done))',
+              failed:    'hsl(var(--status-failed))',
+            },
+            hier: {
+              ic:   'hsl(var(--hier-ic))',
+              team: 'hsl(var(--hier-team))',
+              org:  'hsl(var(--hier-org))',
+            },
+          },
+          borderRadius: {
+            DEFAULT: 'var(--radius)',
+            md: 'var(--radius)',
+            lg: 'calc(var(--radius) + 2px)',
+            xl: 'calc(var(--radius) + 6px)',
+          },
+        },
+      },
+    };
+  </script>
+</head>
+<body class="min-h-screen">
+
+  <!-- Top bar (this is the only mock without the sidebar — it's a public marketing page) -->
+  <header class="border-b border-border">
+    <div class="max-w-6xl mx-auto px-6 h-14 flex items-center justify-between">
+      <a href="#" class="flex items-center gap-2.5">
+        <div class="h-6 w-6 rounded bg-primary flex items-center justify-center">
+          <span class="text-primary-foreground text-sm font-bold leading-none">b</span>
+        </div>
+        <span class="font-semibold tracking-tight">beevibe</span>
+      </a>
+      <nav class="hidden md:flex items-center gap-6 text-sm text-muted-foreground">
+        <a href="#promise" class="hover:text-foreground transition-colors">How it works</a>
+        <a href="#moments" class="hover:text-foreground transition-colors">Demo</a>
+        <a href="#" class="hover:text-foreground transition-colors">Docs</a>
+        <a href="#" class="hover:text-foreground transition-colors inline-flex items-center gap-1">
+          <i data-lucide="github" class="h-4 w-4"></i>
+          GitHub
+        </a>
+      </nav>
+      <div class="flex items-center gap-2">
+        <button id="theme-toggle" class="h-8 w-8 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary cursor-pointer transition-colors" title="Toggle theme">
+          <i data-lucide="sun" class="h-4 w-4 hidden dark:block"></i>
+          <i data-lucide="moon" class="h-4 w-4 block dark:hidden"></i>
+        </button>
+        <a href="home.html" class="inline-flex items-center gap-1.5 h-8 px-3 rounded bg-primary text-primary-foreground text-xs font-semibold hover:opacity-90 active:scale-[0.98] transition-all duration-150">
+          Open dashboard
+        </a>
+      </div>
+    </div>
+  </header>
+
+  <!-- HERO -->
+  <section class="border-b border-border">
+    <div class="max-w-6xl mx-auto px-6 pt-16 pb-12">
+
+      <!-- Headline -->
+      <div class="max-w-3xl mb-12">
+        <div class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-secondary text-xs text-muted-foreground mb-5">
+          <span class="h-1.5 w-1.5 rounded-full bg-primary"></span>
+          <span>Open source · MIT · self-host or hosted</span>
+        </div>
+        <h1 class="text-4xl md:text-5xl font-bold tracking-tight leading-[1.1] mb-5">
+          The agent runtime with the right opinion about <span class="bg-primary text-primary-foreground px-1.5 -mx-0.5 rounded-sm">multi-agent shape</span>.
+        </h1>
+        <p class="text-lg text-muted-foreground leading-relaxed max-w-2xl">
+          Bounded domain-expert agents that accumulate real depth, share what genuinely generalizes through a curated commons, and ask each other for the rest. Drop into your stack and your agents start composing like a team — not averaging into one mediocre brain.
+        </p>
+        <div class="mt-7 flex flex-wrap items-center gap-3">
+          <a href="#" class="inline-flex items-center gap-2 h-10 px-4 rounded bg-primary text-primary-foreground text-sm font-semibold hover:opacity-90 active:scale-[0.98] transition-all duration-150">
+            <i data-lucide="terminal" class="h-4 w-4"></i>
+            <span class="font-mono">npm i @beevibe/core</span>
+          </a>
+          <a href="#moments" class="inline-flex items-center gap-1.5 h-10 px-4 rounded text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors">
+            See the three magic moments
+            <i data-lucide="arrow-right" class="h-4 w-4"></i>
+          </a>
+        </div>
+      </div>
+
+      <!-- ── SIDE-BY-SIDE ANIMATION ──────────────────────────────────── -->
+      <div class="grid md:grid-cols-2 gap-6">
+
+        <!-- LEFT — flat memory pattern (mem0 / generic) -->
+        <div class="rounded-xl border border-border bg-card overflow-hidden">
+          <div class="px-5 py-4 border-b border-border flex items-center justify-between">
+            <div>
+              <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-0.5">flat memory</div>
+              <div class="text-sm font-semibold">Every agent reads the same pool</div>
+            </div>
+            <span class="text-[10px] text-muted-foreground font-mono">mem0 / generic</span>
+          </div>
+
+          <div class="p-5">
+            <svg viewBox="0 0 360 280" class="w-full h-[280px]">
+              <!-- The pool -->
+              <rect x="40" y="60" width="280" height="200" rx="10"
+                    fill="hsl(var(--muted-foreground) / 0.08)"
+                    stroke="hsl(var(--border))" stroke-width="1.5" stroke-dasharray="3 3" />
+              <text x="180" y="80" text-anchor="middle" font-size="10" font-family="JetBrains Mono"
+                    fill="hsl(var(--muted-foreground))">shared memory pool</text>
+
+              <!-- Three agent dots reading from pool -->
+              <g>
+                <circle cx="80"  cy="140" r="12" fill="hsl(var(--card))" stroke="hsl(var(--muted-foreground))" stroke-width="1.5" />
+                <text x="80"  y="143" text-anchor="middle" font-size="9" font-weight="600" fill="hsl(var(--foreground))" font-family="JetBrains Mono">A</text>
+              </g>
+              <g>
+                <circle cx="180" cy="190" r="12" fill="hsl(var(--card))" stroke="hsl(var(--muted-foreground))" stroke-width="1.5" />
+                <text x="180" y="193" text-anchor="middle" font-size="9" font-weight="600" fill="hsl(var(--foreground))" font-family="JetBrains Mono">B</text>
+              </g>
+              <g>
+                <circle cx="280" cy="140" r="12" fill="hsl(var(--card))" stroke="hsl(var(--muted-foreground))" stroke-width="1.5" />
+                <text x="280" y="143" text-anchor="middle" font-size="9" font-weight="600" fill="hsl(var(--foreground))" font-family="JetBrains Mono">C</text>
+              </g>
+
+              <!-- Fact 1 dropping in: animates first -->
+              <g class="anim-flat-1">
+                <rect x="120" y="105" width="120" height="22" rx="4" fill="hsl(var(--primary) / 0.2)" stroke="hsl(var(--primary))" stroke-width="1" />
+                <text x="180" y="120" text-anchor="middle" font-size="9" fill="hsl(var(--foreground))" font-family="JetBrains Mono">fact #1 (no scope)</text>
+              </g>
+
+              <!-- Fact 2 — appears later, also in pool -->
+              <g class="anim-flat-2">
+                <rect x="120" y="135" width="120" height="22" rx="4" fill="hsl(var(--primary) / 0.2)" stroke="hsl(var(--primary))" stroke-width="1" />
+                <text x="180" y="150" text-anchor="middle" font-size="9" fill="hsl(var(--foreground))" font-family="JetBrains Mono">fact #2 (no scope)</text>
+              </g>
+
+              <!-- All agents have read lines into the pool — static -->
+              <line x1="92"  y1="140" x2="120" y2="140" stroke="hsl(var(--muted-foreground))" stroke-width="1" opacity="0.3" />
+              <line x1="180" y1="178" x2="180" y2="160" stroke="hsl(var(--muted-foreground))" stroke-width="1" opacity="0.3" />
+              <line x1="268" y1="140" x2="240" y2="140" stroke="hsl(var(--muted-foreground))" stroke-width="1" opacity="0.3" />
+            </svg>
+
+            <ul class="mt-4 space-y-1.5 text-xs text-muted-foreground">
+              <li class="flex items-start gap-2"><i data-lucide="x" class="h-3.5 w-3.5 text-status-failed shrink-0 mt-0.5"></i>No specialization — every agent inherits everyone's notes.</li>
+              <li class="flex items-start gap-2"><i data-lucide="x" class="h-3.5 w-3.5 text-status-failed shrink-0 mt-0.5"></i>No provenance — facts arrive sourceless once written.</li>
+              <li class="flex items-start gap-2"><i data-lucide="x" class="h-3.5 w-3.5 text-status-failed shrink-0 mt-0.5"></i>Context window dilutes — depth competes with everyone else's domain.</li>
+            </ul>
+          </div>
+        </div>
+
+        <!-- RIGHT — bounded specialists (beevibe) -->
+        <div class="rounded-xl border-2 border-primary/40 bg-card overflow-hidden">
+          <div class="px-5 py-4 border-b border-border flex items-center justify-between">
+            <div>
+              <div class="text-[10px] uppercase tracking-wider text-primary mb-0.5">bounded specialists</div>
+              <div class="text-sm font-semibold">Each agent keeps its own context</div>
+            </div>
+            <span class="text-[10px] text-muted-foreground font-mono">beevibe</span>
+          </div>
+
+          <div class="p-5">
+            <svg viewBox="0 0 360 280" class="w-full h-[280px]">
+              <!-- COMMONS at top — narrow strip, with promotion bubble appearing later -->
+              <rect x="80" y="14" width="200" height="46" rx="8"
+                    fill="hsl(var(--hier-team) / 0.06)"
+                    stroke="hsl(var(--hier-team))" stroke-width="1" stroke-dasharray="3 3" />
+              <text x="180" y="30" text-anchor="middle" font-size="9" font-family="JetBrains Mono"
+                    fill="hsl(var(--hier-team))">curated commons · team scope</text>
+
+              <!-- promotion bubble (appears after merge) -->
+              <g class="anim-promo">
+                <rect x="100" y="36" width="160" height="18" rx="4"
+                      fill="hsl(var(--hier-team) / 0.18)" stroke="hsl(var(--hier-team))" stroke-width="1" />
+                <text x="180" y="48" text-anchor="middle" font-size="8" fill="hsl(var(--foreground))" font-family="JetBrains Mono">fact promoted (provenance kept)</text>
+              </g>
+
+              <!-- Agent A box (left) — has its own bounded fact -->
+              <rect x="20" y="100" width="100" height="120" rx="8"
+                    fill="hsl(var(--background))" stroke="hsl(var(--hier-ic))" stroke-width="1.5" />
+              <circle cx="40" cy="120" r="10" fill="hsl(var(--card))" stroke="hsl(var(--hier-ic))" stroke-width="1.5" />
+              <text x="40" y="123" text-anchor="middle" font-size="9" font-weight="600" fill="hsl(var(--foreground))" font-family="JetBrains Mono">A</text>
+              <text x="56" y="123" font-size="9" fill="hsl(var(--muted-foreground))" font-family="JetBrains Mono">auth</text>
+              <line x1="28" y1="140" x2="112" y2="140" stroke="hsl(var(--border))" stroke-width="1" />
+              <!-- Agent A's fact appears -->
+              <g class="anim-bound-a">
+                <rect x="28" y="148" width="84" height="14" rx="3"
+                      fill="hsl(var(--hier-ic) / 0.12)" stroke="hsl(var(--hier-ic))" stroke-width="0.8" />
+                <text x="70" y="158" text-anchor="middle" font-size="8" fill="hsl(var(--foreground))" font-family="JetBrains Mono">fact (ic, by A)</text>
+              </g>
+              <text x="28" y="180" font-size="8" fill="hsl(var(--muted-foreground))" font-family="JetBrains Mono">+ persona</text>
+              <text x="28" y="194" font-size="8" fill="hsl(var(--muted-foreground))" font-family="JetBrains Mono">+ domain</text>
+              <text x="28" y="208" font-size="8" fill="hsl(var(--muted-foreground))" font-family="JetBrains Mono">+ constraints</text>
+
+              <!-- Agent B box (middle) — has its own bounded fact (similar, will merge) -->
+              <rect x="130" y="100" width="100" height="120" rx="8"
+                    fill="hsl(var(--background))" stroke="hsl(var(--hier-ic))" stroke-width="1.5" />
+              <circle cx="150" cy="120" r="10" fill="hsl(var(--card))" stroke="hsl(var(--hier-ic))" stroke-width="1.5" />
+              <text x="150" y="123" text-anchor="middle" font-size="9" font-weight="600" fill="hsl(var(--foreground))" font-family="JetBrains Mono">B</text>
+              <text x="166" y="123" font-size="9" fill="hsl(var(--muted-foreground))" font-family="JetBrains Mono">infra</text>
+              <line x1="138" y1="140" x2="222" y2="140" stroke="hsl(var(--border))" stroke-width="1" />
+              <g class="anim-bound-b">
+                <rect x="138" y="148" width="84" height="14" rx="3"
+                      fill="hsl(var(--hier-ic) / 0.12)" stroke="hsl(var(--hier-ic))" stroke-width="0.8" />
+                <text x="180" y="158" text-anchor="middle" font-size="8" fill="hsl(var(--foreground))" font-family="JetBrains Mono">fact (ic, by B)</text>
+              </g>
+              <text x="138" y="180" font-size="8" fill="hsl(var(--muted-foreground))" font-family="JetBrains Mono">+ persona</text>
+              <text x="138" y="194" font-size="8" fill="hsl(var(--muted-foreground))" font-family="JetBrains Mono">+ domain</text>
+              <text x="138" y="208" font-size="8" fill="hsl(var(--muted-foreground))" font-family="JetBrains Mono">+ constraints</text>
+
+              <!-- Agent C box (right) -->
+              <rect x="240" y="100" width="100" height="120" rx="8"
+                    fill="hsl(var(--background))" stroke="hsl(var(--hier-ic))" stroke-width="1.5" />
+              <circle cx="260" cy="120" r="10" fill="hsl(var(--card))" stroke="hsl(var(--hier-ic))" stroke-width="1.5" />
+              <text x="260" y="123" text-anchor="middle" font-size="9" font-weight="600" fill="hsl(var(--foreground))" font-family="JetBrains Mono">C</text>
+              <text x="276" y="123" font-size="9" fill="hsl(var(--muted-foreground))" font-family="JetBrains Mono">data</text>
+              <line x1="248" y1="140" x2="332" y2="140" stroke="hsl(var(--border))" stroke-width="1" />
+              <text x="248" y="160" font-size="8" fill="hsl(var(--muted-foreground))" font-family="JetBrains Mono">+ persona</text>
+              <text x="248" y="174" font-size="8" fill="hsl(var(--muted-foreground))" font-family="JetBrains Mono">+ domain</text>
+              <text x="248" y="188" font-size="8" fill="hsl(var(--muted-foreground))" font-family="JetBrains Mono">+ constraints</text>
+
+              <!-- Animated MESH ASK arrow A → C -->
+              <g class="anim-ask">
+                <path d="M 70 100 Q 165 70, 260 100" fill="none"
+                      stroke="hsl(var(--status-running))" stroke-width="1.5"
+                      class="anim-ask-line" />
+                <text x="165" y="74" text-anchor="middle" font-size="8" font-family="JetBrains Mono"
+                      fill="hsl(var(--status-running))">ask</text>
+              </g>
+
+              <!-- Promotion arrow A → commons (appears with promo bubble) -->
+              <g class="anim-promo">
+                <path d="M 70 100 Q 80 80, 110 60" fill="none"
+                      stroke="hsl(var(--hier-team))" stroke-width="1" stroke-dasharray="2 2" />
+              </g>
+
+            </svg>
+
+            <ul class="mt-4 space-y-1.5 text-xs text-muted-foreground">
+              <li class="flex items-start gap-2"><i data-lucide="check" class="h-3.5 w-3.5 text-status-done shrink-0 mt-0.5"></i><span><span class="text-foreground">Specialization compounds.</span> Each agent's depth doesn't dilute into a global pool.</span></li>
+              <li class="flex items-start gap-2"><i data-lucide="check" class="h-3.5 w-3.5 text-status-done shrink-0 mt-0.5"></i><span><span class="text-foreground">Provenance preserved.</span> Every fact carries its originating agent — even after promotion.</span></li>
+              <li class="flex items-start gap-2"><i data-lucide="check" class="h-3.5 w-3.5 text-status-done shrink-0 mt-0.5"></i><span><span class="text-foreground">Curated commons.</span> Facts earn wider scope through editorial judgment, not auto-pooling.</span></li>
+              <li class="flex items-start gap-2"><i data-lucide="check" class="h-3.5 w-3.5 text-status-done shrink-0 mt-0.5"></i><span><span class="text-foreground">Mesh asks for the rest.</span> When an agent doesn't know, it asks the specialist who does.</span></li>
+            </ul>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- Tiny caption under the animation -->
+      <p class="mt-4 text-xs text-muted-foreground text-center">
+        Same logical event sequence in both panels — fact written, second agent observes a similar one, merge / promotion, mesh ask. Watch what each architecture does with it.
+      </p>
+
+    </div>
+  </section>
+
+  <!-- THE THREE PROMISES -->
+  <section id="promise" class="border-b border-border">
+    <div class="max-w-6xl mx-auto px-6 py-20">
+      <div class="max-w-2xl mb-12">
+        <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">How it works</div>
+        <h2 class="text-2xl font-bold tracking-tight mb-3">Three architectural commitments. Verifiable in your terminal.</h2>
+        <p class="text-muted-foreground leading-relaxed">
+          beevibe is not a chat product. It's an opinionated runtime for multi-agent systems — open source, MIT-licensed, drop-in for any MCP-speaking agent (Claude Code, Cursor, Codex, whatever ships next).
+        </p>
+      </div>
+
+      <div class="grid md:grid-cols-3 gap-6">
+
+        <div class="rounded-lg border border-border bg-card p-5">
+          <div class="h-9 w-9 rounded-full bg-hier-ic/10 flex items-center justify-center text-hier-ic mb-4">
+            <i data-lucide="square-stack" class="h-5 w-5"></i>
+          </div>
+          <h3 class="text-base font-semibold mb-2">Bounded specialists</h3>
+          <p class="text-sm text-muted-foreground leading-relaxed mb-3">
+            Each agent has its own bounded core memory and fact store. Sessions accumulate depth via merge-on-similarity — the same observation hit twice consolidates, doesn't duplicate. No global pool exists anywhere in the runtime.
+          </p>
+          <code class="block text-[11px] font-mono text-muted-foreground bg-secondary/50 rounded px-2 py-1.5 mb-3">memory_fact.agent_id NOT NULL</code>
+          <a href="agent-detail.html" class="text-xs font-medium text-foreground hover:underline inline-flex items-center gap-1">
+            See an agent's memory
+            <i data-lucide="arrow-right" class="h-3 w-3"></i>
+          </a>
+        </div>
+
+        <div class="rounded-lg border border-border bg-card p-5">
+          <div class="h-9 w-9 rounded-full bg-hier-team/10 flex items-center justify-center text-hier-team mb-4">
+            <i data-lucide="trending-up" class="h-5 w-5"></i>
+          </div>
+          <h3 class="text-base font-semibold mb-2">Curated commons</h3>
+          <p class="text-sm text-muted-foreground leading-relaxed mb-3">
+            Facts earn wider scope through an editorial promoter — an LLM classifier that decides per-fact whether <span class="font-mono text-xs">ic → team</span> or <span class="font-mono text-xs">team → org</span> movement is warranted, with a stated reason. Default is to keep narrow.
+          </p>
+          <code class="block text-[11px] font-mono text-muted-foreground bg-secondary/50 rounded px-2 py-1.5 mb-3">FactPromoter.evaluate(fact)</code>
+          <a href="promotions.html" class="text-xs font-medium text-foreground hover:underline inline-flex items-center gap-1">
+            Read promotion log
+            <i data-lucide="arrow-right" class="h-3 w-3"></i>
+          </a>
+        </div>
+
+        <div class="rounded-lg border border-border bg-card p-5">
+          <div class="h-9 w-9 rounded-full bg-status-running/10 flex items-center justify-center text-status-running mb-4">
+            <i data-lucide="link" class="h-5 w-5"></i>
+          </div>
+          <h3 class="text-base font-semibold mb-2">Mesh asks</h3>
+          <p class="text-sm text-muted-foreground leading-relaxed mb-3">
+            When a specialist doesn't know, it asks. <span class="font-mono text-xs">ask</span>, <span class="font-mono text-xs">negotiate</span>, <span class="font-mono text-xs">report_blocker</span> are first-class tools with chain-budget guards against runaway loops. The target answers from <em>its own bounded memory</em>.
+          </p>
+          <code class="block text-[11px] font-mono text-muted-foreground bg-secondary/50 rounded px-2 py-1.5 mb-3">ask(target_agent_id, question)</code>
+          <a href="mesh.html" class="text-xs font-medium text-foreground hover:underline inline-flex items-center gap-1">
+            See the live mesh
+            <i data-lucide="arrow-right" class="h-3 w-3"></i>
+          </a>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
+  <!-- THREE MAGIC MOMENTS -->
+  <section id="moments" class="border-b border-border">
+    <div class="max-w-6xl mx-auto px-6 py-20">
+      <div class="max-w-2xl mb-10">
+        <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Demo</div>
+        <h2 class="text-2xl font-bold tracking-tight mb-3">Three things you can verify in your own terminal.</h2>
+        <p class="text-muted-foreground leading-relaxed">
+          Open the dashboard at any point and these three are observable on real data — not stubs, not fixtures.
+        </p>
+      </div>
+
+      <div class="space-y-10">
+
+        <!-- Moment 1: depth accrues -->
+        <div class="grid md:grid-cols-5 gap-8 items-center">
+          <div class="md:col-span-2">
+            <div class="text-xs font-mono text-muted-foreground mb-2">001 · DEPTH</div>
+            <h3 class="text-xl font-semibold mb-3">An agent gets visibly sharper.</h3>
+            <p class="text-sm text-muted-foreground leading-relaxed mb-4">
+              Open <span class="font-mono text-foreground">agent_codebase</span> — 5 facts. Run a Claude Code session against your repo. Open again — 8 facts, 2 tagged "merged from prior" with the LLM-merged content visible. Depth accrues, observable. No "Claude with a costume."
+            </p>
+            <a href="agent-detail.html" class="text-sm font-medium text-foreground hover:underline inline-flex items-center gap-1">
+              Open an agent's memory
+              <i data-lucide="arrow-right" class="h-4 w-4"></i>
+            </a>
+          </div>
+          <div class="md:col-span-3 rounded-lg border border-border bg-card p-5">
+            <div class="flex items-center gap-3 mb-4">
+              <div class="h-10 w-10 rounded-full bg-hier-ic/10 flex items-center justify-center text-hier-ic">
+                <i data-lucide="key-round" class="h-5 w-5"></i>
+              </div>
+              <div class="flex-1">
+                <div class="font-mono text-sm font-semibold">ic-agent-1</div>
+                <div class="text-xs text-muted-foreground">specialty: auth</div>
+              </div>
+            </div>
+            <div class="grid grid-cols-3 gap-4 text-center">
+              <div>
+                <div class="text-2xl font-bold tabular-nums">47</div>
+                <div class="text-[10px] uppercase tracking-wider text-muted-foreground mt-1">sessions</div>
+              </div>
+              <div>
+                <div class="text-2xl font-bold tabular-nums">23</div>
+                <div class="text-[10px] uppercase tracking-wider text-muted-foreground mt-1">facts learned</div>
+              </div>
+              <div>
+                <div class="text-2xl font-bold tabular-nums">8</div>
+                <div class="text-[10px] uppercase tracking-wider text-muted-foreground mt-1">merge events</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Moment 2: promotion -->
+        <div class="grid md:grid-cols-5 gap-8 items-center">
+          <div class="md:col-span-3 md:order-2">
+            <div class="rounded-lg border border-border bg-card p-5">
+              <div class="flex items-center gap-2 text-xs mb-3">
+                <span class="inline-flex items-center h-5 px-1.5 rounded font-medium bg-hier-ic/15 text-hier-ic">ic</span>
+                <i data-lucide="arrow-right" class="h-3 w-3 text-muted-foreground"></i>
+                <span class="inline-flex items-center h-5 px-1.5 rounded font-medium bg-hier-team/10 text-hier-team">team</span>
+                <span class="text-border">·</span>
+                <span class="text-muted-foreground">by <span class="font-mono text-foreground">ic-agent-1</span></span>
+              </div>
+              <p class="text-sm leading-relaxed mb-3">
+                Postgres NOTIFY payload is capped at 8KB. Keep payloads to id, status, and timestamps; clients refetch full rows via HTTP after the event.
+              </p>
+              <div class="rounded bg-secondary/50 p-3 text-xs leading-relaxed flex items-start gap-2">
+                <i data-lucide="brain-circuit" class="h-3.5 w-3.5 text-primary shrink-0 mt-0.5"></i>
+                <div class="text-muted-foreground">
+                  <span class="text-foreground font-medium">FactPromoter:</span>
+                  "Observed independently in 3 sessions across 2 different agents. The constraint generalizes across infrastructure work — not domain-specific to auth or any single agent's specialty. Promote to team."
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="md:col-span-2 md:order-1">
+            <div class="text-xs font-mono text-muted-foreground mb-2">002 · COMMONS</div>
+            <h3 class="text-xl font-semibold mb-3">A fact earns promotion.</h3>
+            <p class="text-sm text-muted-foreground leading-relaxed mb-4">
+              When the same observation reappears across sessions, the editorial promoter decides per-fact whether it's earned wider visibility — with a stated reason for the decision. The commons is curated, not pooled. Provenance is preserved through the promotion.
+            </p>
+            <a href="promotions.html" class="text-sm font-medium text-foreground hover:underline inline-flex items-center gap-1">
+              Read the promotion log
+              <i data-lucide="arrow-right" class="h-4 w-4"></i>
+            </a>
+          </div>
+        </div>
+
+        <!-- Moment 3: mesh -->
+        <div class="grid md:grid-cols-5 gap-8 items-center">
+          <div class="md:col-span-2">
+            <div class="text-xs font-mono text-muted-foreground mb-2">003 · MESH</div>
+            <h3 class="text-xl font-semibold mb-3">Agents ask each other live.</h3>
+            <p class="text-sm text-muted-foreground leading-relaxed mb-4">
+              A session in <span class="font-mono text-foreground">ic-agent-1</span> calls <span class="font-mono text-foreground">ask(db-agent, …)</span>. The mesh activity feed surfaces the request and response in real time; <span class="font-mono text-foreground">db-agent</span> answers from <em>its own</em> bounded memory. Bounded specialists collaborating, not merging.
+            </p>
+            <a href="mesh.html" class="text-sm font-medium text-foreground hover:underline inline-flex items-center gap-1">
+              Open the mesh view
+              <i data-lucide="arrow-right" class="h-4 w-4"></i>
+            </a>
+          </div>
+          <div class="md:col-span-3 rounded-lg border border-status-running/30 bg-status-running/5 p-5">
+            <div class="flex items-center gap-2 mb-3 text-xs">
+              <span class="font-mono text-foreground font-medium">ic-agent-1</span>
+              <i data-lucide="arrow-right" class="h-3 w-3 text-status-running"></i>
+              <span class="font-mono text-foreground font-medium">db-agent</span>
+              <span class="ml-auto inline-flex items-center gap-1 h-5 px-2 rounded text-[10px] font-medium bg-status-done/10 text-status-done">
+                <i data-lucide="check" class="h-3 w-3"></i>
+                resolved · 8s
+              </span>
+            </div>
+            <p class="text-sm leading-relaxed text-foreground/85 mb-3">
+              "Schema for refresh-token storage? Need a column for the encrypted blob plus rotation metadata. Concurrent rotation has to be safe."
+            </p>
+            <div class="rounded bg-secondary/40 p-3 text-xs leading-relaxed">
+              <div class="text-[10px] text-muted-foreground mb-1">db-agent · from its own bounded memory</div>
+              <p class="text-foreground/85">
+                "Add <span class="font-mono">refresh_token</span> table. Read with <span class="font-mono">FOR UPDATE SKIP LOCKED</span> in the rotation flow, or two concurrent rotations race the increment."
+              </p>
+            </div>
+            <div class="mt-3 text-[10px] text-muted-foreground font-mono">
+              chain depth 1/4 · ChainBudget enforced · session sess_a4f9 spawned for db-agent
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
+  <!-- HOW IT FITS in your stack -->
+  <section class="border-b border-border">
+    <div class="max-w-6xl mx-auto px-6 py-20">
+      <div class="max-w-2xl mb-8">
+        <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Where this fits</div>
+        <h2 class="text-2xl font-bold tracking-tight mb-3">Library-shaped. Drop-in. Self-host or hosted.</h2>
+        <p class="text-muted-foreground leading-relaxed">
+          beevibe is not an app users open. It's the opinionated cognition layer that sits under your agent stack, exposed via MCP for any tool that speaks it.
+        </p>
+      </div>
+
+      <div class="grid md:grid-cols-2 gap-4">
+        <div class="rounded-lg border border-border bg-card p-5">
+          <div class="flex items-center gap-2 mb-3">
+            <code class="text-sm font-mono font-semibold">@beevibe/core</code>
+            <span class="text-[10px] text-muted-foreground">library</span>
+          </div>
+          <p class="text-sm text-muted-foreground leading-relaxed mb-4">
+            The runtime: bounded memory store, FactStore with merge-on-similarity, FactPromoter, mesh tool definitions. Adapter ports keep your LLM, embedding, and Postgres choices open.
+          </p>
+          <pre class="text-[11px] font-mono text-muted-foreground bg-secondary/50 rounded px-3 py-2 leading-relaxed">npm i @beevibe/core
+import { FactStore, FactPromoter } from '@beevibe/core'</pre>
+        </div>
+
+        <div class="rounded-lg border border-border bg-card p-5">
+          <div class="flex items-center gap-2 mb-3">
+            <code class="text-sm font-mono font-semibold">beevibe-mcp-server</code>
+            <span class="text-[10px] text-muted-foreground">binary</span>
+          </div>
+          <p class="text-sm text-muted-foreground leading-relaxed mb-4">
+            HTTP+MCP exposure of the core, for Claude Code / Cursor / Codex / any MCP-speaking agent runtime. Run as a daemon, point your agent at it.
+          </p>
+          <pre class="text-[11px] font-mono text-muted-foreground bg-secondary/50 rounded px-3 py-2 leading-relaxed">docker compose up
+claude mcp add beevibe http://localhost:3002</pre>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- POSITIONING vs the field -->
+  <section class="border-b border-border">
+    <div class="max-w-6xl mx-auto px-6 py-20">
+      <div class="max-w-2xl mb-8">
+        <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Compared to</div>
+        <h2 class="text-2xl font-bold tracking-tight mb-3">Where the architectural opinion lives.</h2>
+      </div>
+
+      <div class="rounded-lg border border-border bg-card overflow-hidden">
+        <table class="w-full text-sm">
+          <thead class="bg-secondary/60 text-xs uppercase tracking-wider text-muted-foreground">
+            <tr>
+              <th class="text-left px-4 py-3 font-medium">Stack layer</th>
+              <th class="text-left px-4 py-3 font-medium">mem0</th>
+              <th class="text-left px-4 py-3 font-medium">Multica</th>
+              <th class="text-left px-4 py-3 font-medium">Mastra</th>
+              <th class="text-left px-4 py-3 font-medium bg-primary/10">beevibe</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="border-t border-border">
+              <td class="px-4 py-3 text-muted-foreground">Per-agent bounded memory</td>
+              <td class="px-4 py-3 text-status-failed/70"><i data-lucide="x" class="h-4 w-4 inline"></i> flat per-user pool</td>
+              <td class="px-4 py-3 text-muted-foreground">none</td>
+              <td class="px-4 py-3 text-muted-foreground">none</td>
+              <td class="px-4 py-3 text-status-done bg-primary/5"><i data-lucide="check" class="h-4 w-4 inline"></i> bounded + char-limited</td>
+            </tr>
+            <tr class="border-t border-border">
+              <td class="px-4 py-3 text-muted-foreground">Editorial promotion / scope gradient</td>
+              <td class="px-4 py-3 text-muted-foreground">no scope</td>
+              <td class="px-4 py-3 text-muted-foreground">no memory</td>
+              <td class="px-4 py-3 text-muted-foreground">no memory</td>
+              <td class="px-4 py-3 text-status-done bg-primary/5"><i data-lucide="check" class="h-4 w-4 inline"></i> ic / team / org + LLM gate</td>
+            </tr>
+            <tr class="border-t border-border">
+              <td class="px-4 py-3 text-muted-foreground">Agent-to-agent ask protocol</td>
+              <td class="px-4 py-3 text-muted-foreground">none</td>
+              <td class="px-4 py-3 text-status-review/70">work routing only</td>
+              <td class="px-4 py-3 text-muted-foreground">none</td>
+              <td class="px-4 py-3 text-status-done bg-primary/5"><i data-lucide="check" class="h-4 w-4 inline"></i> ask / negotiate / blocker</td>
+            </tr>
+            <tr class="border-t border-border">
+              <td class="px-4 py-3 text-muted-foreground">Provenance preserved through promotion</td>
+              <td class="px-4 py-3 text-muted-foreground">no provenance</td>
+              <td class="px-4 py-3 text-muted-foreground">n/a</td>
+              <td class="px-4 py-3 text-muted-foreground">n/a</td>
+              <td class="px-4 py-3 text-status-done bg-primary/5"><i data-lucide="check" class="h-4 w-4 inline"></i> agent_id non-null at every scope</td>
+            </tr>
+            <tr class="border-t border-border">
+              <td class="px-4 py-3 text-muted-foreground">Self-host + open source</td>
+              <td class="px-4 py-3 text-status-done"><i data-lucide="check" class="h-4 w-4 inline"></i></td>
+              <td class="px-4 py-3 text-status-done"><i data-lucide="check" class="h-4 w-4 inline"></i></td>
+              <td class="px-4 py-3 text-status-done"><i data-lucide="check" class="h-4 w-4 inline"></i></td>
+              <td class="px-4 py-3 text-status-done bg-primary/5"><i data-lucide="check" class="h-4 w-4 inline"></i> MIT</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section>
+    <div class="max-w-3xl mx-auto px-6 py-20 text-center">
+      <h2 class="text-2xl md:text-3xl font-bold tracking-tight mb-4">Try it in five minutes.</h2>
+      <p class="text-muted-foreground leading-relaxed mb-7">
+        Run the runtime locally, point Claude Code at the MCP server, work in your repo for a session. Open the dashboard. Watch your agent get visibly sharper.
+      </p>
+      <div class="flex flex-wrap items-center justify-center gap-3">
+        <a href="#" class="inline-flex items-center gap-2 h-10 px-5 rounded bg-primary text-primary-foreground text-sm font-semibold hover:opacity-90 active:scale-[0.98] transition-all duration-150">
+          <i data-lucide="terminal" class="h-4 w-4"></i>
+          Quickstart
+        </a>
+        <a href="home.html" class="inline-flex items-center gap-1.5 h-10 px-5 rounded text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors">
+          Open the dashboard
+          <i data-lucide="arrow-right" class="h-4 w-4"></i>
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <footer class="border-t border-border">
+    <div class="max-w-6xl mx-auto px-6 py-8 flex flex-wrap items-center justify-between gap-4 text-xs text-muted-foreground">
+      <div class="flex items-center gap-2">
+        <div class="h-5 w-5 rounded bg-primary flex items-center justify-center">
+          <span class="text-primary-foreground text-xs font-bold leading-none">b</span>
+        </div>
+        <span>beevibe · MIT licensed · self-hosted</span>
+      </div>
+      <div class="flex items-center gap-5">
+        <a href="#" class="hover:text-foreground transition-colors">Docs</a>
+        <a href="#" class="hover:text-foreground transition-colors">GitHub</a>
+        <a href="#" class="hover:text-foreground transition-colors">Discord</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    lucide.createIcons();
+    document.getElementById('theme-toggle').addEventListener('click', () => {
+      document.documentElement.classList.toggle('dark');
+      lucide.createIcons();
+    });
+  </script>
+</body>
+</html>

--- a/mocks/showcase.html
+++ b/mocks/showcase.html
@@ -406,6 +406,19 @@
     </div>
   </section>
 
+  <!-- THE PROBLEM — felt-pain framing right after the hero, before how-it-works -->
+  <section class="border-b border-border bg-secondary/30">
+    <div class="max-w-5xl mx-auto px-6 py-20">
+      <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-3">The problem</div>
+      <h2 class="text-3xl md:text-4xl font-bold tracking-tight leading-[1.15] mb-5 max-w-3xl">
+        End the silos between every person and every AI agent on your team.
+      </h2>
+      <p class="text-lg text-muted-foreground leading-relaxed max-w-3xl">
+        Today, everyone works with AI in their own private chat. beevibe brings humans and their agents into a shared workspace where context, decisions, and work-in-progress are visible to whoever needs them — and where agents can ask other agents when their own context isn't enough.
+      </p>
+    </div>
+  </section>
+
   <!-- THREE THINGS THAT MAKE A HYBRID TEAM WORK -->
   <section id="promise" class="border-b border-border">
     <div class="max-w-6xl mx-auto px-6 py-20">
@@ -705,12 +718,15 @@ claude mcp add beevibe http://localhost:3002</pre>
     </div>
   </section>
 
-  <!-- CTA -->
+  <!-- CTA — action-outcome framing -->
   <section>
     <div class="max-w-3xl mx-auto px-6 py-20 text-center">
-      <h2 class="text-2xl md:text-3xl font-bold tracking-tight mb-4">Bring your team into one workspace.</h2>
+      <h2 class="text-2xl md:text-3xl font-bold tracking-tight mb-4 leading-tight">
+        Your team's AI agents stop working in silos.<br>
+        They start <span class="bg-primary text-primary-foreground px-1.5 -mx-0.5 rounded-sm">working together</span>.
+      </h2>
       <p class="text-muted-foreground leading-relaxed mb-7">
-        Spin up the workspace locally, invite your teammates, and point each person's agents at it via MCP. Watch context start flowing where it needs to — across asks, handoffs, and reviews — without dissolving into one shared brain.
+        beevibe is the open-source runtime that turns scattered, single-user AI tools into a coordinated team. Agents ask each other, escalate to humans, share work products, and stay in sync across sessions. Every person on your team and every agent they spawn — one shared workspace.
       </p>
       <div class="flex flex-wrap items-center justify-center gap-3">
         <a href="#" class="inline-flex items-center gap-2 h-10 px-5 rounded bg-primary text-primary-foreground text-sm font-semibold hover:opacity-90 active:scale-[0.98] transition-all duration-150">

--- a/mocks/showcase.html
+++ b/mocks/showcase.html
@@ -654,14 +654,14 @@ claude mcp add beevibe http://localhost:3002</pre>
     </div>
   </section>
 
-  <!-- POSITIONING vs the field -->
+  <!-- POSITIONING — Multica vs Paperclip vs beevibe -->
   <section class="border-b border-border">
     <div class="max-w-6xl mx-auto px-6 py-20">
-      <div class="max-w-2xl mb-8">
+      <div class="max-w-2xl mb-10">
         <div class="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">Compared to</div>
-        <h2 class="text-2xl font-bold tracking-tight mb-3">How beevibe differs from the field.</h2>
-        <p class="text-muted-foreground leading-relaxed mt-3">
-          mem0 ships memory. Multica ships task tracking. Mastra ships an agent framework. None of them ship the workspace where humans and their agents coordinate as one team.
+        <h2 class="text-2xl font-bold tracking-tight mb-3">How beevibe differs from Multica and Paperclip.</h2>
+        <p class="text-muted-foreground leading-relaxed">
+          Multica ships team task-tracking with agents as routing targets. Paperclip ships solo company simulation with agents as scheduled workers. beevibe ships a hybrid team where each agent is a persistent specialist that grows expertise over time and asks other agents when it needs help.
         </p>
       </div>
 
@@ -669,51 +669,71 @@ claude mcp add beevibe http://localhost:3002</pre>
         <table class="w-full text-sm">
           <thead class="bg-secondary/60 text-xs uppercase tracking-wider text-muted-foreground">
             <tr>
-              <th class="text-left px-4 py-3 font-medium">Stack layer</th>
-              <th class="text-left px-4 py-3 font-medium">mem0</th>
+              <th class="text-left px-4 py-3 font-medium">Axis</th>
               <th class="text-left px-4 py-3 font-medium">Multica</th>
-              <th class="text-left px-4 py-3 font-medium">Mastra</th>
+              <th class="text-left px-4 py-3 font-medium">Paperclip</th>
               <th class="text-left px-4 py-3 font-medium bg-primary/10">beevibe</th>
             </tr>
           </thead>
           <tbody>
             <tr class="border-t border-border">
-              <td class="px-4 py-3 text-muted-foreground">Per-agent bounded memory</td>
-              <td class="px-4 py-3 text-status-failed/70"><i data-lucide="x" class="h-4 w-4 inline"></i> flat per-user pool</td>
-              <td class="px-4 py-3 text-muted-foreground">none</td>
-              <td class="px-4 py-3 text-muted-foreground">none</td>
-              <td class="px-4 py-3 text-status-done bg-primary/5"><i data-lucide="check" class="h-4 w-4 inline"></i> bounded + char-limited</td>
+              <td class="px-4 py-3 font-medium text-foreground">Focus</td>
+              <td class="px-4 py-3 text-muted-foreground">Team AI agent collaboration platform</td>
+              <td class="px-4 py-3 text-muted-foreground">Solo AI agent company simulator</td>
+              <td class="px-4 py-3 text-foreground bg-primary/5">Hybrid team of humans + persistent agent specialists</td>
             </tr>
             <tr class="border-t border-border">
-              <td class="px-4 py-3 text-muted-foreground">Editorial promotion / scope gradient</td>
-              <td class="px-4 py-3 text-muted-foreground">no scope</td>
-              <td class="px-4 py-3 text-muted-foreground">no memory</td>
-              <td class="px-4 py-3 text-muted-foreground">no memory</td>
-              <td class="px-4 py-3 text-status-done bg-primary/5"><i data-lucide="check" class="h-4 w-4 inline"></i> ic / team / org + LLM gate</td>
+              <td class="px-4 py-3 font-medium text-foreground">User model</td>
+              <td class="px-4 py-3 text-muted-foreground">Multi-user teams with roles + permissions</td>
+              <td class="px-4 py-3 text-muted-foreground">Single board operator</td>
+              <td class="px-4 py-3 text-foreground bg-primary/5">Multi-human; agents form lasting roles in a hierarchy</td>
+            </tr>
+            <!-- THE LOAD-BEARING DIFFERENTIATION ROW -->
+            <tr class="border-t border-border">
+              <td class="px-4 py-3 font-medium text-foreground">Agent identity</td>
+              <td class="px-4 py-3 text-muted-foreground">Routing target — expertise lives in shared workspace skills</td>
+              <td class="px-4 py-3 text-muted-foreground">Scheduled worker — expertise lives in plugin code</td>
+              <td class="px-4 py-3 text-foreground bg-primary/5"><strong>Persistent specialist</strong> — expertise lives in the agent's own bounded memory and grows session over session</td>
             </tr>
             <tr class="border-t border-border">
-              <td class="px-4 py-3 text-muted-foreground">Agent-to-agent ask protocol</td>
-              <td class="px-4 py-3 text-muted-foreground">none</td>
-              <td class="px-4 py-3 text-status-review/70">work routing only</td>
-              <td class="px-4 py-3 text-muted-foreground">none</td>
-              <td class="px-4 py-3 text-status-done bg-primary/5"><i data-lucide="check" class="h-4 w-4 inline"></i> ask / negotiate / blocker</td>
+              <td class="px-4 py-3 font-medium text-foreground">Agent interaction</td>
+              <td class="px-4 py-3 text-muted-foreground">Issues + chat conversations</td>
+              <td class="px-4 py-3 text-muted-foreground">Issues + heartbeats</td>
+              <td class="px-4 py-3 text-foreground bg-primary/5">Tasks + agent-to-agent asks (mesh)</td>
             </tr>
             <tr class="border-t border-border">
-              <td class="px-4 py-3 text-muted-foreground">Provenance preserved through promotion</td>
-              <td class="px-4 py-3 text-muted-foreground">no provenance</td>
-              <td class="px-4 py-3 text-muted-foreground">n/a</td>
-              <td class="px-4 py-3 text-muted-foreground">n/a</td>
-              <td class="px-4 py-3 text-status-done bg-primary/5"><i data-lucide="check" class="h-4 w-4 inline"></i> agent_id non-null at every scope</td>
+              <td class="px-4 py-3 font-medium text-foreground">Deployment</td>
+              <td class="px-4 py-3 text-muted-foreground">Cloud-first</td>
+              <td class="px-4 py-3 text-muted-foreground">Local-first</td>
+              <td class="px-4 py-3 text-foreground bg-primary/5">Self-host or hosted</td>
             </tr>
             <tr class="border-t border-border">
-              <td class="px-4 py-3 text-muted-foreground">Self-host + open source</td>
-              <td class="px-4 py-3 text-status-done"><i data-lucide="check" class="h-4 w-4 inline"></i></td>
-              <td class="px-4 py-3 text-status-done"><i data-lucide="check" class="h-4 w-4 inline"></i></td>
-              <td class="px-4 py-3 text-status-done"><i data-lucide="check" class="h-4 w-4 inline"></i></td>
-              <td class="px-4 py-3 text-status-done bg-primary/5"><i data-lucide="check" class="h-4 w-4 inline"></i> MIT</td>
+              <td class="px-4 py-3 font-medium text-foreground">Management depth</td>
+              <td class="px-4 py-3 text-muted-foreground">Lightweight (Issues / Projects / Labels)</td>
+              <td class="px-4 py-3 text-muted-foreground">Heavy governance (Org chart / Approvals / Budgets)</td>
+              <td class="px-4 py-3 text-foreground bg-primary/5">Hierarchy + escalation routing + reviewable work products</td>
+            </tr>
+            <tr class="border-t border-border">
+              <td class="px-4 py-3 font-medium text-foreground">Extensibility</td>
+              <td class="px-4 py-3 text-muted-foreground">Skills system</td>
+              <td class="px-4 py-3 text-muted-foreground">Skills + plugin system</td>
+              <td class="px-4 py-3 text-foreground bg-primary/5">Skills + bounded per-agent memory + mesh ask protocol</td>
             </tr>
           </tbody>
         </table>
+      </div>
+
+      <!-- Differentiation callout — the thesis the table is making -->
+      <div class="mt-8 rounded-lg border-l-4 border-primary bg-primary/5 px-5 py-4">
+        <div class="flex items-start gap-3">
+          <i data-lucide="quote" class="h-5 w-5 text-primary shrink-0 mt-0.5"></i>
+          <div class="text-sm leading-relaxed">
+            <span class="font-semibold text-foreground">The key difference.</span>
+            <span class="text-muted-foreground"> Multica and Paperclip agents are largely one-off — assignment targets that pull from a shared static skills library or run a heartbeat-triggered script. </span>
+            <span class="text-foreground">beevibe agents are persistent specialists.</span>
+            <span class="text-muted-foreground"> Each agent has its own bounded memory that grows session over session via merge-on-similarity. Same observation rediscovered → consolidated, not duplicated. Their expertise compounds; their identity persists; their collaborations form the team's actual shape.</span>
+          </div>
+        </div>
       </div>
     </div>
   </section>

--- a/mocks/task-detail.html
+++ b/mocks/task-detail.html
@@ -1,0 +1,374 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>beevibe — task detail mock</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+  <script>
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.classList.add('dark');
+    }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+  <style>
+    :root {
+      --background: 0 0% 100%;
+      --foreground: 240 10% 4%;
+      --card: 240 5% 98%;
+      --card-foreground: 240 10% 4%;
+      --popover: 0 0% 100%;
+      --popover-foreground: 240 10% 4%;
+      --primary: 48 96% 53%;
+      --primary-foreground: 240 10% 4%;
+      --secondary: 240 5% 96%;
+      --secondary-foreground: 240 6% 10%;
+      --muted: 240 5% 96%;
+      --muted-foreground: 240 4% 46%;
+      --accent: 240 5% 96%;
+      --accent-foreground: 240 6% 10%;
+      --destructive: 0 84% 60%;
+      --destructive-foreground: 0 0% 98%;
+      --border: 240 6% 90%;
+      --input: 240 6% 90%;
+      --ring: 47 96% 47%;
+      --radius: 0.375rem;
+
+      --status-pending: 240 4% 46%;
+      --status-running: 217 91% 60%;
+      --status-review:  38 92% 50%;
+      --status-blocked: 25 95% 53%;
+      --status-done:    160 84% 39%;
+      --status-failed:  0 84% 60%;
+
+      --hier-ic:   240 4% 46%;
+      --hier-team: 262 83% 58%;
+      --hier-org:  38 92% 50%;
+    }
+
+    .dark {
+      --background: 240 10% 4%;
+      --foreground: 0 0% 98%;
+      --card: 240 6% 10%;
+      --card-foreground: 0 0% 98%;
+      --popover: 240 6% 10%;
+      --popover-foreground: 0 0% 98%;
+      --primary: 48 96% 53%;
+      --primary-foreground: 240 10% 4%;
+      --secondary: 240 4% 16%;
+      --secondary-foreground: 0 0% 98%;
+      --muted: 240 4% 16%;
+      --muted-foreground: 240 5% 65%;
+      --accent: 240 4% 16%;
+      --accent-foreground: 0 0% 98%;
+      --destructive: 0 63% 51%;
+      --destructive-foreground: 0 0% 98%;
+      --border: 240 4% 16%;
+      --input: 240 4% 16%;
+      --ring: 48 96% 53%;
+    }
+
+    body {
+      font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
+      font-feature-settings: 'cv11', 'ss01';
+      background-color: hsl(var(--background));
+      color: hsl(var(--foreground));
+      -webkit-font-smoothing: antialiased;
+    }
+    .font-mono {
+      font-family: 'JetBrains Mono', ui-monospace, 'Menlo', monospace;
+    }
+
+    @keyframes pulse-breathe {
+      0%, 100% { opacity: 1; transform: scale(1); }
+      50%      { opacity: 0.55; transform: scale(0.92); }
+    }
+    .pulse-dot { animation: pulse-breathe 2s ease-in-out infinite; }
+
+    @keyframes row-flash {
+      0%   { background-color: hsl(48 96% 53% / 0.12); }
+      100% { background-color: transparent; }
+    }
+    .row-flash { animation: row-flash 600ms ease-out; }
+
+    @media (prefers-reduced-motion: reduce) {
+      .pulse-dot { animation: none; }
+      .row-flash { animation: none; }
+    }
+
+    button:focus-visible,
+    a:focus-visible {
+      outline: 2px solid hsl(var(--ring));
+      outline-offset: 2px;
+      border-radius: var(--radius);
+    }
+  </style>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+            mono: ['JetBrains Mono', 'ui-monospace', 'Menlo', 'monospace'],
+          },
+          colors: {
+            border: 'hsl(var(--border))',
+            input: 'hsl(var(--input))',
+            ring: 'hsl(var(--ring))',
+            background: 'hsl(var(--background))',
+            foreground: 'hsl(var(--foreground))',
+            primary: { DEFAULT: 'hsl(var(--primary))', foreground: 'hsl(var(--primary-foreground))' },
+            secondary: { DEFAULT: 'hsl(var(--secondary))', foreground: 'hsl(var(--secondary-foreground))' },
+            muted: { DEFAULT: 'hsl(var(--muted))', foreground: 'hsl(var(--muted-foreground))' },
+            accent: { DEFAULT: 'hsl(var(--accent))', foreground: 'hsl(var(--accent-foreground))' },
+            destructive: { DEFAULT: 'hsl(var(--destructive))', foreground: 'hsl(var(--destructive-foreground))' },
+            card: { DEFAULT: 'hsl(var(--card))', foreground: 'hsl(var(--card-foreground))' },
+            status: {
+              pending: 'hsl(var(--status-pending))',
+              running: 'hsl(var(--status-running))',
+              review:  'hsl(var(--status-review))',
+              blocked: 'hsl(var(--status-blocked))',
+              done:    'hsl(var(--status-done))',
+              failed:  'hsl(var(--status-failed))',
+            },
+            hier: {
+              ic:   'hsl(var(--hier-ic))',
+              team: 'hsl(var(--hier-team))',
+              org:  'hsl(var(--hier-org))',
+            },
+          },
+          borderRadius: {
+            DEFAULT: 'var(--radius)',
+            md: 'var(--radius)',
+            lg: 'calc(var(--radius) + 2px)',
+            xl: 'calc(var(--radius) + 6px)',
+          },
+        },
+      },
+    };
+  </script>
+</head>
+<body class="min-h-screen">
+  <div class="flex min-h-screen">
+
+    <!-- Sidebar -->
+    <aside class="w-[220px] shrink-0 bg-card flex flex-col">
+      <div class="h-14 flex items-center gap-2.5 px-4">
+        <div class="h-6 w-6 rounded bg-primary flex items-center justify-center">
+          <span class="text-primary-foreground text-sm font-bold leading-none">b</span>
+        </div>
+        <span class="font-semibold tracking-tight">beevibe</span>
+      </div>
+      <nav class="flex-1 p-2 space-y-0.5 text-sm">
+        <a href="#" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="home" class="h-4 w-4"></i>
+          <span>Home</span>
+        </a>
+        <a href="tasks-list.html" class="flex items-center gap-3 px-3 py-2 rounded bg-secondary text-foreground font-medium">
+          <i data-lucide="list-checks" class="h-4 w-4"></i>
+          <span>Tasks</span>
+        </a>
+        <a href="agents-list.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="circle-dot" class="h-4 w-4"></i>
+          <span>Agents</span>
+        </a>
+        <a href="threads.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="message-square" class="h-4 w-4"></i>
+          <span>Threads</span>
+        </a>
+        <a href="memory.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="sparkles" class="h-4 w-4"></i>
+          <span>Memory</span>
+        </a>
+      </nav>
+
+      <div class="p-3">
+        <div class="flex items-center gap-1">
+          <button class="flex-1 min-w-0 flex items-center gap-2 px-2 py-1.5 rounded hover:bg-secondary cursor-pointer transition-colors text-left">
+            <div class="h-7 w-7 rounded-full bg-secondary border border-border flex items-center justify-center text-xs font-medium shrink-0">W</div>
+            <div class="flex-1 min-w-0">
+              <div class="text-sm font-medium truncate leading-tight">Weijia</div>
+              <div class="text-[10px] text-muted-foreground flex items-center gap-1 leading-tight mt-0.5">
+                <span class="pulse-dot inline-block h-1 w-1 rounded-full" style="background: hsl(217 91% 60%);"></span>
+                live
+              </div>
+            </div>
+            <i data-lucide="chevrons-up-down" class="h-3.5 w-3.5 text-muted-foreground shrink-0"></i>
+          </button>
+          <button id="theme-toggle" class="h-8 w-8 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary cursor-pointer transition-colors shrink-0" title="Toggle theme">
+            <i data-lucide="sun" class="h-4 w-4 hidden dark:block"></i>
+            <i data-lucide="moon" class="h-4 w-4 block dark:hidden"></i>
+          </button>
+        </div>
+      </div>
+    </aside>
+
+    <!-- Main -->
+    <main class="flex-1 min-w-0 flex flex-col">
+
+      <!-- Page content -->
+      <div class="flex-1 overflow-auto">
+        <div class="max-w-5xl mx-auto px-6 py-8">
+
+          <!-- Back link -->
+          <a href="#" class="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-3">
+            <i data-lucide="chevron-left" class="h-3.5 w-3.5"></i>
+            Tasks
+          </a>
+
+          <!-- Page header row -->
+          <div class="flex items-start justify-between gap-6 mb-1.5">
+            <div class="flex-1 min-w-0">
+              <h1 class="text-2xl leading-8 font-semibold tracking-tight">Implement OAuth flow</h1>
+            </div>
+            <div class="flex items-center gap-1.5 shrink-0 mt-1.5">
+              <span class="inline-flex items-center gap-1.5 h-6 px-2 rounded text-xs font-medium bg-status-review/10 text-status-review">
+                <span class="h-1.5 w-1.5 rounded-full bg-status-review"></span>
+                review
+              </span>
+              <span class="inline-flex items-center h-6 px-2 rounded text-xs font-medium bg-secondary text-secondary-foreground">
+                high
+              </span>
+            </div>
+          </div>
+
+          <!-- Meta line -->
+          <div class="text-sm text-muted-foreground flex items-center gap-2 flex-wrap mb-5">
+            <span>Created by</span>
+            <span class="inline-flex items-center gap-1.5 text-foreground">
+              <span class="h-4 w-4 rounded-full bg-secondary border border-border flex items-center justify-center text-[10px] font-medium">W</span>
+              Weijia
+            </span>
+            <span class="text-border">·</span>
+            <span>Assigned to</span>
+            <span class="inline-flex items-center gap-1.5 text-foreground">
+              <span class="h-4 w-4 rounded-full bg-hier-ic/15 border border-hier-ic/40"></span>
+              <span class="font-mono text-xs">ic-agent-1</span>
+            </span>
+            <span class="text-border">·</span>
+            <span>Updated <span class="text-foreground">2m ago</span></span>
+          </div>
+
+          <!-- Action row -->
+          <div class="flex justify-end gap-2 mb-6">
+            <button class="inline-flex items-center gap-2 h-9 px-3 rounded text-sm font-medium border border-border text-foreground hover:bg-secondary active:scale-[0.98] cursor-pointer transition-all duration-150">
+              <i data-lucide="x" class="h-4 w-4"></i>
+              Reject
+            </button>
+            <button class="inline-flex items-center gap-2 h-9 px-3 rounded text-sm font-medium border border-border text-foreground hover:bg-secondary active:scale-[0.98] cursor-pointer transition-all duration-150">
+              <i data-lucide="rotate-ccw" class="h-4 w-4"></i>
+              Request revisions
+            </button>
+            <button class="inline-flex items-center gap-2 h-9 px-3 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 active:scale-[0.98] cursor-pointer transition-all duration-150">
+              <i data-lucide="check" class="h-4 w-4"></i>
+              Approve
+            </button>
+          </div>
+
+          <!-- Tabs -->
+          <div class="border-b border-border mb-6">
+            <div class="flex items-center gap-1 -mb-px">
+              <button class="px-3 py-2.5 text-sm font-medium border-b-2 border-foreground text-foreground cursor-pointer">
+                Overview
+              </button>
+              <button class="px-3 py-2.5 text-sm font-medium border-b-2 border-transparent text-muted-foreground hover:text-foreground cursor-pointer transition-colors">
+                Sessions
+                <span class="ml-1.5 inline-flex items-center justify-center h-4 min-w-[1rem] px-1 rounded text-[10px] font-medium bg-secondary text-muted-foreground">3</span>
+              </button>
+              <button class="px-3 py-2.5 text-sm font-medium border-b-2 border-transparent text-muted-foreground hover:text-foreground cursor-pointer transition-colors">
+                Work products
+                <span class="ml-1.5 inline-flex items-center justify-center h-4 min-w-[1rem] px-1 rounded text-[10px] font-medium bg-secondary text-muted-foreground">1</span>
+              </button>
+            </div>
+          </div>
+
+          <!-- Two-column body -->
+          <div class="grid grid-cols-3 gap-6">
+
+            <!-- Left column -->
+            <div class="col-span-2 space-y-5">
+
+              <!-- Description -->
+              <section class="rounded-lg border border-border bg-card p-5">
+                <h3 class="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3">Description</h3>
+                <div class="space-y-3 text-sm leading-6">
+                  <p>Add an OAuth 2.0 authorization code flow to the API so external clients can authenticate as a person without sharing their <code class="font-mono text-xs px-1 py-0.5 rounded bg-secondary text-foreground">bv_u_*</code> API key.</p>
+                  <p>Provider: Google. Tokens stored in <code class="font-mono text-xs px-1 py-0.5 rounded bg-secondary text-foreground">person.oauth_tokens</code> (JSONB). PKCE required.</p>
+                </div>
+              </section>
+
+              <!-- Result summary (set by agent on submit-for-review) -->
+              <section class="rounded-lg border border-border bg-card p-5">
+                <h3 class="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3">Result summary</h3>
+                <div class="space-y-3 text-sm leading-6">
+                  <p>Implemented the authorization code + PKCE flow against Google. Tokens stored on <code class="font-mono text-xs px-1 py-0.5 rounded bg-secondary text-foreground">person.oauth_tokens</code>. Refresh handled in middleware on 401. Added integration tests covering success, denied-consent, expired-state, and refresh paths.</p>
+                </div>
+              </section>
+            </div>
+
+            <!-- Right rail — active signal only -->
+            <aside class="col-span-1 space-y-4">
+
+              <!-- Latest session — what's happening right now -->
+              <section class="rounded-lg border border-border bg-card p-4">
+                <div class="flex items-center justify-between mb-3">
+                  <h3 class="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Latest session</h3>
+                  <a href="#" class="text-xs text-muted-foreground hover:text-foreground transition-colors">View all 3</a>
+                </div>
+                <a href="#" class="block group -mx-1 -my-1 px-1 py-1 rounded hover:bg-secondary/60 transition-colors">
+                  <div class="flex items-center justify-between text-sm">
+                    <span class="font-mono text-xs text-foreground">9c1f4b2a…</span>
+                    <span class="inline-flex items-center gap-1.5 h-5 px-1.5 rounded text-[10px] font-medium bg-status-running/10 text-status-running">
+                      <span class="pulse-dot h-1.5 w-1.5 rounded-full bg-status-running"></span>
+                      running
+                    </span>
+                  </div>
+                  <div class="mt-1 text-xs text-muted-foreground">4m elapsed · ic-agent-1</div>
+                </a>
+              </section>
+
+              <!-- Blocker (real fields: blocker_agent_id, blocker_reason) — only renders if present -->
+              <!-- Empty state for now: -->
+              <section class="rounded-lg border border-dashed border-border p-4 text-center">
+                <div class="text-xs text-muted-foreground">No active blocker</div>
+              </section>
+            </aside>
+          </div>
+
+          <!-- Quiet metadata footer — secondary info that doesn't deserve a card -->
+          <div class="mt-8 pt-4 border-t border-border flex items-center gap-3 text-xs text-muted-foreground">
+            <button class="inline-flex items-center gap-1.5 font-mono hover:text-foreground transition-colors cursor-pointer" title="Copy task ID">
+              <i data-lucide="hash" class="h-3 w-3"></i>
+              8a3f1c2e9b4d
+              <i data-lucide="copy" class="h-3 w-3"></i>
+            </button>
+            <span class="text-border">·</span>
+            <span>Created <span class="text-foreground">2 days ago</span></span>
+            <span class="text-border">·</span>
+            <span>No parent task</span>
+          </div>
+
+          <!-- Foot note -->
+          <div class="mt-12 text-xs text-muted-foreground flex items-center gap-3">
+            <span class="font-mono">mock</span>
+            <span class="text-border">·</span>
+            <span>Honors prefers-color-scheme. Click the <i data-lucide="moon" class="h-3 w-3 inline align-[-1px]"></i>/<i data-lucide="sun" class="h-3 w-3 inline align-[-1px]"></i> in the header to override.</span>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+
+  <script>
+    lucide.createIcons();
+    document.getElementById('theme-toggle').addEventListener('click', () => {
+      document.documentElement.classList.toggle('dark');
+      lucide.createIcons();
+    });
+  </script>
+</body>
+</html>

--- a/mocks/tasks-list.html
+++ b/mocks/tasks-list.html
@@ -1,0 +1,555 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>beevibe — tasks list mock</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+  <script>
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.classList.add('dark');
+    }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+  <style>
+    :root {
+      --background: 0 0% 100%;
+      --foreground: 240 10% 4%;
+      --card: 240 5% 98%;
+      --card-foreground: 240 10% 4%;
+      --primary: 48 96% 53%;
+      --primary-foreground: 240 10% 4%;
+      --secondary: 240 5% 96%;
+      --secondary-foreground: 240 6% 10%;
+      --muted: 240 5% 96%;
+      --muted-foreground: 240 4% 46%;
+      --border: 240 6% 90%;
+      --input: 240 6% 90%;
+      --ring: 47 96% 47%;
+      --radius: 0.375rem;
+
+      --status-pending:   240 4% 46%;
+      --status-running:   217 91% 60%;
+      --status-review:    38 92% 50%;
+      --status-blocked:   25 95% 53%;
+      --status-done:      160 84% 39%;
+      --status-failed:    0 84% 60%;
+      --status-cancelled: 240 4% 46%;
+
+      --hier-ic:   240 4% 46%;
+      --hier-team: 262 83% 58%;
+      --hier-org:  38 92% 50%;
+    }
+    .dark {
+      --background: 240 10% 4%;
+      --foreground: 0 0% 98%;
+      --card: 240 6% 10%;
+      --card-foreground: 0 0% 98%;
+      --primary: 48 96% 53%;
+      --primary-foreground: 240 10% 4%;
+      --secondary: 240 4% 16%;
+      --secondary-foreground: 0 0% 98%;
+      --muted: 240 4% 16%;
+      --muted-foreground: 240 5% 65%;
+      --border: 240 4% 16%;
+      --input: 240 4% 16%;
+      --ring: 48 96% 53%;
+    }
+
+    body {
+      font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
+      font-feature-settings: 'cv11', 'ss01';
+      background-color: hsl(var(--background));
+      color: hsl(var(--foreground));
+      -webkit-font-smoothing: antialiased;
+    }
+    .font-mono { font-family: 'JetBrains Mono', ui-monospace, 'Menlo', monospace; }
+
+    @keyframes pulse-breathe {
+      0%, 100% { opacity: 1; transform: scale(1); }
+      50%      { opacity: 0.55; transform: scale(0.92); }
+    }
+    .pulse-dot { animation: pulse-breathe 2s ease-in-out infinite; }
+
+    @keyframes spin-slow {
+      to { transform: rotate(360deg); }
+    }
+    .spin-slow { animation: spin-slow 2.5s linear infinite; }
+
+    @keyframes row-flash {
+      0%   { background-color: hsl(48 96% 53% / 0.16); }
+      100% { background-color: transparent; }
+    }
+    .row-flash { animation: row-flash 1200ms ease-out; }
+
+    @media (prefers-reduced-motion: reduce) {
+      .pulse-dot, .row-flash, .spin-slow { animation: none; }
+    }
+
+    button:focus-visible, a:focus-visible {
+      outline: 2px solid hsl(var(--ring));
+      outline-offset: 2px;
+      border-radius: var(--radius);
+    }
+
+    .strike { text-decoration: line-through; text-decoration-color: hsl(var(--muted-foreground)); }
+  </style>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+            mono: ['JetBrains Mono', 'ui-monospace', 'Menlo', 'monospace'],
+          },
+          colors: {
+            border: 'hsl(var(--border))',
+            input: 'hsl(var(--input))',
+            ring: 'hsl(var(--ring))',
+            background: 'hsl(var(--background))',
+            foreground: 'hsl(var(--foreground))',
+            primary: { DEFAULT: 'hsl(var(--primary))', foreground: 'hsl(var(--primary-foreground))' },
+            secondary: { DEFAULT: 'hsl(var(--secondary))', foreground: 'hsl(var(--secondary-foreground))' },
+            muted: { DEFAULT: 'hsl(var(--muted))', foreground: 'hsl(var(--muted-foreground))' },
+            card: { DEFAULT: 'hsl(var(--card))', foreground: 'hsl(var(--card-foreground))' },
+            status: {
+              pending:   'hsl(var(--status-pending))',
+              running:   'hsl(var(--status-running))',
+              review:    'hsl(var(--status-review))',
+              blocked:   'hsl(var(--status-blocked))',
+              done:      'hsl(var(--status-done))',
+              failed:    'hsl(var(--status-failed))',
+              cancelled: 'hsl(var(--status-cancelled))',
+            },
+            hier: {
+              ic:   'hsl(var(--hier-ic))',
+              team: 'hsl(var(--hier-team))',
+              org:  'hsl(var(--hier-org))',
+            },
+          },
+          borderRadius: {
+            DEFAULT: 'var(--radius)',
+            md: 'var(--radius)',
+            lg: 'calc(var(--radius) + 2px)',
+            xl: 'calc(var(--radius) + 6px)',
+          },
+        },
+      },
+    };
+  </script>
+</head>
+<body class="min-h-screen">
+  <div class="flex min-h-screen">
+
+    <!-- Sidebar -->
+    <aside class="w-[220px] shrink-0 bg-card flex flex-col">
+      <div class="h-14 flex items-center gap-2.5 px-4">
+        <div class="h-6 w-6 rounded bg-primary flex items-center justify-center">
+          <span class="text-primary-foreground text-sm font-bold leading-none">b</span>
+        </div>
+        <span class="font-semibold tracking-tight">beevibe</span>
+      </div>
+      <nav class="flex-1 p-2 space-y-0.5 text-sm">
+        <a href="#" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="home" class="h-4 w-4"></i>
+          <span>Home</span>
+        </a>
+        <a href="#" class="flex items-center gap-3 px-3 py-2 rounded bg-secondary text-foreground font-medium">
+          <i data-lucide="list-checks" class="h-4 w-4"></i>
+          <span>Tasks</span>
+        </a>
+        <a href="agents-list.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="circle-dot" class="h-4 w-4"></i>
+          <span>Agents</span>
+        </a>
+        <a href="threads.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="message-square" class="h-4 w-4"></i>
+          <span>Threads</span>
+        </a>
+        <a href="memory.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="sparkles" class="h-4 w-4"></i>
+          <span>Memory</span>
+        </a>
+      </nav>
+
+      <div class="p-3">
+        <div class="flex items-center gap-1">
+          <button class="flex-1 min-w-0 flex items-center gap-2 px-2 py-1.5 rounded hover:bg-secondary cursor-pointer transition-colors text-left">
+            <div class="h-7 w-7 rounded-full bg-secondary border border-border flex items-center justify-center text-xs font-medium shrink-0">W</div>
+            <div class="flex-1 min-w-0">
+              <div class="text-sm font-medium truncate leading-tight">Weijia</div>
+              <div class="text-[10px] text-muted-foreground flex items-center gap-1 leading-tight mt-0.5">
+                <span class="pulse-dot inline-block h-1 w-1 rounded-full bg-status-running"></span>
+                live
+              </div>
+            </div>
+            <i data-lucide="chevrons-up-down" class="h-3.5 w-3.5 text-muted-foreground shrink-0"></i>
+          </button>
+          <button id="theme-toggle" class="h-8 w-8 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary cursor-pointer transition-colors shrink-0" title="Toggle theme">
+            <i data-lucide="sun" class="h-4 w-4 hidden dark:block"></i>
+            <i data-lucide="moon" class="h-4 w-4 block dark:hidden"></i>
+          </button>
+        </div>
+      </div>
+    </aside>
+
+    <!-- Main -->
+    <main class="flex-1 min-w-0 flex flex-col">
+
+      <!-- Page content -->
+      <div class="flex-1 overflow-auto">
+        <div class="max-w-6xl mx-auto pb-6">
+
+          <!-- Flat horizontal bands — no outer container box. Each band is a full-width strip with its own bottom border. -->
+          <div>
+
+            <!-- Tabs -->
+            <div class="flex items-center gap-5 px-6 pt-8">
+              <button class="pb-3 -mb-px text-sm font-semibold border-b-2 border-foreground text-foreground inline-flex items-center gap-2 cursor-pointer">
+                <i data-lucide="circle-dot" class="h-4 w-4"></i>
+                Active
+                <span class="text-muted-foreground font-normal">27</span>
+              </button>
+              <button class="pb-3 -mb-px text-sm font-medium border-b-2 border-transparent text-muted-foreground hover:text-foreground transition-colors inline-flex items-center gap-2 cursor-pointer">
+                <i data-lucide="check-circle-2" class="h-4 w-4"></i>
+                Archive
+                <span class="font-normal">20</span>
+              </button>
+              <button class="pb-3 -mb-px text-sm font-medium border-b-2 border-transparent text-muted-foreground hover:text-foreground transition-colors inline-flex items-center gap-2 cursor-pointer">
+                <i data-lucide="layers" class="h-4 w-4"></i>
+                All
+                <span class="font-normal">47</span>
+              </button>
+              <button class="ml-auto pb-3 -mb-px text-sm font-medium border-b-2 border-transparent text-muted-foreground hover:text-foreground transition-colors inline-flex items-center gap-1.5 cursor-pointer">
+                <i data-lucide="inbox" class="h-4 w-4"></i>
+                Mine to review
+                <span class="inline-flex items-center justify-center h-4 min-w-[1rem] px-1 rounded text-[10px] font-medium bg-status-review/15 text-status-review">7</span>
+              </button>
+              <button class="mb-2 inline-flex items-center gap-1.5 h-7 px-2.5 rounded bg-primary text-primary-foreground text-xs font-medium hover:opacity-90 active:scale-[0.98] transition-all duration-150 cursor-pointer">
+                <i data-lucide="plus" class="h-3.5 w-3.5"></i>
+                New task
+              </button>
+            </div>
+
+            <!-- Filter bar -->
+            <div class="flex items-center gap-2 px-6 py-2.5 mt-3">
+              <button class="inline-flex items-center gap-1.5 h-7 px-2.5 text-xs rounded border border-border bg-background hover:bg-secondary cursor-pointer transition-colors">
+                <span class="text-muted-foreground">Status</span>
+                <i data-lucide="chevron-down" class="h-3 w-3 text-muted-foreground"></i>
+              </button>
+              <button class="inline-flex items-center gap-1.5 h-7 px-2.5 text-xs rounded border border-border bg-background hover:bg-secondary cursor-pointer transition-colors">
+                <span class="text-muted-foreground">Priority</span>
+                <i data-lucide="chevron-down" class="h-3 w-3 text-muted-foreground"></i>
+              </button>
+              <button class="inline-flex items-center gap-1.5 h-7 px-2.5 text-xs rounded border border-border bg-background hover:bg-secondary cursor-pointer transition-colors">
+                <span class="text-muted-foreground">Assignee</span>
+                <i data-lucide="chevron-down" class="h-3 w-3 text-muted-foreground"></i>
+              </button>
+
+              <div class="relative flex-1 max-w-md ml-2">
+                <i data-lucide="search" class="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground"></i>
+                <input type="text" placeholder="Search tasks…" class="w-full h-7 pl-8 pr-3 text-xs rounded border border-border bg-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 transition-shadow" />
+              </div>
+
+              <button class="ml-auto inline-flex items-center gap-1.5 h-7 px-2.5 text-xs rounded border border-border bg-background hover:bg-secondary cursor-pointer transition-colors">
+                <i data-lucide="arrow-up-down" class="h-3 w-3 text-muted-foreground"></i>
+                <span>Sort: status, then updated</span>
+                <i data-lucide="chevron-down" class="h-3 w-3 text-muted-foreground"></i>
+              </button>
+            </div>
+
+            <!-- Flat list — sorted by status priority (review/blocked first) then updated desc -->
+            <ul>
+
+              <!-- review -->
+              <li id="demo-flash-row" class="hover:bg-secondary/40 transition-colors">
+                <a href="task-detail.html" class="flex items-start gap-3 px-6 py-3 cursor-pointer">
+                  <i data-lucide="alert-circle" class="h-4 w-4 mt-0.5 shrink-0 text-status-review"></i>
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-baseline gap-2">
+                      <span class="font-medium truncate">Implement OAuth flow</span>
+                      <span class="text-xs text-muted-foreground shrink-0">high</span>
+                    </div>
+                    <div class="mt-0.5 text-xs text-muted-foreground flex items-center gap-1.5 flex-wrap">
+                      <span class="font-mono">#8a3f1c</span>
+                      <span>·</span>
+                      <span class="text-status-review">review</span>
+                      <span>·</span>
+                      <span>updated 2m ago by</span>
+                      <span class="font-mono text-foreground">ic-agent-1</span>
+                      <span class="inline-flex items-center h-3.5 px-1 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic">ic</span>
+                    </div>
+                  </div>
+                </a>
+              </li>
+
+              <!-- review -->
+              <li class="hover:bg-secondary/40 transition-colors">
+                <a href="#" class="flex items-start gap-3 px-6 py-3 cursor-pointer">
+                  <i data-lucide="alert-circle" class="h-4 w-4 mt-0.5 shrink-0 text-status-review"></i>
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-baseline gap-2">
+                      <span class="font-medium truncate">Audit task dispatch index for hot-row contention</span>
+                      <span class="text-xs text-muted-foreground shrink-0">medium</span>
+                    </div>
+                    <div class="mt-0.5 text-xs text-muted-foreground flex items-center gap-1.5 flex-wrap">
+                      <span class="font-mono">#5e3c8b</span>
+                      <span>·</span>
+                      <span class="text-status-review">review</span>
+                      <span>·</span>
+                      <span>updated 11h ago by</span>
+                      <span class="font-mono text-foreground">db-agent</span>
+                      <span class="inline-flex items-center h-3.5 px-1 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic">ic</span>
+                    </div>
+                  </div>
+                </a>
+              </li>
+
+              <!-- review -->
+              <li class="hover:bg-secondary/40 transition-colors">
+                <a href="#" class="flex items-start gap-3 px-6 py-3 cursor-pointer">
+                  <i data-lucide="alert-circle" class="h-4 w-4 mt-0.5 shrink-0 text-status-review"></i>
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-baseline gap-2">
+                      <span class="font-medium truncate">Add LISTEN/NOTIFY triggers for SSE</span>
+                      <span class="text-xs text-muted-foreground shrink-0">medium</span>
+                    </div>
+                    <div class="mt-0.5 text-xs text-muted-foreground flex items-center gap-1.5 flex-wrap">
+                      <span class="font-mono">#7c1a4f</span>
+                      <span>·</span>
+                      <span class="text-status-review">review</span>
+                      <span>·</span>
+                      <span>updated 1d ago by</span>
+                      <span class="font-mono text-foreground">db-agent</span>
+                      <span class="inline-flex items-center h-3.5 px-1 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic">ic</span>
+                    </div>
+                  </div>
+                </a>
+              </li>
+
+              <!-- blocked -->
+              <li class="hover:bg-secondary/40 transition-colors">
+                <a href="#" class="flex items-start gap-3 px-6 py-3 cursor-pointer">
+                  <i data-lucide="ban" class="h-4 w-4 mt-0.5 shrink-0 text-status-blocked"></i>
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-baseline gap-2">
+                      <span class="font-medium truncate">Add OAuth provider configuration UI</span>
+                      <span class="text-xs text-muted-foreground shrink-0">low</span>
+                    </div>
+                    <div class="mt-0.5 text-xs text-muted-foreground flex items-center gap-1.5 flex-wrap">
+                      <span class="font-mono">#2c8d4f</span>
+                      <span>·</span>
+                      <span class="text-status-blocked">blocked</span>
+                      <span class="text-muted-foreground/70">— waiting on org-agent decision</span>
+                      <span>·</span>
+                      <span>3h ago by</span>
+                      <span class="font-mono text-foreground">team-alpha</span>
+                      <span class="inline-flex items-center h-3.5 px-1 rounded text-[10px] font-medium bg-hier-team/10 text-hier-team">team</span>
+                    </div>
+                  </div>
+                </a>
+              </li>
+
+              <!-- blocked -->
+              <li class="hover:bg-secondary/40 transition-colors">
+                <a href="#" class="flex items-start gap-3 px-6 py-3 cursor-pointer">
+                  <i data-lucide="ban" class="h-4 w-4 mt-0.5 shrink-0 text-status-blocked"></i>
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-baseline gap-2">
+                      <span class="font-medium truncate">Wire memory_fact promotion threshold</span>
+                      <span class="text-xs text-muted-foreground shrink-0">medium</span>
+                    </div>
+                    <div class="mt-0.5 text-xs text-muted-foreground flex items-center gap-1.5 flex-wrap">
+                      <span class="font-mono">#a4b7c2</span>
+                      <span>·</span>
+                      <span class="text-status-blocked">blocked</span>
+                      <span>·</span>
+                      <span>8h ago by</span>
+                      <span class="font-mono text-foreground">ic-agent-2</span>
+                      <span class="inline-flex items-center h-3.5 px-1 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic">ic</span>
+                    </div>
+                  </div>
+                </a>
+              </li>
+
+              <!-- in_progress -->
+              <li class="hover:bg-secondary/40 transition-colors">
+                <a href="#" class="flex items-start gap-3 px-6 py-3 cursor-pointer">
+                  <i data-lucide="loader-2" class="spin-slow h-4 w-4 mt-0.5 shrink-0 text-status-running"></i>
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-baseline gap-2">
+                      <span class="font-medium truncate">Refactor task repo to use repository pattern</span>
+                      <span class="text-xs text-muted-foreground shrink-0">medium</span>
+                    </div>
+                    <div class="mt-0.5 text-xs text-muted-foreground flex items-center gap-1.5 flex-wrap">
+                      <span class="font-mono">#4f2e9b</span>
+                      <span>·</span>
+                      <span class="text-status-running">in progress</span>
+                      <span>·</span>
+                      <span>updated 4m ago by</span>
+                      <span class="font-mono text-foreground">ic-agent-3</span>
+                      <span class="inline-flex items-center h-3.5 px-1 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic">ic</span>
+                    </div>
+                  </div>
+                </a>
+              </li>
+
+              <!-- revision (also running) -->
+              <li class="hover:bg-secondary/40 transition-colors">
+                <a href="#" class="flex items-start gap-3 px-6 py-3 cursor-pointer">
+                  <i data-lucide="loader-2" class="spin-slow h-4 w-4 mt-0.5 shrink-0 text-status-running"></i>
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-baseline gap-2">
+                      <span class="font-medium truncate">Migrate logging to pino across services</span>
+                      <span class="text-xs text-muted-foreground shrink-0">medium</span>
+                    </div>
+                    <div class="mt-0.5 text-xs text-muted-foreground flex items-center gap-1.5 flex-wrap">
+                      <span class="font-mono">#1c8d4f</span>
+                      <span>·</span>
+                      <span class="text-status-running">revision</span>
+                      <span>·</span>
+                      <span>updated 30m ago by</span>
+                      <span class="font-mono text-foreground">ic-agent-2</span>
+                      <span class="inline-flex items-center h-3.5 px-1 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic">ic</span>
+                    </div>
+                  </div>
+                </a>
+              </li>
+
+              <!-- in_progress -->
+              <li class="hover:bg-secondary/40 transition-colors">
+                <a href="#" class="flex items-start gap-3 px-6 py-3 cursor-pointer">
+                  <i data-lucide="loader-2" class="spin-slow h-4 w-4 mt-0.5 shrink-0 text-status-running"></i>
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-baseline gap-2">
+                      <span class="font-medium truncate">Quarterly planning doc for Q2</span>
+                      <span class="text-xs text-muted-foreground shrink-0">high</span>
+                    </div>
+                    <div class="mt-0.5 text-xs text-muted-foreground flex items-center gap-1.5 flex-wrap">
+                      <span class="font-mono">#9d2a1f</span>
+                      <span>·</span>
+                      <span class="text-status-running">in progress</span>
+                      <span>·</span>
+                      <span>7h ago by</span>
+                      <span class="font-mono text-foreground">team-alpha</span>
+                      <span class="inline-flex items-center h-3.5 px-1 rounded text-[10px] font-medium bg-hier-team/10 text-hier-team">team</span>
+                    </div>
+                  </div>
+                </a>
+              </li>
+
+              <!-- assigned -->
+              <li class="hover:bg-secondary/40 transition-colors">
+                <a href="#" class="flex items-start gap-3 px-6 py-3 cursor-pointer">
+                  <i data-lucide="circle-dashed" class="h-4 w-4 mt-0.5 shrink-0 text-status-pending"></i>
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-baseline gap-2">
+                      <span class="font-medium truncate">Update changelog with M5 release notes</span>
+                      <span class="text-xs text-muted-foreground shrink-0">low</span>
+                    </div>
+                    <div class="mt-0.5 text-xs text-muted-foreground flex items-center gap-1.5 flex-wrap">
+                      <span class="font-mono">#6b3a9c</span>
+                      <span>·</span>
+                      <span>assigned</span>
+                      <span>·</span>
+                      <span>5h ago to</span>
+                      <span class="font-mono text-foreground">ic-agent-1</span>
+                      <span class="inline-flex items-center h-3.5 px-1 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic">ic</span>
+                    </div>
+                  </div>
+                </a>
+              </li>
+
+              <!-- assigned -->
+              <li class="hover:bg-secondary/40 transition-colors">
+                <a href="#" class="flex items-start gap-3 px-6 py-3 cursor-pointer">
+                  <i data-lucide="circle-dashed" class="h-4 w-4 mt-0.5 shrink-0 text-status-pending"></i>
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-baseline gap-2">
+                      <span class="font-medium truncate">Draft RFC for OAuth scopes</span>
+                      <span class="text-xs text-muted-foreground shrink-0">medium</span>
+                    </div>
+                    <div class="mt-0.5 text-xs text-muted-foreground flex items-center gap-1.5 flex-wrap">
+                      <span class="font-mono">#8e4d2a</span>
+                      <span>·</span>
+                      <span>assigned</span>
+                      <span>·</span>
+                      <span>6h ago to</span>
+                      <span class="font-mono text-foreground">team-alpha</span>
+                      <span class="inline-flex items-center h-3.5 px-1 rounded text-[10px] font-medium bg-hier-team/10 text-hier-team">team</span>
+                    </div>
+                  </div>
+                </a>
+              </li>
+
+              <!-- pending -->
+              <li class="hover:bg-secondary/40 transition-colors">
+                <a href="#" class="flex items-start gap-3 px-6 py-3 cursor-pointer">
+                  <i data-lucide="circle" class="h-4 w-4 mt-0.5 shrink-0 text-status-pending"></i>
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-baseline gap-2">
+                      <span class="font-medium truncate">Audit npm dependencies for security advisories</span>
+                      <span class="text-xs text-muted-foreground shrink-0">medium</span>
+                    </div>
+                    <div class="mt-0.5 text-xs text-muted-foreground flex items-center gap-1.5 flex-wrap">
+                      <span class="font-mono">#3f7e1d</span>
+                      <span>·</span>
+                      <span>pending</span>
+                      <span class="text-muted-foreground/70">— no assignee</span>
+                      <span>·</span>
+                      <span>created 2d ago by Weijia</span>
+                    </div>
+                  </div>
+                </a>
+              </li>
+
+            </ul>
+
+            <!-- Footer -->
+            <div class="flex items-center justify-between px-6 py-3 mt-2 text-xs">
+              <span class="text-muted-foreground">Showing <span class="text-foreground">1–11</span> of <span class="text-foreground">27</span> active</span>
+              <div class="flex items-center gap-1">
+                <button class="h-7 w-7 rounded inline-flex items-center justify-center hover:bg-secondary cursor-pointer transition-colors disabled:opacity-30 disabled:cursor-not-allowed" disabled>
+                  <i data-lucide="chevron-left" class="h-3.5 w-3.5"></i>
+                </button>
+                <button class="h-7 min-w-7 px-2 rounded text-foreground bg-secondary font-medium cursor-pointer">1</button>
+                <button class="h-7 min-w-7 px-2 rounded hover:bg-secondary cursor-pointer transition-colors">2</button>
+                <button class="h-7 min-w-7 px-2 rounded hover:bg-secondary cursor-pointer transition-colors">3</button>
+                <button class="h-7 w-7 rounded inline-flex items-center justify-center hover:bg-secondary cursor-pointer transition-colors">
+                  <i data-lucide="chevron-right" class="h-3.5 w-3.5"></i>
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <!-- Foot note -->
+          <div class="mt-12 px-6 text-xs text-muted-foreground flex items-center gap-3">
+            <span class="font-mono">mock</span>
+            <span class="text-border">·</span>
+            <span>Single bordered container, GitHub Issues + Paperclip ticket pattern. Status conveyed via leading icon, not card backgrounds. Top row auto-flashes on load.</span>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+
+  <script>
+    lucide.createIcons();
+
+    document.getElementById('theme-toggle').addEventListener('click', () => {
+      document.documentElement.classList.toggle('dark');
+      lucide.createIcons();
+    });
+
+    requestAnimationFrame(() => {
+      const row = document.getElementById('demo-flash-row');
+      row.classList.add('row-flash');
+      row.addEventListener('animationend', () => row.classList.remove('row-flash'), { once: true });
+    });
+  </script>
+</body>
+</html>

--- a/mocks/threads.html
+++ b/mocks/threads.html
@@ -1,0 +1,604 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>beevibe — threads mock</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+  <script>
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.classList.add('dark');
+    }
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
+  <style>
+    :root {
+      --background: 0 0% 100%;
+      --foreground: 240 10% 4%;
+      --card: 240 5% 98%;
+      --card-foreground: 240 10% 4%;
+      --primary: 48 96% 53%;
+      --primary-foreground: 240 10% 4%;
+      --secondary: 240 5% 96%;
+      --secondary-foreground: 240 6% 10%;
+      --muted: 240 5% 96%;
+      --muted-foreground: 240 4% 46%;
+      --border: 240 6% 90%;
+      --input: 240 6% 90%;
+      --ring: 47 96% 47%;
+      --radius: 0.375rem;
+
+      --status-pending:   240 4% 46%;
+      --status-running:   217 91% 60%;
+      --status-review:    38 92% 50%;
+      --status-blocked:   25 95% 53%;
+      --status-done:      160 84% 39%;
+      --status-failed:    0 84% 60%;
+
+      --hier-ic:   240 4% 46%;
+      --hier-team: 262 83% 58%;
+      --hier-org:  38 92% 50%;
+    }
+    .dark {
+      --background: 240 10% 4%;
+      --foreground: 0 0% 98%;
+      --card: 240 6% 10%;
+      --card-foreground: 0 0% 98%;
+      --primary: 48 96% 53%;
+      --primary-foreground: 240 10% 4%;
+      --secondary: 240 4% 16%;
+      --secondary-foreground: 0 0% 98%;
+      --muted: 240 4% 16%;
+      --muted-foreground: 240 5% 65%;
+      --border: 240 4% 16%;
+      --input: 240 4% 16%;
+      --ring: 48 96% 53%;
+    }
+
+    body {
+      font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
+      font-feature-settings: 'cv11', 'ss01';
+      background-color: hsl(var(--background));
+      color: hsl(var(--foreground));
+      -webkit-font-smoothing: antialiased;
+    }
+    .font-mono { font-family: 'JetBrains Mono', ui-monospace, 'Menlo', monospace; }
+
+    @keyframes pulse-breathe {
+      0%, 100% { opacity: 1; transform: scale(1); }
+      50%      { opacity: 0.55; transform: scale(0.92); }
+    }
+    .pulse-dot { animation: pulse-breathe 2s ease-in-out infinite; }
+
+    @keyframes spin-slow { to { transform: rotate(360deg); } }
+    .spin-slow { animation: spin-slow 2.5s linear infinite; }
+
+    @media (prefers-reduced-motion: reduce) {
+      .pulse-dot, .spin-slow { animation: none; }
+    }
+
+    button:focus-visible, a:focus-visible, input:focus-visible, textarea:focus-visible {
+      outline: 2px solid hsl(var(--ring));
+      outline-offset: 2px;
+      border-radius: var(--radius);
+    }
+
+    /* Avatar */
+    .av { width: 28px; height: 28px; border-radius: 9999px; display: inline-flex; align-items: center; justify-content: center; font-size: 11px; font-weight: 600; flex-shrink: 0; }
+    .av-person { background: hsl(var(--secondary)); color: hsl(var(--foreground)); border: 1px solid hsl(var(--border)); }
+    .av-ic     { background: hsl(var(--hier-ic) / 0.12);   color: hsl(var(--hier-ic)); }
+    .av-team   { background: hsl(var(--hier-team) / 0.12); color: hsl(var(--hier-team)); }
+    .av-org    { background: hsl(var(--hier-org) / 0.12);  color: hsl(var(--hier-org)); }
+
+    /* Presence dot on avatar */
+    .presence {
+      position: absolute;
+      bottom: -1px; right: -1px;
+      width: 9px; height: 9px;
+      border-radius: 9999px;
+      border: 2px solid hsl(var(--background));
+    }
+    .presence-running { background: hsl(var(--status-running)); }
+    .presence-idle    { background: hsl(var(--muted-foreground)); }
+
+    /* Timeline rail line — connects messages */
+    .timeline-rail::before {
+      content: '';
+      position: absolute;
+      left: 13px;
+      top: 28px;
+      bottom: 0;
+      width: 1px;
+      background: hsl(var(--border));
+    }
+  </style>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+            mono: ['JetBrains Mono', 'ui-monospace', 'Menlo', 'monospace'],
+          },
+          colors: {
+            border: 'hsl(var(--border))',
+            input: 'hsl(var(--input))',
+            ring: 'hsl(var(--ring))',
+            background: 'hsl(var(--background))',
+            foreground: 'hsl(var(--foreground))',
+            primary: { DEFAULT: 'hsl(var(--primary))', foreground: 'hsl(var(--primary-foreground))' },
+            secondary: { DEFAULT: 'hsl(var(--secondary))', foreground: 'hsl(var(--secondary-foreground))' },
+            muted: { DEFAULT: 'hsl(var(--muted))', foreground: 'hsl(var(--muted-foreground))' },
+            card: { DEFAULT: 'hsl(var(--card))', foreground: 'hsl(var(--card-foreground))' },
+            status: {
+              pending:   'hsl(var(--status-pending))',
+              running:   'hsl(var(--status-running))',
+              review:    'hsl(var(--status-review))',
+              blocked:   'hsl(var(--status-blocked))',
+              done:      'hsl(var(--status-done))',
+              failed:    'hsl(var(--status-failed))',
+            },
+            hier: {
+              ic:   'hsl(var(--hier-ic))',
+              team: 'hsl(var(--hier-team))',
+              org:  'hsl(var(--hier-org))',
+            },
+          },
+          borderRadius: {
+            DEFAULT: 'var(--radius)',
+            md: 'var(--radius)',
+            lg: 'calc(var(--radius) + 2px)',
+            xl: 'calc(var(--radius) + 6px)',
+          },
+        },
+      },
+    };
+  </script>
+</head>
+<body class="h-screen overflow-hidden">
+  <div class="flex h-screen">
+
+    <!-- App sidebar (Threads active — new nav item) -->
+    <aside class="w-[220px] shrink-0 bg-card flex flex-col">
+      <div class="h-14 flex items-center gap-2.5 px-4">
+        <div class="h-6 w-6 rounded bg-primary flex items-center justify-center">
+          <span class="text-primary-foreground text-sm font-bold leading-none">b</span>
+        </div>
+        <span class="font-semibold tracking-tight">beevibe</span>
+      </div>
+      <nav class="flex-1 p-2 space-y-0.5 text-sm">
+        <a href="#" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="home" class="h-4 w-4"></i>
+          <span>Home</span>
+        </a>
+        <a href="tasks-list.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="list-checks" class="h-4 w-4"></i>
+          <span>Tasks</span>
+        </a>
+        <a href="agents-list.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="circle-dot" class="h-4 w-4"></i>
+          <span>Agents</span>
+        </a>
+        <a href="#" class="flex items-center gap-3 px-3 py-2 rounded bg-secondary text-foreground font-medium">
+          <i data-lucide="message-square" class="h-4 w-4"></i>
+          <span>Threads</span>
+        </a>
+        <a href="memory.html" class="flex items-center gap-3 px-3 py-2 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors duration-150">
+          <i data-lucide="sparkles" class="h-4 w-4"></i>
+          <span>Memory</span>
+        </a>
+      </nav>
+
+      <div class="p-3">
+        <div class="flex items-center gap-1">
+          <button class="flex-1 min-w-0 flex items-center gap-2 px-2 py-1.5 rounded hover:bg-secondary cursor-pointer transition-colors text-left">
+            <div class="h-7 w-7 rounded-full bg-secondary border border-border flex items-center justify-center text-xs font-medium shrink-0">W</div>
+            <div class="flex-1 min-w-0">
+              <div class="text-sm font-medium truncate leading-tight">Weijia</div>
+              <div class="text-[10px] text-muted-foreground flex items-center gap-1 leading-tight mt-0.5">
+                <span class="pulse-dot inline-block h-1 w-1 rounded-full" style="background: hsl(217 91% 60%);"></span>
+                live
+              </div>
+            </div>
+            <i data-lucide="chevrons-up-down" class="h-3.5 w-3.5 text-muted-foreground shrink-0"></i>
+          </button>
+          <button id="theme-toggle" class="h-8 w-8 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary cursor-pointer transition-colors shrink-0" title="Toggle theme">
+            <i data-lucide="sun" class="h-4 w-4 hidden dark:block"></i>
+            <i data-lucide="moon" class="h-4 w-4 block dark:hidden"></i>
+          </button>
+        </div>
+      </div>
+    </aside>
+
+    <!-- Channel list rail (280px) -->
+    <aside class="w-[280px] shrink-0 bg-secondary/30 flex flex-col overflow-hidden">
+      <div class="px-4 pt-5 pb-3 flex items-center justify-between">
+        <h2 class="text-sm font-semibold">Threads</h2>
+        <button class="inline-flex items-center gap-1.5 h-7 px-2.5 rounded bg-primary text-primary-foreground text-xs font-medium hover:opacity-90 active:scale-[0.98] transition-all duration-150 cursor-pointer">
+          <i data-lucide="plus" class="h-3.5 w-3.5"></i>
+          New task
+        </button>
+      </div>
+
+      <div class="flex-1 overflow-y-auto px-2 pb-4 space-y-4">
+
+        <!-- Section: Needs you (review queue) -->
+        <div>
+          <div class="px-2 pb-1 flex items-center justify-between text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+            <span>Needs you</span><span class="tabular-nums">7</span>
+          </div>
+          <a href="#" class="flex items-center gap-2 px-2 py-1.5 rounded bg-secondary text-foreground transition-colors">
+            <i data-lucide="alert-circle" class="h-3.5 w-3.5 text-status-review shrink-0"></i>
+            <span class="text-sm font-medium truncate flex-1">Implement OAuth flow</span>
+            <span class="text-[10px] text-muted-foreground tabular-nums">2m</span>
+          </a>
+          <a href="#" class="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-secondary/60 cursor-pointer transition-colors">
+            <i data-lucide="alert-circle" class="h-3.5 w-3.5 text-status-review shrink-0"></i>
+            <span class="text-sm truncate flex-1 text-muted-foreground">Audit task dispatch index</span>
+            <span class="text-[10px] text-muted-foreground tabular-nums">11h</span>
+          </a>
+          <a href="#" class="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-secondary/60 cursor-pointer transition-colors">
+            <i data-lucide="alert-circle" class="h-3.5 w-3.5 text-status-review shrink-0"></i>
+            <span class="text-sm truncate flex-1 text-muted-foreground">Add LISTEN/NOTIFY triggers</span>
+            <span class="text-[10px] text-muted-foreground tabular-nums">1d</span>
+          </a>
+        </div>
+
+        <!-- Section: Active -->
+        <div>
+          <div class="px-2 pb-1 flex items-center justify-between text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+            <span>Active</span><span class="tabular-nums">3</span>
+          </div>
+          <a href="#" class="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-secondary/60 cursor-pointer transition-colors">
+            <i data-lucide="loader-2" class="spin-slow h-3.5 w-3.5 text-status-running shrink-0"></i>
+            <span class="text-sm truncate flex-1 text-muted-foreground">Refactor task repo</span>
+            <span class="text-[10px] text-muted-foreground tabular-nums">4m</span>
+          </a>
+          <a href="#" class="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-secondary/60 cursor-pointer transition-colors">
+            <i data-lucide="loader-2" class="spin-slow h-3.5 w-3.5 text-status-running shrink-0"></i>
+            <span class="text-sm truncate flex-1 text-muted-foreground">Quarterly planning</span>
+            <span class="text-[10px] text-muted-foreground tabular-nums">7h</span>
+          </a>
+          <a href="#" class="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-secondary/60 cursor-pointer transition-colors">
+            <i data-lucide="loader-2" class="spin-slow h-3.5 w-3.5 text-status-running shrink-0"></i>
+            <span class="text-sm truncate flex-1 text-muted-foreground">Generate SDK docs</span>
+            <span class="text-[10px] text-muted-foreground tabular-nums">2h</span>
+          </a>
+        </div>
+
+        <!-- Section: Blocked -->
+        <div>
+          <div class="px-2 pb-1 flex items-center justify-between text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+            <span>Blocked</span><span class="tabular-nums">2</span>
+          </div>
+          <a href="#" class="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-secondary/60 cursor-pointer transition-colors">
+            <i data-lucide="ban" class="h-3.5 w-3.5 text-status-blocked shrink-0"></i>
+            <span class="text-sm truncate flex-1 text-muted-foreground">OAuth provider config</span>
+            <span class="text-[10px] text-muted-foreground tabular-nums">3h</span>
+          </a>
+          <a href="#" class="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-secondary/60 cursor-pointer transition-colors">
+            <i data-lucide="ban" class="h-3.5 w-3.5 text-status-blocked shrink-0"></i>
+            <span class="text-sm truncate flex-1 text-muted-foreground">Memory_fact threshold</span>
+            <span class="text-[10px] text-muted-foreground tabular-nums">8h</span>
+          </a>
+        </div>
+
+        <!-- Section: Direct messages (chat-type sessions per agent) -->
+        <div>
+          <div class="px-2 pb-1 flex items-center justify-between text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+            <span>Direct messages</span><span class="tabular-nums">5</span>
+          </div>
+          <a href="#" class="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-secondary/60 cursor-pointer transition-colors">
+            <span class="relative">
+              <span class="av av-team" style="width: 18px; height: 18px; font-size: 9px;">α</span>
+              <span class="presence presence-running" style="width: 7px; height: 7px;"></span>
+            </span>
+            <span class="text-sm truncate flex-1 font-mono text-muted-foreground">team-alpha</span>
+            <span class="text-[10px] text-muted-foreground tabular-nums">1h</span>
+          </a>
+          <a href="#" class="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-secondary/60 cursor-pointer transition-colors">
+            <span class="relative">
+              <span class="av av-ic" style="width: 18px; height: 18px; font-size: 9px;">1</span>
+              <span class="presence presence-running" style="width: 7px; height: 7px;"></span>
+            </span>
+            <span class="text-sm truncate flex-1 font-mono text-muted-foreground">ic-agent-1</span>
+            <span class="text-[10px] text-muted-foreground tabular-nums">3h</span>
+          </a>
+          <a href="#" class="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-secondary/60 cursor-pointer transition-colors">
+            <span class="relative">
+              <span class="av av-org" style="width: 18px; height: 18px; font-size: 9px;">O</span>
+              <span class="presence presence-idle" style="width: 7px; height: 7px;"></span>
+            </span>
+            <span class="text-sm truncate flex-1 font-mono text-muted-foreground">root-org</span>
+            <span class="text-[10px] text-muted-foreground tabular-nums">5d</span>
+          </a>
+        </div>
+
+        <!-- Section: Archive (collapsed) -->
+        <div>
+          <div class="px-2 pb-1 flex items-center justify-between text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+            <span>Archive</span><span class="tabular-nums">20</span>
+          </div>
+        </div>
+      </div>
+    </aside>
+
+    <!-- Main chat area -->
+    <main class="flex-1 min-w-0 flex flex-col bg-background">
+
+      <!-- Channel header — task title + status + members -->
+      <header class="px-6 py-3 flex items-center justify-between gap-4 shrink-0">
+        <div class="flex items-center gap-3 min-w-0">
+          <i data-lucide="hash" class="h-4 w-4 text-muted-foreground shrink-0"></i>
+          <div class="min-w-0">
+            <div class="flex items-center gap-2">
+              <h1 class="text-base font-semibold truncate">Implement OAuth flow</h1>
+              <span class="inline-flex items-center gap-1.5 h-5 px-1.5 rounded text-[10px] font-medium bg-status-review/10 text-status-review">
+                <span class="h-1 w-1 rounded-full bg-status-review"></span>
+                review
+              </span>
+              <span class="inline-flex items-center h-5 px-1.5 rounded text-[10px] font-medium bg-secondary text-secondary-foreground">high</span>
+            </div>
+            <div class="text-xs text-muted-foreground mt-0.5 flex items-center gap-1.5">
+              <span class="font-mono">tsk_8a3f1c2e</span>
+              <span class="text-border">·</span>
+              <span>4 messages · 2 sessions</span>
+            </div>
+          </div>
+        </div>
+        <div class="flex items-center gap-3 shrink-0">
+          <!-- Member stack -->
+          <div class="flex -space-x-1.5">
+            <span class="av av-person" style="width: 22px; height: 22px; box-shadow: 0 0 0 2px hsl(var(--background));">W</span>
+            <span class="av av-ic" style="width: 22px; height: 22px; box-shadow: 0 0 0 2px hsl(var(--background));">1</span>
+            <span class="av av-team" style="width: 22px; height: 22px; box-shadow: 0 0 0 2px hsl(var(--background));">α</span>
+          </div>
+          <button class="h-7 w-7 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary cursor-pointer transition-colors" title="Thread details">
+            <i data-lucide="info" class="h-4 w-4"></i>
+          </button>
+        </div>
+      </header>
+
+      <!-- Timeline of events (sessions, blockers, status, work products) -->
+      <div class="flex-1 overflow-y-auto px-6 py-4">
+        <div class="max-w-3xl mx-auto space-y-1">
+
+          <!-- Date separator -->
+          <div class="flex items-center gap-3 py-3 text-[10px] uppercase tracking-wider text-muted-foreground">
+            <span class="flex-1 h-px bg-border"></span>
+            <span>2 days ago · April 24</span>
+            <span class="flex-1 h-px bg-border"></span>
+          </div>
+
+          <!-- System message: task created -->
+          <div class="text-xs text-muted-foreground py-1.5 px-2 flex items-center gap-2">
+            <i data-lucide="plus-circle" class="h-3 w-3"></i>
+            <span><span class="font-medium text-foreground">Weijia</span> created this task and assigned it to <span class="font-mono text-foreground">ic-agent-1</span></span>
+            <span class="text-border ml-auto">10:14 AM</span>
+          </div>
+
+          <!-- Session start: ic-agent-1 -->
+          <div class="flex gap-3 py-2 px-2 rounded hover:bg-secondary/30 transition-colors group">
+            <span class="relative">
+              <span class="av av-ic">1</span>
+              <span class="presence presence-running"></span>
+            </span>
+            <div class="flex-1 min-w-0">
+              <div class="flex items-baseline gap-2">
+                <span class="font-semibold text-sm">ic-agent-1</span>
+                <span class="inline-flex items-center h-3.5 px-1 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic">ic</span>
+                <span class="text-[10px] text-muted-foreground">started session <span class="font-mono">9c1f4b2a</span></span>
+                <span class="ml-auto text-[10px] text-muted-foreground tabular-nums">10:15 AM</span>
+              </div>
+              <p class="mt-0.5 text-sm leading-6 text-muted-foreground italic">
+                Implementing OAuth 2.0 authorization code flow against Google. Adding PKCE challenge generation and state param verification…
+              </p>
+            </div>
+          </div>
+
+          <!-- Session result: ic-agent-1 finished -->
+          <div class="flex gap-3 py-2 px-2 rounded hover:bg-secondary/30 transition-colors">
+            <span class="av av-ic">1</span>
+            <div class="flex-1 min-w-0">
+              <div class="flex items-baseline gap-2">
+                <span class="font-semibold text-sm">ic-agent-1</span>
+                <i data-lucide="check-circle-2" class="h-3 w-3 text-status-done"></i>
+                <span class="text-[10px] text-muted-foreground">session completed in 47m</span>
+                <span class="ml-auto text-[10px] text-muted-foreground tabular-nums">11:02 AM</span>
+              </div>
+              <p class="mt-0.5 text-sm leading-6">
+                Implemented the OAuth authorization code flow against Google. Tokens stored on <code class="font-mono text-xs px-1 py-0.5 rounded bg-secondary">person.oauth_tokens</code>. Refresh handled in middleware on 401. Tests pass for the happy path.
+              </p>
+              <!-- Work product attachment -->
+              <a href="#" class="mt-2 inline-flex items-center gap-2 px-2.5 py-1.5 rounded border border-border hover:border-ring transition-colors group cursor-pointer">
+                <i data-lucide="git-pull-request" class="h-3.5 w-3.5 text-status-running"></i>
+                <span class="text-xs font-medium">PR #42</span>
+                <span class="text-xs text-muted-foreground">feat: add OAuth flow</span>
+                <i data-lucide="arrow-up-right" class="h-3 w-3 text-muted-foreground group-hover:text-foreground"></i>
+              </a>
+            </div>
+          </div>
+
+          <!-- System message: status change -->
+          <div class="text-xs text-muted-foreground py-1.5 px-2 flex items-center gap-2">
+            <i data-lucide="arrow-right" class="h-3 w-3"></i>
+            <span>Task moved to <span class="text-status-review font-medium">review</span></span>
+            <span class="text-border ml-auto">11:02 AM</span>
+          </div>
+
+          <!-- Date separator -->
+          <div class="flex items-center gap-3 py-4 text-[10px] uppercase tracking-wider text-muted-foreground">
+            <span class="flex-1 h-px bg-border"></span>
+            <span>Yesterday · April 25</span>
+            <span class="flex-1 h-px bg-border"></span>
+          </div>
+
+          <!-- Blocker raised — special treatment, prominent -->
+          <div class="my-1 px-3 py-2.5 rounded-md bg-status-blocked/8 flex gap-3" style="background: hsl(var(--status-blocked) / 0.08);">
+            <span class="av av-ic">1</span>
+            <div class="flex-1 min-w-0">
+              <div class="flex items-baseline gap-2">
+                <span class="font-semibold text-sm">ic-agent-1</span>
+                <span class="inline-flex items-center gap-1 text-status-blocked text-xs font-medium">
+                  <i data-lucide="ban" class="h-3 w-3"></i>
+                  raised a blocker
+                </span>
+                <span class="ml-auto text-[10px] text-muted-foreground tabular-nums">9:40 AM</span>
+              </div>
+              <p class="mt-1 text-sm leading-6">
+                Need a decision: Google's OAuth flow can use either authorization code with PKCE, or implicit flow. Which do we want? Implicit is simpler but PKCE is required for public clients per RFC 8252.
+              </p>
+              <div class="mt-1.5 text-[10px] text-muted-foreground">
+                blocker_agent_id: <span class="font-mono text-foreground">root-org</span> · awaiting decision from organizational scope
+              </div>
+            </div>
+          </div>
+
+          <!-- Human reply: cleared blocker -->
+          <div class="flex gap-3 py-2 px-2 rounded hover:bg-secondary/30 transition-colors">
+            <span class="av av-person">W</span>
+            <div class="flex-1 min-w-0">
+              <div class="flex items-baseline gap-2">
+                <span class="font-semibold text-sm">Weijia</span>
+                <i data-lucide="check" class="h-3 w-3 text-status-done"></i>
+                <span class="text-[10px] text-muted-foreground">cleared the blocker</span>
+                <span class="ml-auto text-[10px] text-muted-foreground tabular-nums">10:12 AM</span>
+              </div>
+              <p class="mt-0.5 text-sm leading-6">
+                Use authorization code with PKCE. We need to support public clients eventually and the security floor is higher.
+              </p>
+            </div>
+          </div>
+
+          <!-- Date separator -->
+          <div class="flex items-center gap-3 py-4 text-[10px] uppercase tracking-wider text-muted-foreground">
+            <span class="flex-1 h-px bg-border"></span>
+            <span>1 hour ago</span>
+            <span class="flex-1 h-px bg-border"></span>
+          </div>
+
+          <!-- Human review feedback -->
+          <div class="flex gap-3 py-2 px-2 rounded hover:bg-secondary/30 transition-colors">
+            <span class="av av-person">W</span>
+            <div class="flex-1 min-w-0">
+              <div class="flex items-baseline gap-2">
+                <span class="font-semibold text-sm">Weijia</span>
+                <i data-lucide="rotate-ccw" class="h-3 w-3 text-status-review"></i>
+                <span class="text-[10px] text-muted-foreground">requested revisions</span>
+                <span class="ml-auto text-[10px] text-muted-foreground tabular-nums">12:48 PM</span>
+              </div>
+              <p class="mt-0.5 text-sm leading-6">
+                Almost there. Missing CSRF state param check on the callback. The state token needs to be validated before exchanging the auth code, otherwise this is open to login-CSRF.
+              </p>
+            </div>
+          </div>
+
+          <!-- System: status change -->
+          <div class="text-xs text-muted-foreground py-1.5 px-2 flex items-center gap-2">
+            <i data-lucide="arrow-right" class="h-3 w-3"></i>
+            <span>Task moved to <span class="text-status-running font-medium">revision</span></span>
+            <span class="text-border ml-auto">12:48 PM</span>
+          </div>
+
+          <!-- Session start: revision -->
+          <div class="flex gap-3 py-2 px-2 rounded hover:bg-secondary/30 transition-colors">
+            <span class="relative">
+              <span class="av av-ic">1</span>
+              <span class="presence presence-running"></span>
+            </span>
+            <div class="flex-1 min-w-0">
+              <div class="flex items-baseline gap-2">
+                <span class="font-semibold text-sm">ic-agent-1</span>
+                <span class="inline-flex items-center h-3.5 px-1 rounded text-[10px] font-medium bg-hier-ic/15 text-hier-ic">ic</span>
+                <span class="text-[10px] text-muted-foreground">started session <span class="font-mono">4f2e9b13</span> (revision)</span>
+                <span class="ml-auto text-[10px] text-muted-foreground tabular-nums">12:50 PM</span>
+              </div>
+              <p class="mt-0.5 text-sm leading-6 text-muted-foreground italic">
+                Adding state param verification on callback. Will validate the cookie matches before exchange.
+              </p>
+            </div>
+          </div>
+
+          <!-- Session result: revision finished -->
+          <div class="flex gap-3 py-2 px-2 rounded hover:bg-secondary/30 transition-colors">
+            <span class="av av-ic">1</span>
+            <div class="flex-1 min-w-0">
+              <div class="flex items-baseline gap-2">
+                <span class="font-semibold text-sm">ic-agent-1</span>
+                <i data-lucide="check-circle-2" class="h-3 w-3 text-status-done"></i>
+                <span class="text-[10px] text-muted-foreground">session completed in 18m · resubmitted for review</span>
+                <span class="ml-auto text-[10px] text-muted-foreground tabular-nums">1:08 PM</span>
+              </div>
+              <p class="mt-0.5 text-sm leading-6">
+                Added CSRF state param verification. State is generated server-side, stored in HttpOnly cookie, validated on callback before token exchange. Test added for state mismatch case.
+              </p>
+            </div>
+          </div>
+
+          <!-- Currently running indicator -->
+          <div class="text-xs text-muted-foreground py-1.5 px-2 flex items-center gap-2">
+            <span class="pulse-dot inline-block h-1.5 w-1.5 rounded-full bg-status-review"></span>
+            <span>Awaiting your review</span>
+          </div>
+
+        </div>
+      </div>
+
+      <!-- Action bar — context-aware. Status='review' shows approve/reject/revise. -->
+      <footer class="px-6 py-3 shrink-0">
+        <div class="max-w-3xl mx-auto">
+          <!-- Primary actions for review state -->
+          <div class="flex items-center gap-2 mb-2">
+            <button class="inline-flex items-center gap-2 h-9 px-4 rounded bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 active:scale-[0.98] transition-all duration-150 cursor-pointer">
+              <i data-lucide="check" class="h-4 w-4"></i>
+              Approve
+            </button>
+            <button class="inline-flex items-center gap-2 h-9 px-3 rounded text-sm font-medium hover:bg-secondary cursor-pointer transition-all duration-150">
+              <i data-lucide="rotate-ccw" class="h-4 w-4"></i>
+              Request revisions
+            </button>
+            <button class="inline-flex items-center gap-2 h-9 px-3 rounded text-sm font-medium text-status-failed hover:bg-status-failed/10 cursor-pointer transition-all duration-150">
+              <i data-lucide="x" class="h-4 w-4"></i>
+              Reject
+            </button>
+            <span class="ml-auto text-xs text-muted-foreground">↵ to send · /agent to delegate</span>
+          </div>
+          <!-- Compose textarea — sends to ic-agent-1 as a chat-type session -->
+          <div class="rounded-md bg-secondary/50 px-3 py-2.5 focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 transition-shadow">
+            <textarea
+              rows="1"
+              placeholder="Reply to ic-agent-1, or note for the next session…"
+              class="w-full bg-transparent text-sm placeholder:text-muted-foreground focus:outline-none resize-none"
+            ></textarea>
+            <div class="flex items-center gap-2 mt-1">
+              <button class="h-6 w-6 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors cursor-pointer" title="Attach">
+                <i data-lucide="paperclip" class="h-3.5 w-3.5"></i>
+              </button>
+              <button class="h-6 w-6 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors cursor-pointer" title="Mention agent">
+                <i data-lucide="at-sign" class="h-3.5 w-3.5"></i>
+              </button>
+              <button class="h-6 px-2 rounded inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer" title="Delegate as new task">
+                <i data-lucide="git-branch" class="h-3 w-3"></i>
+                Delegate
+              </button>
+              <span class="ml-auto text-[10px] text-muted-foreground">creates a chat-type session targeting <span class="font-mono">ic-agent-1</span></span>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </main>
+  </div>
+
+  <script>
+    lucide.createIcons();
+    document.getElementById('theme-toggle').addEventListener('click', () => {
+      document.documentElement.classList.toggle('dark');
+      lucide.createIcons();
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Self-contained HTML mocks exploring the M8 frontend before we scaffold the Next.js package. Each opens directly in a browser (Tailwind CDN + Lucide + Google Fonts) — no build step. All schema-honest: only renders fields that exist on `task`, `session`, `agent`, `memory_fact`, `work_product`, `core_memory_block`.

## Mocks (v1 — original six)

| File | Pattern |
|---|---|
| `mocks/home.html` | Fleet stats dashboard — KPI tiles, status breakdown bar, 7-day trend chart |
| `mocks/tasks-list.html` | Flat list with lifecycle tabs (GitHub Issues + Paperclip ticket pattern) |
| `mocks/task-detail.html` | Detail view: description + result summary + approve/reject/revise |
| `mocks/agents-list.html` | SVG org chart (Multica/Paperclip pattern) — 200×100 cards, orthogonal connectors |
| `mocks/threads.html` | Slack/Discord-flavored: app nav + channel rail + chat timeline. Each message maps to a real primitive (session, status change, blocker, work product) |
| `mocks/memory.html` | Mem0 OpenMemory pattern — table with bulk select, soft type tags |

## Mocks (v2 — architectural showcase, extends #20)

The original six prove beevibe is a competent team-AI dashboard. The next set proves the **architectural opinion** that differentiates beevibe from mem0 / Multica / Mastra / Paperclip: bounded specialists + curated commons + mesh asks. These mocks are what the open-source launch and YC video screenshot.

### New mocks

| File | Pattern | Architectural claim it proves |
|---|---|---|
| `mocks/agent-detail.html` | Per-agent memory page: core memory blocks (editable, with `char_limit` ring), facts list with provenance, derived themes, depth metrics (sessions / facts learned / merge events). **No global pool view exists anywhere — that absence is the architectural statement.** | Bounded specialists |
| `mocks/session-detail.html` | Session viewer: BriefingComposer block (which core blocks + which retrieved facts + which scope they came from) at top, transcript in middle, inline AskThread cards when this session called `ask`/`negotiate` to another agent | Mesh asks (bonus: also shows briefing transparency, which Letta/mem0 dashboards don't) |
| `mocks/mesh.html` | Mesh activity feed (left): `agent_codebase asked agent_security — is the new auth path safe? → 12s response`. Mesh graph (right): force-directed nodes (agents) + animated directed edges (asks), chain depth coloring approaching `ChainBudget` limit | Mesh asks |
| `mocks/promotions.html` | Promotion timeline: each row shows fact content + originating agent + scope transition (`ic → team`) + FactPromoter's reason text (`\"observed independently across 4 sessions across 3 agents — generalizes\"`) + the source session ids that led to promotion | Curated commons |
| `mocks/showcase.html` | Public-facing landing page hero: side-by-side animation. Left = \"Flat memory\" (one pool, every agent reads everything — captioned as the mem0 pattern). Right = \"Bounded specialists\" (3 small per-agent memory boxes, scope-tagged facts, animated ask edges). A new fact gets written; left dumps it into the pool; right keeps in originating agent, accumulates similar facts in others, animates promotion to commons with provenance preserved | All three claims, before any copy |

### Refinements to existing mocks

- **`memory.html`** — add **scope chip column** (`ic` / `team` / `org` with the locked semantic colors), filter tabs at top (**Mine / Team / Org**), originating agent chip on each row, and a small \"recently promoted\" sidebar
- **`agents-list.html`** — add depth metrics on each agent card (sessions count / facts learned / merge events) so the org chart isn't just structural — it shows specialization accruing visibly
- **`threads.html`** — when a thread message comes from an agent that called `ask` mid-session, render the ask as a nested AskThread card inline, with the responder agent's chip clickable to its agent-detail page

### The three magic moments these mocks must support

The combined surfaces have to make these demonstrable in a 90-second launch video, in this order:

1. **An agent gets visibly sharper.** Open `agent-detail.html` for `agent_codebase` showing 5 facts → screenshot of running a CC session → reopen showing 8 facts, 2 tagged \"merged from prior\" with the LLM-merged content visible. *Depth accrues, observable.*
2. **A fact earns promotion.** Show the same fact in `agent-detail.html` at ic-scope, then in `promotions.html` as a promotion event with FactPromoter's reason text, then in `memory.html` filtered to Team showing it's now there with provenance preserved. *The commons is curated, not pooled.*
3. **Agents ask each other live.** Open `mesh.html` showing the activity feed with a fresh ask animating in the graph view. Click into the ask thread — see the request from `agent_codebase` and `agent_security`'s response from its own bounded memory. *Bounded specialists collaborating, not merging.*

If those land in 90 seconds using only these mock surfaces, the architectural opinion is undeniable.

## Locked design system

- **Brand:** beevibe yellow (#FACC15) primary, dark text always
- **Aesthetic:** dark-first OLED minimalism, monochrome chrome with saturated semantic accents
- **Typography:** Inter (UI) + JetBrains Mono (IDs / code)
- **Mode:** `prefers-color-scheme` default, manual toggle override
- **Chrome:** sidebar identical on every page (nav + user widget at bottom). No global \"+ New task\" button — primary CTAs live contextually (tabs row on tasks list, channel rail on threads, etc.)
- **Density modes:** LIST / DETAIL / READING / CANVAS with locked tokens (max-w, padding, row spacing) per mode

### Density assignments for the new mocks

| Mock | Mode | Container | Notes |
|---|---|---|---|
| `agent-detail.html` | DETAIL | `max-w-5xl`, `space-y-5` between cards | Three sections: identity header, core blocks, facts list |
| `session-detail.html` | DETAIL | `max-w-5xl` | Briefing composer accordion + transcript + ask threads |
| `mesh.html` | CANVAS | `max-w-5xl` for feed; graph can overflow | Two-pane: feed (left) + graph (right) |
| `promotions.html` | LIST | `max-w-6xl`, `py-2.5` rows | Timeline-shaped, abuts |
| `showcase.html` | CANVAS | full-width hero | Public landing — only mock that breaks the chrome |

## Honest data

Every UI element maps to a real schema column. Status icons map to `task.status` / `session.status`. Hierarchy chips from `agent.hierarchy_level`. Scope chips from `memory_fact.scope`. Provenance lines from `memory_fact.agent_id`. The agents page tree comes from `parent_agent_id`. The mesh graph derives edges from `session.type IN ('mesh_ask', 'mesh_negotiate', 'blocker')` joined to the target agent. Promotion events derive from FactPromoter's per-fact reason output joined back to the fact's current scope. The threads page renders the OAuth task's full lifecycle (creation → session → blocker → review → revision) using only fields that exist today.

**Specifically excluded as fields:** anything from the trimmed columns (`memory_fact` had `confidence`, `valid_from`, `tags`, `metadata` removed in migration 1777000000000 — none of those should appear in any mock).

## Out of scope

- Next.js scaffolding (separate PR after design lock)
- LISTEN/NOTIFY trigger migration (separate PR)
- Real auth wiring (mocks use a static \"Weijia\" user widget)
- Mobile responsive polish
- Multi-workspace switcher (deferred to #16)
- Retraction / demotion UI (gap noted in earlier critique cycle; tracked separately once `retract_fact`/`demote_fact` tools land)

## Test plan

- [ ] Open each `mocks/*.html` directly in Chrome / Safari and verify it renders
- [ ] Toggle the sun/moon button on each page → confirm dark/light mode parity
- [ ] Verify all internal links between mocks navigate correctly
- [ ] Confirm `prefers-color-scheme` is honored on first load (system default)
- [ ] Eyeball density consistency — no `pt-12`, no `space-y-10`, no `max-w-2xl` drift
- [ ] **Architectural-claim check:** confirm there is no global memory pool view anywhere; every fact-rendering surface is either per-agent (`agent-detail.html`) or scope-filtered (`memory.html`, `promotions.html`)
- [ ] **Magic-moment dry run:** record a 90-second screen capture using only the mock surfaces, hitting all three magic moments. If a moment isn't filmable, the mock has a gap

## Relationship to other issues

- **#20** — defines the showcase UI requirements; this issue's v2 mocks are its design-mock layer
- **#16** — multi-user product; the visibility chip vocabulary is shared across both
- **#19** — session room POC; AskThread / BriefingComposer / PromotionEvent components defined here are reused there

🤖 Generated with [Claude Code](https://claude.com/claude-code)