### PR TITLE
M8 — web API contract scaffold + detail pages

### DIFF
--- a/packages/web/.env.local.example
+++ b/packages/web/.env.local.example
@@ -1,0 +1,6 @@
+# Base URL for the beevibe MCP server HTTP API. When unset, the web app
+# renders empty states and fires no network requests — this is the
+# intended dev default until M6 ships routes.
+#
+# When backend is running locally:
+# NEXT_PUBLIC_BV_API_URL=http://localhost:3002

--- a/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
+++ b/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft, AlertTriangle, Bot } from "lucide-react";
+import { useAgent } from "@/lib/hooks/use-agents";
+import { isApiConfigured } from "@/lib/api/config";
+import { Avatar } from "@/components/avatar";
+import { HierChip } from "@/components/hier-chip";
+import { CoreBlockCard } from "@/components/agents/core-block-card";
+import { EmptyState } from "@/components/empty-state";
+import { Skeleton } from "@/components/skeleton";
+import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
+import { DetailShell } from "@/components/detail/detail-shell";
+import { FooterField } from "@/components/detail/footer-field";
+import { Metric } from "@/components/detail/metric";
+import { cn } from "@/lib/utils";
+import type { AgentDetail } from "@/lib/api/types";
+import type { RecentSession } from "@/lib/types/agents";
+
+const RECENT_SESSION_DOT: Record<RecentSession["status"], string> = {
+  running: "bg-status-running animate-pulse-breathe",
+  review: "bg-status-review",
+  succeeded: "bg-status-done",
+};
+
+const AgentsBackLink = () => (
+  <Link
+    href="/agents"
+    className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors mb-3"
+  >
+    <ArrowLeft className="h-3 w-3" />
+    Agents
+  </Link>
+);
+
+export function AgentDetailClient({ agentId }: { agentId: string }) {
+  const { data, isLoading, isError } = useAgent(agentId);
+
+  if (!isApiConfigured) {
+    return (
+      <DetailShell nav={<AgentsBackLink />}>
+        <EmptyState
+          icon={Bot}
+          title="API not configured"
+          description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load this agent."
+        />
+      </DetailShell>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <DetailShell nav={<AgentsBackLink />}>
+        <Skeleton className="h-14 w-full mb-6" />
+        <div className="grid grid-cols-3 gap-6">
+          <div className="col-span-2 space-y-4">
+            <Skeleton className="h-32 w-full rounded-lg" />
+            <Skeleton className="h-40 w-full rounded-lg" />
+          </div>
+          <Skeleton className="h-40 w-full rounded-lg" />
+        </div>
+      </DetailShell>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <DetailShell nav={<AgentsBackLink />}>
+        <EmptyState
+          icon={AlertTriangle}
+          title="Couldn't load agent"
+          description={`Agent ${agentId} could not be fetched.`}
+        />
+      </DetailShell>
+    );
+  }
+
+  return <AgentDetailLoaded agent={data} />;
+}
+
+function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
+  const initial = agent.display_name.charAt(0).toUpperCase();
+  const presence = agent.metrics.sessions > 0 ? "idle" : "off";
+
+  return (
+    <DetailShell nav={<AgentsBackLink />}>
+      <header className="mb-6">
+        <div className="flex items-start gap-4">
+          <Avatar initial={initial} kind={agent.hierarchy} size={56} presence={presence} />
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1">
+              <h1 className="text-xl font-semibold leading-tight">{agent.display_name}</h1>
+              <HierChip hier={agent.hierarchy} />
+            </div>
+            {agent.specialization ? (
+              <p className="text-sm text-muted-foreground">{agent.specialization}</p>
+            ) : null}
+          </div>
+          <div className="shrink-0">
+            <button
+              type="button"
+              className="h-8 px-3 rounded text-xs font-medium border border-border hover:bg-secondary transition-colors cursor-pointer"
+            >
+              Edit
+            </button>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-4 gap-x-8 mt-6 pt-6 border-t border-border">
+          <Metric label="Sessions" value={agent.metrics.sessions} />
+          <Metric label="Facts learned" value={agent.metrics.facts} />
+          <Metric label="Merges" value={agent.metrics.merges} />
+          <Metric label="Promoted" value={agent.metrics.promoted} />
+        </div>
+      </header>
+
+      <div className="grid grid-cols-3 gap-6">
+        <div className="col-span-2 space-y-5">
+          <section>
+            <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-3 font-medium">
+              Core memory{" "}
+              <span className="text-muted-foreground/70 tabular-nums">
+                {agent.core_blocks.length}
+              </span>
+            </h2>
+            {agent.core_blocks.length === 0 ? (
+              <p className="text-sm text-muted-foreground italic">No core blocks.</p>
+            ) : (
+              <div className="space-y-3">
+                {agent.core_blocks.map((b) => (
+                  <CoreBlockCard key={b.id} block={b} />
+                ))}
+              </div>
+            )}
+          </section>
+
+          <section>
+            <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-3 font-medium">
+              Recent sessions{" "}
+              <span className="text-muted-foreground/70 tabular-nums">
+                {agent.recent_sessions.length}
+              </span>
+            </h2>
+            {agent.recent_sessions.length === 0 ? (
+              <p className="text-sm text-muted-foreground italic">No recent sessions.</p>
+            ) : (
+              <ul className="space-y-2">
+                {agent.recent_sessions.map((s, i) => (
+                  <RecentSessionRow key={s.short_id ?? i} session={s} />
+                ))}
+              </ul>
+            )}
+          </section>
+        </div>
+
+        <aside className="col-span-1 space-y-4">
+          {agent.outgoing_mesh_hints.length ? (
+            <section className="rounded-lg border border-border bg-card p-4">
+              <h3 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-2 font-medium">
+                Outgoing mesh
+              </h3>
+              <ul className="space-y-2">
+                {agent.outgoing_mesh_hints.map((hint, i) => (
+                  <li key={i} className="text-xs">
+                    <span className="text-foreground/85">{hint.target}</span>{" "}
+                    <span className="text-muted-foreground/70">· {hint.age}</span>
+                    <p className="text-muted-foreground line-clamp-1">{hint.intent}</p>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
+        </aside>
+      </div>
+
+      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+        <FooterField label="ID">
+          <ClickToCopyId id={agent.id} />
+        </FooterField>
+        <FooterField label="Hierarchy">{agent.hierarchy}</FooterField>
+        {agent.runtime ? <FooterField label="Runtime">{agent.runtime}</FooterField> : null}
+        {agent.review_policy ? (
+          <FooterField label="Review policy">{agent.review_policy}</FooterField>
+        ) : null}
+      </footer>
+    </DetailShell>
+  );
+}
+
+function RecentSessionRow({ session }: { session: RecentSession }) {
+  return (
+    <li className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-sm">
+      <span
+        className={cn("h-1.5 w-1.5 rounded-full", RECENT_SESSION_DOT[session.status])}
+        aria-hidden
+      />
+      <span className="flex-1 min-w-0 truncate">{session.title}</span>
+      {session.short_id ? (
+        <span className="font-mono text-xs text-muted-foreground">{session.short_id}</span>
+      ) : null}
+      <span className="text-xs text-muted-foreground tabular-nums shrink-0">{session.age}</span>
+    </li>
+  );
+}

--- a/packages/web/app/(authed)/agents/[id]/page.tsx
+++ b/packages/web/app/(authed)/agents/[id]/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
-import { notFound } from "next/navigation";
+import { AgentDetailClient } from "./agent-detail-client";
 
 export const metadata: Metadata = { title: "Agent" };
 
-export default function AgentDetailPage(_props: { params: { id: string } }) {
-  notFound();
+export default function AgentDetailPage({ params }: { params: { id: string } }) {
+  return <AgentDetailClient agentId={params.id} />;
 }

--- a/packages/web/app/(authed)/agents/agents-client.test.tsx
+++ b/packages/web/app/(authed)/agents/agents-client.test.tsx
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { AgentDisplay } from "@/lib/types/agents";
+
+const apiState = { isApiConfigured: true };
+
+vi.mock("@/lib/api/config", () => ({
+  get isApiConfigured() {
+    return apiState.isApiConfigured;
+  },
+}));
+
+vi.mock("@/lib/api/client", () => ({
+  api: { agents: { list: vi.fn(), get: vi.fn() } },
+}));
+
+import { AgentsClient } from "./agents-client";
+import { api } from "@/lib/api/client";
+
+const listMock = vi.mocked(api.agents.list);
+
+function renderAgents() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  }
+  return render(<AgentsClient />, { wrapper: Wrapper });
+}
+
+const baseAgent: AgentDisplay = {
+  id: "agt_1",
+  name: "alice",
+  display_name: "Alice",
+  hierarchy: "ic",
+  hierarchy_level: "ic",
+  owner_id: "u_1",
+  created_at: new Date(),
+  updated_at: new Date(),
+};
+
+beforeEach(() => {
+  apiState.isApiConfigured = true;
+  listMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("AgentsClient", () => {
+  it("renders the not-configured empty state when env is unset", () => {
+    apiState.isApiConfigured = false;
+    renderAgents();
+    expect(screen.getByText("API not configured")).toBeInTheDocument();
+    expect(listMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to OrgChart + SpecializationTable when api returns []", async () => {
+    listMock.mockResolvedValue([]);
+    renderAgents();
+    expect(
+      await screen.findByRole("heading", { name: /Specialization depth/i }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("No agents yet").length).toBeGreaterThan(0);
+  });
+
+  it("renders agent rows with hierarchy chip + session count when populated", async () => {
+    listMock.mockResolvedValue([
+      { ...baseAgent, id: "a1", display_name: "Alice", sessions_count: 5 },
+      { ...baseAgent, id: "a2", display_name: "Bob", hierarchy: "team", sessions_count: 12 },
+    ]);
+    renderAgents();
+    expect(await screen.findByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+    expect(screen.getByText("5 sessions")).toBeInTheDocument();
+    expect(screen.getByText("12 sessions")).toBeInTheDocument();
+    expect(
+      screen.getByText((_, el) => el?.textContent === "2 agents in your org."),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/web/app/(authed)/agents/agents-client.tsx
+++ b/packages/web/app/(authed)/agents/agents-client.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import Link from "next/link";
+import { AlertTriangle, Bot, Plus } from "lucide-react";
+import { useAgents } from "@/lib/hooks/use-agents";
+import { isApiConfigured } from "@/lib/api/config";
+import { OrgChart } from "@/components/agents/org-chart";
+import { SpecializationTable } from "@/components/agents/specialization-table";
+import { EmptyState } from "@/components/empty-state";
+import { Skeleton } from "@/components/skeleton";
+import { Avatar } from "@/components/avatar";
+import { HierChip } from "@/components/hier-chip";
+import type { AgentDisplay } from "@/lib/types/agents";
+
+export function AgentsClient() {
+  const { data, isLoading, isError } = useAgents();
+  const count = data?.length ?? 0;
+
+  return (
+    <div className="flex-1 overflow-auto">
+      <div className="pt-8 pb-12 px-6">
+        <div className="max-w-5xl mx-auto flex items-end justify-between gap-6 mb-8">
+          <div className="text-base text-muted-foreground">
+            {count > 0 ? (
+              <>
+                <span className="text-foreground font-medium tabular-nums">{count}</span>{" "}
+                {count === 1 ? "agent" : "agents"} in your org.
+              </>
+            ) : (
+              <>
+                <span className="text-foreground font-medium">No agents</span> in your org yet.
+              </>
+            )}
+          </div>
+          <button
+            type="button"
+            className="inline-flex items-center gap-2 h-8 px-3 rounded bg-primary text-primary-foreground text-xs font-medium hover:opacity-90 active:scale-[0.98] transition-all duration-150 cursor-pointer shrink-0"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            New agent
+          </button>
+        </div>
+
+        <div className="max-w-5xl mx-auto">
+          <Body data={data} isLoading={isLoading} isError={isError} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Body({
+  data,
+  isLoading,
+  isError,
+}: {
+  data: AgentDisplay[] | undefined;
+  isLoading: boolean;
+  isError: boolean;
+}) {
+  if (!isApiConfigured) {
+    return (
+      <div className="rounded-lg border border-dashed border-border">
+        <EmptyState
+          icon={Bot}
+          title="API not configured"
+          description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load agents."
+        />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-lg border border-dashed border-border">
+        <EmptyState icon={AlertTriangle} title="Couldn't load agents" />
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        {[0, 1, 2, 3].map((i) => (
+          <Skeleton key={i} className="h-16 rounded-lg" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <>
+        <OrgChart />
+        <SpecializationTable />
+      </>
+    );
+  }
+
+  return (
+    <ul className="space-y-2">
+      {data.map((agent) => (
+        <AgentRow key={agent.id} agent={agent} />
+      ))}
+    </ul>
+  );
+}
+
+function AgentRow({ agent }: { agent: AgentDisplay }) {
+  const initial = agent.display_name.charAt(0).toUpperCase();
+  return (
+    <li>
+      <Link
+        href={`/agents/${agent.id}`}
+        className="flex items-center gap-3 rounded-lg border border-border bg-card p-3 hover:bg-secondary/30 transition-colors"
+      >
+        <Avatar initial={initial} kind={agent.hierarchy} size={36} />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium truncate">{agent.display_name}</span>
+            <HierChip hier={agent.hierarchy} />
+          </div>
+          {agent.specialization ? (
+            <p className="text-xs text-muted-foreground truncate mt-0.5">{agent.specialization}</p>
+          ) : null}
+        </div>
+        <div className="text-xs text-muted-foreground tabular-nums shrink-0">
+          {agent.sessions_count ?? 0} sessions
+        </div>
+      </Link>
+    </li>
+  );
+}

--- a/packages/web/app/(authed)/agents/page.tsx
+++ b/packages/web/app/(authed)/agents/page.tsx
@@ -1,29 +1,8 @@
 import type { Metadata } from "next";
-import { Plus } from "lucide-react";
-import { OrgChart } from "@/components/agents/org-chart";
-import { SpecializationTable } from "@/components/agents/specialization-table";
+import { AgentsClient } from "./agents-client";
 
 export const metadata: Metadata = { title: "Agents" };
 
 export default function AgentsPage() {
-  return (
-    <div className="flex-1 overflow-auto">
-      <div className="pt-8 pb-12 px-6">
-        <div className="max-w-5xl mx-auto flex items-end justify-between gap-6 mb-8">
-          <div className="text-base text-muted-foreground">
-            <span className="text-foreground font-medium">No agents</span> in your org yet.
-          </div>
-          <button className="inline-flex items-center gap-2 h-8 px-3 rounded bg-primary text-primary-foreground text-xs font-medium hover:opacity-90 active:scale-[0.98] transition-all duration-150 cursor-pointer shrink-0">
-            <Plus className="h-3.5 w-3.5" />
-            New agent
-          </button>
-        </div>
-
-        <div className="max-w-5xl mx-auto">
-          <OrgChart />
-          <SpecializationTable />
-        </div>
-      </div>
-    </div>
-  );
+  return <AgentsClient />;
 }

--- a/packages/web/app/(authed)/home-client.test.tsx
+++ b/packages/web/app/(authed)/home-client.test.tsx
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { DashboardSummary } from "@/lib/api/types";
+
+const apiState = { isApiConfigured: true };
+
+vi.mock("@/lib/api/config", () => ({
+  get isApiConfigured() {
+    return apiState.isApiConfigured;
+  },
+}));
+
+vi.mock("@/lib/api/client", () => ({
+  api: { dashboard: { summary: vi.fn() } },
+}));
+
+import { HomeClient } from "./home-client";
+import { api } from "@/lib/api/client";
+
+const summaryMock = vi.mocked(api.dashboard.summary);
+
+function renderHome() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  }
+  return render(<HomeClient />, { wrapper: Wrapper });
+}
+
+const sample: DashboardSummary = {
+  kpis: [
+    {
+      label: "Active sessions",
+      value: "12",
+      meta: [{ text: "rolling 24h" }],
+      href: "/tasks",
+      trend: [1, 2, 3, 4, 5],
+      trend_color: "running",
+      trend_kind: "line",
+    },
+  ],
+  status_breakdown: [
+    { status: "in_progress", label: "running", color: "running", count: 7, percent: 50 },
+  ],
+  status_legend: [{ color: "running", label: "running", count: 7 }],
+  status_total: 14,
+  fleet: [{ hier: "ic", count: 3, percent: 60 }],
+  fleet_total: 5,
+  fleet_active: 2,
+  fleet_idle: 3,
+  trend: [{ label: "Mon", value: 4 }],
+  trend_total: 28,
+  trend_change_percent: 12,
+  attention: [
+    { status: "blocked", title: "needs key", age: "2h", href: "/tasks/t1" },
+  ],
+};
+
+beforeEach(() => {
+  apiState.isApiConfigured = true;
+  summaryMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("HomeClient", () => {
+  it("renders the not-configured empty state and never fetches", () => {
+    apiState.isApiConfigured = false;
+    renderHome();
+    expect(screen.getByText("Dashboard not connected")).toBeInTheDocument();
+    expect(summaryMock).not.toHaveBeenCalled();
+  });
+
+  it("renders the error empty state when fetch fails", async () => {
+    summaryMock.mockRejectedValue(new Error("boom"));
+    renderHome();
+    expect(await screen.findByText("Couldn't load dashboard")).toBeInTheDocument();
+  });
+
+  it("renders KPIs + breakdown + fleet + attention when data is loaded", async () => {
+    summaryMock.mockResolvedValue(sample);
+    renderHome();
+    expect(await screen.findByText("Active sessions")).toBeInTheDocument();
+    expect(screen.getByText("Needs attention")).toBeInTheDocument();
+    expect(screen.getByText("needs key")).toBeInTheDocument();
+  });
+});

--- a/packages/web/app/(authed)/home-client.tsx
+++ b/packages/web/app/(authed)/home-client.tsx
@@ -6,12 +6,20 @@ import { useDashboard } from "@/lib/hooks/use-dashboard";
 import { isApiConfigured } from "@/lib/api/config";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
+import { KpiTileSkeleton } from "@/components/skeletons";
+import { cn } from "@/lib/utils";
 import { KpiTile } from "@/components/home/kpi-tile";
 import { FleetBars } from "@/components/home/fleet-bars";
 import { StatusBreakdownBar } from "@/components/home/status-breakdown";
 import { TrendChart } from "@/components/home/trend-chart";
 import type { DashboardSummary } from "@/lib/api/types";
 import type { AttentionItem } from "@/lib/types/dashboard";
+
+const ATTENTION_DOT: Record<AttentionItem["status"], string> = {
+  blocked: "bg-status-blocked",
+  failed: "bg-status-failed",
+  review: "bg-status-review",
+};
 
 export function HomeClient() {
   const { data, isLoading, isError } = useDashboard();
@@ -63,7 +71,7 @@ function Body({
       <div className="space-y-6">
         <div className="grid grid-cols-4 gap-6">
           {[0, 1, 2, 3].map((i) => (
-            <Skeleton key={i} className="h-24 rounded-lg" />
+            <KpiTileSkeleton key={i} />
           ))}
         </div>
         <Skeleton className="h-32 rounded-lg" />
@@ -124,19 +132,16 @@ function Body({
 }
 
 function AttentionRow({ item }: { item: AttentionItem }) {
-  const dot =
-    item.status === "blocked"
-      ? "bg-status-blocked"
-      : item.status === "failed"
-        ? "bg-status-failed"
-        : "bg-status-review";
   return (
     <li>
       <Link
         href={item.href}
         className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 hover:bg-secondary/30 transition-colors"
       >
-        <span className={`h-1.5 w-1.5 rounded-full shrink-0 ${dot}`} aria-hidden />
+        <span
+          className={cn("h-1.5 w-1.5 rounded-full shrink-0", ATTENTION_DOT[item.status])}
+          aria-hidden
+        />
         <span className="flex-1 min-w-0 truncate text-sm">{item.title}</span>
         <span className="text-xs text-muted-foreground tabular-nums shrink-0">{item.age}</span>
       </Link>

--- a/packages/web/app/(authed)/home-client.tsx
+++ b/packages/web/app/(authed)/home-client.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import Link from "next/link";
+import { AlertTriangle, LayoutDashboard } from "lucide-react";
+import { useDashboard } from "@/lib/hooks/use-dashboard";
+import { isApiConfigured } from "@/lib/api/config";
+import { EmptyState } from "@/components/empty-state";
+import { Skeleton } from "@/components/skeleton";
+import { KpiTile } from "@/components/home/kpi-tile";
+import { FleetBars } from "@/components/home/fleet-bars";
+import { StatusBreakdownBar } from "@/components/home/status-breakdown";
+import { TrendChart } from "@/components/home/trend-chart";
+import type { DashboardSummary } from "@/lib/api/types";
+import type { AttentionItem } from "@/lib/types/dashboard";
+
+export function HomeClient() {
+  const { data, isLoading, isError } = useDashboard();
+
+  return (
+    <div className="flex-1 overflow-auto">
+      <div className="max-w-6xl mx-auto pt-8 pb-12 px-6">
+        <Body data={data} isLoading={isLoading} isError={isError} />
+      </div>
+    </div>
+  );
+}
+
+function Body({
+  data,
+  isLoading,
+  isError,
+}: {
+  data: DashboardSummary | undefined;
+  isLoading: boolean;
+  isError: boolean;
+}) {
+  if (!isApiConfigured) {
+    return (
+      <div className="rounded-lg border border-dashed border-border">
+        <EmptyState
+          icon={LayoutDashboard}
+          title="Dashboard not connected"
+          description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load KPIs and fleet status."
+        />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-lg border border-dashed border-border">
+        <EmptyState
+          icon={AlertTriangle}
+          title="Couldn't load dashboard"
+          description="Check that the MCP server is reachable."
+        />
+      </div>
+    );
+  }
+
+  if (isLoading || !data) {
+    return (
+      <div className="space-y-6">
+        <div className="grid grid-cols-4 gap-6">
+          {[0, 1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-24 rounded-lg" />
+          ))}
+        </div>
+        <Skeleton className="h-32 rounded-lg" />
+        <Skeleton className="h-48 rounded-lg" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-4 gap-6">
+        {data.kpis.map((stat, i) => (
+          <KpiTile key={i} stat={stat} />
+        ))}
+      </div>
+
+      <div className="grid grid-cols-3 gap-6">
+        <div className="col-span-2 rounded-lg border border-border bg-card p-5">
+          <StatusBreakdownBar
+            entries={data.status_breakdown}
+            legend={data.status_legend}
+            total={data.status_total}
+          />
+        </div>
+        <div className="rounded-lg border border-border bg-card p-5">
+          <FleetBars
+            bars={data.fleet}
+            total={data.fleet_total}
+            active={data.fleet_active}
+            idle={data.fleet_idle}
+          />
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-border bg-card p-5">
+        <TrendChart
+          days={data.trend}
+          total={data.trend_total}
+          changePercent={data.trend_change_percent}
+        />
+      </div>
+
+      {data.attention.length > 0 ? (
+        <section>
+          <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-3 font-medium">
+            Needs attention{" "}
+            <span className="text-muted-foreground/70 tabular-nums">{data.attention.length}</span>
+          </h2>
+          <ul className="space-y-2">
+            {data.attention.map((item, i) => (
+              <AttentionRow key={i} item={item} />
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </div>
+  );
+}
+
+function AttentionRow({ item }: { item: AttentionItem }) {
+  const dot =
+    item.status === "blocked"
+      ? "bg-status-blocked"
+      : item.status === "failed"
+        ? "bg-status-failed"
+        : "bg-status-review";
+  return (
+    <li>
+      <Link
+        href={item.href}
+        className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 hover:bg-secondary/30 transition-colors"
+      >
+        <span className={`h-1.5 w-1.5 rounded-full shrink-0 ${dot}`} aria-hidden />
+        <span className="flex-1 min-w-0 truncate text-sm">{item.title}</span>
+        <span className="text-xs text-muted-foreground tabular-nums shrink-0">{item.age}</span>
+      </Link>
+    </li>
+  );
+}

--- a/packages/web/app/(authed)/memory/memory-client.tsx
+++ b/packages/web/app/(authed)/memory/memory-client.tsx
@@ -16,7 +16,7 @@ import {
 import type { MemoryScope } from "@beevibe/core";
 import { ScopeTabs, type ScopeFilter } from "@/components/memory/scope-tabs";
 import { EmptyState } from "@/components/empty-state";
-import { Skeleton } from "@/components/skeleton";
+import { FactRowSkeleton } from "@/components/skeletons";
 import { FactTypeTag } from "@/components/fact-type-tag";
 import { ScopeChip } from "@/components/scope-chip";
 import { RichTextRender } from "@/components/rich-text";
@@ -26,6 +26,7 @@ import { formatRelativeTime } from "@/lib/format";
 import type { MemoryFactDisplay, FactCounts } from "@/lib/types/memory-facts";
 
 const EMPTY_COUNTS: FactCounts = { total: 0, ic: 0, team: 0, org: 0 };
+const EMPTY_FACTS: MemoryFactDisplay[] = [];
 
 export function MemoryClient() {
   const [scope, setScope] = useState<ScopeFilter>("all");
@@ -34,8 +35,10 @@ export function MemoryClient() {
   const filterScope: MemoryScope | undefined = scope === "all" ? undefined : scope;
   const { data, isLoading, isError } = useMemoryFacts({ scope: filterScope });
 
-  const counts = useMemo(() => deriveCounts(data ?? []), [data]);
-  const filtered = useMemo(() => applyFilter(data ?? [], query), [data, query]);
+  const facts = data ?? EMPTY_FACTS;
+  const counts = useMemo(() => deriveCounts(facts), [facts]);
+  const haystacks = useMemo(() => buildHaystacks(facts), [facts]);
+  const filtered = useMemo(() => applyFilter(facts, haystacks, query), [facts, haystacks, query]);
 
   return (
     <>
@@ -136,11 +139,7 @@ function Body({
     return (
       <>
         {[0, 1, 2, 3].map((i) => (
-          <tr key={i}>
-            <td colSpan={5} className="px-3 py-3">
-              <Skeleton className="h-5 w-full" />
-            </td>
-          </tr>
+          <FactRowSkeleton key={i} />
         ))}
       </>
     );
@@ -217,13 +216,22 @@ function deriveCounts(facts: MemoryFactDisplay[]): FactCounts {
   return counts;
 }
 
-function applyFilter(facts: MemoryFactDisplay[], query: string): MemoryFactDisplay[] {
+function buildHaystacks(facts: MemoryFactDisplay[]): string[] {
+  return facts.map((f) => {
+    const content =
+      typeof f.content === "string" ? f.content : f.content.map(stringify).join(" ");
+    return `${content} ${f.agent_label}`.toLowerCase();
+  });
+}
+
+function applyFilter(
+  facts: MemoryFactDisplay[],
+  haystacks: string[],
+  query: string,
+): MemoryFactDisplay[] {
   const q = query.trim().toLowerCase();
   if (!q) return facts;
-  return facts.filter((f) => {
-    const text = typeof f.content === "string" ? f.content : f.content.map(stringify).join(" ");
-    return text.toLowerCase().includes(q) || f.agent_label.toLowerCase().includes(q);
-  });
+  return facts.filter((_, i) => haystacks[i].includes(q));
 }
 
 function stringify(seg: string | { mono: string }): string {

--- a/packages/web/app/(authed)/memory/memory-client.tsx
+++ b/packages/web/app/(authed)/memory/memory-client.tsx
@@ -1,19 +1,45 @@
 "use client";
 
-import { useState } from "react";
-import { ChevronDown, Search, ArrowUpDown, BookText, Bot, Clock, Layers, Sparkles, Tags } from "lucide-react";
+import { useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  ArrowUpDown,
+  BookText,
+  Bot,
+  ChevronDown,
+  Clock,
+  Layers,
+  Search,
+  Sparkles,
+  Tags,
+} from "lucide-react";
+import type { MemoryScope } from "@beevibe/core";
 import { ScopeTabs, type ScopeFilter } from "@/components/memory/scope-tabs";
 import { EmptyState } from "@/components/empty-state";
+import { Skeleton } from "@/components/skeleton";
+import { FactTypeTag } from "@/components/fact-type-tag";
+import { ScopeChip } from "@/components/scope-chip";
+import { RichTextRender } from "@/components/rich-text";
+import { useMemoryFacts } from "@/lib/hooks/use-memory";
+import { isApiConfigured } from "@/lib/api/config";
+import { formatRelativeTime } from "@/lib/format";
+import type { MemoryFactDisplay, FactCounts } from "@/lib/types/memory-facts";
 
-const EMPTY_COUNTS = { total: 0, ic: 0, team: 0, org: 0 };
+const EMPTY_COUNTS: FactCounts = { total: 0, ic: 0, team: 0, org: 0 };
 
 export function MemoryClient() {
   const [scope, setScope] = useState<ScopeFilter>("all");
   const [query, setQuery] = useState("");
 
+  const filterScope: MemoryScope | undefined = scope === "all" ? undefined : scope;
+  const { data, isLoading, isError } = useMemoryFacts({ scope: filterScope });
+
+  const counts = useMemo(() => deriveCounts(data ?? []), [data]);
+  const filtered = useMemo(() => applyFilter(data ?? [], query), [data, query]);
+
   return (
     <>
-      <ScopeTabs current={scope} counts={EMPTY_COUNTS} onChange={setScope} />
+      <ScopeTabs current={scope} counts={counts} onChange={setScope} />
 
       <div className="flex items-center gap-2 mb-3">
         <div className="relative flex-1 max-w-lg">
@@ -34,9 +60,12 @@ export function MemoryClient() {
 
       <div className="flex items-center justify-between mb-2 text-xs text-muted-foreground">
         <span>
-          <span className="text-foreground tabular-nums">0</span> facts
+          <span className="text-foreground tabular-nums">{filtered.length}</span> facts
         </span>
-        <button className="inline-flex items-center gap-1.5 hover:text-foreground transition-colors">
+        <button
+          type="button"
+          className="inline-flex items-center gap-1.5 hover:text-foreground transition-colors"
+        >
           <ArrowUpDown className="h-3 w-3" />
           <span>Sort: recently learned</span>
           <ChevronDown className="h-3 w-3" />
@@ -55,18 +84,105 @@ export function MemoryClient() {
             </tr>
           </thead>
           <tbody>
-            <tr>
-              <td colSpan={5}>
-                <EmptyState
-                  icon={Sparkles}
-                  title="No facts learned yet"
-                  description="Memory facts appear here as agents work and the FactPromoter saves observations."
-                />
-              </td>
-            </tr>
+            <Body
+              facts={filtered}
+              isLoading={isLoading}
+              isError={isError}
+              hasQuery={query.length > 0}
+            />
           </tbody>
         </table>
       </div>
+    </>
+  );
+}
+
+function Body({
+  facts,
+  isLoading,
+  isError,
+  hasQuery,
+}: {
+  facts: MemoryFactDisplay[];
+  isLoading: boolean;
+  isError: boolean;
+  hasQuery: boolean;
+}) {
+  if (!isApiConfigured) {
+    return (
+      <tr>
+        <td colSpan={5}>
+          <EmptyState
+            icon={Sparkles}
+            title="No facts learned yet"
+            description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load memory."
+          />
+        </td>
+      </tr>
+    );
+  }
+
+  if (isError) {
+    return (
+      <tr>
+        <td colSpan={5}>
+          <EmptyState icon={AlertTriangle} title="Couldn't load memory" />
+        </td>
+      </tr>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <>
+        {[0, 1, 2, 3].map((i) => (
+          <tr key={i}>
+            <td colSpan={5} className="px-3 py-3">
+              <Skeleton className="h-5 w-full" />
+            </td>
+          </tr>
+        ))}
+      </>
+    );
+  }
+
+  if (facts.length === 0) {
+    return (
+      <tr>
+        <td colSpan={5}>
+          <EmptyState
+            icon={Sparkles}
+            title={hasQuery ? "No matching facts" : "No facts learned yet"}
+            description={
+              hasQuery
+                ? "Try a different search."
+                : "Memory facts appear here as agents accumulate observations."
+            }
+          />
+        </td>
+      </tr>
+    );
+  }
+
+  return (
+    <>
+      {facts.map((fact) => (
+        <tr key={fact.id} className="border-t border-border">
+          <td className="px-3 py-3">
+            <RichTextRender value={fact.content} />
+          </td>
+          <td className="px-3 py-3">
+            <FactTypeTag type={fact.fact_type} />
+          </td>
+          <td className="px-3 py-3">
+            <ScopeChip scope={fact.scope} />
+          </td>
+          <td className="px-3 py-3 text-xs text-muted-foreground">{fact.agent_label}</td>
+          <td className="px-3 py-3 text-xs text-muted-foreground tabular-nums">
+            {formatRelativeTime(fact.created_at)}
+          </td>
+        </tr>
+      ))}
     </>
   );
 }
@@ -84,9 +200,32 @@ function Th({ icon, children }: { icon: React.ReactNode; children: React.ReactNo
 
 function FilterButton({ label }: { label: string }) {
   return (
-    <button className="inline-flex items-center gap-1.5 h-9 px-3 text-xs rounded-md hover:bg-secondary cursor-pointer transition-colors text-muted-foreground">
+    <button
+      type="button"
+      className="inline-flex items-center gap-1.5 h-9 px-3 text-xs rounded-md hover:bg-secondary cursor-pointer transition-colors text-muted-foreground"
+    >
       <span>{label}</span>
       <ChevronDown className="h-3 w-3" />
     </button>
   );
+}
+
+function deriveCounts(facts: MemoryFactDisplay[]): FactCounts {
+  if (facts.length === 0) return EMPTY_COUNTS;
+  const counts: FactCounts = { total: facts.length, ic: 0, team: 0, org: 0 };
+  for (const f of facts) counts[f.scope] += 1;
+  return counts;
+}
+
+function applyFilter(facts: MemoryFactDisplay[], query: string): MemoryFactDisplay[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return facts;
+  return facts.filter((f) => {
+    const text = typeof f.content === "string" ? f.content : f.content.map(stringify).join(" ");
+    return text.toLowerCase().includes(q) || f.agent_label.toLowerCase().includes(q);
+  });
+}
+
+function stringify(seg: string | { mono: string }): string {
+  return typeof seg === "string" ? seg : seg.mono;
 }

--- a/packages/web/app/(authed)/mesh/mesh-client.tsx
+++ b/packages/web/app/(authed)/mesh/mesh-client.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { AlertTriangle, Info, Network } from "lucide-react";
+import { EmptyState } from "@/components/empty-state";
+import { Skeleton } from "@/components/skeleton";
+import { MeshActivityFeed } from "@/components/mesh/activity-feed";
+import { MeshGraphStatic } from "@/components/mesh/graph-static";
+import { ChainBudget } from "@/components/mesh/chain-budget";
+import { useMeshOverview } from "@/lib/hooks/use-mesh";
+import { isApiConfigured } from "@/lib/api/config";
+import type { MeshOverview } from "@/lib/api/types";
+import type { MeshAsk } from "@/lib/types/mesh";
+
+export function MeshClient() {
+  const { data, isLoading, isError } = useMeshOverview();
+
+  return (
+    <div className="flex-1 overflow-auto">
+      <div className="max-w-5xl mx-auto pt-8 pb-12 px-6">
+        <div className="mb-6 flex items-baseline justify-between gap-6">
+          <div>
+            <h1 className="text-base font-semibold mb-1">Mesh activity</h1>
+            <p className="text-sm text-muted-foreground max-w-prose leading-relaxed">
+              Agents ask each other when their bounded context isn&rsquo;t enough. Each ask is a session
+              — caller&rsquo;s intent, target&rsquo;s response, with provenance.{" "}
+              <span className="font-mono text-foreground">ChainBudget</span> caps depth and total
+              tokens per chain to prevent runaway loops.
+            </p>
+          </div>
+        </div>
+
+        <Body data={data} isLoading={isLoading} isError={isError} />
+
+        <div className="mt-10 text-xs text-muted-foreground flex items-start gap-2 max-w-2xl">
+          <Info className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+          <span>
+            <span className="text-foreground/80">Each ask is a session.</span> Caller and target
+            agents stay bounded — neither dumps its memory into a shared pool. The target answers
+            from its own context; the caller incorporates the answer into its work.{" "}
+            <span className="font-mono">ChainBudget</span> caps depth and total tokens to prevent
+            runaway asks.
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Body({
+  data,
+  isLoading,
+  isError,
+}: {
+  data: MeshOverview | undefined;
+  isLoading: boolean;
+  isError: boolean;
+}) {
+  if (!isApiConfigured) {
+    return (
+      <div className="rounded-lg border border-dashed border-border">
+        <EmptyState
+          icon={Network}
+          title="No mesh asks yet"
+          description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load mesh activity."
+        />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-lg border border-dashed border-border">
+        <EmptyState icon={AlertTriangle} title="Couldn't load mesh activity" />
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-5 gap-6">
+        <div className="col-span-3 space-y-2">
+          {[0, 1, 2].map((i) => (
+            <Skeleton key={i} className="h-20 rounded-lg" />
+          ))}
+        </div>
+        <div className="col-span-2">
+          <Skeleton className="h-[480px] rounded-lg" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!data || data.asks.length === 0) {
+    return (
+      <div className="grid grid-cols-5 gap-6">
+        <MeshActivityFeed />
+        <div className="col-span-2">
+          <MeshGraphStatic />
+          <ChainBudget />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-5 gap-6">
+      <section className="col-span-3">
+        <h2 className="text-[10px] uppercase tracking-wider text-muted-foreground mb-3">
+          Recent asks{" "}
+          <span className="text-muted-foreground/70 tabular-nums">{data.asks.length}</span>
+        </h2>
+        <ul className="space-y-2">
+          {data.asks.map((ask) => (
+            <AskRow key={ask.id} ask={ask} />
+          ))}
+        </ul>
+      </section>
+      <div className="col-span-2 space-y-3">
+        <div className="rounded-lg border border-border bg-card p-4 text-xs text-muted-foreground">
+          <div className="text-[10px] uppercase tracking-wider mb-2 text-foreground">
+            Live graph · last 24h
+          </div>
+          <div>
+            <span className="text-foreground tabular-nums">{data.graph.edges.length}</span> edges ·{" "}
+            <span className="text-foreground tabular-nums">{data.graph.nodes.length}</span> agents
+          </div>
+        </div>
+        <ChainBudget />
+      </div>
+    </div>
+  );
+}
+
+function AskRow({ ask }: { ask: MeshAsk }) {
+  return (
+    <li className="rounded-lg border border-border bg-card p-3 text-sm">
+      <div className="flex items-center gap-2 text-xs text-muted-foreground mb-1">
+        <span className="text-foreground/85">{ask.caller}</span>
+        <span>→</span>
+        <span className="text-foreground/85">{ask.target}</span>
+        <span className="ml-auto tabular-nums">{ask.duration_label}</span>
+      </div>
+    </li>
+  );
+}

--- a/packages/web/app/(authed)/mesh/mesh-client.tsx
+++ b/packages/web/app/(authed)/mesh/mesh-client.tsx
@@ -3,6 +3,7 @@
 import { AlertTriangle, Info, Network } from "lucide-react";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
+import { MeshAskSkeleton } from "@/components/skeletons";
 import { MeshActivityFeed } from "@/components/mesh/activity-feed";
 import { MeshGraphStatic } from "@/components/mesh/graph-static";
 import { ChainBudget } from "@/components/mesh/chain-budget";
@@ -80,7 +81,7 @@ function Body({
       <div className="grid grid-cols-5 gap-6">
         <div className="col-span-3 space-y-2">
           {[0, 1, 2].map((i) => (
-            <Skeleton key={i} className="h-20 rounded-lg" />
+            <MeshAskSkeleton key={i} />
           ))}
         </div>
         <div className="col-span-2">

--- a/packages/web/app/(authed)/mesh/page.tsx
+++ b/packages/web/app/(authed)/mesh/page.tsx
@@ -1,46 +1,8 @@
 import type { Metadata } from "next";
-import { Info } from "lucide-react";
-import { MeshActivityFeed } from "@/components/mesh/activity-feed";
-import { ChainBudget } from "@/components/mesh/chain-budget";
-import { MeshGraphStatic } from "@/components/mesh/graph-static";
+import { MeshClient } from "./mesh-client";
 
 export const metadata: Metadata = { title: "Mesh" };
 
 export default function MeshPage() {
-  return (
-    <div className="flex-1 overflow-auto">
-      <div className="max-w-5xl mx-auto pt-8 pb-12 px-6">
-        <div className="mb-6 flex items-baseline justify-between gap-6">
-          <div>
-            <h1 className="text-base font-semibold mb-1">Mesh activity</h1>
-            <p className="text-sm text-muted-foreground max-w-prose leading-relaxed">
-              Agents ask each other when their bounded context isn&rsquo;t enough. Each ask is a session
-              — caller&rsquo;s intent, target&rsquo;s response, with provenance.{" "}
-              <span className="font-mono text-foreground">ChainBudget</span> caps depth and total
-              tokens per chain to prevent runaway loops.
-            </p>
-          </div>
-        </div>
-
-        <div className="grid grid-cols-5 gap-6">
-          <MeshActivityFeed />
-          <div className="col-span-2">
-            <MeshGraphStatic />
-            <ChainBudget />
-          </div>
-        </div>
-
-        <div className="mt-10 text-xs text-muted-foreground flex items-start gap-2 max-w-2xl">
-          <Info className="h-3.5 w-3.5 shrink-0 mt-0.5" />
-          <span>
-            <span className="text-foreground/80">Each ask is a session.</span> Caller and target
-            agents stay bounded — neither dumps its memory into a shared pool. The target answers
-            from its own context; the caller incorporates the answer into its work.{" "}
-            <span className="font-mono">ChainBudget</span> caps depth and total tokens to prevent
-            runaway asks.
-          </span>
-        </div>
-      </div>
-    </div>
-  );
+  return <MeshClient />;
 }

--- a/packages/web/app/(authed)/page.tsx
+++ b/packages/web/app/(authed)/page.tsx
@@ -1,21 +1,8 @@
 import type { Metadata } from "next";
-import { LayoutDashboard } from "lucide-react";
-import { EmptyState } from "@/components/empty-state";
+import { HomeClient } from "./home-client";
 
 export const metadata: Metadata = { title: "Home" };
 
 export default function HomePage() {
-  return (
-    <div className="flex-1 overflow-auto">
-      <div className="max-w-6xl mx-auto pt-8 pb-12 px-6">
-        <div className="rounded-lg border border-dashed border-border">
-          <EmptyState
-            icon={LayoutDashboard}
-            title="Dashboard not connected"
-            description="KPIs, fleet status, and trend data will appear here once the API is wired up."
-          />
-        </div>
-      </div>
-    </div>
-  );
+  return <HomeClient />;
 }

--- a/packages/web/app/(authed)/promotions/page.tsx
+++ b/packages/web/app/(authed)/promotions/page.tsx
@@ -1,46 +1,8 @@
 import type { Metadata } from "next";
-import { Info, TrendingUp } from "lucide-react";
-import { EmptyState } from "@/components/empty-state";
-import { MemorySubNav } from "@/components/memory/sub-nav";
+import { PromotionsClient } from "./promotions-client";
 
 export const metadata: Metadata = { title: "Promotions" };
 
 export default function PromotionsPage() {
-  return (
-    <div className="flex-1 overflow-auto">
-      <div className="max-w-6xl mx-auto pt-8 pb-12 px-6">
-        <MemorySubNav />
-
-        <div className="mb-6 flex items-baseline justify-between gap-6">
-          <div>
-            <h1 className="text-base font-semibold mb-1">Promotions</h1>
-            <p className="text-sm text-muted-foreground max-w-prose leading-relaxed">
-              When the same observation reappears across sessions,{" "}
-              <span className="font-mono text-foreground">FactPromoter</span> evaluates whether it has
-              earned a wider scope. Each event below is the LLM&rsquo;s per-fact decision with its stated
-              reason. The default is to keep facts narrow.
-            </p>
-          </div>
-        </div>
-
-        <div className="rounded-lg border border-dashed border-border">
-          <EmptyState
-            icon={TrendingUp}
-            title="No promotions yet"
-            description="Promotion decisions appear here as agents accumulate facts across sessions."
-          />
-        </div>
-
-        <div className="mt-10 text-xs text-muted-foreground flex items-start gap-2 max-w-2xl">
-          <Info className="h-3.5 w-3.5 shrink-0 mt-0.5" />
-          <span>
-            <span className="text-foreground/80">No flat pool exists.</span> Every fact, at every
-            scope, is attributed to its originating agent (
-            <span className="font-mono">memory_fact.agent_id</span> is non-null). Promotion changes{" "}
-            <em>visibility radius</em>, not authorship.
-          </span>
-        </div>
-      </div>
-    </div>
-  );
+  return <PromotionsClient />;
 }

--- a/packages/web/app/(authed)/promotions/promotions-client.tsx
+++ b/packages/web/app/(authed)/promotions/promotions-client.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { AlertTriangle, Info, TrendingUp } from "lucide-react";
+import { EmptyState } from "@/components/empty-state";
+import { Skeleton } from "@/components/skeleton";
+import { MemorySubNav } from "@/components/memory/sub-nav";
+import { PromotionEventRow } from "@/components/promotions/event-row";
+import { usePromotions } from "@/lib/hooks/use-promotions";
+import { isApiConfigured } from "@/lib/api/config";
+
+export function PromotionsClient() {
+  const { data, isLoading, isError } = usePromotions();
+
+  return (
+    <div className="flex-1 overflow-auto">
+      <div className="max-w-6xl mx-auto pt-8 pb-12 px-6">
+        <MemorySubNav />
+
+        <div className="mb-6 flex items-baseline justify-between gap-6">
+          <div>
+            <h1 className="text-base font-semibold mb-1">Promotions</h1>
+            <p className="text-sm text-muted-foreground max-w-prose leading-relaxed">
+              When the same observation reappears across sessions,{" "}
+              <span className="font-mono text-foreground">FactPromoter</span> evaluates whether it has
+              earned a wider scope. Each event below is the LLM&rsquo;s per-fact decision with its stated
+              reason. The default is to keep facts narrow.
+            </p>
+          </div>
+        </div>
+
+        {!isApiConfigured ? (
+          <div className="rounded-lg border border-dashed border-border">
+            <EmptyState
+              icon={TrendingUp}
+              title="No promotions yet"
+              description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load promotion events."
+            />
+          </div>
+        ) : isError ? (
+          <div className="rounded-lg border border-dashed border-border">
+            <EmptyState icon={AlertTriangle} title="Couldn't load promotions" />
+          </div>
+        ) : isLoading ? (
+          <div className="pl-8 space-y-3">
+            {[0, 1, 2].map((i) => (
+              <Skeleton key={i} className="h-24 rounded" />
+            ))}
+          </div>
+        ) : !data || data.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border">
+            <EmptyState
+              icon={TrendingUp}
+              title="No promotions yet"
+              description="Promotion decisions appear here as agents accumulate facts across sessions."
+            />
+          </div>
+        ) : (
+          <div className="pl-8 border-l border-border">
+            {data.map((event) => (
+              <PromotionEventRow key={event.id} event={event} />
+            ))}
+          </div>
+        )}
+
+        <div className="mt-10 text-xs text-muted-foreground flex items-start gap-2 max-w-2xl">
+          <Info className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+          <span>
+            <span className="text-foreground/80">No flat pool exists.</span> Every fact, at every
+            scope, is attributed to its originating agent (
+            <span className="font-mono">memory_fact.agent_id</span> is non-null). Promotion changes{" "}
+            <em>visibility radius</em>, not authorship.
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/app/(authed)/promotions/promotions-client.tsx
+++ b/packages/web/app/(authed)/promotions/promotions-client.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { AlertTriangle, Info, TrendingUp } from "lucide-react";
+import { AlertTriangle, Info, TrendingUp, type LucideIcon } from "lucide-react";
 import { EmptyState } from "@/components/empty-state";
-import { Skeleton } from "@/components/skeleton";
+import { PromotionEventSkeleton } from "@/components/skeletons";
 import { MemorySubNav } from "@/components/memory/sub-nav";
 import { PromotionEventRow } from "@/components/promotions/event-row";
 import { usePromotions } from "@/lib/hooks/use-promotions";
 import { isApiConfigured } from "@/lib/api/config";
+import type { PromotionEvent } from "@/lib/types/promotion-events";
 
 export function PromotionsClient() {
   const { data, isLoading, isError } = usePromotions();
@@ -28,39 +29,7 @@ export function PromotionsClient() {
           </div>
         </div>
 
-        {!isApiConfigured ? (
-          <div className="rounded-lg border border-dashed border-border">
-            <EmptyState
-              icon={TrendingUp}
-              title="No promotions yet"
-              description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load promotion events."
-            />
-          </div>
-        ) : isError ? (
-          <div className="rounded-lg border border-dashed border-border">
-            <EmptyState icon={AlertTriangle} title="Couldn't load promotions" />
-          </div>
-        ) : isLoading ? (
-          <div className="pl-8 space-y-3">
-            {[0, 1, 2].map((i) => (
-              <Skeleton key={i} className="h-24 rounded" />
-            ))}
-          </div>
-        ) : !data || data.length === 0 ? (
-          <div className="rounded-lg border border-dashed border-border">
-            <EmptyState
-              icon={TrendingUp}
-              title="No promotions yet"
-              description="Promotion decisions appear here as agents accumulate facts across sessions."
-            />
-          </div>
-        ) : (
-          <div className="pl-8 border-l border-border">
-            {data.map((event) => (
-              <PromotionEventRow key={event.id} event={event} />
-            ))}
-          </div>
-        )}
+        <Body data={data} isLoading={isLoading} isError={isError} />
 
         <div className="mt-10 text-xs text-muted-foreground flex items-start gap-2 max-w-2xl">
           <Info className="h-3.5 w-3.5 shrink-0 mt-0.5" />
@@ -72,6 +41,66 @@ export function PromotionsClient() {
           </span>
         </div>
       </div>
+    </div>
+  );
+}
+
+function Body({
+  data,
+  isLoading,
+  isError,
+}: {
+  data: PromotionEvent[] | undefined;
+  isLoading: boolean;
+  isError: boolean;
+}) {
+  if (!isApiConfigured) {
+    return (
+      <EmptyWrapper
+        icon={TrendingUp}
+        title="No promotions yet"
+        description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load promotion events."
+      />
+    );
+  }
+
+  if (isError) {
+    return <EmptyWrapper icon={AlertTriangle} title="Couldn't load promotions" />;
+  }
+
+  if (isLoading) {
+    return (
+      <div className="pl-8 space-y-3">
+        {[0, 1, 2].map((i) => (
+          <PromotionEventSkeleton key={i} />
+        ))}
+      </div>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <EmptyWrapper
+        icon={TrendingUp}
+        title="No promotions yet"
+        description="Promotion decisions appear here as agents accumulate facts across sessions."
+      />
+    );
+  }
+
+  return (
+    <div className="pl-8 border-l border-border">
+      {data.map((event) => (
+        <PromotionEventRow key={event.id} event={event} />
+      ))}
+    </div>
+  );
+}
+
+function EmptyWrapper(props: { icon: LucideIcon; title: string; description?: string }) {
+  return (
+    <div className="rounded-lg border border-dashed border-border">
+      <EmptyState {...props} />
     </div>
   );
 }

--- a/packages/web/app/(authed)/tasks/[id]/page.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
-import { notFound } from "next/navigation";
+import { TaskDetailClient } from "./task-detail-client";
 
 export const metadata: Metadata = { title: "Task" };
 
-export default function TaskDetailPage(_props: { params: { id: string } }) {
-  notFound();
+export default function TaskDetailPage({ params }: { params: { id: string } }) {
+  return <TaskDetailClient taskId={params.id} />;
 }

--- a/packages/web/app/(authed)/tasks/[id]/sessions/[sid]/page.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/sessions/[sid]/page.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from "next";
-import { notFound } from "next/navigation";
+import { SessionDetailClient } from "./session-detail-client";
 
 export const metadata: Metadata = { title: "Session" };
 
-export default function SessionDetailPage(_props: {
+export default function SessionDetailPage({
+  params,
+}: {
   params: { id: string; sid: string };
 }) {
-  notFound();
+  return <SessionDetailClient taskId={params.id} sessionShortId={params.sid} />;
 }

--- a/packages/web/app/(authed)/tasks/[id]/sessions/[sid]/session-detail-client.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/sessions/[sid]/session-detail-client.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { AlertTriangle, ChevronRight, Terminal } from "lucide-react";
 import { useSession } from "@/lib/hooks/use-sessions";
+import { useCancelSession } from "@/lib/hooks/use-session-mutations";
 import { isApiConfigured } from "@/lib/api/config";
 import { Avatar } from "@/components/avatar";
 import { HierChip } from "@/components/hier-chip";
@@ -65,7 +66,7 @@ export function SessionDetailClient({ taskId, sessionShortId }: Props) {
 
   return (
     <DetailShell nav={nav}>
-      <SessionDetailBody session={data} />
+      <SessionDetailBody session={data} taskId={taskId} />
     </DetailShell>
   );
 }
@@ -100,7 +101,9 @@ function Breadcrumbs({
   );
 }
 
-function SessionDetailBody({ session }: { session: SessionDisplay }) {
+function SessionDetailBody({ session, taskId }: { session: SessionDisplay; taskId: string }) {
+  const cancel = useCancelSession(session.short_id, taskId);
+
   return (
     <>
       <header className="mb-6">
@@ -127,13 +130,20 @@ function SessionDetailBody({ session }: { session: SessionDisplay }) {
             {session.status === "running" ? (
               <button
                 type="button"
-                className="h-8 px-3 rounded text-xs font-medium border border-border hover:bg-secondary transition-colors cursor-pointer"
+                disabled={cancel.isPending}
+                onClick={() => cancel.mutate()}
+                className="h-8 px-3 rounded text-xs font-medium border border-border hover:bg-secondary transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                Cancel
+                {cancel.isPending ? "Canceling…" : "Cancel"}
               </button>
             ) : null}
           </div>
         </div>
+        {cancel.isError ? (
+          <div className="mt-1 text-xs text-status-failed text-right">
+            Couldn&apos;t cancel: {cancel.error.message}
+          </div>
+        ) : null}
       </header>
 
       <BriefingComposer briefing={session.briefing} />

--- a/packages/web/app/(authed)/tasks/[id]/sessions/[sid]/session-detail-client.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/sessions/[sid]/session-detail-client.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import Link from "next/link";
+import { AlertTriangle, ChevronRight, Terminal } from "lucide-react";
+import { useSession } from "@/lib/hooks/use-sessions";
+import { isApiConfigured } from "@/lib/api/config";
+import { Avatar } from "@/components/avatar";
+import { HierChip } from "@/components/hier-chip";
+import { SessionStatusPill } from "@/components/detail/status-pill";
+import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
+import { DetailShell } from "@/components/detail/detail-shell";
+import { FooterField } from "@/components/detail/footer-field";
+import { BriefingComposer } from "@/components/sessions/briefing-composer";
+import { Transcript } from "@/components/sessions/transcript";
+import { EmptyState } from "@/components/empty-state";
+import { Skeleton } from "@/components/skeleton";
+import { shortId } from "@/lib/format";
+import type { SessionDisplay } from "@/lib/types/sessions";
+
+interface Props {
+  taskId: string;
+  sessionShortId: string;
+}
+
+export function SessionDetailClient({ taskId, sessionShortId }: Props) {
+  const { data, isLoading, isError } = useSession(sessionShortId);
+
+  const nav = (
+    <Breadcrumbs taskId={taskId} taskTitle={data?.task_title ?? null} sessionShortId={sessionShortId} />
+  );
+
+  if (!isApiConfigured) {
+    return (
+      <DetailShell nav={nav}>
+        <EmptyState
+          icon={Terminal}
+          title="API not configured"
+          description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load this session."
+        />
+      </DetailShell>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <DetailShell nav={nav}>
+        <Skeleton className="h-14 w-full mb-6" />
+        <Skeleton className="h-32 w-full mb-5 rounded-lg" />
+        <Skeleton className="h-64 w-full rounded-lg" />
+      </DetailShell>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <DetailShell nav={nav}>
+        <EmptyState
+          icon={AlertTriangle}
+          title="Couldn't load session"
+          description={`Session ${sessionShortId} could not be fetched.`}
+        />
+      </DetailShell>
+    );
+  }
+
+  return (
+    <DetailShell nav={nav}>
+      <SessionDetailBody session={data} />
+    </DetailShell>
+  );
+}
+
+function Breadcrumbs({
+  taskId,
+  taskTitle,
+  sessionShortId,
+}: {
+  taskId: string;
+  taskTitle: string | null;
+  sessionShortId: string;
+}) {
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className="flex items-center gap-1.5 text-xs text-muted-foreground mb-4"
+    >
+      <Link href="/tasks" className="hover:text-foreground transition-colors">
+        Tasks
+      </Link>
+      <ChevronRight className="h-3 w-3" />
+      <Link
+        href={`/tasks/${taskId}`}
+        className="hover:text-foreground transition-colors max-w-[18rem] truncate"
+      >
+        {taskTitle ?? shortId(taskId)}
+      </Link>
+      <ChevronRight className="h-3 w-3" />
+      <span className="font-mono text-foreground/80">{sessionShortId}</span>
+    </nav>
+  );
+}
+
+function SessionDetailBody({ session }: { session: SessionDisplay }) {
+  return (
+    <>
+      <header className="mb-6">
+        <div className="flex items-start gap-3">
+          <Avatar
+            initial={session.agent_label.charAt(0).toUpperCase()}
+            kind={session.agent_hierarchy}
+            size={40}
+            presence={session.status === "running" ? "running" : "idle"}
+          />
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1">
+              <h1 className="text-base font-semibold leading-tight truncate">{session.intent}</h1>
+              <SessionStatusPill status={session.status} />
+            </div>
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <span className="text-foreground/85">{session.agent_label}</span>
+              <HierChip hier={session.agent_hierarchy} />
+              <span className="text-muted-foreground/50">·</span>
+              <span className="tabular-nums">{session.duration_label}</span>
+            </div>
+          </div>
+          <div className="flex items-center gap-1 shrink-0">
+            {session.status === "running" ? (
+              <button
+                type="button"
+                className="h-8 px-3 rounded text-xs font-medium border border-border hover:bg-secondary transition-colors cursor-pointer"
+              >
+                Cancel
+              </button>
+            ) : null}
+          </div>
+        </div>
+      </header>
+
+      <BriefingComposer briefing={session.briefing} />
+
+      <Transcript entries={session.transcript} ask_threads={session.ask_threads} />
+
+      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+        <FooterField label="Session ID">
+          <ClickToCopyId id={session.id} />
+        </FooterField>
+        {session.cli_session ? (
+          <FooterField label="CLI session" truncate>
+            <span className="font-mono">{session.cli_session}</span>
+          </FooterField>
+        ) : null}
+        {session.worktree ? (
+          <FooterField label="Worktree" truncate>
+            <span className="font-mono">{session.worktree}</span>
+          </FooterField>
+        ) : null}
+        <FooterField label="Type">{session.type}</FooterField>
+      </footer>
+    </>
+  );
+}

--- a/packages/web/app/(authed)/tasks/[id]/task-detail-client.test.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/task-detail-client.test.tsx
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { TaskDetail } from "@/lib/api/types";
+
+const apiState = { isApiConfigured: true };
+
+vi.mock("@/lib/api/config", () => ({
+  get isApiConfigured() {
+    return apiState.isApiConfigured;
+  },
+}));
+
+vi.mock("@/lib/api/client", () => ({
+  api: { tasks: { list: vi.fn(), get: vi.fn() } },
+}));
+
+import { TaskDetailClient } from "./task-detail-client";
+import { api } from "@/lib/api/client";
+
+const getMock = vi.mocked(api.tasks.get);
+
+function renderDetail(taskId: string) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return render(<TaskDetailClient taskId={taskId} />, { wrapper: Wrapper });
+}
+
+function makeDetail(overrides: Partial<TaskDetail> = {}): TaskDetail {
+  return {
+    id: "t_abc",
+    title: "Wire the Kanban",
+    status: "review",
+    priority: "high",
+    creator_id: "u1",
+    creator_type: "person",
+    created_at: new Date("2026-04-25T00:00:00Z"),
+    updated_at: new Date("2026-04-30T00:00:00Z"),
+    work_products: [],
+    sessions: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  apiState.isApiConfigured = true;
+  getMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("TaskDetailClient", () => {
+  it("renders the not-configured empty state and never fetches", () => {
+    apiState.isApiConfigured = false;
+    renderDetail("t_abc");
+    expect(screen.getByText("API not configured")).toBeInTheDocument();
+    expect(getMock).not.toHaveBeenCalled();
+  });
+
+  it("renders the error empty state and surfaces the task id when fetch fails", async () => {
+    getMock.mockRejectedValue(new Error("boom"));
+    renderDetail("t_abc");
+
+    expect(await screen.findByText("Couldn't load task")).toBeInTheDocument();
+    expect(screen.getByText(/Task t_abc could not be fetched/)).toBeInTheDocument();
+  });
+
+  it("renders the loaded task with title, status, and footer fields", async () => {
+    getMock.mockResolvedValue(
+      makeDetail({
+        title: "Wire the Kanban",
+        status: "review",
+        priority: "high",
+        assignee_label: "alice",
+      }),
+    );
+    renderDetail("t_abc");
+
+    expect(await screen.findByRole("heading", { name: "Wire the Kanban" })).toBeInTheDocument();
+    expect(screen.getByText("review")).toBeInTheDocument();
+    expect(screen.getByText("high")).toBeInTheDocument();
+    expect(screen.getByText("alice")).toBeInTheDocument();
+  });
+
+  it("shows the Approve / Reject / Request revision actions when status is review", async () => {
+    getMock.mockResolvedValue(makeDetail({ status: "review" }));
+    renderDetail("t_abc");
+
+    expect(await screen.findByRole("button", { name: "Approve" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reject" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Request revision" })).toBeInTheDocument();
+  });
+
+  it("hides the Approve action when status is not review", async () => {
+    getMock.mockResolvedValue(makeDetail({ status: "in_progress" }));
+    renderDetail("t_abc");
+
+    await waitFor(() => expect(screen.queryByText("review")).not.toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
+  });
+
+  it("renders the blocked rail when status=blocked with a reason", async () => {
+    getMock.mockResolvedValue(
+      makeDetail({
+        status: "blocked",
+        blocker_reason: "needs API key from alice",
+      }),
+    );
+    renderDetail("t_abc");
+
+    expect(await screen.findByText("needs API key from alice")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Blocked" })).toBeInTheDocument();
+  });
+
+  it("renders an Active session rail when latest_session is running", async () => {
+    getMock.mockResolvedValue(
+      makeDetail({
+        latest_session: {
+          short_id: "s_xyz",
+          status: "running",
+          elapsed: "2m",
+          agent_label: "executor",
+        },
+      }),
+    );
+    renderDetail("t_abc");
+
+    expect(await screen.findByRole("heading", { name: "Active session" })).toBeInTheDocument();
+    expect(screen.getByText("s_xyz")).toBeInTheDocument();
+    expect(screen.getByText(/executor · 2m/)).toBeInTheDocument();
+  });
+});

--- a/packages/web/app/(authed)/tasks/[id]/task-detail-client.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/task-detail-client.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { ArrowLeft, AlertTriangle, FileText, ListChecks, Terminal } from "lucide-react";
 import { useTask } from "@/lib/hooks/use-tasks";
+import { useApproveTask } from "@/lib/hooks/use-task-mutations";
 import { isApiConfigured } from "@/lib/api/config";
 import { TaskStatusPill, SessionStatusPill } from "@/components/detail/status-pill";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
@@ -74,6 +75,7 @@ export function TaskDetailClient({ taskId }: { taskId: string }) {
 function TaskDetailLoaded({ task }: { task: TaskDetail }) {
   const isInReview = task.status === "review";
   const activeSession = task.latest_session?.status === "running" ? task.latest_session : null;
+  const approve = useApproveTask(task.id);
 
   return (
     <DetailShell nav={<TasksBackLink />}>
@@ -90,22 +92,35 @@ function TaskDetailLoaded({ task }: { task: TaskDetail }) {
           <div className="flex justify-end gap-2 mb-2">
             <button
               type="button"
-              className="h-9 px-3 rounded text-sm font-medium border border-border hover:bg-secondary transition-colors cursor-pointer"
+              disabled={approve.isPending}
+              onClick={() => approve.mutate({ action: "reject" })}
+              className="h-9 px-3 rounded text-sm font-medium border border-border hover:bg-secondary transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Reject
             </button>
             <button
               type="button"
-              className="h-9 px-3 rounded text-sm font-medium border border-border hover:bg-secondary transition-colors cursor-pointer"
+              disabled={approve.isPending}
+              onClick={() => approve.mutate({ action: "revise" })}
+              className="h-9 px-3 rounded text-sm font-medium border border-border hover:bg-secondary transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Request revision
             </button>
             <button
               type="button"
-              className="h-9 px-3 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer"
+              disabled={approve.isPending}
+              onClick={() => approve.mutate({ action: "approve" })}
+              className="h-9 px-3 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              Approve
+              {approve.isPending && approve.variables?.action === "approve"
+                ? "Approving…"
+                : "Approve"}
             </button>
+          </div>
+        ) : null}
+        {approve.isError ? (
+          <div className="text-xs text-status-failed text-right">
+            Couldn&apos;t {approve.variables?.action ?? "submit"}: {approve.error.message}
           </div>
         ) : null}
       </header>

--- a/packages/web/app/(authed)/tasks/[id]/task-detail-client.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/task-detail-client.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft, AlertTriangle, FileText, ListChecks, Terminal } from "lucide-react";
+import { useTask } from "@/lib/hooks/use-tasks";
+import { isApiConfigured } from "@/lib/api/config";
+import { TaskStatusPill, SessionStatusPill } from "@/components/detail/status-pill";
+import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
+import { DetailShell } from "@/components/detail/detail-shell";
+import { FooterField } from "@/components/detail/footer-field";
+import { HierChip } from "@/components/hier-chip";
+import { EmptyState } from "@/components/empty-state";
+import { Skeleton } from "@/components/skeleton";
+import { RichTextRender } from "@/components/rich-text";
+import { formatRelativeTime, shortId } from "@/lib/format";
+import type { TaskDetail, TaskDetailSessionRow } from "@/lib/api/types";
+
+const TasksBackLink = () => (
+  <Link
+    href="/tasks"
+    className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors mb-3"
+  >
+    <ArrowLeft className="h-3 w-3" />
+    Tasks
+  </Link>
+);
+
+export function TaskDetailClient({ taskId }: { taskId: string }) {
+  const { data, isLoading, isError } = useTask(taskId);
+
+  if (!isApiConfigured) {
+    return (
+      <DetailShell nav={<TasksBackLink />}>
+        <EmptyState
+          icon={ListChecks}
+          title="API not configured"
+          description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load this task."
+        />
+      </DetailShell>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <DetailShell nav={<TasksBackLink />}>
+        <Skeleton className="h-8 w-2/3 mb-2" />
+        <Skeleton className="h-4 w-1/3 mb-6" />
+        <div className="grid grid-cols-3 gap-6">
+          <div className="col-span-2 space-y-4">
+            <Skeleton className="h-32 w-full rounded-lg" />
+            <Skeleton className="h-24 w-full rounded-lg" />
+          </div>
+          <Skeleton className="h-40 w-full rounded-lg" />
+        </div>
+      </DetailShell>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <DetailShell nav={<TasksBackLink />}>
+        <EmptyState
+          icon={AlertTriangle}
+          title="Couldn't load task"
+          description={`Task ${taskId} could not be fetched. Check the MCP server logs.`}
+        />
+      </DetailShell>
+    );
+  }
+
+  return <TaskDetailLoaded task={data} />;
+}
+
+function TaskDetailLoaded({ task }: { task: TaskDetail }) {
+  const isInReview = task.status === "review";
+  const activeSession = task.latest_session?.status === "running" ? task.latest_session : null;
+
+  return (
+    <DetailShell nav={<TasksBackLink />}>
+      <header className="mb-6">
+        <div className="flex items-start justify-between gap-6 mb-2">
+          <h1 className="text-2xl font-semibold leading-tight flex-1 min-w-0">{task.title}</h1>
+          <div className="flex items-center gap-1.5 mt-1.5 shrink-0">
+            <TaskStatusPill status={task.status} />
+            {task.assignee_hierarchy ? <HierChip hier={task.assignee_hierarchy} /> : null}
+          </div>
+        </div>
+
+        {isInReview ? (
+          <div className="flex justify-end gap-2 mb-2">
+            <button
+              type="button"
+              className="h-9 px-3 rounded text-sm font-medium border border-border hover:bg-secondary transition-colors cursor-pointer"
+            >
+              Reject
+            </button>
+            <button
+              type="button"
+              className="h-9 px-3 rounded text-sm font-medium border border-border hover:bg-secondary transition-colors cursor-pointer"
+            >
+              Request revision
+            </button>
+            <button
+              type="button"
+              className="h-9 px-3 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer"
+            >
+              Approve
+            </button>
+          </div>
+        ) : null}
+      </header>
+
+      <div className="grid grid-cols-3 gap-6">
+        <div className="col-span-2 space-y-5">
+          <section className="rounded-lg border border-border bg-card p-5">
+            <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-3 font-medium">
+              Description
+            </h2>
+            {task.description?.length ? (
+              <div className="prose prose-sm max-w-none text-foreground whitespace-pre-wrap">
+                {task.description.map((part, i) => (
+                  <RichTextRender key={i} value={part} />
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground italic">No description.</p>
+            )}
+          </section>
+
+          {task.result_summary ? (
+            <section className="rounded-lg border border-border bg-card p-5">
+              <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-3 font-medium">
+                Result summary
+              </h2>
+              <div className="text-sm text-foreground whitespace-pre-wrap">
+                <RichTextRender value={task.result_summary} />
+              </div>
+            </section>
+          ) : null}
+
+          <section>
+            <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-3 font-medium">
+              Work products{" "}
+              <span className="text-muted-foreground/70 tabular-nums">
+                {task.work_products.length}
+              </span>
+            </h2>
+            {task.work_products.length === 0 ? (
+              <p className="text-sm text-muted-foreground italic">No work products yet.</p>
+            ) : (
+              <ul className="space-y-2">
+                {task.work_products.map((wp) => (
+                  <li
+                    key={wp.id}
+                    className="rounded-lg border border-border bg-card p-3 flex items-start gap-3"
+                  >
+                    <FileText className="h-4 w-4 mt-0.5 text-muted-foreground shrink-0" />
+                    <div className="flex-1 min-w-0">
+                      <div className="text-sm font-medium truncate">{wp.title}</div>
+                      {wp.summary ? (
+                        <p className="mt-1 text-xs text-muted-foreground line-clamp-2">
+                          {wp.summary}
+                        </p>
+                      ) : null}
+                    </div>
+                    <span className="text-[10px] uppercase tracking-wider text-muted-foreground shrink-0">
+                      {wp.type.replace(/_/g, " ")}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          <section>
+            <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-3 font-medium">
+              Sessions{" "}
+              <span className="text-muted-foreground/70 tabular-nums">{task.sessions.length}</span>
+            </h2>
+            {task.sessions.length === 0 ? (
+              <p className="text-sm text-muted-foreground italic">No sessions yet.</p>
+            ) : (
+              <ul className="space-y-2">
+                {task.sessions.map((s) => (
+                  <SessionRow key={s.id} session={s} taskId={task.id} />
+                ))}
+              </ul>
+            )}
+          </section>
+        </div>
+
+        <aside className="col-span-1 space-y-4">
+          {task.status === "blocked" && task.blocker_reason ? (
+            <section className="rounded-lg border border-status-blocked/40 bg-status-blocked/5 p-4">
+              <h3 className="text-[11px] uppercase tracking-wider text-status-blocked mb-2 font-medium">
+                Blocked
+              </h3>
+              <p className="text-sm text-foreground">{task.blocker_reason}</p>
+            </section>
+          ) : null}
+
+          {activeSession ? (
+            <section className="rounded-lg border border-border bg-card p-4">
+              <h3 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-2 font-medium">
+                Active session
+              </h3>
+              <Link
+                href={`/tasks/${task.id}/sessions/${activeSession.short_id}`}
+                className="block hover:bg-secondary/30 -mx-2 px-2 py-1.5 rounded transition-colors"
+              >
+                <div className="flex items-center gap-2 mb-1">
+                  <Terminal className="h-3.5 w-3.5 text-muted-foreground" />
+                  <span className="font-mono text-xs">{activeSession.short_id}</span>
+                  <SessionStatusPill status="running" className="ml-auto" />
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  {activeSession.agent_label} · {activeSession.elapsed}
+                </div>
+              </Link>
+            </section>
+          ) : null}
+        </aside>
+      </div>
+
+      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+        <FooterField label="ID">
+          <ClickToCopyId id={task.id} />
+        </FooterField>
+        <FooterField label="Priority">{task.priority}</FooterField>
+        <FooterField label="Created">{formatRelativeTime(task.created_at)}</FooterField>
+        <FooterField label="Updated">{formatRelativeTime(task.updated_at)}</FooterField>
+        {task.assignee_label ? (
+          <FooterField label="Assignee">{task.assignee_label}</FooterField>
+        ) : null}
+        {task.creator_label ? (
+          <FooterField label="Creator">{task.creator_label}</FooterField>
+        ) : null}
+        {task.parent_task_id ? (
+          <FooterField label="Parent">
+            <Link
+              href={`/tasks/${task.parent_task_id}`}
+              className="font-mono hover:text-foreground transition-colors"
+            >
+              {shortId(task.parent_task_id)}
+            </Link>
+          </FooterField>
+        ) : null}
+      </footer>
+    </DetailShell>
+  );
+}
+
+function SessionRow({ session, taskId }: { session: TaskDetailSessionRow; taskId: string }) {
+  return (
+    <li>
+      <Link
+        href={`/tasks/${taskId}/sessions/${session.short_id}`}
+        className="block rounded-lg border border-border bg-card p-3 hover:bg-secondary/30 transition-colors"
+      >
+        <div className="flex items-center gap-2 mb-1">
+          <Terminal className="h-3.5 w-3.5 text-muted-foreground" />
+          <span className="font-mono text-xs">{session.short_id}</span>
+          <span className="text-xs text-muted-foreground">{session.agent_label}</span>
+          <SessionStatusPill status={session.status} className="ml-auto" />
+        </div>
+        {session.result_summary ? (
+          <p className="text-xs text-muted-foreground line-clamp-2 mt-1">{session.result_summary}</p>
+        ) : null}
+        <div className="mt-1.5 text-[11px] text-muted-foreground/70 tabular-nums">
+          {session.duration_label} · {formatRelativeTime(session.started_at)}
+        </div>
+      </Link>
+    </li>
+  );
+}

--- a/packages/web/app/(authed)/tasks/tasks-client.test.tsx
+++ b/packages/web/app/(authed)/tasks/tasks-client.test.tsx
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import type { TaskListItem } from "@/lib/types/tasks";
+
+const apiState = { isApiConfigured: true };
+
+vi.mock("@/lib/api/config", () => ({
+  get isApiConfigured() {
+    return apiState.isApiConfigured;
+  },
+}));
+
+vi.mock("@/lib/api/client", () => ({
+  api: {
+    tasks: {
+      list: vi.fn(),
+      get: vi.fn(),
+    },
+  },
+}));
+
+import { TasksClient } from "./tasks-client";
+import { api } from "@/lib/api/client";
+
+const listMock = vi.mocked(api.tasks.list);
+
+function renderClient() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return render(<TasksClient />, { wrapper: Wrapper });
+}
+
+function makeTask(overrides: Partial<TaskListItem>): TaskListItem {
+  return {
+    id: "t1",
+    title: "default",
+    status: "in_progress",
+    priority: "medium",
+    creator_id: "u1",
+    creator_type: "person",
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  apiState.isApiConfigured = true;
+  listMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("TasksClient — empty-state branches", () => {
+  it("renders the not-configured empty state when env is unset (and never calls api)", async () => {
+    apiState.isApiConfigured = false;
+    renderClient();
+
+    expect(await screen.findByText("No tasks yet")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Set NEXT_PUBLIC_BV_API_URL and run the MCP server/i),
+    ).toBeInTheDocument();
+    expect(listMock).not.toHaveBeenCalled();
+  });
+
+  it("renders the error empty state when the api throws", async () => {
+    listMock.mockRejectedValue(new Error("boom"));
+    renderClient();
+
+    expect(await screen.findByText("Couldn't load tasks")).toBeInTheDocument();
+  });
+
+  it("renders the no-results empty state when api returns []", async () => {
+    listMock.mockResolvedValue([]);
+    renderClient();
+
+    expect(await screen.findByText("No tasks yet")).toBeInTheDocument();
+    expect(screen.getByText(/Create a task to assign work/i)).toBeInTheDocument();
+  });
+
+  it("renders the no-matching-search empty state when query has no matches", async () => {
+    listMock.mockResolvedValue([makeTask({ title: "alpha" }), makeTask({ id: "t2", title: "beta" })]);
+    renderClient();
+
+    await waitFor(() => expect(listMock).toHaveBeenCalled());
+
+    const search = screen.getByRole("searchbox", { name: /search tasks/i });
+    await userEvent.type(search, "zeta");
+
+    expect(await screen.findByText("No matching tasks")).toBeInTheDocument();
+    expect(screen.getByText(/Try a different search/i)).toBeInTheDocument();
+  });
+});
+
+describe("TasksClient — lane rendering", () => {
+  it("groups returned tasks into the four lifecycle columns with counts", async () => {
+    listMock.mockResolvedValue([
+      makeTask({ id: "p1", status: "pending", title: "p one" }),
+      makeTask({ id: "p2", status: "assigned", title: "p two" }),
+      makeTask({ id: "ip1", status: "in_progress", title: "ip one" }),
+      makeTask({ id: "rev1", status: "review", title: "review one" }),
+      makeTask({ id: "rev2", status: "blocked", title: "review two" }),
+      makeTask({ id: "d1", status: "done", title: "done one" }),
+    ]);
+    renderClient();
+
+    expect(await screen.findByText("p one")).toBeInTheDocument();
+
+    const counts = ["Pending", "In progress", "In review", "Done"].map((label) => {
+      const lane = screen.getByText(label);
+      const countNode = lane.parentElement?.querySelector(".tabular-nums");
+      return countNode?.textContent;
+    });
+    expect(counts).toEqual(["2", "1", "2", "1"]);
+  });
+
+  it("re-fetches with new view filter when a tab is clicked", async () => {
+    listMock.mockResolvedValue([]);
+    renderClient();
+
+    await waitFor(() => expect(listMock).toHaveBeenCalledWith({}));
+
+    await userEvent.click(screen.getByRole("button", { name: "My tasks" }));
+
+    await waitFor(() =>
+      expect(listMock).toHaveBeenCalledWith({ view: "mine" }),
+    );
+  });
+});

--- a/packages/web/app/(authed)/tasks/tasks-client.test.tsx
+++ b/packages/web/app/(authed)/tasks/tasks-client.test.tsx
@@ -125,12 +125,14 @@ describe("TasksClient — lane rendering", () => {
     listMock.mockResolvedValue([]);
     renderClient();
 
-    await waitFor(() => expect(listMock).toHaveBeenCalledWith({}));
+    await waitFor(() =>
+      expect(listMock).toHaveBeenCalledWith({}, expect.objectContaining({})),
+    );
 
     await userEvent.click(screen.getByRole("button", { name: "My tasks" }));
 
     await waitFor(() =>
-      expect(listMock).toHaveBeenCalledWith({ view: "mine" }),
+      expect(listMock).toHaveBeenCalledWith({ view: "mine" }, expect.objectContaining({})),
     );
   });
 });

--- a/packages/web/app/(authed)/tasks/tasks-client.tsx
+++ b/packages/web/app/(authed)/tasks/tasks-client.tsx
@@ -1,21 +1,49 @@
 "use client";
 
-import { useState } from "react";
-import { ListChecks } from "lucide-react";
+import { useMemo, useState } from "react";
+import { type LucideIcon, AlertTriangle, ListChecks } from "lucide-react";
 import { ViewTabs, type TaskView } from "@/components/tasks/view-tabs";
-import { BoardColumn, type BoardLane } from "@/components/tasks/board-column";
+import { BoardColumn } from "@/components/tasks/board-column";
 import { EmptyState } from "@/components/empty-state";
+import { useTasks } from "@/lib/hooks/use-tasks";
+import { isApiConfigured } from "@/lib/api/config";
+import { groupTasks } from "@/lib/tasks-grouping";
+import type { TaskListFilter } from "@/lib/api/client";
 
-const LANES: BoardLane[] = [
-  { key: "pending", label: "Pending", dot: "bg-muted-foreground/50", count: 0, tasks: [] },
-  { key: "in_progress", label: "In progress", dot: "bg-status-running", count: 0, tasks: [] },
-  { key: "in_review", label: "In review", dot: "bg-status-review", count: 0, tasks: [] },
-  { key: "done", label: "Done", dot: "bg-status-done", count: 0, tasks: [] },
-];
+const VIEW_TO_FILTER: Record<TaskView, TaskListFilter> = {
+  all: {},
+  mine: { view: "mine" },
+  sprint: { view: "sprint" },
+  timeline: { view: "timeline" },
+};
+
+interface EmptyMessage {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+}
 
 export function TasksClient() {
   const [view, setView] = useState<TaskView>("all");
   const [query, setQuery] = useState("");
+
+  const { data, isLoading, isError } = useTasks(VIEW_TO_FILTER[view]);
+
+  const filtered = useMemo(() => {
+    if (!data) return [];
+    const q = query.trim().toLowerCase();
+    if (!q) return data;
+    return data.filter((t) => t.title.toLowerCase().includes(q));
+  }, [data, query]);
+
+  const lanes = useMemo(() => groupTasks(filtered), [filtered]);
+  const emptyMessage = pickEmptyMessage({
+    isApiConfigured,
+    isError,
+    isLoading,
+    hasResults: filtered.length > 0,
+    hasQuery: query.length > 0,
+  });
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
@@ -30,19 +58,50 @@ export function TasksClient() {
 
       <div className="flex-1 overflow-x-auto overflow-y-auto">
         <div className="group/board flex gap-4 px-6 py-5 min-h-full">
-          {LANES.map((lane) => (
+          {lanes.map((lane) => (
             <BoardColumn key={lane.key} lane={lane} />
           ))}
           <div className="shrink-0 w-2" aria-hidden />
         </div>
-        <div className="px-6 pb-8 max-w-md mx-auto">
-          <EmptyState
-            icon={ListChecks}
-            title="No tasks yet"
-            description="Create a task to assign work to an agent."
-          />
-        </div>
+
+        {emptyMessage ? (
+          <div className="px-6 pb-8 max-w-md mx-auto">
+            <EmptyState {...emptyMessage} />
+          </div>
+        ) : null}
       </div>
     </div>
   );
+}
+
+function pickEmptyMessage(state: {
+  isApiConfigured: boolean;
+  isError: boolean;
+  isLoading: boolean;
+  hasResults: boolean;
+  hasQuery: boolean;
+}): EmptyMessage | null {
+  if (state.isError) {
+    return {
+      icon: AlertTriangle,
+      title: "Couldn't load tasks",
+      description:
+        "The API is configured but unreachable. Check that the MCP server is running.",
+    };
+  }
+  if (!state.isApiConfigured) {
+    return {
+      icon: ListChecks,
+      title: "No tasks yet",
+      description: "Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load tasks.",
+    };
+  }
+  if (state.isLoading || state.hasResults) return null;
+  return {
+    icon: ListChecks,
+    title: state.hasQuery ? "No matching tasks" : "No tasks yet",
+    description: state.hasQuery
+      ? "Try a different search."
+      : "Create a task to assign work to an agent.",
+  };
 }

--- a/packages/web/app/(authed)/threads/page.tsx
+++ b/packages/web/app/(authed)/threads/page.tsx
@@ -1,32 +1,8 @@
 import type { Metadata } from "next";
-import { Hash } from "lucide-react";
-import { ChannelRail } from "@/components/threads/channel-rail";
-import { ThreadActionFooter } from "@/components/threads/thread-action-footer";
-import { ThreadTimeline } from "@/components/threads/timeline";
+import { ThreadsClient } from "./threads-client";
 
 export const metadata: Metadata = { title: "Threads" };
 
 export default function ThreadsPage() {
-  return (
-    <div className="flex-1 min-w-0 flex">
-      <ChannelRail />
-
-      <main className="flex-1 min-w-0 flex flex-col bg-background overflow-hidden">
-        <header className="px-6 py-3 flex items-center justify-between gap-4 shrink-0 border-b border-border">
-          <div className="flex items-center gap-3 min-w-0">
-            <Hash className="h-4 w-4 text-muted-foreground shrink-0" />
-            <div className="min-w-0">
-              <h1 className="text-base font-semibold">Select a thread</h1>
-              <div className="text-xs text-muted-foreground mt-0.5">
-                Pick a channel from the rail or create a new task.
-              </div>
-            </div>
-          </div>
-        </header>
-
-        <ThreadTimeline />
-        <ThreadActionFooter />
-      </main>
-    </div>
-  );
+  return <ThreadsClient />;
 }

--- a/packages/web/app/(authed)/threads/threads-client.tsx
+++ b/packages/web/app/(authed)/threads/threads-client.tsx
@@ -24,10 +24,12 @@ export function ThreadsClient() {
             <Hash className="h-4 w-4 text-muted-foreground shrink-0" />
             <div className="min-w-0">
               <h1 className="text-base font-semibold">
-                {data?.active_channel?.title ?? "Select a thread"}
+                {data?.active_channel ? data.active_channel.title : "Select a thread"}
               </h1>
               <div className="text-xs text-muted-foreground mt-0.5">
-                {data?.active_channel?.task_short_id ?? "Pick a channel from the rail or create a new task."}
+                {data?.active_channel
+                  ? data.active_channel.task_short_id
+                  : "Pick a channel from the rail or create a new task."}
               </div>
             </div>
           </div>

--- a/packages/web/app/(authed)/threads/threads-client.tsx
+++ b/packages/web/app/(authed)/threads/threads-client.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { AlertTriangle, Hash, MessageSquare } from "lucide-react";
+import { ChannelRail } from "@/components/threads/channel-rail";
+import { ThreadActionFooter } from "@/components/threads/thread-action-footer";
+import { ThreadTimeline } from "@/components/threads/timeline";
+import { EmptyState } from "@/components/empty-state";
+import { Skeleton } from "@/components/skeleton";
+import { useThreads } from "@/lib/hooks/use-threads";
+import { isApiConfigured } from "@/lib/api/config";
+import type { ThreadsOverview } from "@/lib/api/types";
+import type { ThreadChannel } from "@/lib/types/thread-messages";
+
+export function ThreadsClient() {
+  const { data, isLoading, isError } = useThreads();
+
+  return (
+    <div className="flex-1 min-w-0 flex">
+      <Rail data={data} isLoading={isLoading} isError={isError} />
+
+      <main className="flex-1 min-w-0 flex flex-col bg-background overflow-hidden">
+        <header className="px-6 py-3 flex items-center justify-between gap-4 shrink-0 border-b border-border">
+          <div className="flex items-center gap-3 min-w-0">
+            <Hash className="h-4 w-4 text-muted-foreground shrink-0" />
+            <div className="min-w-0">
+              <h1 className="text-base font-semibold">
+                {data?.active_channel?.title ?? "Select a thread"}
+              </h1>
+              <div className="text-xs text-muted-foreground mt-0.5">
+                {data?.active_channel?.task_short_id ?? "Pick a channel from the rail or create a new task."}
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <Body data={data} isLoading={isLoading} isError={isError} />
+        {data?.active_channel ? <ThreadActionFooter /> : null}
+      </main>
+    </div>
+  );
+}
+
+function Rail({
+  data,
+  isLoading,
+  isError,
+}: {
+  data: ThreadsOverview | undefined;
+  isLoading: boolean;
+  isError: boolean;
+}) {
+  if (!isApiConfigured || isError || isLoading || !data || data.channels.length === 0) {
+    return <ChannelRail />;
+  }
+
+  return (
+    <aside className="w-[280px] shrink-0 bg-secondary/30 flex flex-col overflow-hidden border-r border-border">
+      <div className="px-4 pt-5 pb-3 flex items-center justify-between">
+        <h2 className="text-sm font-semibold">Threads</h2>
+        <button
+          type="button"
+          className="inline-flex items-center gap-1.5 h-7 px-2.5 rounded bg-primary text-primary-foreground text-xs font-medium hover:opacity-90 active:scale-[0.98] transition-all duration-150 cursor-pointer"
+        >
+          + New task
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto px-2 pb-4 space-y-4">
+        <ChannelGroup label="Channels" channels={data.channels} />
+      </div>
+    </aside>
+  );
+}
+
+function ChannelGroup({ label, channels }: { label: string; channels: ThreadChannel[] }) {
+  return (
+    <div>
+      <div className="px-2 mb-1 text-[10px] uppercase tracking-wider text-muted-foreground/60 font-medium">
+        {label}{" "}
+        <span className="text-muted-foreground/50 tabular-nums">{channels.length}</span>
+      </div>
+      <ul className="space-y-0.5">
+        {channels.map((ch) => (
+          <li key={ch.id}>
+            <button
+              type="button"
+              className="w-full flex items-center gap-2 px-2 py-1.5 rounded hover:bg-secondary transition-colors text-sm cursor-pointer"
+            >
+              <Hash className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+              <span className="flex-1 min-w-0 truncate text-left">{ch.title}</span>
+              <span className="text-[10px] text-muted-foreground tabular-nums shrink-0">{ch.age}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function Body({
+  data,
+  isLoading,
+  isError,
+}: {
+  data: ThreadsOverview | undefined;
+  isLoading: boolean;
+  isError: boolean;
+}) {
+  if (!isApiConfigured) {
+    return (
+      <div className="flex-1 overflow-y-auto px-6 py-4">
+        <div className="max-w-3xl mx-auto">
+          <EmptyState
+            icon={MessageSquare}
+            title="No messages yet"
+            description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load thread activity."
+          />
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex-1 overflow-y-auto px-6 py-4">
+        <div className="max-w-3xl mx-auto">
+          <EmptyState icon={AlertTriangle} title="Couldn't load threads" />
+        </div>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex-1 overflow-y-auto px-6 py-4">
+        <div className="max-w-3xl mx-auto space-y-3">
+          {[0, 1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-16 rounded-lg" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return <ThreadTimeline />;
+}

--- a/packages/web/app/providers.tsx
+++ b/packages/web/app/providers.tsx
@@ -3,6 +3,12 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { useState, type ReactNode } from "react";
+import { useLiveUpdates } from "@/lib/sse";
+
+function LiveUpdates() {
+  useLiveUpdates();
+  return null;
+}
 
 export function Providers({ children }: { children: ReactNode }) {
   const [client] = useState(
@@ -20,6 +26,7 @@ export function Providers({ children }: { children: ReactNode }) {
 
   return (
     <QueryClientProvider client={client}>
+      <LiveUpdates />
       {children}
       <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-left" />
     </QueryClientProvider>

--- a/packages/web/components/agents/depth-metrics.tsx
+++ b/packages/web/components/agents/depth-metrics.tsx
@@ -1,3 +1,5 @@
+import { Metric } from "@/components/detail/metric";
+
 interface MetricsProps {
   sessions: number;
   sessions_change: number;
@@ -9,32 +11,15 @@ interface MetricsProps {
 export function DepthMetrics({ sessions, sessions_change, facts, merges, promoted }: MetricsProps) {
   return (
     <div className="grid grid-cols-4 gap-x-8 mt-6 pt-6 border-t border-border">
-      <Metric label="Sessions" value={sessions} suffix={`+${sessions_change} this week`} suffixColor="text-status-done" />
+      <Metric
+        label="Sessions"
+        value={sessions}
+        suffix={`+${sessions_change} this week`}
+        suffixColor="text-status-done"
+      />
       <Metric label="Facts learned" value={facts} suffix="in memory" />
       <Metric label="Merge events" value={merges} suffix="consolidated" />
       <Metric label="Promoted up" value={promoted} suffix="to team / org" />
-    </div>
-  );
-}
-
-function Metric({
-  label,
-  value,
-  suffix,
-  suffixColor = "text-muted-foreground",
-}: {
-  label: string;
-  value: number;
-  suffix: string;
-  suffixColor?: string;
-}) {
-  return (
-    <div>
-      <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">{label}</div>
-      <div className="flex items-baseline gap-1.5">
-        <span className="text-2xl font-semibold tabular-nums leading-none">{value}</span>
-        <span className={`text-xs ${suffixColor}`}>{suffix}</span>
-      </div>
     </div>
   );
 }

--- a/packages/web/components/detail/detail-shell.tsx
+++ b/packages/web/components/detail/detail-shell.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+
+export function DetailShell({ nav, children }: { nav?: ReactNode; children: ReactNode }) {
+  return (
+    <div className="flex-1 overflow-auto">
+      <div className="max-w-5xl mx-auto px-6 py-8">
+        {nav}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/detail/footer-field.tsx
+++ b/packages/web/components/detail/footer-field.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export function FooterField({
+  label,
+  children,
+  truncate,
+}: {
+  label: string;
+  children: ReactNode;
+  truncate?: boolean;
+}) {
+  return (
+    <div className={cn(truncate && "min-w-0")}>
+      <div className="text-[10px] uppercase tracking-wider text-muted-foreground/60 mb-0.5">
+        {label}
+      </div>
+      <div className={cn("text-foreground/80", truncate && "truncate")}>{children}</div>
+    </div>
+  );
+}

--- a/packages/web/components/detail/metric.tsx
+++ b/packages/web/components/detail/metric.tsx
@@ -1,0 +1,23 @@
+export function Metric({
+  label,
+  value,
+  suffix,
+  suffixColor = "text-muted-foreground",
+}: {
+  label: string;
+  value: number;
+  suffix?: string;
+  suffixColor?: string;
+}) {
+  return (
+    <div>
+      <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">{label}</div>
+      <div className="flex items-baseline gap-1.5">
+        <span className="text-2xl font-semibold tabular-nums leading-none">
+          {value.toLocaleString()}
+        </span>
+        {suffix ? <span className={`text-xs ${suffixColor}`}>{suffix}</span> : null}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/tasks/board-column.tsx
+++ b/packages/web/components/tasks/board-column.tsx
@@ -4,9 +4,10 @@ import { MoreHorizontal, Plus } from "lucide-react";
 import { TaskCard } from "./task-card";
 import { cn } from "@/lib/utils";
 import type { TaskListItem } from "@/lib/types/tasks";
+import type { Lifecycle } from "@/lib/tasks-grouping";
 
 export type BoardLane = {
-  key: "pending" | "in_progress" | "in_review" | "done";
+  key: Lifecycle;
   label: string;
   dot: string;
   count: number;

--- a/packages/web/lib/api/client-mutations.test.ts
+++ b/packages/web/lib/api/client-mutations.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./http", () => ({
+  fetchJson: vi.fn(),
+  ApiError: class ApiError extends Error {},
+  ApiNotConfigured: class ApiNotConfigured extends Error {},
+}));
+
+import { api } from "./client";
+import { fetchJson } from "./http";
+
+const fetchJsonMock = vi.mocked(fetchJson);
+
+beforeEach(() => {
+  fetchJsonMock.mockReset();
+  fetchJsonMock.mockResolvedValue({});
+});
+
+describe("api mutations", () => {
+  describe("tasks", () => {
+    it("approve(id, {action}) POSTs to /api/tasks/:id/approve with body", async () => {
+      await api.tasks.approve("t_1", { action: "approve" });
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/tasks/t_1/approve", {
+        method: "POST",
+        body: { action: "approve" },
+      });
+    });
+
+    it("approve forwards optional result_summary", async () => {
+      await api.tasks.approve("t_1", { action: "revise", result_summary: "needs more tests" });
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/tasks/t_1/approve", {
+        method: "POST",
+        body: { action: "revise", result_summary: "needs more tests" },
+      });
+    });
+
+    it("cancel(id) POSTs to /api/tasks/:id/cancel with empty body by default", async () => {
+      await api.tasks.cancel("t_1");
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/tasks/t_1/cancel", {
+        method: "POST",
+        body: {},
+      });
+    });
+
+    it("cancel(id, {force, reason}) forwards both", async () => {
+      await api.tasks.cancel("t_1", { force: true, reason: "scope changed" });
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/tasks/t_1/cancel", {
+        method: "POST",
+        body: { force: true, reason: "scope changed" },
+      });
+    });
+
+    it("create({title}) POSTs to /api/tasks", async () => {
+      await api.tasks.create({ title: "wire it" });
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/tasks", {
+        method: "POST",
+        body: { title: "wire it" },
+      });
+    });
+
+    it("create forwards full input", async () => {
+      await api.tasks.create({
+        title: "wire it",
+        description: "hook the kanban",
+        priority: "high",
+        assignee_id: "agt_1",
+        parent_task_id: "t_root",
+      });
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/tasks", {
+        method: "POST",
+        body: {
+          title: "wire it",
+          description: "hook the kanban",
+          priority: "high",
+          assignee_id: "agt_1",
+          parent_task_id: "t_root",
+        },
+      });
+    });
+  });
+
+  describe("sessions", () => {
+    it("cancel(shortId) POSTs to /api/sessions/:short/cancel", async () => {
+      await api.sessions.cancel("sess_abc");
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/sessions/sess_abc/cancel", {
+        method: "POST",
+      });
+    });
+
+    it("cancel URL-encodes shortId", async () => {
+      await api.sessions.cancel("sess/with/slash");
+      expect(fetchJsonMock).toHaveBeenCalledWith(
+        "/api/sessions/sess%2Fwith%2Fslash/cancel",
+        { method: "POST" },
+      );
+    });
+  });
+});

--- a/packages/web/lib/api/client.test.ts
+++ b/packages/web/lib/api/client.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./http", () => ({
+  fetchJson: vi.fn(),
+  ApiError: class ApiError extends Error {},
+  ApiNotConfigured: class ApiNotConfigured extends Error {},
+}));
+
+import { api } from "./client";
+import { fetchJson } from "./http";
+
+const fetchJsonMock = vi.mocked(fetchJson);
+
+beforeEach(() => {
+  fetchJsonMock.mockReset();
+  fetchJsonMock.mockResolvedValue([]);
+});
+
+describe("api client", () => {
+  describe("tasks", () => {
+    it("list() hits /api/tasks with empty query when no filter is given", async () => {
+      await api.tasks.list();
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/tasks", { query: {} });
+    });
+
+    it("list({lifecycle, view, assignee_id}) forwards every filter to the query", async () => {
+      await api.tasks.list({ lifecycle: "in_review", view: "mine", assignee_id: "a1" });
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/tasks", {
+        query: { lifecycle: "in_review", view: "mine", assignee_id: "a1" },
+      });
+    });
+
+    it("get(id) URL-encodes the id", async () => {
+      await api.tasks.get("task with spaces");
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/tasks/task%20with%20spaces");
+    });
+  });
+
+  describe("agents", () => {
+    it("list() hits /api/agents", async () => {
+      await api.agents.list();
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/agents");
+    });
+
+    it("get(id) URL-encodes the id", async () => {
+      await api.agents.get("agt/slash");
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/agents/agt%2Fslash");
+    });
+  });
+
+  describe("sessions", () => {
+    it("get(shortId) hits /api/sessions/:short", async () => {
+      await api.sessions.get("sess-abc");
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/sessions/sess-abc");
+    });
+  });
+
+  describe("memory", () => {
+    it("listFacts() defaults to empty filter", async () => {
+      await api.memory.listFacts();
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/memory/facts", { query: {} });
+    });
+
+    it("listFacts({scope}) forwards scope", async () => {
+      await api.memory.listFacts({ scope: "team" });
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/memory/facts", { query: { scope: "team" } });
+    });
+  });
+
+  describe("promotions / mesh / threads / dashboard", () => {
+    it("promotions.list() hits /api/promotions", async () => {
+      await api.promotions.list();
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/promotions");
+    });
+
+    it("mesh.overview() hits /api/mesh with optional since", async () => {
+      await api.mesh.overview({ since: "2026-04-30T00:00:00Z" });
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/mesh", {
+        query: { since: "2026-04-30T00:00:00Z" },
+      });
+    });
+
+    it("threads.list() / threads.get(id)", async () => {
+      await api.threads.list();
+      expect(fetchJsonMock).toHaveBeenLastCalledWith("/api/threads");
+      await api.threads.get("ch_1");
+      expect(fetchJsonMock).toHaveBeenLastCalledWith("/api/threads/ch_1");
+    });
+
+    it("dashboard.summary() hits /api/dashboard", async () => {
+      await api.dashboard.summary();
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/dashboard");
+    });
+  });
+});

--- a/packages/web/lib/api/client.test.ts
+++ b/packages/web/lib/api/client.test.ts
@@ -20,76 +20,102 @@ describe("api client", () => {
   describe("tasks", () => {
     it("list() hits /api/tasks with empty query when no filter is given", async () => {
       await api.tasks.list();
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/tasks", { query: {} });
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/tasks", {
+        query: {},
+        signal: undefined,
+      });
     });
 
     it("list({lifecycle, view, assignee_id}) forwards every filter to the query", async () => {
       await api.tasks.list({ lifecycle: "in_review", view: "mine", assignee_id: "a1" });
       expect(fetchJsonMock).toHaveBeenCalledWith("/api/tasks", {
         query: { lifecycle: "in_review", view: "mine", assignee_id: "a1" },
+        signal: undefined,
+      });
+    });
+
+    it("forwards an AbortSignal when one is provided", async () => {
+      const ac = new AbortController();
+      await api.tasks.list({}, { signal: ac.signal });
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/tasks", {
+        query: {},
+        signal: ac.signal,
       });
     });
 
     it("get(id) URL-encodes the id", async () => {
       await api.tasks.get("task with spaces");
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/tasks/task%20with%20spaces");
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/tasks/task%20with%20spaces", {
+        signal: undefined,
+      });
     });
   });
 
   describe("agents", () => {
     it("list() hits /api/agents", async () => {
       await api.agents.list();
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/agents");
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/agents", { signal: undefined });
     });
 
     it("get(id) URL-encodes the id", async () => {
       await api.agents.get("agt/slash");
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/agents/agt%2Fslash");
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/agents/agt%2Fslash", {
+        signal: undefined,
+      });
     });
   });
 
   describe("sessions", () => {
     it("get(shortId) hits /api/sessions/:short", async () => {
       await api.sessions.get("sess-abc");
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/sessions/sess-abc");
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/sessions/sess-abc", {
+        signal: undefined,
+      });
     });
   });
 
   describe("memory", () => {
     it("listFacts() defaults to empty filter", async () => {
       await api.memory.listFacts();
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/memory/facts", { query: {} });
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/memory/facts", {
+        query: {},
+        signal: undefined,
+      });
     });
 
     it("listFacts({scope}) forwards scope", async () => {
       await api.memory.listFacts({ scope: "team" });
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/memory/facts", { query: { scope: "team" } });
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/memory/facts", {
+        query: { scope: "team" },
+        signal: undefined,
+      });
     });
   });
 
   describe("promotions / mesh / threads / dashboard", () => {
     it("promotions.list() hits /api/promotions", async () => {
       await api.promotions.list();
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/promotions");
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/promotions", { signal: undefined });
     });
 
     it("mesh.overview() hits /api/mesh with optional since", async () => {
       await api.mesh.overview({ since: "2026-04-30T00:00:00Z" });
       expect(fetchJsonMock).toHaveBeenCalledWith("/api/mesh", {
         query: { since: "2026-04-30T00:00:00Z" },
+        signal: undefined,
       });
     });
 
     it("threads.list() / threads.get(id)", async () => {
       await api.threads.list();
-      expect(fetchJsonMock).toHaveBeenLastCalledWith("/api/threads");
+      expect(fetchJsonMock).toHaveBeenLastCalledWith("/api/threads", { signal: undefined });
       await api.threads.get("ch_1");
-      expect(fetchJsonMock).toHaveBeenLastCalledWith("/api/threads/ch_1");
+      expect(fetchJsonMock).toHaveBeenLastCalledWith("/api/threads/ch_1", { signal: undefined });
     });
 
     it("dashboard.summary() hits /api/dashboard", async () => {
       await api.dashboard.summary();
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/dashboard");
+      expect(fetchJsonMock).toHaveBeenCalledWith("/api/dashboard", { signal: undefined });
     });
   });
 });

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -12,7 +12,7 @@ import type { AgentDisplay } from "@/lib/types/agents";
 import type { SessionDisplay } from "@/lib/types/sessions";
 import type { MemoryFactDisplay } from "@/lib/types/memory-facts";
 import type { PromotionEvent } from "@/lib/types/promotion-events";
-import type { MemoryScope } from "@beevibe/core";
+import type { Task, MemoryScope, TaskPriority } from "@beevibe/core";
 import type { Lifecycle } from "@/lib/tasks-grouping";
 
 export type TaskView = "all" | "mine" | "sprint" | "timeline";
@@ -23,11 +23,43 @@ export interface TaskListFilter {
   view?: TaskView;
 }
 
+export type ApproveAction = "approve" | "reject" | "revise";
+
+export interface ApproveTaskInput {
+  action: ApproveAction;
+  result_summary?: string;
+}
+
+export interface CancelTaskInput {
+  force?: boolean;
+  reason?: string;
+}
+
+export interface CreateTaskInput {
+  title: string;
+  description?: string;
+  priority?: TaskPriority;
+  assignee_id?: string;
+  parent_task_id?: string;
+}
+
 export const api = {
   tasks: {
     list: (filter: TaskListFilter = {}) =>
       fetchJson<TaskListItem[]>("/api/tasks", { query: { ...filter } }),
     get: (id: string) => fetchJson<TaskDetail>(`/api/tasks/${encodeURIComponent(id)}`),
+    approve: (id: string, input: ApproveTaskInput) =>
+      fetchJson<Task>(`/api/tasks/${encodeURIComponent(id)}/approve`, {
+        method: "POST",
+        body: input,
+      }),
+    cancel: (id: string, input: CancelTaskInput = {}) =>
+      fetchJson<Task>(`/api/tasks/${encodeURIComponent(id)}/cancel`, {
+        method: "POST",
+        body: input,
+      }),
+    create: (input: CreateTaskInput) =>
+      fetchJson<Task>("/api/tasks", { method: "POST", body: input }),
   },
   agents: {
     list: () => fetchJson<AgentDisplay[]>("/api/agents"),
@@ -36,6 +68,8 @@ export const api = {
   sessions: {
     get: (shortId: string) =>
       fetchJson<SessionDisplay>(`/api/sessions/${encodeURIComponent(shortId)}`),
+    cancel: (shortId: string) =>
+      fetchJson<void>(`/api/sessions/${encodeURIComponent(shortId)}/cancel`, { method: "POST" }),
   },
   memory: {
     listFacts: (filter: { scope?: MemoryScope } = {}) =>

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -23,6 +23,10 @@ export interface TaskListFilter {
   view?: TaskView;
 }
 
+export interface ReadOptions {
+  signal?: AbortSignal;
+}
+
 export type ApproveAction = "approve" | "reject" | "revise";
 
 export interface ApproveTaskInput {
@@ -45,9 +49,10 @@ export interface CreateTaskInput {
 
 export const api = {
   tasks: {
-    list: (filter: TaskListFilter = {}) =>
-      fetchJson<TaskListItem[]>("/api/tasks", { query: { ...filter } }),
-    get: (id: string) => fetchJson<TaskDetail>(`/api/tasks/${encodeURIComponent(id)}`),
+    list: (filter: TaskListFilter = {}, opts: ReadOptions = {}) =>
+      fetchJson<TaskListItem[]>("/api/tasks", { query: { ...filter }, signal: opts.signal }),
+    get: (id: string, opts: ReadOptions = {}) =>
+      fetchJson<TaskDetail>(`/api/tasks/${encodeURIComponent(id)}`, { signal: opts.signal }),
     approve: (id: string, input: ApproveTaskInput) =>
       fetchJson<Task>(`/api/tasks/${encodeURIComponent(id)}/approve`, {
         method: "POST",
@@ -62,32 +67,43 @@ export const api = {
       fetchJson<Task>("/api/tasks", { method: "POST", body: input }),
   },
   agents: {
-    list: () => fetchJson<AgentDisplay[]>("/api/agents"),
-    get: (id: string) => fetchJson<AgentDetail>(`/api/agents/${encodeURIComponent(id)}`),
+    list: (opts: ReadOptions = {}) =>
+      fetchJson<AgentDisplay[]>("/api/agents", { signal: opts.signal }),
+    get: (id: string, opts: ReadOptions = {}) =>
+      fetchJson<AgentDetail>(`/api/agents/${encodeURIComponent(id)}`, { signal: opts.signal }),
   },
   sessions: {
-    get: (shortId: string) =>
-      fetchJson<SessionDisplay>(`/api/sessions/${encodeURIComponent(shortId)}`),
+    get: (shortId: string, opts: ReadOptions = {}) =>
+      fetchJson<SessionDisplay>(`/api/sessions/${encodeURIComponent(shortId)}`, {
+        signal: opts.signal,
+      }),
     cancel: (shortId: string) =>
       fetchJson<void>(`/api/sessions/${encodeURIComponent(shortId)}/cancel`, { method: "POST" }),
   },
   memory: {
-    listFacts: (filter: { scope?: MemoryScope } = {}) =>
-      fetchJson<MemoryFactDisplay[]>("/api/memory/facts", { query: { ...filter } }),
+    listFacts: (filter: { scope?: MemoryScope } = {}, opts: ReadOptions = {}) =>
+      fetchJson<MemoryFactDisplay[]>("/api/memory/facts", {
+        query: { ...filter },
+        signal: opts.signal,
+      }),
   },
   promotions: {
-    list: () => fetchJson<PromotionEvent[]>("/api/promotions"),
+    list: (opts: ReadOptions = {}) =>
+      fetchJson<PromotionEvent[]>("/api/promotions", { signal: opts.signal }),
   },
   mesh: {
-    overview: (filter: { since?: string } = {}) =>
-      fetchJson<MeshOverview>("/api/mesh", { query: { ...filter } }),
+    overview: (filter: { since?: string } = {}, opts: ReadOptions = {}) =>
+      fetchJson<MeshOverview>("/api/mesh", { query: { ...filter }, signal: opts.signal }),
   },
   threads: {
-    list: () => fetchJson<ThreadsOverview>("/api/threads"),
-    get: (id: string) => fetchJson<ThreadDetail>(`/api/threads/${encodeURIComponent(id)}`),
+    list: (opts: ReadOptions = {}) =>
+      fetchJson<ThreadsOverview>("/api/threads", { signal: opts.signal }),
+    get: (id: string, opts: ReadOptions = {}) =>
+      fetchJson<ThreadDetail>(`/api/threads/${encodeURIComponent(id)}`, { signal: opts.signal }),
   },
   dashboard: {
-    summary: () => fetchJson<DashboardSummary>("/api/dashboard"),
+    summary: (opts: ReadOptions = {}) =>
+      fetchJson<DashboardSummary>("/api/dashboard", { signal: opts.signal }),
   },
 } as const;
 

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -1,0 +1,60 @@
+import { fetchJson } from "./http";
+import type {
+  TaskDetail,
+  AgentDetail,
+  DashboardSummary,
+  MeshOverview,
+  ThreadsOverview,
+  ThreadDetail,
+} from "./types";
+import type { TaskListItem } from "@/lib/types/tasks";
+import type { AgentDisplay } from "@/lib/types/agents";
+import type { SessionDisplay } from "@/lib/types/sessions";
+import type { MemoryFactDisplay } from "@/lib/types/memory-facts";
+import type { PromotionEvent } from "@/lib/types/promotion-events";
+import type { MemoryScope } from "@beevibe/core";
+import type { Lifecycle } from "@/lib/tasks-grouping";
+
+export type TaskView = "all" | "mine" | "sprint" | "timeline";
+
+export interface TaskListFilter {
+  lifecycle?: Lifecycle;
+  assignee_id?: string;
+  view?: TaskView;
+}
+
+export const api = {
+  tasks: {
+    list: (filter: TaskListFilter = {}) =>
+      fetchJson<TaskListItem[]>("/api/tasks", { query: { ...filter } }),
+    get: (id: string) => fetchJson<TaskDetail>(`/api/tasks/${encodeURIComponent(id)}`),
+  },
+  agents: {
+    list: () => fetchJson<AgentDisplay[]>("/api/agents"),
+    get: (id: string) => fetchJson<AgentDetail>(`/api/agents/${encodeURIComponent(id)}`),
+  },
+  sessions: {
+    get: (shortId: string) =>
+      fetchJson<SessionDisplay>(`/api/sessions/${encodeURIComponent(shortId)}`),
+  },
+  memory: {
+    listFacts: (filter: { scope?: MemoryScope } = {}) =>
+      fetchJson<MemoryFactDisplay[]>("/api/memory/facts", { query: { ...filter } }),
+  },
+  promotions: {
+    list: () => fetchJson<PromotionEvent[]>("/api/promotions"),
+  },
+  mesh: {
+    overview: (filter: { since?: string } = {}) =>
+      fetchJson<MeshOverview>("/api/mesh", { query: { ...filter } }),
+  },
+  threads: {
+    list: () => fetchJson<ThreadsOverview>("/api/threads"),
+    get: (id: string) => fetchJson<ThreadDetail>(`/api/threads/${encodeURIComponent(id)}`),
+  },
+  dashboard: {
+    summary: () => fetchJson<DashboardSummary>("/api/dashboard"),
+  },
+} as const;
+
+export type Api = typeof api;

--- a/packages/web/lib/api/config.test.ts
+++ b/packages/web/lib/api/config.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+async function loadConfig() {
+  return import("./config");
+}
+
+describe("api config", () => {
+  it("treats missing NEXT_PUBLIC_BV_API_URL as not configured", async () => {
+    vi.stubEnv("NEXT_PUBLIC_BV_API_URL", "");
+    vi.resetModules();
+    const { apiBaseUrl, isApiConfigured } = await loadConfig();
+    expect(apiBaseUrl).toBeNull();
+    expect(isApiConfigured).toBe(false);
+  });
+
+  it("trims whitespace and strips trailing slashes", async () => {
+    vi.stubEnv("NEXT_PUBLIC_BV_API_URL", "  https://api.example.com///  ");
+    vi.resetModules();
+    const { apiBaseUrl, isApiConfigured } = await loadConfig();
+    expect(apiBaseUrl).toBe("https://api.example.com");
+    expect(isApiConfigured).toBe(true);
+  });
+
+  it("accepts a clean URL unchanged", async () => {
+    vi.stubEnv("NEXT_PUBLIC_BV_API_URL", "http://localhost:3002");
+    vi.resetModules();
+    const { apiBaseUrl, isApiConfigured } = await loadConfig();
+    expect(apiBaseUrl).toBe("http://localhost:3002");
+    expect(isApiConfigured).toBe(true);
+  });
+
+  it("returns null for a whitespace-only value", async () => {
+    vi.stubEnv("NEXT_PUBLIC_BV_API_URL", "   ");
+    vi.resetModules();
+    const { apiBaseUrl, isApiConfigured } = await loadConfig();
+    expect(apiBaseUrl).toBeNull();
+    expect(isApiConfigured).toBe(false);
+  });
+});

--- a/packages/web/lib/api/config.ts
+++ b/packages/web/lib/api/config.ts
@@ -1,0 +1,6 @@
+const raw = process.env.NEXT_PUBLIC_BV_API_URL?.trim();
+
+export const apiBaseUrl: string | null =
+  raw && raw.length > 0 ? raw.replace(/\/+$/, "") : null;
+
+export const isApiConfigured: boolean = apiBaseUrl !== null;

--- a/packages/web/lib/api/http.test.ts
+++ b/packages/web/lib/api/http.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./config", () => ({
+  apiBaseUrl: "https://api.example.com",
+  isApiConfigured: true,
+}));
+
+import { fetchJson, ApiError } from "./http";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function jsonResponse(body: unknown, init: { status?: number; statusText?: string } = {}) {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    statusText: init.statusText ?? "OK",
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("fetchJson", () => {
+  it("issues GET with Accept header against the configured base URL", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    const result = await fetchJson<{ ok: boolean }>("/api/tasks");
+
+    expect(result).toEqual({ ok: true });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.example.com/api/tasks");
+    expect(init.method).toBeUndefined();
+    expect((init.headers as Record<string, string>).Accept).toBe("application/json");
+    expect(init.body).toBeUndefined();
+  });
+
+  it("appends query params, skipping undefined and null", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([]));
+
+    await fetchJson<unknown[]>("/api/tasks", {
+      query: { view: "mine", limit: 25, archived: false, scope: undefined, owner: null },
+    });
+
+    const [url] = fetchMock.mock.calls[0];
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get("view")).toBe("mine");
+    expect(parsed.searchParams.get("limit")).toBe("25");
+    expect(parsed.searchParams.get("archived")).toBe("false");
+    expect(parsed.searchParams.has("scope")).toBe(false);
+    expect(parsed.searchParams.has("owner")).toBe(false);
+  });
+
+  it("serializes JSON body and sets Content-Type when body present", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: "t1" }));
+
+    await fetchJson("/api/tasks", { method: "POST", body: { title: "hi" } });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.method).toBe("POST");
+    expect(init.body).toBe(JSON.stringify({ title: "hi" }));
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe("application/json");
+  });
+
+  it("normalizes paths without leading slash", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}));
+    await fetchJson("api/tasks");
+    expect(fetchMock.mock.calls[0][0]).toBe("https://api.example.com/api/tasks");
+  });
+
+  it("throws ApiError with status + parsed body on non-2xx", async () => {
+    const respond = () =>
+      new Response(JSON.stringify({ message: "nope" }), {
+        status: 404,
+        statusText: "Not Found",
+        headers: { "Content-Type": "application/json" },
+      });
+    fetchMock.mockResolvedValueOnce(respond()).mockResolvedValueOnce(respond());
+
+    await expect(fetchJson("/api/tasks/missing")).rejects.toMatchObject({
+      name: "ApiError",
+      status: 404,
+      body: { message: "nope" },
+    });
+    await expect(fetchJson("/api/tasks/missing")).rejects.toBeInstanceOf(ApiError);
+  });
+
+  it("returns undefined for an empty 200 body without throwing", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("", { status: 200 }));
+    const result = await fetchJson("/api/no-content");
+    expect(result).toBeUndefined();
+  });
+
+  it("falls back to raw text when body is not JSON", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("plain text response", {
+        status: 500,
+        statusText: "ISE",
+        headers: { "Content-Type": "text/plain" },
+      }),
+    );
+
+    await expect(fetchJson("/api/x")).rejects.toMatchObject({
+      status: 500,
+      body: "plain text response",
+    });
+  });
+});
+
+describe("fetchJson when API is not configured", () => {
+  it("throws ApiNotConfigured without invoking fetch", async () => {
+    vi.resetModules();
+    vi.doMock("./config", () => ({ apiBaseUrl: null, isApiConfigured: false }));
+
+    const { fetchJson: ucFetch, ApiNotConfigured } = await import("./http");
+    await expect(ucFetch("/api/tasks")).rejects.toBeInstanceOf(ApiNotConfigured);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    vi.doUnmock("./config");
+    vi.resetModules();
+  });
+});

--- a/packages/web/lib/api/http.ts
+++ b/packages/web/lib/api/http.ts
@@ -1,0 +1,67 @@
+import { apiBaseUrl } from "./config";
+
+export class ApiError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+export class ApiNotConfigured extends Error {
+  constructor() {
+    super("NEXT_PUBLIC_BV_API_URL is not set");
+    this.name = "ApiNotConfigured";
+  }
+}
+
+export interface FetchOptions extends Omit<RequestInit, "body"> {
+  query?: Record<string, string | number | boolean | undefined | null>;
+  body?: unknown;
+}
+
+function buildUrl(path: string, query?: FetchOptions["query"]): string {
+  if (!apiBaseUrl) throw new ApiNotConfigured();
+  const url = new URL(path.startsWith("/") ? path : `/${path}`, `${apiBaseUrl}/`);
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      if (value === undefined || value === null) continue;
+      url.searchParams.set(key, String(value));
+    }
+  }
+  return url.toString();
+}
+
+export async function fetchJson<T>(path: string, opts: FetchOptions = {}): Promise<T> {
+  const { query, body, headers, ...rest } = opts;
+  const init: RequestInit = {
+    ...rest,
+    headers: {
+      Accept: "application/json",
+      ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+      ...headers,
+    },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  };
+
+  const res = await fetch(buildUrl(path, query), init);
+  const text = await res.text();
+  const parsed: unknown = text ? safeParse(text) : undefined;
+
+  if (!res.ok) {
+    throw new ApiError(`HTTP ${res.status} ${res.statusText}`, res.status, parsed);
+  }
+  return parsed as T;
+}
+
+function safeParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}

--- a/packages/web/lib/api/http.ts
+++ b/packages/web/lib/api/http.ts
@@ -37,9 +37,10 @@ function buildUrl(path: string, query?: FetchOptions["query"]): string {
 }
 
 export async function fetchJson<T>(path: string, opts: FetchOptions = {}): Promise<T> {
-  const { query, body, headers, ...rest } = opts;
+  const { query, body, headers, signal, ...rest } = opts;
   const init: RequestInit = {
     ...rest,
+    signal,
     headers: {
       Accept: "application/json",
       ...(body !== undefined ? { "Content-Type": "application/json" } : {}),

--- a/packages/web/lib/api/types.ts
+++ b/packages/web/lib/api/types.ts
@@ -40,8 +40,14 @@ export interface DashboardSummary {
   kpis: KpiStat[];
   status_breakdown: StatusBreakdownEntry[];
   status_legend: StatusLegendEntry[];
+  status_total: number;
   fleet: FleetBar[];
+  fleet_total: number;
+  fleet_active: number;
+  fleet_idle: number;
   trend: TrendDay[];
+  trend_total: number;
+  trend_change_percent: number;
   attention: AttentionItem[];
 }
 

--- a/packages/web/lib/api/types.ts
+++ b/packages/web/lib/api/types.ts
@@ -1,0 +1,64 @@
+import type { WorkProduct } from "@beevibe/core";
+import type { TaskListItem } from "@/lib/types/tasks";
+import type { AgentDisplay, RecentSession, OutgoingMeshHint } from "@/lib/types/agents";
+import type { CoreBlockDisplay, AgentMetrics } from "@/lib/types/core-memory-blocks";
+import type {
+  KpiStat,
+  StatusBreakdownEntry,
+  StatusLegendEntry,
+  FleetBar,
+  TrendDay,
+  AttentionItem,
+} from "@/lib/types/dashboard";
+import type { ChainBudgetData, GraphNode, GraphEdge, MeshSummary, MeshAsk } from "@/lib/types/mesh";
+import type { ThreadEvent, ThreadChannel, DirectMessage, ActiveChannel } from "@/lib/types/thread-messages";
+
+export interface TaskDetail extends TaskListItem {
+  work_products: WorkProduct[];
+  sessions: TaskDetailSessionRow[];
+}
+
+export interface TaskDetailSessionRow {
+  id: string;
+  short_id: string;
+  agent_id: string;
+  agent_label: string;
+  status: "running" | "succeeded" | "failed" | "cancelled";
+  started_at: Date;
+  duration_label: string;
+  result_summary?: string;
+}
+
+export interface AgentDetail extends AgentDisplay {
+  core_blocks: CoreBlockDisplay[];
+  metrics: AgentMetrics;
+  recent_sessions: RecentSession[];
+  outgoing_mesh_hints: OutgoingMeshHint[];
+}
+
+export interface DashboardSummary {
+  kpis: KpiStat[];
+  status_breakdown: StatusBreakdownEntry[];
+  status_legend: StatusLegendEntry[];
+  fleet: FleetBar[];
+  trend: TrendDay[];
+  attention: AttentionItem[];
+}
+
+export interface MeshOverview {
+  asks: MeshAsk[];
+  graph: { nodes: GraphNode[]; edges: GraphEdge[] };
+  budget: ChainBudgetData;
+  summary: MeshSummary;
+}
+
+export interface ThreadsOverview {
+  channels: ThreadChannel[];
+  direct_messages: DirectMessage[];
+  active_channel?: ActiveChannel;
+}
+
+export interface ThreadDetail {
+  channel: ActiveChannel;
+  events: ThreadEvent[];
+}

--- a/packages/web/lib/hooks/keys.test.ts
+++ b/packages/web/lib/hooks/keys.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { queryKeys } from "./keys";
+
+describe("queryKeys", () => {
+  it("namespaces every domain under a stable root tuple", () => {
+    expect(queryKeys.tasks.all).toEqual(["tasks"]);
+    expect(queryKeys.agents.all).toEqual(["agents"]);
+    expect(queryKeys.sessions.all).toEqual(["sessions"]);
+    expect(queryKeys.memory.all).toEqual(["memory"]);
+    expect(queryKeys.promotions.all).toEqual(["promotions"]);
+    expect(queryKeys.mesh.all).toEqual(["mesh"]);
+    expect(queryKeys.threads.all).toEqual(["threads"]);
+    expect(queryKeys.dashboard.all).toEqual(["dashboard"]);
+  });
+
+  it("derives list/detail keys that share the root prefix (so SSE invalidation cascades work)", () => {
+    const taskList = queryKeys.tasks.list({ view: "mine" });
+    const taskDetail = queryKeys.tasks.detail("t_1");
+    expect(taskList[0]).toBe("tasks");
+    expect(taskDetail[0]).toBe("tasks");
+    expect(taskList).not.toEqual(taskDetail);
+  });
+
+  it("filter args are part of the key (so different filters cache separately)", () => {
+    const a = queryKeys.tasks.list({ view: "mine" });
+    const b = queryKeys.tasks.list({ view: "sprint" });
+    expect(a).not.toEqual(b);
+  });
+
+  it("structural equality across separate calls with the same arg shape", () => {
+    const a = queryKeys.tasks.list({ view: "mine" });
+    const b = queryKeys.tasks.list({ view: "mine" });
+    expect(a).toEqual(b);
+  });
+});

--- a/packages/web/lib/hooks/keys.ts
+++ b/packages/web/lib/hooks/keys.ts
@@ -1,0 +1,40 @@
+import type { TaskListFilter } from "@/lib/api/client";
+import type { MemoryScope } from "@beevibe/core";
+
+export const queryKeys = {
+  tasks: {
+    all: ["tasks"] as const,
+    list: (filter: TaskListFilter) => ["tasks", "list", filter] as const,
+    detail: (id: string) => ["tasks", "detail", id] as const,
+  },
+  agents: {
+    all: ["agents"] as const,
+    list: () => ["agents", "list"] as const,
+    detail: (id: string) => ["agents", "detail", id] as const,
+  },
+  sessions: {
+    all: ["sessions"] as const,
+    detail: (shortId: string) => ["sessions", "detail", shortId] as const,
+  },
+  memory: {
+    all: ["memory"] as const,
+    facts: (filter: { scope?: MemoryScope }) => ["memory", "facts", filter] as const,
+  },
+  promotions: {
+    all: ["promotions"] as const,
+    list: () => ["promotions", "list"] as const,
+  },
+  mesh: {
+    all: ["mesh"] as const,
+    overview: (filter: { since?: string }) => ["mesh", "overview", filter] as const,
+  },
+  threads: {
+    all: ["threads"] as const,
+    list: () => ["threads", "list"] as const,
+    detail: (id: string) => ["threads", "detail", id] as const,
+  },
+  dashboard: {
+    all: ["dashboard"] as const,
+    summary: () => ["dashboard", "summary"] as const,
+  },
+} as const;

--- a/packages/web/lib/hooks/use-agents.ts
+++ b/packages/web/lib/hooks/use-agents.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api/client";
+import { isApiConfigured } from "@/lib/api/config";
+import { queryKeys } from "./keys";
+
+export function useAgents() {
+  return useQuery({
+    queryKey: queryKeys.agents.list(),
+    queryFn: () => api.agents.list(),
+    enabled: isApiConfigured,
+  });
+}
+
+export function useAgent(id: string | undefined) {
+  return useQuery({
+    queryKey: id ? queryKeys.agents.detail(id) : queryKeys.agents.all,
+    queryFn: () => api.agents.get(id as string),
+    enabled: isApiConfigured && !!id,
+  });
+}

--- a/packages/web/lib/hooks/use-agents.ts
+++ b/packages/web/lib/hooks/use-agents.ts
@@ -6,7 +6,7 @@ import { queryKeys } from "./keys";
 export function useAgents() {
   return useQuery({
     queryKey: queryKeys.agents.list(),
-    queryFn: () => api.agents.list(),
+    queryFn: ({ signal }) => api.agents.list({ signal }),
     enabled: isApiConfigured,
   });
 }
@@ -14,7 +14,7 @@ export function useAgents() {
 export function useAgent(id: string | undefined) {
   return useQuery({
     queryKey: id ? queryKeys.agents.detail(id) : queryKeys.agents.all,
-    queryFn: () => api.agents.get(id as string),
+    queryFn: ({ signal }) => api.agents.get(id as string, { signal }),
     enabled: isApiConfigured && !!id,
   });
 }

--- a/packages/web/lib/hooks/use-dashboard.ts
+++ b/packages/web/lib/hooks/use-dashboard.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api/client";
+import { isApiConfigured } from "@/lib/api/config";
+import { queryKeys } from "./keys";
+
+export function useDashboard() {
+  return useQuery({
+    queryKey: queryKeys.dashboard.summary(),
+    queryFn: () => api.dashboard.summary(),
+    enabled: isApiConfigured,
+  });
+}

--- a/packages/web/lib/hooks/use-dashboard.ts
+++ b/packages/web/lib/hooks/use-dashboard.ts
@@ -6,7 +6,7 @@ import { queryKeys } from "./keys";
 export function useDashboard() {
   return useQuery({
     queryKey: queryKeys.dashboard.summary(),
-    queryFn: () => api.dashboard.summary(),
+    queryFn: ({ signal }) => api.dashboard.summary({ signal }),
     enabled: isApiConfigured,
   });
 }

--- a/packages/web/lib/hooks/use-memory.ts
+++ b/packages/web/lib/hooks/use-memory.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import type { MemoryScope } from "@beevibe/core";
+import { api } from "@/lib/api/client";
+import { isApiConfigured } from "@/lib/api/config";
+import { queryKeys } from "./keys";
+
+export function useMemoryFacts(filter: { scope?: MemoryScope } = {}) {
+  return useQuery({
+    queryKey: queryKeys.memory.facts(filter),
+    queryFn: () => api.memory.listFacts(filter),
+    enabled: isApiConfigured,
+  });
+}

--- a/packages/web/lib/hooks/use-memory.ts
+++ b/packages/web/lib/hooks/use-memory.ts
@@ -7,7 +7,7 @@ import { queryKeys } from "./keys";
 export function useMemoryFacts(filter: { scope?: MemoryScope } = {}) {
   return useQuery({
     queryKey: queryKeys.memory.facts(filter),
-    queryFn: () => api.memory.listFacts(filter),
+    queryFn: ({ signal }) => api.memory.listFacts(filter, { signal }),
     enabled: isApiConfigured,
   });
 }

--- a/packages/web/lib/hooks/use-mesh.ts
+++ b/packages/web/lib/hooks/use-mesh.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api/client";
+import { isApiConfigured } from "@/lib/api/config";
+import { queryKeys } from "./keys";
+
+export function useMeshOverview(filter: { since?: string } = {}) {
+  return useQuery({
+    queryKey: queryKeys.mesh.overview(filter),
+    queryFn: () => api.mesh.overview(filter),
+    enabled: isApiConfigured,
+  });
+}

--- a/packages/web/lib/hooks/use-mesh.ts
+++ b/packages/web/lib/hooks/use-mesh.ts
@@ -6,7 +6,7 @@ import { queryKeys } from "./keys";
 export function useMeshOverview(filter: { since?: string } = {}) {
   return useQuery({
     queryKey: queryKeys.mesh.overview(filter),
-    queryFn: () => api.mesh.overview(filter),
+    queryFn: ({ signal }) => api.mesh.overview(filter, { signal }),
     enabled: isApiConfigured,
   });
 }

--- a/packages/web/lib/hooks/use-promotions.ts
+++ b/packages/web/lib/hooks/use-promotions.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api/client";
+import { isApiConfigured } from "@/lib/api/config";
+import { queryKeys } from "./keys";
+
+export function usePromotions() {
+  return useQuery({
+    queryKey: queryKeys.promotions.list(),
+    queryFn: () => api.promotions.list(),
+    enabled: isApiConfigured,
+  });
+}

--- a/packages/web/lib/hooks/use-promotions.ts
+++ b/packages/web/lib/hooks/use-promotions.ts
@@ -6,7 +6,7 @@ import { queryKeys } from "./keys";
 export function usePromotions() {
   return useQuery({
     queryKey: queryKeys.promotions.list(),
-    queryFn: () => api.promotions.list(),
+    queryFn: ({ signal }) => api.promotions.list({ signal }),
     enabled: isApiConfigured,
   });
 }

--- a/packages/web/lib/hooks/use-session-mutations.test.tsx
+++ b/packages/web/lib/hooks/use-session-mutations.test.tsx
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+vi.mock("@/lib/api/client", () => ({
+  api: {
+    sessions: { cancel: vi.fn() },
+  },
+}));
+
+import { useCancelSession } from "./use-session-mutations";
+import { api } from "@/lib/api/client";
+import { queryKeys } from "./keys";
+
+const cancelMock = vi.mocked(api.sessions.cancel);
+
+function makeWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  }
+  return { invalidateSpy, Wrapper };
+}
+
+beforeEach(() => {
+  cancelMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useCancelSession", () => {
+  it("calls api.sessions.cancel with the shortId and invalidates session + task caches", async () => {
+    cancelMock.mockResolvedValue(undefined);
+    const { invalidateSpy, Wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useCancelSession("sess_1", "t_1"), { wrapper: Wrapper });
+
+    await act(async () => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(cancelMock).toHaveBeenCalledWith("sess_1"));
+
+    const invalidated = invalidateSpy.mock.calls.map((c) => c[0]?.queryKey);
+    expect(invalidated).toEqual(
+      expect.arrayContaining([
+        queryKeys.sessions.detail("sess_1"),
+        queryKeys.sessions.all,
+        queryKeys.tasks.detail("t_1"),
+        queryKeys.tasks.all,
+      ]),
+    );
+  });
+
+  it("skips task-detail invalidation when taskId is omitted", async () => {
+    cancelMock.mockResolvedValue(undefined);
+    const { invalidateSpy, Wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useCancelSession("sess_1"), { wrapper: Wrapper });
+
+    await act(async () => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(cancelMock).toHaveBeenCalledWith("sess_1"));
+
+    const invalidated = invalidateSpy.mock.calls.map((c) => c[0]?.queryKey);
+    expect(invalidated).not.toContain(queryKeys.tasks.detail("t_1"));
+  });
+});

--- a/packages/web/lib/hooks/use-session-mutations.ts
+++ b/packages/web/lib/hooks/use-session-mutations.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api/client";
+import { queryKeys } from "./keys";
+
+export function useCancelSession(shortId: string, taskId?: string) {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.sessions.cancel(shortId),
+    onSuccess: () => {
+      client.invalidateQueries({ queryKey: queryKeys.sessions.detail(shortId) });
+      client.invalidateQueries({ queryKey: queryKeys.sessions.all });
+      if (taskId) client.invalidateQueries({ queryKey: queryKeys.tasks.detail(taskId) });
+      client.invalidateQueries({ queryKey: queryKeys.tasks.all });
+    },
+  });
+}

--- a/packages/web/lib/hooks/use-sessions.ts
+++ b/packages/web/lib/hooks/use-sessions.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api/client";
+import { isApiConfigured } from "@/lib/api/config";
+import { queryKeys } from "./keys";
+
+export function useSession(shortId: string | undefined) {
+  return useQuery({
+    queryKey: shortId ? queryKeys.sessions.detail(shortId) : queryKeys.sessions.all,
+    queryFn: () => api.sessions.get(shortId as string),
+    enabled: isApiConfigured && !!shortId,
+  });
+}

--- a/packages/web/lib/hooks/use-sessions.ts
+++ b/packages/web/lib/hooks/use-sessions.ts
@@ -6,7 +6,7 @@ import { queryKeys } from "./keys";
 export function useSession(shortId: string | undefined) {
   return useQuery({
     queryKey: shortId ? queryKeys.sessions.detail(shortId) : queryKeys.sessions.all,
-    queryFn: () => api.sessions.get(shortId as string),
+    queryFn: ({ signal }) => api.sessions.get(shortId as string, { signal }),
     enabled: isApiConfigured && !!shortId,
   });
 }

--- a/packages/web/lib/hooks/use-task-mutations.test.tsx
+++ b/packages/web/lib/hooks/use-task-mutations.test.tsx
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+vi.mock("@/lib/api/client", () => ({
+  api: {
+    tasks: {
+      approve: vi.fn(),
+      cancel: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}));
+
+import {
+  useApproveTask,
+  useCancelTask,
+  useCreateTask,
+} from "./use-task-mutations";
+import { api } from "@/lib/api/client";
+import { queryKeys } from "./keys";
+
+const approveMock = vi.mocked(api.tasks.approve);
+const cancelMock = vi.mocked(api.tasks.cancel);
+const createMock = vi.mocked(api.tasks.create);
+
+function makeWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  }
+  return { client, invalidateSpy, Wrapper };
+}
+
+beforeEach(() => {
+  approveMock.mockReset();
+  cancelMock.mockReset();
+  createMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useApproveTask", () => {
+  it("calls api.tasks.approve with the input and invalidates task + dashboard caches", async () => {
+    approveMock.mockResolvedValue({} as never);
+    const { invalidateSpy, Wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useApproveTask("t_1"), { wrapper: Wrapper });
+
+    await act(async () => {
+      result.current.mutate({ action: "approve" });
+    });
+
+    await waitFor(() => expect(approveMock).toHaveBeenCalledWith("t_1", { action: "approve" }));
+
+    const invalidated = invalidateSpy.mock.calls.map((c) => c[0]?.queryKey);
+    expect(invalidated).toEqual(
+      expect.arrayContaining([
+        queryKeys.tasks.detail("t_1"),
+        queryKeys.tasks.all,
+        queryKeys.dashboard.all,
+      ]),
+    );
+  });
+
+  it("surfaces errors via mutation state", async () => {
+    approveMock.mockRejectedValue(new Error("nope"));
+    const { Wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useApproveTask("t_1"), { wrapper: Wrapper });
+
+    await act(async () => {
+      result.current.mutate({ action: "reject" });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(new Error("nope"));
+  });
+});
+
+describe("useCancelTask", () => {
+  it("calls api.tasks.cancel with no args by default", async () => {
+    cancelMock.mockResolvedValue({} as never);
+    const { Wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useCancelTask("t_1"), { wrapper: Wrapper });
+
+    await act(async () => {
+      result.current.mutate(undefined as never);
+    });
+
+    await waitFor(() => expect(cancelMock).toHaveBeenCalledWith("t_1", {}));
+  });
+
+  it("forwards cancel input when provided", async () => {
+    cancelMock.mockResolvedValue({} as never);
+    const { Wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useCancelTask("t_1"), { wrapper: Wrapper });
+
+    await act(async () => {
+      result.current.mutate({ force: true, reason: "scope" });
+    });
+
+    await waitFor(() =>
+      expect(cancelMock).toHaveBeenCalledWith("t_1", { force: true, reason: "scope" }),
+    );
+  });
+});
+
+describe("useCreateTask", () => {
+  it("calls api.tasks.create and invalidates the task list", async () => {
+    createMock.mockResolvedValue({} as never);
+    const { invalidateSpy, Wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useCreateTask(), { wrapper: Wrapper });
+
+    await act(async () => {
+      result.current.mutate({ title: "wire" });
+    });
+
+    await waitFor(() => expect(createMock).toHaveBeenCalledWith({ title: "wire" }));
+
+    const invalidated = invalidateSpy.mock.calls.map((c) => c[0]?.queryKey);
+    expect(invalidated).toEqual(
+      expect.arrayContaining([queryKeys.tasks.all, queryKeys.dashboard.all]),
+    );
+  });
+});

--- a/packages/web/lib/hooks/use-task-mutations.ts
+++ b/packages/web/lib/hooks/use-task-mutations.ts
@@ -1,0 +1,42 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  api,
+  type ApproveTaskInput,
+  type CancelTaskInput,
+  type CreateTaskInput,
+} from "@/lib/api/client";
+import { queryKeys } from "./keys";
+
+export function useApproveTask(taskId: string) {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: (input: ApproveTaskInput) => api.tasks.approve(taskId, input),
+    onSuccess: () => {
+      client.invalidateQueries({ queryKey: queryKeys.tasks.detail(taskId) });
+      client.invalidateQueries({ queryKey: queryKeys.tasks.all });
+      client.invalidateQueries({ queryKey: queryKeys.dashboard.all });
+    },
+  });
+}
+
+export function useCancelTask(taskId: string) {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: (input: CancelTaskInput = {}) => api.tasks.cancel(taskId, input),
+    onSuccess: () => {
+      client.invalidateQueries({ queryKey: queryKeys.tasks.detail(taskId) });
+      client.invalidateQueries({ queryKey: queryKeys.tasks.all });
+    },
+  });
+}
+
+export function useCreateTask() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: (input: CreateTaskInput) => api.tasks.create(input),
+    onSuccess: () => {
+      client.invalidateQueries({ queryKey: queryKeys.tasks.all });
+      client.invalidateQueries({ queryKey: queryKeys.dashboard.all });
+    },
+  });
+}

--- a/packages/web/lib/hooks/use-tasks.test.tsx
+++ b/packages/web/lib/hooks/use-tasks.test.tsx
@@ -33,9 +33,9 @@ const getMock = vi.mocked(api.tasks.get);
 
 function wrapper() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return ({ children }: { children: ReactNode }) => (
-    <QueryClientProvider client={client}>{children}</QueryClientProvider>
-  );
+  return function TestQueryWrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
 }
 
 const sampleTask: TaskListItem = {

--- a/packages/web/lib/hooks/use-tasks.test.tsx
+++ b/packages/web/lib/hooks/use-tasks.test.tsx
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { TaskListItem } from "@/lib/types/tasks";
+import type { TaskDetail } from "@/lib/api/types";
+
+const apiState = {
+  isApiConfigured: true,
+};
+
+vi.mock("@/lib/api/config", () => ({
+  get isApiConfigured() {
+    return apiState.isApiConfigured;
+  },
+  apiBaseUrl: "https://api.example.com",
+}));
+
+vi.mock("@/lib/api/client", () => ({
+  api: {
+    tasks: {
+      list: vi.fn(),
+      get: vi.fn(),
+    },
+  },
+}));
+
+import { useTasks, useTask } from "./use-tasks";
+import { api } from "@/lib/api/client";
+
+const listMock = vi.mocked(api.tasks.list);
+const getMock = vi.mocked(api.tasks.get);
+
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+const sampleTask: TaskListItem = {
+  id: "t1",
+  title: "sample",
+  status: "in_progress",
+  priority: "medium",
+  creator_id: "u1",
+  creator_type: "person",
+  created_at: new Date(),
+  updated_at: new Date(),
+};
+
+beforeEach(() => {
+  apiState.isApiConfigured = true;
+  listMock.mockReset();
+  getMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useTasks", () => {
+  it("does not fire the request when API is not configured", async () => {
+    apiState.isApiConfigured = false;
+    listMock.mockResolvedValue([sampleTask]);
+
+    const { result } = renderHook(() => useTasks(), { wrapper: wrapper() });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeUndefined();
+    expect(listMock).not.toHaveBeenCalled();
+  });
+
+  it("calls api.tasks.list with the filter and resolves to its return value", async () => {
+    listMock.mockResolvedValue([sampleTask]);
+
+    const { result } = renderHook(() => useTasks({ view: "mine" }), { wrapper: wrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([sampleTask]);
+    expect(listMock).toHaveBeenCalledWith({ view: "mine" });
+  });
+
+  it("treats different filters as separate cache entries", async () => {
+    listMock.mockResolvedValueOnce([sampleTask]).mockResolvedValueOnce([]);
+
+    const wrap = wrapper();
+    const a = renderHook(() => useTasks({ view: "mine" }), { wrapper: wrap });
+    await waitFor(() => expect(a.result.current.isSuccess).toBe(true));
+    const b = renderHook(() => useTasks({ view: "sprint" }), { wrapper: wrap });
+    await waitFor(() => expect(b.result.current.isSuccess).toBe(true));
+
+    expect(listMock).toHaveBeenCalledTimes(2);
+    expect(listMock).toHaveBeenNthCalledWith(1, { view: "mine" });
+    expect(listMock).toHaveBeenNthCalledWith(2, { view: "sprint" });
+  });
+
+  it("surfaces errors from the api", async () => {
+    listMock.mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() => useTasks(), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(new Error("boom"));
+  });
+});
+
+describe("useTask", () => {
+  const detail = {
+    ...sampleTask,
+    work_products: [],
+    sessions: [],
+  } as unknown as TaskDetail;
+
+  it("is disabled when id is undefined", async () => {
+    const { result } = renderHook(() => useTask(undefined), { wrapper: wrapper() });
+    expect(getMock).not.toHaveBeenCalled();
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("is disabled when API is not configured even with an id", async () => {
+    apiState.isApiConfigured = false;
+    const { result } = renderHook(() => useTask("t1"), { wrapper: wrapper() });
+    expect(getMock).not.toHaveBeenCalled();
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("fetches the detail when both id and config are present", async () => {
+    getMock.mockResolvedValue(detail);
+    const { result } = renderHook(() => useTask("t1"), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getMock).toHaveBeenCalledWith("t1");
+    expect(result.current.data).toEqual(detail);
+  });
+});

--- a/packages/web/lib/hooks/use-tasks.test.tsx
+++ b/packages/web/lib/hooks/use-tasks.test.tsx
@@ -78,7 +78,7 @@ describe("useTasks", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual([sampleTask]);
-    expect(listMock).toHaveBeenCalledWith({ view: "mine" });
+    expect(listMock).toHaveBeenCalledWith({ view: "mine" }, expect.objectContaining({}));
   });
 
   it("treats different filters as separate cache entries", async () => {
@@ -91,8 +91,8 @@ describe("useTasks", () => {
     await waitFor(() => expect(b.result.current.isSuccess).toBe(true));
 
     expect(listMock).toHaveBeenCalledTimes(2);
-    expect(listMock).toHaveBeenNthCalledWith(1, { view: "mine" });
-    expect(listMock).toHaveBeenNthCalledWith(2, { view: "sprint" });
+    expect(listMock).toHaveBeenNthCalledWith(1, { view: "mine" }, expect.objectContaining({}));
+    expect(listMock).toHaveBeenNthCalledWith(2, { view: "sprint" }, expect.objectContaining({}));
   });
 
   it("surfaces errors from the api", async () => {
@@ -128,7 +128,7 @@ describe("useTask", () => {
     getMock.mockResolvedValue(detail);
     const { result } = renderHook(() => useTask("t1"), { wrapper: wrapper() });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(getMock).toHaveBeenCalledWith("t1");
+    expect(getMock).toHaveBeenCalledWith("t1", expect.objectContaining({}));
     expect(result.current.data).toEqual(detail);
   });
 });

--- a/packages/web/lib/hooks/use-tasks.ts
+++ b/packages/web/lib/hooks/use-tasks.ts
@@ -6,7 +6,7 @@ import { queryKeys } from "./keys";
 export function useTasks(filter: TaskListFilter = {}) {
   return useQuery({
     queryKey: queryKeys.tasks.list(filter),
-    queryFn: () => api.tasks.list(filter),
+    queryFn: ({ signal }) => api.tasks.list(filter, { signal }),
     enabled: isApiConfigured,
   });
 }
@@ -14,7 +14,7 @@ export function useTasks(filter: TaskListFilter = {}) {
 export function useTask(id: string | undefined) {
   return useQuery({
     queryKey: id ? queryKeys.tasks.detail(id) : queryKeys.tasks.all,
-    queryFn: () => api.tasks.get(id as string),
+    queryFn: ({ signal }) => api.tasks.get(id as string, { signal }),
     enabled: isApiConfigured && !!id,
   });
 }

--- a/packages/web/lib/hooks/use-tasks.ts
+++ b/packages/web/lib/hooks/use-tasks.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import { api, type TaskListFilter } from "@/lib/api/client";
+import { isApiConfigured } from "@/lib/api/config";
+import { queryKeys } from "./keys";
+
+export function useTasks(filter: TaskListFilter = {}) {
+  return useQuery({
+    queryKey: queryKeys.tasks.list(filter),
+    queryFn: () => api.tasks.list(filter),
+    enabled: isApiConfigured,
+  });
+}
+
+export function useTask(id: string | undefined) {
+  return useQuery({
+    queryKey: id ? queryKeys.tasks.detail(id) : queryKeys.tasks.all,
+    queryFn: () => api.tasks.get(id as string),
+    enabled: isApiConfigured && !!id,
+  });
+}

--- a/packages/web/lib/hooks/use-threads.ts
+++ b/packages/web/lib/hooks/use-threads.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api/client";
+import { isApiConfigured } from "@/lib/api/config";
+import { queryKeys } from "./keys";
+
+export function useThreads() {
+  return useQuery({
+    queryKey: queryKeys.threads.list(),
+    queryFn: () => api.threads.list(),
+    enabled: isApiConfigured,
+  });
+}
+
+export function useThread(id: string | undefined) {
+  return useQuery({
+    queryKey: id ? queryKeys.threads.detail(id) : queryKeys.threads.all,
+    queryFn: () => api.threads.get(id as string),
+    enabled: isApiConfigured && !!id,
+  });
+}

--- a/packages/web/lib/hooks/use-threads.ts
+++ b/packages/web/lib/hooks/use-threads.ts
@@ -6,7 +6,7 @@ import { queryKeys } from "./keys";
 export function useThreads() {
   return useQuery({
     queryKey: queryKeys.threads.list(),
-    queryFn: () => api.threads.list(),
+    queryFn: ({ signal }) => api.threads.list({ signal }),
     enabled: isApiConfigured,
   });
 }
@@ -14,7 +14,7 @@ export function useThreads() {
 export function useThread(id: string | undefined) {
   return useQuery({
     queryKey: id ? queryKeys.threads.detail(id) : queryKeys.threads.all,
-    queryFn: () => api.threads.get(id as string),
+    queryFn: ({ signal }) => api.threads.get(id as string, { signal }),
     enabled: isApiConfigured && !!id,
   });
 }

--- a/packages/web/lib/sse.test.tsx
+++ b/packages/web/lib/sse.test.tsx
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, act } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+const apiState: { isApiConfigured: boolean; apiBaseUrl: string | null } = {
+  isApiConfigured: true,
+  apiBaseUrl: "https://api.example.com",
+};
+
+vi.mock("@/lib/api/config", () => ({
+  get isApiConfigured() {
+    return apiState.isApiConfigured;
+  },
+  get apiBaseUrl() {
+    return apiState.apiBaseUrl;
+  },
+}));
+
+import { useLiveUpdates } from "./sse";
+import { queryKeys } from "./hooks/keys";
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  url: string;
+  withCredentials: boolean;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onerror: ((e: Event) => void) | null = null;
+  closed = false;
+
+  constructor(url: string, init?: { withCredentials?: boolean }) {
+    this.url = url;
+    this.withCredentials = init?.withCredentials ?? false;
+    MockEventSource.instances.push(this);
+  }
+
+  emit(data: unknown) {
+    this.onmessage?.({ data: typeof data === "string" ? data : JSON.stringify(data) } as MessageEvent);
+  }
+
+  close() {
+    this.closed = true;
+  }
+}
+
+beforeEach(() => {
+  MockEventSource.instances = [];
+  apiState.isApiConfigured = true;
+  apiState.apiBaseUrl = "https://api.example.com";
+  vi.stubGlobal("EventSource", MockEventSource);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function makeWrapper(client: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useLiveUpdates", () => {
+  it("does not open an EventSource when API is not configured", () => {
+    apiState.isApiConfigured = false;
+    apiState.apiBaseUrl = null;
+    const client = new QueryClient();
+    renderHook(() => useLiveUpdates(), { wrapper: makeWrapper(client) });
+    expect(MockEventSource.instances).toHaveLength(0);
+  });
+
+  it("opens an EventSource on /api/stream with credentials when configured", () => {
+    const client = new QueryClient();
+    renderHook(() => useLiveUpdates(), { wrapper: makeWrapper(client) });
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.instances[0].url).toBe("https://api.example.com/api/stream");
+    expect(MockEventSource.instances[0].withCredentials).toBe(true);
+  });
+
+  it("closes the EventSource on unmount", () => {
+    const client = new QueryClient();
+    const { unmount } = renderHook(() => useLiveUpdates(), { wrapper: makeWrapper(client) });
+    const source = MockEventSource.instances[0];
+    expect(source.closed).toBe(false);
+    unmount();
+    expect(source.closed).toBe(true);
+  });
+
+  it("invalidates the right query keys on a known event", () => {
+    const client = new QueryClient();
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+    renderHook(() => useLiveUpdates(), { wrapper: makeWrapper(client) });
+    const source = MockEventSource.instances[0];
+
+    act(() => {
+      source.emit({ event: "task.updated", task_id: "t1" });
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.tasks.all });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.dashboard.all });
+  });
+
+  it("ignores events without an event field and malformed JSON", () => {
+    const client = new QueryClient();
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+    renderHook(() => useLiveUpdates(), { wrapper: makeWrapper(client) });
+    const source = MockEventSource.instances[0];
+
+    act(() => {
+      source.emit({ no_event_field: true });
+      source.emit("not-json-at-all");
+    });
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("ignores unknown event names without throwing", () => {
+    const client = new QueryClient();
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+    renderHook(() => useLiveUpdates(), { wrapper: makeWrapper(client) });
+    const source = MockEventSource.instances[0];
+
+    act(() => {
+      source.emit({ event: "completely.unknown" });
+    });
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("dispatches mesh + memory + promotion + thread invalidations on their events", () => {
+    const client = new QueryClient();
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+    renderHook(() => useLiveUpdates(), { wrapper: makeWrapper(client) });
+    const source = MockEventSource.instances[0];
+
+    act(() => {
+      source.emit({ event: "mesh.activity" });
+      source.emit({ event: "memory.fact.created" });
+      source.emit({ event: "promotion.created" });
+      source.emit({ event: "thread.message" });
+      source.emit({ event: "session.updated" });
+      source.emit({ event: "agent.updated" });
+    });
+
+    const invocations = invalidateSpy.mock.calls.map((c) => c[0]?.queryKey);
+    expect(invocations).toEqual(
+      expect.arrayContaining([
+        queryKeys.mesh.all,
+        queryKeys.memory.all,
+        queryKeys.promotions.all,
+        queryKeys.threads.all,
+        queryKeys.sessions.all,
+        queryKeys.agents.all,
+      ]),
+    );
+  });
+});

--- a/packages/web/lib/sse.test.tsx
+++ b/packages/web/lib/sse.test.tsx
@@ -55,9 +55,9 @@ afterEach(() => {
 });
 
 function makeWrapper(client: QueryClient) {
-  return ({ children }: { children: ReactNode }) => (
-    <QueryClientProvider client={client}>{children}</QueryClientProvider>
-  );
+  return function TestQueryWrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
 }
 
 describe("useLiveUpdates", () => {

--- a/packages/web/lib/sse.ts
+++ b/packages/web/lib/sse.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect } from "react";
+import { useQueryClient, type QueryClient } from "@tanstack/react-query";
+import { apiBaseUrl, isApiConfigured } from "./api/config";
+import { queryKeys } from "./hooks/keys";
+
+type InvalidationKey = readonly unknown[];
+
+const eventInvalidations: Record<string, InvalidationKey[]> = {
+  "task.updated": [queryKeys.tasks.all, queryKeys.dashboard.all],
+  "task.created": [queryKeys.tasks.all, queryKeys.dashboard.all],
+  "agent.updated": [queryKeys.agents.all],
+  "session.updated": [queryKeys.sessions.all, queryKeys.tasks.all],
+  "memory.fact.created": [queryKeys.memory.all],
+  "promotion.created": [queryKeys.promotions.all, queryKeys.memory.all],
+  "mesh.activity": [queryKeys.mesh.all],
+  "thread.message": [queryKeys.threads.all],
+};
+
+function invalidate(client: QueryClient, eventName: string) {
+  const keys = eventInvalidations[eventName];
+  if (!keys) return;
+  for (const key of keys) {
+    client.invalidateQueries({ queryKey: key });
+  }
+}
+
+export function useLiveUpdates() {
+  const client = useQueryClient();
+
+  useEffect(() => {
+    if (!isApiConfigured || !apiBaseUrl) return;
+
+    const source = new EventSource(`${apiBaseUrl}/api/stream`, { withCredentials: true });
+
+    source.onmessage = (e) => {
+      try {
+        const parsed: unknown = JSON.parse(e.data);
+        if (typeof parsed === "object" && parsed !== null && "event" in parsed) {
+          const eventName = (parsed as { event: unknown }).event;
+          if (typeof eventName === "string") invalidate(client, eventName);
+        }
+      } catch {
+        // ignore non-JSON messages (heartbeats, etc.)
+      }
+    };
+
+    return () => source.close();
+  }, [client]);
+}

--- a/packages/web/lib/tasks-grouping.test.ts
+++ b/packages/web/lib/tasks-grouping.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import type { TaskStatus } from "@beevibe/core";
+import { TASK_STATUSES } from "@beevibe/core";
+import { groupTasks, type Lifecycle } from "./tasks-grouping";
+import type { TaskListItem } from "@/lib/types/tasks";
+
+function makeTask(id: string, status: TaskStatus): TaskListItem {
+  return {
+    id,
+    title: `task-${id}`,
+    status,
+    priority: "medium",
+    creator_id: "u_creator",
+    creator_type: "person",
+    created_at: new Date("2026-04-01T00:00:00Z"),
+    updated_at: new Date("2026-04-01T00:00:00Z"),
+  };
+}
+
+const EXPECTED_LIFECYCLE: Record<TaskStatus, Lifecycle> = {
+  pending: "pending",
+  assigned: "pending",
+  in_progress: "in_progress",
+  revision: "in_progress",
+  needs_revision: "in_progress",
+  review: "in_review",
+  blocked: "in_review",
+  done: "done",
+  failed: "done",
+  cancelled: "done",
+};
+
+describe("groupTasks", () => {
+  it("returns four lanes in pending → in_progress → in_review → done order even when input is empty", () => {
+    const lanes = groupTasks([]);
+    expect(lanes.map((l) => l.key)).toEqual(["pending", "in_progress", "in_review", "done"]);
+    expect(lanes.every((l) => l.count === 0 && l.tasks.length === 0)).toBe(true);
+  });
+
+  it("maps every TaskStatus exhaustively (no status falls through to a wrong lane)", () => {
+    for (const status of TASK_STATUSES) {
+      const [task] = [makeTask("t1", status)];
+      const lanes = groupTasks([task]);
+      const populated = lanes.find((l) => l.tasks.length === 1);
+      expect(populated?.key, `status=${status}`).toBe(EXPECTED_LIFECYCLE[status]);
+    }
+  });
+
+  it("counts tasks within each lane and preserves insertion order", () => {
+    const tasks: TaskListItem[] = [
+      makeTask("a", "pending"),
+      makeTask("b", "in_progress"),
+      makeTask("c", "blocked"),
+      makeTask("d", "review"),
+      makeTask("e", "done"),
+      makeTask("f", "failed"),
+      makeTask("g", "assigned"),
+      makeTask("h", "needs_revision"),
+    ];
+    const lanes = groupTasks(tasks);
+    const byKey = Object.fromEntries(lanes.map((l) => [l.key, l]));
+
+    expect(byKey.pending.count).toBe(2);
+    expect(byKey.pending.tasks.map((t) => t.id)).toEqual(["a", "g"]);
+
+    expect(byKey.in_progress.count).toBe(2);
+    expect(byKey.in_progress.tasks.map((t) => t.id)).toEqual(["b", "h"]);
+
+    expect(byKey.in_review.count).toBe(2);
+    expect(byKey.in_review.tasks.map((t) => t.id)).toEqual(["c", "d"]);
+
+    expect(byKey.done.count).toBe(2);
+    expect(byKey.done.tasks.map((t) => t.id)).toEqual(["e", "f"]);
+  });
+
+  it("attaches a non-empty dot class and label to each lane", () => {
+    const lanes = groupTasks([]);
+    for (const lane of lanes) {
+      expect(lane.dot).toMatch(/^bg-/);
+      expect(lane.label.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/web/lib/tasks-grouping.ts
+++ b/packages/web/lib/tasks-grouping.ts
@@ -1,0 +1,40 @@
+import type { TaskStatus } from "@beevibe/core";
+import type { TaskListItem } from "@/lib/types/tasks";
+import type { BoardLane } from "@/components/tasks/board-column";
+
+export type Lifecycle = "pending" | "in_progress" | "in_review" | "done";
+
+const LIFECYCLE_OF: Record<TaskStatus, Lifecycle> = {
+  pending: "pending",
+  assigned: "pending",
+  in_progress: "in_progress",
+  revision: "in_progress",
+  needs_revision: "in_progress",
+  review: "in_review",
+  blocked: "in_review",
+  done: "done",
+  failed: "done",
+  cancelled: "done",
+};
+
+const LANE_TEMPLATE: { key: Lifecycle; label: string; dot: string }[] = [
+  { key: "pending", label: "Pending", dot: "bg-muted-foreground/50" },
+  { key: "in_progress", label: "In progress", dot: "bg-status-running" },
+  { key: "in_review", label: "In review", dot: "bg-status-review" },
+  { key: "done", label: "Done", dot: "bg-status-done" },
+];
+
+export function groupTasks(tasks: TaskListItem[]): BoardLane[] {
+  const buckets: Record<Lifecycle, TaskListItem[]> = {
+    pending: [],
+    in_progress: [],
+    in_review: [],
+    done: [],
+  };
+  for (const t of tasks) buckets[LIFECYCLE_OF[t.status]].push(t);
+  return LANE_TEMPLATE.map((l) => ({
+    ...l,
+    count: buckets[l.key].length,
+    tasks: buckets[l.key],
+  }));
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "typecheck": "tsc --noEmit",
     "lint": "next lint",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run",
     "clean": "rm -rf .next .turbo *.tsbuildinfo"
   },
   "dependencies": {
@@ -24,12 +24,18 @@
     "tailwind-merge": "^2.5.4"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6",
+    "@testing-library/react": "^16",
+    "@testing-library/user-event": "^14",
     "@types/node": "^20.16.0",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4",
     "autoprefixer": "^10.4.20",
     "eslint-config-next": "^14.2.15",
+    "happy-dom": "^15",
     "postcss": "^8.4.47",
-    "tailwindcss": "^3.4.13"
+    "tailwindcss": "^3.4.13",
+    "vitest": "^2.1.9"
   }
 }

--- a/packages/web/test/setup.ts
+++ b/packages/web/test/setup.ts
@@ -1,0 +1,7 @@
+import "@testing-library/jest-dom/vitest";
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+afterEach(() => {
+  cleanup();
+});

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import { fileURLToPath } from "node:url";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./", import.meta.url)),
+    },
+  },
+  test: {
+    globals: true,
+    environment: "happy-dom",
+    setupFiles: ["./test/setup.ts"],
+    include: ["**/*.test.{ts,tsx}"],
+    exclude: ["**/node_modules/**", "**/.next/**"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
       eslint-plugin-import:
         specifier: ^2.30.0
-        version: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
+        version: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       node-pg-migrate:
         specifier: ^7.7.1
         version: 7.9.1(@types/pg@8.20.0)(pg@8.20.0)
@@ -46,7 +46,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@25.6.0)
+        version: 2.1.9(@types/node@25.6.0)(happy-dom@15.11.7)
 
   packages/core:
     dependencies:
@@ -111,7 +111,7 @@ importers:
         version: 0.453.0(react@18.3.1)
       next:
         specifier: ^14.2.15
-        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -122,6 +122,15 @@ importers:
         specifier: ^2.5.4
         version: 2.6.1
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^20.16.0
         version: 20.19.39
@@ -131,20 +140,32 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.7(@types/react@18.3.28)
+      '@vitejs/plugin-react':
+        specifier: ^4
+        version: 4.7.0(vite@5.4.21(@types/node@20.19.39))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.5.0(postcss@8.5.10)
       eslint-config-next:
         specifier: ^14.2.15
         version: 14.2.35(eslint@8.57.1)(typescript@5.9.3)
+      happy-dom:
+        specifier: ^15
+        version: 15.11.7
       postcss:
         specifier: ^8.4.47
         version: 8.5.10
       tailwindcss:
         specifier: ^3.4.13
         version: 3.4.19(tsx@4.21.0)
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@20.19.39)(happy-dom@15.11.7)
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -159,8 +180,91 @@ packages:
       zod:
         optional: true
 
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.0':
+    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@emnapi/core@1.10.0':
@@ -508,6 +612,9 @@ packages:
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -600,6 +707,9 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
     resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
@@ -755,6 +865,35 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@turbo/darwin-64@2.9.6':
     resolution: {integrity: sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg==}
     cpu: [x64]
@@ -787,6 +926,21 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -970,6 +1124,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
 
@@ -1024,6 +1184,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -1040,6 +1204,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -1218,9 +1385,15 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -1277,6 +1450,10 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
 
@@ -1294,6 +1471,12 @@ packages:
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -1314,6 +1497,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
@@ -1560,6 +1747,10 @@ packages:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
 
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -1625,6 +1816,10 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  happy-dom@15.11.7:
+    resolution: {integrity: sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==}
+    engines: {node: '>=18.0.0'}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -1663,6 +1858,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -1819,6 +2018,11 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -1834,6 +2038,11 @@ packages:
 
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
     hasBin: true
 
   jsx-ast-utils@3.3.5:
@@ -1882,10 +2091,17 @@ packages:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
 
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
   lucide-react@0.453.0:
     resolution: {integrity: sha512-kL+RGZCcJi9BvJtzg2kshO192Ddy9hv3ij+cPrVPWSRzgCWCVazoQJxOjAwgK53NomL07HB7GPHW120FimjNhQ==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1901,6 +2117,10 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -2225,6 +2445,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -2243,6 +2467,13 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -2253,6 +2484,10 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -2438,6 +2673,10 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -2655,6 +2894,14 @@ packages:
       jsdom:
         optional: true
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -2704,6 +2951,9 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -2718,13 +2968,127 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.4.4': {}
+
   '@alloc/quick-lru@5.2.0': {}
 
   '@anthropic-ai/sdk@0.90.0':
     dependencies:
       json-schema-to-ts: 3.1.1
 
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.0': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.0
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/runtime@7.29.2': {}
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -2940,6 +3304,11 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
 
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
@@ -3005,6 +3374,8 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
     optional: true
@@ -3107,6 +3478,40 @@ snapshots:
       '@tanstack/query-core': 5.100.5
       react: 18.3.1
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@turbo/darwin-64@2.9.6':
     optional: true
 
@@ -3129,6 +3534,29 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
 
   '@types/estree@1.0.8': {}
 
@@ -3302,12 +3730,32 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@20.19.39))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 5.4.21(@types/node@20.19.39)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@2.1.9':
     dependencies:
       '@vitest/spy': 2.1.9
       '@vitest/utils': 2.1.9
       chai: 5.3.3
       tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@20.19.39))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@20.19.39)
 
   '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@25.6.0))':
     dependencies:
@@ -3363,6 +3811,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
@@ -3375,6 +3825,10 @@ snapshots:
   arg@5.0.2: {}
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -3579,11 +4033,15 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  convert-source-map@2.0.0: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css.escape@1.5.1: {}
 
   cssesc@3.0.0: {}
 
@@ -3633,6 +4091,8 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  dequal@2.0.3: {}
+
   didyoumean@1.2.2: {}
 
   dir-glob@3.0.1:
@@ -3649,6 +4109,10 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
   dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
@@ -3664,6 +4128,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  entities@4.5.0: {}
 
   es-abstract@1.24.2:
     dependencies:
@@ -3836,7 +4302,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -3866,11 +4332,11 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -3881,7 +4347,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -3892,7 +4358,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -4103,6 +4569,8 @@ snapshots:
 
   generator-function@2.0.1: {}
 
+  gensync@1.0.0-beta.2: {}
+
   get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
@@ -4191,6 +4659,12 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  happy-dom@15.11.7:
+    dependencies:
+      entities: 4.5.0
+      webidl-conversions: 7.0.0
+      whatwg-mimetype: 3.0.0
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -4221,6 +4695,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inflight@1.0.6:
     dependencies:
@@ -4386,6 +4862,8 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsesc@3.1.0: {}
+
   json-buffer@3.0.1: {}
 
   json-schema-to-ts@3.1.1:
@@ -4400,6 +4878,8 @@ snapshots:
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
+
+  json5@2.2.3: {}
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -4443,9 +4923,15 @@ snapshots:
 
   lru-cache@11.3.5: {}
 
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
   lucide-react@0.453.0(react@18.3.1):
     dependencies:
       react: 18.3.1
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -4459,6 +4945,8 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.2
+
+  min-indent@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -4492,7 +4980,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.35(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.35
       '@swc/helpers': 0.5.5
@@ -4502,7 +4990,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.1(react@18.3.1)
+      styled-jsx: 5.1.1(@babel/core@7.29.0)(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.33
       '@next/swc-darwin-x64': 14.2.33
@@ -4744,6 +5232,12 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -4762,6 +5256,10 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-is@17.0.2: {}
+
+  react-refresh@0.17.0: {}
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -4773,6 +5271,11 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.2
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -5035,12 +5538,18 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@3.1.1: {}
 
-  styled-jsx@5.1.1(react@18.3.1):
+  styled-jsx@5.1.1(@babel/core@7.29.0)(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       react: 18.3.1
+    optionalDependencies:
+      '@babel/core': 7.29.0
 
   sucrase@3.35.1:
     dependencies:
@@ -5239,6 +5748,24 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  vite-node@2.1.9(@types/node@20.19.39):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@20.19.39)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-node@2.1.9(@types/node@25.6.0):
     dependencies:
       cac: 6.7.14
@@ -5257,6 +5784,15 @@ snapshots:
       - supports-color
       - terser
 
+  vite@5.4.21(@types/node@20.19.39):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.10
+      rollup: 4.60.1
+    optionalDependencies:
+      '@types/node': 20.19.39
+      fsevents: 2.3.3
+
   vite@5.4.21(@types/node@25.6.0):
     dependencies:
       esbuild: 0.21.5
@@ -5266,7 +5802,43 @@ snapshots:
       '@types/node': 25.6.0
       fsevents: 2.3.3
 
-  vitest@2.1.9(@types/node@25.6.0):
+  vitest@2.1.9(@types/node@20.19.39)(happy-dom@15.11.7):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.39))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@20.19.39)
+      vite-node: 2.1.9(@types/node@20.19.39)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.39
+      happy-dom: 15.11.7
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@2.1.9(@types/node@25.6.0)(happy-dom@15.11.7):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@25.6.0))
@@ -5290,6 +5862,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0
+      happy-dom: 15.11.7
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -5300,6 +5873,10 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -5370,6 +5947,8 @@ snapshots:
   xtend@4.0.2: {}
 
   y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
## Summary

Bridges the gap between the design-complete M8 frontend and the (still-stub) M6 MCP server. Adds a typed API client + React Query hooks + SSE scaffold + the three previously-404 detail pages, plus shared `components/detail/` primitives.

- **Contract layer** ([lib/api/](packages/web/lib/api/), [lib/hooks/](packages/web/lib/hooks/)) — `api.{tasks,agents,sessions,memory,promotions,mesh,threads,dashboard}` namespaced read methods, eight resource hooks, shared query-key tree, typed `ApiError` / `ApiNotConfigured`. Every hook gates on `isApiConfigured`, so unset env = no fetches and pages keep their existing empty states.
- **Pages wired** — `/tasks` Kanban consumes `useTasks` and groups via `lib/tasks-grouping.ts` (10 statuses → 4 lifecycle columns, per the locked design). `/tasks/[id]`, `/agents/[id]`, `/tasks/[id]/sessions/[sid]` are no longer 404 — built as header → body → rail → quiet-footer per the dense-layouts feedback.
- **SSE scaffold** ([lib/sse.ts](packages/web/lib/sse.ts)) — no-ops without config; otherwise opens `EventSource` on `/api/stream` and dispatches `invalidateQueries` per event-name. Mounted inside `QueryClientProvider`.
- **Shared detail primitives** ([components/detail/](packages/web/components/detail/)) — `DetailShell`, `FooterField`, `Metric` extracted from the three new clients; `depth-metrics.tsx` now consumes the same `Metric`.
- **No fixtures** — when `NEXT_PUBLIC_BV_API_URL` is unset, every page renders the same honest empty states it does today, through the production hook path. Day M6 ships routes, the env flip is the only change.

## Test plan

- [x] `pnpm typecheck` clean against `@beevibe/core` types
- [x] `pnpm dev` boots in <1s with `NEXT_PUBLIC_BV_API_URL` unset
- [x] All 10 authed routes return 200 (`/`, `/tasks`, `/agents`, `/memory`, `/threads`, `/mesh`, `/promotions`, `/tasks/<id>`, `/agents/<id>`, `/tasks/<id>/sessions/<sid>`)
- [x] No network requests fire when env is unset; React Query Devtools shows queries as disabled
- [x] Setting `NEXT_PUBLIC_BV_API_URL=http://localhost:9999` causes queries to fail with `ApiError` (connection refused) — proves the env-gated wiring works end-to-end
- [ ] Once M6 ships routes, set `NEXT_PUBLIC_BV_API_URL` and confirm Kanban + the three detail pages populate without component changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)