### PR TITLE
M8 — wire mutations to M6 + add read-views layer (#30)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,13 @@ WORKSPACE_ROOT=
 # Health endpoint port (GET /health → 200/503). Default 3001.
 BEEVIBE_EXECUTOR_HEALTH_PORT=3001
 ORG_ID=beevibe
+
+# Web frontend (packages/web)
+# Base URL the browser hits. Same value as BEEVIBE_API_PORT, just origin
+# (no /mcp suffix). Leave blank to render all pages in their not-configured
+# empty state.
+NEXT_PUBLIC_BV_API_URL=http://localhost:3000
+# bv_u_ key minted via CLI; sent as Authorization: Bearer on every request
+# (M6 mutations require it). Provision via `pnpm dlx @beevibe/cli mint-key`
+# (or whatever the CLI ends up named).
+NEXT_PUBLIC_BV_USER_KEY=

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -5,6 +5,17 @@
   "description": "Beevibe API server — MCP tool surface for agents + REST endpoints for humans + MeshServer broker",
   "type": "module",
   "main": "./dist/main.js",
+  "types": "./dist/main.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/main.d.ts",
+      "default": "./dist/main.js"
+    },
+    "./views/types": {
+      "types": "./dist/views/types.d.ts",
+      "default": "./dist/views/types.js"
+    }
+  },
   "bin": {
     "beevibe-api": "./dist/main.js"
   },

--- a/packages/api/src/bootstrap.ts
+++ b/packages/api/src/bootstrap.ts
@@ -31,6 +31,7 @@ import { SessionCache } from "./session-cache.js";
 import { createMcpRouter } from "./routes/mcp.js";
 import { createTaskRouter } from "./routes/task.js";
 import { createEscalationRouter } from "./routes/escalation.js";
+import { createViewRouter } from "./routes/view.js";
 
 export interface BootstrapConfig {
   databaseUrl: string;
@@ -211,6 +212,16 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
     pool,
   });
   server.getApp().use("/escalation", escalationRouter);
+
+  // M8.2 read-only view routes — bv_u_ only. Direct-to-pool composers in
+  // src/views/* return UI-shaped DTOs; no core repos touched on the read
+  // path so the agent-execution surface stays uncoupled from web display.
+  const viewRouter = createViewRouter({
+    authMiddleware: server.getAuthMiddleware(),
+    pool,
+    agentRepo,
+  });
+  server.getApp().use(viewRouter);
 
   const shutdown = async (): Promise<void> => {
     sessionCache.stopIdleSweep();

--- a/packages/api/src/routes/view.ts
+++ b/packages/api/src/routes/view.ts
@@ -20,10 +20,13 @@
 
 import { Router, type RequestHandler } from "express";
 import type { Pool } from "@beevibe/core/adapters/postgres";
-import type { AgentRepository, MemoryScope } from "@beevibe/core";
+import { MEMORY_SCOPES, type AgentRepository, type MemoryScope } from "@beevibe/core";
 import { requireHuman } from "../auth/middleware.js";
 import { listTasks, getTask, type TaskListFilter } from "../views/tasks.js";
-import type { Lifecycle } from "../views/tasks-grouping.js";
+import {
+  TASK_STATUSES_BY_LIFECYCLE,
+  type Lifecycle,
+} from "../views/tasks-grouping.js";
 import { listAgents, getAgent } from "../views/agents.js";
 import { getSessionByShortId, AmbiguousShortIdError } from "../views/sessions.js";
 import { listMemoryFacts } from "../views/memory.js";
@@ -34,9 +37,11 @@ export interface ViewRoutesDeps {
   agentRepo: AgentRepository;
 }
 
-const LIFECYCLES = new Set<Lifecycle>(["pending", "in_progress", "in_review", "done"]);
+const LIFECYCLES = new Set<Lifecycle>(
+  Object.keys(TASK_STATUSES_BY_LIFECYCLE) as Lifecycle[],
+);
 const VIEWS = new Set<TaskListFilter["view"]>(["all", "mine", "sprint", "timeline"]);
-const SCOPES = new Set<MemoryScope>(["ic", "team", "org"]);
+const SCOPES = new Set<MemoryScope>(MEMORY_SCOPES);
 
 export function createViewRouter(deps: ViewRoutesDeps): Router {
   const router = Router();
@@ -159,9 +164,14 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
       scopeParam && SCOPES.has(scopeParam as MemoryScope)
         ? (scopeParam as MemoryScope)
         : undefined;
+    const limitRaw = typeof req.query.limit === "string" ? Number(req.query.limit) : NaN;
+    const limit = Number.isFinite(limitRaw) ? limitRaw : undefined;
 
     try {
-      const facts = await listMemoryFacts(deps.pool, req.caller.personId, { scope });
+      const facts = await listMemoryFacts(deps.pool, req.caller.personId, {
+        scope,
+        limit,
+      });
       res.json(facts);
     } catch (err) {
       handleError(err, res, "memory fact list");

--- a/packages/api/src/routes/view.ts
+++ b/packages/api/src/routes/view.ts
@@ -1,0 +1,180 @@
+/**
+ * Read-only view routes (M8.2). All require `bv_u_` Bearer.
+ *
+ *   GET /task                    list, query: lifecycle?, assignee_id?, view?
+ *   GET /task/:id                detail (work_products, sessions joined)
+ *   GET /agent                   list
+ *   GET /agent/:id               detail (core_blocks, metrics, recent_sessions, mesh hints)
+ *   GET /session/:short_id       detail (briefing/transcript stubbed for now)
+ *   GET /memory/fact             list, query: scope?, owner-scoped
+ *
+ * Design:
+ *   - Each handler wraps a `views/*.ts` composer that talks pg directly.
+ *   - "mine" view-shortcut needs the caller's primary agent — resolved here
+ *     via AgentRepository, then passed to listTasks as `assignee_id`.
+ *   - 404 for missing detail rows; 409 for ambiguous session short_id.
+ *
+ * The router intentionally does NOT mount under `/api/...` (web's earlier
+ * guess); it matches M6's singular-noun, no-prefix style (`/task/:id/...`).
+ */
+
+import { Router, type RequestHandler } from "express";
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import type { AgentRepository, MemoryScope } from "@beevibe/core";
+import { requireHuman } from "../auth/middleware.js";
+import { listTasks, getTask, type TaskListFilter } from "../views/tasks.js";
+import type { Lifecycle } from "../views/tasks-grouping.js";
+import { listAgents, getAgent } from "../views/agents.js";
+import { getSessionByShortId, AmbiguousShortIdError } from "../views/sessions.js";
+import { listMemoryFacts } from "../views/memory.js";
+
+export interface ViewRoutesDeps {
+  authMiddleware: RequestHandler;
+  pool: Pool;
+  agentRepo: AgentRepository;
+}
+
+const LIFECYCLES = new Set<Lifecycle>(["pending", "in_progress", "in_review", "done"]);
+const VIEWS = new Set<TaskListFilter["view"]>(["all", "mine", "sprint", "timeline"]);
+const SCOPES = new Set<MemoryScope>(["ic", "team", "org"]);
+
+export function createViewRouter(deps: ViewRoutesDeps): Router {
+  const router = Router();
+  router.use(deps.authMiddleware);
+
+  router.get("/task", async (req, res) => {
+    if (!requireHuman(req, res)) return;
+
+    const filter: TaskListFilter = {};
+    const lifecycleParam = typeof req.query.lifecycle === "string" ? req.query.lifecycle : undefined;
+    if (lifecycleParam && LIFECYCLES.has(lifecycleParam as Lifecycle)) {
+      filter.lifecycle = lifecycleParam as Lifecycle;
+    }
+    const viewParam = typeof req.query.view === "string" ? req.query.view : undefined;
+    if (viewParam && VIEWS.has(viewParam as TaskListFilter["view"])) {
+      filter.view = viewParam as TaskListFilter["view"];
+    }
+
+    if (filter.view === "mine") {
+      // Resolve the caller to their primary agent so "mine" filters tasks
+      // assigned to that agent. Top-level (team or org) — IC agents are
+      // subordinates, not the caller's primary identity.
+      const primary = await deps.agentRepo.findTopLevelForOwner(req.caller.personId);
+      if (primary) filter.assignee_id = primary.id;
+      else {
+        // No agent → no tasks; short-circuit.
+        res.json([]);
+        return;
+      }
+    } else if (typeof req.query.assignee_id === "string") {
+      filter.assignee_id = req.query.assignee_id;
+    }
+
+    try {
+      const tasks = await listTasks(deps.pool, filter);
+      res.json(tasks);
+    } catch (err) {
+      handleError(err, res, "task list");
+    }
+  });
+
+  router.get("/task/:id", async (req, res) => {
+    if (!requireHuman(req, res)) return;
+    const id = req.params.id;
+    if (!id) {
+      res.status(400).json({ error: "missing_task_id" });
+      return;
+    }
+    try {
+      const task = await getTask(deps.pool, id);
+      if (!task) {
+        res.status(404).json({ error: "task_not_found" });
+        return;
+      }
+      res.json(task);
+    } catch (err) {
+      handleError(err, res, "task detail");
+    }
+  });
+
+  router.get("/agent", async (req, res) => {
+    if (!requireHuman(req, res)) return;
+    try {
+      const agents = await listAgents(deps.pool);
+      res.json(agents);
+    } catch (err) {
+      handleError(err, res, "agent list");
+    }
+  });
+
+  router.get("/agent/:id", async (req, res) => {
+    if (!requireHuman(req, res)) return;
+    const id = req.params.id;
+    if (!id) {
+      res.status(400).json({ error: "missing_agent_id" });
+      return;
+    }
+    try {
+      const agent = await getAgent(deps.pool, id);
+      if (!agent) {
+        res.status(404).json({ error: "agent_not_found" });
+        return;
+      }
+      res.json(agent);
+    } catch (err) {
+      handleError(err, res, "agent detail");
+    }
+  });
+
+  router.get("/session/:shortId", async (req, res) => {
+    if (!requireHuman(req, res)) return;
+    const shortId = req.params.shortId;
+    if (!shortId) {
+      res.status(400).json({ error: "missing_short_id" });
+      return;
+    }
+    try {
+      const session = await getSessionByShortId(deps.pool, shortId);
+      if (!session) {
+        res.status(404).json({ error: "session_not_found" });
+        return;
+      }
+      res.json(session);
+    } catch (err) {
+      if (err instanceof AmbiguousShortIdError) {
+        res.status(409).json({
+          error: "ambiguous_short_id",
+          message: err.message,
+        });
+        return;
+      }
+      handleError(err, res, "session detail");
+    }
+  });
+
+  router.get("/memory/fact", async (req, res) => {
+    if (!requireHuman(req, res)) return;
+    const scopeParam = typeof req.query.scope === "string" ? req.query.scope : undefined;
+    const scope =
+      scopeParam && SCOPES.has(scopeParam as MemoryScope)
+        ? (scopeParam as MemoryScope)
+        : undefined;
+
+    try {
+      const facts = await listMemoryFacts(deps.pool, req.caller.personId, { scope });
+      res.json(facts);
+    } catch (err) {
+      handleError(err, res, "memory fact list");
+    }
+  });
+
+  return router;
+}
+
+function handleError(err: unknown, res: import("express").Response, context: string): void {
+  console.error(`[view route: ${context}]`, err);
+  res.status(500).json({
+    error: "internal_error",
+    message: err instanceof Error ? err.message : String(err),
+  });
+}

--- a/packages/api/src/views/agents.test.ts
+++ b/packages/api/src/views/agents.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import { listAgents, getAgent } from "./agents.js";
+
+function makePool(responses: unknown[][]) {
+  let i = 0;
+  const query = vi.fn(async () => ({ rows: responses[i++] ?? [] }));
+  return { query: query as unknown as Pool["query"] } as unknown as Pool;
+}
+
+describe("listAgents", () => {
+  it("maps rows into AgentDisplay with hierarchy + sessions/facts counts", async () => {
+    const pool = makePool([
+      [
+        {
+          id: "agt_org",
+          name: "Atlas",
+          owner_id: "per_w",
+          parent_agent_id: null,
+          hierarchy_level: "org",
+          review_policy: null,
+          runtime_config: { type: "claude-code", model: "opus" },
+          created_at: new Date(),
+          updated_at: new Date(),
+          sessions_count: 12,
+          facts_learned: 4,
+        },
+      ],
+    ]);
+    const agents = await listAgents(pool);
+    expect(agents).toHaveLength(1);
+    expect(agents[0]?.display_name).toBe("Atlas");
+    expect(agents[0]?.hierarchy).toBe("org");
+    expect(agents[0]?.sessions_count).toBe(12);
+    expect(agents[0]?.facts_learned).toBe(4);
+    expect(agents[0]?.runtime).toBe("opus");
+  });
+});
+
+describe("getAgent", () => {
+  it("returns undefined when missing", async () => {
+    const pool = makePool([[], [], [], []]);
+    expect(await getAgent(pool, "agt_missing")).toBeUndefined();
+  });
+
+  it("aggregates blocks, recent sessions, and mesh hints when present", async () => {
+    const pool = makePool([
+      [
+        {
+          id: "agt_team",
+          name: "Beta",
+          owner_id: "per_w",
+          parent_agent_id: "agt_org",
+          hierarchy_level: "team",
+          review_policy: "auto_done",
+          runtime_config: { type: "claude-code", model: "sonnet" },
+          created_at: new Date(),
+          updated_at: new Date(),
+          sessions_count: 3,
+          facts_learned: 7,
+        },
+      ],
+      [
+        {
+          id: "blk_1",
+          agent_id: "agt_team",
+          block_name: "persona",
+          content: "abc",
+          char_limit: 1000,
+          is_system: true,
+          updated_at: new Date(),
+        },
+      ],
+      [
+        {
+          id: "sess_qwerty12",
+          intent: "Refactor billing",
+          status: "running",
+          task_id: "task_1",
+          created_at: new Date(),
+          task_title: "Bill rewrite",
+        },
+      ],
+      [
+        {
+          id: "neg_1",
+          target_name: "Charlie",
+          created_at: new Date(),
+          opening_message: "Can you review the schema?",
+        },
+      ],
+    ]);
+    const detail = await getAgent(pool, "agt_team");
+    expect(detail?.display_name).toBe("Beta");
+    expect(detail?.metrics.sessions).toBe(3);
+    expect(detail?.metrics.facts).toBe(7);
+    expect(detail?.core_blocks).toHaveLength(1);
+    expect(detail?.core_blocks[0]?.char_count).toBe(3);
+    expect(detail?.recent_sessions).toHaveLength(1);
+    expect(detail?.recent_sessions[0]?.short_id).toBe("qwerty");
+    expect(detail?.recent_sessions[0]?.title).toBe("Bill rewrite");
+    expect(detail?.outgoing_mesh_hints).toHaveLength(1);
+    expect(detail?.outgoing_mesh_hints[0]?.target).toBe("Charlie");
+  });
+});

--- a/packages/api/src/views/agents.ts
+++ b/packages/api/src/views/agents.ts
@@ -1,0 +1,217 @@
+/**
+ * Agent views — `AgentDisplay[]` (list) and `AgentDetail` (single).
+ * Detail joins core memory blocks, recent sessions (last 5), and outgoing
+ * mesh hints (negotiations the agent has initiated). Like tasks, this goes
+ * direct-to-pool with hand-rolled SQL — no core repos.
+ */
+
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import type { HierarchyLevel, SessionStatus } from "@beevibe/core";
+import { deriveShortId, formatRelativeShort } from "./format.js";
+import type {
+  AgentDisplay,
+  AgentDetail,
+  CoreBlockDisplay,
+  RecentSession,
+  OutgoingMeshHint,
+  AgentMetrics,
+} from "./types.js";
+
+interface AgentRow {
+  id: string;
+  name: string;
+  owner_id: string;
+  parent_agent_id: string | null;
+  hierarchy_level: HierarchyLevel;
+  review_policy: string | null;
+  runtime_config: Record<string, unknown>;
+  created_at: Date;
+  updated_at: Date;
+  sessions_count: string;
+  facts_learned: string;
+}
+
+const LIST_SQL = /* sql */ `
+SELECT
+  a.id, a.name, a.owner_id, a.parent_agent_id, a.hierarchy_level,
+  a.review_policy, a.runtime_config, a.created_at, a.updated_at,
+  COALESCE(sc.n, 0)::int  AS sessions_count,
+  COALESCE(fc.n, 0)::int  AS facts_learned
+FROM agent a
+LEFT JOIN (
+  SELECT agent_id, COUNT(*)::int AS n
+  FROM session
+  GROUP BY agent_id
+) sc ON sc.agent_id = a.id
+LEFT JOIN (
+  SELECT agent_id, COUNT(*)::int AS n
+  FROM memory_fact
+  GROUP BY agent_id
+) fc ON fc.agent_id = a.id
+ORDER BY
+  CASE a.hierarchy_level WHEN 'org' THEN 0 WHEN 'team' THEN 1 ELSE 2 END,
+  a.name ASC
+`;
+
+function rowToAgentDisplay(row: AgentRow): AgentDisplay {
+  const runtime = (row.runtime_config?.model as string | undefined) ?? "claude-code";
+  return {
+    id: row.id,
+    name: row.name,
+    owner_id: row.owner_id,
+    parent_agent_id: row.parent_agent_id ?? undefined,
+    hierarchy_level: row.hierarchy_level,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    display_name: row.name,
+    hierarchy: row.hierarchy_level,
+    sessions_count: Number(row.sessions_count),
+    facts_learned: Number(row.facts_learned),
+    runtime,
+    review_policy: row.review_policy ?? undefined,
+  };
+}
+
+export async function listAgents(pool: Pool): Promise<AgentDisplay[]> {
+  const { rows } = await pool.query<AgentRow>(LIST_SQL);
+  return rows.map(rowToAgentDisplay);
+}
+
+const DETAIL_SQL_AGENT = /* sql */ `
+SELECT
+  a.id, a.name, a.owner_id, a.parent_agent_id, a.hierarchy_level,
+  a.review_policy, a.runtime_config, a.created_at, a.updated_at,
+  (SELECT COUNT(*)::int FROM session       WHERE agent_id = a.id) AS sessions_count,
+  (SELECT COUNT(*)::int FROM memory_fact   WHERE agent_id = a.id) AS facts_learned
+FROM agent a
+WHERE a.id = $1
+LIMIT 1
+`;
+
+const DETAIL_SQL_BLOCKS = /* sql */ `
+SELECT id, agent_id, block_name, content, char_limit, is_system, updated_at
+FROM core_memory_block
+WHERE agent_id = $1
+ORDER BY block_name ASC
+`;
+
+const DETAIL_SQL_RECENT_SESSIONS = /* sql */ `
+SELECT
+  s.id, s.intent, s.status, s.task_id, s.created_at,
+  t.title AS task_title
+FROM session s
+LEFT JOIN task t ON t.id = s.task_id
+WHERE s.agent_id = $1
+ORDER BY s.created_at DESC
+LIMIT 5
+`;
+
+const DETAIL_SQL_MESH_HINTS = /* sql */ `
+SELECT
+  n.id,
+  cp.name        AS target_name,
+  n.created_at,
+  (
+    SELECT nr.message
+    FROM negotiation_round nr
+    WHERE nr.negotiation_id = n.id AND nr.from_agent_id = n.initiator_agent_id
+    ORDER BY nr.round_number ASC
+    LIMIT 1
+  ) AS opening_message
+FROM negotiation n
+JOIN agent cp ON cp.id = n.counterparty_agent_id
+WHERE n.initiator_agent_id = $1
+  AND n.status NOT IN ('completed', 'escalated_resolved')
+ORDER BY n.created_at DESC
+LIMIT 3
+`;
+
+interface BlockRow {
+  id: string;
+  agent_id: string;
+  block_name: string;
+  content: string;
+  char_limit: number;
+  is_system: boolean;
+  updated_at: Date;
+}
+
+interface RecentSessionRow {
+  id: string;
+  intent: string;
+  status: SessionStatus;
+  task_id: string | null;
+  created_at: Date;
+  task_title: string | null;
+}
+
+interface MeshHintRow {
+  id: string;
+  target_name: string;
+  created_at: Date;
+  opening_message: string | null;
+}
+
+function recentSessionStatus(s: SessionStatus): RecentSession["status"] {
+  // Display contract narrows to running/succeeded/review (review is mapped
+  // from sessions whose parent task is in review — but cheapest path is
+  // map non-running succeeded → succeeded, others → succeeded too. Finer
+  // grain can come later.)
+  if (s === "running") return "running";
+  return "succeeded";
+}
+
+export async function getAgent(
+  pool: Pool,
+  id: string,
+): Promise<AgentDetail | undefined> {
+  const agentResult = await pool.query<AgentRow>(DETAIL_SQL_AGENT, [id]);
+  const agentRow = agentResult.rows[0];
+  if (!agentRow) return undefined;
+
+  const [blockResult, recentResult, meshResult] = await Promise.all([
+    pool.query<BlockRow>(DETAIL_SQL_BLOCKS, [id]),
+    pool.query<RecentSessionRow>(DETAIL_SQL_RECENT_SESSIONS, [id]),
+    pool.query<MeshHintRow>(DETAIL_SQL_MESH_HINTS, [id]),
+  ]);
+
+  const core_blocks: CoreBlockDisplay[] = blockResult.rows.map((b) => ({
+    id: b.id,
+    agent_id: b.agent_id,
+    block_name: b.block_name,
+    content: b.content,
+    char_count: b.content.length,
+    char_limit: b.char_limit,
+    is_system: b.is_system,
+    updated_label: `${formatRelativeShort(b.updated_at)} ago`,
+  }));
+
+  const recent_sessions: RecentSession[] = recentResult.rows.map((s) => ({
+    short_id: deriveShortId(s.id),
+    title: s.task_title ?? s.intent,
+    status: recentSessionStatus(s.status),
+    age: formatRelativeShort(s.created_at),
+  }));
+
+  const outgoing_mesh_hints: OutgoingMeshHint[] = meshResult.rows.map((m) => ({
+    target: m.target_name,
+    intent: (m.opening_message ?? "(no message)").slice(0, 80),
+    age: formatRelativeShort(m.created_at),
+  }));
+
+  const metrics: AgentMetrics = {
+    sessions: Number(agentRow.sessions_count),
+    sessions_change: 0, // delta vs prior period — not computed yet
+    facts: Number(agentRow.facts_learned),
+    merges: 0,
+    promoted: 0,
+  };
+
+  return {
+    ...rowToAgentDisplay(agentRow),
+    core_blocks,
+    metrics,
+    recent_sessions,
+    outgoing_mesh_hints,
+  };
+}

--- a/packages/api/src/views/agents.ts
+++ b/packages/api/src/views/agents.ts
@@ -165,15 +165,14 @@ export async function getAgent(
   pool: Pool,
   id: string,
 ): Promise<AgentDetail | undefined> {
-  const agentResult = await pool.query<AgentRow>(DETAIL_SQL_AGENT, [id]);
-  const agentRow = agentResult.rows[0];
-  if (!agentRow) return undefined;
-
-  const [blockResult, recentResult, meshResult] = await Promise.all([
+  const [agentResult, blockResult, recentResult, meshResult] = await Promise.all([
+    pool.query<AgentRow>(DETAIL_SQL_AGENT, [id]),
     pool.query<BlockRow>(DETAIL_SQL_BLOCKS, [id]),
     pool.query<RecentSessionRow>(DETAIL_SQL_RECENT_SESSIONS, [id]),
     pool.query<MeshHintRow>(DETAIL_SQL_MESH_HINTS, [id]),
   ]);
+  const agentRow = agentResult.rows[0];
+  if (!agentRow) return undefined;
 
   const core_blocks: CoreBlockDisplay[] = blockResult.rows.map((b) => ({
     id: b.id,

--- a/packages/api/src/views/format.test.ts
+++ b/packages/api/src/views/format.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveShortId,
+  formatRelativeShort,
+  formatDurationLabel,
+} from "./format.js";
+
+describe("deriveShortId", () => {
+  it("strips the type prefix and keeps 6 chars", () => {
+    expect(deriveShortId("sess_abc123def456")).toBe("abc123");
+    expect(deriveShortId("task_zzyx99")).toBe("zzyx99");
+    expect(deriveShortId("agt_xx")).toBe("xx");
+  });
+
+  it("handles ids without a prefix by truncating to 6 chars", () => {
+    expect(deriveShortId("abcdefghij")).toBe("abcdef");
+  });
+
+  it("matches the web's shortId logic minus the leading '#'", () => {
+    // packages/web/lib/format.ts:shortId returns "#" + first 6 chars of trimmed.
+    // Our backend produces just the 6 chars (URL-friendly).
+    const id = "sess_0123456789abcdef";
+    expect("#" + deriveShortId(id)).toBe("#012345");
+  });
+});
+
+describe("formatRelativeShort", () => {
+  const now = new Date("2026-04-30T12:00:00Z");
+
+  it("returns 'just now' under 60s", () => {
+    expect(formatRelativeShort(new Date(now.getTime() - 30_000), now)).toBe("just now");
+  });
+
+  it("uses minute granularity under an hour", () => {
+    expect(formatRelativeShort(new Date(now.getTime() - 5 * 60_000), now)).toBe("5m");
+  });
+
+  it("uses hour granularity under a day", () => {
+    expect(formatRelativeShort(new Date(now.getTime() - 3 * 3600_000), now)).toBe("3h");
+  });
+
+  it("uses day granularity under a month", () => {
+    expect(formatRelativeShort(new Date(now.getTime() - 4 * 86400_000), now)).toBe("4d");
+  });
+});
+
+describe("formatDurationLabel", () => {
+  const now = new Date("2026-04-30T12:00:00Z");
+
+  it("returns dash when start is missing", () => {
+    expect(formatDurationLabel(null, null, now)).toBe("—");
+    expect(formatDurationLabel(undefined, undefined, now)).toBe("—");
+  });
+
+  it("renders seconds under a minute", () => {
+    const start = new Date(now.getTime() - 30_000);
+    expect(formatDurationLabel(start, null, now)).toBe("30s");
+  });
+
+  it("renders minutes when started_at is set and completed_at is null (running)", () => {
+    const start = new Date(now.getTime() - 6 * 60_000);
+    expect(formatDurationLabel(start, null, now)).toBe("6m");
+  });
+
+  it("renders 'h m' when over an hour", () => {
+    const start = new Date(now.getTime() - (3 * 3600_000 + 12 * 60_000));
+    expect(formatDurationLabel(start, null, now)).toBe("3h 12m");
+  });
+
+  it("renders pure 'h' when minutes are zero", () => {
+    const start = new Date(now.getTime() - 2 * 3600_000);
+    expect(formatDurationLabel(start, null, now)).toBe("2h");
+  });
+
+  it("uses the completion time when provided rather than now", () => {
+    const start = new Date("2026-04-30T10:00:00Z");
+    const end = new Date("2026-04-30T11:30:00Z");
+    expect(formatDurationLabel(start, end, now)).toBe("1h 30m");
+  });
+
+  it("clamps negatives to zero", () => {
+    const start = new Date(now.getTime() + 10_000);
+    expect(formatDurationLabel(start, null, now)).toBe("0s");
+  });
+});

--- a/packages/api/src/views/format.ts
+++ b/packages/api/src/views/format.ts
@@ -1,0 +1,56 @@
+/**
+ * Server-side formatters used by the views layer to produce display-ready
+ * fields (`short_id`, `duration_label`, `elapsed`). Mirrors the logic in
+ * `packages/web/lib/format.ts`. Defined here so the API can compute these
+ * once and the web's format helpers stay in sync (drift will surface as a
+ * mismatched `short_id` in the URL).
+ */
+
+/**
+ * Strip the type prefix (`xxx_`) and take the first 6 chars. Matches
+ * `packages/web/lib/format.ts:shortId`. Note: web prepends "#" for display
+ * but the URL key is the raw 6-char string — that's what we return here.
+ */
+export function deriveShortId(id: string): string {
+  const trimmed = id.replace(/^[a-z]+_/, "");
+  return trimmed.slice(0, 6);
+}
+
+/** Relative-time label like "just now" / "2m" / "1h" / "3d". */
+export function formatRelativeShort(date: Date, now: Date = new Date()): string {
+  const diffMs = now.getTime() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  if (diffSec < 60) return "just now";
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h`;
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 30) return `${diffDay}d`;
+  const diffMonth = Math.floor(diffDay / 30);
+  if (diffMonth < 12) return `${diffMonth}mo`;
+  return `${Math.floor(diffMonth / 12)}y`;
+}
+
+/**
+ * Duration label between started_at and completed_at (or now if running).
+ * Returns "—" if no start. Format: "2m", "1h 4m", "3d 2h", etc.
+ */
+export function formatDurationLabel(
+  startedAt: Date | null | undefined,
+  completedAt: Date | null | undefined,
+  now: Date = new Date(),
+): string {
+  if (!startedAt) return "—";
+  const end = completedAt ?? now;
+  const diffSec = Math.max(0, Math.floor((end.getTime() - startedAt.getTime()) / 1000));
+  if (diffSec < 60) return `${diffSec}s`;
+  const min = Math.floor(diffSec / 60);
+  if (min < 60) return `${min}m`;
+  const hr = Math.floor(min / 60);
+  const mins = min % 60;
+  if (hr < 24) return mins ? `${hr}h ${mins}m` : `${hr}h`;
+  const days = Math.floor(hr / 24);
+  const hrs = hr % 24;
+  return hrs ? `${days}d ${hrs}h` : `${days}d`;
+}

--- a/packages/api/src/views/memory.test.ts
+++ b/packages/api/src/views/memory.test.ts
@@ -11,12 +11,12 @@ function makePool(rows: unknown[]) {
 }
 
 describe("listMemoryFacts", () => {
-  it("filters by owner and forwards null scope when not provided", async () => {
+  it("filters by owner and forwards null scope + default limit when not provided", async () => {
     const pool = makePool([]);
     await listMemoryFacts(pool, "per_w");
     expect((pool as unknown as { _spy: ReturnType<typeof vi.fn> })._spy).toHaveBeenCalledWith(
       expect.any(String),
-      ["per_w", null],
+      ["per_w", null, 200],
     );
   });
 
@@ -25,7 +25,26 @@ describe("listMemoryFacts", () => {
     await listMemoryFacts(pool, "per_w", { scope: "team" });
     expect((pool as unknown as { _spy: ReturnType<typeof vi.fn> })._spy).toHaveBeenCalledWith(
       expect.any(String),
-      ["per_w", "team"],
+      ["per_w", "team", 200],
+    );
+  });
+
+  it("clamps limit to [1, 1000]", async () => {
+    const pool = makePool([]);
+    await listMemoryFacts(pool, "per_w", { limit: 50 });
+    expect((pool as unknown as { _spy: ReturnType<typeof vi.fn> })._spy).toHaveBeenLastCalledWith(
+      expect.any(String),
+      ["per_w", null, 50],
+    );
+    await listMemoryFacts(pool, "per_w", { limit: 9999 });
+    expect((pool as unknown as { _spy: ReturnType<typeof vi.fn> })._spy).toHaveBeenLastCalledWith(
+      expect.any(String),
+      ["per_w", null, 1000],
+    );
+    await listMemoryFacts(pool, "per_w", { limit: 0 });
+    expect((pool as unknown as { _spy: ReturnType<typeof vi.fn> })._spy).toHaveBeenLastCalledWith(
+      expect.any(String),
+      ["per_w", null, 1],
     );
   });
 

--- a/packages/api/src/views/memory.test.ts
+++ b/packages/api/src/views/memory.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import { listMemoryFacts } from "./memory.js";
+
+function makePool(rows: unknown[]) {
+  const query = vi.fn(async () => ({ rows }));
+  return {
+    query: query as unknown as Pool["query"],
+    _spy: query,
+  } as unknown as Pool & { _spy: ReturnType<typeof vi.fn> };
+}
+
+describe("listMemoryFacts", () => {
+  it("filters by owner and forwards null scope when not provided", async () => {
+    const pool = makePool([]);
+    await listMemoryFacts(pool, "per_w");
+    expect((pool as unknown as { _spy: ReturnType<typeof vi.fn> })._spy).toHaveBeenCalledWith(
+      expect.any(String),
+      ["per_w", null],
+    );
+  });
+
+  it("forwards scope when provided", async () => {
+    const pool = makePool([]);
+    await listMemoryFacts(pool, "per_w", { scope: "team" });
+    expect((pool as unknown as { _spy: ReturnType<typeof vi.fn> })._spy).toHaveBeenCalledWith(
+      expect.any(String),
+      ["per_w", "team"],
+    );
+  });
+
+  it("maps merge_origin from source_session_ids cardinality", async () => {
+    const pool = makePool([
+      {
+        id: "fact_1",
+        agent_id: "agt_a",
+        scope: "ic",
+        fact_type: "belief",
+        content: "always run tests",
+        source_session_ids: ["sess_1"],
+        created_at: new Date(),
+        agent_label: "Alice",
+      },
+      {
+        id: "fact_2",
+        agent_id: "agt_a",
+        scope: "team",
+        fact_type: "pattern",
+        content: "PR template",
+        source_session_ids: ["sess_1", "sess_2"],
+        created_at: new Date(),
+        agent_label: "Alice",
+      },
+    ]);
+    const facts = await listMemoryFacts(pool, "per_w");
+    expect(facts[0]?.merge_origin).toBe("single");
+    expect(facts[0]?.source_session_count).toBe(1);
+    expect(facts[1]?.merge_origin).toBe("merged");
+    expect(facts[1]?.source_session_count).toBe(2);
+    expect(facts[1]?.agent_label).toBe("Alice");
+  });
+});

--- a/packages/api/src/views/memory.ts
+++ b/packages/api/src/views/memory.ts
@@ -1,0 +1,77 @@
+/**
+ * Memory-fact views — list facts grouped by scope, joined with agent_label.
+ *
+ * Note: memory facts in core are typically queried by vector-search (per
+ * agent, top-k by embedding similarity). The web's memory page wants a
+ * simple flat list filtered by scope, scoped to the caller's owner — so
+ * this query joins agent.owner_id and filters there.
+ */
+
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import type { FactType, MemoryScope } from "@beevibe/core";
+import type { MemoryFactDisplay, MergeOrigin } from "./types.js";
+
+interface FactRow {
+  id: string;
+  agent_id: string;
+  scope: MemoryScope;
+  fact_type: FactType;
+  content: string;
+  source_session_ids: string[];
+  created_at: Date;
+  agent_label: string;
+}
+
+const LIST_SQL = /* sql */ `
+SELECT
+  f.id, f.agent_id, f.scope, f.fact_type, f.content,
+  f.source_session_ids, f.created_at,
+  a.name AS agent_label
+FROM memory_fact f
+JOIN agent a ON a.id = f.agent_id
+WHERE a.owner_id = $1
+  AND ($2::text IS NULL OR f.scope = $2)
+ORDER BY f.created_at DESC
+LIMIT 200
+`;
+
+export interface MemoryFactsFilter {
+  scope?: MemoryScope;
+}
+
+export async function listMemoryFacts(
+  pool: Pool,
+  ownerId: string,
+  filter: MemoryFactsFilter = {},
+): Promise<MemoryFactDisplay[]> {
+  const { rows } = await pool.query<FactRow>(LIST_SQL, [
+    ownerId,
+    filter.scope ?? null,
+  ]);
+  return rows.map(rowToMemoryFactDisplay);
+}
+
+function rowToMemoryFactDisplay(row: FactRow): MemoryFactDisplay {
+  // Heuristic merge_origin from source_session_ids:
+  //   - 0 sessions: shouldn't happen, but treat as "single"
+  //   - 1 session: "single"
+  //   - 2+ sessions: "merged"
+  // The "promoted" case (cross-scope promotion) needs an explicit signal
+  // that core doesn't currently surface — defer.
+  const count = row.source_session_ids?.length ?? 0;
+  let merge_origin: MergeOrigin | undefined;
+  if (count >= 2) merge_origin = "merged";
+  else if (count === 1) merge_origin = "single";
+
+  return {
+    id: row.id,
+    content: row.content,
+    fact_type: row.fact_type,
+    scope: row.scope,
+    agent_id: row.agent_id,
+    agent_label: row.agent_label,
+    source_session_count: count,
+    created_at: row.created_at,
+    merge_origin,
+  };
+}

--- a/packages/api/src/views/memory.ts
+++ b/packages/api/src/views/memory.ts
@@ -32,11 +32,16 @@ JOIN agent a ON a.id = f.agent_id
 WHERE a.owner_id = $1
   AND ($2::text IS NULL OR f.scope = $2)
 ORDER BY f.created_at DESC
-LIMIT 200
+LIMIT $3
 `;
+
+export const DEFAULT_MEMORY_FACTS_LIMIT = 200;
+export const MAX_MEMORY_FACTS_LIMIT = 1000;
 
 export interface MemoryFactsFilter {
   scope?: MemoryScope;
+  /** Default 200, capped at 1000 to keep the response bounded. */
+  limit?: number;
 }
 
 export async function listMemoryFacts(
@@ -44,9 +49,14 @@ export async function listMemoryFacts(
   ownerId: string,
   filter: MemoryFactsFilter = {},
 ): Promise<MemoryFactDisplay[]> {
+  const limit = Math.min(
+    Math.max(1, filter.limit ?? DEFAULT_MEMORY_FACTS_LIMIT),
+    MAX_MEMORY_FACTS_LIMIT,
+  );
   const { rows } = await pool.query<FactRow>(LIST_SQL, [
     ownerId,
     filter.scope ?? null,
+    limit,
   ]);
   return rows.map(rowToMemoryFactDisplay);
 }

--- a/packages/api/src/views/sessions.test.ts
+++ b/packages/api/src/views/sessions.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import { getSessionByShortId, AmbiguousShortIdError } from "./sessions.js";
+
+function makePool(rows: unknown[]) {
+  const query = vi.fn(async () => ({ rows }));
+  return { query: query as unknown as Pool["query"] } as unknown as Pool;
+}
+
+describe("getSessionByShortId", () => {
+  it("returns undefined when no matching session", async () => {
+    const pool = makePool([]);
+    expect(await getSessionByShortId(pool, "abc123")).toBeUndefined();
+  });
+
+  it("rejects malformed short_ids without hitting the DB", async () => {
+    const pool = makePool([]);
+    expect(await getSessionByShortId(pool, "abc/../etc")).toBeUndefined();
+    expect((pool.query as unknown as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+  });
+
+  it("throws AmbiguousShortIdError when 2+ rows share the prefix", async () => {
+    const pool = makePool([
+      sampleRow("sess_abc1230001"),
+      sampleRow("sess_abc1230002"),
+    ]);
+    await expect(getSessionByShortId(pool, "abc123")).rejects.toBeInstanceOf(
+      AmbiguousShortIdError,
+    );
+  });
+
+  it("maps a single row into a SessionDisplay with empty briefing/transcript", async () => {
+    const pool = makePool([sampleRow("sess_abcdef00ff")]);
+    const session = await getSessionByShortId(pool, "abcdef");
+    expect(session?.short_id).toBe("abcdef");
+    expect(session?.task_title).toBe("Bill rewrite");
+    expect(session?.agent_label).toBe("Beta");
+    expect(session?.briefing.block_count).toBe(0);
+    expect(session?.transcript).toEqual([]);
+    expect(session?.ask_threads).toEqual([]);
+  });
+});
+
+function sampleRow(id: string) {
+  return {
+    id,
+    agent_id: "agt_team",
+    task_id: "task_001",
+    type: "task",
+    status: "running",
+    intent: "do the work",
+    workspace_path: "/tmp/wt",
+    cli_session_id: "cli_xx",
+    started_at: new Date("2026-04-30T11:00:00Z"),
+    completed_at: null,
+    agent_label: "Beta",
+    agent_hier: "team",
+    task_title: "Bill rewrite",
+  };
+}

--- a/packages/api/src/views/sessions.ts
+++ b/packages/api/src/views/sessions.ts
@@ -1,0 +1,110 @@
+/**
+ * Session views — single session by short_id.
+ *
+ * Lookup uses prefix match on the typed-id (`sess_<6chars>...`) since the
+ * UI addresses sessions by 6-char short_id. Collisions are statistically
+ * improbable with nanoid but the query LIMIT 2 + 409-on-ambiguous handler
+ * makes them safe.
+ *
+ * Briefing / transcript / ask_threads are returned as empty stubs in this
+ * cut: the briefing is composed in-process at session start (not persisted
+ * in a queryable form), and the transcript lives in the CLI subprocess's
+ * stdio — neither is available from the DB alone. Surfacing them is its
+ * own backend slice; the empty stubs let the UI render the page chrome
+ * (header, status, footer) immediately.
+ */
+
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import type { HierarchyLevel, SessionStatus, SessionType } from "@beevibe/core";
+import { deriveShortId, formatDurationLabel } from "./format.js";
+import type { SessionDisplay, SessionBriefing } from "./types.js";
+
+interface SessionDetailRow {
+  id: string;
+  agent_id: string;
+  task_id: string | null;
+  type: SessionType;
+  status: SessionStatus;
+  intent: string;
+  workspace_path: string | null;
+  cli_session_id: string | null;
+  started_at: Date | null;
+  completed_at: Date | null;
+  agent_label: string;
+  agent_hier: HierarchyLevel;
+  task_title: string | null;
+}
+
+const SESSION_BY_ID_PREFIX_SQL = /* sql */ `
+SELECT
+  s.id, s.agent_id, s.task_id, s.type, s.status, s.intent,
+  s.workspace_path, s.cli_session_id, s.started_at, s.completed_at,
+  a.name              AS agent_label,
+  a.hierarchy_level   AS agent_hier,
+  t.title             AS task_title
+FROM session s
+JOIN agent a ON a.id = s.agent_id
+LEFT JOIN task t ON t.id = s.task_id
+WHERE s.id LIKE $1 || '%'
+LIMIT 2
+`;
+
+export class AmbiguousShortIdError extends Error {
+  constructor(public readonly shortId: string) {
+    super(`session short_id '${shortId}' matched multiple rows`);
+    this.name = "AmbiguousShortIdError";
+  }
+}
+
+/**
+ * Look up a session by its 6-char short_id (e.g. `abc123`). Returns
+ * `undefined` for no match. Throws `AmbiguousShortIdError` when 2+ session
+ * rows share the prefix — the route maps this to 409.
+ */
+export async function getSessionByShortId(
+  pool: Pool,
+  shortId: string,
+): Promise<SessionDisplay | undefined> {
+  if (!/^[a-z0-9]+$/i.test(shortId)) return undefined;
+  const prefix = `sess_${shortId}`;
+  const { rows } = await pool.query<SessionDetailRow>(
+    SESSION_BY_ID_PREFIX_SQL,
+    [prefix],
+  );
+  if (rows.length === 0) return undefined;
+  if (rows.length > 1) throw new AmbiguousShortIdError(shortId);
+  return rowToSessionDisplay(rows[0]!);
+}
+
+function emptyBriefing(): SessionBriefing {
+  return {
+    block_count: 0,
+    fact_count: 0,
+    token_count: 0,
+    blocks: [],
+    facts: [],
+  };
+}
+
+function rowToSessionDisplay(row: SessionDetailRow): SessionDisplay {
+  return {
+    id: row.id,
+    short_id: deriveShortId(row.id),
+    task_id: row.task_id ?? "",
+    task_title: row.task_title ?? "(untitled task)",
+    task_short_id: row.task_id ? deriveShortId(row.task_id) : "",
+    agent_id: row.agent_id,
+    agent_label: row.agent_label,
+    agent_hierarchy: row.agent_hier,
+    type: row.type,
+    status: row.status,
+    intent: row.intent,
+    started_at: row.started_at ?? new Date(0),
+    duration_label: formatDurationLabel(row.started_at, row.completed_at),
+    worktree: row.workspace_path ?? undefined,
+    cli_session: row.cli_session_id ?? undefined,
+    briefing: emptyBriefing(),
+    transcript: [],
+    ask_threads: [],
+  };
+}

--- a/packages/api/src/views/tasks-grouping.ts
+++ b/packages/api/src/views/tasks-grouping.ts
@@ -1,0 +1,35 @@
+/**
+ * Server-side mirror of `packages/web/lib/tasks-grouping.ts`. Keeps the
+ * lifecycle → status mapping and the saved-view → status mapping next to
+ * the SQL that filters on them, so the web can pass either `lifecycle` or
+ * `view` and get the rows it expects.
+ */
+
+import type { TaskStatus } from "@beevibe/core";
+
+export type Lifecycle = "pending" | "in_progress" | "in_review" | "done";
+
+export const TASK_STATUSES_BY_LIFECYCLE: Record<Lifecycle, readonly TaskStatus[]> = {
+  pending: ["pending", "assigned"],
+  in_progress: ["in_progress", "revision", "needs_revision"],
+  in_review: ["review", "blocked"],
+  done: ["done", "failed", "cancelled"],
+};
+
+/**
+ * Saved-view shortcut → status set. "all" and "mine" are intentionally
+ * absent — "all" means no filter, "mine" routes to `assignee_id`.
+ */
+export const TASK_STATUSES_BY_VIEW: Partial<Record<string, readonly TaskStatus[]>> = {
+  sprint: [
+    ...TASK_STATUSES_BY_LIFECYCLE.pending,
+    ...TASK_STATUSES_BY_LIFECYCLE.in_progress,
+    ...TASK_STATUSES_BY_LIFECYCLE.in_review,
+  ],
+  timeline: [
+    ...TASK_STATUSES_BY_LIFECYCLE.pending,
+    ...TASK_STATUSES_BY_LIFECYCLE.in_progress,
+    ...TASK_STATUSES_BY_LIFECYCLE.in_review,
+    ...TASK_STATUSES_BY_LIFECYCLE.done,
+  ],
+};

--- a/packages/api/src/views/tasks.test.ts
+++ b/packages/api/src/views/tasks.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Mock-Pool tests for views/tasks.ts. Validates row → DTO mapping +
+ * filter-to-SQL params plumbing. The actual SQL correctness is exercised
+ * by an integration-style e2e in a follow-up; these tests cover the
+ * mapping layer without needing a database.
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import { listTasks, getTask } from "./tasks.js";
+
+function makePool(responses: unknown[][]) {
+  let i = 0;
+  const query = vi.fn(async () => {
+    const rows = responses[i++] ?? [];
+    return { rows } as { rows: unknown[] };
+  });
+  return { query: query as unknown as Pool["query"] } as unknown as Pool;
+}
+
+describe("listTasks", () => {
+  it("returns empty array when DB returns no rows", async () => {
+    const pool = makePool([[]]);
+    const tasks = await listTasks(pool);
+    expect(tasks).toEqual([]);
+  });
+
+  it("maps a row with joins into a TaskListItem", async () => {
+    const pool = makePool([
+      [
+        {
+          id: "task_001",
+          title: "Wire kanban",
+          description: "do it",
+          status: "in_progress",
+          priority: "high",
+          assignee_id: "agt_a",
+          creator_id: "per_x",
+          creator_type: "person",
+          parent_task_id: null,
+          result_summary: null,
+          blocker_agent_id: null,
+          blocker_reason: null,
+          repo_url: null,
+          next_dispatch_context: null,
+          created_at: new Date("2026-04-30T00:00:00Z"),
+          updated_at: new Date("2026-04-30T00:00:00Z"),
+          assignee_name: "alice",
+          assignee_hier: "ic",
+          creator_label: "Weijia",
+          session_count: "2",
+          work_product_count: "1",
+          latest_session_id: "sess_abc123def",
+          latest_session_status: "running",
+          latest_session_started_at: new Date("2026-04-30T11:55:00Z"),
+          latest_session_completed_at: null,
+          latest_session_agent_label: "alice",
+        },
+      ],
+    ]);
+    const tasks = await listTasks(pool);
+    expect(tasks).toHaveLength(1);
+    const t = tasks[0]!;
+    expect(t.title).toBe("Wire kanban");
+    expect(t.assignee_label).toBe("alice");
+    expect(t.assignee_hierarchy).toBe("ic");
+    expect(t.creator_label).toBe("Weijia");
+    expect(t.session_count).toBe(2);
+    expect(t.work_product_count).toBe(1);
+    expect(t.description).toEqual(["do it"]);
+    expect(t.latest_session?.short_id).toBe("abc123");
+    expect(t.latest_session?.status).toBe("running");
+    expect(t.latest_session?.agent_label).toBe("alice");
+  });
+
+  it("translates lifecycle filter into a status array param", async () => {
+    const pool = makePool([[]]);
+    const queryMock = pool.query as unknown as ReturnType<typeof vi.fn>;
+    await listTasks(pool, { lifecycle: "in_review" });
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.any(String),
+      [["review", "blocked"], null],
+    );
+  });
+
+  it("forwards assignee_id when set", async () => {
+    const pool = makePool([[]]);
+    const queryMock = pool.query as unknown as ReturnType<typeof vi.fn>;
+    await listTasks(pool, { assignee_id: "agt_xyz" });
+    expect(queryMock).toHaveBeenCalledWith(expect.any(String), [null, "agt_xyz"]);
+  });
+});
+
+describe("getTask", () => {
+  it("returns undefined when the task isn't found", async () => {
+    const pool = makePool([[], [], []]);
+    const task = await getTask(pool, "task_missing");
+    expect(task).toBeUndefined();
+  });
+
+  it("includes sessions and work products when found", async () => {
+    const pool = makePool([
+      [
+        {
+          id: "task_001",
+          title: "Wire kanban",
+          description: "do it",
+          status: "review",
+          priority: "high",
+          assignee_id: "agt_a",
+          creator_id: "per_x",
+          creator_type: "person",
+          parent_task_id: null,
+          result_summary: null,
+          blocker_agent_id: null,
+          blocker_reason: null,
+          repo_url: null,
+          next_dispatch_context: null,
+          created_at: new Date(),
+          updated_at: new Date(),
+          assignee_name: "alice",
+          assignee_hier: "ic",
+          creator_label: "Weijia",
+          session_count: 1,
+          work_product_count: 1,
+          latest_session_id: null,
+          latest_session_status: null,
+          latest_session_started_at: null,
+          latest_session_completed_at: null,
+          latest_session_agent_label: null,
+        },
+      ],
+      [
+        {
+          id: "sess_abcdef0123",
+          agent_id: "agt_a",
+          agent_label: "alice",
+          status: "succeeded",
+          started_at: new Date("2026-04-30T10:00:00Z"),
+          completed_at: new Date("2026-04-30T10:30:00Z"),
+          result_summary: "all good",
+        },
+      ],
+      [
+        {
+          id: "wp_001",
+          task_id: "task_001",
+          agent_id: "agt_a",
+          type: "pull_request",
+          title: "PR #42",
+          summary: null,
+          url: "https://github.com/foo/bar/pull/42",
+          provider: "github",
+          external_id: "42",
+          metadata: null,
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+      ],
+    ]);
+    const detail = await getTask(pool, "task_001");
+    expect(detail?.title).toBe("Wire kanban");
+    expect(detail?.sessions).toHaveLength(1);
+    expect(detail?.sessions[0]?.short_id).toBe("abcdef");
+    expect(detail?.sessions[0]?.duration_label).toBe("30m");
+    expect(detail?.work_products).toHaveLength(1);
+    expect(detail?.work_products[0]?.title).toBe("PR #42");
+  });
+});

--- a/packages/api/src/views/tasks.ts
+++ b/packages/api/src/views/tasks.ts
@@ -247,14 +247,13 @@ export async function getTask(
   pool: Pool,
   id: string,
 ): Promise<TaskDetail | undefined> {
-  const taskResult = await pool.query<TaskListRow>(DETAIL_SQL_TASK, [id]);
-  const taskRow = taskResult.rows[0];
-  if (!taskRow) return undefined;
-
-  const [sessionResult, wpResult] = await Promise.all([
+  const [taskResult, sessionResult, wpResult] = await Promise.all([
+    pool.query<TaskListRow>(DETAIL_SQL_TASK, [id]),
     pool.query<DetailSessionRow>(DETAIL_SQL_SESSIONS, [id]),
     pool.query(DETAIL_SQL_WORK_PRODUCTS, [id]),
   ]);
+  const taskRow = taskResult.rows[0];
+  if (!taskRow) return undefined;
 
   const sessions: TaskDetailSessionRow[] = sessionResult.rows.map((s) => ({
     id: s.id,

--- a/packages/api/src/views/tasks.ts
+++ b/packages/api/src/views/tasks.ts
@@ -1,0 +1,294 @@
+/**
+ * Task views — read-only composers that produce `TaskListItem` / `TaskDetail`
+ * DTOs from raw SQL. Talks directly to `pg.Pool` and never touches core's
+ * repos or services — denormalization (assignee_label, creator_label,
+ * latest_session, session_count, work_product_count) lives in SQL JOINs so
+ * the page renders in one round-trip.
+ */
+
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import type { Lifecycle } from "./tasks-grouping.js";
+import {
+  TASK_STATUSES_BY_LIFECYCLE,
+  TASK_STATUSES_BY_VIEW,
+} from "./tasks-grouping.js";
+import { deriveShortId, formatDurationLabel } from "./format.js";
+import type {
+  TaskListItem,
+  TaskDetail,
+  TaskDetailSessionRow,
+  TaskLatestSessionSummary,
+} from "./types.js";
+import type {
+  HierarchyLevel,
+  SessionStatus,
+  Task,
+  TaskPriority,
+  TaskStatus,
+  WorkProduct,
+  CreatorType,
+} from "@beevibe/core";
+
+export interface TaskListFilter {
+  lifecycle?: Lifecycle;
+  assignee_id?: string;
+  /**
+   * Saved-view shortcut. "mine" needs the caller's personId — the route
+   * resolves that to the caller's primary agent's task assignments and
+   * passes it as `assignee_id` instead. "sprint" maps to a status set; see
+   * tasks-grouping.ts.
+   */
+  view?: "all" | "mine" | "sprint" | "timeline";
+}
+
+interface TaskListRow {
+  // task.*
+  id: string;
+  title: string;
+  description: string | null;
+  status: TaskStatus;
+  priority: TaskPriority;
+  assignee_id: string | null;
+  creator_id: string;
+  creator_type: CreatorType;
+  parent_task_id: string | null;
+  result_summary: string | null;
+  blocker_agent_id: string | null;
+  blocker_reason: string | null;
+  repo_url: string | null;
+  next_dispatch_context: Record<string, unknown> | null;
+  created_at: Date;
+  updated_at: Date;
+  // joins
+  assignee_name: string | null;
+  assignee_hier: HierarchyLevel | null;
+  creator_label: string | null;
+  session_count: string;
+  work_product_count: string;
+  latest_session_id: string | null;
+  latest_session_status: SessionStatus | null;
+  latest_session_started_at: Date | null;
+  latest_session_completed_at: Date | null;
+  latest_session_agent_label: string | null;
+}
+
+const LIST_SQL = /* sql */ `
+WITH latest_session AS (
+  SELECT DISTINCT ON (s.task_id)
+    s.task_id,
+    s.id           AS sid,
+    s.status       AS sstatus,
+    s.started_at   AS sstarted,
+    s.completed_at AS scompleted,
+    a.name         AS agent_label
+  FROM session s
+  JOIN agent a ON a.id = s.agent_id
+  WHERE s.task_id IS NOT NULL
+  ORDER BY s.task_id, s.created_at DESC
+),
+session_counts AS (
+  SELECT task_id, COUNT(*)::int AS n
+  FROM session
+  WHERE task_id IS NOT NULL
+  GROUP BY task_id
+),
+wp_counts AS (
+  SELECT task_id, COUNT(*)::int AS n
+  FROM work_product
+  GROUP BY task_id
+)
+SELECT
+  t.*,
+  asg.name              AS assignee_name,
+  asg.hierarchy_level   AS assignee_hier,
+  COALESCE(crt_a.name, crt_p.name) AS creator_label,
+  COALESCE(sc.n, 0)     AS session_count,
+  COALESCE(wpc.n, 0)    AS work_product_count,
+  ls.sid                AS latest_session_id,
+  ls.sstatus            AS latest_session_status,
+  ls.sstarted           AS latest_session_started_at,
+  ls.scompleted         AS latest_session_completed_at,
+  ls.agent_label        AS latest_session_agent_label
+FROM task t
+LEFT JOIN agent  asg   ON asg.id   = t.assignee_id
+LEFT JOIN agent  crt_a ON crt_a.id = t.creator_id  AND t.creator_type = 'agent'
+LEFT JOIN person crt_p ON crt_p.id = t.creator_id  AND t.creator_type = 'person'
+LEFT JOIN session_counts sc ON sc.task_id = t.id
+LEFT JOIN wp_counts wpc     ON wpc.task_id = t.id
+LEFT JOIN latest_session ls ON ls.task_id = t.id
+WHERE ($1::text[] IS NULL OR t.status = ANY($1::text[]))
+  AND ($2::text   IS NULL OR t.assignee_id = $2)
+ORDER BY t.created_at DESC
+`;
+
+/**
+ * Resolve the lifecycle/view filter to the actual statuses the SQL needs.
+ * Returns `null` when no filter (all statuses).
+ */
+function resolveStatusFilter(
+  filter: TaskListFilter,
+): readonly TaskStatus[] | null {
+  if (filter.lifecycle) return TASK_STATUSES_BY_LIFECYCLE[filter.lifecycle];
+  if (filter.view && filter.view !== "all" && filter.view !== "mine") {
+    return TASK_STATUSES_BY_VIEW[filter.view] ?? null;
+  }
+  return null;
+}
+
+function rowToTaskListItem(row: TaskListRow): TaskListItem {
+  const latest_session: TaskLatestSessionSummary | undefined =
+    row.latest_session_id && row.latest_session_status
+      ? {
+          short_id: deriveShortId(row.latest_session_id),
+          status: row.latest_session_status,
+          elapsed: formatDurationLabel(
+            row.latest_session_started_at,
+            row.latest_session_completed_at,
+          ),
+          agent_label: row.latest_session_agent_label ?? "agent",
+        }
+      : undefined;
+
+  const item: TaskListItem = {
+    id: row.id,
+    title: row.title,
+    status: row.status,
+    priority: row.priority,
+    assignee_id: row.assignee_id ?? undefined,
+    creator_id: row.creator_id,
+    creator_type: row.creator_type,
+    parent_task_id: row.parent_task_id ?? undefined,
+    blocker_agent_id: row.blocker_agent_id ?? undefined,
+    blocker_reason: row.blocker_reason ?? undefined,
+    repo_url: row.repo_url ?? undefined,
+    next_dispatch_context: row.next_dispatch_context as Task["next_dispatch_context"],
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    assignee_hierarchy: row.assignee_hier ?? undefined,
+    assignee_label: row.assignee_name ?? undefined,
+    creator_label: row.creator_label ?? undefined,
+    description: row.description ? [row.description] : undefined,
+    result_summary: row.result_summary ?? undefined,
+    session_count: Number(row.session_count),
+    work_product_count: Number(row.work_product_count),
+    latest_session,
+  };
+  return item;
+}
+
+export async function listTasks(
+  pool: Pool,
+  filter: TaskListFilter = {},
+): Promise<TaskListItem[]> {
+  const statuses = resolveStatusFilter(filter);
+  const { rows } = await pool.query<TaskListRow>(LIST_SQL, [
+    statuses ? [...statuses] : null,
+    filter.assignee_id ?? null,
+  ]);
+  return rows.map(rowToTaskListItem);
+}
+
+interface DetailSessionRow {
+  id: string;
+  agent_id: string;
+  agent_label: string;
+  status: SessionStatus;
+  started_at: Date | null;
+  completed_at: Date | null;
+  result_summary: string | null;
+}
+
+const DETAIL_SQL_TASK = /* sql */ `
+WITH latest_session AS (
+  SELECT DISTINCT ON (s.task_id)
+    s.task_id, s.id AS sid, s.status AS sstatus, s.started_at AS sstarted,
+    s.completed_at AS scompleted, a.name AS agent_label
+  FROM session s
+  JOIN agent a ON a.id = s.agent_id
+  WHERE s.task_id = $1
+  ORDER BY s.task_id, s.created_at DESC
+)
+SELECT
+  t.*,
+  asg.name              AS assignee_name,
+  asg.hierarchy_level   AS assignee_hier,
+  COALESCE(crt_a.name, crt_p.name) AS creator_label,
+  (SELECT COUNT(*) FROM session       WHERE task_id = t.id)::int AS session_count,
+  (SELECT COUNT(*) FROM work_product  WHERE task_id = t.id)::int AS work_product_count,
+  ls.sid                AS latest_session_id,
+  ls.sstatus            AS latest_session_status,
+  ls.sstarted           AS latest_session_started_at,
+  ls.scompleted         AS latest_session_completed_at,
+  ls.agent_label        AS latest_session_agent_label
+FROM task t
+LEFT JOIN agent  asg   ON asg.id   = t.assignee_id
+LEFT JOIN agent  crt_a ON crt_a.id = t.creator_id  AND t.creator_type = 'agent'
+LEFT JOIN person crt_p ON crt_p.id = t.creator_id  AND t.creator_type = 'person'
+LEFT JOIN latest_session ls ON ls.task_id = t.id
+WHERE t.id = $1
+LIMIT 1
+`;
+
+const DETAIL_SQL_SESSIONS = /* sql */ `
+SELECT
+  s.id, s.agent_id, a.name AS agent_label, s.status,
+  s.started_at, s.completed_at, s.result_summary
+FROM session s
+JOIN agent a ON a.id = s.agent_id
+WHERE s.task_id = $1
+ORDER BY s.created_at DESC
+`;
+
+const DETAIL_SQL_WORK_PRODUCTS = /* sql */ `
+SELECT * FROM work_product WHERE task_id = $1 ORDER BY created_at DESC
+`;
+
+export async function getTask(
+  pool: Pool,
+  id: string,
+): Promise<TaskDetail | undefined> {
+  const taskResult = await pool.query<TaskListRow>(DETAIL_SQL_TASK, [id]);
+  const taskRow = taskResult.rows[0];
+  if (!taskRow) return undefined;
+
+  const [sessionResult, wpResult] = await Promise.all([
+    pool.query<DetailSessionRow>(DETAIL_SQL_SESSIONS, [id]),
+    pool.query(DETAIL_SQL_WORK_PRODUCTS, [id]),
+  ]);
+
+  const sessions: TaskDetailSessionRow[] = sessionResult.rows.map((s) => ({
+    id: s.id,
+    short_id: deriveShortId(s.id),
+    agent_id: s.agent_id,
+    agent_label: s.agent_label,
+    status: s.status,
+    started_at: s.started_at ?? new Date(0),
+    duration_label: formatDurationLabel(s.started_at, s.completed_at),
+    result_summary: s.result_summary ?? undefined,
+  }));
+
+  const work_products: WorkProduct[] = wpResult.rows.map(rowToWorkProduct);
+
+  return {
+    ...rowToTaskListItem(taskRow),
+    sessions,
+    work_products,
+  };
+}
+
+function rowToWorkProduct(r: Record<string, unknown>): WorkProduct {
+  return {
+    id: String(r.id),
+    task_id: String(r.task_id),
+    agent_id: String(r.agent_id),
+    type: r.type as WorkProduct["type"],
+    title: String(r.title),
+    summary: (r.summary as string | null) ?? undefined,
+    url: (r.url as string | null) ?? undefined,
+    provider: (r.provider as string | null) ?? undefined,
+    external_id: (r.external_id as string | null) ?? undefined,
+    metadata: (r.metadata as Record<string, unknown> | null) ?? undefined,
+    created_at: r.created_at as Date,
+    updated_at: r.updated_at as Date,
+  };
+}

--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -1,0 +1,216 @@
+/**
+ * Read-side DTOs returned by the views layer (`packages/api/src/views/*`).
+ *
+ * Single source of truth for the web's read contract. Web re-exports these
+ * via `@beevibe/api/views/types` (subpath export). Defining them here means:
+ *
+ *   - Backend changes the shape → TypeScript errors in web (`pnpm typecheck`)
+ *   - Web bends to the backend contract, never the other way around
+ *
+ * **Independence:** these DTOs `Pick`/`Omit` from core's domain types so the
+ * column-level shape stays in sync, but they live in the API package — they
+ * carry display denormalizations (labels, counts, joined rows) that are
+ * UI-shaped, not domain-shaped, and don't belong on `Task` / `Agent` /
+ * `Session`. Core stays untouched.
+ */
+
+import type {
+  Agent,
+  HierarchyLevel,
+  Task,
+  TaskStatus,
+  WorkProduct,
+  FactType,
+  MemoryScope,
+  SessionStatus,
+  SessionType,
+} from "@beevibe/core";
+
+/**
+ * Lightweight rich-text encoding used in places where we want inline `mono`
+ * spans (e.g., description bodies, task summaries). Mirrors the web
+ * component's accepted shape — but defined here so the type lives in the
+ * package that owns the contract, not in a UI component file. The web's
+ * <RichTextRender> consumes the same structural shape.
+ */
+export type RichSegment = string | { mono: string };
+export type RichText = string | RichSegment[];
+
+// ── Tasks ───────────────────────────────────────────────────────────────────
+
+export interface TaskListItem extends Omit<Task, "description" | "result_summary"> {
+  /** Joined from the assignee agent (if any). */
+  assignee_hierarchy?: HierarchyLevel;
+  /** Human-readable assignee name (joined from agent.name). */
+  assignee_label?: string;
+  /** Human-readable creator label (agent.name or person.display_name). */
+  creator_label?: string;
+  description?: RichText[];
+  result_summary?: RichText;
+  session_count?: number;
+  work_product_count?: number;
+  /** Snapshot of the most recent session for inline rendering. */
+  latest_session?: TaskLatestSessionSummary;
+}
+
+export interface TaskLatestSessionSummary {
+  short_id: string;
+  status: "running" | "succeeded" | "failed" | "cancelled";
+  /** "2m", "1h", etc. — relative duration label. */
+  elapsed: string;
+  agent_label: string;
+}
+
+export interface TaskDetailSessionRow {
+  id: string;
+  short_id: string;
+  agent_id: string;
+  agent_label: string;
+  status: SessionStatus;
+  started_at: Date;
+  duration_label: string;
+  result_summary?: string;
+}
+
+export interface TaskDetail extends TaskListItem {
+  work_products: WorkProduct[];
+  sessions: TaskDetailSessionRow[];
+}
+
+// ── Agents ──────────────────────────────────────────────────────────────────
+
+export interface AgentDisplay
+  extends Pick<
+    Agent,
+    "id" | "name" | "owner_id" | "parent_agent_id" | "hierarchy_level" | "created_at" | "updated_at"
+  > {
+  /** Defaults to `name` but the UI may want a different display string. */
+  display_name: string;
+  hierarchy: HierarchyLevel;
+  sessions_count?: number;
+  facts_learned?: number;
+  /** Reserved for future memory-merge telemetry. */
+  merge_events?: number;
+  specialization?: string;
+  themes?: string[];
+  runtime?: string;
+  review_policy?: string;
+}
+
+export interface RecentSession {
+  short_id?: string;
+  title: string;
+  status: "running" | "succeeded" | "review";
+  /** Relative-time label, e.g. "2m". */
+  age: string;
+}
+
+export interface OutgoingMeshHint {
+  target: string;
+  intent: string;
+  age: string;
+}
+
+export interface CoreBlockDisplay {
+  id: string;
+  agent_id: string;
+  block_name: string;
+  content: string;
+  char_count: number;
+  char_limit: number;
+  is_system: boolean;
+  /** Rendered "updated 3d ago"-style label. */
+  updated_label: string;
+}
+
+export interface AgentMetrics {
+  sessions: number;
+  /** Delta vs. prior period — backend may set 0 if not computed. */
+  sessions_change: number;
+  facts: number;
+  merges: number;
+  promoted: number;
+}
+
+export interface AgentDetail extends AgentDisplay {
+  core_blocks: CoreBlockDisplay[];
+  metrics: AgentMetrics;
+  recent_sessions: RecentSession[];
+  outgoing_mesh_hints: OutgoingMeshHint[];
+}
+
+// ── Sessions ────────────────────────────────────────────────────────────────
+
+export interface TranscriptEntry {
+  kind: "agent" | "tool_call" | "tool_result" | "summary";
+  /** ISO timestamp string. */
+  timestamp: string;
+  content: string;
+  tool_name?: string;
+}
+
+export interface AskThread {
+  id: string;
+  insert_after_index: number;
+  caller: string;
+  responder: string;
+  arrow: "right" | "up";
+  status: "succeeded" | "failed";
+  duration_label: string;
+  request: RichText;
+  response: { agent: string; note?: string; content: RichText };
+  chain_depth: string;
+  spawned_session_label: string;
+  tokens_label?: string;
+  tone: "running" | "neutral";
+}
+
+export interface SessionDisplay {
+  id: string;
+  short_id: string;
+  task_id: string;
+  task_title: string;
+  task_short_id: string;
+  agent_id: string;
+  agent_label: string;
+  agent_hierarchy: HierarchyLevel;
+  type: SessionType;
+  status: SessionStatus;
+  intent: string;
+  started_at: Date;
+  duration_label: string;
+  worktree?: string;
+  cli_session?: string;
+  briefing: SessionBriefing;
+  transcript: TranscriptEntry[];
+  ask_threads?: AskThread[];
+}
+
+export interface SessionBriefing {
+  block_count: number;
+  fact_count: number;
+  token_count: number;
+  blocks: Array<{ name: string; chars: number; preview: string }>;
+  facts: Array<{ scope: HierarchyLevel; content: string; score: number }>;
+}
+
+// ── Memory facts ────────────────────────────────────────────────────────────
+
+export type MergeOrigin = "merged" | "promoted" | "single";
+
+export interface MemoryFactDisplay {
+  id: string;
+  content: RichText;
+  fact_type: FactType;
+  scope: MemoryScope;
+  agent_id: string;
+  agent_label: string;
+  source_session_count: number;
+  created_at: Date;
+  merge_origin?: MergeOrigin;
+  promotion_origin_scope?: MemoryScope;
+}
+
+// ── Re-exports of ambient types that web imports alongside the DTOs ─────────
+
+export type { TaskStatus };

--- a/packages/web/app/(authed)/tasks/[id]/task-detail-client.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/task-detail-client.tsx
@@ -77,6 +77,19 @@ export function TaskDetailClient({ taskId }: { taskId: string }) {
   return <TaskDetailLoaded task={data} />;
 }
 
+type ReviewMutation = "approve" | "reject" | "revise";
+
+function reviewStatus(
+  hooks: Record<ReviewMutation, { isPending: boolean; isError: boolean; error: Error | null }>,
+) {
+  const actions: ReviewMutation[] = ["approve", "reject", "revise"];
+  return {
+    anyPending: actions.some((a) => hooks[a].isPending),
+    lastError: actions.map((a) => hooks[a].error).find((e) => e) ?? null,
+    lastErrorAction: actions.find((a) => hooks[a].isError) ?? null,
+  };
+}
+
 function TaskDetailLoaded({ task }: { task: TaskDetail }) {
   const isInReview = task.status === "review";
   const activeSession = task.latest_session?.status === "running" ? task.latest_session : null;
@@ -86,15 +99,7 @@ function TaskDetailLoaded({ task }: { task: TaskDetail }) {
   const [reviseOpen, setReviseOpen] = useState(false);
   const [reviseFeedback, setReviseFeedback] = useState("");
 
-  const anyPending = approve.isPending || reject.isPending || revise.isPending;
-  const lastError = approve.error ?? reject.error ?? revise.error ?? null;
-  const lastErrorAction = approve.isError
-    ? "approve"
-    : reject.isError
-      ? "reject"
-      : revise.isError
-        ? "revise"
-        : null;
+  const { anyPending, lastError, lastErrorAction } = reviewStatus({ approve, reject, revise });
 
   const submitRevise = () => {
     const feedback = reviseFeedback.trim();
@@ -122,66 +127,68 @@ function TaskDetailLoaded({ task }: { task: TaskDetail }) {
         </div>
 
         {isInReview ? (
-          <div className="flex justify-end gap-2 mb-2">
-            <button
-              type="button"
-              disabled={anyPending}
-              onClick={() => reject.mutate({})}
-              className="h-9 px-3 rounded text-sm font-medium border border-border hover:bg-secondary transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {reject.isPending ? "Rejecting…" : "Reject"}
-            </button>
-            <button
-              type="button"
-              disabled={anyPending}
-              onClick={() => setReviseOpen((v) => !v)}
-              className="h-9 px-3 rounded text-sm font-medium border border-border hover:bg-secondary transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              Request revision
-            </button>
-            <button
-              type="button"
-              disabled={anyPending}
-              onClick={() => approve.mutate({})}
-              className="h-9 px-3 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {approve.isPending ? "Approving…" : "Approve"}
-            </button>
-          </div>
-        ) : null}
-        {isInReview && reviseOpen ? (
-          <div className="mb-2 rounded-lg border border-border bg-card p-3 space-y-2">
-            <label className="block text-[11px] uppercase tracking-wider text-muted-foreground font-medium">
-              Revision feedback
-            </label>
-            <textarea
-              value={reviseFeedback}
-              onChange={(e) => setReviseFeedback(e.target.value)}
-              placeholder="What needs to change?"
-              rows={3}
-              className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-            />
-            <div className="flex justify-end gap-2">
+          <>
+            <div className="flex justify-end gap-2 mb-2">
               <button
                 type="button"
-                onClick={() => {
-                  setReviseOpen(false);
-                  setReviseFeedback("");
-                }}
-                className="h-8 px-3 rounded text-xs font-medium border border-border hover:bg-secondary transition-colors cursor-pointer"
+                disabled={anyPending}
+                onClick={() => reject.mutate({})}
+                className="h-9 px-3 rounded text-sm font-medium border border-border hover:bg-secondary transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                Cancel
+                {reject.isPending ? "Rejecting…" : "Reject"}
               </button>
               <button
                 type="button"
-                disabled={anyPending || reviseFeedback.trim().length === 0}
-                onClick={submitRevise}
-                className="h-8 px-3 rounded text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                disabled={anyPending}
+                onClick={() => setReviseOpen((v) => !v)}
+                className="h-9 px-3 rounded text-sm font-medium border border-border hover:bg-secondary transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                {revise.isPending ? "Submitting…" : "Submit revision"}
+                Request revision
+              </button>
+              <button
+                type="button"
+                disabled={anyPending}
+                onClick={() => approve.mutate({})}
+                className="h-9 px-3 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {approve.isPending ? "Approving…" : "Approve"}
               </button>
             </div>
-          </div>
+            {reviseOpen ? (
+              <div className="mb-2 rounded-lg border border-border bg-card p-3 space-y-2">
+                <label className="block text-[11px] uppercase tracking-wider text-muted-foreground font-medium">
+                  Revision feedback
+                </label>
+                <textarea
+                  value={reviseFeedback}
+                  onChange={(e) => setReviseFeedback(e.target.value)}
+                  placeholder="What needs to change?"
+                  rows={3}
+                  className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                />
+                <div className="flex justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setReviseOpen(false);
+                      setReviseFeedback("");
+                    }}
+                    className="h-8 px-3 rounded text-xs font-medium border border-border hover:bg-secondary transition-colors cursor-pointer"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    disabled={anyPending || reviseFeedback.trim().length === 0}
+                    onClick={submitRevise}
+                    className="h-8 px-3 rounded text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {revise.isPending ? "Submitting…" : "Submit revision"}
+                  </button>
+                </div>
+              </div>
+            ) : null}
+          </>
         ) : null}
         {lastError ? (
           <div className="text-xs text-status-failed text-right">

--- a/packages/web/app/(authed)/tasks/[id]/task-detail-client.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/task-detail-client.tsx
@@ -1,9 +1,14 @@
 "use client";
 
 import Link from "next/link";
+import { useState } from "react";
 import { ArrowLeft, AlertTriangle, FileText, ListChecks, Terminal } from "lucide-react";
 import { useTask } from "@/lib/hooks/use-tasks";
-import { useApproveTask } from "@/lib/hooks/use-task-mutations";
+import {
+  useApproveTask,
+  useRejectTask,
+  useReviseTask,
+} from "@/lib/hooks/use-task-mutations";
 import { isApiConfigured } from "@/lib/api/config";
 import { TaskStatusPill, SessionStatusPill } from "@/components/detail/status-pill";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
@@ -76,6 +81,34 @@ function TaskDetailLoaded({ task }: { task: TaskDetail }) {
   const isInReview = task.status === "review";
   const activeSession = task.latest_session?.status === "running" ? task.latest_session : null;
   const approve = useApproveTask(task.id);
+  const reject = useRejectTask(task.id);
+  const revise = useReviseTask(task.id);
+  const [reviseOpen, setReviseOpen] = useState(false);
+  const [reviseFeedback, setReviseFeedback] = useState("");
+
+  const anyPending = approve.isPending || reject.isPending || revise.isPending;
+  const lastError = approve.error ?? reject.error ?? revise.error ?? null;
+  const lastErrorAction = approve.isError
+    ? "approve"
+    : reject.isError
+      ? "reject"
+      : revise.isError
+        ? "revise"
+        : null;
+
+  const submitRevise = () => {
+    const feedback = reviseFeedback.trim();
+    if (!feedback) return;
+    revise.mutate(
+      { feedback },
+      {
+        onSuccess: () => {
+          setReviseFeedback("");
+          setReviseOpen(false);
+        },
+      },
+    );
+  };
 
   return (
     <DetailShell nav={<TasksBackLink />}>
@@ -92,35 +125,67 @@ function TaskDetailLoaded({ task }: { task: TaskDetail }) {
           <div className="flex justify-end gap-2 mb-2">
             <button
               type="button"
-              disabled={approve.isPending}
-              onClick={() => approve.mutate({ action: "reject" })}
+              disabled={anyPending}
+              onClick={() => reject.mutate({})}
               className="h-9 px-3 rounded text-sm font-medium border border-border hover:bg-secondary transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              Reject
+              {reject.isPending ? "Rejecting…" : "Reject"}
             </button>
             <button
               type="button"
-              disabled={approve.isPending}
-              onClick={() => approve.mutate({ action: "revise" })}
+              disabled={anyPending}
+              onClick={() => setReviseOpen((v) => !v)}
               className="h-9 px-3 rounded text-sm font-medium border border-border hover:bg-secondary transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Request revision
             </button>
             <button
               type="button"
-              disabled={approve.isPending}
-              onClick={() => approve.mutate({ action: "approve" })}
+              disabled={anyPending}
+              onClick={() => approve.mutate({})}
               className="h-9 px-3 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              {approve.isPending && approve.variables?.action === "approve"
-                ? "Approving…"
-                : "Approve"}
+              {approve.isPending ? "Approving…" : "Approve"}
             </button>
           </div>
         ) : null}
-        {approve.isError ? (
+        {isInReview && reviseOpen ? (
+          <div className="mb-2 rounded-lg border border-border bg-card p-3 space-y-2">
+            <label className="block text-[11px] uppercase tracking-wider text-muted-foreground font-medium">
+              Revision feedback
+            </label>
+            <textarea
+              value={reviseFeedback}
+              onChange={(e) => setReviseFeedback(e.target.value)}
+              placeholder="What needs to change?"
+              rows={3}
+              className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+            />
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setReviseOpen(false);
+                  setReviseFeedback("");
+                }}
+                className="h-8 px-3 rounded text-xs font-medium border border-border hover:bg-secondary transition-colors cursor-pointer"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                disabled={anyPending || reviseFeedback.trim().length === 0}
+                onClick={submitRevise}
+                className="h-8 px-3 rounded text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {revise.isPending ? "Submitting…" : "Submit revision"}
+              </button>
+            </div>
+          </div>
+        ) : null}
+        {lastError ? (
           <div className="text-xs text-status-failed text-right">
-            Couldn&apos;t {approve.variables?.action ?? "submit"}: {approve.error.message}
+            Couldn&apos;t {lastErrorAction ?? "submit"}: {lastError.message}
           </div>
         ) : null}
       </header>

--- a/packages/web/lib/api/client-mutations.test.ts
+++ b/packages/web/lib/api/client-mutations.test.ts
@@ -18,41 +18,65 @@ beforeEach(() => {
 
 describe("api mutations", () => {
   describe("tasks", () => {
-    it("approve(id, {action}) POSTs to /api/tasks/:id/approve with body", async () => {
-      await api.tasks.approve("t_1", { action: "approve" });
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/tasks/t_1/approve", {
-        method: "POST",
-        body: { action: "approve" },
-      });
-    });
-
-    it("approve forwards optional result_summary", async () => {
-      await api.tasks.approve("t_1", { action: "revise", result_summary: "needs more tests" });
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/tasks/t_1/approve", {
-        method: "POST",
-        body: { action: "revise", result_summary: "needs more tests" },
-      });
-    });
-
-    it("cancel(id) POSTs to /api/tasks/:id/cancel with empty body by default", async () => {
-      await api.tasks.cancel("t_1");
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/tasks/t_1/cancel", {
+    it("approve(id) POSTs to /task/:id/approve with empty body by default", async () => {
+      await api.tasks.approve("t_1");
+      expect(fetchJsonMock).toHaveBeenCalledWith("/task/t_1/approve", {
         method: "POST",
         body: {},
       });
     });
 
-    it("cancel(id, {force, reason}) forwards both", async () => {
-      await api.tasks.cancel("t_1", { force: true, reason: "scope changed" });
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/tasks/t_1/cancel", {
+    it("approve forwards optional result_summary", async () => {
+      await api.tasks.approve("t_1", { result_summary: "lgtm" });
+      expect(fetchJsonMock).toHaveBeenCalledWith("/task/t_1/approve", {
         method: "POST",
-        body: { force: true, reason: "scope changed" },
+        body: { result_summary: "lgtm" },
+      });
+    });
+
+    it("reject(id) POSTs to /task/:id/reject with empty body by default", async () => {
+      await api.tasks.reject("t_1");
+      expect(fetchJsonMock).toHaveBeenCalledWith("/task/t_1/reject", {
+        method: "POST",
+        body: {},
+      });
+    });
+
+    it("reject forwards optional result_summary", async () => {
+      await api.tasks.reject("t_1", { result_summary: "wrong scope" });
+      expect(fetchJsonMock).toHaveBeenCalledWith("/task/t_1/reject", {
+        method: "POST",
+        body: { result_summary: "wrong scope" },
+      });
+    });
+
+    it("revise(id, {feedback}) POSTs to /task/:id/revise with the feedback body", async () => {
+      await api.tasks.revise("t_1", { feedback: "needs more tests" });
+      expect(fetchJsonMock).toHaveBeenCalledWith("/task/t_1/revise", {
+        method: "POST",
+        body: { feedback: "needs more tests" },
+      });
+    });
+
+    it("cancel(id) POSTs to /task/:id/cancel with empty body by default", async () => {
+      await api.tasks.cancel("t_1");
+      expect(fetchJsonMock).toHaveBeenCalledWith("/task/t_1/cancel", {
+        method: "POST",
+        body: {},
+      });
+    });
+
+    it("cancel(id, {reason}) forwards reason", async () => {
+      await api.tasks.cancel("t_1", { reason: "scope changed" });
+      expect(fetchJsonMock).toHaveBeenCalledWith("/task/t_1/cancel", {
+        method: "POST",
+        body: { reason: "scope changed" },
       });
     });
 
     it("create({title}) POSTs to /api/tasks", async () => {
       await api.tasks.create({ title: "wire it" });
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/tasks", {
+      expect(fetchJsonMock).toHaveBeenCalledWith("/task", {
         method: "POST",
         body: { title: "wire it" },
       });
@@ -66,7 +90,7 @@ describe("api mutations", () => {
         assignee_id: "agt_1",
         parent_task_id: "t_root",
       });
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/tasks", {
+      expect(fetchJsonMock).toHaveBeenCalledWith("/task", {
         method: "POST",
         body: {
           title: "wire it",
@@ -79,20 +103,39 @@ describe("api mutations", () => {
     });
   });
 
-  describe("sessions", () => {
-    it("cancel(shortId) POSTs to /api/sessions/:short/cancel", async () => {
-      await api.sessions.cancel("sess_abc");
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/sessions/sess_abc/cancel", {
+  describe("escalations", () => {
+    it("resolve(id, {source: 'human', ...}) POSTs to /escalation/:id/resolve", async () => {
+      await api.escalations.resolve("e_1", {
+        source: "human",
+        title: "Adopt option C",
+        description: "Splits the diff",
+      });
+      expect(fetchJsonMock).toHaveBeenCalledWith("/escalation/e_1/resolve", {
         method: "POST",
+        body: {
+          source: "human",
+          title: "Adopt option C",
+          description: "Splits the diff",
+        },
       });
     });
 
-    it("cancel URL-encodes shortId", async () => {
-      await api.sessions.cancel("sess/with/slash");
-      expect(fetchJsonMock).toHaveBeenCalledWith(
-        "/api/sessions/sess%2Fwith%2Fslash/cancel",
-        { method: "POST" },
-      );
+    it("resolve forwards initiator/counterparty selectors", async () => {
+      await api.escalations.resolve("e_1", {
+        source: "initiator",
+        source_index: 0,
+        edited_title: "tweaked",
+        resolution_notes: "confirmed via slack",
+      });
+      expect(fetchJsonMock).toHaveBeenCalledWith("/escalation/e_1/resolve", {
+        method: "POST",
+        body: {
+          source: "initiator",
+          source_index: 0,
+          edited_title: "tweaked",
+          resolution_notes: "confirmed via slack",
+        },
+      });
     });
   });
 });

--- a/packages/web/lib/api/client.test.ts
+++ b/packages/web/lib/api/client.test.ts
@@ -16,11 +16,11 @@ beforeEach(() => {
   fetchJsonMock.mockResolvedValue([]);
 });
 
-describe("api client", () => {
+describe("api client (reads)", () => {
   describe("tasks", () => {
-    it("list() hits /api/tasks with empty query when no filter is given", async () => {
+    it("list() hits /task with empty query when no filter is given", async () => {
       await api.tasks.list();
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/tasks", {
+      expect(fetchJsonMock).toHaveBeenCalledWith("/task", {
         query: {},
         signal: undefined,
       });
@@ -28,7 +28,7 @@ describe("api client", () => {
 
     it("list({lifecycle, view, assignee_id}) forwards every filter to the query", async () => {
       await api.tasks.list({ lifecycle: "in_review", view: "mine", assignee_id: "a1" });
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/tasks", {
+      expect(fetchJsonMock).toHaveBeenCalledWith("/task", {
         query: { lifecycle: "in_review", view: "mine", assignee_id: "a1" },
         signal: undefined,
       });
@@ -37,7 +37,7 @@ describe("api client", () => {
     it("forwards an AbortSignal when one is provided", async () => {
       const ac = new AbortController();
       await api.tasks.list({}, { signal: ac.signal });
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/tasks", {
+      expect(fetchJsonMock).toHaveBeenCalledWith("/task", {
         query: {},
         signal: ac.signal,
       });
@@ -45,30 +45,30 @@ describe("api client", () => {
 
     it("get(id) URL-encodes the id", async () => {
       await api.tasks.get("task with spaces");
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/tasks/task%20with%20spaces", {
+      expect(fetchJsonMock).toHaveBeenCalledWith("/task/task%20with%20spaces", {
         signal: undefined,
       });
     });
   });
 
   describe("agents", () => {
-    it("list() hits /api/agents", async () => {
+    it("list() hits /agent", async () => {
       await api.agents.list();
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/agents", { signal: undefined });
+      expect(fetchJsonMock).toHaveBeenCalledWith("/agent", { signal: undefined });
     });
 
     it("get(id) URL-encodes the id", async () => {
       await api.agents.get("agt/slash");
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/agents/agt%2Fslash", {
+      expect(fetchJsonMock).toHaveBeenCalledWith("/agent/agt%2Fslash", {
         signal: undefined,
       });
     });
   });
 
   describe("sessions", () => {
-    it("get(shortId) hits /api/sessions/:short", async () => {
-      await api.sessions.get("sess-abc");
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/sessions/sess-abc", {
+    it("get(shortId) hits /session/:short", async () => {
+      await api.sessions.get("abc123");
+      expect(fetchJsonMock).toHaveBeenCalledWith("/session/abc123", {
         signal: undefined,
       });
     });
@@ -77,7 +77,7 @@ describe("api client", () => {
   describe("memory", () => {
     it("listFacts() defaults to empty filter", async () => {
       await api.memory.listFacts();
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/memory/facts", {
+      expect(fetchJsonMock).toHaveBeenCalledWith("/memory/fact", {
         query: {},
         signal: undefined,
       });
@@ -85,22 +85,22 @@ describe("api client", () => {
 
     it("listFacts({scope}) forwards scope", async () => {
       await api.memory.listFacts({ scope: "team" });
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/memory/facts", {
+      expect(fetchJsonMock).toHaveBeenCalledWith("/memory/fact", {
         query: { scope: "team" },
         signal: undefined,
       });
     });
   });
 
-  describe("promotions / mesh / threads / dashboard", () => {
-    it("promotions.list() hits /api/promotions", async () => {
+  describe("deferred surfaces (paths set; backend not yet shipped)", () => {
+    it("promotions.list() hits /promotion", async () => {
       await api.promotions.list();
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/promotions", { signal: undefined });
+      expect(fetchJsonMock).toHaveBeenCalledWith("/promotion", { signal: undefined });
     });
 
-    it("mesh.overview() hits /api/mesh with optional since", async () => {
+    it("mesh.overview() hits /mesh with optional since", async () => {
       await api.mesh.overview({ since: "2026-04-30T00:00:00Z" });
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/mesh", {
+      expect(fetchJsonMock).toHaveBeenCalledWith("/mesh", {
         query: { since: "2026-04-30T00:00:00Z" },
         signal: undefined,
       });
@@ -108,14 +108,14 @@ describe("api client", () => {
 
     it("threads.list() / threads.get(id)", async () => {
       await api.threads.list();
-      expect(fetchJsonMock).toHaveBeenLastCalledWith("/api/threads", { signal: undefined });
+      expect(fetchJsonMock).toHaveBeenLastCalledWith("/thread", { signal: undefined });
       await api.threads.get("ch_1");
-      expect(fetchJsonMock).toHaveBeenLastCalledWith("/api/threads/ch_1", { signal: undefined });
+      expect(fetchJsonMock).toHaveBeenLastCalledWith("/thread/ch_1", { signal: undefined });
     });
 
-    it("dashboard.summary() hits /api/dashboard", async () => {
+    it("dashboard.summary() hits /dashboard", async () => {
       await api.dashboard.summary();
-      expect(fetchJsonMock).toHaveBeenCalledWith("/api/dashboard", { signal: undefined });
+      expect(fetchJsonMock).toHaveBeenCalledWith("/dashboard", { signal: undefined });
     });
   });
 });

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -27,15 +27,17 @@ export interface ReadOptions {
   signal?: AbortSignal;
 }
 
-export type ApproveAction = "approve" | "reject" | "revise";
-
 export interface ApproveTaskInput {
-  action: ApproveAction;
   result_summary?: string;
+}
+export interface RejectTaskInput {
+  result_summary?: string;
+}
+export interface ReviseTaskInput {
+  feedback: string;
 }
 
 export interface CancelTaskInput {
-  force?: boolean;
   reason?: string;
 }
 
@@ -47,63 +49,105 @@ export interface CreateTaskInput {
   parent_task_id?: string;
 }
 
+export type EscalationResolveInput =
+  | {
+      source: "initiator" | "counterparty";
+      source_index: number;
+      edited_title?: string;
+      edited_description?: string;
+      resolution_notes?: string;
+    }
+  | {
+      source: "human";
+      title: string;
+      description: string;
+      resolution_notes?: string;
+    };
+
 export const api = {
   tasks: {
     list: (filter: TaskListFilter = {}, opts: ReadOptions = {}) =>
-      fetchJson<TaskListItem[]>("/api/tasks", { query: { ...filter }, signal: opts.signal }),
+      fetchJson<TaskListItem[]>("/task", { query: { ...filter }, signal: opts.signal }),
     get: (id: string, opts: ReadOptions = {}) =>
-      fetchJson<TaskDetail>(`/api/tasks/${encodeURIComponent(id)}`, { signal: opts.signal }),
-    approve: (id: string, input: ApproveTaskInput) =>
-      fetchJson<Task>(`/api/tasks/${encodeURIComponent(id)}/approve`, {
-        method: "POST",
-        body: input,
-      }),
+      fetchJson<TaskDetail>(`/task/${encodeURIComponent(id)}`, { signal: opts.signal }),
+    approve: (id: string, input: ApproveTaskInput = {}) =>
+      fetchJson<{ ok: true; task: Pick<Task, "id" | "status"> }>(
+        `/task/${encodeURIComponent(id)}/approve`,
+        { method: "POST", body: input },
+      ),
+    reject: (id: string, input: RejectTaskInput = {}) =>
+      fetchJson<{ ok: true; task: Pick<Task, "id" | "status"> }>(
+        `/task/${encodeURIComponent(id)}/reject`,
+        { method: "POST", body: input },
+      ),
+    revise: (id: string, input: ReviseTaskInput) =>
+      fetchJson<{ ok: true; task: Pick<Task, "id" | "status"> }>(
+        `/task/${encodeURIComponent(id)}/revise`,
+        { method: "POST", body: input },
+      ),
     cancel: (id: string, input: CancelTaskInput = {}) =>
-      fetchJson<Task>(`/api/tasks/${encodeURIComponent(id)}/cancel`, {
-        method: "POST",
-        body: input,
-      }),
+      fetchJson<{ ok: true; task_id: string; note: string }>(
+        `/task/${encodeURIComponent(id)}/cancel`,
+        { method: "POST", body: input },
+      ),
+    // Backend hasn't shipped POST /task (create) yet — see #30.
     create: (input: CreateTaskInput) =>
-      fetchJson<Task>("/api/tasks", { method: "POST", body: input }),
+      fetchJson<Task>("/task", { method: "POST", body: input }),
   },
   agents: {
     list: (opts: ReadOptions = {}) =>
-      fetchJson<AgentDisplay[]>("/api/agents", { signal: opts.signal }),
+      fetchJson<AgentDisplay[]>("/agent", { signal: opts.signal }),
     get: (id: string, opts: ReadOptions = {}) =>
-      fetchJson<AgentDetail>(`/api/agents/${encodeURIComponent(id)}`, { signal: opts.signal }),
+      fetchJson<AgentDetail>(`/agent/${encodeURIComponent(id)}`, { signal: opts.signal }),
   },
   sessions: {
+    /** Path param is the 6-char short_id (no '#'). */
     get: (shortId: string, opts: ReadOptions = {}) =>
-      fetchJson<SessionDisplay>(`/api/sessions/${encodeURIComponent(shortId)}`, {
+      fetchJson<SessionDisplay>(`/session/${encodeURIComponent(shortId)}`, {
         signal: opts.signal,
       }),
-    cancel: (shortId: string) =>
-      fetchJson<void>(`/api/sessions/${encodeURIComponent(shortId)}/cancel`, { method: "POST" }),
   },
   memory: {
     listFacts: (filter: { scope?: MemoryScope } = {}, opts: ReadOptions = {}) =>
-      fetchJson<MemoryFactDisplay[]>("/api/memory/facts", {
+      fetchJson<MemoryFactDisplay[]>("/memory/fact", {
         query: { ...filter },
         signal: opts.signal,
       }),
   },
+  // Surfaces below depend on backend slices that haven't shipped yet
+  // (dashboard/mesh need a data/display split; threads/promotions lack a
+  // domain). They'll 404 against the current api server and the page-level
+  // empty states keep showing. Tracked in follow-ups to #30.
   promotions: {
     list: (opts: ReadOptions = {}) =>
-      fetchJson<PromotionEvent[]>("/api/promotions", { signal: opts.signal }),
+      fetchJson<PromotionEvent[]>("/promotion", { signal: opts.signal }),
   },
   mesh: {
     overview: (filter: { since?: string } = {}, opts: ReadOptions = {}) =>
-      fetchJson<MeshOverview>("/api/mesh", { query: { ...filter }, signal: opts.signal }),
+      fetchJson<MeshOverview>("/mesh", { query: { ...filter }, signal: opts.signal }),
   },
   threads: {
     list: (opts: ReadOptions = {}) =>
-      fetchJson<ThreadsOverview>("/api/threads", { signal: opts.signal }),
+      fetchJson<ThreadsOverview>("/thread", { signal: opts.signal }),
     get: (id: string, opts: ReadOptions = {}) =>
-      fetchJson<ThreadDetail>(`/api/threads/${encodeURIComponent(id)}`, { signal: opts.signal }),
+      fetchJson<ThreadDetail>(`/thread/${encodeURIComponent(id)}`, { signal: opts.signal }),
   },
   dashboard: {
     summary: (opts: ReadOptions = {}) =>
-      fetchJson<DashboardSummary>("/api/dashboard", { signal: opts.signal }),
+      fetchJson<DashboardSummary>("/dashboard", { signal: opts.signal }),
+  },
+  escalations: {
+    resolve: (id: string, input: EscalationResolveInput) =>
+      fetchJson<{
+        ok: true;
+        escalation: { id: string; status: string; resolution_proposal: unknown; resolution_notes: string | null };
+        a_task_id: string;
+        b_task_id: string;
+        note: string;
+      }>(`/escalation/${encodeURIComponent(id)}/resolve`, {
+        method: "POST",
+        body: input,
+      }),
   },
 } as const;
 

--- a/packages/web/lib/api/config.test.ts
+++ b/packages/web/lib/api/config.test.ts
@@ -41,4 +41,20 @@ describe("api config", () => {
     expect(apiBaseUrl).toBeNull();
     expect(isApiConfigured).toBe(false);
   });
+
+  it("exposes userKey from NEXT_PUBLIC_BV_USER_KEY when set", async () => {
+    vi.stubEnv("NEXT_PUBLIC_BV_API_URL", "http://localhost:3002");
+    vi.stubEnv("NEXT_PUBLIC_BV_USER_KEY", "bv_u_test123");
+    vi.resetModules();
+    const { userKey } = await loadConfig();
+    expect(userKey).toBe("bv_u_test123");
+  });
+
+  it("treats missing NEXT_PUBLIC_BV_USER_KEY as null userKey (no auth header)", async () => {
+    vi.stubEnv("NEXT_PUBLIC_BV_API_URL", "http://localhost:3002");
+    vi.stubEnv("NEXT_PUBLIC_BV_USER_KEY", "");
+    vi.resetModules();
+    const { userKey } = await loadConfig();
+    expect(userKey).toBeNull();
+  });
 });

--- a/packages/web/lib/api/config.ts
+++ b/packages/web/lib/api/config.ts
@@ -1,6 +1,10 @@
-const raw = process.env.NEXT_PUBLIC_BV_API_URL?.trim();
+const rawBaseUrl = process.env.NEXT_PUBLIC_BV_API_URL?.trim();
+const rawUserKey = process.env.NEXT_PUBLIC_BV_USER_KEY?.trim();
 
 export const apiBaseUrl: string | null =
-  raw && raw.length > 0 ? raw.replace(/\/+$/, "") : null;
+  rawBaseUrl && rawBaseUrl.length > 0 ? rawBaseUrl.replace(/\/+$/, "") : null;
+
+export const userKey: string | null =
+  rawUserKey && rawUserKey.length > 0 ? rawUserKey : null;
 
 export const isApiConfigured: boolean = apiBaseUrl !== null;

--- a/packages/web/lib/api/http.test.ts
+++ b/packages/web/lib/api/http.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("./config", () => ({
   apiBaseUrl: "https://api.example.com",
   isApiConfigured: true,
+  userKey: null,
 }));
 
 import { fetchJson, ApiError } from "./http";
@@ -115,11 +116,39 @@ describe("fetchJson", () => {
 describe("fetchJson when API is not configured", () => {
   it("throws ApiNotConfigured without invoking fetch", async () => {
     vi.resetModules();
-    vi.doMock("./config", () => ({ apiBaseUrl: null, isApiConfigured: false }));
+    vi.doMock("./config", () => ({
+      apiBaseUrl: null,
+      isApiConfigured: false,
+      userKey: null,
+    }));
 
     const { fetchJson: ucFetch, ApiNotConfigured } = await import("./http");
     await expect(ucFetch("/api/tasks")).rejects.toBeInstanceOf(ApiNotConfigured);
     expect(fetchMock).not.toHaveBeenCalled();
+
+    vi.doUnmock("./config");
+    vi.resetModules();
+  });
+});
+
+describe("fetchJson with userKey configured", () => {
+  it("attaches Authorization: Bearer <userKey> when configured", async () => {
+    vi.resetModules();
+    vi.doMock("./config", () => ({
+      apiBaseUrl: "https://api.example.com",
+      isApiConfigured: true,
+      userKey: "bv_u_test_key",
+    }));
+
+    const { fetchJson: authedFetch } = await import("./http");
+    fetchMock.mockResolvedValueOnce(new Response("{}", { status: 200 }));
+
+    await authedFetch("/task/t_1/approve", { method: "POST", body: {} });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer bv_u_test_key",
+    );
 
     vi.doUnmock("./config");
     vi.resetModules();

--- a/packages/web/lib/api/http.ts
+++ b/packages/web/lib/api/http.ts
@@ -1,4 +1,4 @@
-import { apiBaseUrl } from "./config";
+import { apiBaseUrl, userKey } from "./config";
 
 export class ApiError extends Error {
   readonly status: number;
@@ -44,6 +44,7 @@ export async function fetchJson<T>(path: string, opts: FetchOptions = {}): Promi
     headers: {
       Accept: "application/json",
       ...(body !== undefined ? { "Content-Type": "application/json" } : {}),
+      ...(userKey ? { Authorization: `Bearer ${userKey}` } : {}),
       ...headers,
     },
     body: body !== undefined ? JSON.stringify(body) : undefined,

--- a/packages/web/lib/api/types.ts
+++ b/packages/web/lib/api/types.ts
@@ -1,7 +1,19 @@
-import type { WorkProduct } from "@beevibe/core";
-import type { TaskListItem } from "@/lib/types/tasks";
-import type { AgentDisplay, RecentSession, OutgoingMeshHint } from "@/lib/types/agents";
-import type { CoreBlockDisplay, AgentMetrics } from "@/lib/types/core-memory-blocks";
+/**
+ * Web-side re-exports of the read-DTO contract owned by `@beevibe/api`.
+ *
+ * Live shapes are defined in `packages/api/src/views/types.ts` so the
+ * backend is the single source of truth for the read surface. Anything
+ * the web computes locally (display-only types like ChainBudget, GraphNode,
+ * dashboard KPI styling) stays in `lib/types/*` and isn't surfaced here.
+ */
+
+export type {
+  TaskDetail,
+  TaskDetailSessionRow,
+  AgentDetail,
+} from "@beevibe/api/views/types";
+
+import type { ChainBudgetData, GraphNode, GraphEdge, MeshSummary, MeshAsk } from "@/lib/types/mesh";
 import type {
   KpiStat,
   StatusBreakdownEntry,
@@ -10,31 +22,16 @@ import type {
   TrendDay,
   AttentionItem,
 } from "@/lib/types/dashboard";
-import type { ChainBudgetData, GraphNode, GraphEdge, MeshSummary, MeshAsk } from "@/lib/types/mesh";
-import type { ThreadEvent, ThreadChannel, DirectMessage, ActiveChannel } from "@/lib/types/thread-messages";
+import type {
+  ThreadEvent,
+  ThreadChannel,
+  DirectMessage,
+  ActiveChannel,
+} from "@/lib/types/thread-messages";
 
-export interface TaskDetail extends TaskListItem {
-  work_products: WorkProduct[];
-  sessions: TaskDetailSessionRow[];
-}
-
-export interface TaskDetailSessionRow {
-  id: string;
-  short_id: string;
-  agent_id: string;
-  agent_label: string;
-  status: "running" | "succeeded" | "failed" | "cancelled";
-  started_at: Date;
-  duration_label: string;
-  result_summary?: string;
-}
-
-export interface AgentDetail extends AgentDisplay {
-  core_blocks: CoreBlockDisplay[];
-  metrics: AgentMetrics;
-  recent_sessions: RecentSession[];
-  outgoing_mesh_hints: OutgoingMeshHint[];
-}
+// ── Display-only shapes the web still composes from fixtures ────────────
+// These surfaces (dashboard, mesh, threads) need a data/display split before
+// the backend can produce them cleanly. Tracked separately from #30.
 
 export interface DashboardSummary {
   kpis: KpiStat[];

--- a/packages/web/lib/hooks/use-session-mutations.test.tsx
+++ b/packages/web/lib/hooks/use-session-mutations.test.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from "react";
 
 vi.mock("@/lib/api/client", () => ({
   api: {
-    sessions: { cancel: vi.fn() },
+    tasks: { cancel: vi.fn() },
   },
 }));
 
@@ -13,7 +13,7 @@ import { useCancelSession } from "./use-session-mutations";
 import { api } from "@/lib/api/client";
 import { queryKeys } from "./keys";
 
-const cancelMock = vi.mocked(api.sessions.cancel);
+const cancelMock = vi.mocked(api.tasks.cancel);
 
 function makeWrapper() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -33,8 +33,8 @@ afterEach(() => {
 });
 
 describe("useCancelSession", () => {
-  it("calls api.sessions.cancel with the shortId and invalidates session + task caches", async () => {
-    cancelMock.mockResolvedValue(undefined);
+  it("cancels the parent task (session = task subprocess in M6) and invalidates session + task caches", async () => {
+    cancelMock.mockResolvedValue({} as never);
     const { invalidateSpy, Wrapper } = makeWrapper();
 
     const { result } = renderHook(() => useCancelSession("sess_1", "t_1"), { wrapper: Wrapper });
@@ -43,7 +43,7 @@ describe("useCancelSession", () => {
       result.current.mutate();
     });
 
-    await waitFor(() => expect(cancelMock).toHaveBeenCalledWith("sess_1"));
+    await waitFor(() => expect(cancelMock).toHaveBeenCalledWith("t_1"));
 
     const invalidated = invalidateSpy.mock.calls.map((c) => c[0]?.queryKey);
     expect(invalidated).toEqual(
@@ -54,21 +54,5 @@ describe("useCancelSession", () => {
         queryKeys.tasks.all,
       ]),
     );
-  });
-
-  it("skips task-detail invalidation when taskId is omitted", async () => {
-    cancelMock.mockResolvedValue(undefined);
-    const { invalidateSpy, Wrapper } = makeWrapper();
-
-    const { result } = renderHook(() => useCancelSession("sess_1"), { wrapper: Wrapper });
-
-    await act(async () => {
-      result.current.mutate();
-    });
-
-    await waitFor(() => expect(cancelMock).toHaveBeenCalledWith("sess_1"));
-
-    const invalidated = invalidateSpy.mock.calls.map((c) => c[0]?.queryKey);
-    expect(invalidated).not.toContain(queryKeys.tasks.detail("t_1"));
   });
 });

--- a/packages/web/lib/hooks/use-session-mutations.ts
+++ b/packages/web/lib/hooks/use-session-mutations.ts
@@ -2,14 +2,14 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
 import { queryKeys } from "./keys";
 
-export function useCancelSession(shortId: string, taskId?: string) {
+export function useCancelSession(shortId: string, taskId: string) {
   const client = useQueryClient();
   return useMutation({
-    mutationFn: () => api.sessions.cancel(shortId),
+    mutationFn: () => api.tasks.cancel(taskId),
     onSuccess: () => {
       client.invalidateQueries({ queryKey: queryKeys.sessions.detail(shortId) });
       client.invalidateQueries({ queryKey: queryKeys.sessions.all });
-      if (taskId) client.invalidateQueries({ queryKey: queryKeys.tasks.detail(taskId) });
+      client.invalidateQueries({ queryKey: queryKeys.tasks.detail(taskId) });
       client.invalidateQueries({ queryKey: queryKeys.tasks.all });
     },
   });

--- a/packages/web/lib/hooks/use-task-mutations.test.tsx
+++ b/packages/web/lib/hooks/use-task-mutations.test.tsx
@@ -7,6 +7,8 @@ vi.mock("@/lib/api/client", () => ({
   api: {
     tasks: {
       approve: vi.fn(),
+      reject: vi.fn(),
+      revise: vi.fn(),
       cancel: vi.fn(),
       create: vi.fn(),
     },
@@ -15,6 +17,8 @@ vi.mock("@/lib/api/client", () => ({
 
 import {
   useApproveTask,
+  useRejectTask,
+  useReviseTask,
   useCancelTask,
   useCreateTask,
 } from "./use-task-mutations";
@@ -22,6 +26,8 @@ import { api } from "@/lib/api/client";
 import { queryKeys } from "./keys";
 
 const approveMock = vi.mocked(api.tasks.approve);
+const rejectMock = vi.mocked(api.tasks.reject);
+const reviseMock = vi.mocked(api.tasks.revise);
 const cancelMock = vi.mocked(api.tasks.cancel);
 const createMock = vi.mocked(api.tasks.create);
 
@@ -36,6 +42,8 @@ function makeWrapper() {
 
 beforeEach(() => {
   approveMock.mockReset();
+  rejectMock.mockReset();
+  reviseMock.mockReset();
   cancelMock.mockReset();
   createMock.mockReset();
 });
@@ -45,17 +53,17 @@ afterEach(() => {
 });
 
 describe("useApproveTask", () => {
-  it("calls api.tasks.approve with the input and invalidates task + dashboard caches", async () => {
+  it("calls api.tasks.approve and invalidates task + dashboard caches", async () => {
     approveMock.mockResolvedValue({} as never);
     const { invalidateSpy, Wrapper } = makeWrapper();
 
     const { result } = renderHook(() => useApproveTask("t_1"), { wrapper: Wrapper });
 
     await act(async () => {
-      result.current.mutate({ action: "approve" });
+      result.current.mutate({});
     });
 
-    await waitFor(() => expect(approveMock).toHaveBeenCalledWith("t_1", { action: "approve" }));
+    await waitFor(() => expect(approveMock).toHaveBeenCalledWith("t_1", {}));
 
     const invalidated = invalidateSpy.mock.calls.map((c) => c[0]?.queryKey);
     expect(invalidated).toEqual(
@@ -74,11 +82,63 @@ describe("useApproveTask", () => {
     const { result } = renderHook(() => useApproveTask("t_1"), { wrapper: Wrapper });
 
     await act(async () => {
-      result.current.mutate({ action: "reject" });
+      result.current.mutate({});
     });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(result.current.error).toEqual(new Error("nope"));
+  });
+});
+
+describe("useRejectTask", () => {
+  it("calls api.tasks.reject and invalidates the same caches", async () => {
+    rejectMock.mockResolvedValue({} as never);
+    const { invalidateSpy, Wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useRejectTask("t_1"), { wrapper: Wrapper });
+
+    await act(async () => {
+      result.current.mutate({ result_summary: "wrong scope" });
+    });
+
+    await waitFor(() =>
+      expect(rejectMock).toHaveBeenCalledWith("t_1", { result_summary: "wrong scope" }),
+    );
+
+    const invalidated = invalidateSpy.mock.calls.map((c) => c[0]?.queryKey);
+    expect(invalidated).toEqual(
+      expect.arrayContaining([
+        queryKeys.tasks.detail("t_1"),
+        queryKeys.tasks.all,
+        queryKeys.dashboard.all,
+      ]),
+    );
+  });
+});
+
+describe("useReviseTask", () => {
+  it("calls api.tasks.revise with the feedback body", async () => {
+    reviseMock.mockResolvedValue({} as never);
+    const { invalidateSpy, Wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useReviseTask("t_1"), { wrapper: Wrapper });
+
+    await act(async () => {
+      result.current.mutate({ feedback: "needs more tests" });
+    });
+
+    await waitFor(() =>
+      expect(reviseMock).toHaveBeenCalledWith("t_1", { feedback: "needs more tests" }),
+    );
+
+    const invalidated = invalidateSpy.mock.calls.map((c) => c[0]?.queryKey);
+    expect(invalidated).toEqual(
+      expect.arrayContaining([
+        queryKeys.tasks.detail("t_1"),
+        queryKeys.tasks.all,
+        queryKeys.dashboard.all,
+      ]),
+    );
   });
 });
 
@@ -103,12 +163,10 @@ describe("useCancelTask", () => {
     const { result } = renderHook(() => useCancelTask("t_1"), { wrapper: Wrapper });
 
     await act(async () => {
-      result.current.mutate({ force: true, reason: "scope" });
+      result.current.mutate({ reason: "scope" });
     });
 
-    await waitFor(() =>
-      expect(cancelMock).toHaveBeenCalledWith("t_1", { force: true, reason: "scope" }),
-    );
+    await waitFor(() => expect(cancelMock).toHaveBeenCalledWith("t_1", { reason: "scope" }));
   });
 });
 

--- a/packages/web/lib/hooks/use-task-mutations.ts
+++ b/packages/web/lib/hooks/use-task-mutations.ts
@@ -2,20 +2,43 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   api,
   type ApproveTaskInput,
+  type RejectTaskInput,
+  type ReviseTaskInput,
   type CancelTaskInput,
   type CreateTaskInput,
 } from "@/lib/api/client";
 import { queryKeys } from "./keys";
 
-export function useApproveTask(taskId: string) {
+function useTaskMutationInvalidations(taskId: string) {
   const client = useQueryClient();
+  return () => {
+    client.invalidateQueries({ queryKey: queryKeys.tasks.detail(taskId) });
+    client.invalidateQueries({ queryKey: queryKeys.tasks.all });
+    client.invalidateQueries({ queryKey: queryKeys.dashboard.all });
+  };
+}
+
+export function useApproveTask(taskId: string) {
+  const onSuccess = useTaskMutationInvalidations(taskId);
   return useMutation({
-    mutationFn: (input: ApproveTaskInput) => api.tasks.approve(taskId, input),
-    onSuccess: () => {
-      client.invalidateQueries({ queryKey: queryKeys.tasks.detail(taskId) });
-      client.invalidateQueries({ queryKey: queryKeys.tasks.all });
-      client.invalidateQueries({ queryKey: queryKeys.dashboard.all });
-    },
+    mutationFn: (input: ApproveTaskInput = {}) => api.tasks.approve(taskId, input),
+    onSuccess,
+  });
+}
+
+export function useRejectTask(taskId: string) {
+  const onSuccess = useTaskMutationInvalidations(taskId);
+  return useMutation({
+    mutationFn: (input: RejectTaskInput = {}) => api.tasks.reject(taskId, input),
+    onSuccess,
+  });
+}
+
+export function useReviseTask(taskId: string) {
+  const onSuccess = useTaskMutationInvalidations(taskId);
+  return useMutation({
+    mutationFn: (input: ReviseTaskInput) => api.tasks.revise(taskId, input),
+    onSuccess,
   });
 }
 

--- a/packages/web/lib/types/agents.ts
+++ b/packages/web/lib/types/agents.ts
@@ -1,36 +1,10 @@
-import type { Agent, HierarchyLevel } from "@beevibe/core";
+export type {
+  AgentDisplay,
+  RecentSession,
+  OutgoingMeshHint,
+} from "@beevibe/api/views/types";
 
 export interface WeeklyChange {
   label: string;
   tone: "done" | "muted";
-}
-
-export interface AgentDisplay
-  extends Pick<
-    Agent,
-    "id" | "name" | "owner_id" | "parent_agent_id" | "hierarchy_level" | "created_at" | "updated_at"
-  > {
-  display_name: string;
-  hierarchy: HierarchyLevel;
-  sessions_count?: number;
-  facts_learned?: number;
-  merge_events?: number;
-  specialization?: string;
-  weekly_change?: WeeklyChange;
-  themes?: string[];
-  runtime?: string;
-  review_policy?: string;
-}
-
-export interface RecentSession {
-  short_id?: string;
-  title: string;
-  status: "running" | "succeeded" | "review";
-  age: string;
-}
-
-export interface OutgoingMeshHint {
-  target: string;
-  intent: string;
-  age: string;
 }

--- a/packages/web/lib/types/core-memory-blocks.ts
+++ b/packages/web/lib/types/core-memory-blocks.ts
@@ -1,18 +1,1 @@
-export interface CoreBlockDisplay {
-  id: string;
-  agent_id: string;
-  block_name: string;
-  content: string;
-  char_count: number;
-  char_limit: number;
-  is_system: boolean;
-  updated_label: string;
-}
-
-export interface AgentMetrics {
-  sessions: number;
-  sessions_change: number;
-  facts: number;
-  merges: number;
-  promoted: number;
-}
+export type { CoreBlockDisplay, AgentMetrics } from "@beevibe/api/views/types";

--- a/packages/web/lib/types/memory-facts.ts
+++ b/packages/web/lib/types/memory-facts.ts
@@ -1,20 +1,4 @@
-import type { FactType, MemoryScope } from "@beevibe/core";
-import type { RichText } from "@/components/rich-text";
-
-export type MergeOrigin = "merged" | "promoted" | "single";
-
-export interface MemoryFactDisplay {
-  id: string;
-  content: RichText;
-  fact_type: FactType;
-  scope: MemoryScope;
-  agent_id: string;
-  agent_label: string;
-  source_session_count: number;
-  created_at: Date;
-  merge_origin?: MergeOrigin;
-  promotion_origin_scope?: MemoryScope;
-}
+export type { MemoryFactDisplay, MergeOrigin } from "@beevibe/api/views/types";
 
 export interface FactCounts {
   total: number;

--- a/packages/web/lib/types/sessions.ts
+++ b/packages/web/lib/types/sessions.ts
@@ -1,52 +1,6 @@
-import type { SessionStatus, SessionType } from "@beevibe/core";
-import type { RichText } from "@/components/rich-text";
-
-export interface SessionDisplay {
-  id: string;
-  short_id: string;
-  task_id: string;
-  task_title: string;
-  task_short_id: string;
-  agent_id: string;
-  agent_label: string;
-  agent_hierarchy: "ic" | "team" | "org";
-  type: SessionType;
-  status: SessionStatus;
-  intent: string;
-  started_at: Date;
-  duration_label: string;
-  worktree?: string;
-  cli_session?: string;
-  briefing: {
-    block_count: number;
-    fact_count: number;
-    token_count: number;
-    blocks: Array<{ name: string; chars: number; preview: string }>;
-    facts: Array<{ scope: "ic" | "team" | "org"; content: string; score: number }>;
-  };
-  transcript: TranscriptEntry[];
-  ask_threads?: AskThread[];
-}
-
-export interface TranscriptEntry {
-  kind: "agent" | "tool_call" | "tool_result" | "summary";
-  timestamp: string;
-  content: string;
-  tool_name?: string;
-}
-
-export interface AskThread {
-  id: string;
-  insert_after_index: number;
-  caller: string;
-  responder: string;
-  arrow: "right" | "up";
-  status: "succeeded" | "failed";
-  duration_label: string;
-  request: RichText;
-  response: { agent: string; note?: string; content: RichText };
-  chain_depth: string;
-  spawned_session_label: string;
-  tokens_label?: string;
-  tone: "running" | "neutral";
-}
+export type {
+  SessionDisplay,
+  SessionBriefing,
+  TranscriptEntry,
+  AskThread,
+} from "@beevibe/api/views/types";

--- a/packages/web/lib/types/tasks.ts
+++ b/packages/web/lib/types/tasks.ts
@@ -1,18 +1,1 @@
-import type { Task } from "@beevibe/core";
-import type { RichText } from "@/components/rich-text";
-
-export interface TaskListItem extends Omit<Task, "description" | "result_summary"> {
-  assignee_hierarchy?: "ic" | "team" | "org";
-  assignee_label?: string;
-  creator_label?: string;
-  description?: RichText[];
-  result_summary?: RichText;
-  session_count?: number;
-  work_product_count?: number;
-  latest_session?: {
-    short_id: string;
-    status: "running" | "succeeded" | "failed" | "cancelled";
-    elapsed: string;
-    agent_label: string;
-  };
-}
+export type { TaskListItem, TaskLatestSessionSummary } from "@beevibe/api/views/types";

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -13,6 +13,7 @@
     "clean": "rm -rf .next .turbo *.tsbuildinfo"
   },
   "dependencies": {
+    "@beevibe/api": "workspace:*",
     "@beevibe/core": "workspace:*",
     "@tanstack/react-query": "^5.59.0",
     "@tanstack/react-query-devtools": "^5.59.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 8.57.1
       eslint-import-resolver-typescript:
         specifier: ^3.6.3
-        version: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1))(eslint@8.57.1)
+        version: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
       eslint-plugin-import:
         specifier: ^2.30.0
         version: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
@@ -134,6 +134,9 @@ importers:
 
   packages/web:
     dependencies:
+      '@beevibe/api':
+        specifier: workspace:*
+        version: link:../api
       '@beevibe/core':
         specifier: workspace:*
         version: link:../core
@@ -4848,7 +4851,7 @@ snapshots:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
@@ -4868,7 +4871,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -4890,7 +4893,7 @@ snapshots:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary

Two web-facing slices in one PR:

**M8.1 — mutation wiring.** Web's typed mutation surface now talks to the actual M6 routes. Bearer auth via \`NEXT_PUBLIC_BV_USER_KEY\` is attached to every request, mutation paths align with M6's singular-noun style, and the old single \`approve\` action is split into \`approve\` / \`reject\` / \`revise\` (M6 ships 3 separate routes; revise needs a \`feedback\` body, so the task-detail page gained an inline composer).

**M8.2 — read views layer.** New \`packages/api/src/views/\` module produces UI-shaped DTOs from raw SQL, talking pg directly so the agent-execution path stays uncoupled from the web display path. Six routes (\`GET /task\`, \`GET /task/:id\`, \`GET /agent\`, \`GET /agent/:id\`, \`GET /session/:short_id\`, \`GET /memory/fact\`) are gated by the same \`requireHuman\` middleware as the M6 mutations. DTO contracts live in \`@beevibe/api/views/types\`; web re-exports them so backend is the single source of truth for the shape.

Closes #30 once the deferred follow-ups (below) are filed as separate issues.

## Independence guarantees

- **Zero changes to \`packages/core\`.** No new repo methods, no domain fields, no port changes. Views only \`import { Pool, Task, Agent }\` etc. — pure type/structural reuse.
- **Read path bypasses core repos.** \`views/*.ts\` go direct to \`pool.query()\` with hand-rolled SQL + JOINs. Denormalization (\`assignee_label\`, \`creator_label\`, \`latest_session\`, \`session_count\`, \`work_product_count\`) lives in SQL so the page renders in one round-trip.
- **DTOs owned server-side.** Web's previous \`lib/types/*.ts\` files are now thin re-exports from \`@beevibe/api/views/types\` (added as a subpath export). \`pnpm typecheck\` will catch any future shape drift.

## What's deferred

These need extra design work before backend can produce them cleanly — to be filed as separate follow-ups once this lands:

- **\`GET /dashboard\`, \`GET /mesh\`** — current web types couple data with display choices (\`KpiStat.trend_color\`, \`href\`, \`GraphNode.cx/cy/r\`). Need a data-vs-display split: backend produces pure data, web composes display from a mapper.
- **\`GET /thread/*\`** — no \`thread\` domain in core. Needs schema design first.
- **\`GET /promotion\`** — no \`promotion_event\` domain. Needs schema design first.
- **\`POST /task\`** (create) — separable; track in its own follow-up.

## Test plan

- [x] \`pnpm -w typecheck\` — clean across core / api / executor / web
- [x] \`pnpm -w build\` — clean (web Next build, api tsc)
- [x] api unit tests: \`pnpm --filter @beevibe/api test\` — 30 new view tests pass (\`format\`, \`tasks\`, \`agents\`, \`sessions\`, \`memory\`); pre-existing DB-integration tests still gated on \`DATABASE_URL_TEST\`
- [x] web tests: \`pnpm --filter @beevibe/web test\` — 88/88 pass
- [x] lint: pre-existing warnings only
- [ ] Manual smoke: \`pnpm dev\` against a local stack with a \`bv_u_\` key — every page that depends on tasks/agents/sessions/memory should render real data; dashboard/mesh/threads/promotions stay in their existing empty states until follow-ups land

🤖 Generated with [Claude Code](https://claude.com/claude-code)