### PR TITLE
M8.B — GET /dashboard with data/display split (#33)

### DIFF
--- a/migrations/1778000000000_add-dashboard-indexes.sql
+++ b/migrations/1778000000000_add-dashboard-indexes.sql
@@ -1,0 +1,21 @@
+-- M8.B dashboard view indexes.
+--
+-- The KPI_TREND_SQL and TREND_SQL queries in `packages/api/src/views/dashboard.ts`
+-- filter by `(status, updated_at)` and `(status, completed_at|started_at)` over
+-- 7-14 day windows. The existing `idx_task_status` and `idx_session_agent_status`
+-- cover the status leg only; without composite indexes on the timestamp legs,
+-- Postgres scans all rows matching the status before filtering by date.
+--
+-- For dashboard payload latency at workspace scale (10K+ tasks / sessions),
+-- the cost of these indexes is paid back by every home-page render.
+
+CREATE INDEX IF NOT EXISTS idx_task_status_updated
+  ON task(status, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_session_status_started
+  ON session(status, started_at DESC)
+  WHERE started_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_session_status_completed
+  ON session(status, completed_at DESC)
+  WHERE completed_at IS NOT NULL;

--- a/packages/api/src/routes/view.ts
+++ b/packages/api/src/routes/view.ts
@@ -30,6 +30,7 @@ import {
 import { listAgents, getAgent } from "../views/agents.js";
 import { getSessionByShortId, AmbiguousShortIdError } from "../views/sessions.js";
 import { listMemoryFacts } from "../views/memory.js";
+import { getDashboardSummary } from "../views/dashboard.js";
 
 export interface ViewRoutesDeps {
   authMiddleware: RequestHandler;
@@ -154,6 +155,16 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
         return;
       }
       handleError(err, res, "session detail");
+    }
+  });
+
+  router.get("/dashboard", async (req, res) => {
+    if (!requireHuman(req, res)) return;
+    try {
+      const summary = await getDashboardSummary(deps.pool);
+      res.json(summary);
+    } catch (err) {
+      handleError(err, res, "dashboard summary");
     }
   });
 

--- a/packages/api/src/views/agents.test.ts
+++ b/packages/api/src/views/agents.test.ts
@@ -1,16 +1,10 @@
-import { describe, it, expect, vi } from "vitest";
-import type { Pool } from "@beevibe/core/adapters/postgres";
+import { describe, it, expect } from "vitest";
 import { listAgents, getAgent } from "./agents.js";
-
-function makePool(responses: unknown[][]) {
-  let i = 0;
-  const query = vi.fn(async () => ({ rows: responses[i++] ?? [] }));
-  return { query: query as unknown as Pool["query"] } as unknown as Pool;
-}
+import { makeMockPool } from "./test-helpers.js";
 
 describe("listAgents", () => {
   it("maps rows into AgentDisplay with hierarchy + sessions/facts counts", async () => {
-    const pool = makePool([
+    const pool = makeMockPool([
       [
         {
           id: "agt_org",
@@ -39,12 +33,12 @@ describe("listAgents", () => {
 
 describe("getAgent", () => {
   it("returns undefined when missing", async () => {
-    const pool = makePool([[], [], [], []]);
+    const pool = makeMockPool([[], [], [], []]);
     expect(await getAgent(pool, "agt_missing")).toBeUndefined();
   });
 
   it("aggregates blocks, recent sessions, and mesh hints when present", async () => {
-    const pool = makePool([
+    const pool = makeMockPool([
       [
         {
           id: "agt_team",

--- a/packages/api/src/views/dashboard.test.ts
+++ b/packages/api/src/views/dashboard.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Mock-Pool tests for views/dashboard.ts. Validates aggregation logic +
+ * row → DTO mapping. Real query correctness exercised by the existing
+ * api integration test layer; these stay DB-free.
+ *
+ * Query order in the implementation:
+ *   1) STATUS_COUNT_SQL          → status counts
+ *   2) FLEET_SQL                 → per-hier counts + active
+ *   3) TREND_SQL                 → 14 days of completed sessions
+ *   4) ATTENTION_SQL             → blocked/failed/review tasks
+ *   5) KPI_TREND_SQL             → 7 days of per-KPI counts
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import { getDashboardSummary } from "./dashboard.js";
+
+function makePool(responses: unknown[][]) {
+  let i = 0;
+  const query = vi.fn(async () => ({ rows: responses[i++] ?? [] }));
+  return { query: query as unknown as Pool["query"] } as unknown as Pool;
+}
+
+function makeKpiTrendRows(): unknown[] {
+  return Array.from({ length: 7 }, (_, i) => ({
+    day: `2026-04-${24 + i}`,
+    active_sessions: i,
+    in_review: 0,
+    completed_today: i === 6 ? 5 : 0,
+    blocked: 0,
+  }));
+}
+
+function makeTrendRows(): unknown[] {
+  // 14 days: prior 7 = 7×1 = 7 total, recent 7 = 7×2 = 14 total → +100%
+  return Array.from({ length: 14 }, (_, i) => ({
+    day: `2026-04-${17 + i}`,
+    count: i < 7 ? 1 : 2,
+  }));
+}
+
+describe("getDashboardSummary", () => {
+  it("computes percentages from raw status counts and ranks descending", async () => {
+    const pool = makePool([
+      [
+        { status: "in_progress", count: 6 },
+        { status: "review", count: 2 },
+        { status: "done", count: 2 },
+      ],
+      [], // fleet
+      makeTrendRows(),
+      [], // attention
+      makeKpiTrendRows(),
+    ]);
+    const summary = await getDashboardSummary(pool);
+    expect(summary.status_total).toBe(10);
+    expect(summary.status_breakdown[0]).toEqual({
+      status: "in_progress",
+      count: 6,
+      percent: 60,
+    });
+    expect(summary.status_breakdown).toHaveLength(3);
+  });
+
+  it("buckets statuses into the legend's coarser groups", async () => {
+    const pool = makePool([
+      [
+        { status: "pending", count: 1 },
+        { status: "assigned", count: 2 },
+        { status: "in_progress", count: 3 },
+        { status: "revision", count: 4 },
+        { status: "review", count: 5 },
+        { status: "blocked", count: 6 },
+        { status: "done", count: 7 },
+        { status: "failed", count: 8 },
+      ],
+      [],
+      makeTrendRows(),
+      [],
+      makeKpiTrendRows(),
+    ]);
+    const { status_legend } = await getDashboardSummary(pool);
+    const map = new Map(status_legend.map((l) => [l.bucket, l.count]));
+    expect(map.get("pending")).toBe(3); // pending + assigned
+    expect(map.get("running")).toBe(7); // in_progress + revision
+    expect(map.get("review")).toBe(5);
+    expect(map.get("blocked")).toBe(6);
+    expect(map.get("done")).toBe(7);
+    expect(map.get("failed")).toBe(8);
+  });
+
+  it("aggregates fleet counts across hierarchies and computes active total", async () => {
+    const pool = makePool([
+      [],
+      [
+        { hier: "org", count: 1, active: 1 },
+        { hier: "team", count: 2, active: 1 },
+        { hier: "ic", count: 5, active: 0 },
+      ],
+      makeTrendRows(),
+      [],
+      makeKpiTrendRows(),
+    ]);
+    const summary = await getDashboardSummary(pool);
+    expect(summary.fleet_total).toBe(8);
+    expect(summary.fleet_active).toBe(2);
+    expect(summary.fleet_idle).toBe(6);
+    expect(summary.fleet[0]?.percent).toBeCloseTo(12.5, 1);
+  });
+
+  it("splits the trend window in half and computes the change percent", async () => {
+    const pool = makePool([[], [], makeTrendRows(), [], makeKpiTrendRows()]);
+    const { trend, trend_total, trend_change_percent } = await getDashboardSummary(pool);
+    expect(trend).toHaveLength(7);
+    expect(trend_total).toBe(14); // 7 days × 2
+    expect(trend_change_percent).toBe(100); // doubled vs prior
+  });
+
+  it("flags is_today on the most recent trend row", async () => {
+    const pool = makePool([[], [], makeTrendRows(), [], makeKpiTrendRows()]);
+    const { trend } = await getDashboardSummary(pool);
+    expect(trend.filter((d) => d.is_today)).toHaveLength(1);
+    expect(trend[trend.length - 1]?.is_today).toBe(true);
+  });
+
+  it("emits 4 KPIs (active_sessions, in_review, completed_today, blocked) with raw values", async () => {
+    const pool = makePool([
+      [
+        { status: "review", count: 4 },
+        { status: "blocked", count: 2 },
+      ],
+      [{ hier: "team", count: 3, active: 2 }],
+      makeTrendRows(),
+      [],
+      makeKpiTrendRows(),
+    ]);
+    const { kpis } = await getDashboardSummary(pool);
+    expect(kpis.map((k) => k.kind)).toEqual([
+      "active_sessions",
+      "in_review",
+      "completed_today",
+      "blocked",
+    ]);
+    expect(kpis.find((k) => k.kind === "active_sessions")?.value).toBe(2); // fleet_active
+    expect(kpis.find((k) => k.kind === "in_review")?.value).toBe(4);
+    expect(kpis.find((k) => k.kind === "completed_today")?.value).toBe(5); // last day of trend
+    expect(kpis.find((k) => k.kind === "blocked")?.value).toBe(2);
+  });
+
+  it("handles 0 totals without dividing by zero", async () => {
+    const pool = makePool([[], [], makeTrendRows(), [], makeKpiTrendRows()]);
+    const { status_total, status_breakdown, fleet_total, fleet } = await getDashboardSummary(pool);
+    expect(status_total).toBe(0);
+    expect(status_breakdown).toEqual([]);
+    expect(fleet_total).toBe(0);
+    expect(fleet).toEqual([]);
+  });
+
+  it("treats no-prior-period as 0% change when current is also 0", async () => {
+    const flatTrend = Array.from({ length: 14 }, (_, i) => ({
+      day: `2026-04-${17 + i}`,
+      count: 0,
+    }));
+    const pool = makePool([[], [], flatTrend, [], makeKpiTrendRows()]);
+    const { trend_change_percent } = await getDashboardSummary(pool);
+    expect(trend_change_percent).toBe(0);
+  });
+
+  it("treats no-prior-period with positive current as 100% change", async () => {
+    const trendRows = Array.from({ length: 14 }, (_, i) => ({
+      day: `2026-04-${17 + i}`,
+      count: i < 7 ? 0 : 3,
+    }));
+    const pool = makePool([[], [], trendRows, [], makeKpiTrendRows()]);
+    const { trend_change_percent } = await getDashboardSummary(pool);
+    expect(trend_change_percent).toBe(100);
+  });
+
+  it("maps attention rows preserving title, status, and ISO timestamp", async () => {
+    const ts = new Date("2026-04-30T10:00:00Z");
+    const pool = makePool([
+      [],
+      [],
+      makeTrendRows(),
+      [{ id: "task_1", title: "needs API key", status: "blocked", created_at: ts }],
+      makeKpiTrendRows(),
+    ]);
+    const { attention } = await getDashboardSummary(pool);
+    expect(attention).toHaveLength(1);
+    expect(attention[0]).toEqual({
+      task_id: "task_1",
+      title: "needs API key",
+      status: "blocked",
+      created_at: ts,
+    });
+  });
+
+  it("fires all 5 queries in parallel (single Promise.all)", async () => {
+    const calls: number[] = [];
+    let next = 0;
+    const query = vi.fn(async (sql: unknown) => {
+      const i = next++;
+      calls.push(i);
+      // First-issued query resolves last to prove they were issued together,
+      // not awaited sequentially.
+      await new Promise((r) => setTimeout(r, i === 0 ? 10 : 0));
+      const sqlText = String(sql);
+      if (sqlText.includes("FROM days") && sqlText.includes("active_sessions")) return { rows: makeKpiTrendRows() };
+      if (sqlText.includes("FROM days")) return { rows: makeTrendRows() };
+      if (sqlText.includes("FROM agent")) return { rows: [] };
+      if (sqlText.includes("blocked', 'failed'")) return { rows: [] };
+      return { rows: [] };
+    });
+    const pool = { query } as unknown as Pool;
+    await getDashboardSummary(pool);
+    expect(calls).toEqual([0, 1, 2, 3, 4]); // dispatched in order, all together
+    expect(query).toHaveBeenCalledTimes(5);
+  });
+});

--- a/packages/api/src/views/dashboard.test.ts
+++ b/packages/api/src/views/dashboard.test.ts
@@ -13,12 +13,7 @@
 import { describe, it, expect, vi } from "vitest";
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import { getDashboardSummary } from "./dashboard.js";
-
-function makePool(responses: unknown[][]) {
-  let i = 0;
-  const query = vi.fn(async () => ({ rows: responses[i++] ?? [] }));
-  return { query: query as unknown as Pool["query"] } as unknown as Pool;
-}
+import { makeMockPool } from "./test-helpers.js";
 
 function makeKpiTrendRows(): unknown[] {
   return Array.from({ length: 7 }, (_, i) => ({
@@ -40,7 +35,7 @@ function makeTrendRows(): unknown[] {
 
 describe("getDashboardSummary", () => {
   it("computes percentages from raw status counts and ranks descending", async () => {
-    const pool = makePool([
+    const pool = makeMockPool([
       [
         { status: "in_progress", count: 6 },
         { status: "review", count: 2 },
@@ -62,7 +57,7 @@ describe("getDashboardSummary", () => {
   });
 
   it("buckets statuses into the legend's coarser groups", async () => {
-    const pool = makePool([
+    const pool = makeMockPool([
       [
         { status: "pending", count: 1 },
         { status: "assigned", count: 2 },
@@ -89,7 +84,7 @@ describe("getDashboardSummary", () => {
   });
 
   it("aggregates fleet counts across hierarchies and computes active total", async () => {
-    const pool = makePool([
+    const pool = makeMockPool([
       [],
       [
         { hier: "org", count: 1, active: 1 },
@@ -108,7 +103,7 @@ describe("getDashboardSummary", () => {
   });
 
   it("splits the trend window in half and computes the change percent", async () => {
-    const pool = makePool([[], [], makeTrendRows(), [], makeKpiTrendRows()]);
+    const pool = makeMockPool([[], [], makeTrendRows(), [], makeKpiTrendRows()]);
     const { trend, trend_total, trend_change_percent } = await getDashboardSummary(pool);
     expect(trend).toHaveLength(7);
     expect(trend_total).toBe(14); // 7 days × 2
@@ -116,14 +111,14 @@ describe("getDashboardSummary", () => {
   });
 
   it("flags is_today on the most recent trend row", async () => {
-    const pool = makePool([[], [], makeTrendRows(), [], makeKpiTrendRows()]);
+    const pool = makeMockPool([[], [], makeTrendRows(), [], makeKpiTrendRows()]);
     const { trend } = await getDashboardSummary(pool);
     expect(trend.filter((d) => d.is_today)).toHaveLength(1);
     expect(trend[trend.length - 1]?.is_today).toBe(true);
   });
 
   it("emits 4 KPIs (active_sessions, in_review, completed_today, blocked) with raw values", async () => {
-    const pool = makePool([
+    const pool = makeMockPool([
       [
         { status: "review", count: 4 },
         { status: "blocked", count: 2 },
@@ -147,7 +142,7 @@ describe("getDashboardSummary", () => {
   });
 
   it("handles 0 totals without dividing by zero", async () => {
-    const pool = makePool([[], [], makeTrendRows(), [], makeKpiTrendRows()]);
+    const pool = makeMockPool([[], [], makeTrendRows(), [], makeKpiTrendRows()]);
     const { status_total, status_breakdown, fleet_total, fleet } = await getDashboardSummary(pool);
     expect(status_total).toBe(0);
     expect(status_breakdown).toEqual([]);
@@ -160,7 +155,7 @@ describe("getDashboardSummary", () => {
       day: `2026-04-${17 + i}`,
       count: 0,
     }));
-    const pool = makePool([[], [], flatTrend, [], makeKpiTrendRows()]);
+    const pool = makeMockPool([[], [], flatTrend, [], makeKpiTrendRows()]);
     const { trend_change_percent } = await getDashboardSummary(pool);
     expect(trend_change_percent).toBe(0);
   });
@@ -170,14 +165,14 @@ describe("getDashboardSummary", () => {
       day: `2026-04-${17 + i}`,
       count: i < 7 ? 0 : 3,
     }));
-    const pool = makePool([[], [], trendRows, [], makeKpiTrendRows()]);
+    const pool = makeMockPool([[], [], trendRows, [], makeKpiTrendRows()]);
     const { trend_change_percent } = await getDashboardSummary(pool);
     expect(trend_change_percent).toBe(100);
   });
 
   it("maps attention rows preserving title, status, and ISO timestamp", async () => {
     const ts = new Date("2026-04-30T10:00:00Z");
-    const pool = makePool([
+    const pool = makeMockPool([
       [],
       [],
       makeTrendRows(),

--- a/packages/api/src/views/dashboard.ts
+++ b/packages/api/src/views/dashboard.ts
@@ -1,0 +1,289 @@
+/**
+ * Dashboard view — pure data composer for the home page. Returns counts,
+ * percents, and raw IDs/timestamps. Display fields (colors, hrefs, day
+ * labels, "5m ago" age) are computed web-side via `lib/dashboard-display.ts`.
+ *
+ * One round-trip: 5 queries fired in parallel. None depends on the others.
+ */
+
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import type { HierarchyLevel, TaskStatus } from "@beevibe/core";
+import type {
+  DashboardSummary,
+  KpiData,
+  StatusBreakdownData,
+  StatusLegendData,
+  FleetBarData,
+  TrendDayData,
+  AttentionData,
+  LegendBucket,
+} from "./types.js";
+
+interface StatusCountRow {
+  status: TaskStatus;
+  count: string;
+}
+
+interface FleetCountRow {
+  hier: HierarchyLevel;
+  count: string;
+  active: string;
+}
+
+interface TrendRow {
+  day: string;
+  count: string;
+}
+
+interface AttentionRow {
+  id: string;
+  title: string;
+  status: "blocked" | "failed" | "review";
+  created_at: Date;
+}
+
+interface KpiTrendRow {
+  day: string;
+  active_sessions: string;
+  in_review: string;
+  completed_today: string;
+  blocked: string;
+}
+
+const STATUS_COUNT_SQL = /* sql */ `
+SELECT status, COUNT(*)::int AS count
+FROM task
+GROUP BY status
+`;
+
+const FLEET_SQL = /* sql */ `
+WITH active_agents AS (
+  SELECT DISTINCT agent_id FROM session WHERE status = 'running'
+)
+SELECT
+  a.hierarchy_level AS hier,
+  COUNT(*)::int     AS count,
+  COUNT(*) FILTER (WHERE aa.agent_id IS NOT NULL)::int AS active
+FROM agent a
+LEFT JOIN active_agents aa ON aa.agent_id = a.id
+GROUP BY a.hierarchy_level
+`;
+
+const TREND_SQL = /* sql */ `
+WITH days AS (
+  SELECT (CURRENT_DATE - i)::date AS d
+  FROM generate_series(0, $1 - 1) AS i
+),
+session_counts AS (
+  SELECT (completed_at AT TIME ZONE 'UTC')::date AS day, COUNT(*)::int AS n
+  FROM session
+  WHERE status = 'succeeded'
+    AND completed_at >= CURRENT_DATE - $1::int
+  GROUP BY day
+)
+SELECT
+  to_char(days.d, 'YYYY-MM-DD') AS day,
+  COALESCE(sc.n, 0)::int        AS count
+FROM days
+LEFT JOIN session_counts sc ON sc.day = days.d
+ORDER BY days.d ASC
+`;
+
+const ATTENTION_SQL = /* sql */ `
+SELECT id, title, status, updated_at AS created_at
+FROM task
+WHERE status IN ('blocked', 'failed', 'review')
+ORDER BY updated_at DESC
+LIMIT $1
+`;
+
+const KPI_TREND_SQL = /* sql */ `
+WITH days AS (
+  SELECT (CURRENT_DATE - i)::date AS d
+  FROM generate_series(0, $1 - 1) AS i
+),
+sessions_per_day AS (
+  SELECT (started_at AT TIME ZONE 'UTC')::date AS day, COUNT(*)::int AS n
+  FROM session
+  WHERE started_at >= CURRENT_DATE - $1::int
+  GROUP BY day
+),
+review_per_day AS (
+  SELECT (updated_at AT TIME ZONE 'UTC')::date AS day, COUNT(*)::int AS n
+  FROM task
+  WHERE status = 'review'
+    AND updated_at >= CURRENT_DATE - $1::int
+  GROUP BY day
+),
+done_per_day AS (
+  SELECT (updated_at AT TIME ZONE 'UTC')::date AS day, COUNT(*)::int AS n
+  FROM task
+  WHERE status = 'done'
+    AND updated_at >= CURRENT_DATE - $1::int
+  GROUP BY day
+),
+blocked_per_day AS (
+  SELECT (updated_at AT TIME ZONE 'UTC')::date AS day, COUNT(*)::int AS n
+  FROM task
+  WHERE status = 'blocked'
+    AND updated_at >= CURRENT_DATE - $1::int
+  GROUP BY day
+)
+SELECT
+  to_char(days.d, 'YYYY-MM-DD')      AS day,
+  COALESCE(s.n, 0)::int              AS active_sessions,
+  COALESCE(r.n, 0)::int              AS in_review,
+  COALESCE(c.n, 0)::int              AS completed_today,
+  COALESCE(b.n, 0)::int              AS blocked
+FROM days
+LEFT JOIN sessions_per_day s ON s.day = days.d
+LEFT JOIN review_per_day   r ON r.day = days.d
+LEFT JOIN done_per_day     c ON c.day = days.d
+LEFT JOIN blocked_per_day  b ON b.day = days.d
+ORDER BY days.d ASC
+`;
+
+const TREND_WINDOW_DAYS = 7;
+const ATTENTION_LIMIT = 8;
+
+/** Map raw task status to the legend's coarser bucket. */
+function legendBucket(status: TaskStatus): LegendBucket {
+  switch (status) {
+    case "in_progress":
+    case "revision":
+      return "running";
+    case "review":
+      return "review";
+    case "blocked":
+      return "blocked";
+    case "done":
+      return "done";
+    case "failed":
+      return "failed";
+    case "pending":
+    case "assigned":
+    case "needs_revision":
+    case "cancelled":
+      return "pending";
+  }
+}
+
+export async function getDashboardSummary(pool: Pool): Promise<DashboardSummary> {
+  const [statusResult, fleetResult, trendResult, attentionResult, kpiTrendResult] =
+    await Promise.all([
+      pool.query<StatusCountRow>(STATUS_COUNT_SQL),
+      pool.query<FleetCountRow>(FLEET_SQL),
+      pool.query<TrendRow>(TREND_SQL, [TREND_WINDOW_DAYS * 2]),
+      pool.query<AttentionRow>(ATTENTION_SQL, [ATTENTION_LIMIT]),
+      pool.query<KpiTrendRow>(KPI_TREND_SQL, [TREND_WINDOW_DAYS]),
+    ]);
+
+  const status_total = statusResult.rows.reduce((s, r) => s + Number(r.count), 0);
+  const status_breakdown: StatusBreakdownData[] = statusResult.rows
+    .map((r) => ({
+      status: r.status,
+      count: Number(r.count),
+      percent: status_total === 0 ? 0 : (Number(r.count) / status_total) * 100,
+    }))
+    .sort((a, b) => b.count - a.count);
+
+  const legendBuckets = new Map<LegendBucket, number>();
+  for (const r of statusResult.rows) {
+    const b = legendBucket(r.status);
+    legendBuckets.set(b, (legendBuckets.get(b) ?? 0) + Number(r.count));
+  }
+  const status_legend: StatusLegendData[] = Array.from(legendBuckets.entries()).map(
+    ([bucket, count]) => ({ bucket, count }),
+  );
+
+  const fleet_total = fleetResult.rows.reduce((s, r) => s + Number(r.count), 0);
+  const fleet_active = fleetResult.rows.reduce((s, r) => s + Number(r.active), 0);
+  const fleet: FleetBarData[] = fleetResult.rows.map((r) => ({
+    hier: r.hier,
+    count: Number(r.count),
+    percent: fleet_total === 0 ? 0 : (Number(r.count) / fleet_total) * 100,
+  }));
+
+  // Trend window of 14 days: split into prior 7 and current 7 to compute the
+  // "+12% vs prior" delta. Backend produces both numbers; web picks the format.
+  const all = trendResult.rows.map((r) => ({ day: r.day, value: Number(r.count) }));
+  const recent = all.slice(-TREND_WINDOW_DAYS);
+  const prior = all.slice(0, TREND_WINDOW_DAYS);
+  const today = recent[recent.length - 1]?.day;
+  const trend: TrendDayData[] = recent.map((r) => ({
+    date: r.day,
+    value: r.value,
+    is_today: r.day === today,
+  }));
+  const trend_total = recent.reduce((s, r) => s + r.value, 0);
+  const priorTotal = prior.reduce((s, r) => s + r.value, 0);
+  const trend_change_percent =
+    priorTotal === 0
+      ? trend_total === 0
+        ? 0
+        : 100
+      : Math.round(((trend_total - priorTotal) / priorTotal) * 100);
+
+  const attention: AttentionData[] = attentionResult.rows.map((r) => ({
+    task_id: r.id,
+    title: r.title,
+    status: r.status,
+    created_at: r.created_at,
+  }));
+
+  const kpis: KpiData[] = buildKpis(kpiTrendResult.rows, statusResult.rows, fleet_active);
+
+  return {
+    kpis,
+    status_breakdown,
+    status_legend,
+    status_total,
+    fleet,
+    fleet_total,
+    fleet_active,
+    fleet_idle: fleet_total - fleet_active,
+    trend,
+    trend_total,
+    trend_change_percent,
+    attention,
+  };
+}
+
+function buildKpis(
+  kpiRows: KpiTrendRow[],
+  statusRows: StatusCountRow[],
+  activeAgents: number,
+): KpiData[] {
+  const statusMap = new Map<TaskStatus, number>();
+  for (const r of statusRows) statusMap.set(r.status, Number(r.count));
+
+  const last = (key: keyof Omit<KpiTrendRow, "day">): number =>
+    kpiRows.length > 0 ? Number(kpiRows[kpiRows.length - 1]![key]) : 0;
+  const trend = (key: keyof Omit<KpiTrendRow, "day">): number[] =>
+    kpiRows.map((r) => Number(r[key]));
+
+  return [
+    {
+      kind: "active_sessions",
+      value: activeAgents,
+      unit: "running",
+      trend: trend("active_sessions"),
+    },
+    {
+      kind: "in_review",
+      value: statusMap.get("review") ?? 0,
+      trend: trend("in_review"),
+    },
+    {
+      kind: "completed_today",
+      value: last("completed_today"),
+      unit: "today",
+      trend: trend("completed_today"),
+    },
+    {
+      kind: "blocked",
+      value: statusMap.get("blocked") ?? 0,
+      trend: trend("blocked"),
+    },
+  ];
+}

--- a/packages/api/src/views/memory.test.ts
+++ b/packages/api/src/views/memory.test.ts
@@ -1,55 +1,47 @@
-import { describe, it, expect, vi } from "vitest";
-import type { Pool } from "@beevibe/core/adapters/postgres";
+import { describe, it, expect } from "vitest";
 import { listMemoryFacts } from "./memory.js";
-
-function makePool(rows: unknown[]) {
-  const query = vi.fn(async () => ({ rows }));
-  return {
-    query: query as unknown as Pool["query"],
-    _spy: query,
-  } as unknown as Pool & { _spy: ReturnType<typeof vi.fn> };
-}
+import { makeMockPool } from "./test-helpers.js";
 
 describe("listMemoryFacts", () => {
   it("filters by owner and forwards null scope + default limit when not provided", async () => {
-    const pool = makePool([]);
+    const pool = makeMockPool([]);
     await listMemoryFacts(pool, "per_w");
-    expect((pool as unknown as { _spy: ReturnType<typeof vi.fn> })._spy).toHaveBeenCalledWith(
+    expect(pool._spy).toHaveBeenCalledWith(
       expect.any(String),
       ["per_w", null, 200],
     );
   });
 
   it("forwards scope when provided", async () => {
-    const pool = makePool([]);
+    const pool = makeMockPool([]);
     await listMemoryFacts(pool, "per_w", { scope: "team" });
-    expect((pool as unknown as { _spy: ReturnType<typeof vi.fn> })._spy).toHaveBeenCalledWith(
+    expect(pool._spy).toHaveBeenCalledWith(
       expect.any(String),
       ["per_w", "team", 200],
     );
   });
 
   it("clamps limit to [1, 1000]", async () => {
-    const pool = makePool([]);
+    const pool = makeMockPool([]);
     await listMemoryFacts(pool, "per_w", { limit: 50 });
-    expect((pool as unknown as { _spy: ReturnType<typeof vi.fn> })._spy).toHaveBeenLastCalledWith(
+    expect(pool._spy).toHaveBeenLastCalledWith(
       expect.any(String),
       ["per_w", null, 50],
     );
     await listMemoryFacts(pool, "per_w", { limit: 9999 });
-    expect((pool as unknown as { _spy: ReturnType<typeof vi.fn> })._spy).toHaveBeenLastCalledWith(
+    expect(pool._spy).toHaveBeenLastCalledWith(
       expect.any(String),
       ["per_w", null, 1000],
     );
     await listMemoryFacts(pool, "per_w", { limit: 0 });
-    expect((pool as unknown as { _spy: ReturnType<typeof vi.fn> })._spy).toHaveBeenLastCalledWith(
+    expect(pool._spy).toHaveBeenLastCalledWith(
       expect.any(String),
       ["per_w", null, 1],
     );
   });
 
   it("maps merge_origin from source_session_ids cardinality", async () => {
-    const pool = makePool([
+    const pool = makeMockPool([
       {
         id: "fact_1",
         agent_id: "agt_a",

--- a/packages/api/src/views/sessions.test.ts
+++ b/packages/api/src/views/sessions.test.ts
@@ -1,26 +1,21 @@
-import { describe, it, expect, vi } from "vitest";
-import type { Pool } from "@beevibe/core/adapters/postgres";
+import { describe, it, expect } from "vitest";
 import { getSessionByShortId, AmbiguousShortIdError } from "./sessions.js";
-
-function makePool(rows: unknown[]) {
-  const query = vi.fn(async () => ({ rows }));
-  return { query: query as unknown as Pool["query"] } as unknown as Pool;
-}
+import { makeMockPool } from "./test-helpers.js";
 
 describe("getSessionByShortId", () => {
   it("returns undefined when no matching session", async () => {
-    const pool = makePool([]);
+    const pool = makeMockPool([]);
     expect(await getSessionByShortId(pool, "abc123")).toBeUndefined();
   });
 
   it("rejects malformed short_ids without hitting the DB", async () => {
-    const pool = makePool([]);
+    const pool = makeMockPool([]);
     expect(await getSessionByShortId(pool, "abc/../etc")).toBeUndefined();
-    expect((pool.query as unknown as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    expect(pool._spy.mock.calls).toHaveLength(0);
   });
 
   it("throws AmbiguousShortIdError when 2+ rows share the prefix", async () => {
-    const pool = makePool([
+    const pool = makeMockPool([
       sampleRow("sess_abc1230001"),
       sampleRow("sess_abc1230002"),
     ]);
@@ -30,7 +25,7 @@ describe("getSessionByShortId", () => {
   });
 
   it("maps a single row into a SessionDisplay with empty briefing/transcript", async () => {
-    const pool = makePool([sampleRow("sess_abcdef00ff")]);
+    const pool = makeMockPool([sampleRow("sess_abcdef00ff")]);
     const session = await getSessionByShortId(pool, "abcdef");
     expect(session?.short_id).toBe("abcdef");
     expect(session?.task_title).toBe("Bill rewrite");

--- a/packages/api/src/views/tasks.test.ts
+++ b/packages/api/src/views/tasks.test.ts
@@ -4,28 +4,19 @@
  * by an integration-style e2e in a follow-up; these tests cover the
  * mapping layer without needing a database.
  */
-import { describe, it, expect, vi } from "vitest";
-import type { Pool } from "@beevibe/core/adapters/postgres";
+import { describe, it, expect } from "vitest";
 import { listTasks, getTask } from "./tasks.js";
-
-function makePool(responses: unknown[][]) {
-  let i = 0;
-  const query = vi.fn(async () => {
-    const rows = responses[i++] ?? [];
-    return { rows } as { rows: unknown[] };
-  });
-  return { query: query as unknown as Pool["query"] } as unknown as Pool;
-}
+import { makeMockPool } from "./test-helpers.js";
 
 describe("listTasks", () => {
   it("returns empty array when DB returns no rows", async () => {
-    const pool = makePool([[]]);
+    const pool = makeMockPool([[]]);
     const tasks = await listTasks(pool);
     expect(tasks).toEqual([]);
   });
 
   it("maps a row with joins into a TaskListItem", async () => {
-    const pool = makePool([
+    const pool = makeMockPool([
       [
         {
           id: "task_001",
@@ -73,8 +64,8 @@ describe("listTasks", () => {
   });
 
   it("translates lifecycle filter into a status array param", async () => {
-    const pool = makePool([[]]);
-    const queryMock = pool.query as unknown as ReturnType<typeof vi.fn>;
+    const pool = makeMockPool([[]]);
+    const queryMock = pool._spy;
     await listTasks(pool, { lifecycle: "in_review" });
     expect(queryMock).toHaveBeenCalledWith(
       expect.any(String),
@@ -83,8 +74,8 @@ describe("listTasks", () => {
   });
 
   it("forwards assignee_id when set", async () => {
-    const pool = makePool([[]]);
-    const queryMock = pool.query as unknown as ReturnType<typeof vi.fn>;
+    const pool = makeMockPool([[]]);
+    const queryMock = pool._spy;
     await listTasks(pool, { assignee_id: "agt_xyz" });
     expect(queryMock).toHaveBeenCalledWith(expect.any(String), [null, "agt_xyz"]);
   });
@@ -92,13 +83,13 @@ describe("listTasks", () => {
 
 describe("getTask", () => {
   it("returns undefined when the task isn't found", async () => {
-    const pool = makePool([[], [], []]);
+    const pool = makeMockPool([[], [], []]);
     const task = await getTask(pool, "task_missing");
     expect(task).toBeUndefined();
   });
 
   it("includes sessions and work products when found", async () => {
-    const pool = makePool([
+    const pool = makeMockPool([
       [
         {
           id: "task_001",

--- a/packages/api/src/views/test-helpers.ts
+++ b/packages/api/src/views/test-helpers.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared mock-pool fixture for view-layer unit tests. Replaces five
+ * near-identical local `makePool` helpers across `views/*.test.ts`.
+ *
+ * Two call shapes:
+ *   - `makeMockPool([...rowsArray])` — returns the same rows for every
+ *     query (used by single-query views like sessions/memory)
+ *   - `makeMockPool([[rowsForQuery1], [rowsForQuery2], ...])` — ordered
+ *     per-query responses (used by multi-query views like tasks/agents/
+ *     dashboard, where each `pool.query()` gets the next array slot)
+ */
+
+import { vi, type Mock } from "vitest";
+import type { Pool } from "@beevibe/core/adapters/postgres";
+
+export type MockPool = Pool & { _spy: Mock };
+
+function isMultiResponse(input: unknown[] | unknown[][]): input is unknown[][] {
+  return input.length > 0 && Array.isArray(input[0]);
+}
+
+export function makeMockPool(input: unknown[] | unknown[][]): MockPool {
+  if (isMultiResponse(input)) {
+    let i = 0;
+    const query = vi.fn(async () => ({ rows: input[i++] ?? [] }));
+    return {
+      query: query as unknown as Pool["query"],
+      _spy: query,
+    } as unknown as MockPool;
+  }
+  const query = vi.fn(async () => ({ rows: input }));
+  return {
+    query: query as unknown as Pool["query"],
+    _spy: query,
+  } as unknown as MockPool;
+}

--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -211,6 +211,93 @@ export interface MemoryFactDisplay {
   promotion_origin_scope?: MemoryScope;
 }
 
+// ── Dashboard ───────────────────────────────────────────────────────────────
+//
+// The dashboard DTO is intentionally pure data. The web composes display
+// fields (colors, hrefs, sparkline geometry, day labels, "5m ago" age) via
+// `summaryToDisplay()` in `lib/dashboard-display.ts`. Backend shouldn't know
+// the URL structure or status→color CSS map.
+
+/**
+ * Discriminator that lets the web's mapper attach UI config (label, href,
+ * trend chart kind, color enum) per KPI. Adding a new KPI: define a new
+ * kind here, return a row from `views/dashboard.ts`, and add the display
+ * mapping on the web side. No coupled config tables in the backend.
+ */
+export type KpiKind =
+  | "active_sessions"
+  | "in_review"
+  | "completed_today"
+  | "blocked";
+
+export interface KpiData {
+  kind: KpiKind;
+  value: number;
+  unit?: string;
+  /** Last 7 daily counts, oldest → newest. */
+  trend: number[];
+}
+
+export interface StatusBreakdownData {
+  status: TaskStatus;
+  count: number;
+  percent: number;
+}
+
+/**
+ * Legend entries are coarser than the breakdown: lifecycle groupings
+ * mapped onto the UI's 6 status dots. The mapper (web) joins these with
+ * label + color.
+ */
+export type LegendBucket =
+  | "review"
+  | "done"
+  | "blocked"
+  | "failed"
+  | "running"
+  | "pending";
+
+export interface StatusLegendData {
+  bucket: LegendBucket;
+  count: number;
+}
+
+export interface FleetBarData {
+  hier: HierarchyLevel;
+  count: number;
+  percent: number;
+}
+
+export interface TrendDayData {
+  /** ISO date (`YYYY-MM-DD`) — web maps to a short day label like "Mon". */
+  date: string;
+  value: number;
+  is_today: boolean;
+}
+
+export interface AttentionData {
+  task_id: string;
+  title: string;
+  status: "blocked" | "failed" | "review";
+  /** ISO timestamp; web formats with `formatRelativeTime`. */
+  created_at: Date;
+}
+
+export interface DashboardSummary {
+  kpis: KpiData[];
+  status_breakdown: StatusBreakdownData[];
+  status_legend: StatusLegendData[];
+  status_total: number;
+  fleet: FleetBarData[];
+  fleet_total: number;
+  fleet_active: number;
+  fleet_idle: number;
+  trend: TrendDayData[];
+  trend_total: number;
+  trend_change_percent: number;
+  attention: AttentionData[];
+}
+
 // ── Re-exports of ambient types that web imports alongside the DTOs ─────────
 
 export type { TaskStatus };

--- a/packages/web/app/(authed)/home-client.test.tsx
+++ b/packages/web/app/(authed)/home-client.test.tsx
@@ -31,30 +31,25 @@ function renderHome() {
 
 const sample: DashboardSummary = {
   kpis: [
-    {
-      label: "Active sessions",
-      value: "12",
-      meta: [{ text: "rolling 24h" }],
-      href: "/tasks",
-      trend: [1, 2, 3, 4, 5],
-      trend_color: "running",
-      trend_kind: "line",
-    },
+    { kind: "active_sessions", value: 12, unit: "running", trend: [1, 2, 3, 4, 5] },
   ],
-  status_breakdown: [
-    { status: "in_progress", label: "running", color: "running", count: 7, percent: 50 },
-  ],
-  status_legend: [{ color: "running", label: "running", count: 7 }],
+  status_breakdown: [{ status: "in_progress", count: 7, percent: 50 }],
+  status_legend: [{ bucket: "running", count: 7 }],
   status_total: 14,
   fleet: [{ hier: "ic", count: 3, percent: 60 }],
   fleet_total: 5,
   fleet_active: 2,
   fleet_idle: 3,
-  trend: [{ label: "Mon", value: 4 }],
+  trend: [{ date: "2026-04-30", value: 4, is_today: true }],
   trend_total: 28,
   trend_change_percent: 12,
   attention: [
-    { status: "blocked", title: "needs key", age: "2h", href: "/tasks/t1" },
+    {
+      task_id: "t1",
+      title: "needs key",
+      status: "blocked",
+      created_at: new Date("2026-04-30T10:00:00Z"),
+    },
   ],
 };
 

--- a/packages/web/app/(authed)/home-client.tsx
+++ b/packages/web/app/(authed)/home-client.tsx
@@ -12,8 +12,7 @@ import { KpiTile } from "@/components/home/kpi-tile";
 import { FleetBars } from "@/components/home/fleet-bars";
 import { StatusBreakdownBar } from "@/components/home/status-breakdown";
 import { TrendChart } from "@/components/home/trend-chart";
-import type { DashboardSummary } from "@/lib/api/types";
-import type { AttentionItem } from "@/lib/types/dashboard";
+import type { AttentionItem, DashboardDisplay } from "@/lib/types/dashboard";
 
 const ATTENTION_DOT: Record<AttentionItem["status"], string> = {
   blocked: "bg-status-blocked",
@@ -38,7 +37,7 @@ function Body({
   isLoading,
   isError,
 }: {
-  data: DashboardSummary | undefined;
+  data: DashboardDisplay | undefined;
   isLoading: boolean;
   isError: boolean;
 }) {

--- a/packages/web/lib/api/types.ts
+++ b/packages/web/lib/api/types.ts
@@ -4,44 +4,20 @@
  * Live shapes are defined in `packages/api/src/views/types.ts` so the
  * backend is the single source of truth for the read surface. Anything
  * the web computes locally (display-only types like ChainBudget, GraphNode,
- * dashboard KPI styling) stays in `lib/types/*` and isn't surfaced here.
+ * mesh chrome) stays in `lib/types/*` and isn't surfaced here.
  */
 
 export type {
   TaskDetail,
   TaskDetailSessionRow,
   AgentDetail,
+  DashboardSummary,
 } from "@beevibe/api/views/types";
 
 import type { ChainBudgetData, GraphNode, GraphEdge, MeshSummary, MeshAsk } from "@/lib/types/mesh";
-import type {
-  KpiStat,
-  StatusBreakdownEntry,
-  StatusLegendEntry,
-  FleetBar,
-  TrendDay,
-  AttentionItem,
-} from "@/lib/types/dashboard";
 
-// ── Display-only shapes the web still composes from fixtures ────────────
-// Dashboard + mesh need a data/display split before the backend can produce
-// them cleanly — tracked in #33 and #34.
-
-export interface DashboardSummary {
-  kpis: KpiStat[];
-  status_breakdown: StatusBreakdownEntry[];
-  status_legend: StatusLegendEntry[];
-  status_total: number;
-  fleet: FleetBar[];
-  fleet_total: number;
-  fleet_active: number;
-  fleet_idle: number;
-  trend: TrendDay[];
-  trend_total: number;
-  trend_change_percent: number;
-  attention: AttentionItem[];
-}
-
+// Mesh still needs a data/display split before backend can produce it cleanly
+// — tracked in #34.
 export interface MeshOverview {
   asks: MeshAsk[];
   graph: { nodes: GraphNode[]; edges: GraphEdge[] };

--- a/packages/web/lib/dashboard-display.test.ts
+++ b/packages/web/lib/dashboard-display.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for `summaryToDisplay` — the data → display mapper that keeps the
+ * backend's pure-data DashboardSummary uncoupled from the web's URL
+ * structure, color enums, and labelling choices.
+ */
+import { describe, it, expect } from "vitest";
+import { summaryToDisplay } from "./dashboard-display";
+import type { DashboardSummary } from "@/lib/types/dashboard";
+
+function emptyData(): DashboardSummary {
+  return {
+    kpis: [],
+    status_breakdown: [],
+    status_legend: [],
+    status_total: 0,
+    fleet: [],
+    fleet_total: 0,
+    fleet_active: 0,
+    fleet_idle: 0,
+    trend: [],
+    trend_total: 0,
+    trend_change_percent: 0,
+    attention: [],
+  };
+}
+
+describe("summaryToDisplay — KPIs", () => {
+  it("maps each KPI kind to a stable label + href + color + chart kind", () => {
+    const data: DashboardSummary = {
+      ...emptyData(),
+      kpis: [
+        { kind: "active_sessions", value: 5, unit: "running", trend: [1, 2, 3] },
+        { kind: "in_review", value: 2, trend: [0, 1, 0] },
+        { kind: "completed_today", value: 8, unit: "today", trend: [3, 5, 8] },
+        { kind: "blocked", value: 1, trend: [0, 0, 1] },
+      ],
+    };
+    const display = summaryToDisplay(data);
+    const byKpi = (label: string) => display.kpis.find((k) => k.label === label)!;
+
+    expect(byKpi("Active sessions").trend_color).toBe("running");
+    expect(byKpi("Active sessions").trend_kind).toBe("line");
+    expect(byKpi("Active sessions").href).toBe("/tasks?lifecycle=in_progress");
+    expect(byKpi("Active sessions").value).toBe("5");
+    expect(byKpi("Active sessions").unit).toBe("running");
+
+    expect(byKpi("Awaiting review").trend_color).toBe("review");
+    expect(byKpi("Awaiting review").trend_kind).toBe("bar");
+    expect(byKpi("Completed today").trend_color).toBe("done");
+    expect(byKpi("Blocked").trend_color).toBe("primary");
+  });
+
+  it("preserves raw trend arrays (web's sparkline owns geometry)", () => {
+    const data: DashboardSummary = {
+      ...emptyData(),
+      kpis: [{ kind: "active_sessions", value: 0, trend: [1, 2, 3, 4, 5, 6, 7] }],
+    };
+    expect(summaryToDisplay(data).kpis[0]?.trend).toEqual([1, 2, 3, 4, 5, 6, 7]);
+  });
+});
+
+describe("summaryToDisplay — status breakdown + legend", () => {
+  it("attaches deterministic label + color from the status enum", () => {
+    const data: DashboardSummary = {
+      ...emptyData(),
+      status_breakdown: [
+        { status: "in_progress", count: 5, percent: 50 },
+        { status: "review", count: 3, percent: 30 },
+        { status: "blocked", count: 2, percent: 20 },
+      ],
+    };
+    const { status_breakdown } = summaryToDisplay(data);
+    expect(status_breakdown[0]).toEqual({
+      status: "in_progress",
+      label: "In progress",
+      color: "running",
+      count: 5,
+      percent: 50,
+    });
+    expect(status_breakdown[1]?.color).toBe("review");
+    expect(status_breakdown[2]?.color).toBe("blocked");
+  });
+
+  it("maps cancelled to the pending color (de-emphasized terminal state)", () => {
+    const data: DashboardSummary = {
+      ...emptyData(),
+      status_breakdown: [{ status: "cancelled", count: 1, percent: 100 }],
+    };
+    expect(summaryToDisplay(data).status_breakdown[0]?.color).toBe("pending");
+  });
+
+  it("legend uses the bucket as the color and humanizes the label", () => {
+    const data: DashboardSummary = {
+      ...emptyData(),
+      status_legend: [
+        { bucket: "running", count: 7 },
+        { bucket: "blocked", count: 2 },
+      ],
+    };
+    expect(summaryToDisplay(data).status_legend).toEqual([
+      { color: "running", label: "Running", count: 7 },
+      { color: "blocked", label: "Blocked", count: 2 },
+    ]);
+  });
+});
+
+describe("summaryToDisplay — fleet + scalars passthrough", () => {
+  it("forwards fleet bars + scalar totals untouched", () => {
+    const data: DashboardSummary = {
+      ...emptyData(),
+      fleet: [
+        { hier: "org", count: 1, percent: 10 },
+        { hier: "team", count: 4, percent: 40 },
+      ],
+      fleet_total: 5,
+      fleet_active: 3,
+      fleet_idle: 2,
+      status_total: 12,
+      trend_total: 50,
+      trend_change_percent: 25,
+    };
+    const display = summaryToDisplay(data);
+    expect(display.fleet).toEqual(data.fleet);
+    expect(display.fleet_total).toBe(5);
+    expect(display.fleet_active).toBe(3);
+    expect(display.fleet_idle).toBe(2);
+    expect(display.status_total).toBe(12);
+    expect(display.trend_total).toBe(50);
+    expect(display.trend_change_percent).toBe(25);
+  });
+});
+
+describe("summaryToDisplay — trend day labels", () => {
+  it("derives the short weekday label from the ISO date", () => {
+    const data: DashboardSummary = {
+      ...emptyData(),
+      trend: [
+        { date: "2026-04-27", value: 3, is_today: false }, // Monday
+        { date: "2026-04-30", value: 5, is_today: true }, // Thursday
+      ],
+    };
+    const labels = summaryToDisplay(data).trend.map((d) => d.label);
+    expect(labels).toEqual(["Mon", "Thu"]);
+    expect(summaryToDisplay(data).trend[1]?.is_today).toBe(true);
+  });
+});
+
+describe("summaryToDisplay — attention", () => {
+  it("builds task hrefs and formats relative age from created_at", () => {
+    const now = new Date("2026-04-30T12:00:00Z");
+    const recent = new Date(now.getTime() - 5 * 60_000);
+    const data: DashboardSummary = {
+      ...emptyData(),
+      attention: [
+        {
+          task_id: "task_xyz",
+          title: "needs API key",
+          status: "blocked",
+          created_at: recent,
+        },
+      ],
+    };
+    // Note: formatRelativeTime uses `new Date()` as default `now`, so we
+    // can't pin the output exactly without mocking — assert the href +
+    // structure instead and that age is non-empty.
+    const display = summaryToDisplay(data);
+    expect(display.attention[0]?.href).toBe("/tasks/task_xyz");
+    expect(display.attention[0]?.title).toBe("needs API key");
+    expect(display.attention[0]?.status).toBe("blocked");
+    expect(display.attention[0]?.age).toMatch(/m ago|just now|h ago/);
+  });
+});

--- a/packages/web/lib/dashboard-display.test.ts
+++ b/packages/web/lib/dashboard-display.test.ts
@@ -147,8 +147,7 @@ describe("summaryToDisplay — trend day labels", () => {
 
 describe("summaryToDisplay — attention", () => {
   it("builds task hrefs and formats relative age from created_at", () => {
-    const now = new Date("2026-04-30T12:00:00Z");
-    const recent = new Date(now.getTime() - 5 * 60_000);
+    const recent = new Date(Date.now() - 5 * 60_000);
     const data: DashboardSummary = {
       ...emptyData(),
       attention: [
@@ -160,13 +159,10 @@ describe("summaryToDisplay — attention", () => {
         },
       ],
     };
-    // Note: formatRelativeTime uses `new Date()` as default `now`, so we
-    // can't pin the output exactly without mocking — assert the href +
-    // structure instead and that age is non-empty.
     const display = summaryToDisplay(data);
     expect(display.attention[0]?.href).toBe("/tasks/task_xyz");
     expect(display.attention[0]?.title).toBe("needs API key");
     expect(display.attention[0]?.status).toBe("blocked");
-    expect(display.attention[0]?.age).toMatch(/m ago|just now|h ago/);
+    expect(display.attention[0]?.age).toBe("5m ago");
   });
 });

--- a/packages/web/lib/dashboard-display.ts
+++ b/packages/web/lib/dashboard-display.ts
@@ -176,7 +176,7 @@ function attentionToDisplay(data: AttentionData): AttentionItem {
   return {
     status: data.status,
     title: data.title,
-    age: formatRelativeTime(new Date(data.created_at)),
+    age: formatRelativeTime(data.created_at),
     href: `/tasks/${data.task_id}`,
   };
 }

--- a/packages/web/lib/dashboard-display.ts
+++ b/packages/web/lib/dashboard-display.ts
@@ -1,0 +1,182 @@
+import type {
+  DashboardSummary,
+  KpiKind,
+  KpiData,
+  StatusBreakdownData,
+  StatusLegendData,
+  LegendBucket,
+  FleetBarData,
+  TrendDayData,
+  AttentionData,
+  DashboardDisplay,
+  KpiStat,
+  StatusBreakdownEntry,
+  StatusLegendEntry,
+  FleetBar,
+  TrendDay,
+  AttentionItem,
+} from "@/lib/types/dashboard";
+import type { TaskStatus } from "@beevibe/core";
+import { formatRelativeTime } from "@/lib/format";
+
+/**
+ * Pure-data → display mapping. Keeps the API uncoupled from web's URL
+ * structure, CSS color names, and labelling choices.
+ */
+export function summaryToDisplay(summary: DashboardSummary): DashboardDisplay {
+  return {
+    kpis: summary.kpis.map(kpiToDisplay),
+    status_breakdown: summary.status_breakdown.map(breakdownToDisplay),
+    status_legend: summary.status_legend.map(legendToDisplay),
+    status_total: summary.status_total,
+    fleet: summary.fleet.map(fleetToDisplay),
+    fleet_total: summary.fleet_total,
+    fleet_active: summary.fleet_active,
+    fleet_idle: summary.fleet_idle,
+    trend: summary.trend.map(trendDayToDisplay),
+    trend_total: summary.trend_total,
+    trend_change_percent: summary.trend_change_percent,
+    attention: summary.attention.map(attentionToDisplay),
+  };
+}
+
+// ── KPI ────────────────────────────────────────────────────────────────────
+
+interface KpiConfig {
+  label: string;
+  href: string;
+  trend_color: KpiStat["trend_color"];
+  trend_kind: KpiStat["trend_kind"];
+}
+
+const KPI_CONFIG: Record<KpiKind, KpiConfig> = {
+  active_sessions: {
+    label: "Active sessions",
+    href: "/tasks?lifecycle=in_progress",
+    trend_color: "running",
+    trend_kind: "line",
+  },
+  in_review: {
+    label: "Awaiting review",
+    href: "/tasks?lifecycle=in_review",
+    trend_color: "review",
+    trend_kind: "bar",
+  },
+  completed_today: {
+    label: "Completed today",
+    href: "/tasks?lifecycle=done",
+    trend_color: "done",
+    trend_kind: "line",
+  },
+  blocked: {
+    label: "Blocked",
+    href: "/tasks?lifecycle=in_review",
+    trend_color: "primary",
+    trend_kind: "bar",
+  },
+};
+
+function kpiToDisplay(data: KpiData): KpiStat {
+  const cfg = KPI_CONFIG[data.kind];
+  return {
+    label: cfg.label,
+    value: String(data.value),
+    unit: data.unit,
+    meta: [],
+    href: cfg.href,
+    trend: data.trend,
+    trend_color: cfg.trend_color,
+    trend_kind: cfg.trend_kind,
+  };
+}
+
+// ── Status breakdown ───────────────────────────────────────────────────────
+
+const STATUS_LABEL: Record<TaskStatus, string> = {
+  pending: "Pending",
+  assigned: "Assigned",
+  in_progress: "In progress",
+  needs_revision: "Needs revision",
+  revision: "In revision",
+  review: "In review",
+  blocked: "Blocked",
+  done: "Done",
+  failed: "Failed",
+  cancelled: "Cancelled",
+};
+
+const STATUS_COLOR: Record<TaskStatus, StatusBreakdownEntry["color"]> = {
+  pending: "pending",
+  assigned: "pending",
+  in_progress: "running",
+  needs_revision: "running",
+  revision: "running",
+  review: "review",
+  blocked: "blocked",
+  done: "done",
+  failed: "failed",
+  cancelled: "pending",
+};
+
+function breakdownToDisplay(data: StatusBreakdownData): StatusBreakdownEntry {
+  return {
+    status: data.status,
+    label: STATUS_LABEL[data.status],
+    color: STATUS_COLOR[data.status],
+    count: data.count,
+    percent: data.percent,
+  };
+}
+
+// ── Legend ─────────────────────────────────────────────────────────────────
+
+const LEGEND_LABEL: Record<LegendBucket, string> = {
+  pending: "Pending",
+  running: "Running",
+  review: "Review",
+  blocked: "Blocked",
+  done: "Done",
+  failed: "Failed",
+};
+
+function legendToDisplay(data: StatusLegendData): StatusLegendEntry {
+  return {
+    color: data.bucket,
+    label: LEGEND_LABEL[data.bucket],
+    count: data.count,
+  };
+}
+
+// ── Fleet ──────────────────────────────────────────────────────────────────
+
+function fleetToDisplay(data: FleetBarData): FleetBar {
+  return {
+    hier: data.hier,
+    count: data.count,
+    percent: data.percent,
+  };
+}
+
+// ── Trend ──────────────────────────────────────────────────────────────────
+
+const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+
+function trendDayToDisplay(data: TrendDayData): TrendDay {
+  const label = DAY_LABELS[new Date(data.date + "T00:00:00Z").getUTCDay()] ?? data.date;
+  return {
+    label,
+    value: data.value,
+    is_today: data.is_today,
+  };
+}
+
+// ── Attention ──────────────────────────────────────────────────────────────
+
+function attentionToDisplay(data: AttentionData): AttentionItem {
+  return {
+    status: data.status,
+    title: data.title,
+    age: formatRelativeTime(new Date(data.created_at)),
+    href: `/tasks/${data.task_id}`,
+  };
+}

--- a/packages/web/lib/hooks/use-dashboard.ts
+++ b/packages/web/lib/hooks/use-dashboard.ts
@@ -1,12 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
+import { summaryToDisplay } from "@/lib/dashboard-display";
 import { queryKeys } from "./keys";
 
 export function useDashboard() {
   return useQuery({
     queryKey: queryKeys.dashboard.summary(),
     queryFn: ({ signal }) => api.dashboard.summary({ signal }),
+    select: summaryToDisplay,
     enabled: isApiConfigured,
   });
 }

--- a/packages/web/lib/types/dashboard.ts
+++ b/packages/web/lib/types/dashboard.ts
@@ -1,5 +1,11 @@
 import type { TaskStatus } from "@beevibe/core";
 
+// ── Display shapes the home page binds against ─────────────────────────────
+//
+// These are produced by `lib/dashboard-display.ts:summaryToDisplay()` from
+// the pure-data `DashboardSummary` shipped by the backend. Backend never
+// computes colors, hrefs, or sparkline geometry.
+
 export type KpiMetaColor = "muted" | "review" | "done" | "failed";
 
 export interface KpiMetaPart {
@@ -52,3 +58,33 @@ export interface AttentionItem {
   age: string;
   href: string;
 }
+
+/** Aggregated display-shaped dashboard the home page binds to. */
+export interface DashboardDisplay {
+  kpis: KpiStat[];
+  status_breakdown: StatusBreakdownEntry[];
+  status_legend: StatusLegendEntry[];
+  status_total: number;
+  fleet: FleetBar[];
+  fleet_total: number;
+  fleet_active: number;
+  fleet_idle: number;
+  trend: TrendDay[];
+  trend_total: number;
+  trend_change_percent: number;
+  attention: AttentionItem[];
+}
+
+// ── Re-export the backend data DTO ─────────────────────────────────────────
+
+export type {
+  DashboardSummary,
+  KpiKind,
+  KpiData,
+  StatusBreakdownData,
+  StatusLegendData,
+  LegendBucket,
+  FleetBarData,
+  TrendDayData,
+  AttentionData,
+} from "@beevibe/api/views/types";


### PR DESCRIPTION
## Summary

Closes #33. The dashboard is the first read surface to ship the **data/display split** that #30 called for: backend produces pure data; web composes display fields (colors, hrefs, sparkline geometry, day labels, "5m ago" age) via a thin mapper.

The same pattern is the template for M8.C (mesh, #34).

## What ships

### Backend (packages/api)

- **\`views/dashboard.ts\`** — 5-query composer fired in parallel:
  - status counts → breakdown + legend buckets
  - per-hier agent counts + active session join → fleet bars
  - 14-day completed-session trend, split into prior/recent for the delta %
  - blocked/failed/review tasks → attention queue
  - per-KPI 7-day trend rows
- **\`views/types.ts\`** — data DTOs: \`DashboardSummary\`, \`KpiData\`, \`KpiKind\`, \`StatusBreakdownData\`, \`StatusLegendData\`, \`LegendBucket\`, \`FleetBarData\`, \`TrendDayData\`, \`AttentionData\`
- **\`routes/view.ts\`** — mounts \`GET /dashboard\` behind \`requireHuman\`
- **\`views/dashboard.test.ts\`** — 11 mock-Pool tests covering bucketing, fleet aggregation, trend window split, KPI assembly, parallel-dispatch, and zero-totals edge cases

### Web (packages/web)

- **\`lib/types/dashboard.ts\`** — keeps the existing display types (KpiStat etc.) and adds \`DashboardDisplay\` aggregate. Re-exports the backend data DTOs.
- **\`lib/api/types.ts\`** — drops the locally-declared display-coupled \`DashboardSummary\`; re-exports the backend's data DTO so it's the single source of truth.
- **\`lib/dashboard-display.ts\`** — \`summaryToDisplay()\` mapper:
  - \`KpiKind\` → label / href / \`trend_color\` / \`trend_kind\` via \`KPI_CONFIG\` table
  - \`TaskStatus\` → label / color via deterministic maps
  - \`LegendBucket\` → legend color + label
  - ISO date → short weekday name (\`getUTCDay()\` → \`["Sun"…"Sat"]\`)
  - \`task_id\` → \`/tasks/:id\` href; \`created_at\` → \`formatRelativeTime\`
- **\`lib/hooks/use-dashboard.ts\`** — applies the mapper via React Query \`select\`. Memoized; runs once per data change.
- **\`app/(authed)/home-client.tsx\`** — one-line type swap (\`DashboardSummary\` → \`DashboardDisplay\`). No rendering changes.
- **\`lib/dashboard-display.test.ts\`** — 8 mapper tests covering each section.

## KPIs shipped (v1)

| Kind | Source | Color | Chart |
|---|---|---|---|
| \`active_sessions\` | running session count (joined per agent) | running (green) | line |
| \`in_review\` | task count where status='review' | review (amber) | bar |
| \`completed_today\` | task count where status='done' & today | done (emerald) | line |
| \`blocked\` | task count where status='blocked' | primary | bar |

Adding a new KPI: define a \`KpiKind\`, return a row from \`buildKpis()\`, add a \`KPI_CONFIG\` entry web-side. No coupled config in the backend.

## Test plan

- [x] \`pnpm -w typecheck\` — clean across core / api / executor / web
- [x] \`pnpm -w build\` — clean (web Next build, api tsc)
- [x] api unit tests: 11 new dashboard view tests pass; pre-existing DB-integration tests still gated on \`DATABASE_URL_TEST\`
- [x] web tests: 95/95 pass (was 87 — +8 mapper tests)
- [ ] Manual smoke against \`pnpm dev\`: home page renders KPIs, breakdown bar, fleet, 7-day trend, attention queue from a real DB

## Notes

This validates the data/display pattern that mesh (#34) will reuse. Any field the backend doesn't need to know about (colors, route URLs, geometry) lives in \`lib/dashboard-display.ts\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)