### PR TITLE
M8.C — GET /mesh phase 1 (data/display split + radial layout) (#34)

### DIFF
--- a/migrations/1778100000000_add-mesh-indexes.sql
+++ b/migrations/1778100000000_add-mesh-indexes.sql
@@ -1,0 +1,17 @@
+-- M8.C mesh view indexes.
+--
+-- The ASKS_SQL, NODES_SQL, EDGES_SQL, and SUMMARY_SQL queries in
+-- `packages/api/src/views/mesh.ts` filter
+--   WHERE created_at >= NOW() - INTERVAL '24 hours' OR status = 'active'
+-- and the existing indexes only cover (initiator_agent_id) and (task_id) —
+-- no leg of that filter is indexed. For workspaces with thousands of
+-- historical negotiations, the mesh page would scan the whole table.
+--
+-- Composite (status, created_at) serves both filter directions reasonably:
+--   - status='active' → uses leading column directly
+--   - created_at >= ... → bitmap-or with the same index
+--
+-- Matches the pattern set by 1778000000000_add-dashboard-indexes.sql.
+
+CREATE INDEX IF NOT EXISTS idx_negotiation_status_created
+  ON negotiation(status, created_at DESC);

--- a/packages/api/src/routes/view.ts
+++ b/packages/api/src/routes/view.ts
@@ -31,6 +31,7 @@ import { listAgents, getAgent } from "../views/agents.js";
 import { getSessionByShortId, AmbiguousShortIdError } from "../views/sessions.js";
 import { listMemoryFacts } from "../views/memory.js";
 import { getDashboardSummary } from "../views/dashboard.js";
+import { getMeshOverview } from "../views/mesh.js";
 
 export interface ViewRoutesDeps {
   authMiddleware: RequestHandler;
@@ -165,6 +166,16 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
       res.json(summary);
     } catch (err) {
       handleError(err, res, "dashboard summary");
+    }
+  });
+
+  router.get("/mesh", async (req, res) => {
+    if (!requireHuman(req, res)) return;
+    try {
+      const overview = await getMeshOverview(deps.pool);
+      res.json(overview);
+    } catch (err) {
+      handleError(err, res, "mesh overview");
     }
   });
 

--- a/packages/api/src/views/mesh.test.ts
+++ b/packages/api/src/views/mesh.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Mock-Pool tests for views/mesh.ts. Validates row → DTO mapping +
+ * status compression. Real query correctness is covered by integration
+ * tests; these stay DB-free.
+ *
+ * Query order in the implementation:
+ *   1) ASKS_SQL    → recent + in-flight negotiations
+ *   2) NODES_SQL   → distinct involved agents
+ *   3) EDGES_SQL   → aggregated initiator → counterparty pairs
+ *   4) SUMMARY_SQL → total counts
+ */
+import { describe, it, expect } from "vitest";
+import { getMeshOverview } from "./mesh.js";
+import { makeMockPool } from "./test-helpers.js";
+
+const baseAsk = {
+  id: "neg_1",
+  caller_id: "agt_a",
+  caller_label: "Alice",
+  target_id: "agt_b",
+  target_label: "Bob",
+  source_task_id: "task_1",
+  rounds_completed: 2,
+  max_rounds: 5,
+  started_at: new Date("2026-04-30T11:00:00Z"),
+  completed_at_or_updated: new Date("2026-04-30T11:30:00Z"),
+  intent: "Can you review this?",
+};
+
+describe("getMeshOverview — asks", () => {
+  it("returns empty arrays + zero summary when DB is empty", async () => {
+    const pool = makeMockPool([[], [], [], []]);
+    const overview = await getMeshOverview(pool);
+    expect(overview.asks).toEqual([]);
+    expect(overview.graph.nodes).toEqual([]);
+    expect(overview.graph.edges).toEqual([]);
+    expect(overview.summary).toEqual({ asks_24h: 0, in_flight: 0, edge_count: 0 });
+  });
+
+  it("maps an active negotiation to in_flight + omits completed_at", async () => {
+    const pool = makeMockPool([
+      [{ ...baseAsk, status: "active" }],
+      [],
+      [],
+      [],
+    ]);
+    const { asks } = await getMeshOverview(pool);
+    expect(asks).toHaveLength(1);
+    expect(asks[0]?.status).toBe("in_flight");
+    expect(asks[0]?.completed_at).toBeUndefined();
+    expect(asks[0]?.caller_label).toBe("Alice");
+    expect(asks[0]?.target_label).toBe("Bob");
+    expect(asks[0]?.intent).toBe("Can you review this?");
+    expect(asks[0]?.rounds_completed).toBe(2);
+    expect(asks[0]?.max_rounds).toBe(5);
+  });
+
+  it("compresses negotiation.status into MeshAskStatus", async () => {
+    const pool = makeMockPool([
+      [
+        { ...baseAsk, id: "neg_a", status: "active" },
+        { ...baseAsk, id: "neg_b", status: "accepted" },
+        { ...baseAsk, id: "neg_c", status: "rejected" },
+        { ...baseAsk, id: "neg_d", status: "escalated" },
+        { ...baseAsk, id: "neg_e", status: "cancelled" },
+      ],
+      [],
+      [],
+      [],
+    ]);
+    const { asks } = await getMeshOverview(pool);
+    const statusByid = Object.fromEntries(asks.map((a) => [a.id, a.status]));
+    expect(statusByid).toEqual({
+      neg_a: "in_flight",
+      neg_b: "succeeded",
+      neg_c: "rejected",
+      neg_d: "escalated",
+      neg_e: "blocked",
+    });
+  });
+
+  it("populates completed_at from updated_at for terminal asks", async () => {
+    const pool = makeMockPool([
+      [{ ...baseAsk, status: "accepted" }],
+      [],
+      [],
+      [],
+    ]);
+    const { asks } = await getMeshOverview(pool);
+    expect(asks[0]?.completed_at).toEqual(new Date("2026-04-30T11:30:00Z"));
+  });
+
+  it("falls back to '(no message)' when round 1 message is null", async () => {
+    const pool = makeMockPool([
+      [{ ...baseAsk, status: "active", intent: null }],
+      [],
+      [],
+      [],
+    ]);
+    const { asks } = await getMeshOverview(pool);
+    expect(asks[0]?.intent).toBe("(no message)");
+  });
+});
+
+describe("getMeshOverview — nodes + edges + summary", () => {
+  it("maps node rows preserving hierarchy and active state", async () => {
+    const pool = makeMockPool([
+      [],
+      [
+        { id: "agt_a", label: "Alice", hier: "team", is_active: true },
+        { id: "agt_b", label: "Bob", hier: "ic", is_active: false },
+      ],
+      [],
+      [],
+    ]);
+    const { graph } = await getMeshOverview(pool);
+    expect(graph.nodes).toEqual([
+      { id: "agt_a", label: "Alice", hier: "team", state: "active" },
+      { id: "agt_b", label: "Bob", hier: "ic", state: "idle" },
+    ]);
+  });
+
+  it("maps edges with count + live state", async () => {
+    const pool = makeMockPool([
+      [],
+      [],
+      [
+        { from_id: "agt_a", to_id: "agt_b", count: 3, has_live: true },
+        { from_id: "agt_a", to_id: "agt_c", count: 1, has_live: false },
+      ],
+      [],
+    ]);
+    const { graph } = await getMeshOverview(pool);
+    expect(graph.edges).toEqual([
+      { from: "agt_a", to: "agt_b", count: 3, state: "live" },
+      { from: "agt_a", to: "agt_c", count: 1, state: "completed" },
+    ]);
+  });
+
+  it("forwards summary counts", async () => {
+    const pool = makeMockPool([
+      [],
+      [],
+      [],
+      [{ asks_24h: 12, in_flight: 3, edge_count: 7 }],
+    ]);
+    const { summary } = await getMeshOverview(pool);
+    expect(summary).toEqual({ asks_24h: 12, in_flight: 3, edge_count: 7 });
+  });
+});

--- a/packages/api/src/views/mesh.ts
+++ b/packages/api/src/views/mesh.ts
@@ -41,42 +41,39 @@ SELECT
   n.max_rounds,
   n.created_at             AS started_at,
   n.updated_at             AS completed_at_or_updated,
-  (
-    SELECT message
-    FROM negotiation_round nr
-    WHERE nr.negotiation_id = n.id AND nr.round_number = 1
-    LIMIT 1
-  )                        AS intent
+  nr1.message              AS intent
 FROM negotiation n
 JOIN agent ca ON ca.id = n.initiator_agent_id
 JOIN agent ta ON ta.id = n.counterparty_agent_id
+LEFT JOIN negotiation_round nr1
+  ON nr1.negotiation_id = n.id AND nr1.round_number = 1
 WHERE n.created_at >= NOW() - INTERVAL '${WINDOW}'
    OR n.status = 'active'
 ORDER BY n.created_at DESC
 LIMIT $1
 `;
 
+/**
+ * Single negotiation scan, unpivoted into per-endpoint rows, then GROUP BY
+ * agent. `bool_or(status='active')` derives the live-state without a
+ * second pass over the table.
+ */
 const NODES_SQL = /* sql */ `
-WITH involved AS (
-  SELECT initiator_agent_id AS id FROM negotiation
+WITH endpoints AS (
+  SELECT initiator_agent_id AS agent_id, status FROM negotiation
   WHERE created_at >= NOW() - INTERVAL '${WINDOW}' OR status = 'active'
-  UNION
-  SELECT counterparty_agent_id FROM negotiation
+  UNION ALL
+  SELECT counterparty_agent_id AS agent_id, status FROM negotiation
   WHERE created_at >= NOW() - INTERVAL '${WINDOW}' OR status = 'active'
-),
-active_agents AS (
-  SELECT DISTINCT initiator_agent_id    AS id FROM negotiation WHERE status = 'active'
-  UNION
-  SELECT DISTINCT counterparty_agent_id      FROM negotiation WHERE status = 'active'
 )
 SELECT
   a.id,
-  a.name              AS label,
-  a.hierarchy_level   AS hier,
-  (aa.id IS NOT NULL) AS is_active
-FROM involved i
-JOIN agent a ON a.id = i.id
-LEFT JOIN active_agents aa ON aa.id = a.id
+  a.name                       AS label,
+  a.hierarchy_level            AS hier,
+  bool_or(ep.status = 'active') AS is_active
+FROM endpoints ep
+JOIN agent a ON a.id = ep.agent_id
+GROUP BY a.id, a.name, a.hierarchy_level
 ORDER BY
   CASE a.hierarchy_level WHEN 'org' THEN 0 WHEN 'team' THEN 1 ELSE 2 END,
   a.name ASC

--- a/packages/api/src/views/mesh.ts
+++ b/packages/api/src/views/mesh.ts
@@ -1,0 +1,209 @@
+/**
+ * Mesh view — pure-data composer for the mesh activity page.
+ *
+ * V1 ships from the `negotiation` table only (the canonical multi-round
+ * mesh activity, well-grounded in M6's persistence). Mesh-ask sessions
+ * (`session WHERE type = 'mesh_ask'`) and blocker sessions encode their
+ * caller in the intent XML attribute rather than a column, which makes
+ * SQL-side joining awkward; surfacing them is a follow-up.
+ *
+ * 4 queries fired in parallel:
+ *   - `asks`     — recent + in-flight negotiations + agent labels + round-1 message
+ *   - `nodes`    — distinct agents involved in mesh activity in the window
+ *   - `edges`    — aggregated initiator → counterparty pairs with counts
+ *   - `summary`  — totals (asks_24h, in_flight, edge_count)
+ */
+
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import type { HierarchyLevel } from "@beevibe/core";
+import type {
+  MeshOverview,
+  MeshAskData,
+  MeshAskStatus,
+  GraphNodeData,
+  GraphEdgeData,
+  MeshSummaryData,
+} from "./types.js";
+
+const ASKS_LIMIT = 50;
+const WINDOW = "24 hours";
+
+const ASKS_SQL = /* sql */ `
+SELECT
+  n.id,
+  n.initiator_agent_id     AS caller_id,
+  ca.name                  AS caller_label,
+  n.counterparty_agent_id  AS target_id,
+  ta.name                  AS target_label,
+  n.status,
+  n.task_id                AS source_task_id,
+  n.rounds_completed,
+  n.max_rounds,
+  n.created_at             AS started_at,
+  n.updated_at             AS completed_at_or_updated,
+  (
+    SELECT message
+    FROM negotiation_round nr
+    WHERE nr.negotiation_id = n.id AND nr.round_number = 1
+    LIMIT 1
+  )                        AS intent
+FROM negotiation n
+JOIN agent ca ON ca.id = n.initiator_agent_id
+JOIN agent ta ON ta.id = n.counterparty_agent_id
+WHERE n.created_at >= NOW() - INTERVAL '${WINDOW}'
+   OR n.status = 'active'
+ORDER BY n.created_at DESC
+LIMIT $1
+`;
+
+const NODES_SQL = /* sql */ `
+WITH involved AS (
+  SELECT initiator_agent_id AS id FROM negotiation
+  WHERE created_at >= NOW() - INTERVAL '${WINDOW}' OR status = 'active'
+  UNION
+  SELECT counterparty_agent_id FROM negotiation
+  WHERE created_at >= NOW() - INTERVAL '${WINDOW}' OR status = 'active'
+),
+active_agents AS (
+  SELECT DISTINCT initiator_agent_id    AS id FROM negotiation WHERE status = 'active'
+  UNION
+  SELECT DISTINCT counterparty_agent_id      FROM negotiation WHERE status = 'active'
+)
+SELECT
+  a.id,
+  a.name              AS label,
+  a.hierarchy_level   AS hier,
+  (aa.id IS NOT NULL) AS is_active
+FROM involved i
+JOIN agent a ON a.id = i.id
+LEFT JOIN active_agents aa ON aa.id = a.id
+ORDER BY
+  CASE a.hierarchy_level WHEN 'org' THEN 0 WHEN 'team' THEN 1 ELSE 2 END,
+  a.name ASC
+`;
+
+const EDGES_SQL = /* sql */ `
+SELECT
+  initiator_agent_id    AS from_id,
+  counterparty_agent_id AS to_id,
+  COUNT(*)::int         AS count,
+  bool_or(status = 'active') AS has_live
+FROM negotiation
+WHERE created_at >= NOW() - INTERVAL '${WINDOW}' OR status = 'active'
+GROUP BY initiator_agent_id, counterparty_agent_id
+ORDER BY count DESC
+`;
+
+const SUMMARY_SQL = /* sql */ `
+SELECT
+  COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '${WINDOW}')::int  AS asks_24h,
+  COUNT(*) FILTER (WHERE status = 'active')::int                           AS in_flight,
+  COUNT(DISTINCT (initiator_agent_id, counterparty_agent_id))::int         AS edge_count
+FROM negotiation
+WHERE created_at >= NOW() - INTERVAL '${WINDOW}' OR status = 'active'
+`;
+
+interface AsksRow {
+  id: string;
+  caller_id: string;
+  caller_label: string;
+  target_id: string;
+  target_label: string;
+  status: string;
+  source_task_id: string | null;
+  rounds_completed: number;
+  max_rounds: number;
+  started_at: Date;
+  completed_at_or_updated: Date;
+  intent: string | null;
+}
+
+interface NodesRow {
+  id: string;
+  label: string;
+  hier: HierarchyLevel;
+  is_active: boolean;
+}
+
+interface EdgesRow {
+  from_id: string;
+  to_id: string;
+  count: number;
+  has_live: boolean;
+}
+
+interface SummaryRow {
+  asks_24h: number;
+  in_flight: number;
+  edge_count: number;
+}
+
+/** Map negotiation.status → the UI's coarser ask-status display. */
+function mapStatus(raw: string): MeshAskStatus {
+  switch (raw) {
+    case "active":
+      return "in_flight";
+    case "accepted":
+      return "succeeded";
+    case "rejected":
+      return "rejected";
+    case "escalated":
+      return "escalated";
+    case "cancelled":
+      return "blocked";
+    default:
+      return "in_flight";
+  }
+}
+
+export async function getMeshOverview(pool: Pool): Promise<MeshOverview> {
+  const [asksResult, nodesResult, edgesResult, summaryResult] = await Promise.all([
+    pool.query<AsksRow>(ASKS_SQL, [ASKS_LIMIT]),
+    pool.query<NodesRow>(NODES_SQL),
+    pool.query<EdgesRow>(EDGES_SQL),
+    pool.query<SummaryRow>(SUMMARY_SQL),
+  ]);
+
+  const asks: MeshAskData[] = asksResult.rows.map((r) => {
+    const status = mapStatus(r.status);
+    const isTerminal = status !== "in_flight";
+    return {
+      id: r.id,
+      type: "negotiate",
+      caller_id: r.caller_id,
+      caller_label: r.caller_label,
+      target_id: r.target_id,
+      target_label: r.target_label,
+      status,
+      intent: r.intent ?? "(no message)",
+      started_at: r.started_at,
+      completed_at: isTerminal ? r.completed_at_or_updated : undefined,
+      source_task_id: r.source_task_id ?? undefined,
+      rounds_completed: Number(r.rounds_completed),
+      max_rounds: Number(r.max_rounds),
+    };
+  });
+
+  const nodes: GraphNodeData[] = nodesResult.rows.map((r) => ({
+    id: r.id,
+    label: r.label,
+    hier: r.hier,
+    state: r.is_active ? "active" : "idle",
+  }));
+
+  const edges: GraphEdgeData[] = edgesResult.rows.map((r) => ({
+    from: r.from_id,
+    to: r.to_id,
+    count: Number(r.count),
+    state: r.has_live ? "live" : "completed",
+  }));
+
+  const summaryRow = summaryResult.rows[0];
+  const summary: MeshSummaryData = {
+    asks_24h: summaryRow ? Number(summaryRow.asks_24h) : 0,
+    in_flight: summaryRow ? Number(summaryRow.in_flight) : 0,
+    edge_count: summaryRow ? Number(summaryRow.edge_count) : 0,
+  };
+
+  return { asks, graph: { nodes, edges }, summary };
+}

--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -298,6 +298,76 @@ export interface DashboardSummary {
   attention: AttentionData[];
 }
 
+// ── Mesh ────────────────────────────────────────────────────────────────────
+//
+// Mesh data DTO. Like the dashboard, the web composes display fields
+// (SVG geometry, duration labels, color enums) via `lib/mesh-display.ts`
+// and `lib/mesh-layout.ts`.
+//
+// V1 ships from the `negotiation` table (the canonical multi-round mesh
+// activity). Mesh-ask sessions and blocker sessions are not yet surfaced
+// here — their parent agent isn't directly stored on the session row, only
+// embedded in the intent XML — and the live UI doesn't differentiate
+// between ask types yet.
+
+export type MeshAskType = "negotiate" | "ask" | "blocker";
+
+export type MeshAskStatus =
+  | "in_flight"
+  | "succeeded"
+  | "rejected"
+  | "blocked"
+  | "escalated";
+
+export interface MeshAskData {
+  id: string;
+  type: MeshAskType;
+  caller_id: string;
+  caller_label: string;
+  target_id: string;
+  target_label: string;
+  status: MeshAskStatus;
+  /** First-round message; the web shows a preview. */
+  intent: string;
+  started_at: Date;
+  completed_at?: Date;
+  source_task_id?: string;
+  /** Negotiations only. */
+  rounds_completed?: number;
+  max_rounds?: number;
+}
+
+export interface GraphNodeData {
+  /** agent_id. */
+  id: string;
+  /** agent.name. */
+  label: string;
+  hier: HierarchyLevel;
+  /** "active" if the agent is in any in-flight mesh activity. */
+  state: "active" | "idle";
+}
+
+export interface GraphEdgeData {
+  from: string;
+  to: string;
+  /** Number of asks/negotiations between this pair in the window. */
+  count: number;
+  /** "live" if any in-flight, "completed" otherwise. */
+  state: "live" | "completed";
+}
+
+export interface MeshSummaryData {
+  asks_24h: number;
+  in_flight: number;
+  edge_count: number;
+}
+
+export interface MeshOverview {
+  asks: MeshAskData[];
+  graph: { nodes: GraphNodeData[]; edges: GraphEdgeData[] };
+  summary: MeshSummaryData;
+}
+
 // ── Re-exports of ambient types that web imports alongside the DTOs ─────────
 
 export type { TaskStatus };

--- a/packages/web/app/(authed)/mesh/mesh-client.tsx
+++ b/packages/web/app/(authed)/mesh/mesh-client.tsx
@@ -9,8 +9,7 @@ import { MeshGraphStatic } from "@/components/mesh/graph-static";
 import { ChainBudget } from "@/components/mesh/chain-budget";
 import { useMeshOverview } from "@/lib/hooks/use-mesh";
 import { isApiConfigured } from "@/lib/api/config";
-import type { MeshOverview } from "@/lib/api/types";
-import type { MeshAsk } from "@/lib/types/mesh";
+import type { MeshAsk, MeshDisplay } from "@/lib/types/mesh";
 
 export function MeshClient() {
   const { data, isLoading, isError } = useMeshOverview();
@@ -52,7 +51,7 @@ function Body({
   isLoading,
   isError,
 }: {
-  data: MeshOverview | undefined;
+  data: MeshDisplay | undefined;
   isLoading: boolean;
   isError: boolean;
 }) {
@@ -96,7 +95,10 @@ function Body({
       <div className="grid grid-cols-5 gap-6">
         <MeshActivityFeed />
         <div className="col-span-2">
-          <MeshGraphStatic />
+          <MeshGraphStatic
+            nodes={data?.graph.nodes}
+            edges={data?.graph.edges}
+          />
           <ChainBudget />
         </div>
       </div>
@@ -117,15 +119,7 @@ function Body({
         </ul>
       </section>
       <div className="col-span-2 space-y-3">
-        <div className="rounded-lg border border-border bg-card p-4 text-xs text-muted-foreground">
-          <div className="text-[10px] uppercase tracking-wider mb-2 text-foreground">
-            Live graph · last 24h
-          </div>
-          <div>
-            <span className="text-foreground tabular-nums">{data.graph.edges.length}</span> edges ·{" "}
-            <span className="text-foreground tabular-nums">{data.graph.nodes.length}</span> agents
-          </div>
-        </div>
+        <MeshGraphStatic nodes={data.graph.nodes} edges={data.graph.edges} />
         <ChainBudget />
       </div>
     </div>

--- a/packages/web/components/mesh/graph-static.tsx
+++ b/packages/web/components/mesh/graph-static.tsx
@@ -1,7 +1,39 @@
 import { Network } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { EmptyState } from "@/components/empty-state";
+import type { GraphEdge, GraphNode } from "@/lib/types/mesh";
 
-export function MeshGraphStatic() {
+const NODE_FILL: Record<GraphNode["state"], string> = {
+  active: "fill-status-running",
+  blocked: "fill-status-blocked",
+  idle: "fill-muted-foreground",
+};
+
+const EDGE_STROKE: Record<GraphEdge["state"], string> = {
+  live: "stroke-status-running",
+  blocker: "stroke-status-blocked",
+  completed: "stroke-muted-foreground/40",
+};
+
+const HIER_RING: Record<GraphNode["hier"], string> = {
+  org: "stroke-hier-org",
+  team: "stroke-hier-team",
+  ic: "stroke-hier-ic",
+};
+
+interface Props {
+  nodes?: readonly GraphNode[];
+  edges?: readonly GraphEdge[];
+  /** Defaults to 480 — matches `mesh-layout.ts`. */
+  viewBox?: { width: number; height: number };
+}
+
+export function MeshGraphStatic({
+  nodes = [],
+  edges = [],
+  viewBox = { width: 480, height: 480 },
+}: Props) {
+  const empty = nodes.length === 0;
   return (
     <section>
       <div className="flex items-center justify-between mb-3">
@@ -9,18 +41,60 @@ export function MeshGraphStatic() {
           Live graph · last 24h
         </h2>
         <div className="text-[10px] text-muted-foreground">
-          <span className="text-foreground tabular-nums">0</span> edges
+          <span className="text-foreground tabular-nums">{edges.length}</span> edges ·{" "}
+          <span className="text-foreground tabular-nums">{nodes.length}</span> agents
         </div>
       </div>
 
       <div className="rounded-lg border border-border bg-card overflow-hidden">
-        <div className="h-[480px] flex items-center justify-center">
-          <EmptyState
-            icon={Network}
-            title="No mesh activity"
-            description="The graph populates as agents ask each other for help."
-          />
-        </div>
+        {empty ? (
+          <div className="h-[480px] flex items-center justify-center">
+            <EmptyState
+              icon={Network}
+              title="No mesh activity"
+              description="The graph populates as agents ask each other for help."
+            />
+          </div>
+        ) : (
+          <svg
+            viewBox={`0 0 ${viewBox.width} ${viewBox.height}`}
+            className="w-full h-[480px]"
+            aria-label="Mesh activity graph"
+          >
+            {edges.map((e, i) => (
+              <path
+                key={`${e.from}-${e.to}-${i}`}
+                d={e.d}
+                className={cn("fill-none stroke-2", EDGE_STROKE[e.state])}
+                strokeLinecap="round"
+              />
+            ))}
+            {nodes.map((n) => (
+              <g key={n.id}>
+                <circle
+                  cx={n.cx}
+                  cy={n.cy}
+                  r={n.r}
+                  className={cn(
+                    "stroke-[3]",
+                    NODE_FILL[n.state],
+                    HIER_RING[n.hier],
+                  )}
+                />
+                <text
+                  x={n.cx}
+                  y={n.cy + n.r + 14}
+                  textAnchor="middle"
+                  fontSize="11"
+                  fill="hsl(var(--foreground))"
+                  fontFamily="JetBrains Mono"
+                >
+                  {n.label}
+                </text>
+              </g>
+            ))}
+          </svg>
+        )}
       </div>
     </section>
   );

--- a/packages/web/lib/api/types.ts
+++ b/packages/web/lib/api/types.ts
@@ -2,9 +2,7 @@
  * Web-side re-exports of the read-DTO contract owned by `@beevibe/api`.
  *
  * Live shapes are defined in `packages/api/src/views/types.ts` so the
- * backend is the single source of truth for the read surface. Anything
- * the web computes locally (display-only types like ChainBudget, GraphNode,
- * mesh chrome) stays in `lib/types/*` and isn't surfaced here.
+ * backend is the single source of truth for the read surface.
  */
 
 export type {
@@ -12,15 +10,5 @@ export type {
   TaskDetailSessionRow,
   AgentDetail,
   DashboardSummary,
+  MeshOverview,
 } from "@beevibe/api/views/types";
-
-import type { ChainBudgetData, GraphNode, GraphEdge, MeshSummary, MeshAsk } from "@/lib/types/mesh";
-
-// Mesh still needs a data/display split before backend can produce it cleanly
-// — tracked in #34.
-export interface MeshOverview {
-  asks: MeshAsk[];
-  graph: { nodes: GraphNode[]; edges: GraphEdge[] };
-  budget: ChainBudgetData;
-  summary: MeshSummary;
-}

--- a/packages/web/lib/format.ts
+++ b/packages/web/lib/format.ts
@@ -22,3 +22,26 @@ export function sessionHref(sid: string, taskId?: string): string {
   if (taskId) return `/tasks/${taskId}/sessions/${sid}`;
   return "#";
 }
+
+/**
+ * Duration between `startedAt` and `completedAt` (or `now` if running).
+ * "30s" / "5m" / "1h 12m" / "2d 3h". Returns "—" if no start.
+ */
+export function formatDurationLabel(
+  startedAt: Date | null | undefined,
+  completedAt: Date | null | undefined,
+  now: Date = new Date(),
+): string {
+  if (!startedAt) return "—";
+  const end = completedAt ?? now;
+  const diffSec = Math.max(0, Math.floor((end.getTime() - startedAt.getTime()) / 1000));
+  if (diffSec < 60) return `${diffSec}s`;
+  const min = Math.floor(diffSec / 60);
+  if (min < 60) return `${min}m`;
+  const hr = Math.floor(min / 60);
+  const mins = min % 60;
+  if (hr < 24) return mins ? `${hr}h ${mins}m` : `${hr}h`;
+  const days = Math.floor(hr / 24);
+  const hrs = hr % 24;
+  return hrs ? `${days}d ${hrs}h` : `${days}d`;
+}

--- a/packages/web/lib/hooks/use-mesh.ts
+++ b/packages/web/lib/hooks/use-mesh.ts
@@ -1,12 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
+import { overviewToDisplay } from "@/lib/mesh-display";
 import { queryKeys } from "./keys";
 
 export function useMeshOverview(filter: { since?: string } = {}) {
   return useQuery({
     queryKey: queryKeys.mesh.overview(filter),
     queryFn: ({ signal }) => api.mesh.overview(filter, { signal }),
+    select: overviewToDisplay,
     enabled: isApiConfigured,
   });
 }

--- a/packages/web/lib/mesh-display.test.ts
+++ b/packages/web/lib/mesh-display.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import { overviewToDisplay } from "./mesh-display";
+import type { MeshOverview } from "@/lib/types/mesh";
+
+function emptyOverview(): MeshOverview {
+  return {
+    asks: [],
+    graph: { nodes: [], edges: [] },
+    summary: { asks_24h: 0, in_flight: 0, edge_count: 0 },
+  };
+}
+
+describe("overviewToDisplay — asks", () => {
+  it("maps caller/target labels + duration_label + chain depth", () => {
+    const overview: MeshOverview = {
+      ...emptyOverview(),
+      asks: [
+        {
+          id: "neg_1",
+          type: "negotiate",
+          caller_id: "agt_a",
+          caller_label: "Alice",
+          target_id: "agt_b",
+          target_label: "Bob",
+          status: "in_flight",
+          intent: "review the schema",
+          started_at: new Date("2026-04-30T11:00:00Z"),
+          completed_at: new Date("2026-04-30T11:30:00Z"),
+          rounds_completed: 2,
+          max_rounds: 5,
+        },
+      ],
+    };
+    const { asks } = overviewToDisplay(overview);
+    expect(asks).toHaveLength(1);
+    expect(asks[0]?.caller).toBe("Alice");
+    expect(asks[0]?.target).toBe("Bob");
+    expect(asks[0]?.duration_label).toBe("30m");
+    expect(asks[0]?.chain_depth).toBe("2/5");
+    expect(asks[0]?.intent).toBe("review the schema");
+  });
+
+  it("compresses rejected + escalated to blocked for the UI's 3-status palette", () => {
+    const overview: MeshOverview = {
+      ...emptyOverview(),
+      asks: (
+        ["in_flight", "succeeded", "rejected", "blocked", "escalated"] as const
+      ).map((status, i) => ({
+        id: `neg_${i}`,
+        type: "negotiate" as const,
+        caller_id: "agt_a",
+        caller_label: "A",
+        target_id: "agt_b",
+        target_label: "B",
+        status,
+        intent: "x",
+        started_at: new Date(),
+      })),
+    };
+    const { asks } = overviewToDisplay(overview);
+    expect(asks.map((a) => a.status)).toEqual([
+      "in_flight",
+      "succeeded",
+      "blocked",
+      "blocked",
+      "blocked",
+    ]);
+  });
+
+  it("uses '—' for chain_depth when rounds aren't tracked", () => {
+    const overview: MeshOverview = {
+      ...emptyOverview(),
+      asks: [
+        {
+          id: "ask_1",
+          type: "ask",
+          caller_id: "agt_a",
+          caller_label: "A",
+          target_id: "agt_b",
+          target_label: "B",
+          status: "succeeded",
+          intent: "x",
+          started_at: new Date(),
+        },
+      ],
+    };
+    expect(overviewToDisplay(overview).asks[0]?.chain_depth).toBe("—");
+  });
+});
+
+describe("overviewToDisplay — graph layout", () => {
+  it("places N nodes on a circle and produces SVG paths for edges", () => {
+    const overview: MeshOverview = {
+      ...emptyOverview(),
+      graph: {
+        nodes: [
+          { id: "agt_a", label: "Alice", hier: "team", state: "active" },
+          { id: "agt_b", label: "Bob", hier: "ic", state: "idle" },
+          { id: "agt_c", label: "Carol", hier: "ic", state: "active" },
+        ],
+        edges: [
+          { from: "agt_a", to: "agt_b", count: 1, state: "live" },
+          { from: "agt_a", to: "agt_c", count: 2, state: "completed" },
+        ],
+      },
+    };
+    const { graph } = overviewToDisplay(overview);
+    expect(graph.nodes).toHaveLength(3);
+    expect(graph.edges).toHaveLength(2);
+    for (const node of graph.nodes) {
+      expect(node.cx).toBeGreaterThan(0);
+      expect(node.cy).toBeGreaterThan(0);
+      expect(node.r).toBeGreaterThan(0);
+    }
+    expect(graph.edges[0]?.d).toMatch(/^M[\d.]+ [\d.]+ L[\d.]+ [\d.]+$/);
+  });
+
+  it("orders nodes by hierarchy (org → team → ic) then by name", () => {
+    const overview: MeshOverview = {
+      ...emptyOverview(),
+      graph: {
+        nodes: [
+          { id: "agt_z", label: "Zed", hier: "ic", state: "idle" },
+          { id: "agt_o", label: "Orin", hier: "org", state: "idle" },
+          { id: "agt_t", label: "Tara", hier: "team", state: "idle" },
+        ],
+        edges: [],
+      },
+    };
+    const labels = overviewToDisplay(overview).graph.nodes.map((n) => n.label);
+    expect(labels).toEqual(["Orin", "Tara", "Zed"]);
+  });
+
+  it("drops edges whose endpoints aren't in the node list (defensive)", () => {
+    const overview: MeshOverview = {
+      ...emptyOverview(),
+      graph: {
+        nodes: [{ id: "agt_a", label: "A", hier: "ic", state: "idle" }],
+        edges: [{ from: "agt_a", to: "agt_missing", count: 1, state: "completed" }],
+      },
+    };
+    expect(overviewToDisplay(overview).graph.edges).toHaveLength(0);
+  });
+});
+
+describe("overviewToDisplay — summary passthrough", () => {
+  it("forwards summary counts unchanged", () => {
+    const overview: MeshOverview = {
+      ...emptyOverview(),
+      summary: { asks_24h: 12, in_flight: 3, edge_count: 7 },
+    };
+    expect(overviewToDisplay(overview).summary).toEqual({
+      asks_24h: 12,
+      in_flight: 3,
+      edge_count: 7,
+    });
+  });
+});

--- a/packages/web/lib/mesh-display.ts
+++ b/packages/web/lib/mesh-display.ts
@@ -1,0 +1,55 @@
+/**
+ * Pure-data → display mapping for the mesh page.
+ *
+ * Status compression: the backend has 5 ask statuses
+ * ({in_flight, succeeded, rejected, blocked, escalated}) but the live UI
+ * only paints 3 buckets ({in_flight, succeeded, blocked}). The mapper
+ * lumps `rejected` + `escalated` into `blocked` since the visual treatment
+ * is "ask didn't resolve cleanly".
+ *
+ * Geometry: delegated to `lib/mesh-layout.ts`.
+ */
+
+import type {
+  MeshOverview,
+  MeshAskData,
+  MeshAsk,
+  MeshAskStatus,
+  MeshDisplay,
+} from "@/lib/types/mesh";
+import { layoutMeshGraph } from "@/lib/mesh-layout";
+import { formatDurationLabel } from "@/lib/format";
+
+export function overviewToDisplay(overview: MeshOverview): MeshDisplay {
+  const { nodes, edges } = layoutMeshGraph(overview.graph.nodes, overview.graph.edges);
+  return {
+    asks: overview.asks.map(askToDisplay),
+    graph: { nodes, edges },
+    summary: { ...overview.summary },
+  };
+}
+
+const DISPLAY_STATUS: Record<MeshAskStatus, MeshAsk["status"]> = {
+  in_flight: "in_flight",
+  succeeded: "succeeded",
+  rejected: "blocked",
+  blocked: "blocked",
+  escalated: "blocked",
+};
+
+function askToDisplay(data: MeshAskData): MeshAsk {
+  const display: MeshAsk = {
+    id: data.id,
+    caller: data.caller_label,
+    target: data.target_label,
+    type: data.type,
+    status: DISPLAY_STATUS[data.status],
+    duration_label: formatDurationLabel(data.started_at, data.completed_at),
+    intent: data.intent,
+    chain_depth:
+      data.rounds_completed !== undefined && data.max_rounds !== undefined
+        ? `${data.rounds_completed}/${data.max_rounds}`
+        : "—",
+  };
+  return display;
+}

--- a/packages/web/lib/mesh-layout.ts
+++ b/packages/web/lib/mesh-layout.ts
@@ -24,12 +24,6 @@ interface LaidOut {
   viewBox: { width: number; height: number };
 }
 
-const HIER_LABEL: Record<GraphNode["hier"], string> = {
-  org: "org",
-  team: "team",
-  ic: "ic",
-};
-
 const HIER_ORDER: Record<GraphNode["hier"], number> = {
   org: 0,
   team: 1,
@@ -71,7 +65,6 @@ export function layoutMeshGraph(
       id: n.id,
       label: n.label,
       hier: n.hier,
-      hier_label: HIER_LABEL[n.hier],
       cx,
       cy,
       r: NODE_RADIUS,

--- a/packages/web/lib/mesh-layout.ts
+++ b/packages/web/lib/mesh-layout.ts
@@ -1,0 +1,97 @@
+/**
+ * Simple radial layout for the mesh graph. Backend ships node IDs + edge
+ * pairs; this computes 2D positions for SVG rendering. Web-only — backend
+ * never computes geometry.
+ *
+ * Algorithm: place nodes evenly around a circle, ordered by hierarchy
+ * (org outermost, then team, then ic) so the visual matches the org
+ * structure. Edges are straight lines between source and target centers.
+ *
+ * Phase 2 could swap this for a force-directed layout (dagre/d3-force)
+ * once the graph density justifies it. For phase 1 — typically <10 nodes
+ * per page — a circle is enough.
+ */
+
+import type { GraphEdge, GraphNode, GraphEdgeData, GraphNodeData } from "@/lib/types/mesh";
+
+const VIEWBOX_W = 480;
+const VIEWBOX_H = 480;
+const NODE_RADIUS = 14;
+
+interface LaidOut {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  viewBox: { width: number; height: number };
+}
+
+const HIER_LABEL: Record<GraphNode["hier"], string> = {
+  org: "org",
+  team: "team",
+  ic: "ic",
+};
+
+const HIER_ORDER: Record<GraphNode["hier"], number> = {
+  org: 0,
+  team: 1,
+  ic: 2,
+};
+
+const EDGE_STATE: Record<GraphEdgeData["state"], GraphEdge["state"]> = {
+  live: "live",
+  completed: "completed",
+};
+
+const NODE_STATE: Record<GraphNodeData["state"], GraphNode["state"]> = {
+  active: "active",
+  idle: "idle",
+};
+
+export function layoutMeshGraph(
+  nodeData: readonly GraphNodeData[],
+  edgeData: readonly GraphEdgeData[],
+): LaidOut {
+  if (nodeData.length === 0) {
+    return { nodes: [], edges: [], viewBox: { width: VIEWBOX_W, height: VIEWBOX_H } };
+  }
+
+  const center = { x: VIEWBOX_W / 2, y: VIEWBOX_H / 2 };
+  const radius = Math.min(VIEWBOX_W, VIEWBOX_H) / 2 - NODE_RADIUS - 24;
+
+  const ordered = [...nodeData].sort(
+    (a, b) => HIER_ORDER[a.hier] - HIER_ORDER[b.hier] || a.label.localeCompare(b.label),
+  );
+
+  const positions = new Map<string, { cx: number; cy: number }>();
+  const nodes: GraphNode[] = ordered.map((n, i) => {
+    const theta = (2 * Math.PI * i) / ordered.length - Math.PI / 2;
+    const cx = center.x + radius * Math.cos(theta);
+    const cy = center.y + radius * Math.sin(theta);
+    positions.set(n.id, { cx, cy });
+    return {
+      id: n.id,
+      label: n.label,
+      hier: n.hier,
+      hier_label: HIER_LABEL[n.hier],
+      cx,
+      cy,
+      r: NODE_RADIUS,
+      state: NODE_STATE[n.state],
+    };
+  });
+
+  const edges: GraphEdge[] = edgeData.flatMap((e) => {
+    const from = positions.get(e.from);
+    const to = positions.get(e.to);
+    if (!from || !to) return [];
+    return [
+      {
+        from: e.from,
+        to: e.to,
+        d: `M${from.cx.toFixed(1)} ${from.cy.toFixed(1)} L${to.cx.toFixed(1)} ${to.cy.toFixed(1)}`,
+        state: EDGE_STATE[e.state],
+      },
+    ];
+  });
+
+  return { nodes, edges, viewBox: { width: VIEWBOX_W, height: VIEWBOX_H } };
+}

--- a/packages/web/lib/types/mesh.ts
+++ b/packages/web/lib/types/mesh.ts
@@ -1,5 +1,11 @@
 import type { RichText } from "@/components/rich-text";
 
+// ── Display shapes the mesh page binds against ────────────────────────────
+//
+// Produced by `lib/mesh-display.ts:overviewToDisplay()` from the pure-data
+// `MeshOverview` shipped by the backend. Backend never computes SVG
+// geometry, status colors, or relative-time labels.
+
 export interface MeshAsk {
   id: string;
   caller: string;
@@ -58,3 +64,22 @@ export interface MeshSummary {
   in_flight: number;
   edge_count: number;
 }
+
+/** Aggregated display the mesh page binds to. */
+export interface MeshDisplay {
+  asks: MeshAsk[];
+  graph: { nodes: GraphNode[]; edges: GraphEdge[] };
+  summary: MeshSummary;
+}
+
+// ── Re-export the backend data DTO ────────────────────────────────────────
+
+export type {
+  MeshOverview,
+  MeshAskData,
+  MeshAskType,
+  MeshAskStatus,
+  GraphNodeData,
+  GraphEdgeData,
+  MeshSummaryData,
+} from "@beevibe/api/views/types";

--- a/packages/web/lib/types/mesh.ts
+++ b/packages/web/lib/types/mesh.ts
@@ -43,7 +43,6 @@ export interface ChainBudgetData {
 export interface GraphNode {
   id: string;
   label: string;
-  hier_label: string;
   hier: "ic" | "team" | "org";
   cx: number;
   cy: number;


### PR DESCRIPTION
## Summary

Closes #34 (phase 1). Stacked on #39 (M8.B dashboard).

The mesh page is the second read surface to ship the **data/display split** pattern. Backend produces pure data; web composes display via a thin mapper + a small SVG-geometry helper (\`lib/mesh-layout.ts\`). Backend never computes geometry, color enums, or duration labels.

## What ships (phase 1)

V1 sources mesh activity from the **\`negotiation\` table only** — the canonical multi-round mesh activity, well-grounded in M6's persistence. Mesh-ask sessions and blocker sessions encode their caller in intent XML rather than a column, which makes SQL-side joining awkward; surfacing them is a follow-up.

### Backend (packages/api)

- \`views/mesh.ts\` — 4-query composer fired in parallel:
  - **asks** — recent + in-flight negotiations + agent labels + round-1 message
  - **nodes** — distinct agents involved in the window
  - **edges** — aggregated initiator → counterparty pairs with counts
  - **summary** — \`asks_24h\`, \`in_flight\`, \`edge_count\`
- \`views/types.ts\` — data DTOs: \`MeshOverview\`, \`MeshAskData\`, \`MeshAskType\`, \`MeshAskStatus\`, \`GraphNodeData\`, \`GraphEdgeData\`, \`MeshSummaryData\`
- \`routes/view.ts\` — mounts \`GET /mesh\` behind \`requireHuman\`
- \`mesh.test.ts\` — 8 mock-Pool tests covering empty state, status compression, round count passthrough, node/edge mapping

### Web (packages/web)

- \`lib/types/mesh.ts\` — keeps the display types (\`MeshAsk\`, \`GraphNode\` with \`cx/cy/r\`, \`GraphEdge\` with \`d\`); adds \`MeshDisplay\` aggregate. Re-exports backend data DTOs.
- \`lib/api/types.ts\` — drops the locally-declared \`MeshOverview\`; re-exports from \`@beevibe/api/views/types\`.
- \`lib/mesh-layout.ts\` — radial layout: nodes evenly around a circle, ordered by hierarchy (org→team→ic), straight-line edges between them.
- \`lib/mesh-display.ts\` — \`overviewToDisplay()\` mapper:
  - \`MeshAskStatus\` → \`MeshAsk["status"]\` (rejected + escalated → \`"blocked"\` since the UI's 3-status palette doesn't paint either separately)
  - data nodes/edges → display via \`layoutMeshGraph()\`
  - \`duration_label\` via \`formatDurationLabel\`
  - \`chain_depth\` rendered as \`"rounds_completed/max_rounds"\` (or \`"—"\` for non-negotiation asks)
- \`lib/format.ts\` — adds \`formatDurationLabel\` (mirrors backend's: "30s", "5m", "1h 12m", "2d 3h")
- \`lib/hooks/use-mesh.ts\` — applies mapper via React Query \`select\`
- \`mesh-client.tsx\` — binds \`MeshDisplay\`; passes graph nodes/edges to \`MeshGraphStatic\` in both empty and loaded branches
- \`components/mesh/graph-static.tsx\` — renders real SVG (nodes as circles colored by state, edges colored by state, hier-colored ring around each node) when nodes are present; falls back to \`EmptyState\` otherwise
- \`mesh-display.test.ts\` — 7 mapper tests covering status compression, layout positions, hierarchy ordering, defensive edge-drop

## Phase 2 (deferred — separate issues)

- **Chain-budget telemetry** (avg_depth / max_depth / tokens) — needs \`MeshServer\` instrumentation. UI keeps the EMPTY_ROW placeholder for now.
- **Mesh-ask sessions + blocker sessions** — need a \`parent_agent_id\` column on session, or intent-XML parsing in SQL. Currently fire-and-forget asks aren't surfaced.

## Test plan

- [x] \`pnpm -w typecheck\` — clean
- [x] \`pnpm -w build\` — clean (web Next build, api tsc)
- [x] api: 8 new mesh view tests pass; pre-existing DB-integration tests still gated on \`DATABASE_URL_TEST\`
- [x] web: 102/102 pass (was 95, +7 mapper tests)
- [ ] Manual smoke against \`pnpm dev\`: mesh page renders real negotiation activity from a stack with active escalations / negotiations

## Notes

- Stacked on #39 (M8.B). Rebase onto main once that lands.
- Pattern is now validated across two surfaces (dashboard + mesh). Adding a new read surface = ~1 view module + 1 mapper + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)