### PR TITLE
M8.C — GET /mesh phase 1 (re-PR against main)

### DIFF
--- a/migrations/1778000000000_add-dashboard-indexes.sql
+++ b/migrations/1778000000000_add-dashboard-indexes.sql
@@ -1,0 +1,21 @@
+-- M8.B dashboard view indexes.
+--
+-- The KPI_TREND_SQL and TREND_SQL queries in `packages/api/src/views/dashboard.ts`
+-- filter by `(status, updated_at)` and `(status, completed_at|started_at)` over
+-- 7-14 day windows. The existing `idx_task_status` and `idx_session_agent_status`
+-- cover the status leg only; without composite indexes on the timestamp legs,
+-- Postgres scans all rows matching the status before filtering by date.
+--
+-- For dashboard payload latency at workspace scale (10K+ tasks / sessions),
+-- the cost of these indexes is paid back by every home-page render.
+
+CREATE INDEX IF NOT EXISTS idx_task_status_updated
+  ON task(status, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_session_status_started
+  ON session(status, started_at DESC)
+  WHERE started_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_session_status_completed
+  ON session(status, completed_at DESC)
+  WHERE completed_at IS NOT NULL;

--- a/migrations/1778100000000_add-mesh-indexes.sql
+++ b/migrations/1778100000000_add-mesh-indexes.sql
@@ -1,0 +1,17 @@
+-- M8.C mesh view indexes.
+--
+-- The ASKS_SQL, NODES_SQL, EDGES_SQL, and SUMMARY_SQL queries in
+-- `packages/api/src/views/mesh.ts` filter
+--   WHERE created_at >= NOW() - INTERVAL '24 hours' OR status = 'active'
+-- and the existing indexes only cover (initiator_agent_id) and (task_id) —
+-- no leg of that filter is indexed. For workspaces with thousands of
+-- historical negotiations, the mesh page would scan the whole table.
+--
+-- Composite (status, created_at) serves both filter directions reasonably:
+--   - status='active' → uses leading column directly
+--   - created_at >= ... → bitmap-or with the same index
+--
+-- Matches the pattern set by 1778000000000_add-dashboard-indexes.sql.
+
+CREATE INDEX IF NOT EXISTS idx_negotiation_status_created
+  ON negotiation(status, created_at DESC);

--- a/packages/api/src/routes/view.ts
+++ b/packages/api/src/routes/view.ts
@@ -31,6 +31,7 @@ import { listAgents, getAgent } from "../views/agents.js";
 import { getSessionByShortId, AmbiguousShortIdError } from "../views/sessions.js";
 import { listMemoryFacts } from "../views/memory.js";
 import { getDashboardSummary } from "../views/dashboard.js";
+import { getMeshOverview } from "../views/mesh.js";
 
 export interface ViewRoutesDeps {
   authMiddleware: RequestHandler;
@@ -165,6 +166,16 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
       res.json(summary);
     } catch (err) {
       handleError(err, res, "dashboard summary");
+    }
+  });
+
+  router.get("/mesh", async (req, res) => {
+    if (!requireHuman(req, res)) return;
+    try {
+      const overview = await getMeshOverview(deps.pool);
+      res.json(overview);
+    } catch (err) {
+      handleError(err, res, "mesh overview");
     }
   });
 

--- a/packages/api/src/routes/view.ts
+++ b/packages/api/src/routes/view.ts
@@ -30,6 +30,7 @@ import {
 import { listAgents, getAgent } from "../views/agents.js";
 import { getSessionByShortId, AmbiguousShortIdError } from "../views/sessions.js";
 import { listMemoryFacts } from "../views/memory.js";
+import { getDashboardSummary } from "../views/dashboard.js";
 
 export interface ViewRoutesDeps {
   authMiddleware: RequestHandler;
@@ -154,6 +155,16 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
         return;
       }
       handleError(err, res, "session detail");
+    }
+  });
+
+  router.get("/dashboard", async (req, res) => {
+    if (!requireHuman(req, res)) return;
+    try {
+      const summary = await getDashboardSummary(deps.pool);
+      res.json(summary);
+    } catch (err) {
+      handleError(err, res, "dashboard summary");
     }
   });
 

--- a/packages/api/src/views/agents.test.ts
+++ b/packages/api/src/views/agents.test.ts
@@ -1,16 +1,10 @@
-import { describe, it, expect, vi } from "vitest";
-import type { Pool } from "@beevibe/core/adapters/postgres";
+import { describe, it, expect } from "vitest";
 import { listAgents, getAgent } from "./agents.js";
-
-function makePool(responses: unknown[][]) {
-  let i = 0;
-  const query = vi.fn(async () => ({ rows: responses[i++] ?? [] }));
-  return { query: query as unknown as Pool["query"] } as unknown as Pool;
-}
+import { makeMockPool } from "./test-helpers.js";
 
 describe("listAgents", () => {
   it("maps rows into AgentDisplay with hierarchy + sessions/facts counts", async () => {
-    const pool = makePool([
+    const pool = makeMockPool([
       [
         {
           id: "agt_org",
@@ -39,12 +33,12 @@ describe("listAgents", () => {
 
 describe("getAgent", () => {
   it("returns undefined when missing", async () => {
-    const pool = makePool([[], [], [], []]);
+    const pool = makeMockPool([[], [], [], []]);
     expect(await getAgent(pool, "agt_missing")).toBeUndefined();
   });
 
   it("aggregates blocks, recent sessions, and mesh hints when present", async () => {
-    const pool = makePool([
+    const pool = makeMockPool([
       [
         {
           id: "agt_team",

--- a/packages/api/src/views/dashboard.test.ts
+++ b/packages/api/src/views/dashboard.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Mock-Pool tests for views/dashboard.ts. Validates aggregation logic +
+ * row → DTO mapping. Real query correctness exercised by the existing
+ * api integration test layer; these stay DB-free.
+ *
+ * Query order in the implementation:
+ *   1) STATUS_COUNT_SQL          → status counts
+ *   2) FLEET_SQL                 → per-hier counts + active
+ *   3) TREND_SQL                 → 14 days of completed sessions
+ *   4) ATTENTION_SQL             → blocked/failed/review tasks
+ *   5) KPI_TREND_SQL             → 7 days of per-KPI counts
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import { getDashboardSummary } from "./dashboard.js";
+
+function makePool(responses: unknown[][]) {
+  let i = 0;
+  const query = vi.fn(async () => ({ rows: responses[i++] ?? [] }));
+  return { query: query as unknown as Pool["query"] } as unknown as Pool;
+}
+
+function makeKpiTrendRows(): unknown[] {
+  return Array.from({ length: 7 }, (_, i) => ({
+    day: `2026-04-${24 + i}`,
+    active_sessions: i,
+    in_review: 0,
+    completed_today: i === 6 ? 5 : 0,
+    blocked: 0,
+  }));
+}
+
+function makeTrendRows(): unknown[] {
+  // 14 days: prior 7 = 7×1 = 7 total, recent 7 = 7×2 = 14 total → +100%
+  return Array.from({ length: 14 }, (_, i) => ({
+    day: `2026-04-${17 + i}`,
+    count: i < 7 ? 1 : 2,
+  }));
+}
+
+describe("getDashboardSummary", () => {
+  it("computes percentages from raw status counts and ranks descending", async () => {
+    const pool = makePool([
+      [
+        { status: "in_progress", count: 6 },
+        { status: "review", count: 2 },
+        { status: "done", count: 2 },
+      ],
+      [], // fleet
+      makeTrendRows(),
+      [], // attention
+      makeKpiTrendRows(),
+    ]);
+    const summary = await getDashboardSummary(pool);
+    expect(summary.status_total).toBe(10);
+    expect(summary.status_breakdown[0]).toEqual({
+      status: "in_progress",
+      count: 6,
+      percent: 60,
+    });
+    expect(summary.status_breakdown).toHaveLength(3);
+  });
+
+  it("buckets statuses into the legend's coarser groups", async () => {
+    const pool = makePool([
+      [
+        { status: "pending", count: 1 },
+        { status: "assigned", count: 2 },
+        { status: "in_progress", count: 3 },
+        { status: "revision", count: 4 },
+        { status: "review", count: 5 },
+        { status: "blocked", count: 6 },
+        { status: "done", count: 7 },
+        { status: "failed", count: 8 },
+      ],
+      [],
+      makeTrendRows(),
+      [],
+      makeKpiTrendRows(),
+    ]);
+    const { status_legend } = await getDashboardSummary(pool);
+    const map = new Map(status_legend.map((l) => [l.bucket, l.count]));
+    expect(map.get("pending")).toBe(3); // pending + assigned
+    expect(map.get("running")).toBe(7); // in_progress + revision
+    expect(map.get("review")).toBe(5);
+    expect(map.get("blocked")).toBe(6);
+    expect(map.get("done")).toBe(7);
+    expect(map.get("failed")).toBe(8);
+  });
+
+  it("aggregates fleet counts across hierarchies and computes active total", async () => {
+    const pool = makePool([
+      [],
+      [
+        { hier: "org", count: 1, active: 1 },
+        { hier: "team", count: 2, active: 1 },
+        { hier: "ic", count: 5, active: 0 },
+      ],
+      makeTrendRows(),
+      [],
+      makeKpiTrendRows(),
+    ]);
+    const summary = await getDashboardSummary(pool);
+    expect(summary.fleet_total).toBe(8);
+    expect(summary.fleet_active).toBe(2);
+    expect(summary.fleet_idle).toBe(6);
+    expect(summary.fleet[0]?.percent).toBeCloseTo(12.5, 1);
+  });
+
+  it("splits the trend window in half and computes the change percent", async () => {
+    const pool = makePool([[], [], makeTrendRows(), [], makeKpiTrendRows()]);
+    const { trend, trend_total, trend_change_percent } = await getDashboardSummary(pool);
+    expect(trend).toHaveLength(7);
+    expect(trend_total).toBe(14); // 7 days × 2
+    expect(trend_change_percent).toBe(100); // doubled vs prior
+  });
+
+  it("flags is_today on the most recent trend row", async () => {
+    const pool = makePool([[], [], makeTrendRows(), [], makeKpiTrendRows()]);
+    const { trend } = await getDashboardSummary(pool);
+    expect(trend.filter((d) => d.is_today)).toHaveLength(1);
+    expect(trend[trend.length - 1]?.is_today).toBe(true);
+  });
+
+  it("emits 4 KPIs (active_sessions, in_review, completed_today, blocked) with raw values", async () => {
+    const pool = makePool([
+      [
+        { status: "review", count: 4 },
+        { status: "blocked", count: 2 },
+      ],
+      [{ hier: "team", count: 3, active: 2 }],
+      makeTrendRows(),
+      [],
+      makeKpiTrendRows(),
+    ]);
+    const { kpis } = await getDashboardSummary(pool);
+    expect(kpis.map((k) => k.kind)).toEqual([
+      "active_sessions",
+      "in_review",
+      "completed_today",
+      "blocked",
+    ]);
+    expect(kpis.find((k) => k.kind === "active_sessions")?.value).toBe(2); // fleet_active
+    expect(kpis.find((k) => k.kind === "in_review")?.value).toBe(4);
+    expect(kpis.find((k) => k.kind === "completed_today")?.value).toBe(5); // last day of trend
+    expect(kpis.find((k) => k.kind === "blocked")?.value).toBe(2);
+  });
+
+  it("handles 0 totals without dividing by zero", async () => {
+    const pool = makePool([[], [], makeTrendRows(), [], makeKpiTrendRows()]);
+    const { status_total, status_breakdown, fleet_total, fleet } = await getDashboardSummary(pool);
+    expect(status_total).toBe(0);
+    expect(status_breakdown).toEqual([]);
+    expect(fleet_total).toBe(0);
+    expect(fleet).toEqual([]);
+  });
+
+  it("treats no-prior-period as 0% change when current is also 0", async () => {
+    const flatTrend = Array.from({ length: 14 }, (_, i) => ({
+      day: `2026-04-${17 + i}`,
+      count: 0,
+    }));
+    const pool = makePool([[], [], flatTrend, [], makeKpiTrendRows()]);
+    const { trend_change_percent } = await getDashboardSummary(pool);
+    expect(trend_change_percent).toBe(0);
+  });
+
+  it("treats no-prior-period with positive current as 100% change", async () => {
+    const trendRows = Array.from({ length: 14 }, (_, i) => ({
+      day: `2026-04-${17 + i}`,
+      count: i < 7 ? 0 : 3,
+    }));
+    const pool = makePool([[], [], trendRows, [], makeKpiTrendRows()]);
+    const { trend_change_percent } = await getDashboardSummary(pool);
+    expect(trend_change_percent).toBe(100);
+  });
+
+  it("maps attention rows preserving title, status, and ISO timestamp", async () => {
+    const ts = new Date("2026-04-30T10:00:00Z");
+    const pool = makePool([
+      [],
+      [],
+      makeTrendRows(),
+      [{ id: "task_1", title: "needs API key", status: "blocked", created_at: ts }],
+      makeKpiTrendRows(),
+    ]);
+    const { attention } = await getDashboardSummary(pool);
+    expect(attention).toHaveLength(1);
+    expect(attention[0]).toEqual({
+      task_id: "task_1",
+      title: "needs API key",
+      status: "blocked",
+      created_at: ts,
+    });
+  });
+
+  it("fires all 5 queries in parallel (single Promise.all)", async () => {
+    const calls: number[] = [];
+    let next = 0;
+    const query = vi.fn(async (sql: unknown) => {
+      const i = next++;
+      calls.push(i);
+      // First-issued query resolves last to prove they were issued together,
+      // not awaited sequentially.
+      await new Promise((r) => setTimeout(r, i === 0 ? 10 : 0));
+      const sqlText = String(sql);
+      if (sqlText.includes("FROM days") && sqlText.includes("active_sessions")) return { rows: makeKpiTrendRows() };
+      if (sqlText.includes("FROM days")) return { rows: makeTrendRows() };
+      if (sqlText.includes("FROM agent")) return { rows: [] };
+      if (sqlText.includes("blocked', 'failed'")) return { rows: [] };
+      return { rows: [] };
+    });
+    const pool = { query } as unknown as Pool;
+    await getDashboardSummary(pool);
+    expect(calls).toEqual([0, 1, 2, 3, 4]); // dispatched in order, all together
+    expect(query).toHaveBeenCalledTimes(5);
+  });
+});

--- a/packages/api/src/views/dashboard.test.ts
+++ b/packages/api/src/views/dashboard.test.ts
@@ -13,12 +13,7 @@
 import { describe, it, expect, vi } from "vitest";
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import { getDashboardSummary } from "./dashboard.js";
-
-function makePool(responses: unknown[][]) {
-  let i = 0;
-  const query = vi.fn(async () => ({ rows: responses[i++] ?? [] }));
-  return { query: query as unknown as Pool["query"] } as unknown as Pool;
-}
+import { makeMockPool } from "./test-helpers.js";
 
 function makeKpiTrendRows(): unknown[] {
   return Array.from({ length: 7 }, (_, i) => ({
@@ -40,7 +35,7 @@ function makeTrendRows(): unknown[] {
 
 describe("getDashboardSummary", () => {
   it("computes percentages from raw status counts and ranks descending", async () => {
-    const pool = makePool([
+    const pool = makeMockPool([
       [
         { status: "in_progress", count: 6 },
         { status: "review", count: 2 },
@@ -62,7 +57,7 @@ describe("getDashboardSummary", () => {
   });
 
   it("buckets statuses into the legend's coarser groups", async () => {
-    const pool = makePool([
+    const pool = makeMockPool([
       [
         { status: "pending", count: 1 },
         { status: "assigned", count: 2 },
@@ -89,7 +84,7 @@ describe("getDashboardSummary", () => {
   });
 
   it("aggregates fleet counts across hierarchies and computes active total", async () => {
-    const pool = makePool([
+    const pool = makeMockPool([
       [],
       [
         { hier: "org", count: 1, active: 1 },
@@ -108,7 +103,7 @@ describe("getDashboardSummary", () => {
   });
 
   it("splits the trend window in half and computes the change percent", async () => {
-    const pool = makePool([[], [], makeTrendRows(), [], makeKpiTrendRows()]);
+    const pool = makeMockPool([[], [], makeTrendRows(), [], makeKpiTrendRows()]);
     const { trend, trend_total, trend_change_percent } = await getDashboardSummary(pool);
     expect(trend).toHaveLength(7);
     expect(trend_total).toBe(14); // 7 days × 2
@@ -116,14 +111,14 @@ describe("getDashboardSummary", () => {
   });
 
   it("flags is_today on the most recent trend row", async () => {
-    const pool = makePool([[], [], makeTrendRows(), [], makeKpiTrendRows()]);
+    const pool = makeMockPool([[], [], makeTrendRows(), [], makeKpiTrendRows()]);
     const { trend } = await getDashboardSummary(pool);
     expect(trend.filter((d) => d.is_today)).toHaveLength(1);
     expect(trend[trend.length - 1]?.is_today).toBe(true);
   });
 
   it("emits 4 KPIs (active_sessions, in_review, completed_today, blocked) with raw values", async () => {
-    const pool = makePool([
+    const pool = makeMockPool([
       [
         { status: "review", count: 4 },
         { status: "blocked", count: 2 },
@@ -147,7 +142,7 @@ describe("getDashboardSummary", () => {
   });
 
   it("handles 0 totals without dividing by zero", async () => {
-    const pool = makePool([[], [], makeTrendRows(), [], makeKpiTrendRows()]);
+    const pool = makeMockPool([[], [], makeTrendRows(), [], makeKpiTrendRows()]);
     const { status_total, status_breakdown, fleet_total, fleet } = await getDashboardSummary(pool);
     expect(status_total).toBe(0);
     expect(status_breakdown).toEqual([]);
@@ -160,7 +155,7 @@ describe("getDashboardSummary", () => {
       day: `2026-04-${17 + i}`,
       count: 0,
     }));
-    const pool = makePool([[], [], flatTrend, [], makeKpiTrendRows()]);
+    const pool = makeMockPool([[], [], flatTrend, [], makeKpiTrendRows()]);
     const { trend_change_percent } = await getDashboardSummary(pool);
     expect(trend_change_percent).toBe(0);
   });
@@ -170,14 +165,14 @@ describe("getDashboardSummary", () => {
       day: `2026-04-${17 + i}`,
       count: i < 7 ? 0 : 3,
     }));
-    const pool = makePool([[], [], trendRows, [], makeKpiTrendRows()]);
+    const pool = makeMockPool([[], [], trendRows, [], makeKpiTrendRows()]);
     const { trend_change_percent } = await getDashboardSummary(pool);
     expect(trend_change_percent).toBe(100);
   });
 
   it("maps attention rows preserving title, status, and ISO timestamp", async () => {
     const ts = new Date("2026-04-30T10:00:00Z");
-    const pool = makePool([
+    const pool = makeMockPool([
       [],
       [],
       makeTrendRows(),

--- a/packages/api/src/views/dashboard.ts
+++ b/packages/api/src/views/dashboard.ts
@@ -1,0 +1,289 @@
+/**
+ * Dashboard view — pure data composer for the home page. Returns counts,
+ * percents, and raw IDs/timestamps. Display fields (colors, hrefs, day
+ * labels, "5m ago" age) are computed web-side via `lib/dashboard-display.ts`.
+ *
+ * One round-trip: 5 queries fired in parallel. None depends on the others.
+ */
+
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import type { HierarchyLevel, TaskStatus } from "@beevibe/core";
+import type {
+  DashboardSummary,
+  KpiData,
+  StatusBreakdownData,
+  StatusLegendData,
+  FleetBarData,
+  TrendDayData,
+  AttentionData,
+  LegendBucket,
+} from "./types.js";
+
+interface StatusCountRow {
+  status: TaskStatus;
+  count: string;
+}
+
+interface FleetCountRow {
+  hier: HierarchyLevel;
+  count: string;
+  active: string;
+}
+
+interface TrendRow {
+  day: string;
+  count: string;
+}
+
+interface AttentionRow {
+  id: string;
+  title: string;
+  status: "blocked" | "failed" | "review";
+  created_at: Date;
+}
+
+interface KpiTrendRow {
+  day: string;
+  active_sessions: string;
+  in_review: string;
+  completed_today: string;
+  blocked: string;
+}
+
+const STATUS_COUNT_SQL = /* sql */ `
+SELECT status, COUNT(*)::int AS count
+FROM task
+GROUP BY status
+`;
+
+const FLEET_SQL = /* sql */ `
+WITH active_agents AS (
+  SELECT DISTINCT agent_id FROM session WHERE status = 'running'
+)
+SELECT
+  a.hierarchy_level AS hier,
+  COUNT(*)::int     AS count,
+  COUNT(*) FILTER (WHERE aa.agent_id IS NOT NULL)::int AS active
+FROM agent a
+LEFT JOIN active_agents aa ON aa.agent_id = a.id
+GROUP BY a.hierarchy_level
+`;
+
+const TREND_SQL = /* sql */ `
+WITH days AS (
+  SELECT (CURRENT_DATE - i)::date AS d
+  FROM generate_series(0, $1 - 1) AS i
+),
+session_counts AS (
+  SELECT (completed_at AT TIME ZONE 'UTC')::date AS day, COUNT(*)::int AS n
+  FROM session
+  WHERE status = 'succeeded'
+    AND completed_at >= CURRENT_DATE - $1::int
+  GROUP BY day
+)
+SELECT
+  to_char(days.d, 'YYYY-MM-DD') AS day,
+  COALESCE(sc.n, 0)::int        AS count
+FROM days
+LEFT JOIN session_counts sc ON sc.day = days.d
+ORDER BY days.d ASC
+`;
+
+const ATTENTION_SQL = /* sql */ `
+SELECT id, title, status, updated_at AS created_at
+FROM task
+WHERE status IN ('blocked', 'failed', 'review')
+ORDER BY updated_at DESC
+LIMIT $1
+`;
+
+const KPI_TREND_SQL = /* sql */ `
+WITH days AS (
+  SELECT (CURRENT_DATE - i)::date AS d
+  FROM generate_series(0, $1 - 1) AS i
+),
+sessions_per_day AS (
+  SELECT (started_at AT TIME ZONE 'UTC')::date AS day, COUNT(*)::int AS n
+  FROM session
+  WHERE started_at >= CURRENT_DATE - $1::int
+  GROUP BY day
+),
+review_per_day AS (
+  SELECT (updated_at AT TIME ZONE 'UTC')::date AS day, COUNT(*)::int AS n
+  FROM task
+  WHERE status = 'review'
+    AND updated_at >= CURRENT_DATE - $1::int
+  GROUP BY day
+),
+done_per_day AS (
+  SELECT (updated_at AT TIME ZONE 'UTC')::date AS day, COUNT(*)::int AS n
+  FROM task
+  WHERE status = 'done'
+    AND updated_at >= CURRENT_DATE - $1::int
+  GROUP BY day
+),
+blocked_per_day AS (
+  SELECT (updated_at AT TIME ZONE 'UTC')::date AS day, COUNT(*)::int AS n
+  FROM task
+  WHERE status = 'blocked'
+    AND updated_at >= CURRENT_DATE - $1::int
+  GROUP BY day
+)
+SELECT
+  to_char(days.d, 'YYYY-MM-DD')      AS day,
+  COALESCE(s.n, 0)::int              AS active_sessions,
+  COALESCE(r.n, 0)::int              AS in_review,
+  COALESCE(c.n, 0)::int              AS completed_today,
+  COALESCE(b.n, 0)::int              AS blocked
+FROM days
+LEFT JOIN sessions_per_day s ON s.day = days.d
+LEFT JOIN review_per_day   r ON r.day = days.d
+LEFT JOIN done_per_day     c ON c.day = days.d
+LEFT JOIN blocked_per_day  b ON b.day = days.d
+ORDER BY days.d ASC
+`;
+
+const TREND_WINDOW_DAYS = 7;
+const ATTENTION_LIMIT = 8;
+
+/** Map raw task status to the legend's coarser bucket. */
+function legendBucket(status: TaskStatus): LegendBucket {
+  switch (status) {
+    case "in_progress":
+    case "revision":
+      return "running";
+    case "review":
+      return "review";
+    case "blocked":
+      return "blocked";
+    case "done":
+      return "done";
+    case "failed":
+      return "failed";
+    case "pending":
+    case "assigned":
+    case "needs_revision":
+    case "cancelled":
+      return "pending";
+  }
+}
+
+export async function getDashboardSummary(pool: Pool): Promise<DashboardSummary> {
+  const [statusResult, fleetResult, trendResult, attentionResult, kpiTrendResult] =
+    await Promise.all([
+      pool.query<StatusCountRow>(STATUS_COUNT_SQL),
+      pool.query<FleetCountRow>(FLEET_SQL),
+      pool.query<TrendRow>(TREND_SQL, [TREND_WINDOW_DAYS * 2]),
+      pool.query<AttentionRow>(ATTENTION_SQL, [ATTENTION_LIMIT]),
+      pool.query<KpiTrendRow>(KPI_TREND_SQL, [TREND_WINDOW_DAYS]),
+    ]);
+
+  const status_total = statusResult.rows.reduce((s, r) => s + Number(r.count), 0);
+  const status_breakdown: StatusBreakdownData[] = statusResult.rows
+    .map((r) => ({
+      status: r.status,
+      count: Number(r.count),
+      percent: status_total === 0 ? 0 : (Number(r.count) / status_total) * 100,
+    }))
+    .sort((a, b) => b.count - a.count);
+
+  const legendBuckets = new Map<LegendBucket, number>();
+  for (const r of statusResult.rows) {
+    const b = legendBucket(r.status);
+    legendBuckets.set(b, (legendBuckets.get(b) ?? 0) + Number(r.count));
+  }
+  const status_legend: StatusLegendData[] = Array.from(legendBuckets.entries()).map(
+    ([bucket, count]) => ({ bucket, count }),
+  );
+
+  const fleet_total = fleetResult.rows.reduce((s, r) => s + Number(r.count), 0);
+  const fleet_active = fleetResult.rows.reduce((s, r) => s + Number(r.active), 0);
+  const fleet: FleetBarData[] = fleetResult.rows.map((r) => ({
+    hier: r.hier,
+    count: Number(r.count),
+    percent: fleet_total === 0 ? 0 : (Number(r.count) / fleet_total) * 100,
+  }));
+
+  // Trend window of 14 days: split into prior 7 and current 7 to compute the
+  // "+12% vs prior" delta. Backend produces both numbers; web picks the format.
+  const all = trendResult.rows.map((r) => ({ day: r.day, value: Number(r.count) }));
+  const recent = all.slice(-TREND_WINDOW_DAYS);
+  const prior = all.slice(0, TREND_WINDOW_DAYS);
+  const today = recent[recent.length - 1]?.day;
+  const trend: TrendDayData[] = recent.map((r) => ({
+    date: r.day,
+    value: r.value,
+    is_today: r.day === today,
+  }));
+  const trend_total = recent.reduce((s, r) => s + r.value, 0);
+  const priorTotal = prior.reduce((s, r) => s + r.value, 0);
+  const trend_change_percent =
+    priorTotal === 0
+      ? trend_total === 0
+        ? 0
+        : 100
+      : Math.round(((trend_total - priorTotal) / priorTotal) * 100);
+
+  const attention: AttentionData[] = attentionResult.rows.map((r) => ({
+    task_id: r.id,
+    title: r.title,
+    status: r.status,
+    created_at: r.created_at,
+  }));
+
+  const kpis: KpiData[] = buildKpis(kpiTrendResult.rows, statusResult.rows, fleet_active);
+
+  return {
+    kpis,
+    status_breakdown,
+    status_legend,
+    status_total,
+    fleet,
+    fleet_total,
+    fleet_active,
+    fleet_idle: fleet_total - fleet_active,
+    trend,
+    trend_total,
+    trend_change_percent,
+    attention,
+  };
+}
+
+function buildKpis(
+  kpiRows: KpiTrendRow[],
+  statusRows: StatusCountRow[],
+  activeAgents: number,
+): KpiData[] {
+  const statusMap = new Map<TaskStatus, number>();
+  for (const r of statusRows) statusMap.set(r.status, Number(r.count));
+
+  const last = (key: keyof Omit<KpiTrendRow, "day">): number =>
+    kpiRows.length > 0 ? Number(kpiRows[kpiRows.length - 1]![key]) : 0;
+  const trend = (key: keyof Omit<KpiTrendRow, "day">): number[] =>
+    kpiRows.map((r) => Number(r[key]));
+
+  return [
+    {
+      kind: "active_sessions",
+      value: activeAgents,
+      unit: "running",
+      trend: trend("active_sessions"),
+    },
+    {
+      kind: "in_review",
+      value: statusMap.get("review") ?? 0,
+      trend: trend("in_review"),
+    },
+    {
+      kind: "completed_today",
+      value: last("completed_today"),
+      unit: "today",
+      trend: trend("completed_today"),
+    },
+    {
+      kind: "blocked",
+      value: statusMap.get("blocked") ?? 0,
+      trend: trend("blocked"),
+    },
+  ];
+}

--- a/packages/api/src/views/memory.test.ts
+++ b/packages/api/src/views/memory.test.ts
@@ -1,55 +1,47 @@
-import { describe, it, expect, vi } from "vitest";
-import type { Pool } from "@beevibe/core/adapters/postgres";
+import { describe, it, expect } from "vitest";
 import { listMemoryFacts } from "./memory.js";
-
-function makePool(rows: unknown[]) {
-  const query = vi.fn(async () => ({ rows }));
-  return {
-    query: query as unknown as Pool["query"],
-    _spy: query,
-  } as unknown as Pool & { _spy: ReturnType<typeof vi.fn> };
-}
+import { makeMockPool } from "./test-helpers.js";
 
 describe("listMemoryFacts", () => {
   it("filters by owner and forwards null scope + default limit when not provided", async () => {
-    const pool = makePool([]);
+    const pool = makeMockPool([]);
     await listMemoryFacts(pool, "per_w");
-    expect((pool as unknown as { _spy: ReturnType<typeof vi.fn> })._spy).toHaveBeenCalledWith(
+    expect(pool._spy).toHaveBeenCalledWith(
       expect.any(String),
       ["per_w", null, 200],
     );
   });
 
   it("forwards scope when provided", async () => {
-    const pool = makePool([]);
+    const pool = makeMockPool([]);
     await listMemoryFacts(pool, "per_w", { scope: "team" });
-    expect((pool as unknown as { _spy: ReturnType<typeof vi.fn> })._spy).toHaveBeenCalledWith(
+    expect(pool._spy).toHaveBeenCalledWith(
       expect.any(String),
       ["per_w", "team", 200],
     );
   });
 
   it("clamps limit to [1, 1000]", async () => {
-    const pool = makePool([]);
+    const pool = makeMockPool([]);
     await listMemoryFacts(pool, "per_w", { limit: 50 });
-    expect((pool as unknown as { _spy: ReturnType<typeof vi.fn> })._spy).toHaveBeenLastCalledWith(
+    expect(pool._spy).toHaveBeenLastCalledWith(
       expect.any(String),
       ["per_w", null, 50],
     );
     await listMemoryFacts(pool, "per_w", { limit: 9999 });
-    expect((pool as unknown as { _spy: ReturnType<typeof vi.fn> })._spy).toHaveBeenLastCalledWith(
+    expect(pool._spy).toHaveBeenLastCalledWith(
       expect.any(String),
       ["per_w", null, 1000],
     );
     await listMemoryFacts(pool, "per_w", { limit: 0 });
-    expect((pool as unknown as { _spy: ReturnType<typeof vi.fn> })._spy).toHaveBeenLastCalledWith(
+    expect(pool._spy).toHaveBeenLastCalledWith(
       expect.any(String),
       ["per_w", null, 1],
     );
   });
 
   it("maps merge_origin from source_session_ids cardinality", async () => {
-    const pool = makePool([
+    const pool = makeMockPool([
       {
         id: "fact_1",
         agent_id: "agt_a",

--- a/packages/api/src/views/mesh.test.ts
+++ b/packages/api/src/views/mesh.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Mock-Pool tests for views/mesh.ts. Validates row → DTO mapping +
+ * status compression. Real query correctness is covered by integration
+ * tests; these stay DB-free.
+ *
+ * Query order in the implementation:
+ *   1) ASKS_SQL    → recent + in-flight negotiations
+ *   2) NODES_SQL   → distinct involved agents
+ *   3) EDGES_SQL   → aggregated initiator → counterparty pairs
+ *   4) SUMMARY_SQL → total counts
+ */
+import { describe, it, expect } from "vitest";
+import { getMeshOverview } from "./mesh.js";
+import { makeMockPool } from "./test-helpers.js";
+
+const baseAsk = {
+  id: "neg_1",
+  caller_id: "agt_a",
+  caller_label: "Alice",
+  target_id: "agt_b",
+  target_label: "Bob",
+  source_task_id: "task_1",
+  rounds_completed: 2,
+  max_rounds: 5,
+  started_at: new Date("2026-04-30T11:00:00Z"),
+  completed_at_or_updated: new Date("2026-04-30T11:30:00Z"),
+  intent: "Can you review this?",
+};
+
+describe("getMeshOverview — asks", () => {
+  it("returns empty arrays + zero summary when DB is empty", async () => {
+    const pool = makeMockPool([[], [], [], []]);
+    const overview = await getMeshOverview(pool);
+    expect(overview.asks).toEqual([]);
+    expect(overview.graph.nodes).toEqual([]);
+    expect(overview.graph.edges).toEqual([]);
+    expect(overview.summary).toEqual({ asks_24h: 0, in_flight: 0, edge_count: 0 });
+  });
+
+  it("maps an active negotiation to in_flight + omits completed_at", async () => {
+    const pool = makeMockPool([
+      [{ ...baseAsk, status: "active" }],
+      [],
+      [],
+      [],
+    ]);
+    const { asks } = await getMeshOverview(pool);
+    expect(asks).toHaveLength(1);
+    expect(asks[0]?.status).toBe("in_flight");
+    expect(asks[0]?.completed_at).toBeUndefined();
+    expect(asks[0]?.caller_label).toBe("Alice");
+    expect(asks[0]?.target_label).toBe("Bob");
+    expect(asks[0]?.intent).toBe("Can you review this?");
+    expect(asks[0]?.rounds_completed).toBe(2);
+    expect(asks[0]?.max_rounds).toBe(5);
+  });
+
+  it("compresses negotiation.status into MeshAskStatus", async () => {
+    const pool = makeMockPool([
+      [
+        { ...baseAsk, id: "neg_a", status: "active" },
+        { ...baseAsk, id: "neg_b", status: "accepted" },
+        { ...baseAsk, id: "neg_c", status: "rejected" },
+        { ...baseAsk, id: "neg_d", status: "escalated" },
+        { ...baseAsk, id: "neg_e", status: "cancelled" },
+      ],
+      [],
+      [],
+      [],
+    ]);
+    const { asks } = await getMeshOverview(pool);
+    const statusByid = Object.fromEntries(asks.map((a) => [a.id, a.status]));
+    expect(statusByid).toEqual({
+      neg_a: "in_flight",
+      neg_b: "succeeded",
+      neg_c: "rejected",
+      neg_d: "escalated",
+      neg_e: "blocked",
+    });
+  });
+
+  it("populates completed_at from updated_at for terminal asks", async () => {
+    const pool = makeMockPool([
+      [{ ...baseAsk, status: "accepted" }],
+      [],
+      [],
+      [],
+    ]);
+    const { asks } = await getMeshOverview(pool);
+    expect(asks[0]?.completed_at).toEqual(new Date("2026-04-30T11:30:00Z"));
+  });
+
+  it("falls back to '(no message)' when round 1 message is null", async () => {
+    const pool = makeMockPool([
+      [{ ...baseAsk, status: "active", intent: null }],
+      [],
+      [],
+      [],
+    ]);
+    const { asks } = await getMeshOverview(pool);
+    expect(asks[0]?.intent).toBe("(no message)");
+  });
+});
+
+describe("getMeshOverview — nodes + edges + summary", () => {
+  it("maps node rows preserving hierarchy and active state", async () => {
+    const pool = makeMockPool([
+      [],
+      [
+        { id: "agt_a", label: "Alice", hier: "team", is_active: true },
+        { id: "agt_b", label: "Bob", hier: "ic", is_active: false },
+      ],
+      [],
+      [],
+    ]);
+    const { graph } = await getMeshOverview(pool);
+    expect(graph.nodes).toEqual([
+      { id: "agt_a", label: "Alice", hier: "team", state: "active" },
+      { id: "agt_b", label: "Bob", hier: "ic", state: "idle" },
+    ]);
+  });
+
+  it("maps edges with count + live state", async () => {
+    const pool = makeMockPool([
+      [],
+      [],
+      [
+        { from_id: "agt_a", to_id: "agt_b", count: 3, has_live: true },
+        { from_id: "agt_a", to_id: "agt_c", count: 1, has_live: false },
+      ],
+      [],
+    ]);
+    const { graph } = await getMeshOverview(pool);
+    expect(graph.edges).toEqual([
+      { from: "agt_a", to: "agt_b", count: 3, state: "live" },
+      { from: "agt_a", to: "agt_c", count: 1, state: "completed" },
+    ]);
+  });
+
+  it("forwards summary counts", async () => {
+    const pool = makeMockPool([
+      [],
+      [],
+      [],
+      [{ asks_24h: 12, in_flight: 3, edge_count: 7 }],
+    ]);
+    const { summary } = await getMeshOverview(pool);
+    expect(summary).toEqual({ asks_24h: 12, in_flight: 3, edge_count: 7 });
+  });
+});

--- a/packages/api/src/views/mesh.ts
+++ b/packages/api/src/views/mesh.ts
@@ -1,0 +1,206 @@
+/**
+ * Mesh view — pure-data composer for the mesh activity page.
+ *
+ * V1 ships from the `negotiation` table only (the canonical multi-round
+ * mesh activity, well-grounded in M6's persistence). Mesh-ask sessions
+ * (`session WHERE type = 'mesh_ask'`) and blocker sessions encode their
+ * caller in the intent XML attribute rather than a column, which makes
+ * SQL-side joining awkward; surfacing them is a follow-up.
+ *
+ * 4 queries fired in parallel:
+ *   - `asks`     — recent + in-flight negotiations + agent labels + round-1 message
+ *   - `nodes`    — distinct agents involved in mesh activity in the window
+ *   - `edges`    — aggregated initiator → counterparty pairs with counts
+ *   - `summary`  — totals (asks_24h, in_flight, edge_count)
+ */
+
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import type { HierarchyLevel } from "@beevibe/core";
+import type {
+  MeshOverview,
+  MeshAskData,
+  MeshAskStatus,
+  GraphNodeData,
+  GraphEdgeData,
+  MeshSummaryData,
+} from "./types.js";
+
+const ASKS_LIMIT = 50;
+const WINDOW = "24 hours";
+
+const ASKS_SQL = /* sql */ `
+SELECT
+  n.id,
+  n.initiator_agent_id     AS caller_id,
+  ca.name                  AS caller_label,
+  n.counterparty_agent_id  AS target_id,
+  ta.name                  AS target_label,
+  n.status,
+  n.task_id                AS source_task_id,
+  n.rounds_completed,
+  n.max_rounds,
+  n.created_at             AS started_at,
+  n.updated_at             AS completed_at_or_updated,
+  nr1.message              AS intent
+FROM negotiation n
+JOIN agent ca ON ca.id = n.initiator_agent_id
+JOIN agent ta ON ta.id = n.counterparty_agent_id
+LEFT JOIN negotiation_round nr1
+  ON nr1.negotiation_id = n.id AND nr1.round_number = 1
+WHERE n.created_at >= NOW() - INTERVAL '${WINDOW}'
+   OR n.status = 'active'
+ORDER BY n.created_at DESC
+LIMIT $1
+`;
+
+/**
+ * Single negotiation scan, unpivoted into per-endpoint rows, then GROUP BY
+ * agent. `bool_or(status='active')` derives the live-state without a
+ * second pass over the table.
+ */
+const NODES_SQL = /* sql */ `
+WITH endpoints AS (
+  SELECT initiator_agent_id AS agent_id, status FROM negotiation
+  WHERE created_at >= NOW() - INTERVAL '${WINDOW}' OR status = 'active'
+  UNION ALL
+  SELECT counterparty_agent_id AS agent_id, status FROM negotiation
+  WHERE created_at >= NOW() - INTERVAL '${WINDOW}' OR status = 'active'
+)
+SELECT
+  a.id,
+  a.name                       AS label,
+  a.hierarchy_level            AS hier,
+  bool_or(ep.status = 'active') AS is_active
+FROM endpoints ep
+JOIN agent a ON a.id = ep.agent_id
+GROUP BY a.id, a.name, a.hierarchy_level
+ORDER BY
+  CASE a.hierarchy_level WHEN 'org' THEN 0 WHEN 'team' THEN 1 ELSE 2 END,
+  a.name ASC
+`;
+
+const EDGES_SQL = /* sql */ `
+SELECT
+  initiator_agent_id    AS from_id,
+  counterparty_agent_id AS to_id,
+  COUNT(*)::int         AS count,
+  bool_or(status = 'active') AS has_live
+FROM negotiation
+WHERE created_at >= NOW() - INTERVAL '${WINDOW}' OR status = 'active'
+GROUP BY initiator_agent_id, counterparty_agent_id
+ORDER BY count DESC
+`;
+
+const SUMMARY_SQL = /* sql */ `
+SELECT
+  COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '${WINDOW}')::int  AS asks_24h,
+  COUNT(*) FILTER (WHERE status = 'active')::int                           AS in_flight,
+  COUNT(DISTINCT (initiator_agent_id, counterparty_agent_id))::int         AS edge_count
+FROM negotiation
+WHERE created_at >= NOW() - INTERVAL '${WINDOW}' OR status = 'active'
+`;
+
+interface AsksRow {
+  id: string;
+  caller_id: string;
+  caller_label: string;
+  target_id: string;
+  target_label: string;
+  status: string;
+  source_task_id: string | null;
+  rounds_completed: number;
+  max_rounds: number;
+  started_at: Date;
+  completed_at_or_updated: Date;
+  intent: string | null;
+}
+
+interface NodesRow {
+  id: string;
+  label: string;
+  hier: HierarchyLevel;
+  is_active: boolean;
+}
+
+interface EdgesRow {
+  from_id: string;
+  to_id: string;
+  count: number;
+  has_live: boolean;
+}
+
+interface SummaryRow {
+  asks_24h: number;
+  in_flight: number;
+  edge_count: number;
+}
+
+/** Map negotiation.status → the UI's coarser ask-status display. */
+function mapStatus(raw: string): MeshAskStatus {
+  switch (raw) {
+    case "active":
+      return "in_flight";
+    case "accepted":
+      return "succeeded";
+    case "rejected":
+      return "rejected";
+    case "escalated":
+      return "escalated";
+    case "cancelled":
+      return "blocked";
+    default:
+      return "in_flight";
+  }
+}
+
+export async function getMeshOverview(pool: Pool): Promise<MeshOverview> {
+  const [asksResult, nodesResult, edgesResult, summaryResult] = await Promise.all([
+    pool.query<AsksRow>(ASKS_SQL, [ASKS_LIMIT]),
+    pool.query<NodesRow>(NODES_SQL),
+    pool.query<EdgesRow>(EDGES_SQL),
+    pool.query<SummaryRow>(SUMMARY_SQL),
+  ]);
+
+  const asks: MeshAskData[] = asksResult.rows.map((r) => {
+    const status = mapStatus(r.status);
+    const isTerminal = status !== "in_flight";
+    return {
+      id: r.id,
+      type: "negotiate",
+      caller_id: r.caller_id,
+      caller_label: r.caller_label,
+      target_id: r.target_id,
+      target_label: r.target_label,
+      status,
+      intent: r.intent ?? "(no message)",
+      started_at: r.started_at,
+      completed_at: isTerminal ? r.completed_at_or_updated : undefined,
+      source_task_id: r.source_task_id ?? undefined,
+      rounds_completed: Number(r.rounds_completed),
+      max_rounds: Number(r.max_rounds),
+    };
+  });
+
+  const nodes: GraphNodeData[] = nodesResult.rows.map((r) => ({
+    id: r.id,
+    label: r.label,
+    hier: r.hier,
+    state: r.is_active ? "active" : "idle",
+  }));
+
+  const edges: GraphEdgeData[] = edgesResult.rows.map((r) => ({
+    from: r.from_id,
+    to: r.to_id,
+    count: Number(r.count),
+    state: r.has_live ? "live" : "completed",
+  }));
+
+  const summaryRow = summaryResult.rows[0];
+  const summary: MeshSummaryData = {
+    asks_24h: summaryRow ? Number(summaryRow.asks_24h) : 0,
+    in_flight: summaryRow ? Number(summaryRow.in_flight) : 0,
+    edge_count: summaryRow ? Number(summaryRow.edge_count) : 0,
+  };
+
+  return { asks, graph: { nodes, edges }, summary };
+}

--- a/packages/api/src/views/sessions.test.ts
+++ b/packages/api/src/views/sessions.test.ts
@@ -1,26 +1,21 @@
-import { describe, it, expect, vi } from "vitest";
-import type { Pool } from "@beevibe/core/adapters/postgres";
+import { describe, it, expect } from "vitest";
 import { getSessionByShortId, AmbiguousShortIdError } from "./sessions.js";
-
-function makePool(rows: unknown[]) {
-  const query = vi.fn(async () => ({ rows }));
-  return { query: query as unknown as Pool["query"] } as unknown as Pool;
-}
+import { makeMockPool } from "./test-helpers.js";
 
 describe("getSessionByShortId", () => {
   it("returns undefined when no matching session", async () => {
-    const pool = makePool([]);
+    const pool = makeMockPool([]);
     expect(await getSessionByShortId(pool, "abc123")).toBeUndefined();
   });
 
   it("rejects malformed short_ids without hitting the DB", async () => {
-    const pool = makePool([]);
+    const pool = makeMockPool([]);
     expect(await getSessionByShortId(pool, "abc/../etc")).toBeUndefined();
-    expect((pool.query as unknown as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    expect(pool._spy.mock.calls).toHaveLength(0);
   });
 
   it("throws AmbiguousShortIdError when 2+ rows share the prefix", async () => {
-    const pool = makePool([
+    const pool = makeMockPool([
       sampleRow("sess_abc1230001"),
       sampleRow("sess_abc1230002"),
     ]);
@@ -30,7 +25,7 @@ describe("getSessionByShortId", () => {
   });
 
   it("maps a single row into a SessionDisplay with empty briefing/transcript", async () => {
-    const pool = makePool([sampleRow("sess_abcdef00ff")]);
+    const pool = makeMockPool([sampleRow("sess_abcdef00ff")]);
     const session = await getSessionByShortId(pool, "abcdef");
     expect(session?.short_id).toBe("abcdef");
     expect(session?.task_title).toBe("Bill rewrite");

--- a/packages/api/src/views/tasks.test.ts
+++ b/packages/api/src/views/tasks.test.ts
@@ -4,28 +4,19 @@
  * by an integration-style e2e in a follow-up; these tests cover the
  * mapping layer without needing a database.
  */
-import { describe, it, expect, vi } from "vitest";
-import type { Pool } from "@beevibe/core/adapters/postgres";
+import { describe, it, expect } from "vitest";
 import { listTasks, getTask } from "./tasks.js";
-
-function makePool(responses: unknown[][]) {
-  let i = 0;
-  const query = vi.fn(async () => {
-    const rows = responses[i++] ?? [];
-    return { rows } as { rows: unknown[] };
-  });
-  return { query: query as unknown as Pool["query"] } as unknown as Pool;
-}
+import { makeMockPool } from "./test-helpers.js";
 
 describe("listTasks", () => {
   it("returns empty array when DB returns no rows", async () => {
-    const pool = makePool([[]]);
+    const pool = makeMockPool([[]]);
     const tasks = await listTasks(pool);
     expect(tasks).toEqual([]);
   });
 
   it("maps a row with joins into a TaskListItem", async () => {
-    const pool = makePool([
+    const pool = makeMockPool([
       [
         {
           id: "task_001",
@@ -73,8 +64,8 @@ describe("listTasks", () => {
   });
 
   it("translates lifecycle filter into a status array param", async () => {
-    const pool = makePool([[]]);
-    const queryMock = pool.query as unknown as ReturnType<typeof vi.fn>;
+    const pool = makeMockPool([[]]);
+    const queryMock = pool._spy;
     await listTasks(pool, { lifecycle: "in_review" });
     expect(queryMock).toHaveBeenCalledWith(
       expect.any(String),
@@ -83,8 +74,8 @@ describe("listTasks", () => {
   });
 
   it("forwards assignee_id when set", async () => {
-    const pool = makePool([[]]);
-    const queryMock = pool.query as unknown as ReturnType<typeof vi.fn>;
+    const pool = makeMockPool([[]]);
+    const queryMock = pool._spy;
     await listTasks(pool, { assignee_id: "agt_xyz" });
     expect(queryMock).toHaveBeenCalledWith(expect.any(String), [null, "agt_xyz"]);
   });
@@ -92,13 +83,13 @@ describe("listTasks", () => {
 
 describe("getTask", () => {
   it("returns undefined when the task isn't found", async () => {
-    const pool = makePool([[], [], []]);
+    const pool = makeMockPool([[], [], []]);
     const task = await getTask(pool, "task_missing");
     expect(task).toBeUndefined();
   });
 
   it("includes sessions and work products when found", async () => {
-    const pool = makePool([
+    const pool = makeMockPool([
       [
         {
           id: "task_001",

--- a/packages/api/src/views/test-helpers.ts
+++ b/packages/api/src/views/test-helpers.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared mock-pool fixture for view-layer unit tests. Replaces five
+ * near-identical local `makePool` helpers across `views/*.test.ts`.
+ *
+ * Two call shapes:
+ *   - `makeMockPool([...rowsArray])` — returns the same rows for every
+ *     query (used by single-query views like sessions/memory)
+ *   - `makeMockPool([[rowsForQuery1], [rowsForQuery2], ...])` — ordered
+ *     per-query responses (used by multi-query views like tasks/agents/
+ *     dashboard, where each `pool.query()` gets the next array slot)
+ */
+
+import { vi, type Mock } from "vitest";
+import type { Pool } from "@beevibe/core/adapters/postgres";
+
+export type MockPool = Pool & { _spy: Mock };
+
+function isMultiResponse(input: unknown[] | unknown[][]): input is unknown[][] {
+  return input.length > 0 && Array.isArray(input[0]);
+}
+
+export function makeMockPool(input: unknown[] | unknown[][]): MockPool {
+  if (isMultiResponse(input)) {
+    let i = 0;
+    const query = vi.fn(async () => ({ rows: input[i++] ?? [] }));
+    return {
+      query: query as unknown as Pool["query"],
+      _spy: query,
+    } as unknown as MockPool;
+  }
+  const query = vi.fn(async () => ({ rows: input }));
+  return {
+    query: query as unknown as Pool["query"],
+    _spy: query,
+  } as unknown as MockPool;
+}

--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -211,6 +211,93 @@ export interface MemoryFactDisplay {
   promotion_origin_scope?: MemoryScope;
 }
 
+// ── Dashboard ───────────────────────────────────────────────────────────────
+//
+// The dashboard DTO is intentionally pure data. The web composes display
+// fields (colors, hrefs, sparkline geometry, day labels, "5m ago" age) via
+// `summaryToDisplay()` in `lib/dashboard-display.ts`. Backend shouldn't know
+// the URL structure or status→color CSS map.
+
+/**
+ * Discriminator that lets the web's mapper attach UI config (label, href,
+ * trend chart kind, color enum) per KPI. Adding a new KPI: define a new
+ * kind here, return a row from `views/dashboard.ts`, and add the display
+ * mapping on the web side. No coupled config tables in the backend.
+ */
+export type KpiKind =
+  | "active_sessions"
+  | "in_review"
+  | "completed_today"
+  | "blocked";
+
+export interface KpiData {
+  kind: KpiKind;
+  value: number;
+  unit?: string;
+  /** Last 7 daily counts, oldest → newest. */
+  trend: number[];
+}
+
+export interface StatusBreakdownData {
+  status: TaskStatus;
+  count: number;
+  percent: number;
+}
+
+/**
+ * Legend entries are coarser than the breakdown: lifecycle groupings
+ * mapped onto the UI's 6 status dots. The mapper (web) joins these with
+ * label + color.
+ */
+export type LegendBucket =
+  | "review"
+  | "done"
+  | "blocked"
+  | "failed"
+  | "running"
+  | "pending";
+
+export interface StatusLegendData {
+  bucket: LegendBucket;
+  count: number;
+}
+
+export interface FleetBarData {
+  hier: HierarchyLevel;
+  count: number;
+  percent: number;
+}
+
+export interface TrendDayData {
+  /** ISO date (`YYYY-MM-DD`) — web maps to a short day label like "Mon". */
+  date: string;
+  value: number;
+  is_today: boolean;
+}
+
+export interface AttentionData {
+  task_id: string;
+  title: string;
+  status: "blocked" | "failed" | "review";
+  /** ISO timestamp; web formats with `formatRelativeTime`. */
+  created_at: Date;
+}
+
+export interface DashboardSummary {
+  kpis: KpiData[];
+  status_breakdown: StatusBreakdownData[];
+  status_legend: StatusLegendData[];
+  status_total: number;
+  fleet: FleetBarData[];
+  fleet_total: number;
+  fleet_active: number;
+  fleet_idle: number;
+  trend: TrendDayData[];
+  trend_total: number;
+  trend_change_percent: number;
+  attention: AttentionData[];
+}
+
 // ── Re-exports of ambient types that web imports alongside the DTOs ─────────
 
 export type { TaskStatus };

--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -298,6 +298,76 @@ export interface DashboardSummary {
   attention: AttentionData[];
 }
 
+// ── Mesh ────────────────────────────────────────────────────────────────────
+//
+// Mesh data DTO. Like the dashboard, the web composes display fields
+// (SVG geometry, duration labels, color enums) via `lib/mesh-display.ts`
+// and `lib/mesh-layout.ts`.
+//
+// V1 ships from the `negotiation` table (the canonical multi-round mesh
+// activity). Mesh-ask sessions and blocker sessions are not yet surfaced
+// here — their parent agent isn't directly stored on the session row, only
+// embedded in the intent XML — and the live UI doesn't differentiate
+// between ask types yet.
+
+export type MeshAskType = "negotiate" | "ask" | "blocker";
+
+export type MeshAskStatus =
+  | "in_flight"
+  | "succeeded"
+  | "rejected"
+  | "blocked"
+  | "escalated";
+
+export interface MeshAskData {
+  id: string;
+  type: MeshAskType;
+  caller_id: string;
+  caller_label: string;
+  target_id: string;
+  target_label: string;
+  status: MeshAskStatus;
+  /** First-round message; the web shows a preview. */
+  intent: string;
+  started_at: Date;
+  completed_at?: Date;
+  source_task_id?: string;
+  /** Negotiations only. */
+  rounds_completed?: number;
+  max_rounds?: number;
+}
+
+export interface GraphNodeData {
+  /** agent_id. */
+  id: string;
+  /** agent.name. */
+  label: string;
+  hier: HierarchyLevel;
+  /** "active" if the agent is in any in-flight mesh activity. */
+  state: "active" | "idle";
+}
+
+export interface GraphEdgeData {
+  from: string;
+  to: string;
+  /** Number of asks/negotiations between this pair in the window. */
+  count: number;
+  /** "live" if any in-flight, "completed" otherwise. */
+  state: "live" | "completed";
+}
+
+export interface MeshSummaryData {
+  asks_24h: number;
+  in_flight: number;
+  edge_count: number;
+}
+
+export interface MeshOverview {
+  asks: MeshAskData[];
+  graph: { nodes: GraphNodeData[]; edges: GraphEdgeData[] };
+  summary: MeshSummaryData;
+}
+
 // ── Re-exports of ambient types that web imports alongside the DTOs ─────────
 
 export type { TaskStatus };

--- a/packages/web/app/(authed)/home-client.test.tsx
+++ b/packages/web/app/(authed)/home-client.test.tsx
@@ -31,30 +31,25 @@ function renderHome() {
 
 const sample: DashboardSummary = {
   kpis: [
-    {
-      label: "Active sessions",
-      value: "12",
-      meta: [{ text: "rolling 24h" }],
-      href: "/tasks",
-      trend: [1, 2, 3, 4, 5],
-      trend_color: "running",
-      trend_kind: "line",
-    },
+    { kind: "active_sessions", value: 12, unit: "running", trend: [1, 2, 3, 4, 5] },
   ],
-  status_breakdown: [
-    { status: "in_progress", label: "running", color: "running", count: 7, percent: 50 },
-  ],
-  status_legend: [{ color: "running", label: "running", count: 7 }],
+  status_breakdown: [{ status: "in_progress", count: 7, percent: 50 }],
+  status_legend: [{ bucket: "running", count: 7 }],
   status_total: 14,
   fleet: [{ hier: "ic", count: 3, percent: 60 }],
   fleet_total: 5,
   fleet_active: 2,
   fleet_idle: 3,
-  trend: [{ label: "Mon", value: 4 }],
+  trend: [{ date: "2026-04-30", value: 4, is_today: true }],
   trend_total: 28,
   trend_change_percent: 12,
   attention: [
-    { status: "blocked", title: "needs key", age: "2h", href: "/tasks/t1" },
+    {
+      task_id: "t1",
+      title: "needs key",
+      status: "blocked",
+      created_at: new Date("2026-04-30T10:00:00Z"),
+    },
   ],
 };
 

--- a/packages/web/app/(authed)/home-client.tsx
+++ b/packages/web/app/(authed)/home-client.tsx
@@ -12,8 +12,7 @@ import { KpiTile } from "@/components/home/kpi-tile";
 import { FleetBars } from "@/components/home/fleet-bars";
 import { StatusBreakdownBar } from "@/components/home/status-breakdown";
 import { TrendChart } from "@/components/home/trend-chart";
-import type { DashboardSummary } from "@/lib/api/types";
-import type { AttentionItem } from "@/lib/types/dashboard";
+import type { AttentionItem, DashboardDisplay } from "@/lib/types/dashboard";
 
 const ATTENTION_DOT: Record<AttentionItem["status"], string> = {
   blocked: "bg-status-blocked",
@@ -38,7 +37,7 @@ function Body({
   isLoading,
   isError,
 }: {
-  data: DashboardSummary | undefined;
+  data: DashboardDisplay | undefined;
   isLoading: boolean;
   isError: boolean;
 }) {

--- a/packages/web/app/(authed)/mesh/mesh-client.tsx
+++ b/packages/web/app/(authed)/mesh/mesh-client.tsx
@@ -9,8 +9,7 @@ import { MeshGraphStatic } from "@/components/mesh/graph-static";
 import { ChainBudget } from "@/components/mesh/chain-budget";
 import { useMeshOverview } from "@/lib/hooks/use-mesh";
 import { isApiConfigured } from "@/lib/api/config";
-import type { MeshOverview } from "@/lib/api/types";
-import type { MeshAsk } from "@/lib/types/mesh";
+import type { MeshAsk, MeshDisplay } from "@/lib/types/mesh";
 
 export function MeshClient() {
   const { data, isLoading, isError } = useMeshOverview();
@@ -52,7 +51,7 @@ function Body({
   isLoading,
   isError,
 }: {
-  data: MeshOverview | undefined;
+  data: MeshDisplay | undefined;
   isLoading: boolean;
   isError: boolean;
 }) {
@@ -96,7 +95,10 @@ function Body({
       <div className="grid grid-cols-5 gap-6">
         <MeshActivityFeed />
         <div className="col-span-2">
-          <MeshGraphStatic />
+          <MeshGraphStatic
+            nodes={data?.graph.nodes}
+            edges={data?.graph.edges}
+          />
           <ChainBudget />
         </div>
       </div>
@@ -117,15 +119,7 @@ function Body({
         </ul>
       </section>
       <div className="col-span-2 space-y-3">
-        <div className="rounded-lg border border-border bg-card p-4 text-xs text-muted-foreground">
-          <div className="text-[10px] uppercase tracking-wider mb-2 text-foreground">
-            Live graph · last 24h
-          </div>
-          <div>
-            <span className="text-foreground tabular-nums">{data.graph.edges.length}</span> edges ·{" "}
-            <span className="text-foreground tabular-nums">{data.graph.nodes.length}</span> agents
-          </div>
-        </div>
+        <MeshGraphStatic nodes={data.graph.nodes} edges={data.graph.edges} />
         <ChainBudget />
       </div>
     </div>

--- a/packages/web/components/mesh/graph-static.tsx
+++ b/packages/web/components/mesh/graph-static.tsx
@@ -1,7 +1,39 @@
 import { Network } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { EmptyState } from "@/components/empty-state";
+import type { GraphEdge, GraphNode } from "@/lib/types/mesh";
 
-export function MeshGraphStatic() {
+const NODE_FILL: Record<GraphNode["state"], string> = {
+  active: "fill-status-running",
+  blocked: "fill-status-blocked",
+  idle: "fill-muted-foreground",
+};
+
+const EDGE_STROKE: Record<GraphEdge["state"], string> = {
+  live: "stroke-status-running",
+  blocker: "stroke-status-blocked",
+  completed: "stroke-muted-foreground/40",
+};
+
+const HIER_RING: Record<GraphNode["hier"], string> = {
+  org: "stroke-hier-org",
+  team: "stroke-hier-team",
+  ic: "stroke-hier-ic",
+};
+
+interface Props {
+  nodes?: readonly GraphNode[];
+  edges?: readonly GraphEdge[];
+  /** Defaults to 480 — matches `mesh-layout.ts`. */
+  viewBox?: { width: number; height: number };
+}
+
+export function MeshGraphStatic({
+  nodes = [],
+  edges = [],
+  viewBox = { width: 480, height: 480 },
+}: Props) {
+  const empty = nodes.length === 0;
   return (
     <section>
       <div className="flex items-center justify-between mb-3">
@@ -9,18 +41,60 @@ export function MeshGraphStatic() {
           Live graph · last 24h
         </h2>
         <div className="text-[10px] text-muted-foreground">
-          <span className="text-foreground tabular-nums">0</span> edges
+          <span className="text-foreground tabular-nums">{edges.length}</span> edges ·{" "}
+          <span className="text-foreground tabular-nums">{nodes.length}</span> agents
         </div>
       </div>
 
       <div className="rounded-lg border border-border bg-card overflow-hidden">
-        <div className="h-[480px] flex items-center justify-center">
-          <EmptyState
-            icon={Network}
-            title="No mesh activity"
-            description="The graph populates as agents ask each other for help."
-          />
-        </div>
+        {empty ? (
+          <div className="h-[480px] flex items-center justify-center">
+            <EmptyState
+              icon={Network}
+              title="No mesh activity"
+              description="The graph populates as agents ask each other for help."
+            />
+          </div>
+        ) : (
+          <svg
+            viewBox={`0 0 ${viewBox.width} ${viewBox.height}`}
+            className="w-full h-[480px]"
+            aria-label="Mesh activity graph"
+          >
+            {edges.map((e, i) => (
+              <path
+                key={`${e.from}-${e.to}-${i}`}
+                d={e.d}
+                className={cn("fill-none stroke-2", EDGE_STROKE[e.state])}
+                strokeLinecap="round"
+              />
+            ))}
+            {nodes.map((n) => (
+              <g key={n.id}>
+                <circle
+                  cx={n.cx}
+                  cy={n.cy}
+                  r={n.r}
+                  className={cn(
+                    "stroke-[3]",
+                    NODE_FILL[n.state],
+                    HIER_RING[n.hier],
+                  )}
+                />
+                <text
+                  x={n.cx}
+                  y={n.cy + n.r + 14}
+                  textAnchor="middle"
+                  fontSize="11"
+                  fill="hsl(var(--foreground))"
+                  fontFamily="JetBrains Mono"
+                >
+                  {n.label}
+                </text>
+              </g>
+            ))}
+          </svg>
+        )}
       </div>
     </section>
   );

--- a/packages/web/lib/api/types.ts
+++ b/packages/web/lib/api/types.ts
@@ -2,9 +2,7 @@
  * Web-side re-exports of the read-DTO contract owned by `@beevibe/api`.
  *
  * Live shapes are defined in `packages/api/src/views/types.ts` so the
- * backend is the single source of truth for the read surface. Anything
- * the web computes locally (display-only types like ChainBudget, GraphNode,
- * mesh chrome) stays in `lib/types/*` and isn't surfaced here.
+ * backend is the single source of truth for the read surface.
  */
 
 export type {
@@ -12,15 +10,5 @@ export type {
   TaskDetailSessionRow,
   AgentDetail,
   DashboardSummary,
+  MeshOverview,
 } from "@beevibe/api/views/types";
-
-import type { ChainBudgetData, GraphNode, GraphEdge, MeshSummary, MeshAsk } from "@/lib/types/mesh";
-
-// Mesh still needs a data/display split before backend can produce it cleanly
-// — tracked in #34.
-export interface MeshOverview {
-  asks: MeshAsk[];
-  graph: { nodes: GraphNode[]; edges: GraphEdge[] };
-  budget: ChainBudgetData;
-  summary: MeshSummary;
-}

--- a/packages/web/lib/api/types.ts
+++ b/packages/web/lib/api/types.ts
@@ -4,44 +4,20 @@
  * Live shapes are defined in `packages/api/src/views/types.ts` so the
  * backend is the single source of truth for the read surface. Anything
  * the web computes locally (display-only types like ChainBudget, GraphNode,
- * dashboard KPI styling) stays in `lib/types/*` and isn't surfaced here.
+ * mesh chrome) stays in `lib/types/*` and isn't surfaced here.
  */
 
 export type {
   TaskDetail,
   TaskDetailSessionRow,
   AgentDetail,
+  DashboardSummary,
 } from "@beevibe/api/views/types";
 
 import type { ChainBudgetData, GraphNode, GraphEdge, MeshSummary, MeshAsk } from "@/lib/types/mesh";
-import type {
-  KpiStat,
-  StatusBreakdownEntry,
-  StatusLegendEntry,
-  FleetBar,
-  TrendDay,
-  AttentionItem,
-} from "@/lib/types/dashboard";
 
-// ── Display-only shapes the web still composes from fixtures ────────────
-// Dashboard + mesh need a data/display split before the backend can produce
-// them cleanly — tracked in #33 and #34.
-
-export interface DashboardSummary {
-  kpis: KpiStat[];
-  status_breakdown: StatusBreakdownEntry[];
-  status_legend: StatusLegendEntry[];
-  status_total: number;
-  fleet: FleetBar[];
-  fleet_total: number;
-  fleet_active: number;
-  fleet_idle: number;
-  trend: TrendDay[];
-  trend_total: number;
-  trend_change_percent: number;
-  attention: AttentionItem[];
-}
-
+// Mesh still needs a data/display split before backend can produce it cleanly
+// — tracked in #34.
 export interface MeshOverview {
   asks: MeshAsk[];
   graph: { nodes: GraphNode[]; edges: GraphEdge[] };

--- a/packages/web/lib/dashboard-display.test.ts
+++ b/packages/web/lib/dashboard-display.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for `summaryToDisplay` — the data → display mapper that keeps the
+ * backend's pure-data DashboardSummary uncoupled from the web's URL
+ * structure, color enums, and labelling choices.
+ */
+import { describe, it, expect } from "vitest";
+import { summaryToDisplay } from "./dashboard-display";
+import type { DashboardSummary } from "@/lib/types/dashboard";
+
+function emptyData(): DashboardSummary {
+  return {
+    kpis: [],
+    status_breakdown: [],
+    status_legend: [],
+    status_total: 0,
+    fleet: [],
+    fleet_total: 0,
+    fleet_active: 0,
+    fleet_idle: 0,
+    trend: [],
+    trend_total: 0,
+    trend_change_percent: 0,
+    attention: [],
+  };
+}
+
+describe("summaryToDisplay — KPIs", () => {
+  it("maps each KPI kind to a stable label + href + color + chart kind", () => {
+    const data: DashboardSummary = {
+      ...emptyData(),
+      kpis: [
+        { kind: "active_sessions", value: 5, unit: "running", trend: [1, 2, 3] },
+        { kind: "in_review", value: 2, trend: [0, 1, 0] },
+        { kind: "completed_today", value: 8, unit: "today", trend: [3, 5, 8] },
+        { kind: "blocked", value: 1, trend: [0, 0, 1] },
+      ],
+    };
+    const display = summaryToDisplay(data);
+    const byKpi = (label: string) => display.kpis.find((k) => k.label === label)!;
+
+    expect(byKpi("Active sessions").trend_color).toBe("running");
+    expect(byKpi("Active sessions").trend_kind).toBe("line");
+    expect(byKpi("Active sessions").href).toBe("/tasks?lifecycle=in_progress");
+    expect(byKpi("Active sessions").value).toBe("5");
+    expect(byKpi("Active sessions").unit).toBe("running");
+
+    expect(byKpi("Awaiting review").trend_color).toBe("review");
+    expect(byKpi("Awaiting review").trend_kind).toBe("bar");
+    expect(byKpi("Completed today").trend_color).toBe("done");
+    expect(byKpi("Blocked").trend_color).toBe("primary");
+  });
+
+  it("preserves raw trend arrays (web's sparkline owns geometry)", () => {
+    const data: DashboardSummary = {
+      ...emptyData(),
+      kpis: [{ kind: "active_sessions", value: 0, trend: [1, 2, 3, 4, 5, 6, 7] }],
+    };
+    expect(summaryToDisplay(data).kpis[0]?.trend).toEqual([1, 2, 3, 4, 5, 6, 7]);
+  });
+});
+
+describe("summaryToDisplay — status breakdown + legend", () => {
+  it("attaches deterministic label + color from the status enum", () => {
+    const data: DashboardSummary = {
+      ...emptyData(),
+      status_breakdown: [
+        { status: "in_progress", count: 5, percent: 50 },
+        { status: "review", count: 3, percent: 30 },
+        { status: "blocked", count: 2, percent: 20 },
+      ],
+    };
+    const { status_breakdown } = summaryToDisplay(data);
+    expect(status_breakdown[0]).toEqual({
+      status: "in_progress",
+      label: "In progress",
+      color: "running",
+      count: 5,
+      percent: 50,
+    });
+    expect(status_breakdown[1]?.color).toBe("review");
+    expect(status_breakdown[2]?.color).toBe("blocked");
+  });
+
+  it("maps cancelled to the pending color (de-emphasized terminal state)", () => {
+    const data: DashboardSummary = {
+      ...emptyData(),
+      status_breakdown: [{ status: "cancelled", count: 1, percent: 100 }],
+    };
+    expect(summaryToDisplay(data).status_breakdown[0]?.color).toBe("pending");
+  });
+
+  it("legend uses the bucket as the color and humanizes the label", () => {
+    const data: DashboardSummary = {
+      ...emptyData(),
+      status_legend: [
+        { bucket: "running", count: 7 },
+        { bucket: "blocked", count: 2 },
+      ],
+    };
+    expect(summaryToDisplay(data).status_legend).toEqual([
+      { color: "running", label: "Running", count: 7 },
+      { color: "blocked", label: "Blocked", count: 2 },
+    ]);
+  });
+});
+
+describe("summaryToDisplay — fleet + scalars passthrough", () => {
+  it("forwards fleet bars + scalar totals untouched", () => {
+    const data: DashboardSummary = {
+      ...emptyData(),
+      fleet: [
+        { hier: "org", count: 1, percent: 10 },
+        { hier: "team", count: 4, percent: 40 },
+      ],
+      fleet_total: 5,
+      fleet_active: 3,
+      fleet_idle: 2,
+      status_total: 12,
+      trend_total: 50,
+      trend_change_percent: 25,
+    };
+    const display = summaryToDisplay(data);
+    expect(display.fleet).toEqual(data.fleet);
+    expect(display.fleet_total).toBe(5);
+    expect(display.fleet_active).toBe(3);
+    expect(display.fleet_idle).toBe(2);
+    expect(display.status_total).toBe(12);
+    expect(display.trend_total).toBe(50);
+    expect(display.trend_change_percent).toBe(25);
+  });
+});
+
+describe("summaryToDisplay — trend day labels", () => {
+  it("derives the short weekday label from the ISO date", () => {
+    const data: DashboardSummary = {
+      ...emptyData(),
+      trend: [
+        { date: "2026-04-27", value: 3, is_today: false }, // Monday
+        { date: "2026-04-30", value: 5, is_today: true }, // Thursday
+      ],
+    };
+    const labels = summaryToDisplay(data).trend.map((d) => d.label);
+    expect(labels).toEqual(["Mon", "Thu"]);
+    expect(summaryToDisplay(data).trend[1]?.is_today).toBe(true);
+  });
+});
+
+describe("summaryToDisplay — attention", () => {
+  it("builds task hrefs and formats relative age from created_at", () => {
+    const now = new Date("2026-04-30T12:00:00Z");
+    const recent = new Date(now.getTime() - 5 * 60_000);
+    const data: DashboardSummary = {
+      ...emptyData(),
+      attention: [
+        {
+          task_id: "task_xyz",
+          title: "needs API key",
+          status: "blocked",
+          created_at: recent,
+        },
+      ],
+    };
+    // Note: formatRelativeTime uses `new Date()` as default `now`, so we
+    // can't pin the output exactly without mocking — assert the href +
+    // structure instead and that age is non-empty.
+    const display = summaryToDisplay(data);
+    expect(display.attention[0]?.href).toBe("/tasks/task_xyz");
+    expect(display.attention[0]?.title).toBe("needs API key");
+    expect(display.attention[0]?.status).toBe("blocked");
+    expect(display.attention[0]?.age).toMatch(/m ago|just now|h ago/);
+  });
+});

--- a/packages/web/lib/dashboard-display.test.ts
+++ b/packages/web/lib/dashboard-display.test.ts
@@ -147,8 +147,7 @@ describe("summaryToDisplay — trend day labels", () => {
 
 describe("summaryToDisplay — attention", () => {
   it("builds task hrefs and formats relative age from created_at", () => {
-    const now = new Date("2026-04-30T12:00:00Z");
-    const recent = new Date(now.getTime() - 5 * 60_000);
+    const recent = new Date(Date.now() - 5 * 60_000);
     const data: DashboardSummary = {
       ...emptyData(),
       attention: [
@@ -160,13 +159,10 @@ describe("summaryToDisplay — attention", () => {
         },
       ],
     };
-    // Note: formatRelativeTime uses `new Date()` as default `now`, so we
-    // can't pin the output exactly without mocking — assert the href +
-    // structure instead and that age is non-empty.
     const display = summaryToDisplay(data);
     expect(display.attention[0]?.href).toBe("/tasks/task_xyz");
     expect(display.attention[0]?.title).toBe("needs API key");
     expect(display.attention[0]?.status).toBe("blocked");
-    expect(display.attention[0]?.age).toMatch(/m ago|just now|h ago/);
+    expect(display.attention[0]?.age).toBe("5m ago");
   });
 });

--- a/packages/web/lib/dashboard-display.ts
+++ b/packages/web/lib/dashboard-display.ts
@@ -176,7 +176,7 @@ function attentionToDisplay(data: AttentionData): AttentionItem {
   return {
     status: data.status,
     title: data.title,
-    age: formatRelativeTime(new Date(data.created_at)),
+    age: formatRelativeTime(data.created_at),
     href: `/tasks/${data.task_id}`,
   };
 }

--- a/packages/web/lib/dashboard-display.ts
+++ b/packages/web/lib/dashboard-display.ts
@@ -1,0 +1,182 @@
+import type {
+  DashboardSummary,
+  KpiKind,
+  KpiData,
+  StatusBreakdownData,
+  StatusLegendData,
+  LegendBucket,
+  FleetBarData,
+  TrendDayData,
+  AttentionData,
+  DashboardDisplay,
+  KpiStat,
+  StatusBreakdownEntry,
+  StatusLegendEntry,
+  FleetBar,
+  TrendDay,
+  AttentionItem,
+} from "@/lib/types/dashboard";
+import type { TaskStatus } from "@beevibe/core";
+import { formatRelativeTime } from "@/lib/format";
+
+/**
+ * Pure-data → display mapping. Keeps the API uncoupled from web's URL
+ * structure, CSS color names, and labelling choices.
+ */
+export function summaryToDisplay(summary: DashboardSummary): DashboardDisplay {
+  return {
+    kpis: summary.kpis.map(kpiToDisplay),
+    status_breakdown: summary.status_breakdown.map(breakdownToDisplay),
+    status_legend: summary.status_legend.map(legendToDisplay),
+    status_total: summary.status_total,
+    fleet: summary.fleet.map(fleetToDisplay),
+    fleet_total: summary.fleet_total,
+    fleet_active: summary.fleet_active,
+    fleet_idle: summary.fleet_idle,
+    trend: summary.trend.map(trendDayToDisplay),
+    trend_total: summary.trend_total,
+    trend_change_percent: summary.trend_change_percent,
+    attention: summary.attention.map(attentionToDisplay),
+  };
+}
+
+// ── KPI ────────────────────────────────────────────────────────────────────
+
+interface KpiConfig {
+  label: string;
+  href: string;
+  trend_color: KpiStat["trend_color"];
+  trend_kind: KpiStat["trend_kind"];
+}
+
+const KPI_CONFIG: Record<KpiKind, KpiConfig> = {
+  active_sessions: {
+    label: "Active sessions",
+    href: "/tasks?lifecycle=in_progress",
+    trend_color: "running",
+    trend_kind: "line",
+  },
+  in_review: {
+    label: "Awaiting review",
+    href: "/tasks?lifecycle=in_review",
+    trend_color: "review",
+    trend_kind: "bar",
+  },
+  completed_today: {
+    label: "Completed today",
+    href: "/tasks?lifecycle=done",
+    trend_color: "done",
+    trend_kind: "line",
+  },
+  blocked: {
+    label: "Blocked",
+    href: "/tasks?lifecycle=in_review",
+    trend_color: "primary",
+    trend_kind: "bar",
+  },
+};
+
+function kpiToDisplay(data: KpiData): KpiStat {
+  const cfg = KPI_CONFIG[data.kind];
+  return {
+    label: cfg.label,
+    value: String(data.value),
+    unit: data.unit,
+    meta: [],
+    href: cfg.href,
+    trend: data.trend,
+    trend_color: cfg.trend_color,
+    trend_kind: cfg.trend_kind,
+  };
+}
+
+// ── Status breakdown ───────────────────────────────────────────────────────
+
+const STATUS_LABEL: Record<TaskStatus, string> = {
+  pending: "Pending",
+  assigned: "Assigned",
+  in_progress: "In progress",
+  needs_revision: "Needs revision",
+  revision: "In revision",
+  review: "In review",
+  blocked: "Blocked",
+  done: "Done",
+  failed: "Failed",
+  cancelled: "Cancelled",
+};
+
+const STATUS_COLOR: Record<TaskStatus, StatusBreakdownEntry["color"]> = {
+  pending: "pending",
+  assigned: "pending",
+  in_progress: "running",
+  needs_revision: "running",
+  revision: "running",
+  review: "review",
+  blocked: "blocked",
+  done: "done",
+  failed: "failed",
+  cancelled: "pending",
+};
+
+function breakdownToDisplay(data: StatusBreakdownData): StatusBreakdownEntry {
+  return {
+    status: data.status,
+    label: STATUS_LABEL[data.status],
+    color: STATUS_COLOR[data.status],
+    count: data.count,
+    percent: data.percent,
+  };
+}
+
+// ── Legend ─────────────────────────────────────────────────────────────────
+
+const LEGEND_LABEL: Record<LegendBucket, string> = {
+  pending: "Pending",
+  running: "Running",
+  review: "Review",
+  blocked: "Blocked",
+  done: "Done",
+  failed: "Failed",
+};
+
+function legendToDisplay(data: StatusLegendData): StatusLegendEntry {
+  return {
+    color: data.bucket,
+    label: LEGEND_LABEL[data.bucket],
+    count: data.count,
+  };
+}
+
+// ── Fleet ──────────────────────────────────────────────────────────────────
+
+function fleetToDisplay(data: FleetBarData): FleetBar {
+  return {
+    hier: data.hier,
+    count: data.count,
+    percent: data.percent,
+  };
+}
+
+// ── Trend ──────────────────────────────────────────────────────────────────
+
+const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+
+function trendDayToDisplay(data: TrendDayData): TrendDay {
+  const label = DAY_LABELS[new Date(data.date + "T00:00:00Z").getUTCDay()] ?? data.date;
+  return {
+    label,
+    value: data.value,
+    is_today: data.is_today,
+  };
+}
+
+// ── Attention ──────────────────────────────────────────────────────────────
+
+function attentionToDisplay(data: AttentionData): AttentionItem {
+  return {
+    status: data.status,
+    title: data.title,
+    age: formatRelativeTime(new Date(data.created_at)),
+    href: `/tasks/${data.task_id}`,
+  };
+}

--- a/packages/web/lib/format.ts
+++ b/packages/web/lib/format.ts
@@ -22,3 +22,26 @@ export function sessionHref(sid: string, taskId?: string): string {
   if (taskId) return `/tasks/${taskId}/sessions/${sid}`;
   return "#";
 }
+
+/**
+ * Duration between `startedAt` and `completedAt` (or `now` if running).
+ * "30s" / "5m" / "1h 12m" / "2d 3h". Returns "—" if no start.
+ */
+export function formatDurationLabel(
+  startedAt: Date | null | undefined,
+  completedAt: Date | null | undefined,
+  now: Date = new Date(),
+): string {
+  if (!startedAt) return "—";
+  const end = completedAt ?? now;
+  const diffSec = Math.max(0, Math.floor((end.getTime() - startedAt.getTime()) / 1000));
+  if (diffSec < 60) return `${diffSec}s`;
+  const min = Math.floor(diffSec / 60);
+  if (min < 60) return `${min}m`;
+  const hr = Math.floor(min / 60);
+  const mins = min % 60;
+  if (hr < 24) return mins ? `${hr}h ${mins}m` : `${hr}h`;
+  const days = Math.floor(hr / 24);
+  const hrs = hr % 24;
+  return hrs ? `${days}d ${hrs}h` : `${days}d`;
+}

--- a/packages/web/lib/hooks/use-dashboard.ts
+++ b/packages/web/lib/hooks/use-dashboard.ts
@@ -1,12 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
+import { summaryToDisplay } from "@/lib/dashboard-display";
 import { queryKeys } from "./keys";
 
 export function useDashboard() {
   return useQuery({
     queryKey: queryKeys.dashboard.summary(),
     queryFn: ({ signal }) => api.dashboard.summary({ signal }),
+    select: summaryToDisplay,
     enabled: isApiConfigured,
   });
 }

--- a/packages/web/lib/hooks/use-mesh.ts
+++ b/packages/web/lib/hooks/use-mesh.ts
@@ -1,12 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
+import { overviewToDisplay } from "@/lib/mesh-display";
 import { queryKeys } from "./keys";
 
 export function useMeshOverview(filter: { since?: string } = {}) {
   return useQuery({
     queryKey: queryKeys.mesh.overview(filter),
     queryFn: ({ signal }) => api.mesh.overview(filter, { signal }),
+    select: overviewToDisplay,
     enabled: isApiConfigured,
   });
 }

--- a/packages/web/lib/mesh-display.test.ts
+++ b/packages/web/lib/mesh-display.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import { overviewToDisplay } from "./mesh-display";
+import type { MeshOverview } from "@/lib/types/mesh";
+
+function emptyOverview(): MeshOverview {
+  return {
+    asks: [],
+    graph: { nodes: [], edges: [] },
+    summary: { asks_24h: 0, in_flight: 0, edge_count: 0 },
+  };
+}
+
+describe("overviewToDisplay — asks", () => {
+  it("maps caller/target labels + duration_label + chain depth", () => {
+    const overview: MeshOverview = {
+      ...emptyOverview(),
+      asks: [
+        {
+          id: "neg_1",
+          type: "negotiate",
+          caller_id: "agt_a",
+          caller_label: "Alice",
+          target_id: "agt_b",
+          target_label: "Bob",
+          status: "in_flight",
+          intent: "review the schema",
+          started_at: new Date("2026-04-30T11:00:00Z"),
+          completed_at: new Date("2026-04-30T11:30:00Z"),
+          rounds_completed: 2,
+          max_rounds: 5,
+        },
+      ],
+    };
+    const { asks } = overviewToDisplay(overview);
+    expect(asks).toHaveLength(1);
+    expect(asks[0]?.caller).toBe("Alice");
+    expect(asks[0]?.target).toBe("Bob");
+    expect(asks[0]?.duration_label).toBe("30m");
+    expect(asks[0]?.chain_depth).toBe("2/5");
+    expect(asks[0]?.intent).toBe("review the schema");
+  });
+
+  it("compresses rejected + escalated to blocked for the UI's 3-status palette", () => {
+    const overview: MeshOverview = {
+      ...emptyOverview(),
+      asks: (
+        ["in_flight", "succeeded", "rejected", "blocked", "escalated"] as const
+      ).map((status, i) => ({
+        id: `neg_${i}`,
+        type: "negotiate" as const,
+        caller_id: "agt_a",
+        caller_label: "A",
+        target_id: "agt_b",
+        target_label: "B",
+        status,
+        intent: "x",
+        started_at: new Date(),
+      })),
+    };
+    const { asks } = overviewToDisplay(overview);
+    expect(asks.map((a) => a.status)).toEqual([
+      "in_flight",
+      "succeeded",
+      "blocked",
+      "blocked",
+      "blocked",
+    ]);
+  });
+
+  it("uses '—' for chain_depth when rounds aren't tracked", () => {
+    const overview: MeshOverview = {
+      ...emptyOverview(),
+      asks: [
+        {
+          id: "ask_1",
+          type: "ask",
+          caller_id: "agt_a",
+          caller_label: "A",
+          target_id: "agt_b",
+          target_label: "B",
+          status: "succeeded",
+          intent: "x",
+          started_at: new Date(),
+        },
+      ],
+    };
+    expect(overviewToDisplay(overview).asks[0]?.chain_depth).toBe("—");
+  });
+});
+
+describe("overviewToDisplay — graph layout", () => {
+  it("places N nodes on a circle and produces SVG paths for edges", () => {
+    const overview: MeshOverview = {
+      ...emptyOverview(),
+      graph: {
+        nodes: [
+          { id: "agt_a", label: "Alice", hier: "team", state: "active" },
+          { id: "agt_b", label: "Bob", hier: "ic", state: "idle" },
+          { id: "agt_c", label: "Carol", hier: "ic", state: "active" },
+        ],
+        edges: [
+          { from: "agt_a", to: "agt_b", count: 1, state: "live" },
+          { from: "agt_a", to: "agt_c", count: 2, state: "completed" },
+        ],
+      },
+    };
+    const { graph } = overviewToDisplay(overview);
+    expect(graph.nodes).toHaveLength(3);
+    expect(graph.edges).toHaveLength(2);
+    for (const node of graph.nodes) {
+      expect(node.cx).toBeGreaterThan(0);
+      expect(node.cy).toBeGreaterThan(0);
+      expect(node.r).toBeGreaterThan(0);
+    }
+    expect(graph.edges[0]?.d).toMatch(/^M[\d.]+ [\d.]+ L[\d.]+ [\d.]+$/);
+  });
+
+  it("orders nodes by hierarchy (org → team → ic) then by name", () => {
+    const overview: MeshOverview = {
+      ...emptyOverview(),
+      graph: {
+        nodes: [
+          { id: "agt_z", label: "Zed", hier: "ic", state: "idle" },
+          { id: "agt_o", label: "Orin", hier: "org", state: "idle" },
+          { id: "agt_t", label: "Tara", hier: "team", state: "idle" },
+        ],
+        edges: [],
+      },
+    };
+    const labels = overviewToDisplay(overview).graph.nodes.map((n) => n.label);
+    expect(labels).toEqual(["Orin", "Tara", "Zed"]);
+  });
+
+  it("drops edges whose endpoints aren't in the node list (defensive)", () => {
+    const overview: MeshOverview = {
+      ...emptyOverview(),
+      graph: {
+        nodes: [{ id: "agt_a", label: "A", hier: "ic", state: "idle" }],
+        edges: [{ from: "agt_a", to: "agt_missing", count: 1, state: "completed" }],
+      },
+    };
+    expect(overviewToDisplay(overview).graph.edges).toHaveLength(0);
+  });
+});
+
+describe("overviewToDisplay — summary passthrough", () => {
+  it("forwards summary counts unchanged", () => {
+    const overview: MeshOverview = {
+      ...emptyOverview(),
+      summary: { asks_24h: 12, in_flight: 3, edge_count: 7 },
+    };
+    expect(overviewToDisplay(overview).summary).toEqual({
+      asks_24h: 12,
+      in_flight: 3,
+      edge_count: 7,
+    });
+  });
+});

--- a/packages/web/lib/mesh-display.ts
+++ b/packages/web/lib/mesh-display.ts
@@ -1,0 +1,55 @@
+/**
+ * Pure-data → display mapping for the mesh page.
+ *
+ * Status compression: the backend has 5 ask statuses
+ * ({in_flight, succeeded, rejected, blocked, escalated}) but the live UI
+ * only paints 3 buckets ({in_flight, succeeded, blocked}). The mapper
+ * lumps `rejected` + `escalated` into `blocked` since the visual treatment
+ * is "ask didn't resolve cleanly".
+ *
+ * Geometry: delegated to `lib/mesh-layout.ts`.
+ */
+
+import type {
+  MeshOverview,
+  MeshAskData,
+  MeshAsk,
+  MeshAskStatus,
+  MeshDisplay,
+} from "@/lib/types/mesh";
+import { layoutMeshGraph } from "@/lib/mesh-layout";
+import { formatDurationLabel } from "@/lib/format";
+
+export function overviewToDisplay(overview: MeshOverview): MeshDisplay {
+  const { nodes, edges } = layoutMeshGraph(overview.graph.nodes, overview.graph.edges);
+  return {
+    asks: overview.asks.map(askToDisplay),
+    graph: { nodes, edges },
+    summary: { ...overview.summary },
+  };
+}
+
+const DISPLAY_STATUS: Record<MeshAskStatus, MeshAsk["status"]> = {
+  in_flight: "in_flight",
+  succeeded: "succeeded",
+  rejected: "blocked",
+  blocked: "blocked",
+  escalated: "blocked",
+};
+
+function askToDisplay(data: MeshAskData): MeshAsk {
+  const display: MeshAsk = {
+    id: data.id,
+    caller: data.caller_label,
+    target: data.target_label,
+    type: data.type,
+    status: DISPLAY_STATUS[data.status],
+    duration_label: formatDurationLabel(data.started_at, data.completed_at),
+    intent: data.intent,
+    chain_depth:
+      data.rounds_completed !== undefined && data.max_rounds !== undefined
+        ? `${data.rounds_completed}/${data.max_rounds}`
+        : "—",
+  };
+  return display;
+}

--- a/packages/web/lib/mesh-layout.ts
+++ b/packages/web/lib/mesh-layout.ts
@@ -1,0 +1,90 @@
+/**
+ * Simple radial layout for the mesh graph. Backend ships node IDs + edge
+ * pairs; this computes 2D positions for SVG rendering. Web-only — backend
+ * never computes geometry.
+ *
+ * Algorithm: place nodes evenly around a circle, ordered by hierarchy
+ * (org outermost, then team, then ic) so the visual matches the org
+ * structure. Edges are straight lines between source and target centers.
+ *
+ * Phase 2 could swap this for a force-directed layout (dagre/d3-force)
+ * once the graph density justifies it. For phase 1 — typically <10 nodes
+ * per page — a circle is enough.
+ */
+
+import type { GraphEdge, GraphNode, GraphEdgeData, GraphNodeData } from "@/lib/types/mesh";
+
+const VIEWBOX_W = 480;
+const VIEWBOX_H = 480;
+const NODE_RADIUS = 14;
+
+interface LaidOut {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  viewBox: { width: number; height: number };
+}
+
+const HIER_ORDER: Record<GraphNode["hier"], number> = {
+  org: 0,
+  team: 1,
+  ic: 2,
+};
+
+const EDGE_STATE: Record<GraphEdgeData["state"], GraphEdge["state"]> = {
+  live: "live",
+  completed: "completed",
+};
+
+const NODE_STATE: Record<GraphNodeData["state"], GraphNode["state"]> = {
+  active: "active",
+  idle: "idle",
+};
+
+export function layoutMeshGraph(
+  nodeData: readonly GraphNodeData[],
+  edgeData: readonly GraphEdgeData[],
+): LaidOut {
+  if (nodeData.length === 0) {
+    return { nodes: [], edges: [], viewBox: { width: VIEWBOX_W, height: VIEWBOX_H } };
+  }
+
+  const center = { x: VIEWBOX_W / 2, y: VIEWBOX_H / 2 };
+  const radius = Math.min(VIEWBOX_W, VIEWBOX_H) / 2 - NODE_RADIUS - 24;
+
+  const ordered = [...nodeData].sort(
+    (a, b) => HIER_ORDER[a.hier] - HIER_ORDER[b.hier] || a.label.localeCompare(b.label),
+  );
+
+  const positions = new Map<string, { cx: number; cy: number }>();
+  const nodes: GraphNode[] = ordered.map((n, i) => {
+    const theta = (2 * Math.PI * i) / ordered.length - Math.PI / 2;
+    const cx = center.x + radius * Math.cos(theta);
+    const cy = center.y + radius * Math.sin(theta);
+    positions.set(n.id, { cx, cy });
+    return {
+      id: n.id,
+      label: n.label,
+      hier: n.hier,
+      cx,
+      cy,
+      r: NODE_RADIUS,
+      state: NODE_STATE[n.state],
+    };
+  });
+
+  const edges: GraphEdge[] = edgeData.flatMap((e) => {
+    const from = positions.get(e.from);
+    const to = positions.get(e.to);
+    if (!from || !to) return [];
+    return [
+      {
+        from: e.from,
+        to: e.to,
+        d: `M${from.cx.toFixed(1)} ${from.cy.toFixed(1)} L${to.cx.toFixed(1)} ${to.cy.toFixed(1)}`,
+        state: EDGE_STATE[e.state],
+      },
+    ];
+  });
+
+  return { nodes, edges, viewBox: { width: VIEWBOX_W, height: VIEWBOX_H } };
+}

--- a/packages/web/lib/types/dashboard.ts
+++ b/packages/web/lib/types/dashboard.ts
@@ -1,5 +1,11 @@
 import type { TaskStatus } from "@beevibe/core";
 
+// ── Display shapes the home page binds against ─────────────────────────────
+//
+// These are produced by `lib/dashboard-display.ts:summaryToDisplay()` from
+// the pure-data `DashboardSummary` shipped by the backend. Backend never
+// computes colors, hrefs, or sparkline geometry.
+
 export type KpiMetaColor = "muted" | "review" | "done" | "failed";
 
 export interface KpiMetaPart {
@@ -52,3 +58,33 @@ export interface AttentionItem {
   age: string;
   href: string;
 }
+
+/** Aggregated display-shaped dashboard the home page binds to. */
+export interface DashboardDisplay {
+  kpis: KpiStat[];
+  status_breakdown: StatusBreakdownEntry[];
+  status_legend: StatusLegendEntry[];
+  status_total: number;
+  fleet: FleetBar[];
+  fleet_total: number;
+  fleet_active: number;
+  fleet_idle: number;
+  trend: TrendDay[];
+  trend_total: number;
+  trend_change_percent: number;
+  attention: AttentionItem[];
+}
+
+// ── Re-export the backend data DTO ─────────────────────────────────────────
+
+export type {
+  DashboardSummary,
+  KpiKind,
+  KpiData,
+  StatusBreakdownData,
+  StatusLegendData,
+  LegendBucket,
+  FleetBarData,
+  TrendDayData,
+  AttentionData,
+} from "@beevibe/api/views/types";

--- a/packages/web/lib/types/mesh.ts
+++ b/packages/web/lib/types/mesh.ts
@@ -1,5 +1,11 @@
 import type { RichText } from "@/components/rich-text";
 
+// ── Display shapes the mesh page binds against ────────────────────────────
+//
+// Produced by `lib/mesh-display.ts:overviewToDisplay()` from the pure-data
+// `MeshOverview` shipped by the backend. Backend never computes SVG
+// geometry, status colors, or relative-time labels.
+
 export interface MeshAsk {
   id: string;
   caller: string;
@@ -37,7 +43,6 @@ export interface ChainBudgetData {
 export interface GraphNode {
   id: string;
   label: string;
-  hier_label: string;
   hier: "ic" | "team" | "org";
   cx: number;
   cy: number;
@@ -58,3 +63,22 @@ export interface MeshSummary {
   in_flight: number;
   edge_count: number;
 }
+
+/** Aggregated display the mesh page binds to. */
+export interface MeshDisplay {
+  asks: MeshAsk[];
+  graph: { nodes: GraphNode[]; edges: GraphEdge[] };
+  summary: MeshSummary;
+}
+
+// ── Re-export the backend data DTO ────────────────────────────────────────
+
+export type {
+  MeshOverview,
+  MeshAskData,
+  MeshAskType,
+  MeshAskStatus,
+  GraphNodeData,
+  GraphEdgeData,
+  MeshSummaryData,
+} from "@beevibe/api/views/types";


### PR DESCRIPTION
## Summary

Re-opens the content of #40 against \`main\`. Same stacking gotcha as #38: #40 merged into its base branch (\`m8-b-dashboard\`) about 10 seconds *after* #39 squashed into main, so M8.C's content lives on the now-orphaned base branch and never reached main.

This PR is the same content, retargeted to land on main directly.

## What's in here

- **M8.C phase 1** (closes #34): \`GET /mesh\` view + data/display split + radial SVG layout. Same content as #40.

(See #40 for the full PR description; nothing has changed.)

## Verification

- [x] \`pnpm -w typecheck\` — clean against main
- [x] \`pnpm --filter @beevibe/web test\` — 102/102 pass
- [x] api: 8 mesh view tests pass; pre-existing DB-integration tests gated on \`DATABASE_URL_TEST\`

## Lesson learned (again)

Stacking is fine when the parent merges normally. When the parent **squash-merges** into main *first*, the child's PR base branch becomes orphaned even if the child is later "merged into" it — the squash already shipped without the child's commits. Workaround: re-target the child to main and re-PR.

This was the third time we hit this in a row (#37 → #38, original M8.C → this re-PR). Future M8 follow-ups should branch directly off main and accept any merge conflicts on \`views/types.ts\` / \`routes/view.ts\` / \`web/lib/api/types.ts\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)