### PR TITLE
M8 cleanup — remove no-op `+ New agent` affordances

### DIFF
--- a/packages/web/app/(authed)/agents/agents-client.test.tsx
+++ b/packages/web/app/(authed)/agents/agents-client.test.tsx
@@ -77,7 +77,7 @@ describe("AgentsClient", () => {
     expect(screen.getByText("5 sessions")).toBeInTheDocument();
     expect(screen.getByText("12 sessions")).toBeInTheDocument();
     expect(
-      screen.getByText((_, el) => el?.textContent === "2 agents in your org."),
-    ).toBeInTheDocument();
+      screen.getAllByText((_, el) => el?.textContent === "2 agents in your org.").length,
+    ).toBeGreaterThan(0);
   });
 });

--- a/packages/web/app/(authed)/agents/agents-client.tsx
+++ b/packages/web/app/(authed)/agents/agents-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { AlertTriangle, Bot, Plus } from "lucide-react";
+import { AlertTriangle, Bot } from "lucide-react";
 import { useAgents } from "@/lib/hooks/use-agents";
 import { isApiConfigured } from "@/lib/api/config";
 import { OrgChart } from "@/components/agents/org-chart";
@@ -19,7 +19,7 @@ export function AgentsClient() {
   return (
     <div className="flex-1 overflow-auto">
       <div className="pt-8 pb-12 px-6">
-        <div className="max-w-5xl mx-auto flex items-end justify-between gap-6 mb-8">
+        <div className="max-w-5xl mx-auto mb-8">
           <div className="text-base text-muted-foreground">
             {count > 0 ? (
               <>
@@ -32,13 +32,6 @@ export function AgentsClient() {
               </>
             )}
           </div>
-          <button
-            type="button"
-            className="inline-flex items-center gap-2 h-8 px-3 rounded bg-primary text-primary-foreground text-xs font-medium hover:opacity-90 active:scale-[0.98] transition-all duration-150 cursor-pointer shrink-0"
-          >
-            <Plus className="h-3.5 w-3.5" />
-            New agent
-          </button>
         </div>
 
         <div className="max-w-5xl mx-auto">

--- a/packages/web/components/sidebar.tsx
+++ b/packages/web/components/sidebar.tsx
@@ -124,8 +124,6 @@ export function Sidebar() {
           title="Agents"
           open={openAgents}
           onToggle={() => setOpenAgents((v) => !v)}
-          actionLabel="New agent"
-          onAction={() => {}}
         >
           <EmptyAgentList />
         </Section>
@@ -271,13 +269,9 @@ function NavRow({ item, pathname }: { item: NavItem; pathname: string }) {
 
 function EmptyAgentList() {
   return (
-    <button
-      type="button"
-      className="flex items-center gap-2 h-7 pl-5 pr-2 rounded-md text-sm text-muted-foreground/70 hover:text-foreground hover:bg-secondary/70 cursor-pointer transition-colors w-full"
-    >
-      <Plus className="h-3.5 w-3.5 shrink-0" />
-      <span className="flex-1 truncate text-left">New agent</span>
-    </button>
+    <div className="h-7 pl-5 pr-2 flex items-center text-sm text-muted-foreground/60">
+      No agents yet
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

- Removes the sidebar Agents-section `+` icon button (was a no-op `onClick={() => {}}`)
- Removes the agents-page lead-line `+ New agent` primary CTA (also a no-op — there's no `POST /agent` route)
- Replaces the empty agent list's "+ New agent" placeholder button with muted "No agents yet" text

## Why

Per #45 §5 (and the new #46), human-driven agent creation has been reframed as a governance act and is moving to a team-proposed → human-approved Inbox flow in M9. Until that ships, M8 shouldn't include buttons that do nothing — they train the wrong affordance and frustrate users on first contact.

This PR is purely the deletion. The actual creation surface lives in #46.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 102/102 pass (one assertion in `agents-client.test.tsx` had to loosen because removing the button made the wrapper div's `textContent` equal to its inner div's; switched from `getByText` to `getAllByText(...).length > 0`)
- [ ] Visual check in dev browser (not done — pure deletion of two buttons + one placeholder swap, low risk; flag if you'd like me to run the full stack to verify)

## Related

- Closes the §5 cleanup checkbox in #45
- Sets up #46 (M9 — Team-driven agent creation via domain gap proposals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)