### PR TITLE
M7 — full-stack integration test + manual smoke recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ beevibe/
 ├── packages/
 │   ├── core/          shared library: domain, ports, services, adapters, auth
 │   ├── api/           binary: MCP tool surface for agents + REST endpoints for humans + MeshServer
-│   └── executor/      binary: task polling + session dispatch
+│   ├── executor/      binary: task polling + session dispatch
+│   └── web/           Next.js UI + API routes (M8)
 │
-├── migrations/        Drizzle migrations (populated in M1)
-└── docker-compose.yml Postgres with pgvector
+├── migrations/        node-pg-migrate SQL files
+├── scripts/           dev orchestrator + e2e smokes + provisioning helpers
+└── docker-compose.yml Postgres 16 + pgvector
 ```
 
 ### Dependency direction (enforced via ESLint)
@@ -30,42 +32,117 @@ executor/       → core (composition root)
 
 - TypeScript strict (ES2022, NodeNext)
 - pnpm workspaces + Turborepo
-- Postgres 16 + pgvector
-- Drizzle ORM (from M1)
+- Postgres 16 + pgvector, raw `pg` driver (no ORM)
+- node-pg-migrate
 - Claude Code CLI runtime
 - `@modelcontextprotocol/sdk`
 
-## Dev setup
+## Quick start
 
-Requires Node ≥ 20 and pnpm 9.
+Requires Node ≥ 20, pnpm 9, Docker, and the `claude` CLI on PATH.
 
 ```bash
 pnpm install
-docker compose up -d
-cp .env.example .env
-# fill in ANTHROPIC_API_KEY, OPENAI_API_KEY
+docker compose up -d                     # postgres + pgvector
+cp .env.example .env                     # fill in ANTHROPIC_API_KEY + OPENAI_API_KEY
+pnpm migrate up                          # apply migrations to dev DB
+pnpm dev                                 # postgres + api + executor + cloudflared tunnel
 ```
+
+`pnpm dev` runs `scripts/dev.sh`, which:
+- starts Postgres if it isn't already running
+- applies migrations
+- spawns `@beevibe/api` (port 3000 by default) and `@beevibe/executor` (health on 3001) in watch mode with `[api]` / `[exec]` log prefixes
+- if `cloudflared` is on PATH, exposes the api at a `*.trycloudflare.com` URL and prints a paste-ready `mcp.json` snippet for remote Claude CLI access. Pass `--no-tunnel` to disable.
+
+Ctrl+C tears the whole tree down via `trap 'kill 0' EXIT`.
 
 ### Common commands
 
 ```bash
-pnpm build        # tsc across all packages
-pnpm typecheck    # typecheck without emit
-pnpm lint         # eslint
-pnpm test         # vitest
-pnpm dev          # (from M5+) run services in watch mode
+pnpm build              # tsc across all packages
+pnpm typecheck          # typecheck without emit
+pnpm lint               # eslint
+pnpm test               # vitest (unit + integration)
+pnpm dev                # full local stack (postgres + api + executor + tunnel)
+pnpm migrate up         # apply migrations to DATABASE_URL
+pnpm migrate:test up    # apply migrations to DATABASE_URL_TEST
 ```
+
+## Manual smoke against the tunnel
+
+To exercise the MCP tool surface end-to-end with your own Claude CLI as the human user:
+
+```bash
+# Terminal 1 — start the stack
+pnpm dev
+# Wait for: "Tunnel URL: https://<random>.trycloudflare.com"
+# (the URL is also written to ~/.beevibe/last-tunnel-url)
+
+# Terminal 2 — provision a demo team
+pnpm tsx scripts/provision-demo.ts
+```
+
+`provision-demo.ts` creates an idempotent demo topology in the dev DB:
+
+```
+person:   demo-user (bv_u_<token>)
+  └── captain   (team-tier, owned by demo-user) ← bv_u_ resolves here
+        ├── ic-alice  (ic-tier)
+        └── ic-bob    (ic-tier)
+```
+
+It prints a paste-ready `mcp.json` snippet pointing at the live tunnel URL. Drop that into your local Claude CLI's MCP config (`~/.config/claude/mcp.json` or wherever your CLI reads it), then in any directory:
+
+```bash
+claude
+# In the chat, try:
+#   "who are my subordinates?"        → find_subordinates → [ic-alice, ic-bob]
+#   "create a task for ic-alice: write a hello-world bash script"
+#   wait ~30-60s, watching [exec] logs in Terminal 1
+#   "what's the status of that task?" → get_task → done
+#   "ask ic-alice: where is hello.sh?" → mesh-ask round-trip
+```
+
+When done:
+
+```bash
+pnpm tsx scripts/provision-demo.ts --print  # re-print existing keys/snippet
+pnpm tsx scripts/provision-demo.ts --clean  # wipe demo rows (no reseed)
+```
+
+`--clean` only removes rows owned by `demo-user`; other dev-DB data is untouched. It refuses if a demo agent has a live OS process to avoid wedging mid-flight tasks.
+
+## Integration tests
+
+Live E2E smokes that exercise real Postgres + LLM APIs. Each is gated by an env flag; CI runs them under separate jobs.
+
+```bash
+# In-process smoke (10 scenarios; api+executor bootstrapped in the same VM)
+RUN_M6_E2E=1 \
+  DATABASE_URL_TEST=postgresql://beevibe:beevibe@localhost:5433/beevibe_test \
+  OPENAI_API_KEY=... ANTHROPIC_API_KEY=... \
+  pnpm tsx scripts/m6-e2e.ts
+
+# Multi-process smoke (api + executor as actual `node dist/main.js`
+# subprocesses; verifies cross-process IPC, signal propagation, no orphans)
+RUN_M7_E2E=1 \
+  DATABASE_URL_TEST=postgresql://beevibe:beevibe@localhost:5433/beevibe_test \
+  OPENAI_API_KEY=... ANTHROPIC_API_KEY=... \
+  pnpm tsx scripts/m7-e2e.ts
+```
+
+Apply test-DB migrations first with `pnpm migrate:test up`. Both scripts truncate the test DB at start; back-to-back runs work.
 
 ## Status
 
 - **M0**: scaffold ✅
-- **M1**: domain + ports + postgres adapter + schema + migrations
-- **M2**: claude-code runtime adapter + git adapter
-- **M3**: services + pgvector + llm providers
-- **M4**: auth
-- **M5**: executor binary (polling + dispatch)
-- **M6**: api binary (MCP tool surface + REST + mesh + escalation + cancellation)
-- **M7**: integration test
-- **M8+**: web package (Next.js UI + API routes)
-
-See the old repo's project memory for the full migration plan and schema review.
+- **M1**: domain + ports + postgres adapter + schema + migrations ✅
+- **M2**: claude-code runtime adapter + git adapter ✅
+- **M3**: services + pgvector + llm providers ✅
+- **M4**: auth ✅
+- **M5**: executor binary (polling + dispatch) ✅
+- **M6**: api binary (MCP tool surface + REST + mesh + escalation + cancellation) ✅
+- **M7**: full-stack integration test (multi-process smoke + dev orchestrator + manual smoke recipe) ✅
+- **M8**: web package (Next.js UI + API routes) ✅
+- **M9**: agent skill system (markdown behavioral fragments) — placeholder, see issue #9

--- a/packages/api/src/mesh/server.ts
+++ b/packages/api/src/mesh/server.ts
@@ -107,7 +107,13 @@ export class MeshServer {
   ): Promise<AskResponse> {
     await this.checkMeshCapacity(toAgentId);
 
-    const intent = `<mesh-ask request_id="${escapeAttr(requestId)}" from="${escapeAttr(fromAgentId)}">${question}</mesh-ask>`;
+    const intent =
+      `<mesh-ask request_id="${escapeAttr(requestId)}" from="${escapeAttr(fromAgentId)}">\n` +
+      `${question}\n` +
+      `</mesh-ask>\n` +
+      `<context type="ask_response">\n` +
+      `Read the question, search relevant context if needed, and respond by calling respond_ask(request_id="${requestId}", answer="..."). The answer is delivered to the asker via that tool — replying in chat alone does NOT reach them. After respond_ask returns, exit.\n` +
+      `</context>`;
 
     void this.spawnTargetSession({
       targetAgentId: toAgentId,

--- a/packages/api/src/tools/assemble.ts
+++ b/packages/api/src/tools/assemble.ts
@@ -40,13 +40,14 @@ export interface AssembleToolsContext {
  *
  * Tier breakdown (M6.4 final):
  *
- *   IC (10 tools):
+ *   IC (13 tools):
  *     2 memory: save_memory, update_core_memory
  *     8 hierarchy (shared): search_context, update_progress, find_up,
  *       get_agent_profile, get_task, create_work_product,
  *       list_work_products, update_work_product
- *     0 mesh — except report_blocker (parent escalation path).
- *     Effectively IC = 11 (memory + 8 shared + report_blocker).
+ *     3 mesh: report_blocker (escalate up), respond_ask + respond_negotiate
+ *       (response-only — needed when team-tier agents target an IC with
+ *       `ask`/`negotiate`; without these the asker hangs).
  *
  *   Team / org (22 tools):
  *     2 memory + 14 hierarchy (8 shared + 6 team-only) +

--- a/packages/api/src/tools/mesh.ts
+++ b/packages/api/src/tools/mesh.ts
@@ -438,17 +438,24 @@ function escalateToHumansTool(
 // ── Assemble mesh tool sets ──────────────────────────────────────────────
 
 /**
- * IC tier mesh tools. ICs only get `report_blocker` — the canonical
- * escalate-to-parent path. They don't initiate ask/negotiate (lateral
- * coordination is team-tier work) and don't terminate mesh calls
- * (respond_ask / respond_negotiate are only meaningful when the session was
- * spawned as a mesh peer, which doesn't happen at IC tier).
+ * IC tier mesh tools. ICs can't INITIATE lateral coordination (no `ask` or
+ * `negotiate`), but they DO need response-side tools because team-tier
+ * agents can target ICs with `ask` / `negotiate` — when that happens the
+ * IC is spawned as a mesh_ask / mesh_negotiate peer and must call
+ * `respond_ask` / `respond_negotiate` to deliver its answer through the
+ * resolver. Without these, the asker's tool call hangs until the upstream
+ * timeout. ICs also keep `report_blocker` as the canonical escalate-to-
+ * parent path.
  */
 export function buildIcMeshTools(
   ctx: MeshToolContext,
   services: MeshToolServices,
 ): AgentTool[] {
-  return [reportBlockerTool(ctx, services)];
+  return [
+    respondAskTool(ctx, services),
+    respondNegotiateTool(ctx, services),
+    reportBlockerTool(ctx, services),
+  ];
 }
 
 /**

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -129,22 +129,18 @@ if [ "$TUNNEL_ENABLED" = "1" ]; then
       echo "[tunnel] $line"
       if [[ "$line" =~ (https://[^[:space:]]+\.trycloudflare\.com) ]]; then
         url="${BASH_REMATCH[1]}"
+        # Persist for `scripts/provision-demo.ts` to auto-pick up.
+        mkdir -p "$HOME/.beevibe"
+        printf '%s\n' "$url" > "$HOME/.beevibe/last-tunnel-url"
         cat <<EOF
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-For remote Claude CLI access, paste into ~/.config/claude/mcp.json:
+Tunnel URL: ${url}
 
-  {
-    "mcpServers": {
-      "beevibe": {
-        "type": "http",
-        "url": "${url}/mcp",
-        "headers": { "Authorization": "Bearer <YOUR_BV_U_TOKEN>" }
-      }
-    }
-  }
-
-(Provision a bv_u_ token via the M8 web UI when it lands.)
+For a manual Claude CLI smoke, run in another terminal:
+  pnpm tsx scripts/provision-demo.ts
+which prints a paste-ready ~/.config/claude/mcp.json snippet
+(captain + IC subordinates + bv_u_ token, pre-pointed at this tunnel).
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 EOF

--- a/scripts/m7-e2e.ts
+++ b/scripts/m7-e2e.ts
@@ -128,7 +128,8 @@ async function pollUntil<T>(
 
 async function fetchHealth(url: string): Promise<boolean> {
   try {
-    const res = await fetch(url);
+    // Per-request timeout so a stalled endpoint can't outlive the poll deadline.
+    const res = await fetch(url, { signal: AbortSignal.timeout(2_000) });
     return res.status === 200;
   } catch {
     return false;

--- a/scripts/m7-e2e.ts
+++ b/scripts/m7-e2e.ts
@@ -1,0 +1,433 @@
+/**
+ * M7 multi-process integration smoke.
+ *
+ * What it tests that m6-e2e CAN'T:
+ *   - api + executor spawned as actual `node dist/main.js` subprocesses
+ *     (m6-e2e bootstraps both in-process — same Node VM).
+ *   - Cross-process IPC: executor's spawned CLI subprocesses hit the api's
+ *     real HTTP endpoint (not an in-memory MCP transport).
+ *   - Env-var passthrough across processes.
+ *   - Signal propagation: parent SIGTERM → graceful child shutdown.
+ *   - Orphan-process cleanup after teardown.
+ *
+ *   RUN_M7_E2E=1 \
+ *   DATABASE_URL_TEST=postgresql://... \
+ *   OPENAI_API_KEY=... ANTHROPIC_API_KEY=... \
+ *     pnpm tsx scripts/m7-e2e.ts
+ *
+ * Requires `claude` on PATH and built dist/ for both binaries (the script
+ * calls `pnpm build --filter` before spawning so cold runs work).
+ */
+
+import { config as loadEnv } from "dotenv";
+import {
+  spawn,
+  type ChildProcess,
+  type ChildProcessWithoutNullStreams,
+} from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { createServer, type AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..");
+loadEnv({ path: resolve(repoRoot, ".env") });
+
+import {
+  agentId as makeAgentId,
+  personId as makePersonId,
+  taskId as makeTaskId,
+} from "../packages/core/src/domain/ids.js";
+import { DEFAULT_RUNTIME_CONFIG } from "../packages/core/src/domain/agent.js";
+import { provisionAgent } from "../packages/core/src/auth/provision.js";
+import { PostgresAgentRepository } from "../packages/core/src/adapters/postgres/agent-repo.js";
+import { PostgresCoreMemoryRepository } from "../packages/core/src/adapters/postgres/core-memory-repo.js";
+import { PostgresPersonRepository } from "../packages/core/src/adapters/postgres/person-repo.js";
+import { PostgresTaskRepository } from "../packages/core/src/adapters/postgres/task-repo.js";
+import { createPool, type Pool } from "../packages/core/src/adapters/postgres/client.js";
+import type { Task } from "../packages/core/src/domain/task.js";
+
+// ───────────────────────── env ─────────────────────────
+
+const REQUIRED_ENV = [
+  "RUN_M7_E2E",
+  "DATABASE_URL_TEST",
+  "OPENAI_API_KEY",
+  "ANTHROPIC_API_KEY",
+] as const;
+
+for (const k of REQUIRED_ENV) {
+  if (!process.env[k]) {
+    console.error(`✗ M7 E2E: missing env var ${k}`);
+    process.exit(1);
+  }
+}
+
+const TABLES = [
+  "escalation",
+  "negotiation_round",
+  "negotiation",
+  "memory_promotion_event",
+  "memory_fact",
+  "work_product",
+  "core_memory_block",
+  "session",
+  "task",
+  "agent",
+  "person",
+];
+
+const HEALTH_DEADLINE_MS = 15_000;
+const TASK_DEADLINE_MS = 90_000;
+const SHUTDOWN_DEADLINE_MS = 5_000;
+
+// ───────────────────────── helpers ─────────────────────────
+
+function log(msg: string): void {
+  console.log(msg);
+}
+
+function assert(cond: unknown, msg: string): asserts cond {
+  if (!cond) {
+    console.error(`    ✗ ${msg}`);
+    process.exit(1);
+  }
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((r) => setTimeout(r, ms));
+
+async function getFreePort(): Promise<number> {
+  return new Promise((resolveP, reject) => {
+    const srv = createServer();
+    srv.unref();
+    srv.on("error", reject);
+    srv.listen(0, () => {
+      const port = (srv.address() as AddressInfo).port;
+      srv.close((err) => (err ? reject(err) : resolveP(port)));
+    });
+  });
+}
+
+async function pollUntil<T>(
+  fetch: () => Promise<T | null | undefined>,
+  pred: (v: T) => boolean,
+  deadlineMs: number,
+  tag: string,
+): Promise<T> {
+  const end = Date.now() + deadlineMs;
+  while (Date.now() < end) {
+    const v = await fetch();
+    if (v != null && pred(v)) return v;
+    await sleep(500);
+  }
+  throw new Error(`pollUntil timed out: "${tag}" (deadline ${deadlineMs}ms)`);
+}
+
+async function fetchHealth(url: string): Promise<boolean> {
+  try {
+    const res = await fetch(url);
+    return res.status === 200;
+  } catch {
+    return false;
+  }
+}
+
+async function resetDb(pool: Pool): Promise<void> {
+  await pool.query(`TRUNCATE ${TABLES.join(", ")} RESTART IDENTITY CASCADE`);
+}
+
+/**
+ * Spawn a binary as `node dist/main.js`. detached:true puts it in its own
+ * process group so we can SIGTERM the whole group at teardown — that's how
+ * we propagate shutdown to grandchildren (executor → claude CLI subprocesses).
+ *
+ * stdio is piped so we can prefix and surface logs in the parent.
+ */
+function spawnBinary(opts: {
+  tag: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+}): ChildProcessWithoutNullStreams {
+  const child = spawn("node", ["dist/main.js"], {
+    cwd: opts.cwd,
+    env: opts.env,
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: true,
+  });
+
+  const prefix = (chunk: Buffer, stream: "out" | "err"): void => {
+    const s = chunk.toString("utf8");
+    for (const line of s.split("\n")) {
+      if (line.length === 0) continue;
+      if (stream === "err") {
+        process.stderr.write(`[${opts.tag}] ${line}\n`);
+      } else {
+        process.stdout.write(`[${opts.tag}] ${line}\n`);
+      }
+    }
+  };
+
+  child.stdout.on("data", (c: Buffer) => prefix(c, "out"));
+  child.stderr.on("data", (c: Buffer) => prefix(c, "err"));
+
+  return child;
+}
+
+/**
+ * SIGTERM the whole process group (kill -pgid). Returns the exit code or
+ * throws if the process didn't exit within deadlineMs (caller should
+ * SIGKILL in that case — production teardown shouldn't tolerate hangs).
+ */
+async function shutdownPGroup(
+  child: ChildProcess,
+  deadlineMs: number,
+  tag: string,
+): Promise<number> {
+  const pid = child.pid;
+  if (!pid) throw new Error(`${tag}: child has no pid`);
+
+  const exited = new Promise<number>((resolveP) => {
+    child.once("exit", (code, _signal) => {
+      resolveP(code ?? -1);
+    });
+  });
+
+  // Negative pid → process group. detached:true at spawn time made the
+  // child its own pgroup leader, so SIGTERM(-pid) reaches the executor's
+  // CLI subprocesses too.
+  try {
+    process.kill(-pid, "SIGTERM");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ESRCH") throw err;
+    return 0;
+  }
+
+  const winner = await Promise.race([
+    exited,
+    sleep(deadlineMs).then(() => -2 as const),
+  ]);
+
+  if (winner === -2) {
+    process.stderr.write(
+      `[m7] ${tag} did not exit within ${deadlineMs}ms — SIGKILL\n`,
+    );
+    try {
+      process.kill(-pid, "SIGKILL");
+    } catch {
+      // process gone, ok
+    }
+    throw new Error(`${tag}: graceful shutdown exceeded ${deadlineMs}ms`);
+  }
+
+  return winner;
+}
+
+/**
+ * `pgrep -g <pgid>` — returns true if any process is still alive in the
+ * given process group. Used post-shutdown to assert clean teardown.
+ */
+function pgroupAlive(pgid: number): boolean {
+  try {
+    // Signal 0 to negative pgid: returns OK if any process in the group
+    // exists, throws ESRCH if none.
+    process.kill(-pgid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+// ───────────────────────── seed ─────────────────────────
+
+interface Deps {
+  pool: Pool;
+  persons: PostgresPersonRepository;
+  agents: PostgresAgentRepository;
+  coreMemoryRepo: PostgresCoreMemoryRepository;
+  tasks: PostgresTaskRepository;
+}
+
+async function provisionTestData(deps: Deps): Promise<{ task: Task }> {
+  const owner = await deps.persons.create({
+    id: makePersonId(),
+    name: "m7-owner",
+  });
+
+  const { agent } = await provisionAgent(
+    {
+      agentRepo: deps.agents,
+      coreMemoryRepo: deps.coreMemoryRepo,
+    },
+    {
+      id: makeAgentId(),
+      name: "m7-ic",
+      owner_id: owner.id,
+      hierarchy_level: "ic",
+      // Explicit completion instruction works around the M9-deferred
+      // "agent forgets update_progress" footgun (see issue #9, scenario 6).
+      // Without this the agent does the work, exits, and we burn a retry
+      // session. m7-e2e's whole point is "single happy-path roundtrip" so
+      // we want a clean one-session flow.
+      runtime_config: {
+        ...DEFAULT_RUNTIME_CONFIG,
+        system_prompt_addition:
+          "When you finish your task, you MUST call the update_progress " +
+          "MCP tool with status='done' and a one-sentence summary. " +
+          "Do not exit without calling it.",
+      },
+    },
+  );
+
+  const task = await deps.tasks.create({
+    id: makeTaskId(),
+    title: "m7 smoke task",
+    description:
+      "Reply with the literal string 'm7-roundtrip-ok'. " +
+      "When done, call update_progress(status='done', summary='m7 ok').",
+    status: "assigned",
+    priority: "medium",
+    assignee_id: agent.id,
+    creator_id: owner.id,
+    creator_type: "person",
+  });
+
+  return { task };
+}
+
+// ───────────────────────── main ─────────────────────────
+
+async function main(): Promise<void> {
+  const databaseUrl = process.env.DATABASE_URL_TEST!;
+  const workspaceRoot = mkdtempSync(`${tmpdir()}/beevibe-m7-`);
+
+  const pool = createPool({ connectionString: databaseUrl });
+  const deps: Deps = {
+    pool,
+    persons: new PostgresPersonRepository(pool),
+    agents: new PostgresAgentRepository(pool),
+    coreMemoryRepo: new PostgresCoreMemoryRepository(pool),
+    tasks: new PostgresTaskRepository(pool),
+  };
+
+  log("═══ m7-e2e: multi-process integration smoke ═══");
+  let api: ChildProcessWithoutNullStreams | undefined;
+  let exec: ChildProcessWithoutNullStreams | undefined;
+
+  try {
+    log("→ build api + executor (incremental)");
+    await new Promise<void>((resolveP, reject) => {
+      const child = spawn(
+        "pnpm",
+        ["-r", "--filter", "@beevibe/api", "--filter", "@beevibe/executor", "build"],
+        { cwd: repoRoot, stdio: "inherit" },
+      );
+      child.on("exit", (code) =>
+        code === 0 ? resolveP() : reject(new Error(`build exited ${code}`)),
+      );
+    });
+
+    log("→ reset test DB + provision");
+    await resetDb(pool);
+    const { task } = await provisionTestData(deps);
+    log(`  task=${task.id} agent=${task.assignee_id}`);
+
+    log("→ pick free ports");
+    const apiPort = await getFreePort();
+    const executorHealthPort = await getFreePort();
+    const apiUrl = `http://localhost:${apiPort}`;
+    const mcpUrl = `${apiUrl}/mcp`;
+    log(`  api=${apiPort} executor-health=${executorHealthPort}`);
+
+    const childEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      DATABASE_URL: databaseUrl,
+      BEEVIBE_API_PORT: String(apiPort),
+      BEEVIBE_MCP_SERVER_URL: mcpUrl,
+      BEEVIBE_EXECUTOR_HEALTH_PORT: String(executorHealthPort),
+      WORKSPACE_ROOT: workspaceRoot,
+      // Tighten poll interval so the smoke completes faster than dev's 30s.
+      POLL_INTERVAL_MS: "2000",
+    };
+
+    log("→ spawn api + executor as subprocesses");
+    api = spawnBinary({
+      tag: "api",
+      cwd: resolve(repoRoot, "packages/api"),
+      env: childEnv,
+    });
+    exec = spawnBinary({
+      tag: "exec",
+      cwd: resolve(repoRoot, "packages/executor"),
+      env: childEnv,
+    });
+    log(`  api pid=${api.pid} exec pid=${exec.pid}`);
+
+    log("→ wait for both health endpoints");
+    await pollUntil(
+      async () => {
+        const [a, e] = await Promise.all([
+          fetchHealth(`${apiUrl}/health`),
+          fetchHealth(`http://localhost:${executorHealthPort}/health`),
+        ]);
+        return a && e ? true : null;
+      },
+      (v) => v === true,
+      HEALTH_DEADLINE_MS,
+      "both health endpoints 200",
+    );
+    log("  ✓ api + executor healthy");
+
+    log("→ wait for task done");
+    const done = await pollUntil(
+      () => deps.tasks.findById(task.id),
+      (t) => t.status === "done",
+      TASK_DEADLINE_MS,
+      `task ${task.id} → done`,
+    );
+    log(`  ✓ task=${done.id} status=${done.status} summary="${done.result_summary ?? ""}"`);
+
+    log("→ SIGTERM both subprocesses");
+    const apiPgid = api.pid!;
+    const execPgid = exec.pid!;
+    const [apiCode, execCode] = await Promise.all([
+      shutdownPGroup(api, SHUTDOWN_DEADLINE_MS, "api"),
+      shutdownPGroup(exec, SHUTDOWN_DEADLINE_MS, "exec"),
+    ]);
+    log(`  api exit=${apiCode} exec exit=${execCode}`);
+    assert(apiCode === 0, `api exit code ${apiCode} (expected 0)`);
+    assert(execCode === 0, `exec exit code ${execCode} (expected 0)`);
+
+    // Brief settle so any lingering claude grandchildren have a chance to
+    // be reaped (their exit signal travels up the tree before we check).
+    await sleep(500);
+
+    log("→ verify no orphans in either process group");
+    assert(!pgroupAlive(apiPgid), `api pgroup ${apiPgid} still has live processes`);
+    assert(!pgroupAlive(execPgid), `exec pgroup ${execPgid} still has live processes`);
+    log("  ✓ no orphan processes");
+
+    log("\n═══ ✓ m7-e2e passed ═══");
+  } finally {
+    // Belt-and-suspenders teardown: if any of the asserts above blew up
+    // before the SIGTERM block ran, kill subprocesses now so we don't
+    // leak them into the user's shell.
+    for (const child of [api, exec]) {
+      if (!child || child.exitCode !== null) continue;
+      try {
+        process.kill(-child.pid!, "SIGKILL");
+      } catch {
+        // already gone
+      }
+    }
+    await pool.end();
+    rmSync(workspaceRoot, { recursive: true, force: true });
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/provision-demo.ts
+++ b/scripts/provision-demo.ts
@@ -1,0 +1,399 @@
+/**
+ * Demo seeder for the M7 manual smoke flow.
+ *
+ * Targets the *dev* DB (DATABASE_URL) — same DB the running `pnpm dev`
+ * api+executor are connected to. Provisions a fixed topology so a human
+ * can connect their own Claude Code CLI via the cloudflared tunnel +
+ * bv_u_ token and exercise the MCP tool surface:
+ *
+ *     person:   demo-user (bv_u_<token>)
+ *       └── captain  (team-tier, owned by demo-user) ← bv_u_ resolves here
+ *             ├── ic-alice (ic-tier)
+ *             └── ic-bob   (ic-tier)
+ *
+ * Usage:
+ *   pnpm tsx scripts/provision-demo.ts            # idempotent create + print
+ *   pnpm tsx scripts/provision-demo.ts --print    # re-print existing keys
+ *   pnpm tsx scripts/provision-demo.ts --clean    # wipe demo rows (no reseed)
+ *
+ * The paste-ready mcp.json snippet uses the tunnel URL written to
+ * ~/.beevibe/last-tunnel-url by `scripts/dev.sh` if present, else
+ * falls back to http://localhost:3000.
+ */
+
+import { config as loadEnv } from "dotenv";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+loadEnv({ path: resolve(here, "../.env") });
+
+import { agentId as makeAgentId, personId as makePersonId } from "../packages/core/src/domain/ids.js";
+import { DEFAULT_RUNTIME_CONFIG } from "../packages/core/src/domain/agent.js";
+import {
+  provisionAgent,
+  provisionUser,
+} from "../packages/core/src/auth/provision.js";
+import { PostgresAgentRepository } from "../packages/core/src/adapters/postgres/agent-repo.js";
+import { PostgresCoreMemoryRepository } from "../packages/core/src/adapters/postgres/core-memory-repo.js";
+import { PostgresPersonRepository } from "../packages/core/src/adapters/postgres/person-repo.js";
+import { createPool, type Pool } from "../packages/core/src/adapters/postgres/client.js";
+import type { Agent } from "../packages/core/src/domain/agent.js";
+import type { Person } from "../packages/core/src/domain/person.js";
+
+const DEMO_PERSON_NAME = "demo-user";
+const DEMO_CAPTAIN_NAME = "captain";
+const DEMO_IC_NAMES = ["ic-alice", "ic-bob"] as const;
+
+const TUNNEL_URL_FILE = join(homedir(), ".beevibe", "last-tunnel-url");
+const DEFAULT_API_URL = "http://localhost:3000";
+
+// ───────────────────────── helpers ─────────────────────────
+
+/**
+ * Mirrors `packages/executor/src/worker.ts:isProcessAlive`. EPERM means the
+ * pid exists but in another uid — treat as alive to avoid spurious "safe
+ * to clean" verdicts. ESRCH (or any other errno) means the process is gone.
+ */
+function isProcessAlive(pid: number | null | undefined): boolean {
+  if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException)?.code === "EPERM";
+  }
+}
+
+function readTunnelUrl(): string {
+  try {
+    if (existsSync(TUNNEL_URL_FILE)) {
+      const url = readFileSync(TUNNEL_URL_FILE, "utf8").trim();
+      if (url.startsWith("http")) return url;
+    }
+  } catch {
+    // fall through to default
+  }
+  return DEFAULT_API_URL;
+}
+
+function printSnippet(opts: {
+  apiUrl: string;
+  bvUToken: string;
+  captain: Agent;
+  ics: Agent[];
+}): void {
+  const { apiUrl, bvUToken, captain, ics } = opts;
+  const bar = "━".repeat(64);
+  console.log("");
+  console.log(bar);
+  console.log("Demo topology:");
+  console.log(`  person:   ${DEMO_PERSON_NAME}`);
+  console.log(`  └── ${captain.name}  (team-tier, your auth identity)  id=${captain.id}`);
+  for (const ic of ics) {
+    console.log(`        ├── ${ic.name}  (ic-tier)  id=${ic.id}`);
+  }
+  console.log("");
+  console.log(`bv_u_ token:  ${bvUToken}`);
+  console.log(`api URL:      ${apiUrl}`);
+  console.log("");
+  console.log("Paste into ~/.config/claude/mcp.json (or your local Claude mcp config):");
+  console.log("");
+  console.log(
+    JSON.stringify(
+      {
+        mcpServers: {
+          beevibe: {
+            type: "http",
+            url: `${apiUrl}/mcp`,
+            headers: { Authorization: `Bearer ${bvUToken}` },
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  console.log("");
+  console.log("Then run `claude` in any directory and try:");
+  console.log("  - \"who are my subordinates?\"");
+  console.log("  - \"create a task for ic-alice: write a hello-world bash script\"");
+  console.log("  - \"what's the status of that task?\"");
+  console.log("");
+  console.log(`To clean up:  pnpm tsx scripts/provision-demo.ts --clean`);
+  console.log(bar);
+}
+
+// ───────────────────────── lookup ─────────────────────────
+
+async function findDemoPerson(pool: Pool): Promise<Person | undefined> {
+  const { rows } = await pool.query<Person>(
+    `SELECT * FROM person WHERE name = $1 LIMIT 1`,
+    [DEMO_PERSON_NAME],
+  );
+  return rows[0];
+}
+
+async function findDemoAgents(
+  pool: Pool,
+  ownerId: string,
+): Promise<{ captain?: Agent; ics: Agent[] }> {
+  const { rows } = await pool.query<Agent>(
+    `SELECT * FROM agent WHERE owner_id = $1 ORDER BY hierarchy_level DESC, name ASC`,
+    [ownerId],
+  );
+  const captain = rows.find((a) => a.name === DEMO_CAPTAIN_NAME);
+  const ics = rows.filter((a) => DEMO_IC_NAMES.includes(a.name as (typeof DEMO_IC_NAMES)[number]));
+  return { captain, ics };
+}
+
+// ───────────────────────── create ─────────────────────────
+
+async function createDemo(pool: Pool): Promise<{
+  bvUToken: string;
+  captain: Agent;
+  ics: Agent[];
+}> {
+  const persons = new PostgresPersonRepository(pool);
+  const agents = new PostgresAgentRepository(pool);
+  const coreMemoryRepo = new PostgresCoreMemoryRepository(pool);
+
+  const { person, apiKey: bvUToken } = await provisionUser(
+    { personRepo: persons },
+    { id: makePersonId(), name: DEMO_PERSON_NAME },
+  );
+
+  const { agent: captain } = await provisionAgent(
+    { agentRepo: agents, coreMemoryRepo },
+    {
+      id: makeAgentId(),
+      name: DEMO_CAPTAIN_NAME,
+      owner_id: person.id,
+      hierarchy_level: "team",
+      runtime_config: DEFAULT_RUNTIME_CONFIG,
+    },
+  );
+
+  const ics: Agent[] = [];
+  for (const name of DEMO_IC_NAMES) {
+    const { agent } = await provisionAgent(
+      { agentRepo: agents, coreMemoryRepo },
+      {
+        id: makeAgentId(),
+        name,
+        owner_id: person.id,
+        parent_agent_id: captain.id,
+        hierarchy_level: "ic",
+        runtime_config: DEFAULT_RUNTIME_CONFIG,
+      },
+    );
+    ics.push(agent);
+  }
+
+  return { bvUToken, captain, ics };
+}
+
+// ───────────────────────── clean ─────────────────────────
+
+async function cleanDemoData(pool: Pool): Promise<void> {
+  const person = await findDemoPerson(pool);
+  if (!person) {
+    console.log("No demo data found — nothing to clean.");
+    return;
+  }
+
+  const { rows: agentRows } = await pool.query<{ id: string }>(
+    `SELECT id FROM agent WHERE owner_id = $1`,
+    [person.id],
+  );
+  const agentIds = agentRows.map((r) => r.id);
+
+  if (agentIds.length === 0) {
+    // Person row exists but no agents — just delete the person.
+    await pool.query(`DELETE FROM person WHERE id = $1`, [person.id]);
+    console.log(`Cleaned demo person (no agents found).`);
+    return;
+  }
+
+  // Safety: refuse only if a session has a *live* OS process backing it.
+  // Sessions stuck at status='running' after `pnpm dev` was killed
+  // ungracefully have no live process — those are safe to wipe. Chat
+  // sessions never had a process_pid (they ride the api's lifetime), so
+  // they're treated as dead too.
+  const { rows: liveRows } = await pool.query<{
+    id: string;
+    process_pid: number | null;
+  }>(
+    `SELECT id, process_pid FROM session
+      WHERE agent_id = ANY($1::text[]) AND status = 'running'`,
+    [agentIds],
+  );
+  const trulyLive = liveRows.filter(
+    (r) => r.process_pid !== null && isProcessAlive(r.process_pid),
+  );
+  if (trulyLive.length > 0) {
+    console.error(
+      `✗ Refusing to clean: ${trulyLive.length} demo session(s) have live OS ` +
+        `processes (pids: ${trulyLive.map((r) => r.process_pid).join(", ")}). ` +
+        `Stop pnpm dev (or wait for tasks to settle) and retry.`,
+    );
+    process.exit(1);
+  }
+  if (liveRows.length > 0) {
+    console.log(
+      `(${liveRows.length} stale 'running' session row(s) detected — cleaning anyway since their processes are gone.)`,
+    );
+  }
+
+  await pool.query("BEGIN");
+  try {
+    // Order matters — delete things that reference others first.
+    //
+    // FK-CASCADE chains we rely on (don't need explicit deletes):
+    //   negotiation        → negotiation_round       (CASCADE)
+    //   memory_fact        → memory_promotion_event  (CASCADE)
+    //   agent              → core_memory_block       (CASCADE)
+    //   agent              → memory_fact             (CASCADE)
+    //   task               → work_product            (CASCADE)
+    //
+    // FKs without CASCADE — we delete explicitly:
+    //   escalation         → session, negotiation
+    //   negotiation        → agent, session, task
+    //   memory_promotion_event → agent (origin)
+    //   task               → agent (assignee/creator/blocker), task (parent), person
+    //   session            → agent, task, session (prior)
+    //   agent              → person, agent (parent)
+
+    await pool.query(
+      `DELETE FROM escalation
+        WHERE initiator_session_id IN (SELECT id FROM session WHERE agent_id = ANY($1::text[]))
+           OR counterparty_session_id IN (SELECT id FROM session WHERE agent_id = ANY($1::text[]))`,
+      [agentIds],
+    );
+
+    await pool.query(
+      `DELETE FROM negotiation
+        WHERE initiator_agent_id = ANY($1::text[])
+           OR counterparty_agent_id = ANY($1::text[])`,
+      [agentIds],
+    );
+
+    await pool.query(
+      `DELETE FROM memory_promotion_event
+        WHERE origin_agent_id = ANY($1::text[])`,
+      [agentIds],
+    );
+
+    // Sessions reference tasks (session.task_id), so sessions must go FIRST.
+    // Sessions also self-reference via prior_session_id — null first.
+    await pool.query(
+      `UPDATE session SET prior_session_id = NULL WHERE agent_id = ANY($1::text[])`,
+      [agentIds],
+    );
+    await pool.query(`DELETE FROM session WHERE agent_id = ANY($1::text[])`, [agentIds]);
+
+    // Tasks form a self-referential tree. Build the closure of demo-related
+    // tasks (assignee/creator in demo set OR descendant of one of those),
+    // null out parent_task_id within the closure to break the self-FK, then
+    // delete the closure. work_product CASCADEs.
+    const { rows: taskRows } = await pool.query<{ id: string }>(
+      `WITH RECURSIVE demo_tasks AS (
+         SELECT id FROM task
+          WHERE assignee_id = ANY($1::text[])
+             OR (creator_type = 'agent' AND creator_id = ANY($1::text[]))
+             OR (creator_type = 'person' AND creator_id = $2)
+         UNION
+         SELECT t.id FROM task t
+           JOIN demo_tasks dt ON t.parent_task_id = dt.id
+       )
+       SELECT id FROM demo_tasks`,
+      [agentIds, person.id],
+    );
+    if (taskRows.length > 0) {
+      const taskIds = taskRows.map((r) => r.id);
+      await pool.query(
+        `UPDATE task SET parent_task_id = NULL WHERE id = ANY($1::text[])`,
+        [taskIds],
+      );
+      await pool.query(`DELETE FROM task WHERE id = ANY($1::text[])`, [taskIds]);
+    }
+
+    // Agents reference each other via parent_agent_id; null first.
+    await pool.query(
+      `UPDATE agent SET parent_agent_id = NULL WHERE id = ANY($1::text[])`,
+      [agentIds],
+    );
+    await pool.query(`DELETE FROM agent WHERE owner_id = $1`, [person.id]);
+
+    await pool.query(`DELETE FROM person WHERE id = $1`, [person.id]);
+
+    await pool.query("COMMIT");
+  } catch (err) {
+    await pool.query("ROLLBACK");
+    throw err;
+  }
+
+  console.log(
+    `Cleaned demo data (person=${person.name}, ${agentIds.length} agent(s)).`,
+  );
+}
+
+// ───────────────────────── main ─────────────────────────
+
+async function main(): Promise<void> {
+  const args = new Set(process.argv.slice(2));
+  const flagPrint = args.has("--print");
+  const flagClean = args.has("--clean");
+
+  if (flagPrint && flagClean) {
+    console.error("✗ --print and --clean are mutually exclusive");
+    process.exit(1);
+  }
+
+  if (!process.env.DATABASE_URL) {
+    console.error(
+      "✗ DATABASE_URL not set. Make sure .env exists at the repo root and contains DATABASE_URL.",
+    );
+    process.exit(1);
+  }
+
+  const pool = createPool({ connectionString: process.env.DATABASE_URL });
+  try {
+    if (flagClean) {
+      await cleanDemoData(pool);
+      return;
+    }
+
+    const existing = await findDemoPerson(pool);
+    if (existing) {
+      const { captain, ics } = await findDemoAgents(pool, existing.id);
+      if (!captain) {
+        console.error(
+          `✗ Found ${DEMO_PERSON_NAME} but no '${DEMO_CAPTAIN_NAME}' agent. DB is in an inconsistent state. Run --clean and retry.`,
+        );
+        process.exit(1);
+      }
+      const apiUrl = readTunnelUrl();
+      printSnippet({ apiUrl, bvUToken: existing.api_key!, captain, ics });
+      return;
+    }
+
+    if (flagPrint) {
+      console.error(`✗ No demo data found. Run without --print to create it.`);
+      process.exit(1);
+    }
+
+    const { bvUToken, captain, ics } = await createDemo(pool);
+    const apiUrl = readTunnelUrl();
+    printSnippet({ apiUrl, bvUToken, captain, ics });
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/provision-demo.ts
+++ b/scripts/provision-demo.ts
@@ -176,21 +176,22 @@ async function createDemo(pool: Pool): Promise<{
     },
   );
 
-  const ics: Agent[] = [];
-  for (const name of DEMO_IC_NAMES) {
-    const { agent } = await provisionAgent(
-      { agentRepo: agents, coreMemoryRepo },
-      {
-        id: makeAgentId(),
-        name,
-        owner_id: person.id,
-        parent_agent_id: captain.id,
-        hierarchy_level: "ic",
-        runtime_config: DEFAULT_RUNTIME_CONFIG,
-      },
-    );
-    ics.push(agent);
-  }
+  const icResults = await Promise.all(
+    DEMO_IC_NAMES.map((name) =>
+      provisionAgent(
+        { agentRepo: agents, coreMemoryRepo },
+        {
+          id: makeAgentId(),
+          name,
+          owner_id: person.id,
+          parent_agent_id: captain.id,
+          hierarchy_level: "ic",
+          runtime_config: DEFAULT_RUNTIME_CONFIG,
+        },
+      ),
+    ),
+  );
+  const ics: Agent[] = icResults.map((r) => r.agent);
 
   return { bvUToken, captain, ics };
 }
@@ -286,8 +287,7 @@ async function cleanDemoData(pool: Pool): Promise<void> {
       [agentIds],
     );
 
-    // Sessions reference tasks (session.task_id), so sessions must go FIRST.
-    // Sessions also self-reference via prior_session_id — null first.
+    // session.task_id forces sessions before tasks; prior_session_id self-FK forces null-first.
     await pool.query(
       `UPDATE session SET prior_session_id = NULL WHERE agent_id = ANY($1::text[])`,
       [agentIds],
@@ -320,7 +320,6 @@ async function cleanDemoData(pool: Pool): Promise<void> {
       await pool.query(`DELETE FROM task WHERE id = ANY($1::text[])`, [taskIds]);
     }
 
-    // Agents reference each other via parent_agent_id; null first.
     await pool.query(
       `UPDATE agent SET parent_agent_id = NULL WHERE id = ANY($1::text[])`,
       [agentIds],


### PR DESCRIPTION
## Summary

- `scripts/m7-e2e.ts` — multi-process integration smoke. Spawns api + executor as actual `node dist/main.js` subprocesses (vs m6-e2e's in-process bootstrap), runs a single trivial task end-to-end, SIGTERMs both, asserts exit code 0 and no orphan processes in either pgroup. Catches what in-process tests can't: env-var passthrough, real HTTP IPC, signal propagation, process-tree teardown.
- `scripts/provision-demo.ts` — idempotent demo team backing the manual Claude-CLI-via-tunnel flow (captain + ic-alice + ic-bob). Targets the dev DB so it shares state with `pnpm dev`. `--print` re-prints existing keys, `--clean` wipes only demo rows with a process-aware safety check.
- `scripts/dev.sh` — writes the trycloudflare URL to `~/.beevibe/last-tunnel-url` so the seeder can auto-fill the paste-ready `mcp.json` snippet.
- README — Quick start, Manual smoke recipe, Integration tests sections.

## Bugs surfaced + fixed during testing

The manual smoke caught two real bugs in M6 that m6-e2e's 10 scenarios didn't cover:

1. **`sendAsk` had no instruction to call `respond_ask`.** Compare to `sendNegotiate` (line 193) and `reportBlocker` (line 377) — both append a `<context type="...">` block telling the spawned agent which MCP tool to call. `sendAsk` was bare. Result: the IC answered in chat, exited cleanly, the answer leaked into `result_summary`, the resolver never fired, and the asker hung until upstream timeout.

2. **IC tier didn't expose `respond_ask` / `respond_negotiate`.** `buildIcMeshTools` returned only `report_blocker`, with a comment claiming "ICs are never spawned as a mesh peer". Wrong — the `ask` and `negotiate` schemas accept any `target_agent_id`, including ICs. Without these tools the IC couldn't terminate the call even with a corrected intent.

Both fixes are in `packages/api/src/mesh/server.ts` and `packages/api/src/tools/mesh.ts`. No tests existed for `sendAsk` or for IC mesh tooling — adding regression coverage for these is queued as follow-up (would belong with a `mesh_ask` scenario in m6-e2e or a new ask scenario in m7-e2e).

## Related

- Closes #7
- Issue #9 updated with section 6 ("task completion") — captures the leaf-vs-parent `update_progress` distinction and the doubled-session footgun observed during the manual smoke.

## Test plan

- [x] `pnpm typecheck` (all packages)
- [x] `pnpm lint` (3 pre-existing warnings, no new ones)
- [x] `pnpm test` (all packages, 102+ tests green)
- [x] `RUN_M7_E2E=1 pnpm tsx scripts/m7-e2e.ts` end-to-end
- [x] Manual smoke against tunnel — find_subordinates, create_task, get_task, ask
- [x] `provision-demo.ts` create + idempotent re-create + --print + --clean
- [x] `provision-demo.ts --clean` after ungraceful pnpm dev kill (process-aware safety)

🤖 Generated with [Claude Code](https://claude.com/claude-code)