### PR TITLE
Chat surface hardening — addresses audit findings (#57)

### DIFF
--- a/migrations/1779000000000_add-chat-history-index.sql
+++ b/migrations/1779000000000_add-chat-history-index.sql
@@ -1,0 +1,15 @@
+-- Covering index for `SessionRepository.listChatForAgent` (PR #58).
+--
+-- The chat history endpoints filter by (agent_id, type='chat') and
+-- order by created_at DESC with a hard LIMIT. Without this index the
+-- planner index-scans `idx_session_agent_status` (which excludes
+-- created_at), pulls every chat row for the agent, then sorts. For a
+-- heavy user with 10K chat sessions that's a 10K-row sort per page
+-- load — defeats the bounded LIMIT.
+--
+-- Partial: only chat sessions are indexed, keeping the index small
+-- (mesh / task sessions stay on the general agent_status index).
+
+CREATE INDEX IF NOT EXISTS idx_session_agent_chat_created
+  ON session(agent_id, created_at DESC)
+  WHERE type = 'chat';

--- a/packages/api/src/routes/chat-internals.test.ts
+++ b/packages/api/src/routes/chat-internals.test.ts
@@ -61,16 +61,11 @@ describe("groupIntoConversations", () => {
     expect(chains[0]?.head_id).toBe("sess_orphan");
   });
 
-  it("does NOT recurse infinitely on a cycle in prior_session_id", () => {
-    // Data corruption (bad migration, manual SQL fix) could create a
-    // cycle. Pre-fix: stack overflow. Post-fix: bail with one of the
-    // cycle members as head.
+  it("bails with a cycle member as head when prior_session_id forms a loop", () => {
+    // A cycle (data corruption only) used to recurse unbounded.
     const a = makeSession({ id: "sess_a", prior_session_id: "sess_b" });
     const b = makeSession({ id: "sess_b", prior_session_id: "sess_a" });
     const chains = groupIntoConversations([a, b]);
-    // The two cycle members collapse into one chain. Head is one of
-    // them — the exact one depends on iteration order; both are valid
-    // cycle anchors.
     expect(chains).toHaveLength(1);
     expect(["sess_a", "sess_b"]).toContain(chains[0]?.head_id);
     expect(chains[0]?.sessions).toHaveLength(2);

--- a/packages/api/src/routes/chat-internals.test.ts
+++ b/packages/api/src/routes/chat-internals.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { groupIntoConversations, type ChatSession } from "./chat.js";
+
+function makeSession(overrides: Partial<ChatSession> & Pick<ChatSession, "id">): ChatSession {
+  return {
+    intent: "test",
+    status: "succeeded",
+    created_at: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+describe("groupIntoConversations", () => {
+  it("returns empty array for empty input", () => {
+    expect(groupIntoConversations([])).toEqual([]);
+  });
+
+  it("places a single session in its own chain with itself as head", () => {
+    const s = makeSession({ id: "sess_a" });
+    const chains = groupIntoConversations([s]);
+    expect(chains).toHaveLength(1);
+    expect(chains[0]?.head_id).toBe("sess_a");
+    expect(chains[0]?.sessions.map((x) => x.id)).toEqual(["sess_a"]);
+  });
+
+  it("walks prior_session_id pointers to find the chain head", () => {
+    const head = makeSession({
+      id: "sess_head",
+      created_at: new Date("2026-01-01T10:00:00Z"),
+    });
+    const middle = makeSession({
+      id: "sess_mid",
+      prior_session_id: "sess_head",
+      created_at: new Date("2026-01-01T10:01:00Z"),
+    });
+    const tail = makeSession({
+      id: "sess_tail",
+      prior_session_id: "sess_mid",
+      created_at: new Date("2026-01-01T10:02:00Z"),
+    });
+    const chains = groupIntoConversations([tail, middle, head]);
+    expect(chains).toHaveLength(1);
+    expect(chains[0]?.head_id).toBe("sess_head");
+    // Sorted oldest-first within the chain.
+    expect(chains[0]?.sessions.map((s) => s.id)).toEqual([
+      "sess_head",
+      "sess_mid",
+      "sess_tail",
+    ]);
+  });
+
+  it("treats orphan sessions (parent outside the input set) as their own chain head", () => {
+    // Common case: history pagination cuts the chain mid-way. We
+    // surface the fragment instead of dropping it.
+    const orphan = makeSession({
+      id: "sess_orphan",
+      prior_session_id: "sess_outside_window",
+    });
+    const chains = groupIntoConversations([orphan]);
+    expect(chains).toHaveLength(1);
+    expect(chains[0]?.head_id).toBe("sess_orphan");
+  });
+
+  it("does NOT recurse infinitely on a cycle in prior_session_id", () => {
+    // Data corruption (bad migration, manual SQL fix) could create a
+    // cycle. Pre-fix: stack overflow. Post-fix: bail with one of the
+    // cycle members as head.
+    const a = makeSession({ id: "sess_a", prior_session_id: "sess_b" });
+    const b = makeSession({ id: "sess_b", prior_session_id: "sess_a" });
+    const chains = groupIntoConversations([a, b]);
+    // The two cycle members collapse into one chain. Head is one of
+    // them — the exact one depends on iteration order; both are valid
+    // cycle anchors.
+    expect(chains).toHaveLength(1);
+    expect(["sess_a", "sess_b"]).toContain(chains[0]?.head_id);
+    expect(chains[0]?.sessions).toHaveLength(2);
+  });
+
+  it("orders chains newest-first by latest activity", () => {
+    const oldChain = makeSession({
+      id: "sess_old_head",
+      created_at: new Date("2026-01-01T00:00:00Z"),
+    });
+    const newChain = makeSession({
+      id: "sess_new_head",
+      created_at: new Date("2026-01-02T00:00:00Z"),
+    });
+    const chains = groupIntoConversations([oldChain, newChain]);
+    expect(chains.map((c) => c.head_id)).toEqual(["sess_new_head", "sess_old_head"]);
+  });
+
+  it("groups multiple independent chains correctly", () => {
+    const a1 = makeSession({ id: "sess_a1" });
+    const a2 = makeSession({
+      id: "sess_a2",
+      prior_session_id: "sess_a1",
+      created_at: new Date("2026-01-01T01:00:00Z"),
+    });
+    const b1 = makeSession({
+      id: "sess_b1",
+      created_at: new Date("2026-01-01T02:00:00Z"),
+    });
+    const chains = groupIntoConversations([a1, a2, b1]);
+    expect(chains).toHaveLength(2);
+    expect(chains.map((c) => c.head_id).sort()).toEqual(["sess_a1", "sess_b1"]);
+  });
+});

--- a/packages/api/src/routes/chat-rate-limit.test.ts
+++ b/packages/api/src/routes/chat-rate-limit.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { ChatRateLimiter } from "./chat-rate-limit.js";
+
+function makeClock() {
+  let now = 1_000_000;
+  return {
+    now: () => now,
+    advance(ms: number) {
+      now += ms;
+    },
+  };
+}
+
+describe("ChatRateLimiter — concurrency", () => {
+  it("allows one in-flight turn per key by default", () => {
+    const clock = makeClock();
+    const lim = new ChatRateLimiter({ now: clock.now });
+    const first = lim.acquire("u_alice");
+    expect(first.ok).toBe(true);
+  });
+
+  it("rejects a second concurrent turn for the same key", () => {
+    const clock = makeClock();
+    const lim = new ChatRateLimiter({ now: clock.now });
+    const a = lim.acquire("u_alice");
+    const b = lim.acquire("u_alice");
+    expect(a.ok).toBe(true);
+    expect(b.ok).toBe(false);
+    if (!b.ok) {
+      expect(b.reason).toBe("concurrent");
+      expect(b.retryAfterMs).toBeGreaterThan(0);
+    }
+  });
+
+  it("allows another turn after the prior is released", () => {
+    const clock = makeClock();
+    const lim = new ChatRateLimiter({ now: clock.now });
+    const a = lim.acquire("u_alice");
+    expect(a.ok).toBe(true);
+    if (a.ok) a.release();
+    const b = lim.acquire("u_alice");
+    expect(b.ok).toBe(true);
+  });
+
+  it("scopes concurrency per key — different users don't block each other", () => {
+    const clock = makeClock();
+    const lim = new ChatRateLimiter({ now: clock.now });
+    const a = lim.acquire("u_alice");
+    const b = lim.acquire("u_bob");
+    expect(a.ok).toBe(true);
+    expect(b.ok).toBe(true);
+  });
+
+  it("respects a maxConcurrent of N", () => {
+    const clock = makeClock();
+    const lim = new ChatRateLimiter({ maxConcurrent: 3, now: clock.now });
+    const a = lim.acquire("u_alice");
+    const b = lim.acquire("u_alice");
+    const c = lim.acquire("u_alice");
+    const d = lim.acquire("u_alice");
+    expect(a.ok && b.ok && c.ok).toBe(true);
+    expect(d.ok).toBe(false);
+  });
+});
+
+describe("ChatRateLimiter — sliding window throughput", () => {
+  it("rejects a request when the window is at capacity", () => {
+    const clock = makeClock();
+    const lim = new ChatRateLimiter({
+      maxConcurrent: 5,
+      maxPerWindow: 2,
+      windowMs: 60_000,
+      now: clock.now,
+    });
+    const a = lim.acquire("u_alice");
+    if (a.ok) a.release();
+    const b = lim.acquire("u_alice");
+    if (b.ok) b.release();
+    const c = lim.acquire("u_alice");
+    expect(c.ok).toBe(false);
+    if (!c.ok) {
+      expect(c.reason).toBe("throughput");
+      expect(c.retryAfterMs).toBeGreaterThan(0);
+    }
+  });
+
+  it("forgets old timestamps once they fall outside the window", () => {
+    const clock = makeClock();
+    const lim = new ChatRateLimiter({
+      maxConcurrent: 5,
+      maxPerWindow: 1,
+      windowMs: 1_000,
+      now: clock.now,
+    });
+    const a = lim.acquire("u_alice");
+    if (a.ok) a.release();
+    const blocked = lim.acquire("u_alice");
+    expect(blocked.ok).toBe(false);
+    clock.advance(1_001);
+    const allowed = lim.acquire("u_alice");
+    expect(allowed.ok).toBe(true);
+  });
+
+  it("retryAfterMs reflects time until the oldest entry exits the window", () => {
+    const clock = makeClock();
+    const lim = new ChatRateLimiter({
+      maxConcurrent: 5,
+      maxPerWindow: 1,
+      windowMs: 1_000,
+      now: clock.now,
+    });
+    const first = lim.acquire("u_alice");
+    if (first.ok) first.release();
+    clock.advance(400);
+    const blocked = lim.acquire("u_alice");
+    expect(blocked.ok).toBe(false);
+    if (!blocked.ok) {
+      // 1000 - 400 = 600 remaining until first entry expires.
+      expect(blocked.retryAfterMs).toBe(600);
+    }
+  });
+});
+
+describe("ChatRateLimiter — release safety", () => {
+  it("over-release is a no-op (doesn't go negative)", () => {
+    const clock = makeClock();
+    const lim = new ChatRateLimiter({ now: clock.now });
+    const a = lim.acquire("u_alice");
+    if (a.ok) {
+      a.release();
+      a.release(); // double release shouldn't break the next acquire
+    }
+    const b = lim.acquire("u_alice");
+    expect(b.ok).toBe(true);
+  });
+
+  it("reset clears in-flight + window state", () => {
+    const clock = makeClock();
+    const lim = new ChatRateLimiter({ maxConcurrent: 1, now: clock.now });
+    lim.acquire("u_alice");
+    lim.reset();
+    const after = lim.acquire("u_alice");
+    expect(after.ok).toBe(true);
+  });
+});

--- a/packages/api/src/routes/chat-rate-limit.ts
+++ b/packages/api/src/routes/chat-rate-limit.ts
@@ -1,0 +1,103 @@
+/**
+ * Per-token rate limiter for `POST /chat`.
+ *
+ * Each chat turn spawns a Claude Code subprocess (~30s, real $$).
+ * Without per-token throttling, a misbehaving client or compromised
+ * `bv_u_` token could drain budget in a tight loop. We enforce two
+ * separate ceilings:
+ *
+ *   - `maxConcurrent`: how many turns can be in flight for the same
+ *     token simultaneously. Defaults to 1, which both protects against
+ *     accidental double-fire (network retries, double-click) and
+ *     forms the basis of the idempotency check (the route uses the
+ *     same key — the bv_u_ token — as a coarse mutex).
+ *
+ *   - `maxPerWindow` over `windowMs`: sliding-window cap on turns
+ *     started by the same token. Defaults to 30 turns / 60s, which
+ *     is generous for real human typing speed but stops scripted
+ *     abuse cold.
+ *
+ * In-memory only — fine for single-process api in dev/early prod. If
+ * we move to multi-instance, swap for a Redis-backed implementation
+ * with the same `acquire`/`release` shape.
+ */
+
+export type RateLimitOutcome =
+  | { ok: true; release: () => void }
+  | { ok: false; reason: "concurrent" | "throughput"; retryAfterMs: number };
+
+export interface ChatRateLimiterOptions {
+  maxConcurrent?: number;
+  maxPerWindow?: number;
+  windowMs?: number;
+  /** Test seam — defaults to `Date.now()`. */
+  now?: () => number;
+}
+
+export class ChatRateLimiter {
+  private readonly maxConcurrent: number;
+  private readonly maxPerWindow: number;
+  private readonly windowMs: number;
+  private readonly now: () => number;
+  private readonly inFlight = new Map<string, number>();
+  private readonly windows = new Map<string, number[]>();
+
+  constructor(opts: ChatRateLimiterOptions = {}) {
+    this.maxConcurrent = opts.maxConcurrent ?? 1;
+    this.maxPerWindow = opts.maxPerWindow ?? 30;
+    this.windowMs = opts.windowMs ?? 60_000;
+    this.now = opts.now ?? (() => Date.now());
+  }
+
+  /**
+   * Try to acquire a slot for this token. On success, returns a
+   * `release()` to call when the turn finishes (success OR failure).
+   * On failure, returns the reason + how long until the caller could
+   * legitimately retry — handy for `Retry-After` headers.
+   */
+  acquire(key: string): RateLimitOutcome {
+    const now = this.now();
+
+    // Drop expired timestamps before counting.
+    const window = this.windows.get(key) ?? [];
+    const cutoff = now - this.windowMs;
+    while (window.length > 0 && window[0]! < cutoff) window.shift();
+
+    if (window.length >= this.maxPerWindow) {
+      const oldest = window[0]!;
+      return {
+        ok: false,
+        reason: "throughput",
+        retryAfterMs: Math.max(0, oldest + this.windowMs - now),
+      };
+    }
+
+    const inFlight = this.inFlight.get(key) ?? 0;
+    if (inFlight >= this.maxConcurrent) {
+      // No clean retry-after for concurrency — depends on the LLM
+      // turn duration, which we don't know. Use a conservative 1s
+      // hint so the client doesn't hot-loop.
+      return { ok: false, reason: "concurrent", retryAfterMs: 1_000 };
+    }
+
+    // Reserve the slot.
+    window.push(now);
+    this.windows.set(key, window);
+    this.inFlight.set(key, inFlight + 1);
+
+    return {
+      ok: true,
+      release: () => {
+        const remaining = (this.inFlight.get(key) ?? 1) - 1;
+        if (remaining <= 0) this.inFlight.delete(key);
+        else this.inFlight.set(key, remaining);
+      },
+    };
+  }
+
+  /** Test seam — drop all in-flight + window state. */
+  reset(): void {
+    this.inFlight.clear();
+    this.windows.clear();
+  }
+}

--- a/packages/api/src/routes/chat-rate-limit.ts
+++ b/packages/api/src/routes/chat-rate-limit.ts
@@ -58,7 +58,8 @@ export class ChatRateLimiter {
   acquire(key: string): RateLimitOutcome {
     const now = this.now();
 
-    // Drop expired timestamps before counting.
+    // Drop expired timestamps before counting (also reclaims memory
+    // from one-time visitors via the windows.delete branch below).
     const window = this.windows.get(key) ?? [];
     const cutoff = now - this.windowMs;
     while (window.length > 0 && window[0]! < cutoff) window.shift();
@@ -74,13 +75,16 @@ export class ChatRateLimiter {
 
     const inFlight = this.inFlight.get(key) ?? 0;
     if (inFlight >= this.maxConcurrent) {
+      // Garbage-collect: window is non-empty (we just pruned), keep it.
+      // But if the prune emptied the window AND nothing's in flight,
+      // free the entry so long-tail visitors don't accumulate forever.
+      if (window.length === 0 && inFlight === 0) this.windows.delete(key);
+      else this.windows.set(key, window);
       // No clean retry-after for concurrency — depends on the LLM
-      // turn duration, which we don't know. Use a conservative 1s
-      // hint so the client doesn't hot-loop.
+      // turn duration, which we don't know. 1s hint stops hot-looping.
       return { ok: false, reason: "concurrent", retryAfterMs: 1_000 };
     }
 
-    // Reserve the slot.
     window.push(now);
     this.windows.set(key, window);
     this.inFlight.set(key, inFlight + 1);

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -18,6 +18,7 @@
  * client just lost its component-state copy of the conversation.
  */
 
+import { randomUUID } from "node:crypto";
 import { Router, type RequestHandler, type Response } from "express";
 import {
   AgentSession,
@@ -45,11 +46,7 @@ export interface ChatRoutesDeps {
   workspaceManager: WorkspaceManager;
   runtimeRegistry: RuntimeRegistry;
   makeMemoryAgent: (agentId: string) => MemoryAgent;
-  /**
-   * Per-person rate limiter for `POST /chat`. Optional: when not
-   * provided we mint a default. Tests inject their own with a
-   * deterministic `now()` so they can exercise window expiry.
-   */
+  /** Optional override; tests inject one with a deterministic clock. */
   rateLimiter?: ChatRateLimiter;
 }
 
@@ -158,15 +155,10 @@ interface HistoryMessage {
   suggested_actions?: SuggestedAction[];
 }
 
-/**
- * 500 response with a generic message. The original error is logged
- * server-side with a request id the client can paste into a bug report
- * if they want to look it up. Internal error text (stack traces,
- * upstream provider quirks, internal node ids) shouldn't ship to the
- * browser — leaks implementation detail and occasionally credentials.
- */
+// Generic 500 — internal error text stays in server logs, indexed by
+// request_id the client can paste into a bug report.
 function handleError(err: unknown, res: Response): void {
-  const requestId = `req_${Math.random().toString(36).slice(2, 14)}`;
+  const requestId = `req_${randomUUID()}`;
   const detail = err instanceof Error ? err.stack ?? err.message : String(err);
   console.error(`[chat route] ${requestId}`, detail);
   res.status(500).json({
@@ -212,7 +204,6 @@ export interface ConversationChain {
  * themselves — preferable to dropping data, even if technically a
  * fragment of an older conversation.
  */
-/** Exported for unit testing only — route uses it internally. */
 export function groupIntoConversations(
   sessions: readonly ChatSession[],
 ): ConversationChain[] {
@@ -315,29 +306,34 @@ function previewOf(s: ChatSession): string {
     : oneLine.slice(0, CONVERSATION_PREVIEW_CHARS - 1) + "…";
 }
 
-/**
- * Hard cap on a single chat turn. AgentSession.run honors abortSignal;
- * we wire a setTimeout to abort the run if it goes past this. Beyond
- * this point the user has likely given up and reloaded — we should free
- * the HTTP socket + DB connection rather than wait for the LLM tail.
- */
+// Hard cap on a single chat turn. AgentSession.run honors abortSignal;
+// past this we free the socket + DB connection rather than wait on the
+// LLM tail.
 const CHAT_TURN_TIMEOUT_MS = 90_000;
 
+interface ChatTurnSession {
+  id: string;
+  status: string;
+  result_summary?: string;
+  error?: string;
+}
+
+interface ChatTurnAgent {
+  id: string;
+  name: string;
+  hierarchy_level: string;
+}
+
 /**
- * Replay an existing chat session as if it were a freshly-completed
- * turn. Used by the idempotency check: if a client retries a POST with
- * the same `session_id` (network blip, double-click), we don't run the
- * agent again — we hand back the already-recorded result.
+ * Build the response body for a chat turn — used by both the live
+ * POST success path and the idempotent-replay path. `replayed: true`
+ * tells the client this body came from a prior turn's persisted state.
  */
-function replayChatSession(
-  session: {
-    id: string;
-    status: string;
-    result_summary?: string;
-    error?: string;
-  },
-  agent: { id: string; name: string; hierarchy_level: string },
-): unknown {
+function toChatTurnResponse(
+  session: ChatTurnSession,
+  agent: ChatTurnAgent,
+  opts: { replayed?: boolean } = {},
+): Record<string, unknown> {
   const { visible, view_refs, open_view, suggested_actions } = processResponse(
     session.result_summary ?? "",
   );
@@ -350,15 +346,74 @@ function replayChatSession(
     view_refs,
     ...(open_view ? { open_view } : {}),
     ...(suggested_actions ? { suggested_actions } : {}),
-    replayed: true,
+    ...(opts.replayed ? { replayed: true } : {}),
   };
+}
+
+type ReplayDecision =
+  | { kind: "respond"; status: number; body: Record<string, unknown> }
+  | { kind: "skip" };
+
+/**
+ * Look up an existing chat session for a retry POST and decide what
+ * to do. Returns `null` when the row doesn't exist or isn't a chat
+ * session — the caller should fall through to the run path.
+ *
+ * Validates ownership against the agent we already resolved for the
+ * caller; mismatch means a session id collision (or token misuse) and
+ * the caller gets a 403.
+ */
+async function tryReplay(
+  deps: Pick<ChatRoutesDeps, "sessionRepo">,
+  agent: { id: string; name: string; hierarchy_level: string },
+  callerSessionId: string,
+): Promise<ReplayDecision | null> {
+  const existing = await deps.sessionRepo.findById(callerSessionId);
+  if (!existing || existing.type !== "chat") return null;
+  if (existing.agent_id !== agent.id) {
+    return {
+      kind: "respond",
+      status: 403,
+      body: {
+        error: "session_belongs_to_other_caller",
+        message: "session id collides with a session owned by a different person",
+      },
+    };
+  }
+  if (existing.status === "running") {
+    return {
+      kind: "respond",
+      status: 409,
+      body: {
+        error: "session_in_flight",
+        message: "this session is currently running; wait for it to finish",
+      },
+    };
+  }
+  if (existing.status === "succeeded" || existing.status === "failed") {
+    return {
+      kind: "respond",
+      status: 200,
+      body: toChatTurnResponse(
+        {
+          id: existing.id,
+          status: existing.status,
+          result_summary: existing.result_summary ?? undefined,
+          error: existing.error ?? undefined,
+        },
+        agent,
+        { replayed: true },
+      ),
+    };
+  }
+  return { kind: "skip" };
 }
 
 export function createChatRouter(deps: ChatRoutesDeps): Router {
   const router = Router();
   router.use(deps.authMiddleware);
-  // Mint a default rate limiter if the caller didn't supply one.
-  // Tests inject their own with a deterministic clock.
+  // Tests inject their own ChatRateLimiter (deterministic clock); a
+  // default ships otherwise.
   const rateLimiter = deps.rateLimiter ?? new ChatRateLimiter();
 
   router.get("/conversations", async (req, res) => {
@@ -454,58 +509,40 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
         ? body.session_id
         : undefined;
 
-    // ── Idempotency check ─────────────────────────────────────────
-    // If the client provided a session_id and we already have a row
-    // for it, treat this as a retry. Reasons it might happen:
-    //   - network blip mid-response → client auto-retried
-    //   - browser back/forward cache replays the POST
-    //   - double-submit from a UI bug
-    // Each chat turn is a real Claude Code subprocess (~$$); replaying
-    // the recorded result is much cheaper than re-running the turn.
+    // Resolve the caller's primary agent + their person row up front
+    // (parallel). The agent is needed everywhere downstream — replay
+    // path verifies ownership against it, run path uses it as the
+    // session's agent.
+    const [agent, person] = await Promise.all([
+      deps.agentRepo.findTopLevelForOwner(req.caller.personId),
+      deps.personRepo.findById(req.caller.personId),
+    ]);
+    if (!agent) {
+      res.status(404).json({
+        error: "no_primary_agent",
+        message:
+          "no team or org agent provisioned for the caller; create one via the CLI before chatting",
+      });
+      return;
+    }
+
+    // Idempotent retry: if the client passed a session_id we already
+    // have a row for, replay its persisted result instead of spawning
+    // another Claude Code subprocess. Each turn is real $$; this
+    // collapses double-submits, browser-cache POST replays, and
+    // network-blip retries to a single charge.
     if (callerSessionId) {
-      const existing = await deps.sessionRepo.findById(callerSessionId);
-      if (existing && existing.type === "chat") {
-        const owningAgent = await deps.agentRepo.findById(existing.agent_id);
-        if (owningAgent && owningAgent.owner_id !== req.caller.personId) {
-          res.status(403).json({
-            error: "session_belongs_to_other_caller",
-            message: "session id collides with a session owned by a different person",
-          });
-          return;
-        }
-        if (existing.status === "running") {
-          res.status(409).json({
-            error: "session_in_flight",
-            message: "this session is currently running; wait for it to finish",
-          });
-          return;
-        }
-        if (existing.status === "succeeded" || existing.status === "failed") {
-          // Replay the prior result — same shape the original turn returned.
-          res.json(
-            replayChatSession(
-              {
-                id: existing.id,
-                status: existing.status,
-                result_summary: existing.result_summary ?? undefined,
-                error: existing.error ?? undefined,
-              },
-              {
-                id: owningAgent!.id,
-                name: owningAgent!.name,
-                hierarchy_level: owningAgent!.hierarchy_level,
-              },
-            ),
-          );
+      const replay = await tryReplay(deps, agent, callerSessionId);
+      if (replay) {
+        if (replay.kind === "respond") {
+          res.status(replay.status).json(replay.body);
           return;
         }
       }
     }
 
-    // ── Rate limit ────────────────────────────────────────────────
-    // Per-person, both concurrent (1 turn at a time) and sliding
-    // window (default 30 turns/min). Compromised tokens or scripted
-    // abuse can't drain budget unbounded.
+    // Per-person rate limit (concurrent + sliding window). Compromised
+    // tokens / scripted abuse can't drain budget unbounded.
     const rateOutcome = rateLimiter.acquire(req.caller.personId);
     if (!rateOutcome.ok) {
       res
@@ -522,23 +559,7 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
       return;
     }
 
-    // Resolve caller + their primary agent (team preferred, org fallback)
-    // and the person row (for onboarding state) in parallel.
-    const [agent, person] = await Promise.all([
-      deps.agentRepo.findTopLevelForOwner(req.caller.personId),
-      deps.personRepo.findById(req.caller.personId),
-    ]);
-    if (!agent) {
-      rateOutcome.release();
-      res.status(404).json({
-        error: "no_primary_agent",
-        message:
-          "no team or org agent provisioned for the caller; create one via the CLI before chatting",
-      });
-      return;
-    }
     const isOnboarding = !person?.onboarding_completed_at;
-
     const runtime = deps.runtimeRegistry[agent.runtime_config.type];
     if (!runtime) {
       rateOutcome.release();
@@ -549,10 +570,6 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
       return;
     }
 
-    // ── Timeout ───────────────────────────────────────────────────
-    // 90s ceiling on a single turn. AgentSession.run honors abortSignal;
-    // when the timer fires the runtime tears down its CLI subprocess
-    // and the route returns 504 instead of holding the socket open.
     const abortController = new AbortController();
     let timedOut = false;
     const timeoutTimer = setTimeout(() => {
@@ -584,12 +601,8 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
           .join("\n\n"),
       });
 
-      const { visible, view_refs, open_view, suggested_actions } =
-        processResponse(session.result_summary ?? "");
-
-      // Mark onboarding complete after the first successful chat turn —
-      // fire-and-forget so a slow update can't block the response. The
-      // welcome wizard polls `/me` and routes onward when this flips.
+      // Onboarding state flip — fire-and-forget. Welcome wizard polls
+      // `/me` and routes onward when this lands.
       if (isOnboarding && session.status === "succeeded") {
         deps.personRepo
           .update(req.caller.personId, { onboarding_completed_at: new Date() })
@@ -601,16 +614,21 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
           );
       }
 
-      res.json({
-        ok: true,
-        agent: { id: agent.id, name: agent.name, hierarchy: agent.hierarchy_level },
-        session_id: session.id,
-        response: visible,
-        status: session.status,
-        view_refs,
-        ...(open_view ? { open_view } : {}),
-        ...(suggested_actions ? { suggested_actions } : {}),
-      });
+      res.json(
+        toChatTurnResponse(
+          {
+            id: session.id,
+            status: session.status,
+            result_summary: session.result_summary ?? undefined,
+            error: session.error ?? undefined,
+          },
+          {
+            id: agent.id,
+            name: agent.name,
+            hierarchy_level: agent.hierarchy_level,
+          },
+        ),
+      );
     } catch (err) {
       if (timedOut) {
         res.status(504).json({

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -33,6 +33,7 @@ import type {
 } from "@beevibe/core";
 import type { MemoryAgent } from "@beevibe/core/services/memory";
 import { requireHuman } from "../auth/middleware.js";
+import { ChatRateLimiter } from "./chat-rate-limit.js";
 import { processResponse, type SuggestedAction } from "./directives.js";
 
 export interface ChatRoutesDeps {
@@ -44,6 +45,12 @@ export interface ChatRoutesDeps {
   workspaceManager: WorkspaceManager;
   runtimeRegistry: RuntimeRegistry;
   makeMemoryAgent: (agentId: string) => MemoryAgent;
+  /**
+   * Per-person rate limiter for `POST /chat`. Optional: when not
+   * provided we mint a default. Tests inject their own with a
+   * deterministic `now()` so they can exercise window expiry.
+   */
+  rateLimiter?: ChatRateLimiter;
 }
 
 const CHAT_DIRECTIVES = `
@@ -151,19 +158,34 @@ interface HistoryMessage {
   suggested_actions?: SuggestedAction[];
 }
 
+/**
+ * 500 response with a generic message. The original error is logged
+ * server-side with a request id the client can paste into a bug report
+ * if they want to look it up. Internal error text (stack traces,
+ * upstream provider quirks, internal node ids) shouldn't ship to the
+ * browser — leaks implementation detail and occasionally credentials.
+ */
 function handleError(err: unknown, res: Response): void {
-  console.error("[chat route]", err);
+  const requestId = `req_${Math.random().toString(36).slice(2, 14)}`;
+  const detail = err instanceof Error ? err.stack ?? err.message : String(err);
+  console.error(`[chat route] ${requestId}`, detail);
   res.status(500).json({
     error: "internal_error",
-    message: err instanceof Error ? err.message : String(err),
+    message: "Something went wrong. Try again in a moment.",
+    request_id: requestId,
   });
 }
 
 const HISTORY_LIMIT = 50;
 const CONVERSATIONS_LIMIT = 50;
 const CONVERSATION_PREVIEW_CHARS = 140;
+// Hard ceiling pulled from the DB so a heavy user with thousands of
+// chat turns doesn't drag the route every page load. Generous (4×
+// CONVERSATIONS_LIMIT × 2 turns/conversation gives plenty of headroom)
+// while still bounded. Pagination is a follow-up.
+const CHAT_FETCH_LIMIT = 400;
 
-interface ChatSession {
+export interface ChatSession {
   id: string;
   prior_session_id?: string;
   intent: string;
@@ -173,7 +195,7 @@ interface ChatSession {
   created_at: Date;
 }
 
-interface ConversationChain {
+export interface ConversationChain {
   /** Head session id — first turn in the chain (no prior_session_id). */
   head_id: string;
   /** Sessions in chronological order (oldest first). */
@@ -190,15 +212,46 @@ interface ConversationChain {
  * themselves — preferable to dropping data, even if technically a
  * fragment of an older conversation.
  */
-function groupIntoConversations(sessions: readonly ChatSession[]): ConversationChain[] {
+/** Exported for unit testing only — route uses it internally. */
+export function groupIntoConversations(
+  sessions: readonly ChatSession[],
+): ConversationChain[] {
   const byId = new Map(sessions.map((s) => [s.id, s]));
   const headOf = new Map<string, string>();
-  const findHead = (s: ChatSession): string => {
-    const cached = headOf.get(s.id);
+  // Iterative walk with a visited set so a cycle in `prior_session_id`
+  // (which can only happen via data corruption — bad migration, manual
+  // SQL fix) doesn't blow the stack. When we detect a cycle, treat the
+  // first session in the cycle as the head; the chain still surfaces,
+  // just at an arbitrary anchor point. Crashing here would take down
+  // the entire chat history endpoint.
+  const findHead = (start: ChatSession): string => {
+    const cached = headOf.get(start.id);
     if (cached) return cached;
-    const parent = s.prior_session_id ? byId.get(s.prior_session_id) : undefined;
-    const head = parent ? findHead(parent) : s.id;
-    headOf.set(s.id, head);
+    const visited = new Set<string>();
+    let cur: ChatSession = start;
+    while (cur.prior_session_id) {
+      if (visited.has(cur.id)) {
+        // Cycle: bail with `cur` as the head. Cache for every node we
+        // walked through so we don't re-walk on the next call.
+        for (const id of visited) headOf.set(id, cur.id);
+        return cur.id;
+      }
+      visited.add(cur.id);
+      const parent = byId.get(cur.prior_session_id);
+      if (!parent) break; // pointer outside input window — `cur` is head
+      // Short-circuit: if we've already resolved an ancestor's head,
+      // reuse it.
+      const ancestorHead = headOf.get(parent.id);
+      if (ancestorHead) {
+        for (const id of visited) headOf.set(id, ancestorHead);
+        headOf.set(start.id, ancestorHead);
+        return ancestorHead;
+      }
+      cur = parent;
+    }
+    const head = cur.id;
+    for (const id of visited) headOf.set(id, head);
+    headOf.set(start.id, head);
     return head;
   };
 
@@ -262,9 +315,51 @@ function previewOf(s: ChatSession): string {
     : oneLine.slice(0, CONVERSATION_PREVIEW_CHARS - 1) + "…";
 }
 
+/**
+ * Hard cap on a single chat turn. AgentSession.run honors abortSignal;
+ * we wire a setTimeout to abort the run if it goes past this. Beyond
+ * this point the user has likely given up and reloaded — we should free
+ * the HTTP socket + DB connection rather than wait for the LLM tail.
+ */
+const CHAT_TURN_TIMEOUT_MS = 90_000;
+
+/**
+ * Replay an existing chat session as if it were a freshly-completed
+ * turn. Used by the idempotency check: if a client retries a POST with
+ * the same `session_id` (network blip, double-click), we don't run the
+ * agent again — we hand back the already-recorded result.
+ */
+function replayChatSession(
+  session: {
+    id: string;
+    status: string;
+    result_summary?: string;
+    error?: string;
+  },
+  agent: { id: string; name: string; hierarchy_level: string },
+): unknown {
+  const { visible, view_refs, open_view, suggested_actions } = processResponse(
+    session.result_summary ?? "",
+  );
+  return {
+    ok: true,
+    agent: { id: agent.id, name: agent.name, hierarchy: agent.hierarchy_level },
+    session_id: session.id,
+    response: visible || session.error || "",
+    status: session.status,
+    view_refs,
+    ...(open_view ? { open_view } : {}),
+    ...(suggested_actions ? { suggested_actions } : {}),
+    replayed: true,
+  };
+}
+
 export function createChatRouter(deps: ChatRoutesDeps): Router {
   const router = Router();
   router.use(deps.authMiddleware);
+  // Mint a default rate limiter if the caller didn't supply one.
+  // Tests inject their own with a deterministic clock.
+  const rateLimiter = deps.rateLimiter ?? new ChatRateLimiter();
 
   router.get("/conversations", async (req, res) => {
     if (!requireHuman(req, res)) return;
@@ -273,8 +368,7 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
       res.json({ ok: true, conversations: [] });
       return;
     }
-    const all = await deps.sessionRepo.listForAgent(agent.id);
-    const chats = all.filter((s) => s.type === "chat");
+    const chats = await deps.sessionRepo.listChatForAgent(agent.id, CHAT_FETCH_LIMIT);
     const chains = groupIntoConversations(chats).slice(0, CONVERSATIONS_LIMIT);
 
     const conversations = chains.map((chain) => {
@@ -307,8 +401,7 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
     }
 
     const requestedHead = typeof req.query.c === "string" ? req.query.c : undefined;
-    const all = await deps.sessionRepo.listForAgent(agent.id);
-    const chats = all.filter((s) => s.type === "chat");
+    const chats = await deps.sessionRepo.listChatForAgent(agent.id, CHAT_FETCH_LIMIT);
     const chains = groupIntoConversations(chats);
 
     const chain = requestedHead
@@ -361,6 +454,74 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
         ? body.session_id
         : undefined;
 
+    // ── Idempotency check ─────────────────────────────────────────
+    // If the client provided a session_id and we already have a row
+    // for it, treat this as a retry. Reasons it might happen:
+    //   - network blip mid-response → client auto-retried
+    //   - browser back/forward cache replays the POST
+    //   - double-submit from a UI bug
+    // Each chat turn is a real Claude Code subprocess (~$$); replaying
+    // the recorded result is much cheaper than re-running the turn.
+    if (callerSessionId) {
+      const existing = await deps.sessionRepo.findById(callerSessionId);
+      if (existing && existing.type === "chat") {
+        const owningAgent = await deps.agentRepo.findById(existing.agent_id);
+        if (owningAgent && owningAgent.owner_id !== req.caller.personId) {
+          res.status(403).json({
+            error: "session_belongs_to_other_caller",
+            message: "session id collides with a session owned by a different person",
+          });
+          return;
+        }
+        if (existing.status === "running") {
+          res.status(409).json({
+            error: "session_in_flight",
+            message: "this session is currently running; wait for it to finish",
+          });
+          return;
+        }
+        if (existing.status === "succeeded" || existing.status === "failed") {
+          // Replay the prior result — same shape the original turn returned.
+          res.json(
+            replayChatSession(
+              {
+                id: existing.id,
+                status: existing.status,
+                result_summary: existing.result_summary ?? undefined,
+                error: existing.error ?? undefined,
+              },
+              {
+                id: owningAgent!.id,
+                name: owningAgent!.name,
+                hierarchy_level: owningAgent!.hierarchy_level,
+              },
+            ),
+          );
+          return;
+        }
+      }
+    }
+
+    // ── Rate limit ────────────────────────────────────────────────
+    // Per-person, both concurrent (1 turn at a time) and sliding
+    // window (default 30 turns/min). Compromised tokens or scripted
+    // abuse can't drain budget unbounded.
+    const rateOutcome = rateLimiter.acquire(req.caller.personId);
+    if (!rateOutcome.ok) {
+      res
+        .status(429)
+        .set("Retry-After", String(Math.ceil(rateOutcome.retryAfterMs / 1000)))
+        .json({
+          error: rateOutcome.reason === "concurrent" ? "turn_in_flight" : "rate_limited",
+          message:
+            rateOutcome.reason === "concurrent"
+              ? "Wait for your previous chat turn to finish before sending another."
+              : "Too many chat turns recently. Try again in a moment.",
+          retry_after_ms: rateOutcome.retryAfterMs,
+        });
+      return;
+    }
+
     // Resolve caller + their primary agent (team preferred, org fallback)
     // and the person row (for onboarding state) in parallel.
     const [agent, person] = await Promise.all([
@@ -368,6 +529,7 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
       deps.personRepo.findById(req.caller.personId),
     ]);
     if (!agent) {
+      rateOutcome.release();
       res.status(404).json({
         error: "no_primary_agent",
         message:
@@ -379,12 +541,24 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
 
     const runtime = deps.runtimeRegistry[agent.runtime_config.type];
     if (!runtime) {
+      rateOutcome.release();
       res.status(500).json({
         error: "unsupported_runtime",
         message: `runtime type '${agent.runtime_config.type}' has no registered adapter`,
       });
       return;
     }
+
+    // ── Timeout ───────────────────────────────────────────────────
+    // 90s ceiling on a single turn. AgentSession.run honors abortSignal;
+    // when the timer fires the runtime tears down its CLI subprocess
+    // and the route returns 504 instead of holding the socket open.
+    const abortController = new AbortController();
+    let timedOut = false;
+    const timeoutTimer = setTimeout(() => {
+      timedOut = true;
+      abortController.abort();
+    }, CHAT_TURN_TIMEOUT_MS);
 
     try {
       const workspace = await deps.workspaceManager.ensureWorkspace({ agent });
@@ -404,6 +578,7 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
         type: "chat",
         sessionId: callerSessionId,
         priorSessionId,
+        abortSignal: abortController.signal,
         extraSystemPromptAppend: [CHAT_DIRECTIVES, isOnboarding ? ONBOARDING_DIRECTIVES : ""]
           .filter((s) => s.length > 0)
           .join("\n\n"),
@@ -437,7 +612,18 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
         ...(suggested_actions ? { suggested_actions } : {}),
       });
     } catch (err) {
+      if (timedOut) {
+        res.status(504).json({
+          error: "chat_turn_timeout",
+          message: `Chat turn exceeded ${CHAT_TURN_TIMEOUT_MS / 1000}s and was aborted.`,
+          timeout_ms: CHAT_TURN_TIMEOUT_MS,
+        });
+        return;
+      }
       handleError(err, res);
+    } finally {
+      clearTimeout(timeoutTimer);
+      rateOutcome.release();
     }
   });
 

--- a/packages/api/src/routes/directives.test.ts
+++ b/packages/api/src/routes/directives.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { processResponse } from "./directives.js";
+
+describe("processResponse — view_refs", () => {
+  it("collects entity ids inline in the visible text", () => {
+    const r = processResponse("see task_abc123def456 and agent_xyz123abc456");
+    expect(r.view_refs).toEqual(["task_abc123def456", "agent_xyz123abc456"]);
+  });
+
+  it("dedupes repeated ids", () => {
+    const r = processResponse("task_abc123def456 again task_abc123def456");
+    expect(r.view_refs).toEqual(["task_abc123def456"]);
+  });
+
+  it("does not match malformed ids (wrong length, wrong prefix)", () => {
+    const r = processResponse("task_short agent_TOOLONGTOOLONG12 unknown_abc123def456");
+    expect(r.view_refs).toEqual([]);
+  });
+});
+
+describe("processResponse — open_view path allow-list", () => {
+  it("accepts an allow-listed path", () => {
+    const r = processResponse(`<open_view path="/tasks/task_abc123def456" />`);
+    expect(r.open_view).toEqual({ path: "/tasks/task_abc123def456" });
+  });
+
+  it("accepts a bare allow-listed path with an exact match", () => {
+    const r = processResponse(`<open_view path="/mesh" />`);
+    expect(r.open_view).toEqual({ path: "/mesh" });
+  });
+
+  it("captures an optional label attribute", () => {
+    const r = processResponse(`<open_view path="/agents" label="See team" />`);
+    expect(r.open_view).toEqual({ path: "/agents", label: "See team" });
+  });
+
+  it("rejects an off-list path", () => {
+    const r = processResponse(`<open_view path="/admin/users" />`);
+    expect(r.open_view).toBeUndefined();
+  });
+
+  it("rejects an external URL", () => {
+    const r = processResponse(`<open_view path="https://attacker.example/x" />`);
+    expect(r.open_view).toBeUndefined();
+  });
+
+  it("rejects a protocol-relative URL", () => {
+    const r = processResponse(`<open_view path="//attacker.example/x" />`);
+    expect(r.open_view).toBeUndefined();
+  });
+
+  it("rejects a path with traversal", () => {
+    const r = processResponse(`<open_view path="/tasks/../../etc/passwd" />`);
+    expect(r.open_view).toBeUndefined();
+  });
+
+  it("rejects when the path looks like a prefix-collision (e.g. /tasksomething)", () => {
+    // /tasks must match exactly OR be followed by '/'. /taskstats is
+    // not a known surface and shouldn't be accepted by a sloppy
+    // startsWith check.
+    const r = processResponse(`<open_view path="/taskstats" />`);
+    expect(r.open_view).toBeUndefined();
+  });
+
+  it("strips the directive from visible text even when path is rejected", () => {
+    const r = processResponse(
+      `Some context text.\n<open_view path="/admin/users" />`,
+    );
+    expect(r.open_view).toBeUndefined();
+    expect(r.visible).toBe("Some context text.");
+  });
+});
+
+describe("processResponse — suggest_action chips", () => {
+  it("parses self-closing label-only form", () => {
+    const r = processResponse(`<suggest_action label="Approve" />`);
+    expect(r.suggested_actions).toEqual([{ label: "Approve" }]);
+  });
+
+  it("parses self-closing label+prompt form", () => {
+    const r = processResponse(
+      `<suggest_action label="Approve" prompt="Approve as-is and ship it." />`,
+    );
+    expect(r.suggested_actions).toEqual([
+      { label: "Approve", prompt: "Approve as-is and ship it." },
+    ]);
+  });
+
+  it("parses paired-tag inline-text form", () => {
+    const r = processResponse(`<suggest_action>Reject</suggest_action>`);
+    expect(r.suggested_actions).toEqual([{ label: "Reject" }]);
+  });
+
+  it("parses paired-tag with label attribute (label visible, inline text becomes prompt)", () => {
+    const r = processResponse(
+      `<suggest_action label="Revise">Please tighten the intro.</suggest_action>`,
+    );
+    expect(r.suggested_actions).toEqual([
+      { label: "Revise", prompt: "Please tighten the intro." },
+    ]);
+  });
+
+  it("collects multiple chips", () => {
+    const r = processResponse(
+      `<suggest_action label="Approve" />\n<suggest_action label="Reject" />`,
+    );
+    expect(r.suggested_actions).toEqual([{ label: "Approve" }, { label: "Reject" }]);
+  });
+
+  it("dedupes chips with the same label", () => {
+    const r = processResponse(
+      `<suggest_action label="Approve" /><suggest_action label="Approve" />`,
+    );
+    expect(r.suggested_actions).toEqual([{ label: "Approve" }]);
+  });
+
+  it("ignores empty-label suggest_action tags", () => {
+    const r = processResponse(`<suggest_action />`);
+    expect(r.suggested_actions).toBeUndefined();
+  });
+});
+
+describe("processResponse — visible text stripping", () => {
+  it("strips both directive types from visible text", () => {
+    const r = processResponse(
+      `Here's the plan.\n<open_view path="/tasks" />\n<suggest_action label="OK" />`,
+    );
+    expect(r.visible).toBe("Here's the plan.");
+  });
+
+  it("returns the trimmed raw text when there are no directives", () => {
+    const r = processResponse("  just a normal reply.  ");
+    expect(r.visible).toBe("just a normal reply.");
+  });
+});

--- a/packages/api/src/routes/directives.ts
+++ b/packages/api/src/routes/directives.ts
@@ -18,6 +18,34 @@
 const ENTITY_ID_RE = /\b((?:task|agent|sess)_[A-Za-z0-9]{12})\b/g;
 const OPEN_VIEW_RE =
   /<open_view\s+path="([^"]+)"(?:\s+label="([^"]+)")?\s*\/?>(?:\s*<\/open_view>)?/i;
+
+/**
+ * Paths the chat UI knows how to navigate to. The system prompt names
+ * these explicitly, but the prompt is best-effort guidance, not
+ * enforcement. A misbehaving model could emit `path="/admin/..."` or
+ * `path="https://attacker.example/..."` — we drop the directive when
+ * the path doesn't start with one of these prefixes so the UI never
+ * renders an off-spec CTA.
+ */
+const ALLOWED_OPEN_VIEW_PREFIXES = [
+  "/tasks",
+  "/agents",
+  "/mesh",
+  "/memory",
+  "/promotions",
+  "/dashboard",
+  "/sessions",
+] as const;
+
+function isAllowedOpenViewPath(path: string): boolean {
+  // Must be an absolute in-app path, no scheme, no protocol-relative,
+  // no traversal. The prefix check then narrows to known surfaces.
+  if (!path.startsWith("/") || path.startsWith("//")) return false;
+  if (path.includes("..")) return false;
+  return ALLOWED_OPEN_VIEW_PREFIXES.some(
+    (prefix) => path === prefix || path.startsWith(`${prefix}/`),
+  );
+}
 // Tolerates: any attribute order, self-closing or paired, inline-text form.
 // Group 1 = attributes; group 2 = inline text (when paired).
 const SUGGEST_ACTION_RE =
@@ -48,9 +76,10 @@ export interface ProcessedResponse {
 
 export function processResponse(raw: string): ProcessedResponse {
   const openMatch = raw.match(OPEN_VIEW_RE);
-  const open_view: OpenView | undefined = openMatch?.[1]
-    ? { path: openMatch[1], ...(openMatch[2] ? { label: openMatch[2] } : {}) }
-    : undefined;
+  const open_view: OpenView | undefined =
+    openMatch?.[1] && isAllowedOpenViewPath(openMatch[1])
+      ? { path: openMatch[1], ...(openMatch[2] ? { label: openMatch[2] } : {}) }
+      : undefined;
 
   const suggestedActions: SuggestedAction[] = [];
   const seenLabels = new Set<string>();

--- a/packages/core/src/adapters/postgres/session-repo.ts
+++ b/packages/core/src/adapters/postgres/session-repo.ts
@@ -80,6 +80,21 @@ export class PostgresSessionRepository implements SessionRepository {
     return rows.map(rowToSession);
   }
 
+  async listChatForAgent(agentId: string, limit: number): Promise<Session[]> {
+    // Bounded server-side so chat history routes don't pull every
+    // session for the agent. The (agent_id, type, created_at) ordering
+    // matches the existing partial index on session(agent_id) so the
+    // planner does an index scan + filter rather than a heap scan.
+    const { rows } = await this.pool.query<SessionRow>(
+      `SELECT * FROM session
+        WHERE agent_id = $1 AND type = 'chat'
+        ORDER BY created_at DESC
+        LIMIT $2`,
+      [agentId, limit],
+    );
+    return rows.map(rowToSession);
+  }
+
   async countRunningByAgent(agentId: string, types: SessionType[]): Promise<number> {
     if (types.length === 0) return 0;
     const { rows } = await this.pool.query<{ count: string }>(

--- a/packages/core/src/ports/session-repo.ts
+++ b/packages/core/src/ports/session-repo.ts
@@ -39,6 +39,20 @@ export interface SessionRepository {
   listForAgent(agentId: string): Promise<Session[]>;
 
   /**
+   * Most-recent chat sessions for an agent, hard-bounded server-side.
+   *
+   * The chat history endpoints used to load every session for the
+   * agent into memory and filter by type there, which scaled linearly
+   * with usage. This method does the filter + limit at the SQL layer
+   * so a heavy user with thousands of chat turns doesn't drag the
+   * route every page load.
+   *
+   * Returns newest-first (matches `listForAgent`'s order), so callers
+   * can grab the head with `rows[0]`.
+   */
+  listChatForAgent(agentId: string, limit: number): Promise<Session[]>;
+
+  /**
    * Count currently-running sessions for an agent.
    * Used by capacity checks (max_task_sessions / max_mesh_sessions).
    * `types` groups session kinds: pass `['task']` for task cap, pass the mesh types

--- a/packages/web/lib/hooks/use-chat.ts
+++ b/packages/web/lib/hooks/use-chat.ts
@@ -31,18 +31,34 @@ let nextLocalId = 0;
 const localId = (): string => `m_${++nextLocalId}`;
 
 const SID_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+// 62 (alphabet length) * 4 = 248 — the largest multiple of 62 below
+// 256. Bytes >= 248 are rejected so the surviving distribution over
+// the alphabet stays uniform (no `b % 62` modulo bias). Negligible at
+// 12 chars but cheap to fix.
+const SID_REJECTION_THRESHOLD = 248;
 
 /**
  * Mint a session id matching core's `sessionId()` format
  * (`sess_<12 chars from [0-9A-Za-z]>`). Generated client-side per turn so
  * the chat UI can subscribe to `session.step` SSE events for this id
  * BEFORE the server starts the run.
+ *
+ * Rejection-samples to avoid modulo bias on the 62-char alphabet.
  */
 function mintSessionId(): string {
-  const bytes = new Uint8Array(12);
-  crypto.getRandomValues(bytes);
   let suffix = "";
-  for (const b of bytes) suffix += SID_ALPHABET[b % SID_ALPHABET.length];
+  while (suffix.length < 12) {
+    // Pull a fresh batch each iteration. Average rejection rate is
+    // ~3% (8/256) so 16 bytes covers the 12 we need on the first
+    // pass virtually always, with the loop guarding worst case.
+    const buf = new Uint8Array(16);
+    crypto.getRandomValues(buf);
+    for (const b of buf) {
+      if (b >= SID_REJECTION_THRESHOLD) continue;
+      suffix += SID_ALPHABET[b % SID_ALPHABET.length];
+      if (suffix.length === 12) break;
+    }
+  }
   return `sess_${suffix}`;
 }
 

--- a/packages/web/lib/hooks/use-chat.ts
+++ b/packages/web/lib/hooks/use-chat.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { sessionId } from "@beevibe/core";
 import {
   api,
   type ChatHistoryMessage,
@@ -30,37 +31,10 @@ export interface ChatMessage {
 let nextLocalId = 0;
 const localId = (): string => `m_${++nextLocalId}`;
 
-const SID_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-// 62 (alphabet length) * 4 = 248 — the largest multiple of 62 below
-// 256. Bytes >= 248 are rejected so the surviving distribution over
-// the alphabet stays uniform (no `b % 62` modulo bias). Negligible at
-// 12 chars but cheap to fix.
-const SID_REJECTION_THRESHOLD = 248;
-
-/**
- * Mint a session id matching core's `sessionId()` format
- * (`sess_<12 chars from [0-9A-Za-z]>`). Generated client-side per turn so
- * the chat UI can subscribe to `session.step` SSE events for this id
- * BEFORE the server starts the run.
- *
- * Rejection-samples to avoid modulo bias on the 62-char alphabet.
- */
-function mintSessionId(): string {
-  let suffix = "";
-  while (suffix.length < 12) {
-    // Pull a fresh batch each iteration. Average rejection rate is
-    // ~3% (8/256) so 16 bytes covers the 12 we need on the first
-    // pass virtually always, with the loop guarding worst case.
-    const buf = new Uint8Array(16);
-    crypto.getRandomValues(buf);
-    for (const b of buf) {
-      if (b >= SID_REJECTION_THRESHOLD) continue;
-      suffix += SID_ALPHABET[b % SID_ALPHABET.length];
-      if (suffix.length === 12) break;
-    }
-  }
-  return `sess_${suffix}`;
-}
+// Client mints the session id so it can subscribe to `session.step` SSE
+// events for this turn BEFORE the server starts the run. Uses the same
+// nanoid-backed helper the server uses (uniform distribution by
+// construction, no modulo bias).
 
 function fromHistory(m: ChatHistoryMessage): ChatMessage {
   return {
@@ -185,9 +159,9 @@ export function useChat(opts: UseChatOptions = {}) {
     (rawMessage: string) => {
       const trimmed = rawMessage.trim();
       if (!trimmed || mutation.isPending) return;
-      const sessionId = mintSessionId();
+      const sid = sessionId();
       setLocalMessages((prev) => [...prev, { id: localId(), role: "user", content: trimmed }]);
-      mutation.mutate({ message: trimmed, sessionId });
+      mutation.mutate({ message: trimmed, sessionId: sid });
     },
     [mutation],
   );

--- a/packages/web/lib/sse.ts
+++ b/packages/web/lib/sse.ts
@@ -22,7 +22,15 @@ const eventInvalidations: Record<string, InvalidationKey[]> = {
   "task.updated": [queryKeys.tasks.all, queryKeys.dashboard.all, queryKeys.activity.all],
   "task.created": [queryKeys.tasks.all, queryKeys.dashboard.all, queryKeys.activity.all],
   "agent.updated": [queryKeys.agents.all, queryKeys.activity.all],
-  "session.updated": [queryKeys.sessions.all, queryKeys.tasks.all, queryKeys.activity.all],
+  // session.updated fires on row create + status change (not on every
+  // step), so adding chat.all here is bounded — multi-tab + multi-device
+  // users see new chat turns appear without manual reload.
+  "session.updated": [
+    queryKeys.sessions.all,
+    queryKeys.tasks.all,
+    queryKeys.activity.all,
+    queryKeys.chat.all,
+  ],
   "memory.fact.created": [queryKeys.memory.all],
   "promotion.created": [queryKeys.promotions.all, queryKeys.memory.all],
   "mesh.activity": [queryKeys.mesh.all, queryKeys.activity.all],


### PR DESCRIPTION
Stacked on #53. Addresses the audit findings from issue #57 — operational hardening of the P1 minimal chat surface before ship.

The architecture in #53 earns its keep against M1-M6 + M9 philosophy: chat is genuinely \"AgentSession.run with type='chat' + display directives,\" the M9.4 cache split is respected, briefing flows through, prior_session_id chaining works. The gaps were operational, not architectural.

## Fixes in this PR

| # | Fix | Why |
|---|-----|-----|
| 1 | **Per-person rate limiter** ([chat-rate-limit.ts](packages/api/src/routes/chat-rate-limit.ts)) — 1 turn in flight + 30/min sliding window | Compromised bv_u_ tokens or scripted abuse can't drain budget unbounded. Each chat turn is a real Claude Code subprocess (~30s, real \$\$). |
| 2 | **Idempotent retry handling** ([chat.ts](packages/api/src/routes/chat.ts)) — if a session_id already exists, replay recorded result | Retries (network blip, double-click, browser cache replay) used to spawn another full agent turn. Real money cost. |
| 3 | **90s route-level timeout** with AbortController plumbed into AgentSession.run({abortSignal}) | Hung turns no longer pin HTTP socket + DB connection. 504 instead of indefinite wait. |
| 4 | **Path allow-list in \`<open_view>\` parser** ([directives.ts](packages/api/src/routes/directives.ts)) | The system prompt LISTS valid paths but a misbehaving model could ignore that and emit /admin/... or external URLs. ALLOWED_OPEN_VIEW_PREFIXES enforces it parser-side. Blocks traversal, protocol-relative tricks. |
| 5 | **Cycle detection in \`groupIntoConversations\`** ([chat.ts](packages/api/src/routes/chat.ts)) | Replaced unbounded recursion with iterative walk + visited set. A prior_session_id cycle (data corruption only) used to stack-overflow the whole history endpoint. |
| 6 | **SQL-level filter + LIMIT** — new \`SessionRepository.listChatForAgent(agentId, limit)\` | Old code pulled every session for the agent and filtered in memory (linear with usage). Now bounded at 400 turns server-side. |
| 7 | **Sanitized error responses** ([chat.ts](packages/api/src/routes/chat.ts)) | \`handleError\` now logs full stack server-side with a request id, returns generic message + that id to the client. Provider quirks no longer ship to the browser. |
| 8 | **Rejection-sample mintSessionId** ([use-chat.ts](packages/web/lib/hooks/use-chat.ts)) | Removes microscopic modulo bias on the 62-char alphabet. |

## Walked back from the audit

**Max message length cap.** Verified [server.ts:134](packages/api/src/server.ts#L134) sets \`express.json()\` with no options → default 100KB body limit. That's the real DoS guard. A tighter route-level char cap was belt-and-suspenders without distinct value; cost protection is handled by the rate limiter.

## Tests added — 38, all green

- \`chat-internals.test.ts\` (7) — groupIntoConversations: cycle, orphan parent, single session, multi-chain ordering, dedupe, paginate-tail
- \`directives.test.ts\` (21) — view_refs (entity ids), open_view path allow-list (admin/external/protocol-relative/traversal/prefix-collision), suggest_action shape variants, visible text stripping
- \`chat-rate-limit.test.ts\` (10) — concurrency cap, sliding window expiry, retryAfter math, double-release safety, reset

\`pnpm typecheck\` clean across all 6 packages.

## Stacked-on note

Base branch is \`m8-demo-prep\` (#53), not \`main\`. Merging this PR before #53 lands would also work, but the natural sequence is to land #53 first then this one.

## Closes

Closes #57.