### PR TITLE
docs: per-package READMEs + open-source root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,80 +1,132 @@
 # beevibe
 
-Beevibe core — modular monolith for the agent runtime platform.
+> A self-hosted runtime for autonomous AI agent teams. Tasks flow between agents through hierarchy and peer mesh; memory carries forward; humans review and approve from a dashboard.
 
-## Architecture
+beevibe lets you run a small organization of Claude Code agents that delegate to each other, negotiate, escalate to humans when stuck, and build up shared memory over time. You provide the agents (a captain and a few ICs is a fine starting point), the work, and the review judgment. The platform handles the rest.
+
+It's open source under the Apache-2.0 license. Everything is self-hosted: your Postgres, your `claude` CLI binaries, your filesystem.
+
+## What's inside
 
 ```
 beevibe/
 ├── packages/
-│   ├── core/          shared library: domain, ports, services, adapters, auth
-│   ├── api/           binary: MCP tool surface for agents + REST endpoints for humans + MeshServer
-│   ├── executor/      binary: task polling + session dispatch
-│   └── web/           Next.js UI + API routes (M8)
+│   ├── core/         shared library (domain, ports, services, adapters, auth)
+│   ├── api/          MCP tool surface for agents + REST for humans + mesh broker
+│   ├── executor/     polls Postgres → spawns Claude Code sessions
+│   └── web/          Next.js dashboard with live updates over SSE
 │
-├── migrations/        node-pg-migrate SQL files
-├── scripts/           dev orchestrator + e2e smokes + provisioning helpers
+├── skills/           Anthropic Agent Skills (markdown behavioral protocols)
+├── migrations/       node-pg-migrate SQL files
+├── scripts/          dev orchestrator + e2e smokes + provisioning helpers
 └── docker-compose.yml Postgres 16 + pgvector
 ```
 
-### Dependency direction (enforced via ESLint)
+Each package has its own README with details:
 
-```
-core/domain     → nothing
-core/ports      → domain
-core/services   → domain + ports  (NEVER adapters)
-core/adapters   → ports it implements + domain
-api/            → core (composition root)
-executor/       → core (composition root)
-```
+- [packages/core](./packages/core/README.md) — the library
+- [packages/api](./packages/api/README.md) — the agent + human API server
+- [packages/executor](./packages/executor/README.md) — the task dispatcher
+- [packages/web](./packages/web/README.md) — the dashboard
 
-## Tech stack
+## Concepts in 60 seconds
 
-- TypeScript strict (ES2022, NodeNext)
-- pnpm workspaces + Turborepo
-- Postgres 16 + pgvector, raw `pg` driver (no ORM)
-- node-pg-migrate
-- Claude Code CLI runtime
-- `@modelcontextprotocol/sdk`
+- **Agent**. Has a hierarchy level — `ic` (worker), `team` (delegator), or `org` (decider). Owns a persona, a set of stable core-memory blocks, and a vector-indexed archive of facts. Identified by an `agent_id` and authenticates with a `bv_a_…` API key.
+- **Person / user**. A human owner. Authenticates with a `bv_u_…` API key. Can act as their top-level agent through MCP, or use the dashboard for review.
+- **Task**. A unit of work assigned to an agent. Moves through `pending → running → review → done` (or `failed` / `blocked` / `cancelled`). Tasks can spawn child tasks; parents auto-complete when their children settle.
+- **Session**. One run of the `claude` CLI for one task. Has a transcript, a `cli_session_id` (for `--resume`), and usage telemetry (including cache-hit ratios).
+- **Mesh**. Agents can `ask` peers one-shot questions or `negotiate` with team/org peers across multiple rounds. If they can't agree, either side can `escalate_to_humans` and a person resolves it from the dashboard.
+- **Memory**. `save_memory(...)` archives a fact (`belief`/`pattern`/`gotcha`/`preference`/`decision`); after the session ends, the FactPromoter LLM may elevate it from `ic` scope to `team` or `org` based on whether it generalizes. `update_core_memory(...)` writes the durable per-agent blocks.
+- **Skills**. Markdown procedural protocols ([Anthropic Agent Skills standard](https://agentskills.io/specification)) auto-discovered by `claude` from `<workspace>/.claude/skills/`. We ship two: `beevibe-pre-task-setup` and `beevibe-team-mesh-negotiation`.
 
 ## Quick start
 
-Requires Node ≥ 20, pnpm 9, Docker, and the `claude` CLI on PATH.
+You'll need:
+
+- Node ≥ 20 + pnpm 9
+- Docker (for the Postgres + pgvector container)
+- The [`claude`](https://docs.claude.com/en/docs/claude-code/overview) CLI on PATH
+- An Anthropic API key + an OpenAI API key (the latter is for embeddings)
 
 ```bash
+git clone https://github.com/beevibe-ai/beevibe.git
+cd beevibe
 pnpm install
-docker compose up -d                     # postgres + pgvector
-cp .env.example .env                     # fill in ANTHROPIC_API_KEY + OPENAI_API_KEY
-pnpm migrate up                          # apply migrations to dev DB
-pnpm dev                                 # postgres + api + executor + cloudflared tunnel
+
+cp .env.example .env
+# fill in ANTHROPIC_API_KEY and OPENAI_API_KEY
+
+docker compose up -d                  # postgres + pgvector
+pnpm migrate up                       # apply migrations to dev DB
+pnpm dev                              # postgres + api + executor (+ tunnel if cloudflared is on PATH)
 ```
 
-`pnpm dev` runs `scripts/dev.sh`, which:
+`pnpm dev` runs [`scripts/dev.sh`](./scripts/dev.sh), which:
+
 - starts Postgres if it isn't already running
 - applies migrations
-- spawns `@beevibe/api` (port 3000 by default) and `@beevibe/executor` (health on 3001) in watch mode with `[api]` / `[exec]` log prefixes
-- if `cloudflared` is on PATH, exposes the api at a `*.trycloudflare.com` URL and prints a paste-ready `mcp.json` snippet for remote Claude CLI access. Pass `--no-tunnel` to disable.
+- spawns `@beevibe/api` (port 3000) and `@beevibe/executor` (health on 3001) in watch mode with `[api]` / `[exec]` log prefixes
+- if `cloudflared` is on PATH, exposes the api at a `*.trycloudflare.com` URL and prints a paste-ready `mcp.json` snippet for remote `claude` CLI access (pass `--no-tunnel` to disable)
 
-Ctrl+C tears the whole tree down via `trap 'kill 0' EXIT`.
+`Ctrl+C` tears the whole tree down.
 
-### Common commands
+To bring up the dashboard alongside, in a second terminal:
 
 ```bash
-pnpm build              # tsc across all packages
-pnpm typecheck          # typecheck without emit
-pnpm lint               # eslint
-pnpm test               # vitest (unit + integration)
-pnpm dev                # full local stack (postgres + api + executor + tunnel)
-pnpm migrate up         # apply migrations to DATABASE_URL
-pnpm migrate:test up    # apply migrations to DATABASE_URL_TEST
-pnpm install-skills     # install beevibe skills into ~/.claude/skills/
+pnpm --filter @beevibe/web dev -- -p 3030
+# then visit http://localhost:3030
 ```
+
+(The web app needs `NEXT_PUBLIC_BV_USER_KEY` set — see [its README](./packages/web/README.md). Mint a key with `pnpm tsx scripts/provision-demo.ts`.)
+
+## Try it from your own Claude CLI
+
+The `provision-demo.ts` script creates an idempotent demo team in your dev DB and prints a paste-ready MCP config so you can act *as* the captain agent from your own `claude` CLI:
+
+```bash
+# Terminal 1
+pnpm dev
+# Wait for: "Tunnel URL: https://<random>.trycloudflare.com"
+
+# Terminal 2
+pnpm tsx scripts/provision-demo.ts
+```
+
+This creates:
+
+```
+person:   demo-user (bv_u_<token>)
+  └── captain   (team-tier, owned by demo-user)
+        ├── ic-alice  (ic-tier)
+        └── ic-bob    (ic-tier)
+```
+
+Drop the printed snippet into your local `claude` CLI's MCP config (`~/.config/claude/mcp.json` or wherever your CLI reads it), then in any directory:
+
+```bash
+claude
+# In the chat, try:
+#   "who are my subordinates?"        → find_subordinates → [ic-alice, ic-bob]
+#   "create a task for ic-alice: write a hello-world bash script"
+#   wait ~30-60s, watching [exec] logs in Terminal 1
+#   "what's the status of that task?" → check_work_status → done
+#   "ask ic-alice: where is hello.sh?" → mesh-ask round-trip
+```
+
+Cleanup:
+
+```bash
+pnpm tsx scripts/provision-demo.ts --print  # re-print existing keys/snippet
+pnpm tsx scripts/provision-demo.ts --clean  # wipe demo rows (no reseed)
+```
+
+`--clean` only removes rows owned by `demo-user`. It refuses if a demo agent has a live OS process so you don't wedge mid-flight tasks.
 
 ## Skills
 
-Beevibe ships agent behavioral skills as `SKILL.md` files in `/skills/` (Anthropic [Agent Skills open standard](https://agentskills.io/specification)). The api and executor sync them into each agent's workspace at dispatch time automatically — agent-spawned sessions get them for free.
+beevibe ships agent behavioral skills as `SKILL.md` files in [`/skills/`](./skills) — Anthropic's [Agent Skills open standard](https://agentskills.io/specification). The api and executor sync them into each agent's workspace at dispatch time automatically; agent-spawned sessions get them for free.
 
-For human users running `claude` locally and acting AS a beevibe agent (the M7 manual-smoke path), install them once into your local Claude Code skill discovery dir:
+For human users running `claude` locally and acting *as* a beevibe agent (the manual-smoke path above), install them once into your local Claude Code skill discovery dir:
 
 ```bash
 pnpm install-skills
@@ -84,80 +136,108 @@ The install is idempotent — re-run after `git pull` to refresh. Only dirs name
 
 > **Reserved namespace**: the `beevibe-` prefix in `~/.claude/skills/` is reserved for skills shipped by this repo. If you author your own personal skills, use a different prefix (e.g., `mybeevibe-foo`) — anything not matching `beevibe-*` is invisible to the install command.
 
-## Manual smoke against the tunnel
+## Architecture
 
-To exercise the MCP tool surface end-to-end with your own Claude CLI as the human user:
+The dependency direction across packages is one-way and ESLint-enforced:
+
+```
+core/domain     → nothing
+core/ports      → domain
+core/services   → domain + ports     (NEVER adapters)
+core/adapters   → ports it implements + domain
+api/            → core (composition root)
+executor/       → core (composition root)
+web/            → core (types only) + api (HTTP)
+```
+
+The api and executor are independent processes. They never talk to each other over HTTP — both use Postgres as the integration point:
+
+- The api writes task lifecycle changes (created, approved, revised, cancelled).
+- The executor polls for work, runs sessions, writes results back.
+- Cancellation: api `UPDATE`s the row + `pg_notify('cancel_task', task_id)`; executor's dedicated `LISTEN` client aborts the in-flight session in <200ms.
+- Live updates: every state-changing INSERT/UPDATE fires a `pg_notify`; api's `/api/stream` SSE endpoint relays them to the dashboard.
+
+That decoupling means you can scale the executor horizontally (run as many replicas as you want — task claims are atomic) and restart either side independently.
+
+## Common commands
 
 ```bash
-# Terminal 1 — start the stack
-pnpm dev
-# Wait for: "Tunnel URL: https://<random>.trycloudflare.com"
-# (the URL is also written to ~/.beevibe/last-tunnel-url)
-
-# Terminal 2 — provision a demo team
-pnpm tsx scripts/provision-demo.ts
+pnpm build              # tsc across all packages (turbo-cached)
+pnpm typecheck          # types only
+pnpm lint               # eslint
+pnpm test               # vitest (unit + integration)
+pnpm dev                # full local stack (postgres + api + executor + tunnel)
+pnpm migrate up         # apply migrations to DATABASE_URL
+pnpm migrate:test up    # apply migrations to DATABASE_URL_TEST
+pnpm install-skills     # install beevibe skills into ~/.claude/skills/
 ```
 
-`provision-demo.ts` creates an idempotent demo topology in the dev DB:
+## Tech stack
 
-```
-person:   demo-user (bv_u_<token>)
-  └── captain   (team-tier, owned by demo-user) ← bv_u_ resolves here
-        ├── ic-alice  (ic-tier)
-        └── ic-bob    (ic-tier)
-```
+- TypeScript strict (ES2022, NodeNext)
+- pnpm workspaces + Turborepo
+- Postgres 16 + pgvector, raw `pg` driver (no ORM)
+- node-pg-migrate
+- Claude Code CLI runtime (spawned per-session)
+- `@modelcontextprotocol/sdk`
+- Next.js 14 + TanStack Query + Tailwind (dashboard)
 
-It prints a paste-ready `mcp.json` snippet pointing at the live tunnel URL. Drop that into your local Claude CLI's MCP config (`~/.config/claude/mcp.json` or wherever your CLI reads it), then in any directory:
+## End-to-end smokes
+
+Live integration tests against real Postgres + LLM APIs. Each is gated by an env flag.
 
 ```bash
-claude
-# In the chat, try:
-#   "who are my subordinates?"        → find_subordinates → [ic-alice, ic-bob]
-#   "create a task for ic-alice: write a hello-world bash script"
-#   wait ~30-60s, watching [exec] logs in Terminal 1
-#   "what's the status of that task?" → get_task → done
-#   "ask ic-alice: where is hello.sh?" → mesh-ask round-trip
-```
-
-When done:
-
-```bash
-pnpm tsx scripts/provision-demo.ts --print  # re-print existing keys/snippet
-pnpm tsx scripts/provision-demo.ts --clean  # wipe demo rows (no reseed)
-```
-
-`--clean` only removes rows owned by `demo-user`; other dev-DB data is untouched. It refuses if a demo agent has a live OS process to avoid wedging mid-flight tasks.
-
-## Integration tests
-
-Live E2E smokes that exercise real Postgres + LLM APIs. Each is gated by an env flag; CI runs them under separate jobs.
-
-```bash
-# In-process smoke (10 scenarios; api+executor bootstrapped in the same VM)
+# In-process smoke — api + executor bootstrapped in the same VM
 RUN_M6_E2E=1 \
   DATABASE_URL_TEST=postgresql://beevibe:beevibe@localhost:5433/beevibe_test \
   OPENAI_API_KEY=... ANTHROPIC_API_KEY=... \
   pnpm tsx scripts/m6-e2e.ts
 
-# Multi-process smoke (api + executor as actual `node dist/main.js`
-# subprocesses; verifies cross-process IPC, signal propagation, no orphans)
+# Multi-process smoke — api + executor as actual `node dist/main.js`
+# subprocesses; verifies cross-process IPC, signal propagation, no orphans
 RUN_M7_E2E=1 \
   DATABASE_URL_TEST=postgresql://beevibe:beevibe@localhost:5433/beevibe_test \
   OPENAI_API_KEY=... ANTHROPIC_API_KEY=... \
   pnpm tsx scripts/m7-e2e.ts
+
+# Skills + memory + cache-hit ratio smoke (M9 features)
+RUN_M9_E2E=1 \
+  DATABASE_URL_TEST=postgresql://beevibe:beevibe@localhost:5433/beevibe_test \
+  OPENAI_API_KEY=... ANTHROPIC_API_KEY=... \
+  pnpm tsx scripts/m9-e2e.ts
 ```
 
-Apply test-DB migrations first with `pnpm migrate:test up`. Both scripts truncate the test DB at start; back-to-back runs work.
+Apply test-DB migrations first with `pnpm migrate:test up`. All scripts truncate the test DB at the start, so back-to-back runs work.
 
-## Status
+## Project status
 
-- **M0**: scaffold ✅
-- **M1**: domain + ports + postgres adapter + schema + migrations ✅
-- **M2**: claude-code runtime adapter + git adapter ✅
-- **M3**: services + pgvector + llm providers ✅
-- **M4**: auth ✅
-- **M5**: executor binary (polling + dispatch) ✅
-- **M6**: api binary (MCP tool surface + REST + mesh + escalation + cancellation) ✅
-- **M7**: full-stack integration test (multi-process smoke + dev orchestrator + manual smoke recipe) ✅
-- **M8**: web package (Next.js UI + API routes) ✅
-- **M9**: agent skill system (markdown behavioral fragments) — placeholder, see issue #9
+The platform was built in milestones (M0 → M9), each with its own integration test:
+
+| Milestone | What landed |
+|---|---|
+| M0 | Repo scaffold |
+| M1 | Domain + ports + Postgres adapter + schema + migrations |
+| M2 | Claude Code runtime adapter + workspace adapter |
+| M3 | Memory subsystem + pgvector + LLM providers |
+| M4 | API-key auth + agent provisioning |
+| M5 | Executor binary (polling + dispatch) |
+| M6 | API binary (MCP tools + REST + mesh + escalation + cancellation) |
+| M7 | Multi-process integration test + dev orchestrator |
+| M8 | Web dashboard (Next.js + SSE) |
+| M9 | Skill system (auto-discovered behavioral protocols) + memory tooling refresh |
+
+The full design discussions and PR references live in the [closed issues](https://github.com/beevibe-ai/beevibe/issues?q=is%3Aissue+is%3Aclosed) — each milestone has one tracking issue.
+
+## Contributing
+
+Issues and PRs welcome. For non-trivial changes, open an issue first so we can align on direction.
+
+A few conventions worth knowing:
+
+- **Plan first, build second.** Each milestone is scoped end-to-end (schema → types → unit tests → integration test) before any code is written. See `tasks/` (gitignored) for the workflow.
+- **TDD where it pays.** Domain types and pure services are test-first. Adapters get integration tests against real services (Postgres, real LLM keys).
+- **No parallel systems.** When a feature replaces an older one, the old code is deleted in the same PR — no `if (new) ... else if (old) ...` branches.
+
+## License
+
+[Apache-2.0](./LICENSE)

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1,0 +1,147 @@
+# @beevibe/api
+
+The API server. One Node binary that wears two hats:
+
+1. **MCP server for agents** — exposes the tool surface that spawned `claude` CLIs call into (save memory, ask peers, report blockers, create tasks, …).
+2. **REST + SSE server for humans** — endpoints that the [web UI](../web) and CLI tooling use to view / approve / revise tasks and resolve escalations.
+
+It also contains the in-process `MeshServer` — the broker that handles agent-to-agent `ask` and `negotiate`.
+
+If you're running beevibe locally, you don't start this directly — `pnpm dev` at the repo root brings up Postgres + api + executor together.
+
+## Run it
+
+```bash
+# from repo root
+pnpm --filter @beevibe/api build
+pnpm --filter @beevibe/api start            # node dist/main.js
+# or watch mode:
+pnpm --filter @beevibe/api dev
+```
+
+Required env (validated at startup):
+
+| Var | Purpose |
+|---|---|
+| `DATABASE_URL` | Postgres connection string |
+| `BEEVIBE_MCP_SERVER_URL` | The URL spawned agents will call back to (e.g. `http://localhost:3000/mcp`). Baked into each agent's `mcp-config.json` by the executor. |
+| `OPENAI_API_KEY` | Embeddings (memory recall) |
+| `ANTHROPIC_API_KEY` | LLM (fact merging + promotion) |
+
+Optional:
+
+| Var | Default | Purpose |
+|---|---|---|
+| `BEEVIBE_API_PORT` | `3000` | HTTP listen port |
+| `WORKSPACE_ROOT` | `~/.beevibe/workspaces` | Per-agent sandbox root |
+| `BEEVIBE_SKILLS_DIR` | `<repo>/skills` | Source dir for skill sync |
+
+`GET /health` (no auth) returns `{ ok, version }` and is suitable for liveness probes.
+
+## Auth
+
+Bearer tokens, two prefixes:
+
+- `bv_a_…` — **agent** key. Permits MCP calls on `/mcp/*`. Tier-gated by `agent.hierarchy_level` (`ic` / `team` / `org`).
+- `bv_u_…` — **user** key. Permits REST mutations on `/task/*`, `/escalation/*` and SSE on `/api/stream`.
+
+The token is taken from the `Authorization: Bearer …` header (or `?token=…` query param for SSE — `EventSource` can't set headers). Validation routes to `@beevibe/core/auth.lookupApiKey` and the resolved caller is attached to `req.caller`.
+
+## MCP tools (agent-facing, mounted at `/mcp`)
+
+The exact tool inventory depends on the calling agent's tier. The IC tier is the worker tier — fewer tools, no peer negotiation. The team / org tier adds delegation and negotiation.
+
+### All tiers (12 tools)
+
+| Tool | Purpose |
+|---|---|
+| `save_memory` | Archive a fact (`belief`/`pattern`/`gotcha`/`preference`/`decision`). |
+| `update_core_memory` | Append/replace a stable block (persona/domain/constraints/learnings). |
+| `search_context` | Vector-search archival memory mid-session. |
+| `update_progress` | Set the task's terminal status (`done`/`failed`/`blocked`). Exit after. |
+| `find_up` | Get my direct parent agent. |
+| `get_agent_profile` | Look up an agent's hierarchy + capacity + memory. |
+| `get_task` | Fetch a task's full row (title, description, status). |
+| `create_work_product` | Record a deliverable (PR/branch/commit/document/…). |
+| `list_work_products` | List the task's deliverables (call this before `create_work_product` to dedupe). |
+| `update_work_product` | Edit an existing deliverable. |
+| `respond_ask` | Answer a peer who called `ask()` against me. |
+| `report_blocker` | Tell my parent I can't proceed. Server uses my parent implicitly — top-level agents can't call this. Exit after. |
+
+### Team / org additions (10 more tools, 22 total)
+
+| Tool | Purpose |
+|---|---|
+| `find_subordinates` | List my direct reports. |
+| `find_peers` | List same-level siblings. |
+| `create_task` | Spawn new work for myself or a subordinate. |
+| `check_work_status` | DB-only status check (no session spawn — use this instead of `ask` for status). |
+| `revise_task` | Unblock a subordinate's blocked task with feedback. |
+| `ask` | One-shot question to a peer. Spawns their CLI; blocks until they call `respond_ask`. |
+| `negotiate` | Propose a multi-round deal with a team/org peer. Rejected against ICs. |
+| `respond_negotiate` | Reply to an in-flight negotiation. |
+| `escalate_to_humans` | Promote a stuck negotiation to a human decision. Exit after. |
+| `add_to_escalation` | Join an escalation as the second party (sentinel-prompted). |
+
+Tier filtering happens in `src/tools/assemble.ts:assembleTools(caller)`. Tool descriptions follow the Letta pattern — HOW + best practices + examples in the docstring; WHY + cadence in the system-prompt reminders that `AgentSession` injects.
+
+## REST (human-facing, `bv_u_` only)
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/task` | Create a task. |
+| `POST` | `/task/:id/approve` | Approve (terminal `done`). |
+| `POST` | `/task/:id/reject` | Reject (terminal `failed`). |
+| `POST` | `/task/:id/revise` | Reopen with reviewer feedback. |
+| `POST` | `/task/:id/cancel` | Abort a non-terminal task (PG-NOTIFY signals the executor). |
+| `GET` | `/task` / `/task/:id` | Read-only views. |
+| `GET` | `/agent` / `/agent/:id` | Read-only views. |
+| `GET` | `/session/:short_id` | Session detail (for the UI's transcript view). |
+| `GET` | `/memory/fact` | List facts (filter by scope/owner/type). |
+| `GET` | `/promotion` | Memory-promotion audit log. |
+| `GET` | `/mesh` / `/dashboard` | UI summary endpoints. |
+| `POST` | `/escalation/:id/resolve` | Human decides; both parties get re-queued tasks with post-resolution context. |
+| `GET` | `/api/stream` | Server-Sent Events for live updates (see below). |
+| `GET` | `/health` | Public liveness. |
+
+### Live updates
+
+`GET /api/stream` opens a long-lived SSE connection. Internally it's PG `LISTEN/NOTIFY` (`task_updated`, `session_updated`, `memory.fact.created`, `promotion.created`, `mesh.activity`, …) bridged to `text/event-stream`. The web UI uses this to invalidate React Query caches; data refetches happen on the read endpoints above.
+
+## Mesh
+
+`MeshServer` (`src/mesh/server.ts`) is the in-process broker for agent-to-agent calls:
+
+- **Capacity**: max 3 concurrent mesh sessions per agent (across `ask` / `negotiate` / `report_blocker`). Over capacity → fail-fast with `mesh_capacity_exceeded` to the caller.
+- **Spawn**: when an agent calls `ask` / `negotiate`, the api server provisions the target's workspace and runs an `AgentSession` for them.
+- **Resolver map**: the caller's tool call awaits a peer's `respond_ask` / `respond_negotiate`. Resolvers keyed by `request_id:role`.
+- **Negotiation**: B-resident — agent B is spawned once on round 1, stays alive across rounds (max 5, configurable per-agent via `agent.max_negotiation_rounds`).
+- **Escalation sentinel**: when one party calls `escalate_to_humans`, the peer's blocked `respond_negotiate` resolves with `{decision: "escalated", escalation_id}` and both sessions exit cleanly.
+
+Caveat: resolver state is in-memory. An api restart drops in-flight mesh requests. Persistence is on the deferred list — see issue #6 design notes.
+
+## Source layout
+
+```
+src/
+├── main.ts          startup: env validation → bootstrap → listen
+├── bootstrap.ts     composition root: pool + repos + services + routers
+├── server.ts        Express app builder
+├── auth/            bearer-token middleware + caller resolution
+├── tools/           MCP tool definitions (assemble.ts is the inventory)
+├── routes/          REST handlers (task, escalation, view routes)
+├── mesh/            MeshServer (ask + negotiate brokering)
+├── sse/             PG LISTEN/NOTIFY → SSE bridge
+├── views/           shared response shapes for read endpoints
+└── session-cache.ts MCP session cache (30-min idle sweep, fact promotion on evict)
+```
+
+## Build / test
+
+```bash
+pnpm --filter @beevibe/api build
+pnpm --filter @beevibe/api typecheck
+pnpm --filter @beevibe/api test
+```
+
+End-to-end smokes for the api are in [`/scripts/m6-e2e.ts`](../../scripts/m6-e2e.ts) (in-process) and [`/scripts/m7-e2e.ts`](../../scripts/m7-e2e.ts) (multi-process) — both gated by env flags, see the [root README](../../README.md).

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,144 @@
+# @beevibe/core
+
+Shared library for the beevibe agent runtime: domain types, port interfaces, services, adapters, and auth.
+
+This package has no entry point of its own — it's imported by [`@beevibe/api`](../api), [`@beevibe/executor`](../executor), and [`@beevibe/web`](../web). If you want to run beevibe end-to-end, start at the [repo root README](../../README.md). If you want to embed pieces of beevibe in another Node program, this is the package you depend on.
+
+## Layout
+
+```
+src/
+├── domain/      pure types — agents, tasks, sessions, memory, work products
+├── ports/       interfaces — repos, runtime, workspace, LLM provider, embeddings
+├── services/    business logic — agent-session, task, escalation, memory, skills
+├── adapters/    impls — postgres, claude-code, openai, anthropic, local-workspace
+└── auth/        api key validation, caller resolution, agent provisioning
+```
+
+The dependency direction is one-way and ESLint-enforced:
+
+```
+domain      → nothing
+ports       → domain
+services    → domain + ports     (NEVER adapters)
+adapters    → ports + domain
+auth        → domain + ports
+```
+
+## Subpath exports
+
+Tree-shake-friendly subpaths via the `exports` map in `package.json`:
+
+| Import path | What's there |
+|---|---|
+| `@beevibe/core` | Main barrel — domain types, ports, auth |
+| `@beevibe/core/auth` | API-key validation, `ResolvedCaller`, `provisionAgent` |
+| `@beevibe/core/adapters/postgres` | All 10 repository implementations + `createPool` |
+| `@beevibe/core/adapters/claude-code` | `ClaudeCodeRuntime` (spawns `claude` CLI) |
+| `@beevibe/core/adapters/openai` | `OpenAIEmbeddingService`, `OpenAILlmProvider` |
+| `@beevibe/core/adapters/anthropic` | `AnthropicLlmProvider` |
+| `@beevibe/core/adapters/local-workspace` | `LocalWorkspaceManager` |
+| `@beevibe/core/adapters/runtime-registry` | `createDefaultRuntimeRegistry` |
+| `@beevibe/core/services/agent-session` | `AgentSession` (orchestrates one CLI run) |
+| `@beevibe/core/services/task-service` | Task state machine — approve/reject/revise/cancel |
+| `@beevibe/core/services/escalation-service` | Escalation creation + resolution |
+| `@beevibe/core/services/memory` | `MemoryAgent`, `CoreMemory`, `FactStore`, `FactPromoter` |
+| `@beevibe/core/services/skills` | `syncSkills`, `tierFilterFor` |
+| `@beevibe/core/test-helpers` | `createTestPool`, `truncateAll` for integration tests |
+
+## Quick example — wire a session
+
+```ts
+import { createPool, PostgresAgentRepository, /* … */ } from "@beevibe/core/adapters/postgres";
+import { ClaudeCodeRuntime } from "@beevibe/core/adapters/claude-code";
+import { LocalWorkspaceManager } from "@beevibe/core/adapters/local-workspace";
+import { AgentSession } from "@beevibe/core/services/agent-session";
+
+const pool = createPool({ connectionString: process.env.DATABASE_URL! });
+const runtime = new ClaudeCodeRuntime({ maxTurns: 50 });
+const workspaces = new LocalWorkspaceManager({ /* … */ });
+const session = new AgentSession({ /* repos + runtime + memoryAgent */ });
+
+const result = await session.run({
+  agentId: "agt_…",
+  intent: "Reply with the single word 'ok'.",
+  workspace: await workspaces.ensureWorkspace(/* … */),
+});
+// → { id, status, cli_session_id, usage }
+```
+
+The full wiring lives in `packages/api/src/bootstrap.ts` and `packages/executor/src/bootstrap.ts` — copy from there.
+
+## Domain at a glance
+
+The domain layer is pure types — no I/O, no dependencies beyond `nanoid` for ID minting.
+
+| File | Key types |
+|---|---|
+| `domain/agent.ts` | `Agent`, `HierarchyLevel` (`ic`/`team`/`org`), `RuntimeConfig`, `ReviewPolicy` |
+| `domain/task.ts` | `Task`, `TaskStatus`, `TaskPriority`, `NextDispatchContext` |
+| `domain/session.ts` | `Session`, `SessionType`, `SessionStatus`, `SessionUsage` (incl. cache tokens) |
+| `domain/core-memory.ts` | `CoreMemoryBlock`, default block templates, char limits |
+| `domain/memory.ts` | `MemoryFact`, `FactType`, `MemoryScope` (`ic`/`team`/`org`) |
+| `domain/work-product.ts` | `WorkProduct`, `WorkProductType` (PR, branch, commit, document, …) |
+| `domain/negotiation.ts` | `Negotiation`, `NegotiationRound` |
+| `domain/escalation.ts` | `Escalation`, `Proposal`, `ResolutionProposal` |
+| `domain/person.ts` | `Person` |
+| `domain/ids.ts` | `agentId()`, `taskId()`, `sessionId()`, … (prefixed nanoid) |
+
+## Ports
+
+Every external dependency lives behind a port. New runtimes (e.g., a different CLI), new vector stores, or new LLM providers slot in by implementing the relevant interface — the rest of the codebase doesn't move.
+
+```
+AgentRepository, TaskRepository, SessionRepository, PersonRepository,
+CoreMemoryRepository, WorkProductRepository, MemoryFactRepository,
+NegotiationRepository, EscalationRepository, MemoryPromotionEventRepository
+LlmProvider, EmbeddingService
+AgentRuntime, WorkspaceManager
+```
+
+## Services
+
+| Service | What it does |
+|---|---|
+| `AgentSession` | Runs one CLI session end-to-end. Composes the system prompt (memory briefing + lifecycle/memory reminders), invokes the runtime, persists the session row, fires the post-dispatch hook. |
+| `TaskService` | Task state machine. `approveTask` / `rejectTask` / `reviseTask` / `cancelTask`, parent rollup when all children settle. |
+| `EscalationService` | Creates escalations, resolves them, re-queues both parties' tasks with post-resolution context. |
+| `MemoryAgent` | Per-agent memory orchestrator. `prepareBriefing(intent)` (system + user split for cache), `searchArchival(query)` for mid-session recall, `onTaskComplete` for fact promotion. |
+| `CoreMemory` | Reads/writes the agent's stable per-agent blocks (persona, domain, constraints, learnings). |
+| `FactStore` / `FactPromoter` | Vector-indexed archival facts; LLM-judged scope promotion (ic → team → org). |
+| `syncSkills` | Per-workspace mtime-diff sync of `SKILL.md` files into `<workspace>/.claude/skills/`. Namespace-safe — only touches `beevibe`/`beevibe-*` dirs. |
+
+## Adapters
+
+| Adapter group | Implements | Notes |
+|---|---|---|
+| `postgres/` | All 10 repos + `createPool` | Raw `pg` driver, no ORM. Schema in [`/migrations/`](../../migrations). |
+| `claude-code/` | `AgentRuntime` | Spawns `claude` CLI as subprocess, parses stream-JSON output, captures cache tokens. |
+| `openai/` | `EmbeddingService`, `LlmProvider` | `text-embedding-3-small` (1536 dims), GPT-4o for fact merging. |
+| `anthropic/` | `LlmProvider` | Claude Sonnet for fact promotion (native JSON schema output). |
+| `local-workspace/` | `WorkspaceManager` | Per-agent dirs under `~/.beevibe/workspaces/<agent_id>/`, manages `mcp-config.json`. |
+
+## Auth
+
+```ts
+import { lookupApiKey, provisionAgent } from "@beevibe/core/auth";
+
+// API key prefixes:
+//   bv_a_…  → agent (MCP calls)
+//   bv_u_…  → user  (REST + SSE)
+const caller = await lookupApiKey(repos, "bv_a_…");
+// → { source: "agent", agent_id, hierarchy_level, … }
+//   or { source: "human", person_id, … }
+```
+
+## Build / test
+
+```bash
+pnpm --filter @beevibe/core build
+pnpm --filter @beevibe/core typecheck
+pnpm --filter @beevibe/core test
+```
+
+Tests are colocated next to source (`*.test.ts`). Integration tests that need Postgres use `@beevibe/core/test-helpers` for setup/teardown.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -90,13 +90,9 @@ The domain layer is pure types — no I/O, no dependencies beyond `nanoid` for I
 
 Every external dependency lives behind a port. New runtimes (e.g., a different CLI), new vector stores, or new LLM providers slot in by implementing the relevant interface — the rest of the codebase doesn't move.
 
-```
-AgentRepository, TaskRepository, SessionRepository, PersonRepository,
-CoreMemoryRepository, WorkProductRepository, MemoryFactRepository,
-NegotiationRepository, EscalationRepository, MemoryPromotionEventRepository
-LlmProvider, EmbeddingService
-AgentRuntime, WorkspaceManager
-```
+- **Repositories** (10) — `AgentRepository`, `TaskRepository`, `SessionRepository`, `PersonRepository`, `CoreMemoryRepository`, `WorkProductRepository`, `MemoryFactRepository`, `NegotiationRepository`, `EscalationRepository`, `MemoryPromotionEventRepository`
+- **LLM + embeddings** — `LlmProvider`, `EmbeddingService`
+- **Execution** — `AgentRuntime`, `WorkspaceManager`
 
 ## Services
 

--- a/packages/executor/README.md
+++ b/packages/executor/README.md
@@ -1,0 +1,92 @@
+# @beevibe/executor
+
+The long-running worker. Polls Postgres for assigned tasks, provisions agent workspaces, and dispatches `claude` CLI sessions for each one. Stateless — restart at any time.
+
+It only depends on `@beevibe/core`. It never talks to [`@beevibe/api`](../api) over HTTP — both processes use the database as the integration point.
+
+If you're running beevibe locally, `pnpm dev` at the repo root brings this up alongside the api server.
+
+## What it does, per cycle
+
+Default cadence: **every 30 seconds** (override via `POLL_INTERVAL_MS`).
+
+1. **Reap orphans.** Any session whose CLI process has died (`isProcessAlive(pid)`) is marked `failed` and its task is re-queued.
+2. **Dispatch ready tasks.** For each assignable task:
+   - Check the agent's per-agent capacity (`agent.max_task_sessions`, default 1).
+   - Atomically claim via `TaskRepository.claimById` (race-safe across multiple executor replicas).
+   - Provision the workspace (`LocalWorkspaceManager.ensureWorkspace`). This also syncs the agent's tier-filtered `SKILL.md` files into `<workspace>/.claude/skills/`.
+   - Hand off to the dispatcher: `AgentSession.run(...)` from `@beevibe/core`. Fire-and-forget, tracked by an `AbortController`.
+
+The dispatcher figures out the right session shape from `task.next_dispatch_context` (set by api on revisions / escalation resolutions) — fresh, crash-recovery, post-escalation, or revision.
+
+## Cancellation
+
+The api's `POST /task/:id/cancel` writes the DB row and fires a Postgres `NOTIFY cancel_task <task_id>`. A dedicated `pg.Client` in the executor (`src/cancel-listener.ts`) is `LISTEN`ing on that channel and aborts the in-flight session's `AbortController`. The CLI subprocess gets `SIGTERM`. End-to-end latency is sub-200ms.
+
+If the executor is down when the NOTIFY fires, the notification is lost — but the task's `cancelled` status is durable, so the next worker boot won't dispatch it. No reliable delivery is needed.
+
+## Post-dispatch hook
+
+After every session, an `onSessionComplete` hook runs:
+
+- If the agent forgot to call `update_progress`, retry the task once with a `<context type="nudge_completion">` nudge intent. Fail it on the second silent exit.
+- If all of a parent task's children have settled, roll the parent up via `TaskService.checkAndCompleteParent`.
+
+This is where M6.5's "two sessions per leaf task" footgun used to live; M9 closed most of it via the `BEEVIBE_LIFECYCLE_REMINDER` system-prompt instruction (see issue #9), but the hook stays as the safety net.
+
+## Run it
+
+```bash
+pnpm --filter @beevibe/executor build
+pnpm --filter @beevibe/executor start            # node dist/main.js
+# or watch mode:
+pnpm --filter @beevibe/executor dev
+```
+
+Required env (validated at startup):
+
+| Var | Purpose |
+|---|---|
+| `DATABASE_URL` | Postgres connection string |
+| `BEEVIBE_MCP_SERVER_URL` | The URL spawned agents will call back to. Baked into each agent's `mcp-config.json`. |
+| `OPENAI_API_KEY` | Embeddings (for the memory subsystem the spawned agents use) |
+| `ANTHROPIC_API_KEY` | LLM (fact merging + promotion at session end) |
+
+Optional:
+
+| Var | Default | Purpose |
+|---|---|---|
+| `WORKSPACE_ROOT` | `~/.beevibe/workspaces` | Per-agent sandbox root |
+| `BEEVIBE_SKILLS_DIR` | `<repo>/skills` | Source dir for skill sync |
+| `POLL_INTERVAL_MS` | `30000` | Polling cadence |
+| `BEEVIBE_EXECUTOR_HEALTH_PORT` | `3001` | `GET /health` listener |
+
+`GET /health` returns:
+
+```json
+{ "ok": true, "polling": true, "last_poll_at": "...", "in_flight_count": 2, "poll_interval_ms": 30000 }
+```
+
+`ok` is `false` (with HTTP 503) if the worker has stopped polling or the last poll is older than 3× the interval — suitable for liveness probes.
+
+## Source layout
+
+```
+src/
+├── main.ts            startup: env validation → bootstrap → start workers
+├── bootstrap.ts       composition root: pool + repos + services + dispatcher + listener
+├── worker.ts          poll-claim-dispatch loop (the heart of this package)
+├── dispatch.ts        per-task dispatcher: ResumeReason resolution + AgentSession.run
+├── cancel-listener.ts dedicated PG client subscribed to `cancel_task`
+└── health-server.ts   GET /health
+```
+
+## Build / test
+
+```bash
+pnpm --filter @beevibe/executor build
+pnpm --filter @beevibe/executor typecheck
+pnpm --filter @beevibe/executor test
+```
+
+End-to-end coverage for the dispatch path lives in [`/scripts/m5-e2e.ts`](../../scripts/m5-e2e.ts) (in-process) and [`/scripts/m7-e2e.ts`](../../scripts/m7-e2e.ts) (multi-process). The latter spawns this binary as an actual `node dist/main.js` subprocess and verifies signal propagation + no orphan `claude` processes after `SIGTERM`.

--- a/packages/executor/README.md
+++ b/packages/executor/README.md
@@ -4,7 +4,7 @@ The long-running worker. Polls Postgres for assigned tasks, provisions agent wor
 
 It only depends on `@beevibe/core`. It never talks to [`@beevibe/api`](../api) over HTTP — both processes use the database as the integration point.
 
-If you're running beevibe locally, `pnpm dev` at the repo root brings this up alongside the api server.
+If you're running beevibe locally, `pnpm dev` at the repo root brings this up alongside the api server. For full setup, see the [root README](../../README.md).
 
 ## What it does, per cycle
 
@@ -32,7 +32,7 @@ After every session, an `onSessionComplete` hook runs:
 - If the agent forgot to call `update_progress`, retry the task once with a `<context type="nudge_completion">` nudge intent. Fail it on the second silent exit.
 - If all of a parent task's children have settled, roll the parent up via `TaskService.checkAndCompleteParent`.
 
-This is where M6.5's "two sessions per leaf task" footgun used to live; M9 closed most of it via the `BEEVIBE_LIFECYCLE_REMINDER` system-prompt instruction (see issue #9), but the hook stays as the safety net.
+It's a safety net for agents that exit without setting their task's terminal status. The system-prompt lifecycle reminder injected by `AgentSession` covers most cases proactively; this hook is the catch-all when the LLM still slips.
 
 ## Run it
 

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -1,0 +1,96 @@
+# @beevibe/web
+
+The Next.js dashboard. Humans use this to view agents, watch tasks move through their lifecycle, read session transcripts, browse memory, and approve/revise/cancel work.
+
+It's a thin, read-mostly UI — there are **no API routes** in this package. All data goes through [`@beevibe/api`](../api), and live updates arrive over SSE from `GET /api/stream` on that server.
+
+## Run it
+
+```bash
+pnpm --filter @beevibe/web dev    # Next.js dev server
+```
+
+Next.js defaults to port 3000, which collides with the api's default. Either run the api on a different port (`BEEVIBE_API_PORT=3001 pnpm dev`) or run web on a different port (`pnpm --filter @beevibe/web dev -- -p 3030`).
+
+## Env vars
+
+| Var | Required | Example | Purpose |
+|---|---|---|---|
+| `NEXT_PUBLIC_BV_API_URL` | yes\* | `http://localhost:3000` | Origin of the api server (no `/mcp` suffix). |
+| `NEXT_PUBLIC_BV_USER_KEY` | yes\* | `bv_u_…` | Bearer token sent on every request. |
+
+\* When unset, the app boots but every page renders an empty/not-configured state. Useful for layout work without a backing api.
+
+To mint a `bv_u_` key for local dev, run `pnpm tsx scripts/provision-demo.ts` from the repo root — it creates a captain + IC team and prints the token (along with a paste-ready `mcp.json` snippet, separately useful for the Claude CLI smoke).
+
+## Pages
+
+All pages live under `app/(authed)/` — there's no public surface and no login flow yet (token is sourced from the env var above).
+
+| Path | What you see |
+|---|---|
+| `/` | Home dashboard — KPI tiles, fleet status bars, task breakdown |
+| `/tasks` | Kanban board grouped by lifecycle (backlog / ready / running / done / archived); filterable by view, assignee, lifecycle |
+| `/tasks/:id` | Task detail — metadata, sessions rail, controls (approve / reject / revise / cancel) |
+| `/tasks/:id/sessions/:sid` | Session transcript + escalation-resolution UI |
+| `/agents` | Agent list with hierarchy and organization layout |
+| `/memory` | Fact browser with scope tabs (`ic` / `team` / `org`) |
+| `/mesh` | Agent-to-agent activity feed + request graph |
+| `/promotions` | Audit log of memory facts that the promoter elevated across scopes |
+
+## Data flow
+
+```
+Browser ──HTTP──> @beevibe/api  ──SQL──> Postgres
+   ▲                  │
+   └───SSE(/api/stream)┘   ←── PG NOTIFY
+```
+
+- **Reads** go through `lib/api/client.ts` — a tiny fetch wrapper around `@beevibe/api`'s read endpoints (`GET /task`, `GET /agent`, `GET /memory/fact`, `GET /session/:short_id`, …). Wrapped in [TanStack Query](https://tanstack.com/query) for caching + retries.
+- **Mutations** call the same client (`POST /task/:id/approve`, `POST /escalation/:id/resolve`, …). On success, React Query invalidates the relevant keys.
+- **Live updates** flow via `useLiveUpdates()` (`lib/sse.ts`). It opens an `EventSource` to `/api/stream` (token passed as `?token=` because `EventSource` can't set headers), and on each `task.updated` / `session.updated` / `memory.fact.created` / etc. invalidates the matching React Query keys — pages refetch automatically.
+
+The web package only imports `@beevibe/core` for **types** (`TaskStatus`, `MemoryScope`, `HierarchyLevel`, …). It never touches the database directly.
+
+## Source layout
+
+```
+app/
+├── layout.tsx          root layout, theme provider
+├── providers.tsx       QueryClientProvider + useLiveUpdates
+├── globals.css         Tailwind + CSS variables (light/dark)
+└── (authed)/           every page lives under this group
+    ├── page.tsx        home / dashboard
+    ├── tasks/
+    ├── agents/
+    ├── memory/
+    ├── mesh/
+    └── promotions/
+
+components/
+├── tasks/, agents/, memory/, mesh/, promotions/, sessions/
+├── kpi-tile.tsx, status-pill.tsx, priority-pill.tsx, …
+└── skeletons/          loading states for every list/detail page
+
+lib/
+├── api/client.ts       fetch wrapper around @beevibe/api
+├── sse.ts              useLiveUpdates() — EventSource → React Query invalidate
+└── types.ts            UI-only shapes
+```
+
+## Styling
+
+- [Tailwind CSS](https://tailwindcss.com/) for utilities; theme tokens in `globals.css`.
+- [`lucide-react`](https://lucide.dev/) for icons.
+- Light/dark toggle persisted to `localStorage`.
+
+## Build / test
+
+```bash
+pnpm --filter @beevibe/web build       # next build
+pnpm --filter @beevibe/web start       # production server
+pnpm --filter @beevibe/web typecheck
+pnpm --filter @beevibe/web test        # vitest + @testing-library/react
+```
+
+Tests colocate next to components (`*.test.tsx`).

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -2,7 +2,7 @@
 
 The Next.js dashboard. Humans use this to view agents, watch tasks move through their lifecycle, read session transcripts, browse memory, and approve/revise/cancel work.
 
-It's a thin, read-mostly UI — there are **no API routes** in this package. All data goes through [`@beevibe/api`](../api), and live updates arrive over SSE from `GET /api/stream` on that server.
+It's a thin, read-mostly UI — there are **no API routes** in this package. All data goes through [`@beevibe/api`](../api), and live updates arrive over SSE from `GET /api/stream` on that server. For full setup, see the [root README](../../README.md).
 
 ## Run it
 


### PR DESCRIPTION
## Summary
- Adds a README for each of the four packages (`core`, `api`, `executor`, `web`).
- Rewrites the root README as a friendly open-source landing page — concepts in 60s, quick start, demo recipe, architecture diagram, links into each package.
- Cross-links throughout: root → packages, packages → root, packages → each other.

## What each package README covers

| Package | Highlights |
|---|---|
| `core` | Subpath exports table (one row per `@beevibe/core/*`), one-way dependency rules, wiring example |
| `api` | MCP tool inventory by tier (12 IC / 22 team), REST routes, mesh broker behavior, `bv_a_` / `bv_u_` auth |
| `executor` | Poll/dispatch lifecycle, `pg_notify('cancel_task', ...)` cancellation path, post-dispatch hook |
| `web` | "Pure SPA, no API routes" pattern, SSE → React Query invalidation flow, port-collision note vs api |

## Verification
- Cross-checked tool counts against `packages/api/src/tools/assemble.ts` (`IC (12 tools)` / `Team / org (22 tools)` per the in-code comment).
- Cross-checked mesh capacity default (3) against `mesh/server.ts:65`.
- Cross-checked Apache-2.0 license against `LICENSE`.
- Cross-checked subpath exports against `packages/core/package.json`.

## Test plan
- [ ] Skim each README for any factual drift since recent code changes.
- [ ] Click every relative link to confirm it resolves on GitHub.
- [ ] Confirm the demo recipe (`provision-demo.ts`) wording matches what the script actually prints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)