### PR TITLE
Phase 2: per-user SSE isolation + dev orchestration

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "clean": "turbo clean && rm -rf node_modules",
     "migrate": "node-pg-migrate --envPath .env",
     "migrate:test": "node-pg-migrate --envPath .env -d DATABASE_URL_TEST",
-    "install-skills": "tsx scripts/install-skills.ts"
+    "install-skills": "tsx scripts/install-skills.ts",
+    "bootstrap": "tsx scripts/init.ts",
+    "provision-user": "tsx scripts/provision-user.ts"
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/packages/api/src/bootstrap.ts
+++ b/packages/api/src/bootstrap.ts
@@ -38,6 +38,7 @@ import { createStreamRouter } from "./routes/stream.js";
 import { createStreamAuthMiddleware } from "./auth/middleware.js";
 import { SseManager } from "./sse/manager.js";
 import { SseListener } from "./sse/listener.js";
+import { OwnerLookup } from "./sse/owner-lookup.js";
 
 export interface BootstrapConfig {
   databaseUrl: string;
@@ -245,7 +246,12 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
   // LISTENs on a dedicated pg.Client and fans out via SseManager;
   // /api/stream pushes to subscribed browsers.
   const sseManager = new SseManager();
-  const sseListener = new SseListener({ databaseUrl: cfg.databaseUrl, manager: sseManager });
+  const ownerLookup = new OwnerLookup(pool);
+  const sseListener = new SseListener({
+    databaseUrl: cfg.databaseUrl,
+    manager: sseManager,
+    ownerLookup,
+  });
   sseListener.start();
   const streamRouter = createStreamRouter({
     authMiddleware: createStreamAuthMiddleware({ agentRepo, personRepo }),

--- a/packages/api/src/routes/stream.ts
+++ b/packages/api/src/routes/stream.ts
@@ -27,6 +27,7 @@ export function createStreamRouter(deps: StreamRoutesDeps): Router {
 
   router.get("/stream", (req, res) => {
     if (!requireHuman(req, res)) return;
+    const personId = req.caller!.personId;
 
     res.writeHead(200, {
       "Content-Type": "text/event-stream",
@@ -40,7 +41,7 @@ export function createStreamRouter(deps: StreamRoutesDeps): Router {
       res.write(`data: ${JSON.stringify(event)}\n\n`);
     };
 
-    const unsubscribe = deps.sseManager.subscribe(send);
+    const unsubscribe = deps.sseManager.subscribe(personId, send);
     const heartbeat = setInterval(() => {
       res.write(": heartbeat\n\n");
     }, HEARTBEAT_INTERVAL_MS);

--- a/packages/api/src/sse/listener.ts
+++ b/packages/api/src/sse/listener.ts
@@ -9,10 +9,12 @@
 
 import { Client } from "pg";
 import type { SseManager, BvEvent } from "./manager.js";
+import type { OwnerLookup } from "./owner-lookup.js";
 
 export interface SseListenerConfig {
   databaseUrl: string;
   manager: SseManager;
+  ownerLookup: OwnerLookup;
   /** Default 5s. */
   reconnectDelayMs?: number;
 }
@@ -72,7 +74,10 @@ export class SseListener {
     client.on("notification", (msg) => {
       if (msg.channel !== "bv_event" || !msg.payload) return;
       const parsed = parseEvent(msg.payload);
-      if (parsed) this.config.manager.publish(parsed);
+      if (!parsed) return;
+      void this.config.ownerLookup.ownersOf(parsed).then((owners) => {
+        this.config.manager.publish(parsed, owners);
+      });
     });
 
     // pg.Client emits 'error' for socket-level issues, then ends the connection.

--- a/packages/api/src/sse/manager.test.ts
+++ b/packages/api/src/sse/manager.test.ts
@@ -1,29 +1,53 @@
 import { describe, it, expect, vi } from "vitest";
 import { SseManager, type BvEvent } from "./manager.js";
 
+const event: BvEvent = { event: "task.updated", id: "task_1" };
+
 describe("SseManager", () => {
-  it("delivers published events to all subscribers", () => {
+  it("delivers events to subscribers whose personId is in the owner set", () => {
     const manager = new SseManager();
     const a = vi.fn();
     const b = vi.fn();
-    manager.subscribe(a);
-    manager.subscribe(b);
+    manager.subscribe("person_a", a);
+    manager.subscribe("person_b", b);
 
-    const event: BvEvent = { event: "task.updated", id: "task_1" };
-    manager.publish(event);
+    manager.publish(event, new Set(["person_a", "person_b"]));
 
     expect(a).toHaveBeenCalledWith(event);
     expect(b).toHaveBeenCalledWith(event);
   });
 
+  it("skips subscribers not in the owner set", () => {
+    const manager = new SseManager();
+    const a = vi.fn();
+    const b = vi.fn();
+    manager.subscribe("person_a", a);
+    manager.subscribe("person_b", b);
+
+    manager.publish(event, new Set(["person_a"]));
+
+    expect(a).toHaveBeenCalledOnce();
+    expect(b).not.toHaveBeenCalled();
+  });
+
+  it("drops events with an empty owner set (fail-closed)", () => {
+    const manager = new SseManager();
+    const a = vi.fn();
+    manager.subscribe("person_a", a);
+
+    manager.publish(event, new Set());
+
+    expect(a).not.toHaveBeenCalled();
+  });
+
   it("returns an unsubscribe handle that removes the callback", () => {
     const manager = new SseManager();
     const cb = vi.fn();
-    const unsubscribe = manager.subscribe(cb);
+    const unsubscribe = manager.subscribe("person_a", cb);
 
-    manager.publish({ event: "task.created", id: "t1" });
+    manager.publish({ event: "task.created", id: "t1" }, new Set(["person_a"]));
     unsubscribe();
-    manager.publish({ event: "task.created", id: "t2" });
+    manager.publish({ event: "task.created", id: "t2" }, new Set(["person_a"]));
 
     expect(cb).toHaveBeenCalledTimes(1);
     expect(manager.size()).toBe(0);
@@ -37,9 +61,9 @@ describe("SseManager", () => {
     });
     const ok = vi.fn();
 
-    manager.subscribe(failing);
-    manager.subscribe(ok);
-    manager.publish({ event: "agent.updated", id: "a1" });
+    manager.subscribe("person_a", failing);
+    manager.subscribe("person_a", ok);
+    manager.publish({ event: "agent.updated", id: "a1" }, new Set(["person_a"]));
 
     expect(failing).toHaveBeenCalledOnce();
     expect(ok).toHaveBeenCalledOnce();
@@ -50,10 +74,26 @@ describe("SseManager", () => {
   it("size() reflects current subscriber count", () => {
     const manager = new SseManager();
     expect(manager.size()).toBe(0);
-    const u1 = manager.subscribe(() => {});
-    manager.subscribe(() => {});
+    const u1 = manager.subscribe("person_a", () => {});
+    manager.subscribe("person_b", () => {});
     expect(manager.size()).toBe(2);
     u1();
     expect(manager.size()).toBe(1);
+  });
+
+  it("delivers an event to the same subscriber once even when registered twice with same personId", () => {
+    // The same person opening two browser tabs should get one delivery per
+    // registered subscriber — and `subscribe` returns a per-call entry, so
+    // two subscriptions with the same personId both fire.
+    const manager = new SseManager();
+    const cb1 = vi.fn();
+    const cb2 = vi.fn();
+    manager.subscribe("person_a", cb1);
+    manager.subscribe("person_a", cb2);
+
+    manager.publish(event, new Set(["person_a"]));
+
+    expect(cb1).toHaveBeenCalledOnce();
+    expect(cb2).toHaveBeenCalledOnce();
   });
 });

--- a/packages/api/src/sse/manager.ts
+++ b/packages/api/src/sse/manager.ts
@@ -4,6 +4,14 @@
  * `routes/stream.ts` per-browser handlers register callbacks via
  * `subscribe`. No persistence: an event missed during a disconnect is
  * lost, but React Query refetches on focus/reconnect so it converges.
+ *
+ * Per-user filtering: each subscriber registers with the caller's
+ * `personId`. The listener resolves an event's owner set (via
+ * `OwnerLookup`) and passes it to `publish`; subscribers only fire when
+ * their personId is in the owner set. Events with an empty owner set
+ * (entity gone, unknown event type, or DB lookup failed) are dropped —
+ * fail-closed so we never leak across users when ownership lookup
+ * fails.
  */
 
 export interface BvEvent {
@@ -15,20 +23,38 @@ export interface BvEvent {
 
 export type SseSubscriber = (event: BvEvent) => void;
 
-export class SseManager {
-  private readonly subscribers = new Set<SseSubscriber>();
+interface RegisteredSubscriber {
+  personId: string;
+  cb: SseSubscriber;
+}
 
-  subscribe(cb: SseSubscriber): () => void {
-    this.subscribers.add(cb);
+export class SseManager {
+  private readonly subscribers = new Set<RegisteredSubscriber>();
+
+  /**
+   * Register a subscriber for events owned by `personId`. Events
+   * published with an owner set that does NOT contain `personId` are
+   * skipped for this subscriber.
+   */
+  subscribe(personId: string, cb: SseSubscriber): () => void {
+    const entry: RegisteredSubscriber = { personId, cb };
+    this.subscribers.add(entry);
     return () => {
-      this.subscribers.delete(cb);
+      this.subscribers.delete(entry);
     };
   }
 
-  publish(event: BvEvent): void {
-    for (const cb of this.subscribers) {
+  /**
+   * Fan out an event to subscribers whose personId is in `owners`.
+   * `owners` is a frozen set produced by the listener via OwnerLookup;
+   * empty set drops the event (fail-closed).
+   */
+  publish(event: BvEvent, owners: ReadonlySet<string>): void {
+    if (owners.size === 0) return;
+    for (const sub of this.subscribers) {
+      if (!owners.has(sub.personId)) continue;
       try {
-        cb(event);
+        sub.cb(event);
       } catch (err) {
         console.error("[SseManager] subscriber threw:", (err as Error).message);
       }

--- a/packages/api/src/sse/owner-lookup.test.ts
+++ b/packages/api/src/sse/owner-lookup.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi } from "vitest";
+import { OwnerLookup } from "./owner-lookup.js";
+import type { Pool } from "@beevibe/core/adapters/postgres";
+
+function fakePool(rows: Record<string, unknown>[] = []) {
+  const query = vi.fn(async () => ({ rows }));
+  return { pool: { query } as unknown as Pool, query };
+}
+
+describe("OwnerLookup", () => {
+  it("resolves task events via assignee.owner_id", async () => {
+    const { pool, query } = fakePool([{ owner: "person_a" }]);
+    const lookup = new OwnerLookup(pool);
+    const owners = await lookup.ownersOf({ event: "task.updated", id: "task_1" });
+    expect([...owners]).toEqual(["person_a"]);
+    expect(query).toHaveBeenCalledOnce();
+  });
+
+  it("resolves agent events via agent.owner_id", async () => {
+    const { pool } = fakePool([{ owner: "person_b" }]);
+    const lookup = new OwnerLookup(pool);
+    const owners = await lookup.ownersOf({ event: "agent.updated", id: "agent_1" });
+    expect([...owners]).toEqual(["person_b"]);
+  });
+
+  it("resolves session events via agent.owner_id", async () => {
+    const { pool } = fakePool([{ owner: "person_c" }]);
+    const lookup = new OwnerLookup(pool);
+    const owners = await lookup.ownersOf({ event: "session.event", id: "sess_1" });
+    expect([...owners]).toEqual(["person_c"]);
+  });
+
+  it("resolves mesh.activity to both initiator and counterparty owners", async () => {
+    const { pool } = fakePool([{ initiator: "person_a", counterparty: "person_b" }]);
+    const lookup = new OwnerLookup(pool);
+    const owners = await lookup.ownersOf({ event: "mesh.activity", id: "neg_1" });
+    expect([...owners].sort()).toEqual(["person_a", "person_b"]);
+  });
+
+  it("resolves runtime.updated via daemon.owner_person_id", async () => {
+    const { pool } = fakePool([{ owner: "person_d" }]);
+    const lookup = new OwnerLookup(pool);
+    const owners = await lookup.ownersOf({ event: "runtime.updated", id: "rt_1" });
+    expect([...owners]).toEqual(["person_d"]);
+  });
+
+  it("returns empty set for missing entity (fail-closed)", async () => {
+    const { pool } = fakePool([]);
+    const lookup = new OwnerLookup(pool);
+    const owners = await lookup.ownersOf({ event: "task.updated", id: "task_x" });
+    expect(owners.size).toBe(0);
+  });
+
+  it("returns empty set for unknown event type without querying the DB", async () => {
+    const { pool, query } = fakePool();
+    const lookup = new OwnerLookup(pool);
+    const owners = await lookup.ownersOf({ event: "unrelated.event", id: "x" });
+    expect(owners.size).toBe(0);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it("caches successive lookups for the same event id", async () => {
+    const { pool, query } = fakePool([{ owner: "person_a" }]);
+    const lookup = new OwnerLookup(pool);
+    await lookup.ownersOf({ event: "task.updated", id: "task_1" });
+    await lookup.ownersOf({ event: "task.updated", id: "task_1" });
+    expect(query).toHaveBeenCalledOnce();
+  });
+
+  it("respects the configured cache cap via FIFO eviction", async () => {
+    const { pool } = fakePool([{ owner: "person_a" }]);
+    const lookup = new OwnerLookup(pool, { cacheMaxEntries: 2 });
+
+    await lookup.ownersOf({ event: "task.updated", id: "task_1" });
+    await lookup.ownersOf({ event: "task.updated", id: "task_2" });
+    await lookup.ownersOf({ event: "task.updated", id: "task_3" });
+
+    // Cache should hold at most 2 entries; FIFO drops task_1 first.
+    // Verify by re-querying task_1 and asserting another DB hit.
+    const before = (pool as unknown as { query: { mock: { calls: unknown[] } } }).query.mock.calls.length;
+    await lookup.ownersOf({ event: "task.updated", id: "task_1" });
+    const after = (pool as unknown as { query: { mock: { calls: unknown[] } } }).query.mock.calls.length;
+    expect(after).toBe(before + 1);
+  });
+
+  it("dedupes concurrent lookups for the same key (no N+1)", async () => {
+    let resolveQuery: (value: { rows: Array<{ owner: string }> }) => void = () => {};
+    const query = vi.fn(
+      () =>
+        new Promise<{ rows: Array<{ owner: string }> }>((resolve) => {
+          resolveQuery = resolve;
+        }),
+    );
+    const pool = { query } as unknown as Pool;
+    const lookup = new OwnerLookup(pool);
+
+    // Fire two lookups for the same key BEFORE the first promise resolves.
+    const first = lookup.ownersOf({ event: "task.updated", id: "task_1" });
+    const second = lookup.ownersOf({ event: "task.updated", id: "task_1" });
+    expect(query).toHaveBeenCalledOnce();
+
+    resolveQuery({ rows: [{ owner: "person_a" }] });
+    const [a, b] = await Promise.all([first, second]);
+    expect([...a]).toEqual(["person_a"]);
+    expect([...b]).toEqual(["person_a"]);
+    expect(query).toHaveBeenCalledOnce();
+  });
+
+  it("returns empty set when the DB query throws (drops the event)", async () => {
+    const query = vi.fn(async () => {
+      throw new Error("connection refused");
+    });
+    const pool = { query } as unknown as Pool;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const lookup = new OwnerLookup(pool);
+    const owners = await lookup.ownersOf({ event: "task.updated", id: "task_1" });
+
+    expect(owners.size).toBe(0);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("treats owner_id as immutable for the cache window — staleness is documented", async () => {
+    // If a future feature reassigns owner_id (not currently possible), the
+    // cached result is masked for cacheTtlMs. This test pins that
+    // assumption: changing the underlying row doesn't affect cached
+    // results until TTL elapses or clearCache() is called.
+    const owners1 = [{ owner: "person_a" }];
+    const owners2 = [{ owner: "person_b" }];
+    let returnFirst = true;
+    const query = vi.fn(async () => ({ rows: returnFirst ? owners1 : owners2 }));
+    const pool = { query } as unknown as Pool;
+
+    const lookup = new OwnerLookup(pool, { cacheTtlMs: 10_000 });
+    const a = await lookup.ownersOf({ event: "agent.updated", id: "agent_1" });
+    expect([...a]).toEqual(["person_a"]);
+
+    returnFirst = false;
+    const b = await lookup.ownersOf({ event: "agent.updated", id: "agent_1" });
+    expect([...b]).toEqual(["person_a"]); // still cached
+
+    lookup.clearCache();
+    const c = await lookup.ownersOf({ event: "agent.updated", id: "agent_1" });
+    expect([...c]).toEqual(["person_b"]); // post-eviction
+  });
+});

--- a/packages/api/src/sse/owner-lookup.ts
+++ b/packages/api/src/sse/owner-lookup.ts
@@ -12,9 +12,8 @@
  * if a future feature reassigns agents across owners, that change is
  * masked from SSE for up to TTL_MS. Tests cover this assumption.
  *
- * Room-scoped fan-out is intentionally absent here: rooms come back in
- * Phase 9 of the daemon-first restructure plan; this module re-grows
- * the room.message and session.room_id branches at that point.
+ * Single-owner only here. Multi-owner room fan-out belongs in a
+ * separate handler when rooms ship.
  */
 
 import type { Pool } from "@beevibe/core/adapters/postgres";
@@ -22,10 +21,13 @@ import type { BvEvent } from "./manager.js";
 
 const DEFAULT_CACHE_TTL_MS = 30_000;
 const DEFAULT_CACHE_MAX_ENTRIES = 5_000;
+/** Cap any single owner-resolution query at 2s — beyond that the SSE
+ *  pipeline back-pressures and we'd rather drop than block. */
+const QUERY_TIMEOUT_MS = 2_000;
 
 interface CacheEntry {
   owners: ReadonlySet<string>;
-  expires_at: number;
+  expiresAt: number;
 }
 
 export interface OwnerLookupConfig {
@@ -34,6 +36,53 @@ export interface OwnerLookupConfig {
   /** Override default cap. Reads `BEEVIBE_OWNER_CACHE_MAX_ENTRIES` if unset. */
   cacheMaxEntries?: number;
 }
+
+/**
+ * One row per resolution shape. Most events resolve to exactly one
+ * owner via a single-row JOIN; mesh.activity is the lone two-owner
+ * shape. Lookup matches by prefix (with optional dot) or by exact name.
+ */
+interface ResolverRule {
+  match: (eventName: string) => boolean;
+  resolve: (lookup: OwnerLookup, id: string) => Promise<ReadonlySet<string>>;
+}
+
+const SINGLE_OWNER_SQL = {
+  task: `SELECT a.owner_id AS owner
+         FROM task t LEFT JOIN agent a ON a.id = t.assignee_id
+         WHERE t.id = $1`,
+  agent: `SELECT owner_id AS owner FROM agent WHERE id = $1`,
+  session: `SELECT a.owner_id AS owner
+            FROM session s JOIN agent a ON a.id = s.agent_id
+            WHERE s.id = $1`,
+  memoryFact: `SELECT a.owner_id AS owner
+               FROM memory_fact f JOIN agent a ON a.id = f.agent_id
+               WHERE f.id = $1`,
+  promotion: `SELECT a.owner_id AS owner
+              FROM memory_promotion_event mpe JOIN agent a ON a.id = mpe.origin_agent_id
+              WHERE mpe.id = $1`,
+  runtime: `SELECT d.owner_person_id AS owner
+            FROM runtime r JOIN daemon d ON d.id = r.daemon_id
+            WHERE r.id = $1`,
+} as const;
+
+const MESH_ACTIVITY_SQL = `SELECT
+    ai.owner_id AS initiator,
+    ac.owner_id AS counterparty
+  FROM negotiation n
+  LEFT JOIN agent ai ON ai.id = n.initiator_agent_id
+  LEFT JOIN agent ac ON ac.id = n.counterparty_agent_id
+  WHERE n.id = $1`;
+
+const RESOLVERS: ResolverRule[] = [
+  { match: (e) => e.startsWith("task."),        resolve: (l, id) => l.singleOwnerSet(SINGLE_OWNER_SQL.task, id) },
+  { match: (e) => e.startsWith("agent."),       resolve: (l, id) => l.singleOwnerSet(SINGLE_OWNER_SQL.agent, id) },
+  { match: (e) => e.startsWith("session."),     resolve: (l, id) => l.singleOwnerSet(SINGLE_OWNER_SQL.session, id) },
+  { match: (e) => e.startsWith("memory.fact."), resolve: (l, id) => l.singleOwnerSet(SINGLE_OWNER_SQL.memoryFact, id) },
+  { match: (e) => e === "promotion.created",    resolve: (l, id) => l.singleOwnerSet(SINGLE_OWNER_SQL.promotion, id) },
+  { match: (e) => e === "runtime.updated",      resolve: (l, id) => l.singleOwnerSet(SINGLE_OWNER_SQL.runtime, id) },
+  { match: (e) => e === "mesh.activity",        resolve: (l, id) => l.meshOwners(id) },
+];
 
 export class OwnerLookup {
   private cache = new Map<string, CacheEntry>();
@@ -59,14 +108,15 @@ export class OwnerLookup {
   /**
    * Returns the set of person ids that should receive `event`. Empty set
    * means the entity is gone (deleted between trigger and lookup), the
-   * event type isn't owner-scoped, or the lookup query failed — in any
-   * of those cases the manager drops the event rather than fan out.
+   * event type isn't owner-scoped, or the lookup query failed/timed
+   * out — in any of those cases the manager drops the event rather
+   * than fan out.
    */
   async ownersOf(event: BvEvent): Promise<ReadonlySet<string>> {
     const cacheKey = `${event.event}|${event.id}`;
     const now = Date.now();
     const cached = this.cache.get(cacheKey);
-    if (cached && cached.expires_at > now) return cached.owners;
+    if (cached && cached.expiresAt > now) return cached.owners;
 
     // N+1 guard: if a concurrent caller is already resolving this same
     // key, share its in-flight promise rather than firing a duplicate
@@ -105,97 +155,47 @@ export class OwnerLookup {
       const firstKey = this.cache.keys().next().value;
       if (firstKey !== undefined) this.cache.delete(firstKey);
     }
-    this.cache.set(cacheKey, { owners, expires_at: now + this.cacheTtlMs });
+    // Reinsert at tail so a stale-then-refreshed entry behaves as
+    // "recently used" under FIFO eviction.
+    this.cache.delete(cacheKey);
+    this.cache.set(cacheKey, { owners, expiresAt: now + this.cacheTtlMs });
     return owners;
   }
 
   private async lookup(event: BvEvent): Promise<ReadonlySet<string>> {
-    if (event.event.startsWith("task.")) {
-      const { rows } = await this.pool.query<{ owner: string | null }>(
-        `SELECT a.owner_id AS owner
-         FROM task t
-         LEFT JOIN agent a ON a.id = t.assignee_id
-         WHERE t.id = $1`,
-        [event.id],
-      );
-      return rows[0]?.owner ? new Set([rows[0].owner]) : new Set();
-    }
+    const rule = RESOLVERS.find((r) => r.match(event.event));
+    return rule ? rule.resolve(this, event.id) : new Set();
+  }
 
-    if (event.event.startsWith("agent.")) {
-      const { rows } = await this.pool.query<{ owner: string | null }>(
-        `SELECT owner_id AS owner FROM agent WHERE id = $1`,
-        [event.id],
-      );
-      return rows[0]?.owner ? new Set([rows[0].owner]) : new Set();
-    }
+  /** @internal — used by the resolver table. */
+  async singleOwnerSet(sql: string, id: string): Promise<ReadonlySet<string>> {
+    const { rows } = await this.queryWithTimeout<{ owner: string | null }>(sql, [id]);
+    return rows[0]?.owner ? new Set([rows[0].owner]) : new Set();
+  }
 
-    if (event.event.startsWith("session.")) {
-      // Single-tenant: just the agent's owner. Room fan-out re-grows
-      // here in Phase 9 when rooms come back.
-      const { rows } = await this.pool.query<{ owner: string | null }>(
-        `SELECT a.owner_id AS owner
-         FROM session s
-         JOIN agent a ON a.id = s.agent_id
-         WHERE s.id = $1`,
-        [event.id],
-      );
-      return rows[0]?.owner ? new Set([rows[0].owner]) : new Set();
-    }
+  /** @internal — used by the resolver table. */
+  async meshOwners(id: string): Promise<ReadonlySet<string>> {
+    const { rows } = await this.queryWithTimeout<{
+      initiator: string | null;
+      counterparty: string | null;
+    }>(MESH_ACTIVITY_SQL, [id]);
+    const set = new Set<string>();
+    if (rows[0]?.initiator) set.add(rows[0].initiator);
+    if (rows[0]?.counterparty) set.add(rows[0].counterparty);
+    return set;
+  }
 
-    if (event.event.startsWith("memory.fact.")) {
-      const { rows } = await this.pool.query<{ owner: string | null }>(
-        `SELECT a.owner_id AS owner
-         FROM memory_fact f
-         JOIN agent a ON a.id = f.agent_id
-         WHERE f.id = $1`,
-        [event.id],
-      );
-      return rows[0]?.owner ? new Set([rows[0].owner]) : new Set();
-    }
-
-    if (event.event === "promotion.created") {
-      const { rows } = await this.pool.query<{ owner: string | null }>(
-        `SELECT a.owner_id AS owner
-         FROM memory_promotion_event mpe
-         JOIN agent a ON a.id = mpe.origin_agent_id
-         WHERE mpe.id = $1`,
-        [event.id],
-      );
-      return rows[0]?.owner ? new Set([rows[0].owner]) : new Set();
-    }
-
-    if (event.event === "mesh.activity") {
-      const { rows } = await this.pool.query<{
-        initiator: string | null;
-        counterparty: string | null;
-      }>(
-        `SELECT
-           ai.owner_id AS initiator,
-           ac.owner_id AS counterparty
-         FROM negotiation n
-         LEFT JOIN agent ai ON ai.id = n.initiator_agent_id
-         LEFT JOIN agent ac ON ac.id = n.counterparty_agent_id
-         WHERE n.id = $1`,
-        [event.id],
-      );
-      const set = new Set<string>();
-      if (rows[0]?.initiator) set.add(rows[0].initiator);
-      if (rows[0]?.counterparty) set.add(rows[0].counterparty);
-      return set;
-    }
-
-    if (event.event === "runtime.updated") {
-      const { rows } = await this.pool.query<{ owner: string | null }>(
-        `SELECT d.owner_person_id AS owner
-         FROM runtime r
-         JOIN daemon d ON d.id = r.daemon_id
-         WHERE r.id = $1`,
-        [event.id],
-      );
-      return rows[0]?.owner ? new Set([rows[0].owner]) : new Set();
-    }
-
-    return new Set();
+  private async queryWithTimeout<R extends Record<string, unknown>>(
+    sql: string,
+    params: unknown[],
+  ): Promise<{ rows: R[] }> {
+    const timeout = new Promise<never>((_, reject) => {
+      setTimeout(() => reject(new Error(`owner-lookup timeout (${QUERY_TIMEOUT_MS}ms)`)), QUERY_TIMEOUT_MS);
+    });
+    return Promise.race([
+      this.pool.query<R>(sql, params) as Promise<{ rows: R[] }>,
+      timeout,
+    ]);
   }
 
   /** @internal Tests only. */

--- a/packages/api/src/sse/owner-lookup.ts
+++ b/packages/api/src/sse/owner-lookup.ts
@@ -1,0 +1,211 @@
+/**
+ * Per-event owner lookup for SSE filtering.
+ *
+ * The pg_notify triggers don't carry owner info — payload is just
+ * `{event, id}`. To deliver an event only to its owning user(s), the
+ * listener resolves the entity row by id and walks to its agent's
+ * `owner_id`. Most events have a single owner; mesh activity has two
+ * (initiator + counterparty).
+ *
+ * Lookups are cached for `BEEVIBE_OWNER_CACHE_TTL_MS` (default 30s).
+ * `owner_id` is treated as immutable for the lifetime of an entity —
+ * if a future feature reassigns agents across owners, that change is
+ * masked from SSE for up to TTL_MS. Tests cover this assumption.
+ *
+ * Room-scoped fan-out is intentionally absent here: rooms come back in
+ * Phase 9 of the daemon-first restructure plan; this module re-grows
+ * the room.message and session.room_id branches at that point.
+ */
+
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import type { BvEvent } from "./manager.js";
+
+const DEFAULT_CACHE_TTL_MS = 30_000;
+const DEFAULT_CACHE_MAX_ENTRIES = 5_000;
+
+interface CacheEntry {
+  owners: ReadonlySet<string>;
+  expires_at: number;
+}
+
+export interface OwnerLookupConfig {
+  /** Override default TTL. Reads `BEEVIBE_OWNER_CACHE_TTL_MS` if unset. */
+  cacheTtlMs?: number;
+  /** Override default cap. Reads `BEEVIBE_OWNER_CACHE_MAX_ENTRIES` if unset. */
+  cacheMaxEntries?: number;
+}
+
+export class OwnerLookup {
+  private cache = new Map<string, CacheEntry>();
+  private inFlight = new Map<string, Promise<ReadonlySet<string>>>();
+  private readonly cacheTtlMs: number;
+  private readonly cacheMaxEntries: number;
+
+  constructor(
+    private readonly pool: Pool,
+    config: OwnerLookupConfig = {},
+  ) {
+    this.cacheTtlMs =
+      config.cacheTtlMs ??
+      readPositiveInt(process.env.BEEVIBE_OWNER_CACHE_TTL_MS, DEFAULT_CACHE_TTL_MS);
+    this.cacheMaxEntries =
+      config.cacheMaxEntries ??
+      readPositiveInt(
+        process.env.BEEVIBE_OWNER_CACHE_MAX_ENTRIES,
+        DEFAULT_CACHE_MAX_ENTRIES,
+      );
+  }
+
+  /**
+   * Returns the set of person ids that should receive `event`. Empty set
+   * means the entity is gone (deleted between trigger and lookup), the
+   * event type isn't owner-scoped, or the lookup query failed — in any
+   * of those cases the manager drops the event rather than fan out.
+   */
+  async ownersOf(event: BvEvent): Promise<ReadonlySet<string>> {
+    const cacheKey = `${event.event}|${event.id}`;
+    const now = Date.now();
+    const cached = this.cache.get(cacheKey);
+    if (cached && cached.expires_at > now) return cached.owners;
+
+    // N+1 guard: if a concurrent caller is already resolving this same
+    // key, share its in-flight promise rather than firing a duplicate
+    // query.
+    const existing = this.inFlight.get(cacheKey);
+    if (existing) return existing;
+
+    const promise = this.fetchAndCache(cacheKey, event, now);
+    this.inFlight.set(cacheKey, promise);
+    try {
+      return await promise;
+    } finally {
+      this.inFlight.delete(cacheKey);
+    }
+  }
+
+  private async fetchAndCache(
+    cacheKey: string,
+    event: BvEvent,
+    now: number,
+  ): Promise<ReadonlySet<string>> {
+    let owners: ReadonlySet<string>;
+    try {
+      owners = await this.lookup(event);
+    } catch (err) {
+      // Drop the event rather than crash the SSE pipeline. Pool flakes
+      // shouldn't fan out to disconnect every subscribed browser.
+      console.warn(
+        `[OwnerLookup] lookup failed for ${event.event}/${event.id}: ${(err as Error).message}`,
+      );
+      return new Set();
+    }
+    if (this.cache.size >= this.cacheMaxEntries) {
+      // FIFO eviction: drop the oldest entry. Map iteration is insertion
+      // order so the first key is the oldest. LRU is a follow-up.
+      const firstKey = this.cache.keys().next().value;
+      if (firstKey !== undefined) this.cache.delete(firstKey);
+    }
+    this.cache.set(cacheKey, { owners, expires_at: now + this.cacheTtlMs });
+    return owners;
+  }
+
+  private async lookup(event: BvEvent): Promise<ReadonlySet<string>> {
+    if (event.event.startsWith("task.")) {
+      const { rows } = await this.pool.query<{ owner: string | null }>(
+        `SELECT a.owner_id AS owner
+         FROM task t
+         LEFT JOIN agent a ON a.id = t.assignee_id
+         WHERE t.id = $1`,
+        [event.id],
+      );
+      return rows[0]?.owner ? new Set([rows[0].owner]) : new Set();
+    }
+
+    if (event.event.startsWith("agent.")) {
+      const { rows } = await this.pool.query<{ owner: string | null }>(
+        `SELECT owner_id AS owner FROM agent WHERE id = $1`,
+        [event.id],
+      );
+      return rows[0]?.owner ? new Set([rows[0].owner]) : new Set();
+    }
+
+    if (event.event.startsWith("session.")) {
+      // Single-tenant: just the agent's owner. Room fan-out re-grows
+      // here in Phase 9 when rooms come back.
+      const { rows } = await this.pool.query<{ owner: string | null }>(
+        `SELECT a.owner_id AS owner
+         FROM session s
+         JOIN agent a ON a.id = s.agent_id
+         WHERE s.id = $1`,
+        [event.id],
+      );
+      return rows[0]?.owner ? new Set([rows[0].owner]) : new Set();
+    }
+
+    if (event.event.startsWith("memory.fact.")) {
+      const { rows } = await this.pool.query<{ owner: string | null }>(
+        `SELECT a.owner_id AS owner
+         FROM memory_fact f
+         JOIN agent a ON a.id = f.agent_id
+         WHERE f.id = $1`,
+        [event.id],
+      );
+      return rows[0]?.owner ? new Set([rows[0].owner]) : new Set();
+    }
+
+    if (event.event === "promotion.created") {
+      const { rows } = await this.pool.query<{ owner: string | null }>(
+        `SELECT a.owner_id AS owner
+         FROM memory_promotion_event mpe
+         JOIN agent a ON a.id = mpe.origin_agent_id
+         WHERE mpe.id = $1`,
+        [event.id],
+      );
+      return rows[0]?.owner ? new Set([rows[0].owner]) : new Set();
+    }
+
+    if (event.event === "mesh.activity") {
+      const { rows } = await this.pool.query<{
+        initiator: string | null;
+        counterparty: string | null;
+      }>(
+        `SELECT
+           ai.owner_id AS initiator,
+           ac.owner_id AS counterparty
+         FROM negotiation n
+         LEFT JOIN agent ai ON ai.id = n.initiator_agent_id
+         LEFT JOIN agent ac ON ac.id = n.counterparty_agent_id
+         WHERE n.id = $1`,
+        [event.id],
+      );
+      const set = new Set<string>();
+      if (rows[0]?.initiator) set.add(rows[0].initiator);
+      if (rows[0]?.counterparty) set.add(rows[0].counterparty);
+      return set;
+    }
+
+    if (event.event === "runtime.updated") {
+      const { rows } = await this.pool.query<{ owner: string | null }>(
+        `SELECT d.owner_person_id AS owner
+         FROM runtime r
+         JOIN daemon d ON d.id = r.daemon_id
+         WHERE r.id = $1`,
+        [event.id],
+      );
+      return rows[0]?.owner ? new Set([rows[0].owner]) : new Set();
+    }
+
+    return new Set();
+  }
+
+  /** @internal Tests only. */
+  clearCache(): void {
+    this.cache.clear();
+  }
+}
+
+function readPositiveInt(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw === "") return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -36,9 +36,7 @@ fi
 
 # ─────────────────── env file ───────────────────
 if [ ! -f .env ]; then
-  echo "==> .env missing. Creating from .env.example..."
-  cp .env.example .env
-  echo "    Edit .env to add ANTHROPIC_API_KEY and OPENAI_API_KEY, then re-run."
+  echo "==> .env missing. Run \`pnpm bootstrap\` first to provision the local stack."
   exit 1
 fi
 

--- a/scripts/init.ts
+++ b/scripts/init.ts
@@ -1,0 +1,371 @@
+#!/usr/bin/env node
+/**
+ * `pnpm bootstrap` — first-run setup for a fresh clone.
+ *
+ * Walks the user from `git clone` to "running with a chat-ready team
+ * agent" in one shell command:
+ *
+ *   1. Prompts for ANTHROPIC_API_KEY + OPENAI_API_KEY if .env is missing
+ *      (or has placeholder values), writes .env from .env.example.
+ *   2. Brings up postgres via docker compose if it isn't running, waits
+ *      for pg_isready.
+ *   3. Runs migrations (idempotent).
+ *   4. Provisions an admin person (bv_u_ key) and a top-level team agent
+ *      tied to them, IF none exist for the configured admin email.
+ *   5. Writes the bv_u_ key into BOTH `.env` (so api/executor pick it up)
+ *      AND `packages/web/.env.local` (Next.js doesn't read repo-root
+ *      env files; without this the web shows "not connected").
+ *   6. Tells the user to run `pnpm dev` — we don't spawn it ourselves so
+ *      the user retains stdout / Ctrl+C semantics.
+ *
+ * The script is named `bootstrap` because `pnpm init` and `pnpm setup`
+ * are both pnpm built-in commands (one creates a package.json, the
+ * other configures pnpm itself by mutating ~/.zshrc) and would shadow
+ * any same-named workspace script.
+ *
+ * Idempotent: re-running on a populated .env / postgres / db just
+ * reports state and exits with no changes.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execSync, spawnSync } from "node:child_process";
+import readline from "node:readline/promises";
+import { stdin as input, stdout as output } from "node:process";
+import { parse as parseDotenv } from "dotenv";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const ENV_PATH = join(REPO_ROOT, ".env");
+const ENV_EXAMPLE_PATH = join(REPO_ROOT, ".env.example");
+// Next.js doesn't read repo-root .env — its dev server only picks up
+// .env.local within the package. Without this file the web shell can't
+// see NEXT_PUBLIC_BV_USER_KEY and renders the "not connected" empty state.
+const WEB_ENV_PATH = join(REPO_ROOT, "packages/web/.env.local");
+const ADMIN_EMAIL_DEFAULT = "admin@beevibe.local";
+const TEAM_AGENT_NAME_DEFAULT = "Team agent";
+
+const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;
+const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
+const yellow = (s: string) => `\x1b[33m${s}\x1b[0m`;
+const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
+const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
+const ok = (msg: string) => console.log(`  ${green("✓")} ${msg}`);
+const info = (msg: string) => console.log(`  ${cyan("→")} ${msg}`);
+const warn = (msg: string) => console.log(`  ${yellow("!")} ${msg}`);
+const step = (n: number, msg: string) => console.log(`\n${bold(`Step ${n}.`)} ${msg}`);
+
+async function main(): Promise<void> {
+  console.log(`${bold("beevibe bootstrap")} — first-run setup\n`);
+  console.log(dim("This will set up a local-only stack: postgres + api + executor + web."));
+  console.log(dim("Re-running is safe; existing setup is detected and skipped.\n"));
+
+  // ── Step 1: .env ─────────────────────────────────────────────────────────
+  step(1, "Provider keys + .env");
+  const env = await ensureEnvFile();
+
+  // ── Step 2: docker postgres ─────────────────────────────────────────────
+  step(2, "Postgres");
+  await ensurePostgres();
+
+  // ── Step 3: migrations ───────────────────────────────────────────────────
+  step(3, "Migrations");
+  runMigrations();
+
+  // ── Step 4: provision admin + team agent ─────────────────────────────────
+  step(4, "Admin user + team agent");
+  // Imports happen here (after migrations + .env) so we can build adapters
+  // against the running database with the right env loaded.
+  process.env.DATABASE_URL = env.DATABASE_URL;
+  const userKey = await ensureAdminAndTeamAgent();
+
+  // ── Step 5: write NEXT_PUBLIC_BV_USER_KEY into .env ─────────────────────
+  step(5, "Web key wiring");
+  writeWebUserKey(userKey);
+
+  // ── Step 6: next steps ───────────────────────────────────────────────────
+  step(6, "Ready to start");
+  console.log(`
+  ${green("✓")} Setup complete. Start the stack:
+
+      ${cyan("pnpm dev")}
+      ${cyan("pnpm --filter @beevibe/web dev")}   ${dim("(in a second terminal)")}
+
+  Then open ${cyan("http://localhost:3001")} (Next picks the next free port).
+  Your bv_u_ key has been written to .env — keep it secret.
+`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Step 1: env
+// ─────────────────────────────────────────────────────────────────────────
+
+interface EnvState {
+  DATABASE_URL: string;
+  ANTHROPIC_API_KEY: string;
+  OPENAI_API_KEY: string;
+  BEEVIBE_API_PORT: string;
+  NEXT_PUBLIC_BV_API_URL: string;
+  NEXT_PUBLIC_BV_USER_KEY: string;
+  raw: Record<string, string>;
+}
+
+async function ensureEnvFile(): Promise<EnvState> {
+  if (!existsSync(ENV_PATH)) {
+    if (!existsSync(ENV_EXAMPLE_PATH)) {
+      throw new Error(".env.example missing — can't bootstrap a fresh .env");
+    }
+    writeFileSync(ENV_PATH, readFileSync(ENV_EXAMPLE_PATH, "utf-8"));
+    info("Created .env from .env.example");
+  } else {
+    info(".env exists — checking required keys");
+  }
+
+  const env = readEnv(ENV_PATH);
+
+  const placeholderHints = ["placeholder", "fill-in", "your-key"];
+  const looksLikePlaceholder = (v: string) =>
+    placeholderHints.some((h) => v.toLowerCase().includes(h));
+
+  const rl = readline.createInterface({ input, output });
+  const ask = async (
+    label: string,
+    current: string | undefined,
+    opts: { required?: boolean; help?: string } = {},
+  ) => {
+    const required = opts.required ?? true;
+    // Required: prompt when missing/empty/placeholder.
+    // Optional: prompt only when the value LOOKS like a placeholder (a
+    // truly empty value means "user already chose to skip"; don't re-ask
+    // on every bootstrap re-run).
+    const needsPrompt = required
+      ? !current || looksLikePlaceholder(current)
+      : !!current && looksLikePlaceholder(current);
+    if (!needsPrompt) return current ?? "";
+    if (opts.help) console.log(`    ${dim(opts.help)}`);
+    const prompt = required
+      ? `    ${label} (required, paste): `
+      : `    ${label} (optional, press Enter to skip): `;
+    const value = (await rl.question(prompt)).trim();
+    if (required && !value) {
+      throw new Error(`${label} is required`);
+    }
+    return value;
+  };
+
+  const openai = await ask("OPENAI_API_KEY (sk-...)", env.OPENAI_API_KEY, {
+    required: false,
+    help:
+      "Optional — used for memory recall (text-embedding-3-small). Chat works " +
+      "without it; agents just won't remember across sessions until you add it.",
+  });
+  const anthropic = await ask("ANTHROPIC_API_KEY (sk-ant-...)", env.ANTHROPIC_API_KEY, {
+    required: false,
+    help:
+      "Optional — only used for memory fact merging + promotion. Chat and tasks " +
+      "use the `claude` CLI directly (run `claude login` once).",
+  });
+  rl.close();
+
+  env.OPENAI_API_KEY = openai;
+  env.ANTHROPIC_API_KEY = anthropic;
+
+  // Apply DATABASE_URL default if unset.
+  env.DATABASE_URL ||= "postgresql://beevibe:beevibe@localhost:5433/beevibe";
+  env.BEEVIBE_API_PORT ||= "3000";
+  env.BEEVIBE_MCP_SERVER_URL ||= "http://localhost:3000/mcp";
+  env.NEXT_PUBLIC_BV_API_URL ||= "http://localhost:3000";
+
+  writeEnv(env);
+  ok("Provider keys saved to .env");
+
+  return {
+    DATABASE_URL: env.DATABASE_URL,
+    ANTHROPIC_API_KEY: env.ANTHROPIC_API_KEY,
+    OPENAI_API_KEY: env.OPENAI_API_KEY,
+    BEEVIBE_API_PORT: env.BEEVIBE_API_PORT,
+    NEXT_PUBLIC_BV_API_URL: env.NEXT_PUBLIC_BV_API_URL,
+    NEXT_PUBLIC_BV_USER_KEY: env.NEXT_PUBLIC_BV_USER_KEY ?? "",
+    raw: env,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Step 2: postgres via docker compose
+// ─────────────────────────────────────────────────────────────────────────
+
+async function ensurePostgres(): Promise<void> {
+  try {
+    execSync("docker info", { stdio: "ignore" });
+  } catch {
+    throw new Error("Docker daemon isn't running. Start Docker Desktop and re-run.");
+  }
+
+  const ps = spawnSync("docker", ["compose", "ps", "--status", "running", "postgres"], {
+    cwd: REPO_ROOT,
+    encoding: "utf-8",
+  });
+  const alreadyRunning = ps.stdout.includes("postgres");
+  if (alreadyRunning) {
+    ok("Postgres already running");
+  } else {
+    info("Starting postgres via docker compose");
+    execSync("docker compose up -d postgres", { cwd: REPO_ROOT, stdio: "inherit" });
+    ok("Postgres started");
+  }
+
+  for (let i = 0; i < 30; i++) {
+    const ready = spawnSync(
+      "docker",
+      ["compose", "exec", "-T", "postgres", "pg_isready", "-U", "beevibe", "-d", "beevibe"],
+      { cwd: REPO_ROOT, stdio: "ignore" },
+    );
+    if (ready.status === 0) {
+      ok(`pg_isready (${i + 1}s)`);
+      return;
+    }
+    await new Promise<void>((r) => setTimeout(r, 1000));
+  }
+  throw new Error("Postgres didn't become ready in 30s");
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Step 3: migrations
+// ─────────────────────────────────────────────────────────────────────────
+
+function runMigrations(): void {
+  info("Applying migrations (node-pg-migrate)");
+  execSync("pnpm migrate up", { cwd: REPO_ROOT, stdio: "inherit" });
+  ok("Migrations up to date");
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Step 4: admin user + team agent
+// ─────────────────────────────────────────────────────────────────────────
+
+async function ensureAdminAndTeamAgent(): Promise<string> {
+  const { createPool, PostgresPersonRepository, PostgresAgentRepository, PostgresCoreMemoryRepository } =
+    await import("../packages/core/src/adapters/postgres/index.js");
+  const { provisionAgent, provisionUser } = await import("../packages/core/src/auth/provision.js");
+  const { personId, agentId } = await import("../packages/core/src/domain/ids.js");
+
+  const pool = createPool({ connectionString: process.env.DATABASE_URL! });
+  const personRepo = new PostgresPersonRepository(pool);
+  const agentRepo = new PostgresAgentRepository(pool);
+  const coreMemoryRepo = new PostgresCoreMemoryRepository(pool);
+
+  const teamAgentInput = {
+    name: TEAM_AGENT_NAME_DEFAULT,
+    hierarchy_level: "team" as const,
+    runtime_config: { type: "claude-code" as const, model: "claude-opus-4-7" },
+  };
+
+  try {
+    const existing = await personRepo.findByEmail(ADMIN_EMAIL_DEFAULT);
+    if (!existing?.api_key) {
+      info("Provisioning admin person");
+      const { person, apiKey } = await provisionUser(
+        { personRepo },
+        { id: personId(), name: "Admin", email: ADMIN_EMAIL_DEFAULT },
+      );
+      ok(`Admin user: ${dim(person.id)} (${dim(ADMIN_EMAIL_DEFAULT)})`);
+
+      info("Provisioning team agent");
+      const { agent } = await provisionAgent(
+        { agentRepo, coreMemoryRepo },
+        { ...teamAgentInput, id: agentId(), owner_id: person.id },
+      );
+      ok(`Team agent: ${dim(agent.id)}`);
+      return apiKey;
+    }
+
+    ok(`Admin user already exists: ${dim(existing.id)}`);
+    const existingTeam = await agentRepo.findTopLevelForOwner(existing.id);
+    if (existingTeam) {
+      ok(`Team agent already exists: ${dim(existingTeam.id)}`);
+      return existing.api_key;
+    }
+
+    info("No team agent for existing admin — provisioning one");
+    await provisionAgent(
+      { agentRepo, coreMemoryRepo },
+      { ...teamAgentInput, id: agentId(), owner_id: existing.id },
+    );
+    ok("Team agent provisioned");
+    return existing.api_key;
+  } finally {
+    await pool.end();
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Step 5: write web key into .env
+// ─────────────────────────────────────────────────────────────────────────
+
+function writeWebUserKey(userKey: string): void {
+  // Root .env: api/executor read this. Keep it in sync so anything that
+  // shells out can pick up the user key too.
+  const env = readEnv(ENV_PATH);
+  if (env.NEXT_PUBLIC_BV_USER_KEY !== userKey) {
+    env.NEXT_PUBLIC_BV_USER_KEY = userKey;
+    writeEnv(env);
+    ok(`NEXT_PUBLIC_BV_USER_KEY written to .env: ${dim(userKey.slice(0, 12) + "…")}`);
+  } else {
+    ok("NEXT_PUBLIC_BV_USER_KEY already set in .env");
+  }
+
+  // packages/web/.env.local: Next.js's actual source of truth. Without
+  // this the web shell renders "beevibe isn't connected yet" even though
+  // the api server is up.
+  const webEnv = existsSync(WEB_ENV_PATH) ? readEnv(WEB_ENV_PATH) : {};
+  const apiUrl = env.NEXT_PUBLIC_BV_API_URL ?? "http://localhost:3000";
+  if (webEnv.NEXT_PUBLIC_BV_USER_KEY === userKey && webEnv.NEXT_PUBLIC_BV_API_URL === apiUrl) {
+    ok("packages/web/.env.local already in sync");
+    return;
+  }
+  const webContents =
+    `NEXT_PUBLIC_BV_API_URL=${apiUrl}\n` +
+    `NEXT_PUBLIC_BV_USER_KEY=${userKey}\n`;
+  writeFileSync(WEB_ENV_PATH, webContents);
+  ok(`packages/web/.env.local written (web shell will pick up the key on next start)`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+function readEnv(path: string): Record<string, string> {
+  return parseDotenv(readFileSync(path, "utf-8"));
+}
+
+function writeEnv(env: Record<string, string>): void {
+  const original = existsSync(ENV_EXAMPLE_PATH)
+    ? readFileSync(ENV_EXAMPLE_PATH, "utf-8")
+    : "";
+  // Preserve comment structure from .env.example by rewriting line-by-line:
+  // for each KEY=... line, substitute the current value from `env`. Lines
+  // not in the example get appended at the end.
+  const lines = original.split("\n");
+  const seen = new Set<string>();
+  const rewritten = lines.map((raw) => {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) return raw;
+    const eq = line.indexOf("=");
+    if (eq === -1) return raw;
+    const key = line.slice(0, eq).trim();
+    seen.add(key);
+    const value = env[key] ?? "";
+    return `${key}=${value}`;
+  });
+  // Append any keys present in env that weren't in the example.
+  for (const [k, v] of Object.entries(env)) {
+    if (!seen.has(k)) rewritten.push(`${k}=${v}`);
+  }
+  writeFileSync(ENV_PATH, rewritten.join("\n"));
+}
+
+main().catch((err) => {
+  console.error(`\n${bold("\x1b[31m✗\x1b[0m")} ${err instanceof Error ? err.message : err}`);
+  process.exit(1);
+});

--- a/scripts/init.ts
+++ b/scripts/init.ts
@@ -249,6 +249,7 @@ async function ensureAdminAndTeamAgent(): Promise<string> {
     await import("../packages/core/src/adapters/postgres/index.js");
   const { provisionAgent, provisionUser } = await import("../packages/core/src/auth/provision.js");
   const { personId, agentId } = await import("../packages/core/src/domain/ids.js");
+  const { DEFAULT_RUNTIME_CONFIG } = await import("../packages/core/src/domain/agent.js");
 
   const pool = createPool({ connectionString: process.env.DATABASE_URL! });
   const personRepo = new PostgresPersonRepository(pool);
@@ -258,7 +259,7 @@ async function ensureAdminAndTeamAgent(): Promise<string> {
   const teamAgentInput = {
     name: TEAM_AGENT_NAME_DEFAULT,
     hierarchy_level: "team" as const,
-    runtime_config: { type: "claude-code" as const, model: "claude-opus-4-7" },
+    runtime_config: DEFAULT_RUNTIME_CONFIG,
   };
 
   try {

--- a/scripts/m11-tenant-isolation-e2e.ts
+++ b/scripts/m11-tenant-isolation-e2e.ts
@@ -1,0 +1,230 @@
+/**
+ * M11 e2e — proves OwnerLookup blocks cross-user SSE leakage.
+ *
+ * The gating test: token A subscribed to /api/stream MUST NOT receive
+ * events scoped to token B's agents. This is the load-bearing property
+ * that lets multi-tenant signup (Phase 6, #63) ship safely.
+ *
+ * Verifies in a single live process:
+ *   1. Two distinct persons + agents seeded.
+ *   2. Two SSE subscribers (one per person) registered against the same
+ *      SseManager.
+ *   3. publish() with each person's owner set delivers only to their
+ *      subscriber.
+ *   4. End-to-end through the listener: a real pg_notify → SseListener →
+ *      OwnerLookup → SseManager → only the right subscriber fires.
+ *
+ * Doesn't spawn claude — Phase 2 doesn't change runtime spawning, only
+ * SSE filtering.
+ *
+ * Usage:
+ *   RUN_M11_E2E=1 \
+ *   DATABASE_URL_TEST=postgresql://beevibe:beevibe@localhost:5433/beevibe_test \
+ *     pnpm tsx scripts/m11-tenant-isolation-e2e.ts
+ */
+
+import { config as loadEnv } from "dotenv";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execSync } from "node:child_process";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..");
+loadEnv({ path: resolve(repoRoot, ".env") });
+
+import {
+  agentId as makeAgentId,
+  personId as makePersonId,
+  taskId as makeTaskId,
+} from "../packages/core/src/domain/ids.js";
+import { DEFAULT_RUNTIME_CONFIG } from "../packages/core/src/domain/agent.js";
+import { provisionAgent } from "../packages/core/src/auth/provision.js";
+import { PostgresAgentRepository } from "../packages/core/src/adapters/postgres/agent-repo.js";
+import { PostgresCoreMemoryRepository } from "../packages/core/src/adapters/postgres/core-memory-repo.js";
+import { PostgresPersonRepository } from "../packages/core/src/adapters/postgres/person-repo.js";
+import { createPool, type Pool } from "../packages/core/src/adapters/postgres/client.js";
+import { SseManager, type BvEvent } from "../packages/api/src/sse/manager.js";
+import { SseListener } from "../packages/api/src/sse/listener.js";
+import { OwnerLookup } from "../packages/api/src/sse/owner-lookup.js";
+
+const REQUIRED = ["RUN_M11_E2E", "DATABASE_URL_TEST"] as const;
+for (const k of REQUIRED) {
+  if (!process.env[k]) {
+    console.error(`✗ M11 E2E: missing env var ${k}`);
+    process.exit(1);
+  }
+}
+const databaseUrl = process.env.DATABASE_URL_TEST!;
+
+const log = (msg: string) => console.log(msg);
+const assert = (cond: unknown, msg: string): void => {
+  if (!cond) throw new Error(msg);
+};
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function applyMigrations(): Promise<void> {
+  log("→ applying migrations against DATABASE_URL_TEST");
+  execSync("pnpm migrate:test up", {
+    cwd: repoRoot,
+    env: { ...process.env, DATABASE_URL: databaseUrl },
+    stdio: "inherit",
+  });
+}
+
+async function reset(pool: Pool): Promise<void> {
+  await pool.query(`
+    TRUNCATE TABLE
+      session_event, session, task, work_product, memory_fact,
+      core_memory_block, agent, person
+    CASCADE
+  `);
+}
+
+interface SeededTenant {
+  personId: string;
+  agentId: string;
+}
+
+async function seed(pool: Pool, label: string): Promise<SeededTenant> {
+  const persons = new PostgresPersonRepository(pool);
+  const agents = new PostgresAgentRepository(pool);
+  const coreMemoryRepo = new PostgresCoreMemoryRepository(pool);
+  const owner = await persons.create({
+    id: makePersonId(),
+    name: `m11-${label}`,
+    email: `m11-${label}-${Date.now()}@example.test`,
+  });
+  const { agent } = await provisionAgent(
+    { agentRepo: agents, coreMemoryRepo },
+    {
+      id: makeAgentId(),
+      name: `M11 ${label} agent`,
+      owner_id: owner.id,
+      hierarchy_level: "team",
+      runtime_config: DEFAULT_RUNTIME_CONFIG,
+    },
+  );
+  return { personId: owner.id, agentId: agent.id };
+}
+
+async function insertTask(pool: Pool, agentId: string): Promise<string> {
+  const tid = makeTaskId();
+  await pool.query(
+    `INSERT INTO task (id, title, description, assignee_id, creator_id, creator_type, status)
+     VALUES ($1, $2, $3, $4, $5, 'agent', 'pending')`,
+    [tid, "m11 isolation", "isolation probe", agentId, agentId],
+  );
+  return tid;
+}
+
+// ───────────────────────── scenario 1 ─────────────────────────
+//
+// Direct SseManager.publish() with a known owner set: subscriber A
+// fires when owner set contains person A; subscriber B does NOT fire.
+async function scenarioPublishFiltering(pool: Pool): Promise<void> {
+  log("\n=== scenario 1: SseManager.publish() filters by personId ===");
+  const a = await seed(pool, "A");
+  const b = await seed(pool, "B");
+
+  const manager = new SseManager();
+  const aReceived: BvEvent[] = [];
+  const bReceived: BvEvent[] = [];
+  const unA = manager.subscribe(a.personId, (e) => aReceived.push(e));
+  const unB = manager.subscribe(b.personId, (e) => bReceived.push(e));
+
+  const event: BvEvent = { event: "task.updated", id: "task_x" };
+  manager.publish(event, new Set([a.personId]));
+  assert(aReceived.length === 1, `A should receive 1, got ${aReceived.length}`);
+  assert(bReceived.length === 0, `B should receive 0, got ${bReceived.length}`);
+  log("  ✓ event with owner=A delivered only to A");
+
+  manager.publish(event, new Set([b.personId]));
+  assert(aReceived.length === 1, "A should still be 1");
+  assert(bReceived.length === 1, "B should now be 1");
+  log("  ✓ event with owner=B delivered only to B");
+
+  manager.publish(event, new Set());
+  assert(aReceived.length === 1 && bReceived.length === 1, "empty owner set should drop");
+  log("  ✓ empty owner set drops (fail-closed)");
+
+  unA();
+  unB();
+}
+
+// ───────────────────────── scenario 2 ─────────────────────────
+//
+// Real listener path: OwnerLookup resolves owner from DB, SseListener
+// publishes to manager. Inserting a task for person A's agent fires
+// `task.created` notification; only A's subscriber should see it.
+async function scenarioListenerPath(pool: Pool): Promise<void> {
+  log("\n=== scenario 2: end-to-end via SseListener + OwnerLookup ===");
+  await reset(pool);
+  const a = await seed(pool, "A2");
+  const b = await seed(pool, "B2");
+
+  const manager = new SseManager();
+  const ownerLookup = new OwnerLookup(pool);
+  const listener = new SseListener({
+    databaseUrl,
+    manager,
+    ownerLookup,
+    reconnectDelayMs: 1_000,
+  });
+  listener.start();
+
+  const aReceived: BvEvent[] = [];
+  const bReceived: BvEvent[] = [];
+  manager.subscribe(a.personId, (e) => aReceived.push(e));
+  manager.subscribe(b.personId, (e) => bReceived.push(e));
+
+  // Tiny delay so the listener finishes its LISTEN before we INSERT.
+  await sleep(500);
+
+  const tidA = await insertTask(pool, a.agentId);
+  await sleep(800); // allow notify → ownerLookup query → publish chain
+
+  const aSawA = aReceived.some((e) => e.event === "task.created" && e.id === tidA);
+  const bSawA = bReceived.some((e) => e.event === "task.created" && e.id === tidA);
+  assert(aSawA, "A should see task.created for its own task");
+  assert(!bSawA, "B should NOT see task.created for A's task");
+  log(`  ✓ task.created for A's task (id=${tidA}) reached A only`);
+
+  const tidB = await insertTask(pool, b.agentId);
+  await sleep(800);
+
+  const aSawB = aReceived.some((e) => e.event === "task.created" && e.id === tidB);
+  const bSawB = bReceived.some((e) => e.event === "task.created" && e.id === tidB);
+  assert(bSawB, "B should see task.created for its own task");
+  assert(!aSawB, "A should NOT see task.created for B's task");
+  log(`  ✓ task.created for B's task (id=${tidB}) reached B only`);
+
+  await listener.stop();
+}
+
+// ───────────────────────── runner ─────────────────────────
+
+async function withPool<T>(fn: (pool: Pool) => Promise<T>): Promise<T> {
+  const pool = createPool({ connectionString: databaseUrl });
+  try {
+    return await fn(pool);
+  } finally {
+    await pool.end();
+  }
+}
+
+async function main(): Promise<void> {
+  await applyMigrations();
+  await withPool(async (pool) => {
+    await reset(pool);
+    await scenarioPublishFiltering(pool);
+    await scenarioListenerPath(pool);
+    await reset(pool);
+  });
+  log("\n✓ M11 e2e: all scenarios passed");
+}
+
+main().catch((err) => {
+  console.error("\n✗ M11 e2e failed:");
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/provision-user.ts
+++ b/scripts/provision-user.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * `pnpm provision-user --name "..." --email "..."` — mint a new
+ * person + their primary team agent + a fresh `bv_u_` key.
+ *
+ * Usage:
+ *   pnpm provision-user --name "Alice" --email "alice@example.com"
+ *
+ * Prints the freshly minted bv_u_ key to stdout. Once the web is
+ * exposed externally, share this URL + key with the user and they sign
+ * in via the web's /sign-in page. Each user gets their own team agent
+ * (team-tier, hierarchy isolated by owner_id), so chat and
+ * notifications stay scoped to their own work.
+ *
+ * Idempotent on email: if a person with this email already exists, we
+ * print their existing key (and provision a team agent if missing).
+ */
+
+import { config as loadDotenv } from "dotenv";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+loadDotenv({ path: join(REPO_ROOT, ".env") });
+
+const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;
+const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
+const yellow = (s: string) => `\x1b[33m${s}\x1b[0m`;
+const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
+const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
+
+interface Args {
+  name: string;
+  email: string;
+  agentName?: string;
+}
+
+function parseArgs(): Args {
+  const args = process.argv.slice(2);
+  const out: Partial<Args> = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--name") out.name = args[++i];
+    else if (arg === "--email") out.email = args[++i];
+    else if (arg === "--agent-name") out.agentName = args[++i];
+  }
+  if (!out.name || !out.email) {
+    console.error(
+      `Usage: pnpm provision-user --name "Alice" --email "alice@example.com"\n` +
+        `Optional: --agent-name "Alice's team"`,
+    );
+    process.exit(2);
+  }
+  return out as Args;
+}
+
+async function main(): Promise<void> {
+  const { name, email, agentName } = parseArgs();
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error("DATABASE_URL not set — run pnpm bootstrap first or source .env");
+    process.exit(2);
+  }
+
+  const {
+    createPool,
+    PostgresPersonRepository,
+    PostgresAgentRepository,
+    PostgresCoreMemoryRepository,
+  } = await import("../packages/core/src/adapters/postgres/index.js");
+  const { provisionAgent, provisionUser } = await import(
+    "../packages/core/src/auth/provision.js"
+  );
+  const { personId, agentId } = await import("../packages/core/src/domain/ids.js");
+
+  const pool = createPool({ connectionString: databaseUrl });
+  const personRepo = new PostgresPersonRepository(pool);
+  const agentRepo = new PostgresAgentRepository(pool);
+  const coreMemoryRepo = new PostgresCoreMemoryRepository(pool);
+
+  const teamAgentInput = {
+    name: agentName ?? `${name}'s team`,
+    hierarchy_level: "team" as const,
+    runtime_config: { type: "claude-code" as const, model: "claude-opus-4-7" },
+  };
+
+  try {
+    const existing = await personRepo.findByEmail(email);
+    let key: string;
+    let person_id: string;
+
+    if (!existing?.api_key) {
+      console.log(`${cyan("→")} Provisioning person ${dim(email)}`);
+      const result = await provisionUser(
+        { personRepo },
+        { id: personId(), name, email },
+      );
+      key = result.apiKey;
+      person_id = result.person.id;
+      console.log(`${green("✓")} Person: ${dim(person_id)}`);
+    } else {
+      console.log(`${yellow("!")} Person ${dim(email)} already exists; reusing existing key`);
+      key = existing.api_key;
+      person_id = existing.id;
+    }
+
+    const existingTeam = await agentRepo.findTopLevelForOwner(person_id);
+    if (existingTeam) {
+      console.log(`${green("✓")} Team agent: ${dim(existingTeam.id)} (${existingTeam.name})`);
+    } else {
+      console.log(`${cyan("→")} Provisioning team agent`);
+      const { agent } = await provisionAgent(
+        { agentRepo, coreMemoryRepo },
+        { ...teamAgentInput, id: agentId(), owner_id: person_id },
+      );
+      console.log(`${green("✓")} Team agent: ${dim(agent.id)} (${agent.name})`);
+    }
+
+    console.log(`\n${bold("API key:")} ${key}`);
+    console.log(
+      dim(
+        "\nShare this key with the user. They sign in by pasting it into\n" +
+          "the web's /sign-in page; it's stored in their browser only.\n",
+      ),
+    );
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error("provision-user failed:", err);
+  process.exit(1);
+});

--- a/scripts/provision-user.ts
+++ b/scripts/provision-user.ts
@@ -73,6 +73,9 @@ async function main(): Promise<void> {
     "../packages/core/src/auth/provision.js"
   );
   const { personId, agentId } = await import("../packages/core/src/domain/ids.js");
+  const { DEFAULT_RUNTIME_CONFIG } = await import(
+    "../packages/core/src/domain/agent.js"
+  );
 
   const pool = createPool({ connectionString: databaseUrl });
   const personRepo = new PostgresPersonRepository(pool);
@@ -82,7 +85,7 @@ async function main(): Promise<void> {
   const teamAgentInput = {
     name: agentName ?? `${name}'s team`,
     hierarchy_level: "team" as const,
-    runtime_config: { type: "claude-code" as const, model: "claude-opus-4-7" },
+    runtime_config: DEFAULT_RUNTIME_CONFIG,
   };
 
   try {


### PR DESCRIPTION
Phase 2 of the daemon-first restructure plan. Cherry-picks #60's OwnerLookup + dev-orchestration sub-features against `main` (post-Phase 1), with room branches stripped (return in Phase 9) and `runtime.updated` added pre-emptively for Phase 5's Runtimes panel.

## Summary

**Per-user SSE isolation**
- New `OwnerLookup` resolves each `bv_event`'s owning persons via DB joins (task→assignee→owner_id, mesh.activity→both negotiation parties, runtime.updated→daemon.owner_person_id, etc.).
- `SseManager.publish(event, owners)` now requires an owner set; subscribers register with `personId`; events whose owner set doesn't include the personId get skipped. **Empty owner set drops the event entirely (fail-closed — never leaks across users).**
- `SseListener` resolves owners through `OwnerLookup` before publishing.
- `routes/stream.ts` passes `req.caller.personId` to `subscribe`.
- Bootstrap wires it together.

**OwnerLookup hardening (production-gap closeouts from #60)**
- Cache TTL + max-entries env-configurable (`BEEVIBE_OWNER_CACHE_TTL_MS=30000`, `BEEVIBE_OWNER_CACHE_MAX_ENTRIES=5000`)
- DB errors caught → empty set + warn log (drops the event, doesn't crash SSE)
- N+1 guard via in-flight Promise dedup map
- 30s staleness window pinned by a test

**Dev orchestration**
- `scripts/init.ts` (`pnpm bootstrap`) — first-run: prompt for keys, postgres up, migrate, provision admin + team agent, write `bv_u_` to .env + `packages/web/.env.local`.
- `scripts/provision-user.ts` (`pnpm provision-user --name --email`) — admin CLI for additional users; idempotent on email.
- `scripts/dev.sh` — redirects "==> .env missing" to `pnpm bootstrap`. Full web-tunnel changes deferred to Phase 5 (chat UI).

## Why now

Per the unified plan, Phase 2 is purely additive:
- OwnerLookup unblocks every multi-user surface that comes after (signup #63 in Phase 6, rooms #67 in Phase 9).
- `init.ts` / `provision-user.ts` are independent infra used by Phase 6's signup path.
- No behavioral change to existing flows.

Stripped from #60 sub-feature 2 and deferred to Phase 9: the `room.message` and `session.room_id` branches in OwnerLookup. They re-grow with rooms.

Stripped from #60 sub-feature 3 and deferred to Phase 5: the dev.sh dual-tunnel + `--no-web` flag + the cleanup function that knows about `next-server`/`next dev`. These need the chat UI to test against.

## Test plan

- [x] `pnpm -w build / typecheck / lint / test` — 679 unit tests green (+15 vs phase 1: 8 new owner-lookup, 7 rewritten manager)
- [x] `RUN_M3_E2E=1 pnpm tsx scripts/m3-e2e.ts` — ✓
- [x] `RUN_M5_E2E=1 pnpm tsx scripts/m5-e2e.ts` — ✓ 7/7 scenarios (108s)
- [x] `RUN_M6_E2E=1 pnpm tsx scripts/m6-e2e.ts` — ✓ 10/10 scenarios (224s)
- [x] `RUN_M7_E2E=1 pnpm tsx scripts/m7-e2e.ts` — ✓
- [x] `RUN_M9_E2E=1 pnpm tsx scripts/m9-e2e.ts` — ✓ all scenarios (cache hit ratio >50%)
- [x] `RUN_M10_E2E=1 pnpm tsx scripts/m10-session-event-e2e.ts` — ✓ 4/4
- [x] **`RUN_M11_E2E=1 pnpm tsx scripts/m11-tenant-isolation-e2e.ts` — ✓ 2/2 (NEW gating test)**

The new M11 e2e is the gating property: token A's `/api/stream` MUST NOT receive `task.created` events for token B's tasks. Tested both directly through `publish()` and end-to-end through `SseListener` + `OwnerLookup` with real `pg_notify`.

## Up next

Phase 3 — `dispatchService` + `RuntimeRepository` + `DaemonRepository`. Centralizes session creation in one place. Existing executor still polls + spawns; the structural seam for Phase 4's daemon endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)