### PR TITLE
License: Apache 2.0 + trademark policy + CLA/DCO contributor flow

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -9,8 +9,6 @@ name: DCO
 on:
   pull_request:
     branches: [main]
-  pull_request_target:
-    branches: [main]
 
 jobs:
   dco:

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,48 @@
+name: DCO
+
+# Verify every commit on a PR carries a Signed-off-by trailer matching
+# the Developer Certificate of Origin v1.1. See CONTRIBUTING.md.
+#
+# Lightweight grep-based check: catches the common case ("forgot to add
+# -s") without requiring a third-party action.
+
+on:
+  pull_request:
+    branches: [main]
+  pull_request_target:
+    branches: [main]
+
+jobs:
+  dco:
+    name: Sign-off check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Verify every commit is signed off
+        run: |
+          set -e
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          missing=0
+          while IFS= read -r sha; do
+            [ -z "$sha" ] && continue
+            author_name=$(git log -1 --format='%an' "$sha")
+            author_email=$(git log -1 --format='%ae' "$sha")
+            if ! git log -1 --format='%B' "$sha" | grep -qE "^Signed-off-by: .+ <.+@.+>$"; then
+              echo "::error::Commit $sha by $author_name <$author_email> is missing a Signed-off-by trailer."
+              missing=$((missing + 1))
+            fi
+          done < <(git rev-list "$base..$head")
+
+          if [ "$missing" -gt 0 ]; then
+            echo ""
+            echo "Add the trailer to your commits with 'git commit -s' (or"
+            echo "rebase: 'git rebase --signoff $base && git push --force-with-lease')."
+            echo "See CONTRIBUTING.md for details."
+            exit 1
+          fi
+          echo "All commits signed off."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,134 @@
+# Contributing to Beevibe
+
+Thanks for your interest. The project is small and moves fast — PRs are
+welcome but please skim this first.
+
+## Code of conduct
+
+Be kind. Disagreement is fine; rudeness is not. The maintainers will close
+issues / PRs that don't meet this bar.
+
+## How to contribute
+
+1. **Open an issue first** for non-trivial work (anything beyond a typo,
+   doc fix, or self-contained bug). It's much easier to align on direction
+   in an issue than to rewrite a 500-line PR.
+2. **Fork, branch, PR.** Branch off `main`. PRs should be focused — one
+   logical change per PR.
+3. **Tests.** New behavior needs tests. The repo runs `pnpm -w test` in
+   CI; your PR must keep that green. New features in `packages/api` or
+   `packages/core` should include unit tests; UI changes in
+   `packages/web` should include a vitest case where it makes sense.
+4. **Commits.** Descriptive subject lines. Body explains *why*, not
+   *what* — the diff already shows what changed. Squash WIP commits
+   before requesting review.
+5. **Sign your commits** (see below) — required, CI will block PRs
+   without it.
+
+## Developer Certificate of Origin (DCO)
+
+Every commit in this repository must include a `Signed-off-by:` trailer.
+This is a legally meaningful attestation that you have the right to
+contribute the code under the project's license. It is **not** the same as
+a CLA; it adds about three keystrokes to your workflow.
+
+To sign off, append `-s` (or `--signoff`) to your commit:
+
+```bash
+git commit -s -m "your message"
+```
+
+Or set it once for the repo so you don't have to remember:
+
+```bash
+git config --local format.signoff true
+```
+
+Either form adds a line like:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+The full DCO text is reproduced below — by signing off, you certify
+this for each commit you submit.
+
+A GitHub Action checks every PR for the sign-off and blocks merge if any
+commit is missing it. If you forgot to sign off existing commits, the
+quickest fix is:
+
+```bash
+git rebase --signoff origin/main
+git push --force-with-lease
+```
+
+## License of contributions
+
+By submitting a contribution to this repository:
+
+1. You certify the Developer Certificate of Origin v1.1 (the text below).
+2. You agree that your contribution is licensed under the **Apache License,
+   Version 2.0** — the same license that covers the rest of the
+   repository.
+3. You grant Zhe Pang (and Beevibe Inc. upon its formation, to whom these
+   rights will be assigned) a perpetual, irrevocable, non-exclusive,
+   worldwide, royalty-free license to use, modify, sublicense, and
+   relicense your contribution under any open-source or commercial license
+   the project may adopt in the future.
+
+This last clause is what lets the project add commercial-license terms
+later (for example, to support an enterprise SKU) without re-asking every
+past contributor for permission. Without it, every contributor's copyright
+would be independent, and a future relicense would be impossible.
+
+The project does not currently require a separate signed CLA — the DCO
+sign-off + the agreement above is sufficient. When the project graduates
+to a more formal contribution flow (typically when there are many outside
+contributors, or at the time of company formation), maintainers may
+introduce a signed CLA via [CLA Assistant](https://cla-assistant.io) or
+similar, and existing contributors will be asked to sign retroactively.
+
+## Trademark
+
+The "Beevibe" name and logo are trademarks of the project — see
+[TRADEMARK.md](./TRADEMARK.md). Apache 2.0 grants rights to the source
+code; it does not grant rights to use the project's name or marks.
+
+## Developer Certificate of Origin v1.1
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,25 @@
+Beevibe
+Copyright (c) 2026 Zhe Pang
+
+This product is licensed under the Apache License, Version 2.0 (the "License");
+you may not use this product except in compliance with the License. You may
+obtain a copy of the License in the accompanying LICENSE file or at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+----------------------------------------------------------------------------
+
+Beevibe is a project of Zhe Pang. All rights, title, and interest in the
+Beevibe project (including this codebase, the "Beevibe" name and any
+associated marks) are intended to be assigned to Beevibe Inc. upon its
+formation. Until then, copyright is held by the individual identified above.
+
+The "Beevibe" name and any associated logos are subject to the project's
+Trademark Policy — see TRADEMARK.md. The Apache 2.0 license grants rights
+to the source code; it does not grant rights to use the project's name or
+marks.

--- a/README.md
+++ b/README.md
@@ -253,4 +253,16 @@ A few conventions worth knowing:
 
 ## License
 
-[Apache-2.0](./LICENSE)
+The Beevibe source code is licensed under the [Apache License 2.0](./LICENSE).
+
+The **Beevibe** name and logo are trademarks of the project — see
+[TRADEMARK.md](./TRADEMARK.md). Apache 2.0 grants rights to the source
+code; it does not grant rights to use the project's name or marks. Forks
+and derivative works are welcome under any name that is not "Beevibe."
+
+Contributing? See [CONTRIBUTING.md](./CONTRIBUTING.md). All commits must
+include a `Signed-off-by:` trailer (the [Developer Certificate of Origin
+v1.1](./CONTRIBUTING.md#developer-certificate-of-origin-v11)) — `git commit -s`.
+
+Copyright (c) 2026 Zhe Pang. Rights to be assigned to Beevibe Inc. upon
+its formation.

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,77 @@
+# Beevibe Trademark Policy
+
+The **Beevibe** name and any associated logos (collectively the "Marks") are
+trademarks of Zhe Pang (intended to be assigned to Beevibe Inc. upon its
+formation). The Apache License 2.0 covers the source code in this repository
+— it does **not** grant any right to use the Marks.
+
+This policy describes how you may and may not use the Marks. The goal is
+simple: anyone is free to fork, modify, and redistribute the code, but the
+Beevibe name and brand identify the project itself, and confusing third
+parties about the origin or endorsement of a derivative work is not
+permitted.
+
+## What you can do without asking
+
+You may use "Beevibe" in factual references to the project, including:
+
+- Saying that your software is **compatible with**, **integrates with**,
+  **uses**, or **is built on** Beevibe.
+- Saying that you are a **contributor to** Beevibe (if you are).
+- Saying that your fork is **based on** Beevibe (provided your fork has its
+  own distinct name — see below).
+- Linking to <https://github.com/beevibe-ai/beevibe> in documentation,
+  blog posts, talks, and academic work.
+- Reproducing the Beevibe name and logo in unmodified form when discussing,
+  reviewing, or teaching about the project.
+
+## What requires permission
+
+You **must not** do any of the following without prior written permission:
+
+- Distribute a fork, derivative, or redistribution of Beevibe under the
+  name "Beevibe" or any name that is confusingly similar (e.g., "Beevibe
+  Pro", "Beevibe Cloud", "OpenBeevibe", "BeevibeX"). Pick your own name.
+- Offer a hosted, managed, or commercial service under the Beevibe name.
+- Use the Beevibe name or logo in a way that suggests endorsement,
+  affiliation, or sponsorship by the project that does not exist.
+- Register domain names, social media handles, package names, or company
+  names containing "Beevibe" without permission.
+- Modify the Beevibe logo (color, proportions, added elements) when
+  displaying it.
+
+## Forks and downstream projects
+
+You are explicitly encouraged to fork the source code under Apache 2.0. When
+distributing your fork:
+
+- Choose a distinct project name that does not include "Beevibe."
+- You may state factually that your project is "based on Beevibe" or
+  "originally derived from Beevibe."
+- Remove or replace Beevibe-specific marks (logo, wordmark) in your fork's
+  user-facing surfaces (README, web UI, CLI banner). Strip references to
+  the Beevibe project from places where they could imply endorsement.
+
+## Hosted services
+
+Apache 2.0 permits anyone to run this code as a hosted service. This
+trademark policy does not change that — but any such service must not be
+called "Beevibe" or marketed in a way that suggests it is the official
+Beevibe service. The Beevibe name is reserved for the official project and
+the official commercial offering.
+
+## Updates
+
+This policy may evolve as the project grows. The version in `main` at the
+time of your use is the version that applies to you.
+
+## Questions
+
+For permission requests, ambiguous cases, or anything not covered here,
+contact: licensing@beevibe.ai (mail forwarder; will route to project
+maintainers).
+
+---
+
+*This policy is modeled on the trademark policies of Kubernetes, PostgreSQL,
+and the Linux Foundation's general guidance for project trademarks.*

--- a/package.json
+++ b/package.json
@@ -3,6 +3,13 @@
   "version": "0.0.1",
   "private": true,
   "description": "Beevibe core — modular monolith for agent runtime (MCP server + scheduler + daemon + shared library)",
+  "license": "Apache-2.0",
+  "author": "Zhe Pang",
+  "homepage": "https://github.com/beevibe-ai/beevibe",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/beevibe-ai/beevibe.git"
+  },
   "packageManager": "pnpm@9.12.0",
   "engines": {
     "node": ">=20.0.0"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -3,6 +3,13 @@
   "version": "0.0.1",
   "private": true,
   "description": "Beevibe API server — MCP tool surface for agents + REST endpoints for humans + MeshServer broker",
+  "license": "Apache-2.0",
+  "author": "Zhe Pang",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/beevibe-ai/beevibe.git",
+    "directory": "packages/api"
+  },
   "type": "module",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,13 @@
   "version": "0.0.1",
   "private": true,
   "description": "Shared library: domain, ports, services, adapters, auth",
+  "license": "Apache-2.0",
+  "author": "Zhe Pang",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/beevibe-ai/beevibe.git",
+    "directory": "packages/core"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -3,6 +3,13 @@
   "version": "0.0.1",
   "private": true,
   "description": "Beevibe daemon — runs on each user's machine, claims pending sessions and spawns the CLI locally",
+  "license": "Apache-2.0",
+  "author": "Zhe Pang",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/beevibe-ai/beevibe.git",
+    "directory": "packages/daemon"
+  },
   "type": "module",
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -3,6 +3,13 @@
   "version": "0.0.1",
   "private": true,
   "description": "Beevibe scheduler — claims null-runtime pending sessions as the in-process fallback claimant when no daemon is bound to the agent",
+  "license": "Apache-2.0",
+  "author": "Zhe Pang",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/beevibe-ai/beevibe.git",
+    "directory": "packages/scheduler"
+  },
   "type": "module",
   "main": "./dist/main.js",
   "bin": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -3,6 +3,13 @@
   "version": "0.0.1",
   "private": true,
   "description": "Beevibe web — Next.js app (UI pages + API routes co-located)",
+  "license": "Apache-2.0",
+  "author": "Zhe Pang",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/beevibe-ai/beevibe.git",
+    "directory": "packages/web"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary

Formalizes the project's licensing posture before external contributors arrive. Pure additive — no source code changed.

## What lands

- **`NOTICE`** — Apache 2.0 convention. Names the project + copyright holder (Zhe Pang, with rights to be assigned to Beevibe Inc. upon formation). Spells out that Apache 2.0 covers the code but not the marks.
- **`TRADEMARK.md`** — modeled on Kubernetes / PostgreSQL / Linux Foundation guidance. Permits factual references and forks; forbids redistribution under the "Beevibe" name, hosted services using the name, or implied endorsement.
- **`CONTRIBUTING.md`** — practical PR flow + DCO sign-off requirement + CLA preamble that grants the project the right to relicense or sell commercial licenses later (without re-asking every past contributor).
- **`.github/workflows/dco.yml`** — lightweight grep-based DCO check. Blocks PRs whose commits don't carry a `Signed-off-by:` trailer.
- **`package.json` (root + every workspace package)** — `license: "Apache-2.0"`, `author: "Zhe Pang"`, `repository` entries pointing at each subdirectory. Were missing entirely.
- **`README.md`** — License section expanded to point at all of the above.

## Strategy (the thinking behind the choice)

Apache 2.0 + CLA + trademark policy is the **adoption-first** posture:

- **Apache 2.0** maximizes adoption. Every enterprise's open-source review board pre-approves it; the daemon needs to land on every developer laptop, friction kills daemons.
- **CLA preamble in CONTRIBUTING.md** preserves optionality. If AWS-style hosting becomes a real threat later, the project has the legal right to relicense (e.g., to BSL or ELv2) under terms that block third-party hosting. Without this clause, every contributor's copyright is independent and a future relicense would require re-asking everyone.
- **Trademark policy** does the brand-level lifting that the permissive license can't. AWS *can* run our code as a hosted service under Apache 2.0 — but they can't call it "Beevibe." Customers will know any rebranded fork isn't the official thing. (Worked great for Kubernetes; partially worked for Elasticsearch.)
- **DCO sign-off** (lightweight) instead of a full signed CLA. DCO is enforceable without a third-party service, requires zero contributor onboarding, and provides real legal cover. A formal CLA via [CLA Assistant](https://cla-assistant.io) becomes the natural next step once Beevibe Inc. is formed and outside contributors arrive.

## Test plan

- [ ] CI's new `DCO` workflow runs and passes (this PR's single commit is signed off)
- [ ] Existing `Build, Typecheck, Lint` job still green (no source changes)
- [ ] `pnpm -w build` + `pnpm -w lint` green locally
- [ ] GitHub repo "About" sidebar now shows the Apache-2.0 license badge (auto-detected from `LICENSE` + `package.json`)

## Follow-ups (not in this PR)

- IP assignment from Zhe Pang → Beevibe Inc. at incorporation, then update the `Licensor` / copyright lines in `NOTICE` + `CONTRIBUTING.md` + `README.md` to "Beevibe Inc."
- Set up [CLA Assistant](https://cla-assistant.io) on the repo for explicit per-PR contributor sign-off (post-incorporation).
- If we ever decide hosting is the real threat, the relicense path is: write a new LICENSE under BSL 1.1 (template in `intentcore-platform/.oss/LICENSE`), update `package.json` license fields to `BUSL-1.1`, push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)