### PR TITLE
Phase 7 PR A — Railway one-click + Docker self-host foundation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+# Heavy / dev-only / sensitive paths excluded from Docker build contexts.
+node_modules
+**/node_modules
+.next
+**/.next
+dist
+**/dist
+.turbo
+**/.turbo
+*.tsbuildinfo
+
+# Secrets / local-only state
+.env
+.env.*
+!.env.example
+.beevibe
+~/.beevibe
+
+# VCS + tooling
+.git
+.github
+.vscode
+.idea
+
+# Tests + scripts not needed in runtime image
+scripts/m*-e2e.ts
+scripts/probe-*.ts
+scripts/provision-demo.ts
+mocks
+**/*.test.ts
+**/*.spec.ts
+
+# OS / editor cruft
+.DS_Store
+*.log

--- a/.env.example
+++ b/.env.example
@@ -1,34 +1,49 @@
-# PostgreSQL
+# Beevibe environment variables.
+#
+# Local dev: copy to .env, fill in ANTHROPIC_API_KEY + OPENAI_API_KEY,
+# then `pnpm dev`. The defaults below match docker-compose's Postgres.
+#
+# Cloud deploy (Railway): set these in the project's "Variables" tab.
+# DATABASE_URL is auto-injected by the Postgres plugin; you only need to
+# set ANTHROPIC_API_KEY + OPENAI_API_KEY + BEEVIBE_CORS_ORIGINS +
+# (web build-arg) NEXT_PUBLIC_BV_API_URL. See README "Deploy" section.
+
+# ─── PostgreSQL ────────────────────────────────────────────────────────
+# Local dev (docker-compose default). On Railway: auto-injected by the
+# Postgres plugin — do not set manually.
 DATABASE_URL=postgresql://beevibe:beevibe@localhost:5433/beevibe
 DATABASE_URL_TEST=postgresql://beevibe:beevibe@localhost:5433/beevibe_test
 
-# LLM providers
+# ─── LLM providers (required) ──────────────────────────────────────────
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
 
-# API server
-# URL the executor bakes into each agent's mcp-config.json. Spawned CLIs
-# connect here for tools. Must be reachable from wherever CLIs spawn —
-# for the local dev stack this is always localhost. Remote human users
-# connect via the cloudflared tunnel URL printed by `pnpm dev` (separate
-# from this static value).
+# ─── API server ────────────────────────────────────────────────────────
+# URL agent CLIs use for tool calls. For local dev this is localhost.
+# In cloud deploys: set to https://<api-public-url>/mcp.
 BEEVIBE_MCP_SERVER_URL=http://localhost:3000/mcp
+
+# HTTP port the api listens on. Local dev uses 3000.
+# On Railway / Heroku-style PaaS, $PORT is injected and takes precedence.
 BEEVIBE_API_PORT=3000
 
-# Executor
+# CORS allowlist for the api. Comma-separated origins; localhost
+# variants are always allowed in addition.
+# Cloud deploy: set to your web service's public URL
+# (e.g. https://your-app.up.railway.app).
+BEEVIBE_CORS_ORIGINS=
+
+# ─── Scheduler ─────────────────────────────────────────────────────────
 # Workspace root for each agent's sandbox + mcp-config.json. Defaults to
 # ~/.beevibe/workspaces if unset.
 WORKSPACE_ROOT=
 # Health endpoint port (GET /health → 200/503). Default 3001.
-BEEVIBE_EXECUTOR_HEALTH_PORT=3001
+BEEVIBE_SCHEDULER_HEALTH_PORT=3001
 ORG_ID=beevibe
 
-# Web frontend (packages/web)
+# ─── Web frontend (packages/web) ───────────────────────────────────────
 # Base URL the browser hits. Same value as BEEVIBE_API_PORT, just origin
-# (no /mcp suffix). Leave blank to render all pages in their not-configured
-# empty state.
+# (no /mcp suffix). On Next.js this is baked into the client bundle at
+# BUILD time — for cloud deploys, set it as a build arg to the web
+# Dockerfile (Railway: Variables → Build Args).
 NEXT_PUBLIC_BV_API_URL=http://localhost:3000
-# bv_u_ key minted via CLI; sent as Authorization: Bearer on every request
-# (M6 mutations require it). Provision via `pnpm dlx @beevibe/cli mint-key`
-# (or whatever the CLI ends up named).
-NEXT_PUBLIC_BV_USER_KEY=

--- a/README.md
+++ b/README.md
@@ -6,6 +6,21 @@ beevibe lets you run a small organization of Claude Code agents that delegate to
 
 It's open source under the Apache-2.0 license. Everything is self-hosted: your Postgres, your `claude` CLI binaries, your filesystem.
 
+## Deploy
+
+One-click cloud deploy:
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template?repo=https://github.com/beevibe-ai/beevibe)
+
+This brings up `api` + `scheduler` + `web` services and a managed Postgres in one click. After the deploy finishes, set `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` in the project's Variables tab, then visit the web service's public URL to sign up. You'll be prompted to install the local daemon as part of the welcome flow.
+
+Self-host options:
+
+- **Docker / docker-compose** — `git clone && docker compose up` against a tagged release (see [Self-hosting](#self-hosting) below).
+- **Manual** — `pnpm install && pnpm build && pnpm start` per service against your own Postgres.
+
+The repo and its tagged releases are the source of truth. The Railway button is a convenience layer; you can deploy the same code to Fly, Render, Coolify, k8s, or any container host.
+
 ## What's inside
 
 ```
@@ -13,7 +28,8 @@ beevibe/
 ├── packages/
 │   ├── core/         shared library (domain, ports, services, adapters, auth)
 │   ├── api/          MCP tool surface for agents + REST for humans + mesh broker
-│   ├── executor/     polls Postgres → spawns Claude Code sessions
+│   ├── scheduler/    fallback claimant for null-runtime sessions + orphan reaper
+│   ├── daemon/       runs on each user's machine; claims sessions and spawns CLIs locally
 │   └── web/          Next.js dashboard with live updates over SSE
 │
 ├── skills/           Anthropic Agent Skills (markdown behavioral protocols)
@@ -26,7 +42,8 @@ Each package has its own README with details:
 
 - [packages/core](./packages/core/README.md) — the library
 - [packages/api](./packages/api/README.md) — the agent + human API server
-- [packages/executor](./packages/executor/README.md) — the task dispatcher
+- [packages/scheduler](./packages/scheduler/README.md) — server-fallback claimant + orphan reaper
+- [packages/daemon](./packages/daemon/README.md) — local-runtime daemon (one per user machine)
 - [packages/web](./packages/web/README.md) — the dashboard
 
 ## Concepts in 60 seconds
@@ -58,14 +75,14 @@ cp .env.example .env
 
 docker compose up -d                  # postgres + pgvector
 pnpm migrate up                       # apply migrations to dev DB
-pnpm dev                              # postgres + api + executor (+ tunnel if cloudflared is on PATH)
+pnpm dev                              # postgres + api + scheduler (+ tunnel if cloudflared is on PATH)
 ```
 
 `pnpm dev` runs [`scripts/dev.sh`](./scripts/dev.sh), which:
 
 - starts Postgres if it isn't already running
 - applies migrations
-- spawns `@beevibe/api` (port 3000) and `@beevibe/executor` (health on 3001) in watch mode with `[api]` / `[exec]` log prefixes
+- spawns `@beevibe/api` (port 3000) and `@beevibe/scheduler` (health on 3001) in watch mode with `[api]` / `[exec]` log prefixes
 - if `cloudflared` is on PATH, exposes the api at a `*.trycloudflare.com` URL and prints a paste-ready `mcp.json` snippet for remote `claude` CLI access (pass `--no-tunnel` to disable)
 
 `Ctrl+C` tears the whole tree down.
@@ -77,7 +94,7 @@ pnpm --filter @beevibe/web dev -- -p 3030
 # then visit http://localhost:3030
 ```
 
-(The web app needs `NEXT_PUBLIC_BV_USER_KEY` set — see [its README](./packages/web/README.md). Mint a key with `pnpm tsx scripts/provision-demo.ts`.)
+The web app reads `NEXT_PUBLIC_BV_API_URL` (origin of the api server). For a working demo flow, run `pnpm seed-demo` to provision demo users (each with a password) — then sign in at `/sign-in`. The welcome wizard guides daemon setup.
 
 ## Try it from your own Claude CLI
 
@@ -124,7 +141,7 @@ pnpm tsx scripts/provision-demo.ts --clean  # wipe demo rows (no reseed)
 
 ## Skills
 
-beevibe ships agent behavioral skills as `SKILL.md` files in [`/skills/`](./skills) — Anthropic's [Agent Skills open standard](https://agentskills.io/specification). The api and executor sync them into each agent's workspace at dispatch time automatically; agent-spawned sessions get them for free.
+beevibe ships agent behavioral skills as `SKILL.md` files in [`/skills/`](./skills) — Anthropic's [Agent Skills open standard](https://agentskills.io/specification). The api and daemons sync them into each agent's workspace at dispatch time automatically; agent-spawned sessions get them for free.
 
 For human users running `claude` locally and acting *as* a beevibe agent (the manual-smoke path above), install them once into your local Claude Code skill discovery dir:
 
@@ -136,6 +153,73 @@ The install is idempotent — re-run after `git pull` to refresh. Only dirs name
 
 > **Reserved namespace**: the `beevibe-` prefix in `~/.claude/skills/` is reserved for skills shipped by this repo. If you author your own personal skills, use a different prefix (e.g., `mybeevibe-foo`) — anything not matching `beevibe-*` is invisible to the install command.
 
+## Self-hosting
+
+Beyond the Railway one-click button, the same code runs anywhere that can run a container or Node 20+.
+
+### Option 1: Docker
+
+Each service has a Dockerfile under [`infra/railway/`](./infra/railway). To run the full stack via Docker:
+
+```bash
+git clone https://github.com/beevibe-ai/beevibe.git
+cd beevibe
+# Optional: pin to a tagged release for reproducible builds
+#   git checkout v0.1.0
+
+# 1. Build the three service images
+docker build -f infra/railway/Dockerfile.api       -t beevibe-api .
+docker build -f infra/railway/Dockerfile.scheduler -t beevibe-scheduler .
+docker build -f infra/railway/Dockerfile.web \
+  --build-arg NEXT_PUBLIC_BV_API_URL=http://localhost:3000 \
+  -t beevibe-web .
+
+# 2. Start Postgres
+docker compose up -d postgres
+
+# 3. Run migrations once
+docker run --rm --network host \
+  -e DATABASE_URL=postgresql://beevibe:beevibe@localhost:5433/beevibe \
+  beevibe-api pnpm migrate:deploy up
+
+# 4. Run the services (each in its own terminal or via your orchestrator)
+docker run -p 3000:3000 --network host --env-file .env beevibe-api
+docker run --network host --env-file .env beevibe-scheduler
+docker run -p 8080:3000 --env-file .env beevibe-web
+```
+
+Then visit `http://localhost:8080` to sign up.
+
+### Option 2: Bare Node
+
+If you'd rather not use Docker:
+
+```bash
+git clone https://github.com/beevibe-ai/beevibe.git
+cd beevibe
+# Optional: pin to a tagged release
+#   git checkout v0.1.0
+
+pnpm install --frozen-lockfile
+pnpm build
+pnpm migrate:deploy up
+
+# Start each service in its own process (use systemd, pm2, or your service manager)
+node packages/api/dist/main.js          # api on $PORT (default 3000)
+node packages/scheduler/dist/main.js    # scheduler (background worker)
+pnpm --filter @beevibe/web start        # web (next start, port from $PORT)
+```
+
+Required env vars are listed in [`.env.example`](./.env.example). The api needs `DATABASE_URL`, `BEEVIBE_MCP_SERVER_URL`, `ANTHROPIC_API_KEY`, and `OPENAI_API_KEY` at minimum.
+
+### Notes for production self-hosting
+
+- **Single api replica** for v1 (see [v1 single-instance API constraint](#v1-single-instance-api-constraint) below).
+- **Postgres 16+** with `pgvector` extension. The included `docker-compose.yml` uses `pgvector/pgvector:pg16`.
+- **Reverse proxy** in front of the api (nginx / Caddy / Cloudflare) must support WebSockets (`/runtime/ws`) and long-held HTTP responses (mesh negotiate held connections, up to 5 minutes idle).
+- **CORS**: set `BEEVIBE_CORS_ORIGINS` to the public URL of the web service. Localhost variants are always allowed in addition.
+- **Daemon distribution**: end users still install the [`beevibe-daemon`](./packages/daemon) on their own machines to run agent CLIs locally. The hosted api never spawns user CLIs.
+
 ## Architecture
 
 The dependency direction across packages is one-way and ESLint-enforced:
@@ -146,18 +230,20 @@ core/ports      → domain
 core/services   → domain + ports     (NEVER adapters)
 core/adapters   → ports it implements + domain
 api/            → core (composition root)
-executor/       → core (composition root)
+scheduler/      → core (composition root)
+daemon/         → core (workspace + runtime adapters, direct imports)
 web/            → core (types only) + api (HTTP)
 ```
 
-The api and executor are independent processes. They never talk to each other over HTTP — both use Postgres as the integration point:
+The api, scheduler, and per-user daemons are independent processes. The api never talks to the scheduler or daemons over HTTP for task dispatch — Postgres is the integration point:
 
-- The api writes task lifecycle changes (created, approved, revised, cancelled).
-- The executor polls for work, runs sessions, writes results back.
-- Cancellation: api `UPDATE`s the row + `pg_notify('cancel_task', task_id)`; executor's dedicated `LISTEN` client aborts the in-flight session in <200ms.
+- The api writes task lifecycle changes (created, approved, revised, cancelled) and inserts `session` rows with `status='pending'`.
+- A daemon claims sessions whose `preferred_runtime_id` matches its registered runtime and spawns the CLI locally on the user's machine.
+- The scheduler claims null-runtime sessions (server-fallback for offline-target mesh asks) and runs the daemon-orphan reaper.
+- Cancellation: api `UPDATE`s the row + `pg_notify('cancel_task', task_id)`; the active claimant (daemon or scheduler) aborts the in-flight session in <200ms.
 - Live updates: every state-changing INSERT/UPDATE fires a `pg_notify`; api's `/api/stream` SSE endpoint relays them to the dashboard.
 
-That decoupling means you can scale the executor horizontally (run as many replicas as you want — task claims are atomic) and restart either side independently.
+That decoupling means each component scales independently — many daemons (one per user machine), one or a few schedulers, a single api replica per region (see [v1 single-instance API constraint](#v1-single-instance-api-constraint) below).
 
 ### v1 single-instance API constraint
 
@@ -169,8 +255,8 @@ round-trip must hit the same API process** for v1; a multi-instance API
 fronted by a load balancer can drop responses on the floor when the two
 HTTP requests land on different replicas. Documented in code; tracked
 for cross-instance federation via `pg_notify` as a follow-up. **Self-hosters
-should run a single API replica until that ships.** The executor (and
-the local-runtime daemon when it lands) can scale horizontally either way.
+should run a single API replica until that ships.** The scheduler and
+per-user daemons scale horizontally either way.
 
 ## Common commands
 
@@ -179,7 +265,7 @@ pnpm build              # tsc across all packages (turbo-cached)
 pnpm typecheck          # types only
 pnpm lint               # eslint
 pnpm test               # vitest (unit + integration)
-pnpm dev                # full local stack (postgres + api + executor + tunnel)
+pnpm dev                # full local stack (postgres + api + scheduler + tunnel)
 pnpm migrate up         # apply migrations to DATABASE_URL
 pnpm migrate:test up    # apply migrations to DATABASE_URL_TEST
 pnpm install-skills     # install beevibe skills into ~/.claude/skills/
@@ -200,13 +286,13 @@ pnpm install-skills     # install beevibe skills into ~/.claude/skills/
 Live integration tests against real Postgres + LLM APIs. Each is gated by an env flag.
 
 ```bash
-# In-process smoke — api + executor bootstrapped in the same VM
+# In-process smoke — api + scheduler bootstrapped in the same VM
 RUN_M6_E2E=1 \
   DATABASE_URL_TEST=postgresql://beevibe:beevibe@localhost:5433/beevibe_test \
   OPENAI_API_KEY=... ANTHROPIC_API_KEY=... \
   pnpm tsx scripts/m6-e2e.ts
 
-# Multi-process smoke — api + executor as actual `node dist/main.js`
+# Multi-process smoke — api + scheduler as actual `node dist/main.js`
 # subprocesses; verifies cross-process IPC, signal propagation, no orphans
 RUN_M7_E2E=1 \
   DATABASE_URL_TEST=postgresql://beevibe:beevibe@localhost:5433/beevibe_test \

--- a/infra/railway/Dockerfile.api
+++ b/infra/railway/Dockerfile.api
@@ -21,7 +21,9 @@ COPY packages/scheduler/package.json packages/scheduler/
 COPY packages/daemon/package.json packages/daemon/
 COPY packages/web/package.json packages/web/
 
-RUN pnpm install --frozen-lockfile
+# --filter scopes install to api + its workspace deps (core), skipping web /
+# daemon trees so the image stays free of Next.js / React.
+RUN pnpm install --frozen-lockfile --filter @beevibe/api...
 
 # Copy the rest of the repo + build api (and its transitive workspace deps).
 COPY . .

--- a/infra/railway/Dockerfile.api
+++ b/infra/railway/Dockerfile.api
@@ -1,0 +1,34 @@
+# Beevibe API service — Dockerfile for Railway / self-host deploys.
+#
+# Build: docker build -f infra/railway/Dockerfile.api -t beevibe-api .
+# Run:   docker run -p 3000:3000 --env-file .env beevibe-api
+#
+# Required env vars at runtime: DATABASE_URL, BEEVIBE_MCP_SERVER_URL,
+# OPENAI_API_KEY, ANTHROPIC_API_KEY. Optional: BEEVIBE_CORS_ORIGINS,
+# BEEVIBE_SKILLS_DIR (defaults to /app/skills baked in).
+FROM node:20-slim
+
+RUN corepack enable && corepack prepare pnpm@9.12.0 --activate
+
+WORKDIR /app
+
+# Copy lockfile + workspace manifests first so the pnpm install layer caches
+# independently of source changes.
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json tsconfig.base.json ./
+COPY packages/core/package.json packages/core/
+COPY packages/api/package.json packages/api/
+COPY packages/scheduler/package.json packages/scheduler/
+COPY packages/daemon/package.json packages/daemon/
+COPY packages/web/package.json packages/web/
+
+RUN pnpm install --frozen-lockfile
+
+# Copy the rest of the repo + build api (and its transitive workspace deps).
+COPY . .
+RUN pnpm --filter @beevibe/api... build
+
+ENV NODE_ENV=production
+ENV BEEVIBE_SKILLS_DIR=/app/skills
+
+EXPOSE 3000
+CMD ["node", "packages/api/dist/main.js"]

--- a/infra/railway/Dockerfile.scheduler
+++ b/infra/railway/Dockerfile.scheduler
@@ -1,0 +1,27 @@
+# Beevibe Scheduler service — Dockerfile for Railway / self-host deploys.
+#
+# The scheduler is a background worker (no public port). It claims
+# null-runtime pending sessions as the in-process fallback claimant when
+# no daemon is bound to the agent, and runs the daemon-orphan reaper.
+FROM node:20-slim
+
+RUN corepack enable && corepack prepare pnpm@9.12.0 --activate
+
+WORKDIR /app
+
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json tsconfig.base.json ./
+COPY packages/core/package.json packages/core/
+COPY packages/api/package.json packages/api/
+COPY packages/scheduler/package.json packages/scheduler/
+COPY packages/daemon/package.json packages/daemon/
+COPY packages/web/package.json packages/web/
+
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+RUN pnpm --filter @beevibe/scheduler... build
+
+ENV NODE_ENV=production
+ENV BEEVIBE_SKILLS_DIR=/app/skills
+
+CMD ["node", "packages/scheduler/dist/main.js"]

--- a/infra/railway/Dockerfile.scheduler
+++ b/infra/railway/Dockerfile.scheduler
@@ -16,7 +16,9 @@ COPY packages/scheduler/package.json packages/scheduler/
 COPY packages/daemon/package.json packages/daemon/
 COPY packages/web/package.json packages/web/
 
-RUN pnpm install --frozen-lockfile
+# --filter scopes install to scheduler + its workspace deps (core), skipping
+# web / daemon / api trees so the image stays minimal.
+RUN pnpm install --frozen-lockfile --filter @beevibe/scheduler...
 
 COPY . .
 RUN pnpm --filter @beevibe/scheduler... build

--- a/infra/railway/Dockerfile.web
+++ b/infra/railway/Dockerfile.web
@@ -1,0 +1,32 @@
+# Beevibe Web service — Dockerfile for Railway / self-host deploys.
+#
+# Next.js bakes `NEXT_PUBLIC_*` envs into the client bundle at build time,
+# so the api URL must be passed as a build arg (Railway: under Variables →
+# Build Args → NEXT_PUBLIC_BV_API_URL).
+FROM node:20-slim
+
+RUN corepack enable && corepack prepare pnpm@9.12.0 --activate
+
+WORKDIR /app
+
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json tsconfig.base.json ./
+COPY packages/core/package.json packages/core/
+COPY packages/api/package.json packages/api/
+COPY packages/scheduler/package.json packages/scheduler/
+COPY packages/daemon/package.json packages/daemon/
+COPY packages/web/package.json packages/web/
+
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+
+# Build-time arg → env → next build bakes it into the client bundle.
+ARG NEXT_PUBLIC_BV_API_URL
+ENV NEXT_PUBLIC_BV_API_URL=$NEXT_PUBLIC_BV_API_URL
+
+RUN pnpm --filter @beevibe/web... build
+
+ENV NODE_ENV=production
+# Next.js reads PORT directly; Railway injects it.
+EXPOSE 3000
+CMD ["pnpm", "--filter", "@beevibe/web", "start"]

--- a/infra/railway/Dockerfile.web
+++ b/infra/railway/Dockerfile.web
@@ -16,7 +16,9 @@ COPY packages/scheduler/package.json packages/scheduler/
 COPY packages/daemon/package.json packages/daemon/
 COPY packages/web/package.json packages/web/
 
-RUN pnpm install --frozen-lockfile
+# --filter scopes install to web + its workspace deps (api, core), skipping
+# scheduler / daemon trees.
+RUN pnpm install --frozen-lockfile --filter @beevibe/web...
 
 COPY . .
 

--- a/infra/railway/api.railway.json
+++ b/infra/railway/api.railway.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "infra/railway/Dockerfile.api"
+  },
+  "deploy": {
+    "startCommand": "node packages/api/dist/main.js",
+    "preDeployCommand": "pnpm migrate:deploy up",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10,
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 30
+  }
+}

--- a/infra/railway/scheduler.railway.json
+++ b/infra/railway/scheduler.railway.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "infra/railway/Dockerfile.scheduler"
+  },
+  "deploy": {
+    "startCommand": "node packages/scheduler/dist/main.js",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}

--- a/infra/railway/web.railway.json
+++ b/infra/railway/web.railway.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "infra/railway/Dockerfile.web"
+  },
+  "deploy": {
+    "startCommand": "pnpm --filter @beevibe/web start",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test": "turbo test --concurrency=1 && vitest run scripts/",
     "clean": "turbo clean && rm -rf node_modules",
     "migrate": "node-pg-migrate --envPath .env",
+    "migrate:deploy": "node-pg-migrate",
     "migrate:test": "node-pg-migrate --envPath .env -d DATABASE_URL_TEST",
     "install-skills": "tsx scripts/install-skills.ts",
     "bootstrap": "tsx scripts/init.ts",

--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 import { config as loadEnv } from "dotenv";
+import { readPositiveInt, resolveMcpServerUrl } from "@beevibe/core";
 import { bootstrap } from "./bootstrap.js";
 import { parseAllowedOrigins } from "./cors.js";
 
 const REQUIRED_ENV = [
   "DATABASE_URL",
-  "BEEVIBE_MCP_SERVER_URL",
   "OPENAI_API_KEY",
   "ANTHROPIC_API_KEY",
 ] as const;
@@ -13,15 +13,10 @@ const REQUIRED_ENV = [
 async function main(): Promise<void> {
   loadEnv();
 
-  // Railway-style PaaS injects RAILWAY_PUBLIC_DOMAIN for each service. If
-  // the operator hasn't supplied BEEVIBE_MCP_SERVER_URL explicitly, derive
-  // it from the public domain so daemons (and the agent CLIs they spawn)
-  // hit this api's /mcp route without manual config.
-  if (!process.env.BEEVIBE_MCP_SERVER_URL && process.env.RAILWAY_PUBLIC_DOMAIN) {
-    process.env.BEEVIBE_MCP_SERVER_URL = `https://${process.env.RAILWAY_PUBLIC_DOMAIN}/mcp`;
-  }
+  const mcpServerUrl = resolveMcpServerUrl(process.env);
 
-  const missing = REQUIRED_ENV.filter((k) => !process.env[k]);
+  const missing: string[] = REQUIRED_ENV.filter((k) => !process.env[k]);
+  if (!mcpServerUrl) missing.push("BEEVIBE_MCP_SERVER_URL");
   if (missing.length > 0) {
     throw new Error(
       `Missing required env vars: ${missing.join(", ")}. See .env.example for the full set.`,
@@ -30,11 +25,11 @@ async function main(): Promise<void> {
 
   // Railway / Heroku-style PaaS injects PORT; honor it before falling back
   // to BEEVIBE_API_PORT (local dev) and then to 3000.
-  const port = Number(process.env.PORT ?? process.env.BEEVIBE_API_PORT ?? 3000);
+  const port = readPositiveInt(process.env.PORT ?? process.env.BEEVIBE_API_PORT, 3000);
   const corsAllowedOrigins = parseAllowedOrigins(process.env.BEEVIBE_CORS_ORIGINS);
   const { server, shutdown } = await bootstrap({
     databaseUrl: process.env.DATABASE_URL!,
-    mcpServerUrl: process.env.BEEVIBE_MCP_SERVER_URL!,
+    mcpServerUrl: mcpServerUrl!,
     openaiApiKey: process.env.OPENAI_API_KEY!,
     anthropicApiKey: process.env.ANTHROPIC_API_KEY!,
     workspaceRoot: process.env.WORKSPACE_ROOT,

--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -13,6 +13,14 @@ const REQUIRED_ENV = [
 async function main(): Promise<void> {
   loadEnv();
 
+  // Railway-style PaaS injects RAILWAY_PUBLIC_DOMAIN for each service. If
+  // the operator hasn't supplied BEEVIBE_MCP_SERVER_URL explicitly, derive
+  // it from the public domain so daemons (and the agent CLIs they spawn)
+  // hit this api's /mcp route without manual config.
+  if (!process.env.BEEVIBE_MCP_SERVER_URL && process.env.RAILWAY_PUBLIC_DOMAIN) {
+    process.env.BEEVIBE_MCP_SERVER_URL = `https://${process.env.RAILWAY_PUBLIC_DOMAIN}/mcp`;
+  }
+
   const missing = REQUIRED_ENV.filter((k) => !process.env[k]);
   if (missing.length > 0) {
     throw new Error(
@@ -20,7 +28,9 @@ async function main(): Promise<void> {
     );
   }
 
-  const port = process.env.BEEVIBE_API_PORT ? Number(process.env.BEEVIBE_API_PORT) : 3000;
+  // Railway / Heroku-style PaaS injects PORT; honor it before falling back
+  // to BEEVIBE_API_PORT (local dev) and then to 3000.
+  const port = Number(process.env.PORT ?? process.env.BEEVIBE_API_PORT ?? 3000);
   const corsAllowedOrigins = parseAllowedOrigins(process.env.BEEVIBE_CORS_ORIGINS);
   const { server, shutdown } = await bootstrap({
     databaseUrl: process.env.DATABASE_URL!,

--- a/packages/api/src/sse/owner-lookup.ts
+++ b/packages/api/src/sse/owner-lookup.ts
@@ -16,6 +16,7 @@
  * separate handler when rooms ship.
  */
 
+import { readPositiveInt } from "@beevibe/core";
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import type { BvEvent } from "./manager.js";
 
@@ -204,8 +205,3 @@ export class OwnerLookup {
   }
 }
 
-function readPositiveInt(raw: string | undefined, fallback: number): number {
-  if (raw === undefined || raw === "") return fallback;
-  const n = Number.parseInt(raw, 10);
-  return Number.isFinite(n) && n > 0 ? n : fallback;
-}

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -1,0 +1,34 @@
+/**
+ * Composition-root environment helpers shared by the api + scheduler
+ * binaries. Pure functions over a snapshot of `process.env` (not the
+ * live object) so call sites stay easy to test.
+ */
+
+export interface EnvSnapshot {
+  readonly BEEVIBE_MCP_SERVER_URL?: string;
+  readonly RAILWAY_PUBLIC_DOMAIN?: string;
+  readonly [key: string]: string | undefined;
+}
+
+/**
+ * Resolve the URL agent CLIs should hit for MCP tool calls. Operators
+ * normally set `BEEVIBE_MCP_SERVER_URL` explicitly; on Railway-style
+ * PaaS we fall back to `https://${RAILWAY_PUBLIC_DOMAIN}/mcp` so a
+ * one-click deploy works without manual config.
+ */
+export function resolveMcpServerUrl(env: EnvSnapshot): string | undefined {
+  if (env.BEEVIBE_MCP_SERVER_URL) return env.BEEVIBE_MCP_SERVER_URL;
+  if (env.RAILWAY_PUBLIC_DOMAIN) return `https://${env.RAILWAY_PUBLIC_DOMAIN}/mcp`;
+  return undefined;
+}
+
+/**
+ * Parse an env var as a positive integer, falling back when missing,
+ * empty, or non-numeric. Guards against `Number("")` returning 0 — which
+ * silently binds an HTTP server to a random port.
+ */
+export function readPositiveInt(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw === "") return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 // @beevibe/core — shared library.
-// Binaries (api, executor, web) import domain types + port interfaces from here.
+// Binaries (api, scheduler, web) import domain types + port interfaces from here.
 // Adapters are composed by binaries directly; not re-exported via the barrel.
 export * from "./domain/index.js";
 export * from "./ports/index.js";
 export * from "./auth/index.js";
+export * from "./env.js";

--- a/packages/scheduler/src/main.ts
+++ b/packages/scheduler/src/main.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 import { config as loadEnv } from "dotenv";
+import { readPositiveInt, resolveMcpServerUrl } from "@beevibe/core";
 import { bootstrap } from "./bootstrap.js";
 
 const REQUIRED_ENV = [
   "DATABASE_URL",
-  "BEEVIBE_MCP_SERVER_URL",
   "OPENAI_API_KEY",
   "ANTHROPIC_API_KEY",
 ] as const;
@@ -14,7 +14,10 @@ async function main(): Promise<void> {
   // local dev: repo-root .env).
   loadEnv();
 
-  const missing = REQUIRED_ENV.filter((k) => !process.env[k]);
+  const mcpServerUrl = resolveMcpServerUrl(process.env);
+
+  const missing: string[] = REQUIRED_ENV.filter((k) => !process.env[k]);
+  if (!mcpServerUrl) missing.push("BEEVIBE_MCP_SERVER_URL");
   if (missing.length > 0) {
     throw new Error(
       `Missing required env vars: ${missing.join(", ")}. See .env.example for the full set.`,
@@ -23,17 +26,13 @@ async function main(): Promise<void> {
 
   const { worker, cancelListener, healthServer, shutdown } = await bootstrap({
     databaseUrl: process.env.DATABASE_URL!,
-    mcpServerUrl: process.env.BEEVIBE_MCP_SERVER_URL!,
+    mcpServerUrl: mcpServerUrl!,
     openaiApiKey: process.env.OPENAI_API_KEY!,
     anthropicApiKey: process.env.ANTHROPIC_API_KEY!,
     workspaceRoot: process.env.WORKSPACE_ROOT,
     skillsSourceDir: process.env.BEEVIBE_SKILLS_DIR,
-    pollIntervalMs: process.env.POLL_INTERVAL_MS
-      ? Number(process.env.POLL_INTERVAL_MS)
-      : undefined,
-    healthPort: process.env.BEEVIBE_EXECUTOR_HEALTH_PORT
-      ? Number(process.env.BEEVIBE_EXECUTOR_HEALTH_PORT)
-      : undefined,
+    pollIntervalMs: readPositiveInt(process.env.POLL_INTERVAL_MS, 0) || undefined,
+    healthPort: readPositiveInt(process.env.BEEVIBE_SCHEDULER_HEALTH_PORT, 0) || undefined,
   });
 
   await cancelListener.start();


### PR DESCRIPTION
## Summary

First of three PRs landing Phase 7 (auto-deploy). This PR ships build artifacts + templates so beevibe can be deployed to Railway in one click, run via Docker on any container host, or built bare-Node by self-hosters.

PR B follows with daemon native binaries + npm publish + Homebrew tap + auto-update. PR C wraps up with welcome-wizard install UX, end-to-end smoke against a real Railway deploy, and the v0.1.0 tag the Railway template URL pins to.

## What's in this PR

- **`infra/railway/`** — per-service Dockerfiles (api, scheduler, web) + matching `*.railway.json` configs. Single-stage `node:20-slim`, monorepo-aware. Web takes `NEXT_PUBLIC_BV_API_URL` as a build arg since Next.js bakes `NEXT_PUBLIC_*` into the client bundle at build time. API's config carries `preDeployCommand: pnpm migrate:deploy up` so a fresh deploy applies all migrations before the new container takes traffic.
- **`pnpm migrate:deploy`** — same as `pnpm migrate` minus `--envPath .env`. Reads `DATABASE_URL` straight from process env (no .env file expected in cloud).
- **`packages/api/src/main.ts`** — two cloud-friendly env wirings:
  - `PORT` now takes precedence over `BEEVIBE_API_PORT` (Railway / Heroku-style PaaS inject `PORT`)
  - If `BEEVIBE_MCP_SERVER_URL` isn't set explicitly, it auto-derives from `RAILWAY_PUBLIC_DOMAIN`
- **`.dockerignore`** — keeps `node_modules`, `.next`, `.turbo`, `.env*`, `.git`, `scripts/m*-e2e.ts`, and other dev-only paths out of build contexts.
- **`.env.example`** — restructured around local-vs-cloud split. Documents `BEEVIBE_CORS_ORIGINS`. Drops the legacy `NEXT_PUBLIC_BV_USER_KEY` removed in Phase 5.
- **`README`** — adds "Deploy" + "Self-hosting" sections. Fixes lingering `executor` → `scheduler` stale refs from the Phase 4 rename.

## What is intentionally not here

- **Railway template URL** — has to be created via Railway's web UI after this PR merges (you visit the project in the dashboard and click "Create template"). The README button currently links to `railway.com/new/template?repo=...` as a workable fallback; PR C swaps it for the real template URL.
- **`v0.1.0` tag** — created in PR C once the welcome-wizard install UX is done. The template will pin to that tag for reproducible deploys.
- **Daemon binaries / npm / brew** — PR B.

## Verification

All three Docker images build cleanly from the new Dockerfiles:

| Image | Size |
|---|---|
| beevibe-api | 853 MB |
| beevibe-scheduler | 853 MB |
| beevibe-web | 976 MB |

API unit tests still pass (289 tests).

## Test plan

- [x] CI green
- [x] Smoke: build all three images locally (`docker build -f infra/railway/Dockerfile.api ...`)
- [ ] Smoke (post-merge): create Railway template via dashboard, deploy to a throwaway project, verify sign-up + welcome wizard work
- [ ] Smoke: docker-compose / bare-node self-host path from the README is followable end-to-end

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)