### PR TITLE
deploy: switch npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,13 +106,9 @@ jobs:
   npm-publish:
     needs: build-binaries
     runs-on: ubuntu-latest
-    # `id-token: write` is what makes npm Trusted Publishing work — the
-    # GitHub Actions runner mints a short-lived OIDC token, npm verifies
-    # the token's `repository` + `workflow` claims against the trusted
-    # publisher configured for @beevibe/daemon, and authenticates the
-    # publish without any long-lived token in our secrets. Same token
-    # is used for the provenance attestation that ships with the
-    # published tarball.
+    # `id-token: write` serves two purposes at once: npm Trusted Publishing
+    # auth (no NPM_TOKEN needed) and the provenance attestation that ships
+    # with the published tarball.
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,8 +106,13 @@ jobs:
   npm-publish:
     needs: build-binaries
     runs-on: ubuntu-latest
-    # Required for npm provenance attestation via GitHub Actions OIDC —
-    # buyers downstream can verify the package was built by this repo.
+    # `id-token: write` is what makes npm Trusted Publishing work — the
+    # GitHub Actions runner mints a short-lived OIDC token, npm verifies
+    # the token's `repository` + `workflow` claims against the trusted
+    # publisher configured for @beevibe/daemon, and authenticates the
+    # publish without any long-lived token in our secrets. Same token
+    # is used for the provenance attestation that ships with the
+    # published tarball.
     permissions:
       contents: read
       id-token: write
@@ -125,8 +130,6 @@ jobs:
       - name: npm publish
         working-directory: ./publish-dist
         run: npm publish --access=public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   update-homebrew-tap:
     needs: [build-binaries, github-release]

--- a/infra/RELEASING.md
+++ b/infra/RELEASING.md
@@ -11,15 +11,31 @@ fires on tag push (`v*`) and produces three artifacts:
 
 These pieces have to exist before the first tag push:
 
-### 1. `NPM_TOKEN` secret
+### 1. npm Trusted Publisher (no token needed)
 
-1. Log into [npmjs.com](https://npmjs.com) as a user with publish access to
-   the `@beevibe` org. (If the org doesn't exist, create it first.)
-2. Account → Access Tokens → Generate Token → Automation token (or Classic
-   Granular).
-3. Copy the token.
-4. In this repo: Settings → Secrets and variables → Actions → New repository
-   secret. Name: `NPM_TOKEN`, value: the token.
+The release workflow authenticates to npm via GitHub Actions OIDC —
+no long-lived secret in this repo's GitHub Secrets. Setup is one-time
+via npm's web UI:
+
+1. Log into [npmjs.com](https://npmjs.com) as an owner of the `@beevibe`
+   org. (If the org doesn't exist, create it first at
+   [npmjs.com/org/create](https://www.npmjs.com/org/create) — free
+   plan is fine for public packages.)
+2. Navigate to the `@beevibe/daemon` package settings. The package
+   doesn't exist yet, but npm supports pre-configuring a Trusted
+   Publisher for new packages:
+   - Org page → Packages → "Add Trusted Publisher" (or similar)
+   - OR direct URL pattern: `npmjs.com/package/@beevibe/daemon/access` once
+     the package exists; for pre-publish config, use the org settings
+3. Add the trusted publisher with:
+   - **Publisher**: GitHub Actions
+   - **Repository owner**: `beevibe-ai`
+   - **Repository name**: `beevibe`
+   - **Workflow filename**: `release.yml`
+   - **Environment**: (leave blank)
+
+That's it — no token to generate, no secret to add. The release workflow
+authenticates via OIDC on every run.
 
 ### 2. `HOMEBREW_TAP_TOKEN` secret + tap repo
 


### PR DESCRIPTION
## Summary

Tiny follow-up to PR B (#80). npm's web UI explicitly warns against the bypass-2FA classic-token pattern when generating a granular token, and recommends Trusted Publishing instead. This switches the release workflow to use OIDC.

## Why

- Zero long-lived npm credentials in our secrets — nothing to rotate or accidentally leak
- Cryptographic proof on every publish that the package came from this exact repo + workflow file
- npm's own current recommendation for CI/CD

## What changed

- `release.yml`: dropped `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the publish step. The `id-token: write` permission was already on the job (added for provenance in PR B's simplify cleanup) and is what npm needs for trusted-publisher auth.
- `infra/RELEASING.md`: replaced the NPM_TOKEN setup section with one-time Trusted Publisher config steps via npm's web UI.

## Setup change for the first release

Instead of generating an npm token + adding it as a GitHub secret, you now configure a Trusted Publisher on npm's UI once (no GitHub-side action needed). Documented in `infra/RELEASING.md`. The settings:

- Publisher: GitHub Actions
- Repository owner: `beevibe-ai`
- Repository name: `beevibe`
- Workflow filename: `release.yml`
- Environment: (blank)

npm supports pre-configuring trusted publishers for packages that don't exist yet, so this works for the first publish of `@beevibe/daemon@0.1.0`.

## Test plan

- [ ] CI green
- [ ] After merge: configure Trusted Publisher in npm web UI
- [ ] Tag `v0.0.1-rc1` to dry-run the workflow end-to-end (npm publish will authenticate via OIDC; verify it works against a pre-release version that doesn't get marked as `@latest`)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)