### PR TITLE
deploy: fix release workflow — npm 11.5+ for Trusted Publishing, pre-release detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,9 @@ jobs:
           files: ./release-assets/*
           generate_release_notes: true
           fail_on_unmatched_files: true
+          # Mark v*-rc*, v*-beta*, v*-alpha* tags as pre-releases so they
+          # don't get badged as "Latest release" on the repo page.
+          prerelease: ${{ contains(github.ref_name, '-') }}
 
   npm-publish:
     needs: build-binaries
@@ -123,9 +126,30 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org/"
 
+      # Trusted Publishing (OIDC-based npm publish) requires npm CLI
+      # 11.5.0+. Node 20's bundled npm is 10.x; upgrade explicitly so
+      # `npm publish --provenance` exchanges the GitHub OIDC token for
+      # an npm publish token instead of looking for a static token in
+      # ~/.npmrc.
+      - name: Upgrade npm to a Trusted-Publishing-capable version
+        run: npm install -g npm@latest
+
       - name: npm publish
         working-directory: ./publish-dist
-        run: npm publish --access=public --provenance
+        env:
+          # Passed via env (not inline `${{ }}`) to avoid command-injection
+          # risk and shellcheck false positive on the pattern match.
+          TAG_NAME: ${{ github.ref_name }}
+        # Pre-release tags (v0.0.1-rc1, v0.1.0-beta.2, etc.) ship under
+        # the `next` dist-tag so `npm install @beevibe/daemon` still
+        # pulls the latest stable. The dist-tag becomes `latest` for
+        # any tag without a hyphen.
+        run: |
+          if [[ "$TAG_NAME" == *-* ]]; then
+            npm publish --access=public --provenance --tag next
+          else
+            npm publish --access=public --provenance
+          fi
 
   update-homebrew-tap:
     needs: [build-binaries, github-release]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,9 +130,10 @@ jobs:
       # 11.5.0+. Node 20's bundled npm is 10.x; upgrade explicitly so
       # `npm publish --provenance` exchanges the GitHub OIDC token for
       # an npm publish token instead of looking for a static token in
-      # ~/.npmrc.
+      # ~/.npmrc. Pinned to ^11.5 (not @latest) for reproducibility;
+      # bump when npm publish API changes.
       - name: Upgrade npm to a Trusted-Publishing-capable version
-        run: npm install -g npm@latest
+        run: npm install -g 'npm@^11.5'
 
       - name: npm publish
         working-directory: ./publish-dist
@@ -145,6 +146,7 @@ jobs:
         # pulls the latest stable. The dist-tag becomes `latest` for
         # any tag without a hyphen.
         run: |
+          set -euo pipefail
           if [[ "$TAG_NAME" == *-* ]]; then
             npm publish --access=public --provenance --tag next
           else


### PR DESCRIPTION
## Summary

Three fixes surfaced by the v0.0.1-rc1 dry-run of the release workflow:

1. **npm CLI version**: Trusted Publishing requires npm 11.5.0+; Node 20 ships with npm 10.x. Upgrade `npm install -g npm@latest` before publish. (This is the root cause of the dry-run's 404.)
2. **GitHub release pre-release flag**: `softprops/action-gh-release@v2` doesn't auto-detect pre-release tags. Now explicit via `contains(github.ref_name, '-')`.
3. **npm dist-tag for pre-releases**: route `v0.0.1-rc1` etc. to `@next` instead of `@latest`.

## Root cause analysis

The dry-run (run [25698468773](https://github.com/beevibe-ai/beevibe/actions/runs/25698468773)) showed:

```
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm notice publish Provenance statement published to transparency log
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@beevibe%2fdaemon - Not found
```

The provenance step worked — that's npm CLI doing the OIDC exchange with sigstore for the *attestation*, and that path is supported in npm 10.x. But the actual publish PUT uses npm's standard auth chain, which in 10.x only knows about static tokens in `~/.npmrc`. With no token set, npm sends an unauthenticated PUT and the registry returns 404 (npm's intentional "auth failed" response — they don't say 401 to avoid leaking package existence).

OIDC-based token exchange for the publish itself only landed in **npm CLI 11.5.0** (Oct 2025). Once we upgrade in CI, `npm publish --provenance` exchanges the GitHub OIDC token for a short-lived npm publish token and the trusted-publisher config kicks in.

## Test plan

- [ ] CI green on this PR (no actual release triggered by this PR)
- [ ] After merge: tag `v0.0.1-rc2` to dry-run the fixed workflow
- [ ] Verify all 4 jobs succeed
- [ ] Verify `@beevibe/daemon@0.0.1-rc2` exists on npm under the `next` dist-tag (not `latest`)
- [ ] Verify GitHub release is marked as pre-release

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)