### PR TITLE
Phase 7 PR C — welcome wizard install UX (brew / npx / direct download)

### DIFF
--- a/packages/web/app/welcome/welcome-client.tsx
+++ b/packages/web/app/welcome/welcome-client.tsx
@@ -191,6 +191,73 @@ const INSTALL_OPTIONS: readonly InstallOption[] = [
   { id: "direct", label: "Direct download", hint: "advanced" },
 ];
 
+const RELEASES_URL = "https://github.com/beevibe-ai/beevibe/releases/latest";
+const NPX_BIN = "npx -y @beevibe/daemon@latest";
+const LOCAL_BIN = "beevibe-daemon";
+
+interface InstallStepSpec {
+  /** Short imperative — number is prepended at render time. */
+  label: string;
+  command: string;
+}
+
+interface InstallBundle {
+  /** Optional helper text rendered before the command list. */
+  prelude?: React.ReactNode;
+  steps: readonly InstallStepSpec[];
+}
+
+function buildInstallBundle(channel: InstallChannel, setupArgs: string): InstallBundle {
+  switch (channel) {
+    case "brew":
+      return {
+        steps: [
+          { label: "Install via Homebrew", command: "brew install beevibe-ai/tap/beevibe-daemon" },
+          { label: "Register", command: `${LOCAL_BIN} ${setupArgs}` },
+          { label: "Start (long-running)", command: `${LOCAL_BIN} start` },
+        ],
+      };
+    case "npx":
+      return {
+        steps: [
+          {
+            label: "Register (downloads daemon on first run)",
+            command: `${NPX_BIN} ${setupArgs}`,
+          },
+          { label: "Start (long-running)", command: `${NPX_BIN} start` },
+        ],
+      };
+    case "direct":
+      return {
+        prelude: (
+          <p className="text-xs text-muted-foreground leading-relaxed">
+            Pick the binary that matches your platform from{" "}
+            <a
+              href={RELEASES_URL}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="underline hover:text-foreground"
+            >
+              the latest GitHub release
+            </a>
+            {" "}— darwin-arm64, darwin-x64, linux-x64, or linux-arm64. Then:
+          </p>
+        ),
+        steps: [
+          {
+            label: "Download (substitute your platform)",
+            command:
+              `curl -fsSL -o ~/.local/bin/${LOCAL_BIN} \\\n` +
+              `  "${RELEASES_URL}/download/${LOCAL_BIN}-darwin-arm64" \\\n` +
+              `  && chmod +x ~/.local/bin/${LOCAL_BIN}`,
+          },
+          { label: "Register", command: `${LOCAL_BIN} ${setupArgs}` },
+          { label: "Start (long-running)", command: `${LOCAL_BIN} start` },
+        ],
+      };
+  }
+}
+
 /**
  * Detect the user's OS from navigator.userAgent so we default the tab
  * to whatever is most natural for them. Falls back to `npx` (universal).
@@ -198,8 +265,7 @@ const INSTALL_OPTIONS: readonly InstallOption[] = [
  */
 function detectDefaultChannel(): InstallChannel {
   if (typeof navigator === "undefined") return "npx";
-  const ua = navigator.userAgent;
-  if (/Mac OS X|Macintosh/i.test(ua)) return "brew";
+  if (/Mac OS X|Macintosh/i.test(navigator.userAgent)) return "brew";
   return "npx";
 }
 
@@ -251,56 +317,7 @@ function InstallStep({ onDaemonReady }: { onDaemonReady: () => void }) {
           ))}
         </div>
 
-        {channel === "brew" ? (
-          <div className="space-y-2">
-            <CommandBlock
-              label="1. Install via Homebrew"
-              command="brew install beevibe-ai/tap/beevibe-daemon"
-            />
-            <CommandBlock label="2. Register" command={`beevibe-daemon ${setupArgs}`} />
-            <CommandBlock label="3. Start (long-running)" command="beevibe-daemon start" />
-          </div>
-        ) : null}
-
-        {channel === "npx" ? (
-          <div className="space-y-2">
-            <CommandBlock
-              label="1. Register (downloads daemon on first run)"
-              command={`npx -y @beevibe/daemon@latest ${setupArgs}`}
-            />
-            <CommandBlock
-              label="2. Start (long-running)"
-              command="npx -y @beevibe/daemon@latest start"
-            />
-          </div>
-        ) : null}
-
-        {channel === "direct" ? (
-          <div className="space-y-2">
-            <p className="text-xs text-muted-foreground leading-relaxed">
-              Pick the binary that matches your platform from{" "}
-              <a
-                href="https://github.com/beevibe-ai/beevibe/releases/latest"
-                target="_blank"
-                rel="noreferrer noopener"
-                className="underline hover:text-foreground"
-              >
-                the latest GitHub release
-              </a>
-              {" "}— darwin-arm64, darwin-x64, linux-x64, or linux-arm64. Then:
-            </p>
-            <CommandBlock
-              label="1. Download (substitute your platform)"
-              command={
-                'curl -fsSL -o ~/.local/bin/beevibe-daemon \\\n' +
-                '  "https://github.com/beevibe-ai/beevibe/releases/latest/download/beevibe-daemon-darwin-arm64" \\\n' +
-                '  && chmod +x ~/.local/bin/beevibe-daemon'
-              }
-            />
-            <CommandBlock label="2. Register" command={`beevibe-daemon ${setupArgs}`} />
-            <CommandBlock label="3. Start (long-running)" command="beevibe-daemon start" />
-          </div>
-        ) : null}
+        <InstallStepList bundle={buildInstallBundle(channel, setupArgs)} />
       </div>
 
       <div
@@ -339,6 +356,17 @@ function InstallStep({ onDaemonReady }: { onDaemonReady: () => void }) {
         (<span className="font-mono">npm i -g @anthropic/claude-code</span>) and
         run <span className="font-mono">claude login</span>.
       </p>
+    </div>
+  );
+}
+
+function InstallStepList({ bundle }: { bundle: InstallBundle }) {
+  return (
+    <div className="space-y-2">
+      {bundle.prelude}
+      {bundle.steps.map((step, i) => (
+        <CommandBlock key={i} label={`${i + 1}. ${step.label}`} command={step.command} />
+      ))}
     </div>
   );
 }

--- a/packages/web/app/welcome/welcome-client.tsx
+++ b/packages/web/app/welcome/welcome-client.tsx
@@ -176,12 +176,40 @@ function IntroStep({ onNext }: { onNext: () => void }) {
 
 // ── Step 2: install daemon — show command, poll until it appears ──────
 
+type InstallChannel = "brew" | "npx" | "direct";
+
+interface InstallOption {
+  id: InstallChannel;
+  label: string;
+  /** Short subtitle shown under the label in the tab strip. */
+  hint: string;
+}
+
+const INSTALL_OPTIONS: readonly InstallOption[] = [
+  { id: "brew", label: "Homebrew", hint: "macOS" },
+  { id: "npx", label: "npx", hint: "any platform with Node" },
+  { id: "direct", label: "Direct download", hint: "advanced" },
+];
+
+/**
+ * Detect the user's OS from navigator.userAgent so we default the tab
+ * to whatever is most natural for them. Falls back to `npx` (universal).
+ * Runs once on mount — userAgent doesn't change for the page lifetime.
+ */
+function detectDefaultChannel(): InstallChannel {
+  if (typeof navigator === "undefined") return "npx";
+  const ua = navigator.userAgent;
+  if (/Mac OS X|Macintosh/i.test(ua)) return "brew";
+  return "npx";
+}
+
 function InstallStep({ onDaemonReady }: { onDaemonReady: () => void }) {
   const userKey = typeof window !== "undefined" ? getUserKey() : null;
   const apiUrl = apiBaseUrl ?? "http://localhost:3000";
+  const keyOrPlaceholder = userKey ?? "<your-key>";
+  const setupArgs = `setup --api ${apiUrl} --user-token ${keyOrPlaceholder}`;
 
-  const setupCmd = `pnpm daemon setup --api ${apiUrl} --user-token ${userKey ?? "<your-key>"}`;
-  const startCmd = `pnpm daemon start`;
+  const [channel, setChannel] = useState<InstallChannel>(() => detectDefaultChannel());
 
   // Poll /runtimes every 3s until at least one daemon shows up.
   const query = useQuery<RuntimesListResponse>({
@@ -199,13 +227,80 @@ function InstallStep({ onDaemonReady }: { onDaemonReady: () => void }) {
         <h2 className="text-xl font-semibold">Install the daemon</h2>
         <p className="text-sm text-muted-foreground max-w-prose mx-auto">
           The daemon spawns your agents&apos; CLI subprocesses on your machine.
-          Run these two commands in a new terminal:
+          Pick the install path that fits your setup:
         </p>
       </div>
 
-      <div className="space-y-3 max-w-xl mx-auto">
-        <CommandBlock label="1. Register" command={setupCmd} />
-        <CommandBlock label="2. Start (long-running)" command={startCmd} />
+      <div className="max-w-xl mx-auto space-y-3">
+        <div className="flex gap-1 rounded-lg border border-border bg-card p-1">
+          {INSTALL_OPTIONS.map((opt) => (
+            <button
+              key={opt.id}
+              type="button"
+              onClick={() => setChannel(opt.id)}
+              className={cn(
+                "flex-1 rounded px-3 py-1.5 text-xs font-medium transition-colors cursor-pointer",
+                channel === opt.id
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <div>{opt.label}</div>
+              <div className="text-[10px] font-normal opacity-80 mt-0.5">{opt.hint}</div>
+            </button>
+          ))}
+        </div>
+
+        {channel === "brew" ? (
+          <div className="space-y-2">
+            <CommandBlock
+              label="1. Install via Homebrew"
+              command="brew install beevibe-ai/tap/beevibe-daemon"
+            />
+            <CommandBlock label="2. Register" command={`beevibe-daemon ${setupArgs}`} />
+            <CommandBlock label="3. Start (long-running)" command="beevibe-daemon start" />
+          </div>
+        ) : null}
+
+        {channel === "npx" ? (
+          <div className="space-y-2">
+            <CommandBlock
+              label="1. Register (downloads daemon on first run)"
+              command={`npx -y @beevibe/daemon@latest ${setupArgs}`}
+            />
+            <CommandBlock
+              label="2. Start (long-running)"
+              command="npx -y @beevibe/daemon@latest start"
+            />
+          </div>
+        ) : null}
+
+        {channel === "direct" ? (
+          <div className="space-y-2">
+            <p className="text-xs text-muted-foreground leading-relaxed">
+              Pick the binary that matches your platform from{" "}
+              <a
+                href="https://github.com/beevibe-ai/beevibe/releases/latest"
+                target="_blank"
+                rel="noreferrer noopener"
+                className="underline hover:text-foreground"
+              >
+                the latest GitHub release
+              </a>
+              {" "}— darwin-arm64, darwin-x64, linux-x64, or linux-arm64. Then:
+            </p>
+            <CommandBlock
+              label="1. Download (substitute your platform)"
+              command={
+                'curl -fsSL -o ~/.local/bin/beevibe-daemon \\\n' +
+                '  "https://github.com/beevibe-ai/beevibe/releases/latest/download/beevibe-daemon-darwin-arm64" \\\n' +
+                '  && chmod +x ~/.local/bin/beevibe-daemon'
+              }
+            />
+            <CommandBlock label="2. Register" command={`beevibe-daemon ${setupArgs}`} />
+            <CommandBlock label="3. Start (long-running)" command="beevibe-daemon start" />
+          </div>
+        ) : null}
       </div>
 
       <div


### PR DESCRIPTION
## Summary

Phase 7's third and final PR — wires the welcome wizard's install step to the daemon distribution channels published in v0.1.0 ([PR B](https://github.com/beevibe-ai/beevibe/pull/80) + downstream fixes).

Before: the wizard told users to run \`pnpm daemon setup …\`, which required cloning the repo. Useless for a freshly-deployed Railway tenant.

After: a tabbed UI offering brew, npx, or direct-download install paths, with OS-aware default tab selection.

## What's in this PR

\`packages/web/app/welcome/welcome-client.tsx\` — \`InstallStep\` refactored:

- Three install channels: **Homebrew** (Mac native), **npx** (universal), **Direct download** (advanced curl path)
- Default tab from \`navigator.userAgent\` (Mac → brew, else → npx; SSR safe via \`typeof navigator\`)
- Setup command auto-fills the user's actual api URL + \`bv_u_\` key so copy-paste produces a working command
- All channels point at the published v0.1.0 artifacts: \`beevibe-ai/tap\`, \`@beevibe/daemon@latest\`, and the GitHub release binaries
- Polling for daemon registration + "Continue" affordance unchanged

## Test plan

- [x] Typecheck clean
- [x] Lint clean (0 warnings)
- [x] Web tests pass (113 tests)
- [ ] Manual smoke: open \`/welcome\`, switch tabs, copy commands, verify each install path produces a daemon that registers
- [ ] CI green

## What's NOT in this PR (PR C follow-up)

1. **Railway template URL** — creating the actual Railway template is a manual dashboard step (not API-creatable). Need a Railway project owner to:
   - Visit https://railway.com/dashboard
   - "New project" → configure 3 services (api / scheduler / web) per \`infra/railway/*.railway.json\`
   - Add Postgres plugin
   - Save as template → get the template URL
2. **README badge swap** — replace the current placeholder URL (\`railway.com/new/template?repo=...\`) with the saved template URL once it exists. 1-line follow-up commit.
3. **End-to-end Railway smoke** against the new template — sign up → install daemon via brew (auto-selected on Mac) → first chat works.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)