### PR TITLE
deploy: release workflow auto-updates `release` branch on stable tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,26 @@ jobs:
           # don't get badged as "Latest release" on the repo page.
           prerelease: ${{ contains(github.ref_name, '-') }}
 
+  update-release-branch:
+    # `release` is a movable pointer to the latest stable tag's commit —
+    # the Railway template pins services to this branch instead of a
+    # specific tag, so new template clickers always get the freshest
+    # release at click time without us needing to re-publish the template.
+    # Existing Railway deploys are unaffected because the template's
+    # auto-deploy is off; users manually redeploy to pick up changes.
+    needs: build-binaries
+    if: "!contains(github.ref_name, '-')"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+      - name: Force-update release branch to this tag's commit
+        run: git push --force origin "${{ github.sha }}:refs/heads/release"
+
   npm-publish:
     needs: build-binaries
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a workflow job that force-pushes the `release` branch to point at each new stable tag's commit. This lets the Railway template pin services to `release` (a movable pointer) instead of a specific tag — the template URL stays evergreen.

## Mental model

| Channel | Versioning |
|---|---|
| Daemon (brew / npm / curl) | User explicitly pins; `@latest` dist-tag is the movable pointer |
| Server-side code (api / scheduler / web on Railway) | Template pins to `release` branch; user redeploys to opt in to updates |
| Git tags (v0.1.1, v0.1.2, …) | Single source of truth — drives both daemon publishes AND the `release` branch advance |

## What lands

A new `update-release-branch` job in `.github/workflows/release.yml`:
- Runs on stable tags only (`if: !contains(github.ref_name, '-')`) — pre-releases don't advance the pointer
- Permissions: `contents: write` (needed to force-push the branch)
- Force-pushes `github.sha` to `refs/heads/release`

The branch was bootstrapped at v0.1.1's commit manually (a one-shot `git push origin <sha>:refs/heads/release`); from v0.1.2 onward the workflow keeps it in sync.

## How this affects the Railway template

Template config (set up via Railway dashboard):
- Each service's "Branch" field = `release` (not `main`, not a specific tag)
- Auto-deploy: **off** (so existing tenants don't auto-redeploy on every release-branch advance)
- Result: clicking the template URL today → deploys current `release` HEAD → pinned to that commit going forward. Click on day 30 with v0.2.0 out → deploys v0.2.0's commit.

## Test plan

- [ ] CI green
- [ ] After merge: tag `v0.1.2` (small no-op release to validate) and confirm `release` branch advances to v0.1.2's commit

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)