### PR TITLE
deploy: point Railway badge at published template URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It's open source under the Apache-2.0 license. Everything is self-hosted: your P
 
 One-click cloud deploy:
 
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template?repo=https://github.com/beevibe-ai/beevibe)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/beevibe)
 
 This brings up `api` + `scheduler` + `web` services and a managed Postgres in one click. After the deploy finishes, set `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` in the project's Variables tab, then visit the web service's public URL to sign up. You'll be prompted to install the local daemon as part of the welcome flow.
 


### PR DESCRIPTION
## Summary

Phase 7's final piece. The README's "Deploy on Railway" badge now links to the **published Railway template** at https://railway.com/deploy/beevibe instead of the placeholder generic-deploy URL.

## What clicking the badge actually does now

1. Opens Railway's deploy page for the beevibe template
2. Railway prompts the user for `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` (only two required inputs — everything else is auto-resolved or has sensible defaults)
3. Provisions:
   - Postgres with pgvector
   - api service (Dockerfile.api, pinned to release branch, runs migrations via preDeployCommand)
   - scheduler service (Dockerfile.scheduler, background worker)
   - web service (Dockerfile.web, with NEXT_PUBLIC_BV_API_URL auto-pointed at the api domain)
4. Generates public domains for api + web
5. ~5 min later the user lands on a working sign-up page

## Why this took several follow-on PRs

The template setup surfaced two design constraints worth documenting:
- Railway templates capture the source repo URL **including the branch path** — pinning to a custom branch requires `github.com/owner/repo/tree/branchname` not just `github.com/owner/repo`. Branch overrides via service-settings UI don't propagate into the template.
- Postgres plugin variables (PGDATA, PGPORT, etc.) need explicit values in the source project to avoid being captured as "user must define" — the image-default fallback isn't visible to Railway's template export.

Both addressed in the template itself; no code changes required.

## Test plan

- [ ] CI green
- [ ] After merge: click the badge from a fresh Railway account, full deploy + sign-up flow works

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)