### PR TITLE
deploy: README — document Railway template post-deploy config step

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,30 @@ One-click cloud deploy:
 
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/beevibe)
 
-This brings up `api` + `scheduler` + `web` services and a managed Postgres in one click. After the deploy finishes, set `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` in the project's Variables tab, then visit the web service's public URL to sign up. You'll be prompted to install the local daemon as part of the welcome flow.
+This brings up `api` + `scheduler` + `web` services and a managed Postgres in one click.
 
-Self-host options:
+### Post-deploy setup (required)
+
+Railway templates don't currently propagate per-service "config-as-code file path" through the clone, so each of the three services starts off using Railpack auto-detection and fails to build the monorepo. After the initial deploy, do this **once per service**:
+
+1. Open the project on Railway
+2. Click into the service → **Settings**
+3. Scroll to **Config-as-code → Railway Config File** → click **Add File Path**
+4. Enter the path for that service and save:
+
+| Service | Config file path |
+|---|---|
+| `api` | `infra/railway/api.railway.json` |
+| `scheduler` | `infra/railway/scheduler.railway.json` |
+| `web` | `infra/railway/web.railway.json` |
+
+Saving triggers a redeploy. Each service now builds via its Dockerfile (instead of Railpack auto-detection) and comes up green in ~5 minutes.
+
+Then set `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` in the api + scheduler **Variables** tab (replace the `sk-replace-with-your-*-key` placeholders), redeploy those two services, and visit the web service's public URL to sign up. You'll be prompted to install the local daemon as part of the welcome flow.
+
+> If Railway later propagates config-as-code path through template clones, this manual step will go away. Tracked in [#88](https://github.com/beevibe-ai/beevibe/issues/88).
+
+### Self-host options
 
 - **Docker / docker-compose** — `git clone && docker compose up` against a tagged release (see [Self-hosting](#self-hosting) below).
 - **Manual** — `pnpm install && pnpm build && pnpm start` per service against your own Postgres.


### PR DESCRIPTION
## Summary

Documents the manual post-deploy step Railway template users need to perform — surfaced during end-to-end smoke of Phase 7.

## What's broken in Railway templates

Per-service \`Config-as-code → Railway Config File\` path doesn't propagate through template clones. Each cloned service starts with no config-as-code path → falls back to Railpack auto-detection → can't handle our pnpm workspace monorepo → build fails for all three services.

## What this PR adds

New \"Post-deploy setup (required)\" subsection under \"Deploy\" in the README. Steps the user through setting the config-as-code path for each of the three services after the initial deploy. Once set, each service redeploys via its Dockerfile and comes up green.

Path-to-service table:

| Service | Path |
|---|---|
| api | \`infra/railway/api.railway.json\` |
| scheduler | \`infra/railway/scheduler.railway.json\` |
| web | \`infra/railway/web.railway.json\` |

## Tracking

Linked to [#88](https://github.com/beevibe-ai/beevibe/issues/88), the issue that captures the Railway template limitation and alternative configurations to try (explicit Build/Start commands per service, monolithic railway.toml, etc.). When Railway fixes propagation or we find a cleaner workaround, that issue closes and the README section gets removed.

## Test plan

- [ ] CI green
- [ ] Click the Railway badge from a fresh account
- [ ] Follow the post-deploy steps as documented
- [ ] All three services come up green

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)