### PR TITLE
landing: point Railway CTAs at the published template URL (#87)

### DIFF
--- a/infra/landing/index.html
+++ b/infra/landing/index.html
@@ -106,7 +106,7 @@
         <a href="https://github.com/beevibe-ai/beevibe" class="hover:text-foreground transition-colors">GitHub</a>
       </nav>
       <a
-        href="https://railway.com/new/template?repo=https://github.com/beevibe-ai/beevibe"
+        href="https://railway.com/deploy/beevibe"
         class="inline-flex items-center gap-1.5 h-9 px-4 rounded bg-primary text-primary-foreground text-sm font-semibold hover:opacity-90 transition-opacity"
       >
         Deploy
@@ -135,7 +135,7 @@
       </p>
       <div class="flex flex-wrap items-center gap-3">
         <a
-          href="https://railway.com/new/template?repo=https://github.com/beevibe-ai/beevibe"
+          href="https://railway.com/deploy/beevibe"
           class="inline-flex items-center gap-2 h-11 px-5 rounded bg-primary text-primary-foreground text-sm font-semibold hover:opacity-90 transition-opacity"
         >
           Deploy on Railway
@@ -265,7 +265,7 @@
       </p>
       <div class="flex flex-wrap items-center justify-center gap-3">
         <a
-          href="https://railway.com/new/template?repo=https://github.com/beevibe-ai/beevibe"
+          href="https://railway.com/deploy/beevibe"
           class="inline-flex items-center gap-2 h-11 px-5 rounded bg-primary text-primary-foreground text-sm font-semibold hover:opacity-90 transition-opacity"
         >
           Deploy on Railway


### PR DESCRIPTION
## Summary

- Updates three Railway CTAs in `infra/landing/index.html` to point at the published template URL (`railway.com/deploy/beevibe`) instead of the old placeholder (`railway.com/new/template?repo=...`)
- Brings the landing in sync with [#87](https://github.com/beevibe-ai/beevibe/pull/87) which made the same swap in the README

## Why

[#87](https://github.com/beevibe-ai/beevibe/pull/87) replaced the README's Railway badge URL with the actual published template. The landing page had three copies of the old URL (header CTA, hero CTA, closing CTA) that still pointed at the generic-deploy placeholder. Clicking any of them sent users through Railway's legacy fork-and-deploy flow instead of the streamlined template prompt for `ANTHROPIC_API_KEY` + `OPENAI_API_KEY`.

## Already deployed

Production at https://beevibe.ai already serves the new URL — re-deployed via `vercel --prod` from `infra/landing/` before opening this PR. Verified:

```
$ curl -s https://beevibe.ai | grep -o 'railway.com/[^"]*' | sort -u
railway.com/deploy/beevibe
```

## Test plan

- [ ] CI green
- [ ] Click any of the three Deploy CTAs on https://beevibe.ai — should land on Railway's template prompt for the two API keys, not the generic-deploy fork flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)