### PR TITLE
frontend fixes — clickable agent sessions + restore api typecheck

### DIFF
--- a/migrations/1780400000000_add-usage-window-index.sql
+++ b/migrations/1780400000000_add-usage-window-index.sql
@@ -1,0 +1,18 @@
+-- Partial index for USAGE_WINDOW_SQL (dashboard usage rollup).
+--
+-- The query in `packages/api/src/views/dashboard.ts` is:
+--   WHERE s.usage IS NOT NULL
+--     AND s.completed_at >= NOW() - make_interval(days => $1::int * 2)
+--
+-- Existing `idx_session_status_completed` is keyed on (status, completed_at)
+-- so it doesn't apply — the usage query has no status predicate (succeeded,
+-- failed, and even some cancelled sessions can have usage attached).
+--
+-- The partial index narrows to rows that have telemetry, which is the
+-- only set the dashboard cares about; on workspaces where most sessions
+-- predate M9.8 (no usage column populated) this also keeps the index
+-- compact.
+
+CREATE INDEX IF NOT EXISTS idx_session_usage_completed
+  ON session(completed_at DESC)
+  WHERE usage IS NOT NULL;

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -47,7 +47,7 @@
     "@types/node": "^20.16.0",
     "@types/pg": "^8.11.10",
     "@types/supertest": "^6.0.2",
-    "@types/ws": "^8.5.13",
+    "@types/ws": "^8.18.1",
     "pg": "^8.13.0",
     "supertest": "^7.0.0"
   }

--- a/packages/api/src/runtime/router.ts
+++ b/packages/api/src/runtime/router.ts
@@ -457,7 +457,7 @@ async function composeDispatchPayload(
       agent.runtime_config.system_prompt_addition,
       briefing.systemPromptAppend,
       {
-        appendChatDirectives: isChat,
+        sessionKind: isChat ? "chat" : "task",
         appendOnboardingDirectives: isOnboarding,
         extra: teamRouting,
       },

--- a/packages/api/src/views/dashboard.test.ts
+++ b/packages/api/src/views/dashboard.test.ts
@@ -189,7 +189,7 @@ describe("getDashboardSummary", () => {
     });
   });
 
-  it("fires all 7 queries in parallel (single Promise.all)", async () => {
+  it("fires all 6 queries in parallel (single Promise.all)", async () => {
     const calls: number[] = [];
     let next = 0;
     const query = vi.fn(async (sql: unknown) => {
@@ -203,22 +203,50 @@ describe("getDashboardSummary", () => {
       if (sqlText.includes("FROM days")) return { rows: makeTrendRows() };
       if (sqlText.includes("FROM agent")) return { rows: [] };
       if (sqlText.includes("blocked', 'failed'")) return { rows: [] };
-      // Usage current + prior — empty rows are fine for this dispatch test.
       if (sqlText.includes("usage IS NOT NULL")) return { rows: [] };
       return { rows: [] };
     });
     const pool = { query } as unknown as Pool;
     await getDashboardSummary(pool);
-    expect(calls).toEqual([0, 1, 2, 3, 4, 5, 6]); // dispatched in order, all together
-    expect(query).toHaveBeenCalledTimes(7);
+    expect(calls).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(query).toHaveBeenCalledTimes(6);
   });
 });
 
+// Helper: build a UsageWindowRow with sensible defaults so test bodies
+// stay focused on the field that's actually being exercised.
+function row(
+  bucket: "current" | "prior",
+  overrides: Partial<{
+    agent_id: string;
+    agent_label: string;
+    cost: string;
+    input_tokens: string;
+    output_tokens: string;
+    cache_creation: string;
+    cache_read: string;
+    sessions: string;
+  }> = {},
+) {
+  return {
+    agent_id: "agt_x",
+    agent_label: "x",
+    bucket,
+    cost: "0",
+    input_tokens: "0",
+    output_tokens: "0",
+    cache_creation: "0",
+    cache_read: "0",
+    sessions: "1",
+    ...overrides,
+  };
+}
+
 describe("buildUsageSummary", () => {
-  it("aggregates per-agent rows into window totals + per_agent list", () => {
+  it("splits rows by bucket: current → totals + per_agent, prior → cost only", () => {
     const summary = buildUsageSummary(
       [
-        {
+        row("current", {
           agent_id: "agt_alice",
           agent_label: "alice",
           cost: "0.50",
@@ -227,19 +255,17 @@ describe("buildUsageSummary", () => {
           cache_creation: "200",
           cache_read: "1700",
           sessions: "5",
-        },
-        {
+        }),
+        row("current", {
           agent_id: "agt_bob",
           agent_label: "bob",
           cost: "0.10",
           input_tokens: "10",
           output_tokens: "50",
-          cache_creation: "0",
           cache_read: "100",
-          sessions: "1",
-        },
+        }),
+        row("prior", { cost: "0.40" }),
       ],
-      [{ prior_cost: "0.40" }],
       7,
     );
 
@@ -250,107 +276,73 @@ describe("buildUsageSummary", () => {
     expect(summary.total_cache_creation_tokens).toBe(200);
     expect(summary.total_cache_read_tokens).toBe(1800);
     expect(summary.total_sessions).toBe(6);
+    expect(summary.prior_cost_usd).toBeCloseTo(0.4, 5);
     expect(summary.per_agent).toHaveLength(2);
-    // SQL pre-sorts by cost desc; the builder preserves order.
+    // SQL pre-sorts current by cost desc; the builder preserves order.
     expect(summary.per_agent[0]!.agent_label).toBe("alice");
     expect(summary.per_agent[0]!.cost_usd).toBeCloseTo(0.5, 5);
   });
 
-  it("computes cache_hit_ratio against total_input (input + creation + read), not just fresh input", () => {
-    // 1700 cache_read / (100 + 200 + 1700) = 1700/2000 = 0.85
+  it("sums multiple prior rows into prior_cost_usd", () => {
+    // Prior can span multiple agents — the SQL groups by (agent, bucket).
+    const summary = buildUsageSummary(
+      [row("prior", { cost: "0.30" }), row("prior", { cost: "0.10" })],
+      7,
+    );
+    expect(summary.prior_cost_usd).toBeCloseTo(0.4, 5);
+  });
+
+  it("computes cache_hit_ratio against total_input via the shared helper", () => {
+    // 1700 cache_read / (100 + 200 + 1700) = 0.85
     const summary = buildUsageSummary(
       [
-        {
-          agent_id: "agt_x",
-          agent_label: "x",
-          cost: "0.10",
+        row("current", {
           input_tokens: "100",
           output_tokens: "50",
           cache_creation: "200",
           cache_read: "1700",
-          sessions: "1",
-        },
+        }),
       ],
-      [{ prior_cost: "0" }],
       7,
     );
     expect(summary.cache_hit_ratio).toBeCloseTo(0.85, 5);
   });
 
   it("guards cache_hit_ratio against divide-by-zero (no input in window)", () => {
-    const summary = buildUsageSummary([], [{ prior_cost: "0" }], 7);
+    const summary = buildUsageSummary([], 7);
     expect(summary.cache_hit_ratio).toBe(0);
     expect(Number.isFinite(summary.cache_hit_ratio)).toBe(true);
   });
 
-  it("computes cost_change_percent vs prior window (rounded int)", () => {
-    // current 1.50, prior 1.00 → +50%
+  it("computes cost_change_percent vs prior window (rounded int, both directions)", () => {
     const up = buildUsageSummary(
-      [
-        {
-          agent_id: "agt_x",
-          agent_label: "x",
-          cost: "1.50",
-          input_tokens: "0",
-          output_tokens: "0",
-          cache_creation: "0",
-          cache_read: "0",
-          sessions: "1",
-        },
-      ],
-      [{ prior_cost: "1.00" }],
+      [row("current", { cost: "1.50" }), row("prior", { cost: "1.00" })],
       7,
     );
     expect(up.cost_change_percent).toBe(50);
 
-    // current 0.50, prior 1.00 → -50%
     const down = buildUsageSummary(
-      [
-        {
-          agent_id: "agt_x",
-          agent_label: "x",
-          cost: "0.50",
-          input_tokens: "0",
-          output_tokens: "0",
-          cache_creation: "0",
-          cache_read: "0",
-          sessions: "1",
-        },
-      ],
-      [{ prior_cost: "1.00" }],
+      [row("current", { cost: "0.50" }), row("prior", { cost: "1.00" })],
       7,
     );
     expect(down.cost_change_percent).toBe(-50);
   });
 
   it("saturates cost_change_percent at +100 when prior was zero and current is non-zero", () => {
-    const summary = buildUsageSummary(
-      [
-        {
-          agent_id: "agt_x",
-          agent_label: "x",
-          cost: "0.05",
-          input_tokens: "0",
-          output_tokens: "0",
-          cache_creation: "0",
-          cache_read: "0",
-          sessions: "1",
-        },
-      ],
-      [{ prior_cost: "0" }],
-      7,
-    );
+    const summary = buildUsageSummary([row("current", { cost: "0.05" })], 7);
     expect(summary.cost_change_percent).toBe(100);
   });
 
   it("returns cost_change_percent = 0 when both windows are zero", () => {
-    const summary = buildUsageSummary([], [{ prior_cost: "0" }], 7);
+    const summary = buildUsageSummary([], 7);
     expect(summary.cost_change_percent).toBe(0);
   });
 
-  it("handles missing prior row (defaults prior_cost to 0)", () => {
-    const summary = buildUsageSummary([], [], 7);
-    expect(summary.prior_cost_usd).toBe(0);
-    expect(summary.cost_change_percent).toBe(0);
+  it("handles a row set with only prior bucket (no current sessions)", () => {
+    const summary = buildUsageSummary([row("prior", { cost: "0.50" })], 7);
+    expect(summary.prior_cost_usd).toBeCloseTo(0.5, 5);
+    expect(summary.total_cost_usd).toBe(0);
+    expect(summary.per_agent).toEqual([]);
+    expect(summary.cost_change_percent).toBe(-100); // 0.50 → 0 prior→current
   });
 });

--- a/packages/api/src/views/dashboard.test.ts
+++ b/packages/api/src/views/dashboard.test.ts
@@ -12,7 +12,7 @@
  */
 import { describe, it, expect, vi } from "vitest";
 import type { Pool } from "@beevibe/core/adapters/postgres";
-import { getDashboardSummary } from "./dashboard.js";
+import { buildUsageSummary, getDashboardSummary } from "./dashboard.js";
 import { makeMockPool } from "./test-helpers.js";
 
 function makeKpiTrendRows(): unknown[] {
@@ -189,7 +189,7 @@ describe("getDashboardSummary", () => {
     });
   });
 
-  it("fires all 5 queries in parallel (single Promise.all)", async () => {
+  it("fires all 7 queries in parallel (single Promise.all)", async () => {
     const calls: number[] = [];
     let next = 0;
     const query = vi.fn(async (sql: unknown) => {
@@ -203,11 +203,154 @@ describe("getDashboardSummary", () => {
       if (sqlText.includes("FROM days")) return { rows: makeTrendRows() };
       if (sqlText.includes("FROM agent")) return { rows: [] };
       if (sqlText.includes("blocked', 'failed'")) return { rows: [] };
+      // Usage current + prior — empty rows are fine for this dispatch test.
+      if (sqlText.includes("usage IS NOT NULL")) return { rows: [] };
       return { rows: [] };
     });
     const pool = { query } as unknown as Pool;
     await getDashboardSummary(pool);
-    expect(calls).toEqual([0, 1, 2, 3, 4]); // dispatched in order, all together
-    expect(query).toHaveBeenCalledTimes(5);
+    expect(calls).toEqual([0, 1, 2, 3, 4, 5, 6]); // dispatched in order, all together
+    expect(query).toHaveBeenCalledTimes(7);
+  });
+});
+
+describe("buildUsageSummary", () => {
+  it("aggregates per-agent rows into window totals + per_agent list", () => {
+    const summary = buildUsageSummary(
+      [
+        {
+          agent_id: "agt_alice",
+          agent_label: "alice",
+          cost: "0.50",
+          input_tokens: "100",
+          output_tokens: "500",
+          cache_creation: "200",
+          cache_read: "1700",
+          sessions: "5",
+        },
+        {
+          agent_id: "agt_bob",
+          agent_label: "bob",
+          cost: "0.10",
+          input_tokens: "10",
+          output_tokens: "50",
+          cache_creation: "0",
+          cache_read: "100",
+          sessions: "1",
+        },
+      ],
+      [{ prior_cost: "0.40" }],
+      7,
+    );
+
+    expect(summary.window_days).toBe(7);
+    expect(summary.total_cost_usd).toBeCloseTo(0.6, 5);
+    expect(summary.total_input_tokens).toBe(110);
+    expect(summary.total_output_tokens).toBe(550);
+    expect(summary.total_cache_creation_tokens).toBe(200);
+    expect(summary.total_cache_read_tokens).toBe(1800);
+    expect(summary.total_sessions).toBe(6);
+    expect(summary.per_agent).toHaveLength(2);
+    // SQL pre-sorts by cost desc; the builder preserves order.
+    expect(summary.per_agent[0]!.agent_label).toBe("alice");
+    expect(summary.per_agent[0]!.cost_usd).toBeCloseTo(0.5, 5);
+  });
+
+  it("computes cache_hit_ratio against total_input (input + creation + read), not just fresh input", () => {
+    // 1700 cache_read / (100 + 200 + 1700) = 1700/2000 = 0.85
+    const summary = buildUsageSummary(
+      [
+        {
+          agent_id: "agt_x",
+          agent_label: "x",
+          cost: "0.10",
+          input_tokens: "100",
+          output_tokens: "50",
+          cache_creation: "200",
+          cache_read: "1700",
+          sessions: "1",
+        },
+      ],
+      [{ prior_cost: "0" }],
+      7,
+    );
+    expect(summary.cache_hit_ratio).toBeCloseTo(0.85, 5);
+  });
+
+  it("guards cache_hit_ratio against divide-by-zero (no input in window)", () => {
+    const summary = buildUsageSummary([], [{ prior_cost: "0" }], 7);
+    expect(summary.cache_hit_ratio).toBe(0);
+    expect(Number.isFinite(summary.cache_hit_ratio)).toBe(true);
+  });
+
+  it("computes cost_change_percent vs prior window (rounded int)", () => {
+    // current 1.50, prior 1.00 → +50%
+    const up = buildUsageSummary(
+      [
+        {
+          agent_id: "agt_x",
+          agent_label: "x",
+          cost: "1.50",
+          input_tokens: "0",
+          output_tokens: "0",
+          cache_creation: "0",
+          cache_read: "0",
+          sessions: "1",
+        },
+      ],
+      [{ prior_cost: "1.00" }],
+      7,
+    );
+    expect(up.cost_change_percent).toBe(50);
+
+    // current 0.50, prior 1.00 → -50%
+    const down = buildUsageSummary(
+      [
+        {
+          agent_id: "agt_x",
+          agent_label: "x",
+          cost: "0.50",
+          input_tokens: "0",
+          output_tokens: "0",
+          cache_creation: "0",
+          cache_read: "0",
+          sessions: "1",
+        },
+      ],
+      [{ prior_cost: "1.00" }],
+      7,
+    );
+    expect(down.cost_change_percent).toBe(-50);
+  });
+
+  it("saturates cost_change_percent at +100 when prior was zero and current is non-zero", () => {
+    const summary = buildUsageSummary(
+      [
+        {
+          agent_id: "agt_x",
+          agent_label: "x",
+          cost: "0.05",
+          input_tokens: "0",
+          output_tokens: "0",
+          cache_creation: "0",
+          cache_read: "0",
+          sessions: "1",
+        },
+      ],
+      [{ prior_cost: "0" }],
+      7,
+    );
+    expect(summary.cost_change_percent).toBe(100);
+  });
+
+  it("returns cost_change_percent = 0 when both windows are zero", () => {
+    const summary = buildUsageSummary([], [{ prior_cost: "0" }], 7);
+    expect(summary.cost_change_percent).toBe(0);
+  });
+
+  it("handles missing prior row (defaults prior_cost to 0)", () => {
+    const summary = buildUsageSummary([], [], 7);
+    expect(summary.prior_cost_usd).toBe(0);
+    expect(summary.cost_change_percent).toBe(0);
   });
 });

--- a/packages/api/src/views/dashboard.ts
+++ b/packages/api/src/views/dashboard.ts
@@ -8,6 +8,7 @@
 
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import type { HierarchyLevel, TaskStatus } from "@beevibe/core";
+import { computeCacheHitRatio } from "./format.js";
 import type {
   DashboardSummary,
   KpiData,
@@ -53,24 +54,20 @@ interface KpiTrendRow {
 }
 
 /**
- * Per-agent row from the current-window usage aggregate. All numeric
- * fields are numeric strings from pg (driver doesn't coerce SUM /
- * COUNT to JS Number to preserve precision for large values); the
- * builder converts them with Number(...).
+ * Per-agent per-bucket row from `USAGE_WINDOW_SQL`. Numeric fields
+ * arrive as strings from pg (driver doesn't coerce SUM / COUNT to JS
+ * Number to preserve precision); the builder converts with `Number()`.
  */
-interface UsageAgentRow {
+interface UsageWindowRow {
   agent_id: string;
   agent_label: string;
+  bucket: "current" | "prior";
   cost: string;
   input_tokens: string;
   output_tokens: string;
   cache_creation: string;
   cache_read: string;
   sessions: string;
-}
-
-interface UsagePriorRow {
-  prior_cost: string;
 }
 
 const STATUS_COUNT_SQL = /* sql */ `
@@ -167,51 +164,53 @@ ORDER BY days.d ASC
 `;
 
 /**
- * Per-agent cost + token rollup for the current usage window. Filters
- * out rows where `usage` is null (older sessions captured before M9.8
- * have no usage record) so they don't contribute zero rows that
- * dilute the per-agent ordering.
+ * Per-agent cost + token rollup spanning the current AND prior windows
+ * in one round-trip. Each row carries a `bucket` discriminator so the
+ * builder can split between the current-window per-agent breakdown and
+ * the prior-window cost total used for the delta arrow.
  *
- * Window length comes from $1 as days. Driver passes interval via
- * `make_interval` so we don't string-concatenate (parameterized).
+ * Window length is $1 days. Both windows are equally sized; prior is
+ * [now - 2*days, now - days), current is [now - days, now]. The single
+ * WHERE clause covers both via `>= NOW() - make_interval(days => $1::int * 2)`.
  *
- * `cost` is cast to `numeric` to preserve cent-level precision; the
- * driver returns it as a string and the builder converts with
- * `Number()` (safe for sub-million-dollar totals).
+ * LIMIT bounds payload — far past the dashboard's top-N render, but
+ * defensive against bursts of one-off agents that would otherwise
+ * inflate the network transfer for a list nobody reads.
+ *
+ * Index dependency: `idx_session_usage_completed` (partial,
+ * `WHERE usage IS NOT NULL`) — migration 1780400000000.
  */
-const USAGE_CURRENT_SQL = /* sql */ `
+const USAGE_WINDOW_SQL = /* sql */ `
+WITH bucketed AS (
+  SELECT
+    s.agent_id,
+    a.name AS agent_label,
+    s.usage,
+    CASE
+      WHEN s.completed_at >= NOW() - make_interval(days => $1::int) THEN 'current'
+      ELSE 'prior'
+    END AS bucket
+  FROM session s
+  JOIN agent a ON a.id = s.agent_id
+  WHERE s.usage IS NOT NULL
+    AND s.completed_at >= NOW() - make_interval(days => $1::int * 2)
+)
 SELECT
-  s.agent_id,
-  a.name AS agent_label,
-  COALESCE(SUM((s.usage->>'cost_usd')::numeric), 0)::text AS cost,
-  COALESCE(SUM((s.usage->>'input_tokens')::int), 0)::text AS input_tokens,
-  COALESCE(SUM((s.usage->>'output_tokens')::int), 0)::text AS output_tokens,
-  COALESCE(SUM((s.usage->>'cache_creation_input_tokens')::int), 0)::text AS cache_creation,
-  COALESCE(SUM((s.usage->>'cache_read_input_tokens')::int), 0)::text AS cache_read,
+  agent_id,
+  agent_label,
+  bucket,
+  COALESCE(SUM((usage->>'cost_usd')::numeric), 0)::text AS cost,
+  COALESCE(SUM((usage->>'input_tokens')::int), 0)::text AS input_tokens,
+  COALESCE(SUM((usage->>'output_tokens')::int), 0)::text AS output_tokens,
+  COALESCE(SUM((usage->>'cache_creation_input_tokens')::int), 0)::text AS cache_creation,
+  COALESCE(SUM((usage->>'cache_read_input_tokens')::int), 0)::text AS cache_read,
   COUNT(*)::text AS sessions
-FROM session s
-JOIN agent a ON a.id = s.agent_id
-WHERE s.usage IS NOT NULL
-  AND s.completed_at >= NOW() - make_interval(days => $1::int)
-GROUP BY s.agent_id, a.name
-ORDER BY SUM((s.usage->>'cost_usd')::numeric) DESC NULLS LAST
-`;
-
-/**
- * Prior-window total cost only, used for the cost_change_percent
- * delta. No per-agent breakdown needed for prior — the UI only shows
- * the top-line "vs prior" arrow, not "agent X spent more last week."
- *
- * Prior window = [now - 2*days, now - days), an equally-sized window
- * immediately preceding the current one.
- */
-const USAGE_PRIOR_SQL = /* sql */ `
-SELECT
-  COALESCE(SUM((s.usage->>'cost_usd')::numeric), 0)::text AS prior_cost
-FROM session s
-WHERE s.usage IS NOT NULL
-  AND s.completed_at >= NOW() - make_interval(days => $1::int * 2)
-  AND s.completed_at <  NOW() - make_interval(days => $1::int)
+FROM bucketed
+GROUP BY agent_id, agent_label, bucket
+ORDER BY
+  CASE bucket WHEN 'current' THEN 0 ELSE 1 END,
+  SUM((usage->>'cost_usd')::numeric) DESC NULLS LAST
+LIMIT 100
 `;
 
 const TREND_WINDOW_DAYS = 7;
@@ -246,16 +245,14 @@ export async function getDashboardSummary(pool: Pool): Promise<DashboardSummary>
     trendResult,
     attentionResult,
     kpiTrendResult,
-    usageCurrentResult,
-    usagePriorResult,
+    usageResult,
   ] = await Promise.all([
     pool.query<StatusCountRow>(STATUS_COUNT_SQL),
     pool.query<FleetCountRow>(FLEET_SQL),
     pool.query<TrendRow>(TREND_SQL, [TREND_WINDOW_DAYS * 2]),
     pool.query<AttentionRow>(ATTENTION_SQL, [ATTENTION_LIMIT]),
     pool.query<KpiTrendRow>(KPI_TREND_SQL, [TREND_WINDOW_DAYS]),
-    pool.query<UsageAgentRow>(USAGE_CURRENT_SQL, [TREND_WINDOW_DAYS]),
-    pool.query<UsagePriorRow>(USAGE_PRIOR_SQL, [TREND_WINDOW_DAYS]),
+    pool.query<UsageWindowRow>(USAGE_WINDOW_SQL, [TREND_WINDOW_DAYS]),
   ]);
 
   const status_total = statusResult.rows.reduce((s, r) => s + Number(r.count), 0);
@@ -314,8 +311,7 @@ export async function getDashboardSummary(pool: Pool): Promise<DashboardSummary>
   const kpis: KpiData[] = buildKpis(kpiTrendResult.rows, statusResult.rows, fleet_active);
 
   const usage_summary: UsageSummaryData = buildUsageSummary(
-    usageCurrentResult.rows,
-    usagePriorResult.rows,
+    usageResult.rows,
     TREND_WINDOW_DAYS,
   );
 
@@ -376,22 +372,21 @@ function buildKpis(
 }
 
 /**
- * Aggregate the per-agent + prior-window rows into the wire-shape
- * UsageSummaryData. Pure function so the SQL stays narrow and the
- * shape contract is testable without a database.
+ * Aggregate per-agent per-bucket rows into the wire-shape
+ * UsageSummaryData. Pure function — testable without a database.
  *
  * Delta semantics match the trend block above:
  *   - prior > 0  → round((current - prior) / prior * 100)
  *   - prior == 0 and current > 0 → +100 (saturate, don't divide by 0)
  *   - prior == 0 and current == 0 → 0 (no signal)
  *
- * Weighted cache_hit_ratio: total_cache_read / total_input across the
- * whole window. NOT a simple mean of per-session ratios — those would
- * over-weight tiny sessions. Zero when total_input is zero.
+ * Per-agent is built from `bucket === 'current'` rows; SQL pre-sorts
+ * those by cost DESC so the array is render-ready. Prior rows are
+ * summed for the cost-delta total only (no per-agent — UI doesn't
+ * surface "agent X spent more last week").
  */
 export function buildUsageSummary(
-  currentRows: UsageAgentRow[],
-  priorRows: UsagePriorRow[],
+  rows: UsageWindowRow[],
   windowDays: number,
 ): UsageSummaryData {
   let total_cost_usd = 0;
@@ -400,10 +395,15 @@ export function buildUsageSummary(
   let total_cache_creation_tokens = 0;
   let total_cache_read_tokens = 0;
   let total_sessions = 0;
+  let prior_cost_usd = 0;
   const per_agent: UsageAgentBreakdown[] = [];
 
-  for (const r of currentRows) {
+  for (const r of rows) {
     const cost = Number(r.cost);
+    if (r.bucket === "prior") {
+      prior_cost_usd += cost;
+      continue;
+    }
     const input = Number(r.input_tokens);
     const output = Number(r.output_tokens);
     const cacheCreation = Number(r.cache_creation);
@@ -423,17 +423,12 @@ export function buildUsageSummary(
     });
   }
 
-  // total_input_tokens is the union of fresh + cache_creation + cache_read
-  // (the same denominator used in SessionUsageDisplay). Without summing
-  // all three, we'd compute cache_hit_ratio against only the fresh slice.
-  const total_input_for_ratio =
-    total_input_tokens + total_cache_creation_tokens + total_cache_read_tokens;
-  const cache_hit_ratio =
-    total_input_for_ratio > 0
-      ? total_cache_read_tokens / total_input_for_ratio
-      : 0;
+  const cache_hit_ratio = computeCacheHitRatio({
+    input: total_input_tokens,
+    cacheCreation: total_cache_creation_tokens,
+    cacheRead: total_cache_read_tokens,
+  });
 
-  const prior_cost_usd = Number(priorRows[0]?.prior_cost ?? 0);
   const cost_change_percent =
     prior_cost_usd === 0
       ? total_cost_usd === 0

--- a/packages/api/src/views/dashboard.ts
+++ b/packages/api/src/views/dashboard.ts
@@ -17,6 +17,8 @@ import type {
   TrendDayData,
   AttentionData,
   LegendBucket,
+  UsageAgentBreakdown,
+  UsageSummaryData,
 } from "./types.js";
 
 interface StatusCountRow {
@@ -48,6 +50,27 @@ interface KpiTrendRow {
   in_review: string;
   completed_today: string;
   blocked: string;
+}
+
+/**
+ * Per-agent row from the current-window usage aggregate. All numeric
+ * fields are numeric strings from pg (driver doesn't coerce SUM /
+ * COUNT to JS Number to preserve precision for large values); the
+ * builder converts them with Number(...).
+ */
+interface UsageAgentRow {
+  agent_id: string;
+  agent_label: string;
+  cost: string;
+  input_tokens: string;
+  output_tokens: string;
+  cache_creation: string;
+  cache_read: string;
+  sessions: string;
+}
+
+interface UsagePriorRow {
+  prior_cost: string;
 }
 
 const STATUS_COUNT_SQL = /* sql */ `
@@ -143,6 +166,54 @@ LEFT JOIN blocked_per_day  b ON b.day = days.d
 ORDER BY days.d ASC
 `;
 
+/**
+ * Per-agent cost + token rollup for the current usage window. Filters
+ * out rows where `usage` is null (older sessions captured before M9.8
+ * have no usage record) so they don't contribute zero rows that
+ * dilute the per-agent ordering.
+ *
+ * Window length comes from $1 as days. Driver passes interval via
+ * `make_interval` so we don't string-concatenate (parameterized).
+ *
+ * `cost` is cast to `numeric` to preserve cent-level precision; the
+ * driver returns it as a string and the builder converts with
+ * `Number()` (safe for sub-million-dollar totals).
+ */
+const USAGE_CURRENT_SQL = /* sql */ `
+SELECT
+  s.agent_id,
+  a.name AS agent_label,
+  COALESCE(SUM((s.usage->>'cost_usd')::numeric), 0)::text AS cost,
+  COALESCE(SUM((s.usage->>'input_tokens')::int), 0)::text AS input_tokens,
+  COALESCE(SUM((s.usage->>'output_tokens')::int), 0)::text AS output_tokens,
+  COALESCE(SUM((s.usage->>'cache_creation_input_tokens')::int), 0)::text AS cache_creation,
+  COALESCE(SUM((s.usage->>'cache_read_input_tokens')::int), 0)::text AS cache_read,
+  COUNT(*)::text AS sessions
+FROM session s
+JOIN agent a ON a.id = s.agent_id
+WHERE s.usage IS NOT NULL
+  AND s.completed_at >= NOW() - make_interval(days => $1::int)
+GROUP BY s.agent_id, a.name
+ORDER BY SUM((s.usage->>'cost_usd')::numeric) DESC NULLS LAST
+`;
+
+/**
+ * Prior-window total cost only, used for the cost_change_percent
+ * delta. No per-agent breakdown needed for prior — the UI only shows
+ * the top-line "vs prior" arrow, not "agent X spent more last week."
+ *
+ * Prior window = [now - 2*days, now - days), an equally-sized window
+ * immediately preceding the current one.
+ */
+const USAGE_PRIOR_SQL = /* sql */ `
+SELECT
+  COALESCE(SUM((s.usage->>'cost_usd')::numeric), 0)::text AS prior_cost
+FROM session s
+WHERE s.usage IS NOT NULL
+  AND s.completed_at >= NOW() - make_interval(days => $1::int * 2)
+  AND s.completed_at <  NOW() - make_interval(days => $1::int)
+`;
+
 const TREND_WINDOW_DAYS = 7;
 const ATTENTION_LIMIT = 8;
 
@@ -169,14 +240,23 @@ function legendBucket(status: TaskStatus): LegendBucket {
 }
 
 export async function getDashboardSummary(pool: Pool): Promise<DashboardSummary> {
-  const [statusResult, fleetResult, trendResult, attentionResult, kpiTrendResult] =
-    await Promise.all([
-      pool.query<StatusCountRow>(STATUS_COUNT_SQL),
-      pool.query<FleetCountRow>(FLEET_SQL),
-      pool.query<TrendRow>(TREND_SQL, [TREND_WINDOW_DAYS * 2]),
-      pool.query<AttentionRow>(ATTENTION_SQL, [ATTENTION_LIMIT]),
-      pool.query<KpiTrendRow>(KPI_TREND_SQL, [TREND_WINDOW_DAYS]),
-    ]);
+  const [
+    statusResult,
+    fleetResult,
+    trendResult,
+    attentionResult,
+    kpiTrendResult,
+    usageCurrentResult,
+    usagePriorResult,
+  ] = await Promise.all([
+    pool.query<StatusCountRow>(STATUS_COUNT_SQL),
+    pool.query<FleetCountRow>(FLEET_SQL),
+    pool.query<TrendRow>(TREND_SQL, [TREND_WINDOW_DAYS * 2]),
+    pool.query<AttentionRow>(ATTENTION_SQL, [ATTENTION_LIMIT]),
+    pool.query<KpiTrendRow>(KPI_TREND_SQL, [TREND_WINDOW_DAYS]),
+    pool.query<UsageAgentRow>(USAGE_CURRENT_SQL, [TREND_WINDOW_DAYS]),
+    pool.query<UsagePriorRow>(USAGE_PRIOR_SQL, [TREND_WINDOW_DAYS]),
+  ]);
 
   const status_total = statusResult.rows.reduce((s, r) => s + Number(r.count), 0);
   const status_breakdown: StatusBreakdownData[] = statusResult.rows
@@ -233,6 +313,12 @@ export async function getDashboardSummary(pool: Pool): Promise<DashboardSummary>
 
   const kpis: KpiData[] = buildKpis(kpiTrendResult.rows, statusResult.rows, fleet_active);
 
+  const usage_summary: UsageSummaryData = buildUsageSummary(
+    usageCurrentResult.rows,
+    usagePriorResult.rows,
+    TREND_WINDOW_DAYS,
+  );
+
   return {
     kpis,
     status_breakdown,
@@ -246,6 +332,7 @@ export async function getDashboardSummary(pool: Pool): Promise<DashboardSummary>
     trend_total,
     trend_change_percent,
     attention,
+    usage_summary,
   };
 }
 
@@ -286,4 +373,87 @@ function buildKpis(
       trend: trend("blocked"),
     },
   ];
+}
+
+/**
+ * Aggregate the per-agent + prior-window rows into the wire-shape
+ * UsageSummaryData. Pure function so the SQL stays narrow and the
+ * shape contract is testable without a database.
+ *
+ * Delta semantics match the trend block above:
+ *   - prior > 0  → round((current - prior) / prior * 100)
+ *   - prior == 0 and current > 0 → +100 (saturate, don't divide by 0)
+ *   - prior == 0 and current == 0 → 0 (no signal)
+ *
+ * Weighted cache_hit_ratio: total_cache_read / total_input across the
+ * whole window. NOT a simple mean of per-session ratios — those would
+ * over-weight tiny sessions. Zero when total_input is zero.
+ */
+export function buildUsageSummary(
+  currentRows: UsageAgentRow[],
+  priorRows: UsagePriorRow[],
+  windowDays: number,
+): UsageSummaryData {
+  let total_cost_usd = 0;
+  let total_input_tokens = 0;
+  let total_output_tokens = 0;
+  let total_cache_creation_tokens = 0;
+  let total_cache_read_tokens = 0;
+  let total_sessions = 0;
+  const per_agent: UsageAgentBreakdown[] = [];
+
+  for (const r of currentRows) {
+    const cost = Number(r.cost);
+    const input = Number(r.input_tokens);
+    const output = Number(r.output_tokens);
+    const cacheCreation = Number(r.cache_creation);
+    const cacheRead = Number(r.cache_read);
+    const sessions = Number(r.sessions);
+    total_cost_usd += cost;
+    total_input_tokens += input;
+    total_output_tokens += output;
+    total_cache_creation_tokens += cacheCreation;
+    total_cache_read_tokens += cacheRead;
+    total_sessions += sessions;
+    per_agent.push({
+      agent_id: r.agent_id,
+      agent_label: r.agent_label,
+      cost_usd: cost,
+      sessions,
+    });
+  }
+
+  // total_input_tokens is the union of fresh + cache_creation + cache_read
+  // (the same denominator used in SessionUsageDisplay). Without summing
+  // all three, we'd compute cache_hit_ratio against only the fresh slice.
+  const total_input_for_ratio =
+    total_input_tokens + total_cache_creation_tokens + total_cache_read_tokens;
+  const cache_hit_ratio =
+    total_input_for_ratio > 0
+      ? total_cache_read_tokens / total_input_for_ratio
+      : 0;
+
+  const prior_cost_usd = Number(priorRows[0]?.prior_cost ?? 0);
+  const cost_change_percent =
+    prior_cost_usd === 0
+      ? total_cost_usd === 0
+        ? 0
+        : 100
+      : Math.round(
+          ((total_cost_usd - prior_cost_usd) / prior_cost_usd) * 100,
+        );
+
+  return {
+    window_days: windowDays,
+    total_cost_usd,
+    prior_cost_usd,
+    cost_change_percent,
+    total_input_tokens,
+    total_output_tokens,
+    total_cache_creation_tokens,
+    total_cache_read_tokens,
+    cache_hit_ratio,
+    total_sessions,
+    per_agent,
+  };
 }

--- a/packages/api/src/views/format.ts
+++ b/packages/api/src/views/format.ts
@@ -33,6 +33,23 @@ export function formatRelativeShort(date: Date, now: Date = new Date()): string 
 }
 
 /**
+ * Cache hit ratio against total input. Total input is the sum of all
+ * three input slices per the `SessionUsage` contract — measuring
+ * `cache_read / (input + cache_creation + cache_read)` is the correct
+ * denominator (`cache_read / input` would always read >1× on a warm
+ * second-onward session). Returns 0 when there's no input to score
+ * against — caller decides whether to render that as 0% or N/A.
+ */
+export function computeCacheHitRatio(parts: {
+  input: number;
+  cacheCreation: number;
+  cacheRead: number;
+}): number {
+  const total = parts.input + parts.cacheCreation + parts.cacheRead;
+  return total > 0 ? parts.cacheRead / total : 0;
+}
+
+/**
  * Duration label between started_at and completed_at (or now if running).
  * Returns "—" if no start. Format: "2m", "1h 4m", "3d 2h", etc.
  */

--- a/packages/api/src/views/sessions.test.ts
+++ b/packages/api/src/views/sessions.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { getSessionByShortId, AmbiguousShortIdError } from "./sessions.js";
+import {
+  AmbiguousShortIdError,
+  getSessionByShortId,
+  toSessionUsageDisplay,
+} from "./sessions.js";
 import { makeMockPool } from "./test-helpers.js";
 
 describe("getSessionByShortId", () => {
@@ -50,6 +54,111 @@ describe("getSessionByShortId", () => {
   });
 });
 
+describe("toSessionUsageDisplay", () => {
+  it("returns undefined when usage is null (older sessions pre-M9.8)", () => {
+    expect(toSessionUsageDisplay(null)).toBeUndefined();
+    expect(toSessionUsageDisplay(undefined)).toBeUndefined();
+  });
+
+  it("populates every numeric field, defaulting missing slices to 0", () => {
+    const out = toSessionUsageDisplay({
+      cost_usd: 0.1234,
+      input_tokens: 100,
+      output_tokens: 500,
+      cache_creation_input_tokens: 200,
+      cache_read_input_tokens: 800,
+      model: "claude-opus-4-7",
+    });
+    expect(out).toEqual({
+      cost_usd: 0.1234,
+      cache_hit_ratio: 800 / (100 + 200 + 800), // 0.7272...
+      input_tokens: 100,
+      output_tokens: 500,
+      cache_creation_tokens: 200,
+      cache_read_tokens: 800,
+      total_input_tokens: 1100,
+      model: "claude-opus-4-7",
+    });
+  });
+
+  it("computes cache_hit_ratio as cache_read / total_input", () => {
+    // 90% cache hit — the warm-second-session target case.
+    const warm = toSessionUsageDisplay({
+      input_tokens: 100,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 900,
+    });
+    expect(warm?.cache_hit_ratio).toBeCloseTo(0.9, 5);
+
+    // 0% cache hit — cold first session, no cached prefix.
+    const cold = toSessionUsageDisplay({
+      input_tokens: 1000,
+      cache_creation_input_tokens: 500,
+      cache_read_input_tokens: 0,
+    });
+    expect(cold?.cache_hit_ratio).toBe(0);
+  });
+
+  it("avoids NaN when there's no input at all (degenerate but possible)", () => {
+    // E.g., a session that errored before any tokens were exchanged.
+    // Naïve `cache_read / total_input` would divide by zero; we
+    // guard with `total > 0 ? ratio : 0`.
+    const out = toSessionUsageDisplay({});
+    expect(out?.cache_hit_ratio).toBe(0);
+    expect(out?.total_input_tokens).toBe(0);
+    expect(Number.isFinite(out?.cache_hit_ratio ?? 0)).toBe(true);
+  });
+
+  it("falls back to 'unknown' model when missing or empty", () => {
+    expect(toSessionUsageDisplay({})?.model).toBe("unknown");
+    expect(toSessionUsageDisplay({ model: "" })?.model).toBe("unknown");
+    expect(toSessionUsageDisplay({ model: "claude-sonnet-4-6" })?.model).toBe(
+      "claude-sonnet-4-6",
+    );
+  });
+
+  it("defaults cost_usd to 0 when missing — UI can render '$0.00' instead of '—'", () => {
+    expect(toSessionUsageDisplay({})?.cost_usd).toBe(0);
+  });
+
+  it("total_input_tokens is the sum of all three input slices (per SessionUsage contract)", () => {
+    const out = toSessionUsageDisplay({
+      input_tokens: 11,
+      cache_creation_input_tokens: 22,
+      cache_read_input_tokens: 33,
+    });
+    expect(out?.total_input_tokens).toBe(11 + 22 + 33);
+  });
+});
+
+describe("getSessionByShortId — usage plumbing", () => {
+  it("populates session.usage when the row carries it", async () => {
+    const row = {
+      ...sampleRow("sess_usageff01"),
+      usage: {
+        cost_usd: 0.05,
+        input_tokens: 50,
+        output_tokens: 200,
+        cache_creation_input_tokens: 100,
+        cache_read_input_tokens: 350,
+        model: "claude-opus-4-7",
+      },
+    };
+    const pool = makeMockPool([row]);
+    const session = await getSessionByShortId(pool, "usagef");
+    expect(session?.usage?.cost_usd).toBe(0.05);
+    expect(session?.usage?.model).toBe("claude-opus-4-7");
+    expect(session?.usage?.total_input_tokens).toBe(500);
+    expect(session?.usage?.cache_hit_ratio).toBeCloseTo(350 / 500, 5);
+  });
+
+  it("leaves session.usage undefined when the row has null usage", async () => {
+    const pool = makeMockPool([{ ...sampleRow("sess_nousageff"), usage: null }]);
+    const session = await getSessionByShortId(pool, "nousag");
+    expect(session?.usage).toBeUndefined();
+  });
+});
+
 function sampleRow(id: string) {
   return {
     id,
@@ -66,5 +175,6 @@ function sampleRow(id: string) {
     agent_label: "Beta",
     agent_hier: "team",
     task_title: "Bill rewrite",
+    usage: null,
   };
 }

--- a/packages/api/src/views/sessions.ts
+++ b/packages/api/src/views/sessions.ts
@@ -24,7 +24,11 @@ import type {
   SessionType,
   SessionUsage,
 } from "@beevibe/core";
-import { deriveShortId, formatDurationLabel } from "./format.js";
+import {
+  computeCacheHitRatio,
+  deriveShortId,
+  formatDurationLabel,
+} from "./format.js";
 import type {
   SessionDisplay,
   SessionBriefing,
@@ -197,18 +201,19 @@ export function toSessionUsageDisplay(
   const output_tokens = raw.output_tokens ?? 0;
   const cache_creation_tokens = raw.cache_creation_input_tokens ?? 0;
   const cache_read_tokens = raw.cache_read_input_tokens ?? 0;
-  const total_input_tokens =
-    input_tokens + cache_creation_tokens + cache_read_tokens;
-  const cache_hit_ratio =
-    total_input_tokens > 0 ? cache_read_tokens / total_input_tokens : 0;
   return {
     cost_usd: raw.cost_usd ?? 0,
-    cache_hit_ratio,
+    cache_hit_ratio: computeCacheHitRatio({
+      input: input_tokens,
+      cacheCreation: cache_creation_tokens,
+      cacheRead: cache_read_tokens,
+    }),
     input_tokens,
     output_tokens,
     cache_creation_tokens,
     cache_read_tokens,
-    total_input_tokens,
+    total_input_tokens:
+      input_tokens + cache_creation_tokens + cache_read_tokens,
     model: raw.model && raw.model.length > 0 ? raw.model : "unknown",
   };
 }

--- a/packages/api/src/views/sessions.ts
+++ b/packages/api/src/views/sessions.ts
@@ -22,9 +22,15 @@ import type {
   SessionSpawnMode,
   SessionStatus,
   SessionType,
+  SessionUsage,
 } from "@beevibe/core";
 import { deriveShortId, formatDurationLabel } from "./format.js";
-import type { SessionDisplay, SessionBriefing, TranscriptEntry } from "./types.js";
+import type {
+  SessionDisplay,
+  SessionBriefing,
+  SessionUsageDisplay,
+  TranscriptEntry,
+} from "./types.js";
 
 interface SessionDetailRow {
   id: string;
@@ -47,6 +53,7 @@ interface SessionDetailRow {
   runtime_cli: string | null;
   runtime_cli_version: string | null;
   daemon_device_name: string | null;
+  usage: SessionUsage | null;
 }
 
 interface TranscriptEventRow {
@@ -61,7 +68,7 @@ const SESSION_BY_ID_PREFIX_SQL = /* sql */ `
 SELECT
   s.id, s.agent_id, s.task_id, s.type, s.status, s.intent,
   s.workspace_path, s.cli_session_id, s.started_at, s.completed_at,
-  s.briefing, s.spawn_mode, s.runtime_id,
+  s.briefing, s.spawn_mode, s.runtime_id, s.usage,
   a.name              AS agent_label,
   a.hierarchy_level   AS agent_hier,
   t.title             AS task_title,
@@ -158,6 +165,7 @@ function rowToSessionDisplay(row: SessionDetailRow): SessionDisplay {
     runtime_cli: row.runtime_cli ?? undefined,
     runtime_cli_version: row.runtime_cli_version ?? undefined,
     daemon_device_name: row.daemon_device_name ?? undefined,
+    usage: toSessionUsageDisplay(row.usage),
   };
 }
 
@@ -167,5 +175,40 @@ function toTranscriptEntry(row: TranscriptEventRow): TranscriptEntry {
     timestamp: row.timestamp,
     content: row.content,
     ...(row.tool_name ? { tool_name: row.tool_name } : {}),
+  };
+}
+
+/**
+ * Map the raw `SessionUsage` JSONB shape (all fields optional) to the
+ * display shape (all fields populated, cache_hit_ratio precomputed).
+ * Returns undefined when the row's usage is null so the UI can hide
+ * the panel for older sessions captured before M9.8.
+ *
+ * The cache hit ratio is computed here (not in the UI) so every
+ * consumer agrees on the formula and we don't ship "almost correct"
+ * derivations across surfaces. Denominator is `total_input` — the sum
+ * of all three input slices, per `SessionUsage`'s own contract.
+ */
+export function toSessionUsageDisplay(
+  raw: SessionUsage | null | undefined,
+): SessionUsageDisplay | undefined {
+  if (!raw) return undefined;
+  const input_tokens = raw.input_tokens ?? 0;
+  const output_tokens = raw.output_tokens ?? 0;
+  const cache_creation_tokens = raw.cache_creation_input_tokens ?? 0;
+  const cache_read_tokens = raw.cache_read_input_tokens ?? 0;
+  const total_input_tokens =
+    input_tokens + cache_creation_tokens + cache_read_tokens;
+  const cache_hit_ratio =
+    total_input_tokens > 0 ? cache_read_tokens / total_input_tokens : 0;
+  return {
+    cost_usd: raw.cost_usd ?? 0,
+    cache_hit_ratio,
+    input_tokens,
+    output_tokens,
+    cache_creation_tokens,
+    cache_read_tokens,
+    total_input_tokens,
+    model: raw.model && raw.model.length > 0 ? raw.model : "unknown",
   };
 }

--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -175,6 +175,38 @@ export interface AskThread {
   tone: "running" | "neutral";
 }
 
+/**
+ * Per-session usage telemetry exposed to the UI. Derived from the
+ * `SessionUsage` JSONB column on `session`. All numeric fields default
+ * to 0 (older sessions captured before M9.8 have null `usage`, in which
+ * case the whole object is absent from `SessionDisplay`).
+ *
+ * `cache_hit_ratio` is precomputed server-side so every consumer agrees
+ * on the formula:
+ *   cache_hit_ratio = cache_read_tokens / total_input_tokens
+ *   total_input_tokens = input_tokens + cache_creation_tokens + cache_read_tokens
+ *
+ * Range [0, 1]; 0 when no input was processed.
+ */
+export interface SessionUsageDisplay {
+  /** Total cost in USD for this session, summed across all assistant turns. */
+  cost_usd: number;
+  /** Cache hit ratio in [0, 1]. Target >0.7 on a warm second-onward session. */
+  cache_hit_ratio: number;
+  /** Fresh input tokens (not served from cache). */
+  input_tokens: number;
+  /** Output tokens generated. */
+  output_tokens: number;
+  /** Tokens written to cache (charged at ~1.25× base input rate). */
+  cache_creation_tokens: number;
+  /** Tokens read from cache (charged at ~0.1× base input rate). */
+  cache_read_tokens: number;
+  /** Sum of input + cache_creation + cache_read. Convenience for UI. */
+  total_input_tokens: number;
+  /** Model used. Falls back to "unknown" if the runtime didn't report one. */
+  model: string;
+}
+
 export interface SessionDisplay {
   id: string;
   short_id: string;
@@ -208,6 +240,14 @@ export interface SessionDisplay {
   runtime_cli_version?: string;
   /** Joined from daemon → device_name. Renders as "Ran on <X>". */
   daemon_device_name?: string;
+  /**
+   * Per-session cost + token usage. Absent when the underlying
+   * `session.usage` JSONB column is null (older sessions captured
+   * before M9.8 stamped usage onto every completion). See
+   * {@link SessionUsageDisplay} for field semantics + cache-hit ratio
+   * formula.
+   */
+  usage?: SessionUsageDisplay;
 }
 
 export interface SessionBriefing {

--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -347,6 +347,45 @@ export interface AttentionData {
   created_at: Date;
 }
 
+/**
+ * Per-agent slice of the dashboard usage aggregate. Sorted by `cost_usd`
+ * descending so the UI can render top-N spenders without re-sorting.
+ */
+export interface UsageAgentBreakdown {
+  agent_id: string;
+  agent_label: string;
+  cost_usd: number;
+  sessions: number;
+}
+
+/**
+ * Window-scoped cost + token rollup for the dashboard's Usage section.
+ * `cost_change_percent` compares the current window to the prior window
+ * of the same length — same convention as the existing `trend` block
+ * (round to int percent; ±100% when prior was zero and current > 0).
+ *
+ * `cache_hit_ratio` is the weighted ratio across all sessions in the
+ * window: total_cache_read / total_input. Range [0, 1]. Zero when no
+ * input was processed in the window.
+ */
+export interface UsageSummaryData {
+  /** Window length in days (matches TREND_WINDOW_DAYS). */
+  window_days: number;
+  total_cost_usd: number;
+  prior_cost_usd: number;
+  /** Round int percent vs. prior window. ±100% when prior was 0. */
+  cost_change_percent: number;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  total_cache_creation_tokens: number;
+  total_cache_read_tokens: number;
+  /** Weighted across the whole window. */
+  cache_hit_ratio: number;
+  total_sessions: number;
+  /** Sorted by cost_usd descending. */
+  per_agent: UsageAgentBreakdown[];
+}
+
 export interface DashboardSummary {
   kpis: KpiData[];
   status_breakdown: StatusBreakdownData[];
@@ -360,6 +399,8 @@ export interface DashboardSummary {
   trend_total: number;
   trend_change_percent: number;
   attention: AttentionData[];
+  /** Cost + token aggregate over the current window. M9.8+. */
+  usage_summary: UsageSummaryData;
 }
 
 // ── Mesh ────────────────────────────────────────────────────────────────────

--- a/packages/core/src/services/agent-session.test.ts
+++ b/packages/core/src/services/agent-session.test.ts
@@ -146,7 +146,7 @@ describe("AgentSession.run", () => {
     expect(memoryAgent.prepareBriefing).toHaveBeenCalledWith("Reply with 'ok'.");
     const ctx = vi.mocked(runtime.execute).mock.calls[0]![0];
     // System prompt has FOUR pieces, in cache-stable order:
-    //   1. BEEVIBE_LIFECYCLE_REMINDER (always-on; M9.5+ empirical fix)
+    //   1. BEEVIBE_LIFECYCLE_REMINDER_TASK (always-on; M9.5+ empirical fix)
     //   2. BEEVIBE_MEMORY_REMINDER (always-on; Letta pattern for active
     //      mid-session memory management)
     //   3. agent.runtime_config.system_prompt_addition (per-agent baseline)

--- a/packages/core/src/services/agent-session.ts
+++ b/packages/core/src/services/agent-session.ts
@@ -14,7 +14,8 @@ import type { MemoryAgent } from "./memory/memory-agent.js";
 import { composeIntent, composeSystemPromptAppend } from "./spawn-prep.js";
 
 export {
-  BEEVIBE_LIFECYCLE_REMINDER,
+  BEEVIBE_LIFECYCLE_REMINDER_TASK,
+  BEEVIBE_LIFECYCLE_REMINDER_CHAT,
   BEEVIBE_MEMORY_REMINDER,
   CHAT_DIRECTIVES,
   ONBOARDING_DIRECTIVES,

--- a/packages/core/src/services/skills/tier-filter.ts
+++ b/packages/core/src/services/skills/tier-filter.ts
@@ -24,7 +24,7 @@ export const TEAM_ONLY_SKILLS = ["beevibe-team-mesh-negotiation"] as const;
 // the agent has DECIDED to do it (e.g., git workspace setup, multi-round
 // negotiation protocol).
 //
-//   - `beevibe` (umbrella) + `beevibe-task-completion` → BEEVIBE_LIFECYCLE_REMINDER
+//   - `beevibe` (umbrella) + `beevibe-task-completion` → BEEVIBE_LIFECYCLE_REMINDER_TASK
 //     (always call update_progress; leaf-vs-parent rule; deliverable handling)
 //   - `beevibe-memory-management` → BEEVIBE_MEMORY_REMINDER (active
 //     mid-session memory writeback)
@@ -37,7 +37,7 @@ export const TEAM_ONLY_SKILLS = ["beevibe-team-mesh-negotiation"] as const;
 //     prior tool calls; no re-orientation skill needed). Empirically validated
 //     in m9-e2e scenario 14: zero session-resume invocations, worktree reused
 //     correctly on revision dispatch.
-//   - `beevibe-work-product-decision` → BEEVIBE_LIFECYCLE_REMINDER (call
+//   - `beevibe-work-product-decision` → BEEVIBE_LIFECYCLE_REMINDER_TASK (call
 //     list_work_products first to dedupe) + work-product MCP tool descriptions
 //   - `beevibe-team-mesh-tool-choice` → coverage by tool descriptions (each
 //     mesh tool's description already says when to use it vs alternatives)

--- a/packages/core/src/services/spawn-prep.test.ts
+++ b/packages/core/src/services/spawn-prep.test.ts
@@ -36,7 +36,7 @@ describe("composeSystemPromptAppend with extra", () => {
   it("threads the team-routing directive at the tail (most-volatile slot)", () => {
     const teamRouting = teamAgentRoutingDirective(["frontend", "backend"]);
     const out = composeSystemPromptAppend(undefined, "<core_memory/>", {
-      appendChatDirectives: true,
+      sessionKind: "chat",
       extra: teamRouting,
     });
     // Cache-friendly order: most-stable first. Lifecycle reminder leads.
@@ -51,7 +51,7 @@ describe("composeSystemPromptAppend with extra", () => {
 
   it("omits the team-routing block entirely when specialists is empty", () => {
     const out = composeSystemPromptAppend(undefined, "<core_memory/>", {
-      appendChatDirectives: true,
+      sessionKind: "chat",
       extra: teamAgentRoutingDirective([]),
     });
     expect(out).not.toContain("team_agent_routing");
@@ -65,15 +65,15 @@ describe("composeSystemPromptAppend lifecycle branching", () => {
   // chat intents have no <task> block. The agent was told to do
   // something impossible. Branching the reminder by surface fixes it.
 
-  it("uses the task variant by default (no appendChatDirectives)", () => {
+  it("uses the task variant by default (no sessionKind)", () => {
     const out = composeSystemPromptAppend(undefined, "<core_memory/>");
     expect(out).toContain(BEEVIBE_LIFECYCLE_REMINDER_TASK);
     expect(out).not.toContain(BEEVIBE_LIFECYCLE_REMINDER_CHAT);
   });
 
-  it("uses the chat variant when appendChatDirectives is true", () => {
+  it("uses the chat variant when sessionKind is 'chat'", () => {
     const out = composeSystemPromptAppend(undefined, "<core_memory/>", {
-      appendChatDirectives: true,
+      sessionKind: "chat",
     });
     expect(out).toContain(BEEVIBE_LIFECYCLE_REMINDER_CHAT);
     expect(out).not.toContain(BEEVIBE_LIFECYCLE_REMINDER_TASK);

--- a/packages/core/src/services/spawn-prep.test.ts
+++ b/packages/core/src/services/spawn-prep.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  BEEVIBE_LIFECYCLE_REMINDER_CHAT,
+  BEEVIBE_LIFECYCLE_REMINDER_TASK,
   composeSystemPromptAppend,
   teamAgentRoutingDirective,
 } from "./spawn-prep.js";
@@ -53,5 +55,65 @@ describe("composeSystemPromptAppend with extra", () => {
       extra: teamAgentRoutingDirective([]),
     });
     expect(out).not.toContain("team_agent_routing");
+  });
+});
+
+describe("composeSystemPromptAppend lifecycle branching", () => {
+  // Production bug pre-fix: chat sessions got the task-only lifecycle
+  // reminder telling them to "call update_progress with task_id from
+  // your intent's <task id>" — a directive they can't satisfy because
+  // chat intents have no <task> block. The agent was told to do
+  // something impossible. Branching the reminder by surface fixes it.
+
+  it("uses the task variant by default (no appendChatDirectives)", () => {
+    const out = composeSystemPromptAppend(undefined, "<core_memory/>");
+    expect(out).toContain(BEEVIBE_LIFECYCLE_REMINDER_TASK);
+    expect(out).not.toContain(BEEVIBE_LIFECYCLE_REMINDER_CHAT);
+  });
+
+  it("uses the chat variant when appendChatDirectives is true", () => {
+    const out = composeSystemPromptAppend(undefined, "<core_memory/>", {
+      appendChatDirectives: true,
+    });
+    expect(out).toContain(BEEVIBE_LIFECYCLE_REMINDER_CHAT);
+    expect(out).not.toContain(BEEVIBE_LIFECYCLE_REMINDER_TASK);
+  });
+
+  it("task variant carries the task-tracking directives", () => {
+    // Load-bearing task directives the variant must keep.
+    expect(BEEVIBE_LIFECYCLE_REMINDER_TASK).toContain("update_progress");
+    expect(BEEVIBE_LIFECYCLE_REMINDER_TASK).toContain("work_product");
+    expect(BEEVIBE_LIFECYCLE_REMINDER_TASK).toContain('<task id="..."/>');
+  });
+
+  it("chat variant omits the task-tracking imperative (negative mentions are OK)", () => {
+    // The point of the chat variant: don't tell the agent it MUST
+    // call APIs that need a task_id when the session has none.
+    // Mentioning the same APIs negatively ("no update_progress to
+    // call") is fine and helpful — the agent shouldn't have to infer
+    // that task-only APIs don't apply.
+    expect(BEEVIBE_LIFECYCLE_REMINDER_CHAT).not.toMatch(/MUST call .*update_progress/);
+    expect(BEEVIBE_LIFECYCLE_REMINDER_CHAT).not.toMatch(/Before exiting.*update_progress/);
+    // But it does explicitly disavow them so the agent knows not to try.
+    // Regex tolerates line-wrapping between "NO" and the API name
+    // (template-literal text wraps for source readability).
+    expect(BEEVIBE_LIFECYCLE_REMINDER_CHAT).toMatch(/NO\s+update_progress/);
+    expect(BEEVIBE_LIFECYCLE_REMINDER_CHAT).toMatch(/NO\s+work_product/);
+  });
+
+  it("chat variant still allows create_task for team/org tier", () => {
+    // Discrete work surfaced mid-chat should still be promote-able to
+    // a tracked task — keep the affordance explicit.
+    expect(BEEVIBE_LIFECYCLE_REMINDER_CHAT).toContain("create_task");
+  });
+
+  it("both variants share the outer <beevibe_lifecycle> tag so downstream parsing is stable", () => {
+    // Anything parsing system-prompt sections by tag (telemetry,
+    // future skill discovery, etc.) shouldn't have to branch on
+    // variant — only the body changes.
+    expect(BEEVIBE_LIFECYCLE_REMINDER_TASK.startsWith("<beevibe_lifecycle>")).toBe(true);
+    expect(BEEVIBE_LIFECYCLE_REMINDER_TASK.trimEnd().endsWith("</beevibe_lifecycle>")).toBe(true);
+    expect(BEEVIBE_LIFECYCLE_REMINDER_CHAT.startsWith("<beevibe_lifecycle>")).toBe(true);
+    expect(BEEVIBE_LIFECYCLE_REMINDER_CHAT.trimEnd().endsWith("</beevibe_lifecycle>")).toBe(true);
   });
 });

--- a/packages/core/src/services/spawn-prep.ts
+++ b/packages/core/src/services/spawn-prep.ts
@@ -23,7 +23,18 @@
  * Cache-stable: identical text for every agent. ~500 tokens combined;
  * once cached (≥4096 tokens for Opus 4.7), reads at 0.1× rate.
  */
-export const BEEVIBE_LIFECYCLE_REMINDER = `<beevibe_lifecycle>
+/**
+ * Lifecycle reminder for **task** sessions (intent has a `<task id="..."/>`
+ * block; the agent is expected to drive the task to a terminal state via
+ * `update_progress` and record deliverables as `work_product` rows).
+ *
+ * Chat sessions get the {@link BEEVIBE_LIFECYCLE_REMINDER_CHAT} variant
+ * instead — selected by `composeSystemPromptAppend` based on the
+ * `appendChatDirectives` flag. Mesh-ask / blocker-response sessions
+ * currently fall through to the task variant; those are still
+ * task-anchored (the answering agent is responding inside a task lifecycle).
+ */
+export const BEEVIBE_LIFECYCLE_REMINDER_TASK = `<beevibe_lifecycle>
 You are a beevibe agent (BEEVIBE_AGENT_ID env identifies you). Critical
 behavioral rules for every task session:
 
@@ -55,6 +66,49 @@ behavioral rules for every task session:
 5. For multi-step protocols (mesh negotiation, git workspace setup), the
    relevant beevibe-* skill in .claude/skills/ has the deep guidance —
    invoke via Skill tool when their description matches your situation.
+</beevibe_lifecycle>`;
+
+/**
+ * Lifecycle reminder for **chat** sessions (one-shot conversational turns
+ * in the chat surface; no `<task id>` block in the intent).
+ *
+ * Distinct from {@link BEEVIBE_LIFECYCLE_REMINDER_TASK} because the
+ * task-tracking guidance (`update_progress`, `work_product`,
+ * leaf-vs-parent rule) would tell the agent to call APIs that can't
+ * succeed without a `task_id` — actively misleading. The chat reminder
+ * is deliberately short: respond, don't pretend to be in a task,
+ * optionally `create_task` if the user describes a discrete unit of work.
+ *
+ * Cache-stable: identical text for every chat-mode spawn. Lives in the
+ * cache prefix alongside the task variant; the prefix swap is per-session
+ * so neither path pollutes the other's cache.
+ */
+export const BEEVIBE_LIFECYCLE_REMINDER_CHAT = `<beevibe_lifecycle>
+You are a beevibe agent (BEEVIBE_AGENT_ID env identifies you) responding
+in a 1:1 chat with the user. This session is conversational — there is
+NO <task id="..."/> block in your intent, NO update_progress to call, NO
+work_product to record.
+
+1. Respond directly and concretely to the user's message. Don't pad,
+   don't summarize what they just said back at them, don't open with a
+   meta-acknowledgement of the question.
+
+2. If the user describes a discrete unit of work (a deliverable, a fix,
+   a research goal) and you are team or org tier, you may call
+   mcp__beevibe__create_task to spawn it as a tracked task — to a
+   subordinate (call mcp__beevibe__find_subordinates first to pick a
+   matching specialty) when the domain fits them, or to yourself when
+   it is your specialty.
+
+3. Memory management (see <beevibe_memory>) is especially valuable in
+   chat. Preferences, decisions, and durable context surface here first;
+   save them so the next chat and the next task inherit them.
+
+4. For multi-step protocols whose triggers match your situation (mesh
+   negotiation, etc.) the relevant beevibe-* skill in .claude/skills/
+   has the deep guidance — invoke via the Skill tool. Note that
+   beevibe-pre-task-setup is git-workspace setup for tasks; it does NOT
+   apply here.
 </beevibe_lifecycle>`;
 
 export const BEEVIBE_MEMORY_REMINDER = `<beevibe_memory>
@@ -274,14 +328,25 @@ export function composeSystemPromptAppend(
   agentSystemPromptAddition: string | undefined,
   briefingSystemPromptAppend: string,
   options: {
+    /**
+     * True when the spawn is the chat surface. Drives two things:
+     *   1. `CHAT_DIRECTIVES` (display-token guidance) is appended.
+     *   2. The chat-variant lifecycle reminder is used in place of the
+     *      task variant — task-only directives like `update_progress`
+     *      and `work_product` would tell the agent to call APIs that
+     *      can't succeed without a `task_id`.
+     */
     appendChatDirectives?: boolean;
     appendOnboardingDirectives?: boolean;
     /** Free-form text appended at the very end (e.g., room directives). */
     extra?: string;
   } = {},
 ): string {
+  const lifecycleReminder = options.appendChatDirectives
+    ? BEEVIBE_LIFECYCLE_REMINDER_CHAT
+    : BEEVIBE_LIFECYCLE_REMINDER_TASK;
   return [
-    BEEVIBE_LIFECYCLE_REMINDER,
+    lifecycleReminder,
     BEEVIBE_MEMORY_REMINDER,
     agentSystemPromptAddition ?? "",
     briefingSystemPromptAppend,

--- a/packages/core/src/services/spawn-prep.ts
+++ b/packages/core/src/services/spawn-prep.ts
@@ -324,25 +324,32 @@ Clarifying questions are fine and encouraged — but ask them in service of *rou
  * `appendOnboardingDirectives: true` adds the one-time wizard directives
  * after CHAT_DIRECTIVES.
  */
+export type SessionSurfaceKind = "task" | "chat";
+
 export function composeSystemPromptAppend(
   agentSystemPromptAddition: string | undefined,
   briefingSystemPromptAppend: string,
   options: {
     /**
-     * True when the spawn is the chat surface. Drives two things:
-     *   1. `CHAT_DIRECTIVES` (display-token guidance) is appended.
-     *   2. The chat-variant lifecycle reminder is used in place of the
-     *      task variant — task-only directives like `update_progress`
-     *      and `work_product` would tell the agent to call APIs that
-     *      can't succeed without a `task_id`.
+     * Which session surface is being spawned. Drives both the
+     * lifecycle reminder variant AND whether CHAT_DIRECTIVES is
+     * appended — the two are coupled by definition (chat surface
+     * implies chat lifecycle and display tokens; task surface implies
+     * task lifecycle and no display tokens). Defaults to "task" so
+     * existing task-side callers don't need to pass the flag.
+     *
+     * When mesh-ask / blocker-response sessions eventually need their
+     * own surface treatment, extend this union — don't reintroduce
+     * orthogonal flags.
      */
-    appendChatDirectives?: boolean;
+    sessionKind?: SessionSurfaceKind;
     appendOnboardingDirectives?: boolean;
     /** Free-form text appended at the very end (e.g., room directives). */
     extra?: string;
   } = {},
 ): string {
-  const lifecycleReminder = options.appendChatDirectives
+  const isChat = options.sessionKind === "chat";
+  const lifecycleReminder = isChat
     ? BEEVIBE_LIFECYCLE_REMINDER_CHAT
     : BEEVIBE_LIFECYCLE_REMINDER_TASK;
   return [
@@ -350,7 +357,7 @@ export function composeSystemPromptAppend(
     BEEVIBE_MEMORY_REMINDER,
     agentSystemPromptAddition ?? "",
     briefingSystemPromptAppend,
-    options.appendChatDirectives ? CHAT_DIRECTIVES : "",
+    isChat ? CHAT_DIRECTIVES : "",
     options.appendOnboardingDirectives ? ONBOARDING_DIRECTIVES : "",
     options.extra ?? "",
   ]

--- a/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
+++ b/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
@@ -240,8 +240,8 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
 }
 
 function RecentSessionRow({ session }: { session: RecentSession }) {
-  return (
-    <li className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-sm">
+  const rowInner = (
+    <>
       <span
         className={cn("h-1.5 w-1.5 rounded-full", RECENT_SESSION_DOT[session.status])}
         aria-hidden
@@ -251,6 +251,28 @@ function RecentSessionRow({ session }: { session: RecentSession }) {
         <span className="font-mono text-xs text-muted-foreground">{session.short_id}</span>
       ) : null}
       <span className="text-xs text-muted-foreground tabular-nums shrink-0">{session.age}</span>
+    </>
+  );
+
+  // Without a short_id we can't route anywhere — render unlinked so we
+  // don't ship a dead <Link>. RecentSession.short_id is currently always
+  // populated in practice; this is defensive against future shapes.
+  if (!session.short_id) {
+    return (
+      <li className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-sm">
+        {rowInner}
+      </li>
+    );
+  }
+
+  return (
+    <li>
+      <Link
+        href={`/sessions/${session.short_id}`}
+        className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-sm hover:bg-secondary/50 hover:border-border/80 transition-colors cursor-pointer"
+      >
+        {rowInner}
+      </Link>
     </li>
   );
 }

--- a/packages/web/app/(authed)/dashboard/dashboard-client.test.tsx
+++ b/packages/web/app/(authed)/dashboard/dashboard-client.test.tsx
@@ -51,6 +51,19 @@ const sample: DashboardSummary = {
       created_at: new Date("2026-04-30T10:00:00Z"),
     },
   ],
+  usage_summary: {
+    window_days: 7,
+    total_cost_usd: 0,
+    prior_cost_usd: 0,
+    cost_change_percent: 0,
+    total_input_tokens: 0,
+    total_output_tokens: 0,
+    total_cache_creation_tokens: 0,
+    total_cache_read_tokens: 0,
+    cache_hit_ratio: 0,
+    total_sessions: 0,
+    per_agent: [],
+  },
 };
 
 beforeEach(() => {

--- a/packages/web/app/(authed)/dashboard/dashboard-client.tsx
+++ b/packages/web/app/(authed)/dashboard/dashboard-client.tsx
@@ -10,6 +10,7 @@ import { KpiTile } from "@/components/home/kpi-tile";
 import { FleetBars } from "@/components/home/fleet-bars";
 import { StatusBreakdownBar } from "@/components/home/status-breakdown";
 import { TrendChart } from "@/components/home/trend-chart";
+import { DashboardUsageSection } from "@/components/home/usage-section";
 import type { DashboardDisplay } from "@/lib/types/dashboard";
 
 export function DashboardClient() {
@@ -115,6 +116,8 @@ function Body({
           changePercent={data.trend_change_percent}
         />
       </div>
+
+      <DashboardUsageSection summary={data.usage_summary} />
     </div>
   );
 }

--- a/packages/web/app/(authed)/sessions/[sid]/chat-session-detail-client.tsx
+++ b/packages/web/app/(authed)/sessions/[sid]/chat-session-detail-client.tsx
@@ -13,6 +13,7 @@ import { FooterField } from "@/components/detail/footer-field";
 import { ChatMarkdown } from "@/components/chat/markdown";
 import { HierChip } from "@/components/hier-chip";
 import { Avatar } from "@/components/avatar";
+import { UsagePanel } from "@/components/sessions/usage-panel";
 import type { SessionDisplay, TranscriptEntry } from "@/lib/types/sessions";
 import { cn } from "@/lib/utils";
 
@@ -175,6 +176,8 @@ function ChatSessionBody({ session }: { session: SessionDisplay }) {
           <ToolTranscript entries={toolSteps} />
         </section>
       ) : null}
+
+      {session.usage ? <UsagePanel usage={session.usage} /> : null}
 
       <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
         <FooterField label="Session ID">

--- a/packages/web/components/home/usage-section.test.tsx
+++ b/packages/web/components/home/usage-section.test.tsx
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type {
+  UsageAgentBreakdown,
+  UsageSummaryData,
+} from "@/lib/types/dashboard";
+import { DashboardUsageSection } from "./usage-section";
+
+function mkAgent(overrides: Partial<UsageAgentBreakdown> = {}): UsageAgentBreakdown {
+  return {
+    agent_id: "agt_x",
+    agent_label: "alice",
+    cost_usd: 0.5,
+    sessions: 5,
+    ...overrides,
+  };
+}
+
+function mkSummary(overrides: Partial<UsageSummaryData> = {}): UsageSummaryData {
+  return {
+    window_days: 7,
+    total_cost_usd: 1.0,
+    prior_cost_usd: 0.5,
+    cost_change_percent: 100,
+    total_input_tokens: 100,
+    total_output_tokens: 500,
+    total_cache_creation_tokens: 200,
+    total_cache_read_tokens: 1700,
+    cache_hit_ratio: 1700 / 2000,
+    total_sessions: 6,
+    per_agent: [mkAgent()],
+    ...overrides,
+  };
+}
+
+describe("<DashboardUsageSection />", () => {
+  it("renders the window label in the header", () => {
+    render(<DashboardUsageSection summary={mkSummary({ window_days: 7 })} />);
+    expect(screen.getByText("last 7 days")).toBeInTheDocument();
+  });
+
+  it("renders all four headline tiles", () => {
+    render(
+      <DashboardUsageSection
+        summary={mkSummary({
+          total_cost_usd: 0.1234,
+          total_input_tokens: 1000,
+          total_output_tokens: 500,
+          total_sessions: 7,
+        })}
+      />,
+    );
+    expect(screen.getByText("$0.1234")).toBeInTheDocument();
+    // tokens headline = input + output
+    expect(screen.getByText("1.5K")).toBeInTheDocument();
+    // cache hit pct
+    expect(screen.getByText("85%")).toBeInTheDocument();
+    // sessions count
+    expect(screen.getByText("7")).toBeInTheDocument();
+  });
+
+  it("renders an up-arrow delta when cost increased (cost up = bad → red tone)", () => {
+    const { container } = render(
+      <DashboardUsageSection
+        summary={mkSummary({
+          total_cost_usd: 2,
+          prior_cost_usd: 1,
+          cost_change_percent: 100,
+        })}
+      />,
+    );
+    // The percentage text always renders; the arrow icon is the
+    // direction indicator. We assert the percentage is there and the
+    // arrow svg renders (lucide icons render as <svg>).
+    expect(screen.getByText(/100%/)).toBeInTheDocument();
+    const arrows = container.querySelectorAll("svg.lucide-arrow-up");
+    expect(arrows.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders a down-arrow delta when cost decreased (cost down = good → green tone)", () => {
+    const { container } = render(
+      <DashboardUsageSection
+        summary={mkSummary({
+          total_cost_usd: 0.5,
+          prior_cost_usd: 1,
+          cost_change_percent: -50,
+        })}
+      />,
+    );
+    // The render shows the absolute value of the delta.
+    expect(screen.getByText(/50%/)).toBeInTheDocument();
+    const arrows = container.querySelectorAll("svg.lucide-arrow-down");
+    expect(arrows.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders '—' for cost delta when both windows are zero", () => {
+    render(
+      <DashboardUsageSection
+        summary={mkSummary({
+          total_cost_usd: 0,
+          prior_cost_usd: 0,
+          cost_change_percent: 0,
+        })}
+      />,
+    );
+    // The CostTile meta renders an em-dash; the CacheHitTile also
+    // renders an em-dash when total input is zero (which is also true
+    // in this fixture since defaults include input but we override
+    // both prior/current cost). The em-dash showing up at least once
+    // is enough for this case.
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders '—' for cache hit when there is no input in window", () => {
+    render(
+      <DashboardUsageSection
+        summary={mkSummary({
+          total_input_tokens: 0,
+          total_cache_creation_tokens: 0,
+          total_cache_read_tokens: 0,
+          cache_hit_ratio: 0,
+        })}
+      />,
+    );
+    expect(screen.getByText("no input in window")).toBeInTheDocument();
+  });
+
+  it("renders per-agent bars when per_agent has entries", () => {
+    render(
+      <DashboardUsageSection
+        summary={mkSummary({
+          per_agent: [
+            mkAgent({ agent_id: "agt_a", agent_label: "alice", cost_usd: 0.5, sessions: 5 }),
+            mkAgent({ agent_id: "agt_b", agent_label: "bob", cost_usd: 0.1, sessions: 1 }),
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByText("alice")).toBeInTheDocument();
+    expect(screen.getByText("bob")).toBeInTheDocument();
+    // Shows count of agents in the header.
+    expect(screen.getByText("by agent · top 2")).toBeInTheDocument();
+  });
+
+  it("surfaces an overflow line when more than the top-N agents exist", () => {
+    const agents: UsageAgentBreakdown[] = Array.from({ length: 7 }, (_, i) =>
+      mkAgent({
+        agent_id: `agt_${i}`,
+        agent_label: `agent_${i}`,
+        cost_usd: 0.1 * (7 - i),
+      }),
+    );
+    render(<DashboardUsageSection summary={mkSummary({ per_agent: agents })} />);
+    // 7 agents, top 5 shown → "+ 2 more agents"
+    expect(screen.getByText("+ 2 more agents")).toBeInTheDocument();
+  });
+
+  it("renders an empty-state line when no agents have sessions in the window", () => {
+    render(<DashboardUsageSection summary={mkSummary({ per_agent: [] })} />);
+    expect(screen.getByText("No agent sessions in this window.")).toBeInTheDocument();
+  });
+});

--- a/packages/web/components/home/usage-section.tsx
+++ b/packages/web/components/home/usage-section.tsx
@@ -1,0 +1,319 @@
+import { ArrowDown, ArrowUp, CircleDollarSign } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  formatCost,
+  formatTokens,
+} from "@/components/sessions/usage-panel";
+import type {
+  UsageAgentBreakdown,
+  UsageSummaryData,
+} from "@/lib/types/dashboard";
+
+/**
+ * Dashboard "Usage" section — surfaces the cost + token rollup the
+ * backend ships in `dashboard.usage_summary`. Designed to slot into
+ * the home page alongside the existing KPI tiles + status / fleet /
+ * trend blocks; visual language matches `KpiTile` (label on top,
+ * large tabular value below, small meta line).
+ *
+ * Layout:
+ *   - Section heading "Usage" with a window-length subtitle.
+ *   - 4-up tile row: cost (with delta arrow), tokens, cache hit,
+ *     sessions. Cost delta tone is inverted relative to "good": an
+ *     INCREASE in cost is bad (red), a decrease is good (green).
+ *   - Per-agent breakdown bars below — horizontal bars where width
+ *     is proportional to the top spender's cost. Shows top 5; if
+ *     more exist, surfaces a "+N more" footer.
+ */
+export function DashboardUsageSection({
+  summary,
+}: {
+  summary: UsageSummaryData;
+}) {
+  return (
+    <section
+      className="mt-10 pt-8 border-t border-border/60"
+      aria-label="Usage"
+    >
+      <header className="mb-5 flex items-baseline justify-between gap-4">
+        <h2 className="text-base font-semibold tracking-tight flex items-center gap-2">
+          <CircleDollarSign className="h-4 w-4 text-muted-foreground" />
+          Usage
+        </h2>
+        <span className="text-xs text-muted-foreground">
+          last {summary.window_days} days
+        </span>
+      </header>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-6 mb-8">
+        <CostTile
+          cost={summary.total_cost_usd}
+          deltaPercent={summary.cost_change_percent}
+          priorCost={summary.prior_cost_usd}
+        />
+        <TokensTile
+          input={summary.total_input_tokens}
+          output={summary.total_output_tokens}
+          cacheCreation={summary.total_cache_creation_tokens}
+          cacheRead={summary.total_cache_read_tokens}
+        />
+        <CacheHitTile
+          ratio={summary.cache_hit_ratio}
+          totalInput={
+            summary.total_input_tokens +
+            summary.total_cache_creation_tokens +
+            summary.total_cache_read_tokens
+          }
+        />
+        <SessionsTile count={summary.total_sessions} />
+      </div>
+
+      {summary.per_agent.length > 0 ? (
+        <AgentBreakdown agents={summary.per_agent} totalCost={summary.total_cost_usd} />
+      ) : (
+        <p className="text-xs text-muted-foreground italic">
+          No agent sessions in this window.
+        </p>
+      )}
+    </section>
+  );
+}
+
+// ── tiles ─────────────────────────────────────────────────────────────
+
+function TileLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1.5">
+      {children}
+    </div>
+  );
+}
+
+function TileValue({
+  children,
+  tone,
+}: {
+  children: React.ReactNode;
+  tone?: "done" | "review" | "failed" | "muted";
+}) {
+  const toneClass =
+    tone === "done"
+      ? "text-status-done"
+      : tone === "review"
+        ? "text-status-review"
+        : tone === "failed"
+          ? "text-status-failed"
+          : tone === "muted"
+            ? "text-muted-foreground"
+            : "";
+  return (
+    <div
+      className={cn(
+        "text-3xl font-semibold tabular-nums leading-none",
+        toneClass,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+function TileMeta({ children }: { children: React.ReactNode }) {
+  return <div className="mt-2 text-xs text-muted-foreground">{children}</div>;
+}
+
+function CostTile({
+  cost,
+  deltaPercent,
+  priorCost,
+}: {
+  cost: number;
+  deltaPercent: number;
+  priorCost: number;
+}) {
+  // Inverted tone: cost UP is bad, cost DOWN is good. Zero-prior-zero
+  // current renders as a flat "—" so we don't paint a false-positive
+  // green "down" on an empty window.
+  const flat = priorCost === 0 && cost === 0;
+  const arrow = flat ? null : deltaPercent > 0 ? "up" : deltaPercent < 0 ? "down" : null;
+  const tone: "failed" | "done" | "muted" = flat
+    ? "muted"
+    : deltaPercent > 0
+      ? "failed"
+      : deltaPercent < 0
+        ? "done"
+        : "muted";
+  return (
+    <div>
+      <TileLabel>cost (usd)</TileLabel>
+      <TileValue>{formatCost(cost)}</TileValue>
+      <TileMeta>
+        {flat ? (
+          "—"
+        ) : (
+          <span className={cn("inline-flex items-center gap-0.5", toneClassFor(tone))}>
+            {arrow === "up" ? <ArrowUp className="h-3 w-3" /> : null}
+            {arrow === "down" ? <ArrowDown className="h-3 w-3" /> : null}
+            <span className="tabular-nums">{Math.abs(deltaPercent)}%</span>
+            <span className="text-muted-foreground"> vs prior</span>
+          </span>
+        )}
+      </TileMeta>
+    </div>
+  );
+}
+
+function TokensTile({
+  input,
+  output,
+  cacheCreation,
+  cacheRead,
+}: {
+  input: number;
+  output: number;
+  cacheCreation: number;
+  cacheRead: number;
+}) {
+  // Headline: input + output (the billed-bytes-shaped pair). Meta:
+  // breakdown of the cache slices so the absolute cost picture is
+  // visible without opening individual sessions.
+  const billed = input + output;
+  return (
+    <div>
+      <TileLabel>tokens</TileLabel>
+      <TileValue>{formatTokens(billed)}</TileValue>
+      <TileMeta>
+        <span className="tabular-nums">{formatTokens(input)}</span> in ·{" "}
+        <span className="tabular-nums">{formatTokens(output)}</span> out
+        <br />
+        cache: <span className="tabular-nums">{formatTokens(cacheCreation)}</span> w ·{" "}
+        <span className="tabular-nums">{formatTokens(cacheRead)}</span> r
+      </TileMeta>
+    </div>
+  );
+}
+
+function CacheHitTile({
+  ratio,
+  totalInput,
+}: {
+  ratio: number;
+  totalInput: number;
+}) {
+  if (totalInput === 0) {
+    return (
+      <div>
+        <TileLabel>cache hit</TileLabel>
+        <TileValue tone="muted">—</TileValue>
+        <TileMeta>no input in window</TileMeta>
+      </div>
+    );
+  }
+  const pct = Math.round(ratio * 100);
+  const tone: "done" | "review" | "failed" =
+    ratio >= 0.7 ? "done" : ratio >= 0.4 ? "review" : "failed";
+  return (
+    <div>
+      <TileLabel>cache hit</TileLabel>
+      <TileValue tone={tone}>{pct}%</TileValue>
+      <TileMeta>target &gt; 70% on warm sessions</TileMeta>
+    </div>
+  );
+}
+
+function SessionsTile({ count }: { count: number }) {
+  return (
+    <div>
+      <TileLabel>sessions</TileLabel>
+      <TileValue>{count.toLocaleString("en-US")}</TileValue>
+      <TileMeta>with usage telemetry</TileMeta>
+    </div>
+  );
+}
+
+function toneClassFor(tone: "done" | "review" | "failed" | "muted"): string {
+  if (tone === "done") return "text-status-done";
+  if (tone === "review") return "text-status-review";
+  if (tone === "failed") return "text-status-failed";
+  return "text-muted-foreground";
+}
+
+// ── per-agent breakdown ──────────────────────────────────────────────
+
+const TOP_AGENTS = 5;
+
+function AgentBreakdown({
+  agents,
+  totalCost,
+}: {
+  agents: UsageAgentBreakdown[];
+  totalCost: number;
+}) {
+  const top = agents.slice(0, TOP_AGENTS);
+  const overflow = agents.length - top.length;
+  // Bar width proportional to the highest-cost agent — visually scaled
+  // for the bar group, not for the dashboard at large. With only one
+  // agent (or all-zero), every bar shows full-width which still reads
+  // as a single dominant entry.
+  const max = top.reduce((m, a) => Math.max(m, a.cost_usd), 0);
+  return (
+    <div>
+      <h3 className="text-[10px] uppercase tracking-wider text-muted-foreground mb-3">
+        by agent · top {top.length}
+      </h3>
+      <ul className="space-y-2">
+        {top.map((a) => (
+          <AgentBar
+            key={a.agent_id}
+            agent={a}
+            widthPercent={max === 0 ? 0 : (a.cost_usd / max) * 100}
+            totalCost={totalCost}
+          />
+        ))}
+      </ul>
+      {overflow > 0 ? (
+        <div className="mt-3 text-[11px] text-muted-foreground">
+          + {overflow} more agent{overflow === 1 ? "" : "s"}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function AgentBar({
+  agent,
+  widthPercent,
+  totalCost,
+}: {
+  agent: UsageAgentBreakdown;
+  widthPercent: number;
+  totalCost: number;
+}) {
+  const sharePct = totalCost === 0 ? 0 : Math.round((agent.cost_usd / totalCost) * 100);
+  return (
+    <li className="flex items-center gap-3 text-sm">
+      <span className="w-28 shrink-0 truncate text-foreground/85" title={agent.agent_label}>
+        {agent.agent_label}
+      </span>
+      <div className="flex-1 min-w-0 h-2 rounded-sm bg-secondary/60 overflow-hidden">
+        <div
+          className="h-full bg-primary/70"
+          style={{ width: `${widthPercent}%` }}
+          aria-hidden
+        />
+      </div>
+      <span className="shrink-0 w-20 text-right text-xs text-foreground/85 tabular-nums font-mono">
+        {formatCost(agent.cost_usd)}
+      </span>
+      <span className="shrink-0 w-10 text-right text-[11px] text-muted-foreground tabular-nums">
+        {sharePct}%
+      </span>
+      <span className="shrink-0 w-16 text-right text-[11px] text-muted-foreground tabular-nums">
+        {agent.sessions}{" "}
+        <span className="text-muted-foreground/60">
+          sess{agent.sessions === 1 ? "" : "ions"}
+        </span>
+      </span>
+    </li>
+  );
+}

--- a/packages/web/components/home/usage-section.tsx
+++ b/packages/web/components/home/usage-section.tsx
@@ -3,27 +3,18 @@ import { cn } from "@/lib/utils";
 import {
   formatCost,
   formatTokens,
-} from "@/components/sessions/usage-panel";
+  statusToneClass,
+  type StatusTone,
+} from "@/lib/usage-format";
 import type {
   UsageAgentBreakdown,
   UsageSummaryData,
 } from "@/lib/types/dashboard";
 
 /**
- * Dashboard "Usage" section — surfaces the cost + token rollup the
- * backend ships in `dashboard.usage_summary`. Designed to slot into
- * the home page alongside the existing KPI tiles + status / fleet /
- * trend blocks; visual language matches `KpiTile` (label on top,
- * large tabular value below, small meta line).
- *
- * Layout:
- *   - Section heading "Usage" with a window-length subtitle.
- *   - 4-up tile row: cost (with delta arrow), tokens, cache hit,
- *     sessions. Cost delta tone is inverted relative to "good": an
- *     INCREASE in cost is bad (red), a decrease is good (green).
- *   - Per-agent breakdown bars below — horizontal bars where width
- *     is proportional to the top spender's cost. Shows top 5; if
- *     more exist, surfaces a "+N more" footer.
+ * Dashboard "Usage" section. 4-up KPI tile row + per-agent cost bars.
+ * Visual language matches `KpiTile` so the section reads as part of
+ * the same dashboard family.
  */
 export function DashboardUsageSection({
   summary,
@@ -59,10 +50,11 @@ export function DashboardUsageSection({
         />
         <CacheHitTile
           ratio={summary.cache_hit_ratio}
-          totalInput={
+          hasInput={
             summary.total_input_tokens +
-            summary.total_cache_creation_tokens +
-            summary.total_cache_read_tokens
+              summary.total_cache_creation_tokens +
+              summary.total_cache_read_tokens >
+            0
           }
         />
         <SessionsTile count={summary.total_sessions} />
@@ -79,8 +71,6 @@ export function DashboardUsageSection({
   );
 }
 
-// ── tiles ─────────────────────────────────────────────────────────────
-
 function TileLabel({ children }: { children: React.ReactNode }) {
   return (
     <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1.5">
@@ -94,23 +84,13 @@ function TileValue({
   tone,
 }: {
   children: React.ReactNode;
-  tone?: "done" | "review" | "failed" | "muted";
+  tone?: StatusTone;
 }) {
-  const toneClass =
-    tone === "done"
-      ? "text-status-done"
-      : tone === "review"
-        ? "text-status-review"
-        : tone === "failed"
-          ? "text-status-failed"
-          : tone === "muted"
-            ? "text-muted-foreground"
-            : "";
   return (
     <div
       className={cn(
         "text-3xl font-semibold tabular-nums leading-none",
-        toneClass,
+        tone ? statusToneClass(tone) : undefined,
       )}
     >
       {children}
@@ -122,6 +102,24 @@ function TileMeta({ children }: { children: React.ReactNode }) {
   return <div className="mt-2 text-xs text-muted-foreground">{children}</div>;
 }
 
+/**
+ * Cost delta semantics, inverted vs the "good" convention: an INCREASE
+ * in cost is bad (red), a decrease is good (green). Zero-prior-zero-
+ * current is a flat em-dash so we don't paint a false-positive green
+ * on an empty window.
+ */
+function costDelta(
+  priorCost: number,
+  cost: number,
+  deltaPercent: number,
+): { tone: StatusTone; arrow: "up" | "down" | null; flat: boolean } {
+  const flat = priorCost === 0 && cost === 0;
+  if (flat) return { tone: "muted", arrow: null, flat: true };
+  if (deltaPercent > 0) return { tone: "failed", arrow: "up", flat: false };
+  if (deltaPercent < 0) return { tone: "done", arrow: "down", flat: false };
+  return { tone: "muted", arrow: null, flat: false };
+}
+
 function CostTile({
   cost,
   deltaPercent,
@@ -131,18 +129,7 @@ function CostTile({
   deltaPercent: number;
   priorCost: number;
 }) {
-  // Inverted tone: cost UP is bad, cost DOWN is good. Zero-prior-zero
-  // current renders as a flat "—" so we don't paint a false-positive
-  // green "down" on an empty window.
-  const flat = priorCost === 0 && cost === 0;
-  const arrow = flat ? null : deltaPercent > 0 ? "up" : deltaPercent < 0 ? "down" : null;
-  const tone: "failed" | "done" | "muted" = flat
-    ? "muted"
-    : deltaPercent > 0
-      ? "failed"
-      : deltaPercent < 0
-        ? "done"
-        : "muted";
+  const { tone, arrow, flat } = costDelta(priorCost, cost, deltaPercent);
   return (
     <div>
       <TileLabel>cost (usd)</TileLabel>
@@ -151,7 +138,7 @@ function CostTile({
         {flat ? (
           "—"
         ) : (
-          <span className={cn("inline-flex items-center gap-0.5", toneClassFor(tone))}>
+          <span className={cn("inline-flex items-center gap-0.5", statusToneClass(tone))}>
             {arrow === "up" ? <ArrowUp className="h-3 w-3" /> : null}
             {arrow === "down" ? <ArrowDown className="h-3 w-3" /> : null}
             <span className="tabular-nums">{Math.abs(deltaPercent)}%</span>
@@ -174,14 +161,10 @@ function TokensTile({
   cacheCreation: number;
   cacheRead: number;
 }) {
-  // Headline: input + output (the billed-bytes-shaped pair). Meta:
-  // breakdown of the cache slices so the absolute cost picture is
-  // visible without opening individual sessions.
-  const billed = input + output;
   return (
     <div>
       <TileLabel>tokens</TileLabel>
-      <TileValue>{formatTokens(billed)}</TileValue>
+      <TileValue>{formatTokens(input + output)}</TileValue>
       <TileMeta>
         <span className="tabular-nums">{formatTokens(input)}</span> in ·{" "}
         <span className="tabular-nums">{formatTokens(output)}</span> out
@@ -193,14 +176,8 @@ function TokensTile({
   );
 }
 
-function CacheHitTile({
-  ratio,
-  totalInput,
-}: {
-  ratio: number;
-  totalInput: number;
-}) {
-  if (totalInput === 0) {
+function CacheHitTile({ ratio, hasInput }: { ratio: number; hasInput: boolean }) {
+  if (!hasInput) {
     return (
       <div>
         <TileLabel>cache hit</TileLabel>
@@ -209,13 +186,11 @@ function CacheHitTile({
       </div>
     );
   }
-  const pct = Math.round(ratio * 100);
-  const tone: "done" | "review" | "failed" =
-    ratio >= 0.7 ? "done" : ratio >= 0.4 ? "review" : "failed";
+  const tone: StatusTone = ratio >= 0.7 ? "done" : ratio >= 0.4 ? "review" : "failed";
   return (
     <div>
       <TileLabel>cache hit</TileLabel>
-      <TileValue tone={tone}>{pct}%</TileValue>
+      <TileValue tone={tone}>{Math.round(ratio * 100)}%</TileValue>
       <TileMeta>target &gt; 70% on warm sessions</TileMeta>
     </div>
   );
@@ -231,15 +206,6 @@ function SessionsTile({ count }: { count: number }) {
   );
 }
 
-function toneClassFor(tone: "done" | "review" | "failed" | "muted"): string {
-  if (tone === "done") return "text-status-done";
-  if (tone === "review") return "text-status-review";
-  if (tone === "failed") return "text-status-failed";
-  return "text-muted-foreground";
-}
-
-// ── per-agent breakdown ──────────────────────────────────────────────
-
 const TOP_AGENTS = 5;
 
 function AgentBreakdown({
@@ -251,11 +217,8 @@ function AgentBreakdown({
 }) {
   const top = agents.slice(0, TOP_AGENTS);
   const overflow = agents.length - top.length;
-  // Bar width proportional to the highest-cost agent — visually scaled
-  // for the bar group, not for the dashboard at large. With only one
-  // agent (or all-zero), every bar shows full-width which still reads
-  // as a single dominant entry.
-  const max = top.reduce((m, a) => Math.max(m, a.cost_usd), 0);
+  // SQL pre-sorts ORDER BY cost DESC, so the head row is the max.
+  const max = top[0]?.cost_usd ?? 0;
   return (
     <div>
       <h3 className="text-[10px] uppercase tracking-wider text-muted-foreground mb-3">

--- a/packages/web/components/mesh/activity-feed.tsx
+++ b/packages/web/components/mesh/activity-feed.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import Link from "next/link";
 import { Network } from "lucide-react";
 import { EmptyState } from "@/components/empty-state";
 import { cn } from "@/lib/utils";
@@ -91,19 +92,39 @@ function countByType(asks: MeshAsk[]): Record<MeshAsk["type"], number> {
 }
 
 function AskRow({ ask }: { ask: MeshAsk }) {
+  const inner = (
+    <div className="flex items-center gap-2 text-xs text-muted-foreground mb-1">
+      <span className="text-foreground/85">{ask.caller}</span>
+      <span>→</span>
+      <span className="text-foreground/85">{ask.target}</span>
+      {ask.type !== "negotiate" ? (
+        <span className="px-1.5 py-0.5 rounded bg-secondary/60 text-foreground/70 text-[10px] uppercase tracking-wider">
+          {ask.type}
+        </span>
+      ) : null}
+      <span className="ml-auto tabular-nums">{ask.duration_label}</span>
+    </div>
+  );
+
+  // Each mesh ask is anchored to the source task that initiated it; the
+  // task detail page is the canonical surface for the full conversation
+  // (intent + response + provenance). Defensive fallback to unlinked
+  // when source_task_short_id is missing — currently the backend always
+  // populates it, but the type marks it optional.
+  if (!ask.source_task_short_id) {
+    return (
+      <li className="rounded-lg border border-border bg-card p-3 text-sm">{inner}</li>
+    );
+  }
+
   return (
-    <li className="rounded-lg border border-border bg-card p-3 text-sm">
-      <div className="flex items-center gap-2 text-xs text-muted-foreground mb-1">
-        <span className="text-foreground/85">{ask.caller}</span>
-        <span>→</span>
-        <span className="text-foreground/85">{ask.target}</span>
-        {ask.type !== "negotiate" ? (
-          <span className="px-1.5 py-0.5 rounded bg-secondary/60 text-foreground/70 text-[10px] uppercase tracking-wider">
-            {ask.type}
-          </span>
-        ) : null}
-        <span className="ml-auto tabular-nums">{ask.duration_label}</span>
-      </div>
+    <li>
+      <Link
+        href={`/tasks/${ask.source_task_short_id}`}
+        className="block rounded-lg border border-border bg-card p-3 text-sm hover:bg-secondary/50 hover:border-border/80 transition-colors cursor-pointer"
+      >
+        {inner}
+      </Link>
     </li>
   );
 }

--- a/packages/web/components/sessions/usage-panel.test.tsx
+++ b/packages/web/components/sessions/usage-panel.test.tsx
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { SessionUsageDisplay } from "@/lib/types/sessions";
+import {
+  UsagePanel,
+  cacheHitTone,
+  formatCacheHit,
+  formatCost,
+  formatTokens,
+} from "./usage-panel";
+
+function mkUsage(
+  overrides: Partial<SessionUsageDisplay> = {},
+): SessionUsageDisplay {
+  return {
+    cost_usd: 0.1234,
+    cache_hit_ratio: 0.85,
+    input_tokens: 100,
+    output_tokens: 500,
+    cache_creation_tokens: 200,
+    cache_read_tokens: 1700,
+    total_input_tokens: 2000,
+    model: "claude-opus-4-7",
+    ...overrides,
+  };
+}
+
+describe("formatCost", () => {
+  it("renders 4 decimal places for normal sub-dollar costs", () => {
+    expect(formatCost(0.1234)).toBe("$0.1234");
+    expect(formatCost(0.0089)).toBe("$0.0089");
+  });
+
+  it("renders 4 decimals for whole-dollar costs too (consistency)", () => {
+    expect(formatCost(1.5)).toBe("$1.5000");
+  });
+
+  it("clamps zero / negative to $0.0000", () => {
+    expect(formatCost(0)).toBe("$0.0000");
+    expect(formatCost(-0.01)).toBe("$0.0000");
+  });
+
+  it("shows '<$0.0001' for sub-tenth-cent costs", () => {
+    // Avoid the misleading "$0.0000" when the session actually cost
+    // something tiny but non-zero.
+    expect(formatCost(0.00005)).toBe("<$0.0001");
+  });
+});
+
+describe("formatCacheHit", () => {
+  it("renders integer percent for normal sessions", () => {
+    expect(formatCacheHit(mkUsage({ cache_hit_ratio: 0.7272, total_input_tokens: 1000 }))).toBe("73%");
+    expect(formatCacheHit(mkUsage({ cache_hit_ratio: 0, total_input_tokens: 1000 }))).toBe("0%");
+  });
+
+  it("renders an em-dash when there was no input to score against", () => {
+    // A zero cache ratio against zero input is meaningless, not bad —
+    // don't render it as "0%" or the agent looks like a cache failure.
+    expect(formatCacheHit(mkUsage({ cache_hit_ratio: 0, total_input_tokens: 0 }))).toBe("—");
+  });
+});
+
+describe("cacheHitTone", () => {
+  it("returns 'muted' when there's no input to score against", () => {
+    expect(cacheHitTone(mkUsage({ total_input_tokens: 0 }))).toBe("muted");
+  });
+
+  it("returns 'done' at or above the warm-session target (>=0.7)", () => {
+    expect(cacheHitTone(mkUsage({ cache_hit_ratio: 0.7, total_input_tokens: 100 }))).toBe("done");
+    expect(cacheHitTone(mkUsage({ cache_hit_ratio: 0.95, total_input_tokens: 100 }))).toBe("done");
+  });
+
+  it("returns 'review' in the 0.4-0.7 band (cold-but-warming)", () => {
+    expect(cacheHitTone(mkUsage({ cache_hit_ratio: 0.4, total_input_tokens: 100 }))).toBe("review");
+    expect(cacheHitTone(mkUsage({ cache_hit_ratio: 0.65, total_input_tokens: 100 }))).toBe("review");
+  });
+
+  it("returns 'failed' below 0.4 (cache effectively not working)", () => {
+    expect(cacheHitTone(mkUsage({ cache_hit_ratio: 0.39, total_input_tokens: 100 }))).toBe("failed");
+    expect(cacheHitTone(mkUsage({ cache_hit_ratio: 0, total_input_tokens: 100 }))).toBe("failed");
+  });
+});
+
+describe("formatTokens", () => {
+  it("renders raw integer for small counts", () => {
+    expect(formatTokens(0)).toBe("0");
+    expect(formatTokens(619)).toBe("619");
+    expect(formatTokens(999)).toBe("999");
+  });
+
+  it("renders K-suffix with one decimal for thousands", () => {
+    expect(formatTokens(1000)).toBe("1.0K");
+    expect(formatTokens(13498)).toBe("13.5K");
+    expect(formatTokens(999_999)).toBe("1000.0K"); // edge of K range
+  });
+
+  it("renders M-suffix with two decimals for millions", () => {
+    expect(formatTokens(1_000_000)).toBe("1.00M");
+    expect(formatTokens(2_350_000)).toBe("2.35M");
+  });
+
+  it("uses thousands separator for small counts (en-US locale)", () => {
+    // Won't trip until 4 digits, but verify the locale path renders.
+    // (Below 1000 the K-suffix path doesn't kick in.)
+    expect(formatTokens(42)).toBe("42");
+  });
+});
+
+describe("<UsagePanel />", () => {
+  it("renders the headline cost + cache-hit pair", () => {
+    render(<UsagePanel usage={mkUsage({ cost_usd: 0.1084, cache_hit_ratio: 0.89, total_input_tokens: 1000 })} />);
+    expect(screen.getByText("$0.1084")).toBeInTheDocument();
+    expect(screen.getByText("89%")).toBeInTheDocument();
+  });
+
+  it("renders the token breakdown grid", () => {
+    render(
+      <UsagePanel
+        usage={mkUsage({
+          input_tokens: 6,
+          output_tokens: 619,
+          cache_creation_tokens: 13498,
+          cache_read_tokens: 16250,
+        })}
+      />,
+    );
+    expect(screen.getByText("6")).toBeInTheDocument();
+    expect(screen.getByText("619")).toBeInTheDocument();
+    expect(screen.getByText("13.5K")).toBeInTheDocument();
+    expect(screen.getByText("16.3K")).toBeInTheDocument();
+  });
+
+  it("renders the model name in the tertiary tier", () => {
+    render(<UsagePanel usage={mkUsage({ model: "claude-opus-4-7" })} />);
+    expect(screen.getByText("claude-opus-4-7")).toBeInTheDocument();
+  });
+
+  it("renders an em-dash for cache hit when total_input_tokens is zero", () => {
+    render(<UsagePanel usage={mkUsage({ total_input_tokens: 0, cache_hit_ratio: 0 })} />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("has an aria-label so screen readers can locate the section", () => {
+    const { container } = render(<UsagePanel usage={mkUsage()} />);
+    expect(container.querySelector('[aria-label="Session usage"]')).not.toBeNull();
+  });
+});

--- a/packages/web/components/sessions/usage-panel.test.tsx
+++ b/packages/web/components/sessions/usage-panel.test.tsx
@@ -2,12 +2,12 @@ import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
 import type { SessionUsageDisplay } from "@/lib/types/sessions";
 import {
-  UsagePanel,
   cacheHitTone,
   formatCacheHit,
   formatCost,
   formatTokens,
-} from "./usage-panel";
+} from "@/lib/usage-format";
+import { UsagePanel } from "./usage-panel";
 
 function mkUsage(
   overrides: Partial<SessionUsageDisplay> = {},

--- a/packages/web/components/sessions/usage-panel.tsx
+++ b/packages/web/components/sessions/usage-panel.tsx
@@ -1,0 +1,149 @@
+import { CircleDollarSign } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { SessionUsageDisplay } from "@/lib/types/sessions";
+
+/**
+ * Per-session cost + token usage panel. Tiered visual hierarchy per
+ * the team's UI preference (no flat property lists for dense data —
+ * the eye should land on the load-bearing numbers first):
+ *
+ *   Tier 1 (headline, large): cost + cache hit ratio
+ *     The two numbers a human reviewing a session actually needs to
+ *     decide "was this expensive?" / "was the cache working?"
+ *
+ *   Tier 2 (secondary, mid): four-cell token breakdown
+ *     Input / Output / Cache write / Cache read — the substrate the
+ *     headline numbers derive from. Mono font + tabular nums so the
+ *     digits align in the grid.
+ *
+ *   Tier 3 (tertiary, muted): model name
+ *     Useful for debugging "why did this cost what it did" but
+ *     visually quiet — most sessions use one model.
+ *
+ * Cache-hit color bands are calibrated against the M9.8 target of
+ * >0.7 on a warm second-onward session. Green/amber/red is the
+ * standard semantic so they read at a glance.
+ */
+export function UsagePanel({ usage }: { usage: SessionUsageDisplay }) {
+  return (
+    <section
+      className="mt-8 pt-5 border-t border-border/60"
+      aria-label="Session usage"
+    >
+      <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-4 flex items-center gap-1.5">
+        <CircleDollarSign className="h-3 w-3" />
+        Usage
+      </h2>
+
+      <div className="grid grid-cols-2 gap-4 mb-4">
+        <Headline label="cost" value={formatCost(usage.cost_usd)} />
+        <Headline
+          label="cache hit"
+          value={formatCacheHit(usage)}
+          tone={cacheHitTone(usage)}
+        />
+      </div>
+
+      <dl className="grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-2 text-xs border-t border-border/40 pt-3">
+        <TokenStat label="Input" value={usage.input_tokens} />
+        <TokenStat label="Output" value={usage.output_tokens} />
+        <TokenStat label="Cache write" value={usage.cache_creation_tokens} />
+        <TokenStat label="Cache read" value={usage.cache_read_tokens} />
+      </dl>
+
+      <div className="mt-3 text-[11px] text-muted-foreground/60 font-mono">
+        {usage.model}
+      </div>
+    </section>
+  );
+}
+
+function Headline({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: string;
+  tone?: "done" | "review" | "failed" | "muted";
+}) {
+  const toneClass =
+    tone === "done"
+      ? "text-status-done"
+      : tone === "review"
+        ? "text-status-review"
+        : tone === "failed"
+          ? "text-status-failed"
+          : tone === "muted"
+            ? "text-muted-foreground"
+            : "text-foreground";
+  return (
+    <div>
+      <div className={cn("text-2xl font-semibold tabular-nums", toneClass)}>
+        {value}
+      </div>
+      <div className="text-xs text-muted-foreground mt-0.5">{label}</div>
+    </div>
+  );
+}
+
+function TokenStat({ label, value }: { label: string; value: number }) {
+  return (
+    <div>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="text-foreground/85 tabular-nums font-mono">
+        {formatTokens(value)}
+      </dd>
+    </div>
+  );
+}
+
+// ── formatters ────────────────────────────────────────────────────────
+
+/**
+ * Cost formatter — 4 decimal places to be transparent about token
+ * billing (most session costs land in the $0.0010–$0.5000 range; 2
+ * decimals would round most things to $0.00). Sub-cent sessions
+ * render as `<$0.0001` to avoid a misleading $0.0000.
+ */
+export function formatCost(usd: number): string {
+  if (usd <= 0) return "$0.0000";
+  if (usd < 0.0001) return "<$0.0001";
+  return `$${usd.toFixed(4)}`;
+}
+
+/**
+ * Cache-hit formatter — integer percent for readability. When the
+ * session processed no input at all (`total_input_tokens === 0`),
+ * show an em-dash instead of "0%" — a zero ratio against zero input
+ * is meaningless, not bad.
+ */
+export function formatCacheHit(usage: SessionUsageDisplay): string {
+  if (usage.total_input_tokens === 0) return "—";
+  return `${Math.round(usage.cache_hit_ratio * 100)}%`;
+}
+
+/**
+ * Cache-hit tone — green/amber/red per M9.8 calibration. Returns
+ * `"muted"` when there's no input to score against so the headline
+ * doesn't read as red on an N/A condition.
+ */
+export function cacheHitTone(
+  usage: SessionUsageDisplay,
+): "done" | "review" | "failed" | "muted" {
+  if (usage.total_input_tokens === 0) return "muted";
+  if (usage.cache_hit_ratio >= 0.7) return "done";
+  if (usage.cache_hit_ratio >= 0.4) return "review";
+  return "failed";
+}
+
+/**
+ * Token-count formatter — compact for large numbers, raw for small.
+ * `13498` → `13.5K`, `619` → `619`. Keeps the grid scannable at a
+ * glance; the raw count is one click away in the network response.
+ */
+export function formatTokens(n: number): string {
+  if (n < 1000) return n.toLocaleString("en-US");
+  if (n < 1_000_000) return `${(n / 1000).toFixed(1)}K`;
+  return `${(n / 1_000_000).toFixed(2)}M`;
+}

--- a/packages/web/components/sessions/usage-panel.tsx
+++ b/packages/web/components/sessions/usage-panel.tsx
@@ -1,28 +1,19 @@
 import { CircleDollarSign } from "lucide-react";
 import { cn } from "@/lib/utils";
+import {
+  cacheHitTone,
+  formatCacheHit,
+  formatCost,
+  formatTokens,
+  statusToneClass,
+  type StatusTone,
+} from "@/lib/usage-format";
 import type { SessionUsageDisplay } from "@/lib/types/sessions";
 
 /**
- * Per-session cost + token usage panel. Tiered visual hierarchy per
- * the team's UI preference (no flat property lists for dense data —
- * the eye should land on the load-bearing numbers first):
- *
- *   Tier 1 (headline, large): cost + cache hit ratio
- *     The two numbers a human reviewing a session actually needs to
- *     decide "was this expensive?" / "was the cache working?"
- *
- *   Tier 2 (secondary, mid): four-cell token breakdown
- *     Input / Output / Cache write / Cache read — the substrate the
- *     headline numbers derive from. Mono font + tabular nums so the
- *     digits align in the grid.
- *
- *   Tier 3 (tertiary, muted): model name
- *     Useful for debugging "why did this cost what it did" but
- *     visually quiet — most sessions use one model.
- *
- * Cache-hit color bands are calibrated against the M9.8 target of
- * >0.7 on a warm second-onward session. Green/amber/red is the
- * standard semantic so they read at a glance.
+ * Per-session cost + token usage panel. Tiered visual hierarchy:
+ * headline cost + cache-hit ratio (the two numbers a reviewer needs),
+ * mid-tier token breakdown, muted model name.
  */
 export function UsagePanel({ usage }: { usage: SessionUsageDisplay }) {
   return (
@@ -65,21 +56,16 @@ function Headline({
 }: {
   label: string;
   value: string;
-  tone?: "done" | "review" | "failed" | "muted";
+  tone?: StatusTone;
 }) {
-  const toneClass =
-    tone === "done"
-      ? "text-status-done"
-      : tone === "review"
-        ? "text-status-review"
-        : tone === "failed"
-          ? "text-status-failed"
-          : tone === "muted"
-            ? "text-muted-foreground"
-            : "text-foreground";
   return (
     <div>
-      <div className={cn("text-2xl font-semibold tabular-nums", toneClass)}>
+      <div
+        className={cn(
+          "text-2xl font-semibold tabular-nums",
+          tone ? statusToneClass(tone) : "text-foreground",
+        )}
+      >
         {value}
       </div>
       <div className="text-xs text-muted-foreground mt-0.5">{label}</div>
@@ -96,54 +82,4 @@ function TokenStat({ label, value }: { label: string; value: number }) {
       </dd>
     </div>
   );
-}
-
-// ── formatters ────────────────────────────────────────────────────────
-
-/**
- * Cost formatter — 4 decimal places to be transparent about token
- * billing (most session costs land in the $0.0010–$0.5000 range; 2
- * decimals would round most things to $0.00). Sub-cent sessions
- * render as `<$0.0001` to avoid a misleading $0.0000.
- */
-export function formatCost(usd: number): string {
-  if (usd <= 0) return "$0.0000";
-  if (usd < 0.0001) return "<$0.0001";
-  return `$${usd.toFixed(4)}`;
-}
-
-/**
- * Cache-hit formatter — integer percent for readability. When the
- * session processed no input at all (`total_input_tokens === 0`),
- * show an em-dash instead of "0%" — a zero ratio against zero input
- * is meaningless, not bad.
- */
-export function formatCacheHit(usage: SessionUsageDisplay): string {
-  if (usage.total_input_tokens === 0) return "—";
-  return `${Math.round(usage.cache_hit_ratio * 100)}%`;
-}
-
-/**
- * Cache-hit tone — green/amber/red per M9.8 calibration. Returns
- * `"muted"` when there's no input to score against so the headline
- * doesn't read as red on an N/A condition.
- */
-export function cacheHitTone(
-  usage: SessionUsageDisplay,
-): "done" | "review" | "failed" | "muted" {
-  if (usage.total_input_tokens === 0) return "muted";
-  if (usage.cache_hit_ratio >= 0.7) return "done";
-  if (usage.cache_hit_ratio >= 0.4) return "review";
-  return "failed";
-}
-
-/**
- * Token-count formatter — compact for large numbers, raw for small.
- * `13498` → `13.5K`, `619` → `619`. Keeps the grid scannable at a
- * glance; the raw count is one click away in the network response.
- */
-export function formatTokens(n: number): string {
-  if (n < 1000) return n.toLocaleString("en-US");
-  if (n < 1_000_000) return `${(n / 1000).toFixed(1)}K`;
-  return `${(n / 1_000_000).toFixed(2)}M`;
 }

--- a/packages/web/lib/dashboard-display.test.ts
+++ b/packages/web/lib/dashboard-display.test.ts
@@ -21,6 +21,19 @@ function emptyData(): DashboardSummary {
     trend_total: 0,
     trend_change_percent: 0,
     attention: [],
+    usage_summary: {
+      window_days: 7,
+      total_cost_usd: 0,
+      prior_cost_usd: 0,
+      cost_change_percent: 0,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cache_creation_tokens: 0,
+      total_cache_read_tokens: 0,
+      cache_hit_ratio: 0,
+      total_sessions: 0,
+      per_agent: [],
+    },
   };
 }
 

--- a/packages/web/lib/dashboard-display.ts
+++ b/packages/web/lib/dashboard-display.ts
@@ -37,6 +37,10 @@ export function summaryToDisplay(summary: DashboardSummary): DashboardDisplay {
     trend_total: summary.trend_total,
     trend_change_percent: summary.trend_change_percent,
     attention: summary.attention.map(attentionToDisplay),
+    // Pure pass-through — usage rendering is component-local (see
+    // DashboardUsageSection). Keeps the transformer focused on the
+    // shapes that actually need URL/label/sparkline derivation.
+    usage_summary: summary.usage_summary,
   };
 }
 

--- a/packages/web/lib/types/dashboard.ts
+++ b/packages/web/lib/types/dashboard.ts
@@ -73,6 +73,13 @@ export interface DashboardDisplay {
   trend_total: number;
   trend_change_percent: number;
   attention: AttentionItem[];
+  /**
+   * Pure-data pass-through. Usage rendering (cost formatting, color
+   * bands, per-agent bars) lives in the dashboard component since
+   * UsageSummaryData is already in scalar form — no URL/label/sparkline
+   * derivation needed at the transformer layer.
+   */
+  usage_summary: UsageSummaryData;
 }
 
 // ── Re-export the backend data DTO ─────────────────────────────────────────
@@ -87,4 +94,8 @@ export type {
   FleetBarData,
   TrendDayData,
   AttentionData,
+  UsageSummaryData,
+  UsageAgentBreakdown,
 } from "@beevibe/api/views/types";
+
+import type { UsageSummaryData } from "@beevibe/api/views/types";

--- a/packages/web/lib/types/sessions.ts
+++ b/packages/web/lib/types/sessions.ts
@@ -1,6 +1,7 @@
 export type {
   SessionDisplay,
   SessionBriefing,
+  SessionUsageDisplay,
   TranscriptEntry,
   AskThread,
 } from "@beevibe/api/views/types";

--- a/packages/web/lib/usage-format.ts
+++ b/packages/web/lib/usage-format.ts
@@ -1,0 +1,67 @@
+import type { SessionUsageDisplay } from "@/lib/types/sessions";
+
+/**
+ * Shared display vocabulary for cost / token / cache-hit telemetry.
+ *
+ * Lives in `lib/` so neither the dashboard usage section nor the
+ * per-session usage panel cross-imports from the other's component
+ * module. (Pre-consolidation, `usage-section.tsx` imported formatters
+ * from `usage-panel.tsx` — that direction was a leaky abstraction.)
+ */
+
+export type StatusTone = "muted" | "review" | "done" | "failed";
+
+const STATUS_TONE_CLASS: Record<StatusTone, string> = {
+  muted: "text-muted-foreground",
+  review: "text-status-review",
+  done: "text-status-done",
+  failed: "text-status-failed",
+};
+
+/** Resolve a StatusTone to its Tailwind text-color class. */
+export function statusToneClass(tone: StatusTone): string {
+  return STATUS_TONE_CLASS[tone];
+}
+
+/**
+ * Cost formatter — 4 decimal places to be transparent about token
+ * billing. Sub-tenth-cent costs render as `<$0.0001` to avoid the
+ * misleading `$0.0000` for a session that actually spent something.
+ */
+export function formatCost(usd: number): string {
+  if (usd <= 0) return "$0.0000";
+  if (usd < 0.0001) return "<$0.0001";
+  return `$${usd.toFixed(4)}`;
+}
+
+/**
+ * Cache-hit formatter — integer percent. Em-dash when there's no
+ * input to score against (a zero ratio against zero input is N/A,
+ * not a failure).
+ */
+export function formatCacheHit(usage: SessionUsageDisplay): string {
+  if (usage.total_input_tokens === 0) return "—";
+  return `${Math.round(usage.cache_hit_ratio * 100)}%`;
+}
+
+/**
+ * Cache-hit tone — calibrated against the M9.8 warm-session target
+ * (>0.7). Returns "muted" when there's nothing to score so the
+ * headline doesn't read as red on an N/A condition.
+ */
+export function cacheHitTone(usage: SessionUsageDisplay): StatusTone {
+  if (usage.total_input_tokens === 0) return "muted";
+  if (usage.cache_hit_ratio >= 0.7) return "done";
+  if (usage.cache_hit_ratio >= 0.4) return "review";
+  return "failed";
+}
+
+/**
+ * Token-count formatter — compact for large numbers, raw for small.
+ * `13498` → `13.5K`, `2_350_000` → `2.35M`.
+ */
+export function formatTokens(n: number): string {
+  if (n < 1000) return n.toLocaleString("en-US");
+  if (n < 1_000_000) return `${(n / 1000).toFixed(1)}K`;
+  return `${(n / 1_000_000).toFixed(2)}M`;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,10 +28,10 @@ importers:
         version: 8.57.1
       eslint-import-resolver-typescript:
         specifier: ^3.6.3
-        version: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1))(eslint@8.57.1)
+        version: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
       eslint-plugin-import:
         specifier: ^2.30.0
-        version: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+        version: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
       express:
         specifier: ^5.2.1
         version: 5.2.1
@@ -88,7 +88,7 @@ importers:
         specifier: ^6.0.2
         version: 6.0.3
       '@types/ws':
-        specifier: ^8.5.13
+        specifier: ^8.18.1
         version: 8.18.1
       pg:
         specifier: ^8.13.0
@@ -5234,8 +5234,8 @@ snapshots:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -5254,7 +5254,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -5265,22 +5265,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -5291,7 +5291,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/scripts/m12c-task-daemon-e2e.ts
+++ b/scripts/m12c-task-daemon-e2e.ts
@@ -10,7 +10,7 @@
  *     session bound to the agent's preferred_runtime_id.
  *   - Daemon claims via /runtime/claim (NOT the in-process executor).
  *   - Real claude spawns with --append-system-prompt carrying
- *     BEEVIBE_LIFECYCLE_REMINDER + briefing → agent calls
+ *     BEEVIBE_LIFECYCLE_REMINDER_TASK + briefing → agent calls
  *     update_progress on exit.
  *   - The pre-task-setup skill auto-fires on a code task (repo_url
  *     drives the trigger phrase) — proves daemon-side

--- a/scripts/m9-e2e.ts
+++ b/scripts/m9-e2e.ts
@@ -404,7 +404,7 @@ async function scenarioSix_oneSessionPerTask(
     result.rows.length === 1,
     `expected 1 session per leaf task; got ${result.rows.length} (M7 footgun?)`,
   );
-  log("  ✓ exactly one session — BEEVIBE_LIFECYCLE_REMINDER reliably triggers update_progress");
+  log("  ✓ exactly one session — BEEVIBE_LIFECYCLE_REMINDER_TASK reliably triggers update_progress");
   return result.rows;
 }
 
@@ -641,12 +641,12 @@ async function main(): Promise<void> {
     );
     log(`  ✓ pre-task-setup auto-fired (${ptsCount}x); worktree(s): ${codeWorktrees.join(", ")}`);
 
-    // ── Scenario 11: deliverable handling via BEEVIBE_LIFECYCLE_REMINDER §4 ──
+    // ── Scenario 11: deliverable handling via BEEVIBE_LIFECYCLE_REMINDER_TASK §4 ──
     // Self-contained analysis task — no repo / file deps. Exercises:
     //   - list_work_products(task_id) first (dedup check)
     //   - create_work_product with type='analysis'
     // (work-product-decision skill was removed post-M9; guidance lives in
-    // BEEVIBE_LIFECYCLE_REMINDER §4 + the work-product MCP tool descriptions.)
+    // BEEVIBE_LIFECYCLE_REMINDER_TASK §4 + the work-product MCP tool descriptions.)
     log("→ Scenario 11: deliverable-shaped task; expect list_work_products + create_work_product");
     const wpTask = await dispatchTask(
       deps,


### PR DESCRIPTION
## Summary

Iterative UI/UX fixes branch. PR opens now with the first two commits; more fixes will land on this branch as work continues.

### Landed so far

| # | Commit | Description |
|---|---|---|
| 1 | \`9e35574\` | ui: make agent recent-session rows clickable |
| 2 | \`0566975\` | build: install @types/ws to unblock api typecheck on main |

### 1 — Clickable recent sessions

Sessions on the agent detail page rendered as inert \`<li>\` rows. The only way into a session was via the task detail page. Wrapped each row in a \`<Link href="/sessions/{short_id}">\` (the existing standalone session route) with hover/border feedback. Falls back to unlinked \`<li>\` defensively if \`short_id\` is missing.

### 2 — Restore api typecheck

\`main\` was broken: \`pnpm typecheck\` failed across the web package with ~10 errors all rooted in a single cause — \`@beevibe/api\` couldn't build because \`@types/ws\` was declared but not installed, so its \`dist/\` was stale, so the web couldn't resolve recent type shapes (\`AgentNetwork\`, \`AgentPeerOwner\`, \`InboxItem\`, \`InboxItemKind\`, and the \`archived_at\` / \`preferred_runtime_id\` fields on \`AgentDisplay\`).

Reconciling the install (which bumped \`@types/ws\` from \`^8.5.13\` to \`^8.18.1\` to track runtime \`ws @ 8.18.0\`) makes api build cleanly and web typecheck + lint pass with zero changes to application code.

### Queued (incoming on this branch)

- Done tasks vanish from the UI — need an archive view / restore the archive icon / verify task search works
- Chat UX: only \`thinking\` shows during agent reply; no tool-use / MCP / stream-parser visibility
- Architectural question: should the first chat with the team agent be a task (so it triggers the pre-task-setup skill)?

## Test plan

- [ ] CI green (typecheck + lint should now pass on this branch)
- [ ] Navigate to any agent detail page, click a row in "Recent sessions" → opens the session detail
- [ ] Confirm no regression on task page → session navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)