### PR TITLE
poc: sandboxed repo-powered agent tools

### DIFF
--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@beevibe/sandbox",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Beevibe sandbox — Docker-backed isolated workspace where child agents borrow external repos as tools",
+  "license": "Apache-2.0",
+  "author": "Zhe Pang",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/beevibe-ai/beevibe.git",
+    "directory": "packages/sandbox"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./orchestrator": {
+      "types": "./dist/orchestrator.d.ts",
+      "default": "./dist/orchestrator.js"
+    },
+    "./mcp-server": {
+      "types": "./dist/mcp-server.d.ts",
+      "default": "./dist/mcp-server.js"
+    }
+  },
+  "bin": {
+    "beevibe-sandbox-mcp": "./dist/mcp-server.js",
+    "beevibe-sandbox-smoke": "./dist/scripts/smoke.js"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint src",
+    "test": "vitest run --passWithNoTests",
+    "smoke": "tsx src/scripts/smoke.ts",
+    "clean": "rm -rf dist .turbo *.tsbuildinfo"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.16.0",
+    "tsx": "^4.19.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/sandbox/src/docker.e2e.test.ts
+++ b/packages/sandbox/src/docker.e2e.test.ts
@@ -1,0 +1,76 @@
+/**
+ * End-to-end test for the docker sandbox primitives.
+ *
+ * Skipped by default — pulls a real Docker image, runs a real
+ * container, runs apt-get inside it (~30s on first hit). Enable by:
+ *
+ *   BEEVIBE_E2E_DOCKER=1 pnpm --filter @beevibe/sandbox test
+ *
+ * Verifies the smoke path: createSandbox → prepareBaseEnvironment →
+ * exec (apt-get + python smoke) → writeFileIn / readFileIn → listDir
+ * → exportArtifact → destroySandbox. Does NOT exercise the agent
+ * loop — that's the smoke / orchestrate-pdfplumber scripts.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  createSandbox,
+  destroySandbox,
+  exec,
+  exportArtifact,
+  listDir,
+  prepareBaseEnvironment,
+  readFileIn,
+  writeFileIn,
+  type Sandbox,
+} from "./docker.js";
+
+const ENABLED = process.env.BEEVIBE_E2E_DOCKER === "1";
+const describeOrSkip = ENABLED ? describe : describe.skip;
+
+describeOrSkip("sandbox primitives (e2e — Docker required)", () => {
+  it("creates, executes commands, writes/reads files, exports artifacts, destroys", async () => {
+    let sandbox: Sandbox | null = null;
+    try {
+      sandbox = await createSandbox({ label: "e2e-test" });
+      expect(sandbox.id).toMatch(/^e2e-test-/);
+      expect(sandbox.image).toBe("python:3.12-slim");
+
+      await prepareBaseEnvironment(sandbox);
+
+      const versions = await exec(sandbox, "python --version && git --version");
+      expect(versions.exit_code).toBe(0);
+      expect(versions.stdout).toMatch(/Python 3\.12/);
+      expect(versions.stdout).toMatch(/git version/);
+
+      await writeFileIn(sandbox, "/sandbox/hello.txt", "hello from e2e\n");
+      const read = await readFileIn(sandbox, "/sandbox/hello.txt");
+      expect(read).toBe("hello from e2e\n");
+
+      const list = await listDir(sandbox, "/sandbox");
+      expect(list).toContain("hello.txt");
+      expect(list).toContain("artifacts");
+
+      await exec(
+        sandbox,
+        "cp /sandbox/hello.txt /sandbox/artifacts/hello.txt",
+      );
+      const exported = await exportArtifact(
+        sandbox,
+        "/sandbox/artifacts/hello.txt",
+      );
+      expect(exported.size_bytes).toBeGreaterThan(0);
+      expect(exported.host_path).toContain("hello.txt");
+    } finally {
+      if (sandbox) await destroySandbox(sandbox);
+    }
+  }, 240_000); // 4 min — apt-get pulls take ~30–60s on a cold base image.
+
+  it("surfaces a friendly error when the docker daemon is unreachable", async () => {
+    // Sanity check that the existing path will error rather than hang
+    // when docker is unavailable. We can't easily simulate "daemon
+    // down" without stopping docker, so this test just ensures the
+    // public surface is callable; the friendly-message path is
+    // exercised in classifyStartupError at the orchestrator layer.
+    expect(typeof createSandbox).toBe("function");
+  });
+});

--- a/packages/sandbox/src/docker.ts
+++ b/packages/sandbox/src/docker.ts
@@ -1,0 +1,420 @@
+/**
+ * Docker-backed sandbox primitives.
+ *
+ * The trust boundary for "agent uses external repo" lives here. A sandbox
+ * is a single Docker container plus a host-side artifact directory. The
+ * agent can only touch the container through the functions in this file
+ * (and the MCP wrapper in `./mcp-server.ts` which exposes them to a child
+ * claude session).
+ *
+ * Defaults are conservative — no host filesystem mount, no host network
+ * after the initial clone step, CPU/memory/disk caps. The first POC pins
+ * a single base image (`python:3.12-slim` + git + curl) and only allows
+ * a hardcoded list of GitHub hosts during the clone phase.
+ */
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export interface SandboxLimits {
+  /** Hard wall-clock cap on any single command (seconds). Default 300. */
+  cmd_timeout_seconds?: number;
+  /** CPU quota — fractional cores (e.g. 1.5). Default 2. */
+  cpus?: number;
+  /** Memory cap, "512m" / "2g" etc. Default "2g". */
+  memory?: string;
+  /** Writable-layer disk cap, "5g" etc. Default "4g". */
+  storage?: string;
+  /** Whether the sandbox can reach the network after creation. Default true (we need git clone). Set to false to lock it down further. */
+  network?: boolean;
+}
+
+export interface SandboxOptions {
+  /**
+   * Pinned base image. The first POC only supports `python:3.12-slim`
+   * (with git + curl + pip pre-installed), but the parameter exists so
+   * later images can be swapped without touching callers.
+   */
+  image?: string;
+  limits?: SandboxLimits;
+  /**
+   * Human-readable tag for logs / `docker ps`. Combined with a random
+   * suffix to make the actual container name.
+   */
+  label?: string;
+}
+
+export interface Sandbox {
+  /** Container id (also used as the container name). */
+  id: string;
+  image: string;
+  /** Host directory the sandbox treats as `/sandbox/artifacts/`. Files copied here are exportable. */
+  artifact_dir: string;
+  /** When the sandbox was created. */
+  created_at: Date;
+}
+
+export interface ExecResult {
+  stdout: string;
+  stderr: string;
+  exit_code: number;
+  timed_out: boolean;
+  /** Wall-clock seconds the command ran. */
+  duration_seconds: number;
+}
+
+/**
+ * Default base image for the first POC. Pre-installed: git, curl, pip,
+ * python 3.12. Anything else the agent needs it has to `apt-get install`
+ * or `pip install` inside the sandbox.
+ *
+ * Note: in production this should be a pinned, custom-built image
+ * mirrored to a trusted registry; for the POC we use the upstream
+ * `python:3.12-slim` directly and `apt-get install -y git curl`
+ * on first exec via a `prepare` step.
+ */
+export const DEFAULT_IMAGE = "python:3.12-slim";
+
+const DEFAULT_LIMITS: Required<SandboxLimits> = {
+  cmd_timeout_seconds: 300,
+  cpus: 2,
+  memory: "2g",
+  storage: "4g",
+  network: true,
+};
+
+/**
+ * Allowed hosts during the clone phase. Anything else the sandbox tries
+ * to reach will be rejected at the docker network level.
+ *
+ * NOTE: the first POC does NOT yet enforce this — Docker's default
+ * bridge network gives full egress. Calling out the intended boundary
+ * so it's obvious where the seam is.
+ */
+export const ALLOWED_CLONE_HOSTS = [
+  "github.com",
+  "codeload.github.com",
+  "raw.githubusercontent.com",
+  "pypi.org",
+  "files.pythonhosted.org",
+];
+
+/* ─────────── public API ─────────── */
+
+export async function createSandbox(opts: SandboxOptions = {}): Promise<Sandbox> {
+  const image = opts.image ?? DEFAULT_IMAGE;
+  const limits = { ...DEFAULT_LIMITS, ...(opts.limits ?? {}) };
+  const id = generateId(opts.label ?? "bv-sbx");
+  const artifact_dir = await mkdtemp(join(tmpdir(), `${id}-artifacts-`));
+
+  const args = [
+    "run",
+    "--detach",
+    "--name",
+    id,
+    // Resource caps
+    `--cpus=${limits.cpus}`,
+    `--memory=${limits.memory}`,
+    `--storage-opt=size=${limits.storage}`,
+    // Identity: rootless when the docker daemon supports it; otherwise
+    // run as a non-root in-container user so the agent can't `apt-get`
+    // privileged operations even if it tries.
+    "--user",
+    "1000:1000",
+    // Tmpfs for /tmp so the agent has a writable scratch area without
+    // bloating the writable layer. Disk cap above bounds the layer.
+    "--tmpfs",
+    "/tmp:rw,size=512m",
+    // Mount the artifact dir so we can copy results out without
+    // `docker cp` per file. The agent writes to /sandbox/artifacts/
+    // through the MCP `sandbox_export_artifact` tool, which does the
+    // host-side copy explicitly — this bind is only used for the
+    // export step.
+    "-v",
+    `${artifact_dir}:/sandbox/artifacts:rw`,
+    "--workdir",
+    "/sandbox",
+    // Keep the container alive so we can `docker exec` repeatedly.
+    "--entrypoint",
+    "tail",
+  ];
+
+  if (!limits.network) {
+    args.push("--network=none");
+  }
+
+  args.push(image, "-f", "/dev/null");
+
+  // Some images don't have non-root /sandbox writable; pre-create it
+  // before spawning the long-lived `tail`. Easiest path: prepend a
+  // setup container. For the POC we'll skip and just `mkdir -p` from
+  // exec calls; the bind mount already provides /sandbox/artifacts.
+
+  const result = await runDocker(args, { timeoutMs: 30_000 });
+  if (result.exit_code !== 0) {
+    await rm(artifact_dir, { recursive: true, force: true }).catch(() => {});
+    throw new SandboxError(
+      `Failed to create sandbox: ${result.stderr.trim() || "docker run exited " + result.exit_code}`,
+    );
+  }
+
+  return {
+    id,
+    image,
+    artifact_dir,
+    created_at: new Date(),
+  };
+}
+
+export async function exec(
+  sandbox: Sandbox,
+  cmd: string,
+  opts: {
+    cwd?: string;
+    env?: Record<string, string>;
+    timeout_seconds?: number;
+  } = {},
+): Promise<ExecResult> {
+  const cwd = opts.cwd ?? "/sandbox";
+  const timeoutMs =
+    (opts.timeout_seconds ?? DEFAULT_LIMITS.cmd_timeout_seconds) * 1000;
+
+  const args = ["exec", "--workdir", cwd];
+  for (const [k, v] of Object.entries(opts.env ?? {})) {
+    args.push("--env", `${k}=${v}`);
+  }
+  args.push(sandbox.id, "sh", "-c", cmd);
+
+  const startedAt = Date.now();
+  const r = await runDocker(args, { timeoutMs });
+  return {
+    stdout: r.stdout,
+    stderr: r.stderr,
+    exit_code: r.exit_code,
+    timed_out: r.timed_out,
+    duration_seconds: (Date.now() - startedAt) / 1000,
+  };
+}
+
+export async function readFileIn(
+  sandbox: Sandbox,
+  path: string,
+  opts: { max_bytes?: number } = {},
+): Promise<string> {
+  const max = opts.max_bytes ?? 1_000_000;
+  // `cat` is simplest; we cap the read with `head -c` so a runaway file
+  // can't blow memory.
+  const r = await exec(sandbox, `head -c ${max + 1} ${shellQuote(path)}`, {
+    timeout_seconds: 30,
+  });
+  if (r.exit_code !== 0) {
+    throw new SandboxError(
+      `read ${path} failed (exit ${r.exit_code}): ${r.stderr.trim().slice(0, 500)}`,
+    );
+  }
+  if (r.stdout.length > max) {
+    throw new SandboxError(
+      `read ${path} exceeded max_bytes=${max} (got at least ${r.stdout.length} bytes)`,
+    );
+  }
+  return r.stdout;
+}
+
+export async function writeFileIn(
+  sandbox: Sandbox,
+  path: string,
+  content: string,
+): Promise<void> {
+  // Stage the file on the host artifact bind, then `mv` into place
+  // inside the container — avoids huge stdin-over-`docker-exec`
+  // payloads and lets us write to paths outside /sandbox/artifacts.
+  const stageName = `__stage_${randomBytes(6).toString("hex")}`;
+  const stageHostPath = join(sandbox.artifact_dir, stageName);
+  const stageContainerPath = `/sandbox/artifacts/${stageName}`;
+  await writeFile(stageHostPath, content, "utf8");
+  try {
+    const dir = path.replace(/\/[^/]*$/, "") || "/sandbox";
+    const ensureDir = await exec(sandbox, `mkdir -p ${shellQuote(dir)}`);
+    if (ensureDir.exit_code !== 0) {
+      throw new SandboxError(
+        `mkdir -p ${dir} failed: ${ensureDir.stderr.trim().slice(0, 200)}`,
+      );
+    }
+    const mv = await exec(
+      sandbox,
+      `mv ${shellQuote(stageContainerPath)} ${shellQuote(path)}`,
+    );
+    if (mv.exit_code !== 0) {
+      throw new SandboxError(
+        `write ${path} failed: ${mv.stderr.trim().slice(0, 200)}`,
+      );
+    }
+  } finally {
+    // If the mv succeeded the staging file is gone; if it failed leave
+    // the staging file for debugging but don't crash the cleanup.
+    await rm(stageHostPath, { force: true }).catch(() => {});
+  }
+}
+
+export async function listDir(
+  sandbox: Sandbox,
+  path: string,
+): Promise<string[]> {
+  const r = await exec(sandbox, `ls -1 ${shellQuote(path)}`, {
+    timeout_seconds: 30,
+  });
+  if (r.exit_code !== 0) {
+    throw new SandboxError(
+      `list ${path} failed (exit ${r.exit_code}): ${r.stderr.trim().slice(0, 200)}`,
+    );
+  }
+  return r.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+/**
+ * Export a sandbox path to the host as a real file. The agent calls this
+ * to "publish" an artifact for the parent. The returned host path is
+ * inside the sandbox's artifact_dir, which the api server can read.
+ *
+ * Implementation: `docker cp` the file out of the container into the
+ * sandbox's artifact_dir, preserving the basename.
+ */
+export async function exportArtifact(
+  sandbox: Sandbox,
+  sandboxPath: string,
+): Promise<{ host_path: string; size_bytes: number }> {
+  const basename = sandboxPath.split("/").pop() ?? "artifact";
+  const hostPath = join(sandbox.artifact_dir, basename);
+  const args = ["cp", `${sandbox.id}:${sandboxPath}`, hostPath];
+  const r = await runDocker(args, { timeoutMs: 60_000 });
+  if (r.exit_code !== 0) {
+    throw new SandboxError(
+      `export ${sandboxPath} failed: ${r.stderr.trim().slice(0, 200)}`,
+    );
+  }
+  const buf = await readFile(hostPath);
+  return { host_path: hostPath, size_bytes: buf.byteLength };
+}
+
+export async function destroySandbox(sandbox: Sandbox): Promise<void> {
+  await runDocker(["rm", "-f", sandbox.id], { timeoutMs: 30_000 }).catch(() => {});
+  // NB: artifact_dir on the host is intentionally left in place so the
+  // orchestrator can serve exported artifacts to the UI after the run
+  // ends. The OS will GC /tmp eventually; production code should
+  // promote artifacts to durable storage and call cleanupArtifactDir.
+}
+
+/** Optional cleanup — call when the run's artifacts are no longer needed. */
+export async function cleanupArtifactDir(sandbox: Sandbox): Promise<void> {
+  await rm(sandbox.artifact_dir, { recursive: true, force: true }).catch(() => {});
+}
+
+/**
+ * One-shot helper: setup the base sandbox so the agent has a working
+ * shell. Installs git + curl on top of `python:3.12-slim`. This is
+ * separate from createSandbox so callers can swap base images later
+ * without forcing this prep step.
+ */
+export async function prepareBaseEnvironment(sandbox: Sandbox): Promise<void> {
+  // Run as root for apt-get; from this point onward the agent's
+  // commands run as the in-container user (uid 1000) because that's
+  // what was set on `docker run --user`.
+  const r = await runDocker(
+    [
+      "exec",
+      "--user",
+      "0",
+      sandbox.id,
+      "sh",
+      "-c",
+      "apt-get update -qq && apt-get install -y -qq --no-install-recommends git curl ca-certificates && rm -rf /var/lib/apt/lists/* && mkdir -p /sandbox && chown -R 1000:1000 /sandbox",
+    ],
+    { timeoutMs: 180_000 },
+  );
+  if (r.exit_code !== 0) {
+    throw new SandboxError(
+      `base prep failed (exit ${r.exit_code}): ${r.stderr.trim().slice(0, 500)}`,
+    );
+  }
+}
+
+/* ─────────── internals ─────────── */
+
+export class SandboxError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SandboxError";
+  }
+}
+
+interface RawResult {
+  stdout: string;
+  stderr: string;
+  exit_code: number;
+  timed_out: boolean;
+}
+
+function runDocker(
+  args: string[],
+  opts: { timeoutMs: number },
+): Promise<RawResult> {
+  return new Promise((resolve) => {
+    const proc = spawn("docker", args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      proc.kill("SIGKILL");
+    }, opts.timeoutMs);
+    proc.stdout?.on("data", (c: Buffer) => {
+      stdout += c.toString("utf8");
+    });
+    proc.stderr?.on("data", (c: Buffer) => {
+      stderr += c.toString("utf8");
+    });
+    proc.on("error", (err) => {
+      clearTimeout(timer);
+      resolve({
+        stdout,
+        stderr: stderr + `\n<spawn-error>${err.message}</spawn-error>`,
+        exit_code: -1,
+        timed_out: timedOut,
+      });
+    });
+    proc.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({
+        stdout,
+        stderr,
+        exit_code: code ?? -1,
+        timed_out: timedOut,
+      });
+    });
+  });
+}
+
+function generateId(label: string): string {
+  const suffix = randomBytes(4).toString("hex");
+  // Container names: lowercase alphanumeric + dash + underscore only.
+  const safe = label.toLowerCase().replace(/[^a-z0-9_-]/g, "-").slice(0, 32);
+  return `${safe}-${suffix}`;
+}
+
+function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Ensure the artifact dir exists on the host before bind-mounting.
+ * Exposed only because tests want to construct synthetic sandboxes
+ * without going through the full `createSandbox` path.
+ */
+export async function ensureArtifactDir(path: string): Promise<void> {
+  await mkdir(path, { recursive: true });
+}

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Beevibe sandbox — Docker-backed isolated workspace primitives.
+ *
+ * See `./docker.ts` for the full surface. The MCP server wrapper that
+ * exposes these to a child claude session lives in `./mcp-server.ts`.
+ */
+export {
+  ALLOWED_CLONE_HOSTS,
+  cleanupArtifactDir,
+  createSandbox,
+  DEFAULT_IMAGE,
+  destroySandbox,
+  ensureArtifactDir,
+  exec,
+  exportArtifact,
+  listDir,
+  prepareBaseEnvironment,
+  readFileIn,
+  SandboxError,
+  writeFileIn,
+  type ExecResult,
+  type Sandbox,
+  type SandboxLimits,
+  type SandboxOptions,
+} from "./docker.js";

--- a/packages/sandbox/src/mcp-server.ts
+++ b/packages/sandbox/src/mcp-server.ts
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+/**
+ * Beevibe sandbox MCP server.
+ *
+ * Spawned by the orchestrator per-run via stdio. Exposes five tools
+ * (`sandbox_exec`, `sandbox_read_file`, `sandbox_write_file`,
+ * `sandbox_list`, `sandbox_export_artifact`) that wrap the primitives
+ * in `./docker.ts`. The child claude session connects to this MCP
+ * server via stdio and is restricted via `--allowedTools` to only
+ * these calls — its host `Bash` tool is disabled.
+ *
+ * The server is bound to a single sandbox at startup via two env vars:
+ *   BEEVIBE_SANDBOX_ID         — container id (also docker name)
+ *   BEEVIBE_SANDBOX_ARTIFACTS  — host path of the sandbox's artifact dir
+ *
+ * Both are produced by `createSandbox()` and passed through the
+ * MCP config file the orchestrator writes for the claude CLI.
+ */
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  type CallToolRequest,
+  type ListToolsResult,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  exec,
+  exportArtifact,
+  listDir,
+  readFileIn,
+  SandboxError,
+  writeFileIn,
+  type Sandbox,
+} from "./docker.js";
+
+interface ToolDef {
+  name: string;
+  description: string;
+  inputSchema: {
+    type: "object";
+    properties?: Record<string, object>;
+    required?: string[];
+  };
+  handler: (input: Record<string, unknown>) => Promise<unknown>;
+}
+
+function makeTools(sandbox: Sandbox): ToolDef[] {
+  return [
+    {
+      name: "sandbox_exec",
+      description:
+        "Run a shell command inside the sandbox container. Returns stdout, " +
+        "stderr, exit code, and elapsed seconds. Use this for git clone, " +
+        "package installs, running scripts, listing files, etc. The command " +
+        "runs in /sandbox by default. There is no host shell — every shell " +
+        "operation MUST go through this tool.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          cmd: { type: "string", description: "Shell command to run." },
+          cwd: {
+            type: "string",
+            description: "Working directory inside the sandbox. Defaults to /sandbox.",
+          },
+          timeout_seconds: {
+            type: "number",
+            description: "Per-command timeout (default 300, hard cap).",
+          },
+        },
+        required: ["cmd"],
+      },
+      handler: async (input) => {
+        const cmd = requireString(input, "cmd");
+        const cwd = optionalString(input, "cwd");
+        const timeout = optionalNumber(input, "timeout_seconds");
+        const r = await exec(sandbox, cmd, {
+          cwd,
+          timeout_seconds: timeout,
+        });
+        return {
+          stdout: capBytes(r.stdout, 64_000),
+          stderr: capBytes(r.stderr, 16_000),
+          exit_code: r.exit_code,
+          timed_out: r.timed_out,
+          duration_seconds: r.duration_seconds,
+        };
+      },
+    },
+    {
+      name: "sandbox_read_file",
+      description:
+        "Read a UTF-8 text file from inside the sandbox. Returns the file " +
+        "contents as a string. Capped at 1MB; use sandbox_exec with grep / " +
+        "head / tail for larger files.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          path: {
+            type: "string",
+            description: "Absolute path inside the sandbox, e.g. /sandbox/repo/README.md.",
+          },
+          max_bytes: {
+            type: "number",
+            description: "Hard cap on bytes returned (default 1,000,000).",
+          },
+        },
+        required: ["path"],
+      },
+      handler: async (input) => {
+        const path = requireString(input, "path");
+        const max_bytes = optionalNumber(input, "max_bytes");
+        const content = await readFileIn(sandbox, path, { max_bytes });
+        return { content };
+      },
+    },
+    {
+      name: "sandbox_write_file",
+      description:
+        "Write a UTF-8 text file inside the sandbox. Creates the parent " +
+        "directory if needed. Use this to write glue scripts, adapter code, " +
+        "config files. There is no host filesystem access — every file the " +
+        "agent creates must go through this tool.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          path: {
+            type: "string",
+            description: "Absolute path inside the sandbox.",
+          },
+          content: {
+            type: "string",
+            description: "File contents (UTF-8).",
+          },
+        },
+        required: ["path", "content"],
+      },
+      handler: async (input) => {
+        const path = requireString(input, "path");
+        const content = requireString(input, "content");
+        await writeFileIn(sandbox, path, content);
+        return { ok: true };
+      },
+    },
+    {
+      name: "sandbox_list",
+      description:
+        "List the entries of a directory inside the sandbox. Returns an " +
+        "array of filenames (basenames, not full paths). Use sandbox_exec " +
+        "with `ls -la` if you need details.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          path: {
+            type: "string",
+            description: "Absolute directory path inside the sandbox.",
+          },
+        },
+        required: ["path"],
+      },
+      handler: async (input) => {
+        const path = requireString(input, "path");
+        const entries = await listDir(sandbox, path);
+        return { entries };
+      },
+    },
+    {
+      name: "sandbox_export_artifact",
+      description:
+        "Publish a file from inside the sandbox as an artifact for the " +
+        "parent run. Returns a host-side artifact descriptor (path + size). " +
+        "Call this on every file you want the parent agent / user to see. " +
+        "Files that aren't exported are lost when the sandbox tears down.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          sandbox_path: {
+            type: "string",
+            description: "Absolute path inside the sandbox of the file to export.",
+          },
+          title: {
+            type: "string",
+            description:
+              "Optional human-readable title. The orchestrator uses this for the artifact's display name.",
+          },
+        },
+        required: ["sandbox_path"],
+      },
+      handler: async (input) => {
+        const sandbox_path = requireString(input, "sandbox_path");
+        const title = optionalString(input, "title");
+        const r = await exportArtifact(sandbox, sandbox_path);
+        // Write an artifact-metadata sidecar so the orchestrator can
+        // pick titles back up after the run finishes.
+        try {
+          const meta = {
+            sandbox_path,
+            host_path: r.host_path,
+            size_bytes: r.size_bytes,
+            title: title ?? sandbox_path.split("/").pop() ?? "artifact",
+            exported_at: new Date().toISOString(),
+          };
+          // Sidecar in the artifact dir, kept tiny and parsed by the
+          // orchestrator after the agent exits.
+          const sidecarPath = `${r.host_path}.meta.json`;
+          await (await import("node:fs/promises")).writeFile(
+            sidecarPath,
+            JSON.stringify(meta, null, 2),
+            "utf8",
+          );
+        } catch {
+          // Sidecar is a nice-to-have; the orchestrator can fall back
+          // to filename-only display if it isn't there.
+        }
+        return {
+          host_path: r.host_path,
+          size_bytes: r.size_bytes,
+          title: title ?? sandbox_path.split("/").pop() ?? "artifact",
+        };
+      },
+    },
+  ];
+}
+
+async function main(): Promise<void> {
+  const id = process.env.BEEVIBE_SANDBOX_ID;
+  const artifacts = process.env.BEEVIBE_SANDBOX_ARTIFACTS;
+  if (!id || !artifacts) {
+    process.stderr.write(
+      "[beevibe-sandbox-mcp] missing BEEVIBE_SANDBOX_ID or BEEVIBE_SANDBOX_ARTIFACTS env\n",
+    );
+    process.exit(2);
+  }
+  const sandbox: Sandbox = {
+    id,
+    artifact_dir: artifacts,
+    image: "(bound)",
+    created_at: new Date(),
+  };
+  const tools = makeTools(sandbox);
+  const byName = new Map(tools.map((t) => [t.name, t] as const));
+
+  const server = new Server(
+    { name: "beevibe-sandbox", version: "0.0.1" },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async (): Promise<ListToolsResult> => ({
+    tools: tools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      inputSchema: t.inputSchema,
+    })),
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (req: CallToolRequest) => {
+    const tool = byName.get(req.params.name);
+    if (!tool) {
+      return {
+        content: [{ type: "text", text: `unknown tool: ${req.params.name}` }],
+        isError: true,
+      };
+    }
+    try {
+      const result = await tool.handler(req.params.arguments ?? {});
+      return {
+        content: [{ type: "text", text: JSON.stringify(result) }],
+      };
+    } catch (err) {
+      const msg = err instanceof SandboxError ? err.message : String(err);
+      return {
+        content: [{ type: "text", text: `error: ${msg}` }],
+        isError: true,
+      };
+    }
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+function requireString(obj: Record<string, unknown>, key: string): string {
+  const v = obj[key];
+  if (typeof v !== "string") {
+    throw new SandboxError(`missing or invalid "${key}" (string required)`);
+  }
+  return v;
+}
+
+function optionalString(
+  obj: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const v = obj[key];
+  if (v === undefined || v === null) return undefined;
+  if (typeof v !== "string") {
+    throw new SandboxError(`invalid "${key}" (string expected)`);
+  }
+  return v;
+}
+
+function optionalNumber(
+  obj: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const v = obj[key];
+  if (v === undefined || v === null) return undefined;
+  if (typeof v !== "number") {
+    throw new SandboxError(`invalid "${key}" (number expected)`);
+  }
+  return v;
+}
+
+function capBytes(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max) + `\n…[truncated ${s.length - max} bytes]…\n`;
+}
+
+main().catch((err) => {
+  process.stderr.write(
+    `[beevibe-sandbox-mcp] fatal: ${err instanceof Error ? err.message : String(err)}\n`,
+  );
+  process.exit(1);
+});

--- a/packages/sandbox/src/orchestrator.ts
+++ b/packages/sandbox/src/orchestrator.ts
@@ -126,6 +126,31 @@ function nowIso(): string {
   return new Date().toISOString();
 }
 
+/**
+ * Hard caps to keep run state bounded.
+ *
+ * Without these the transcript grows unboundedly (every tool call +
+ * result is an event) and the orchestrator's response payload to the
+ * UI gets enormous. 500 events with 4KB-each ceilings keeps any single
+ * RunState well under 2MB.
+ */
+const MAX_TRANSCRIPT_EVENTS = 500;
+const MAX_EVENT_TEXT_BYTES = 4_000;
+/** Friendly error rewrites for known failure modes from `docker`/`spawn`. */
+function classifyStartupError(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  if (/Cannot connect to the Docker daemon/i.test(raw)) {
+    return "Docker isn't running. Start Docker Desktop and try the run again.";
+  }
+  if (/ENOENT.*docker/i.test(raw)) {
+    return "The `docker` CLI isn't on PATH. Install Docker Desktop (or set DOCKER_HOST).";
+  }
+  if (/no space left on device/i.test(raw)) {
+    return "Docker is out of disk. Prune containers/images or expand Docker Desktop's allotment.";
+  }
+  return raw;
+}
+
 export async function runRepoAgent(opts: OrchestratorOptions): Promise<RunState> {
   const state: RunState = {
     run_id: opts.run_id,
@@ -138,7 +163,28 @@ export async function runRepoAgent(opts: OrchestratorOptions): Promise<RunState>
   };
   const emit = (): void => opts.on_state?.({ ...state, transcript: state.transcript.slice(), artifacts: state.artifacts.slice() });
   const log = (kind: TranscriptEvent["kind"], text: string): void => {
-    state.transcript.push({ at: nowIso(), kind, text });
+    const trimmed =
+      text.length > MAX_EVENT_TEXT_BYTES
+        ? text.slice(0, MAX_EVENT_TEXT_BYTES) +
+          `\n…[truncated ${text.length - MAX_EVENT_TEXT_BYTES} bytes]…`
+        : text;
+    state.transcript.push({ at: nowIso(), kind, text: trimmed });
+    // Drop oldest events when over the cap. Keep the first event
+    // (usually the "Creating sandbox…" log) and the most recent N-1.
+    if (state.transcript.length > MAX_TRANSCRIPT_EVENTS) {
+      const overflow = state.transcript.length - MAX_TRANSCRIPT_EVENTS;
+      state.transcript.splice(1, overflow);
+      // Insert a synthetic notice on the first overflow so the UI
+      // can show "log truncated" without inserting it every event.
+      const alreadyMarked = state.transcript[1]?.text.startsWith("[log truncated:");
+      if (!alreadyMarked) {
+        state.transcript.splice(1, 0, {
+          at: nowIso(),
+          kind: "log",
+          text: `[log truncated: dropped ${overflow} earlier event${overflow === 1 ? "" : "s"}]`,
+        });
+      }
+    }
     emit();
   };
 
@@ -147,7 +193,11 @@ export async function runRepoAgent(opts: OrchestratorOptions): Promise<RunState>
     log("log", "Creating sandbox container…");
     state.status = "preparing";
     emit();
-    sandbox = await createSandbox({ label: `bv-run-${opts.run_id}` });
+    try {
+      sandbox = await createSandbox({ label: `bv-run-${opts.run_id}` });
+    } catch (err) {
+      throw new Error(classifyStartupError(err));
+    }
     state.sandbox_id = sandbox.id;
     log("log", `Sandbox ${sandbox.id} created (image ${sandbox.image}).`);
 
@@ -206,12 +256,15 @@ export async function runRepoAgent(opts: OrchestratorOptions): Promise<RunState>
     });
 
     if (claudeResult.exit_code !== 0 && claudeResult.exit_code !== null) {
+      const tail = claudeResult.stderr.slice(-500);
       log(
         "error",
-        `Child claude exited with code ${claudeResult.exit_code}: ${claudeResult.stderr.slice(-500)}`,
+        `Child claude exited with code ${claudeResult.exit_code}: ${tail}`,
       );
-      state.status = "failed";
-      state.error = `claude exit ${claudeResult.exit_code}`;
+      state.status = claudeResult.timed_out ? "blocked" : "failed";
+      state.error = claudeResult.timed_out
+        ? `Run hit the ${opts.max_runtime_seconds ?? 600}s wall-clock budget — agent didn't finish in time.`
+        : `Claude exited ${claudeResult.exit_code}.${tail ? " " + tail.slice(-200) : ""}`;
       state.finished_at = nowIso();
       emit();
       return state;
@@ -237,13 +290,15 @@ export async function runRepoAgent(opts: OrchestratorOptions): Promise<RunState>
     return state;
   } finally {
     if (sandbox) {
+      // Cleanup must not change the run's outcome — swallow errors and
+      // log them as a note rather than as a failure.
       try {
         log("log", `Destroying sandbox ${sandbox.id}…`);
         await destroySandbox(sandbox);
       } catch (err) {
         log(
-          "error",
-          `Destroy failed (continuing): ${err instanceof Error ? err.message : String(err)}`,
+          "log",
+          `Sandbox cleanup note: ${err instanceof Error ? err.message : String(err)}. Run with \`docker ps -a --filter name=bv-run-\` to inspect.`,
         );
       }
     }
@@ -381,7 +436,10 @@ function runClaude(args: {
     });
     proc.on("error", (err) => {
       clearTimeout(timer);
-      args.onTranscript("error", `claude spawn error: ${err.message}`);
+      const friendly = /ENOENT/i.test(err.message)
+        ? `Claude CLI not found at ${args.claudeBin}. Set BEEVIBE_CLAUDE_BIN to the binary path.`
+        : `claude spawn error: ${err.message}`;
+      args.onTranscript("error", friendly);
       resolve({ exit_code: -1, stdout, stderr, timed_out: timedOut });
     });
     proc.on("close", (code) => {

--- a/packages/sandbox/src/orchestrator.ts
+++ b/packages/sandbox/src/orchestrator.ts
@@ -1,0 +1,545 @@
+/**
+ * Orchestrator for "agent uses an external repo inside a sandbox."
+ *
+ * Flow:
+ *   1. Create a fresh Docker sandbox.
+ *   2. Install git + curl on top of the base image.
+ *   3. (optional) fetch a sample input file into the sandbox so the
+ *      agent has something to operate on.
+ *   4. Write an MCP config pointing to the per-run sandbox MCP server.
+ *   5. Spawn `claude --print` with that MCP config, with Bash/Read/Edit
+ *      disabled and only the `mcp__beevibe-sandbox__*` tools allowed.
+ *   6. Stream the agent's transcript while it works.
+ *   7. Once the agent exits, scan the artifact dir for files +
+ *      sidecar metadata.
+ *   8. Tear down the sandbox.
+ *
+ * The agent is the driver. The orchestrator never tells it which
+ * commands to run — it provides the repo URL, the goal, the input
+ * location, and the sandbox tools, and the agent figures out
+ * `git clone`, `pip install`, glue scripts, etc. on its own.
+ */
+import { spawn } from "node:child_process";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  createSandbox,
+  destroySandbox,
+  exec as sandboxExec,
+  prepareBaseEnvironment,
+  type Sandbox,
+} from "./docker.js";
+
+export type RunStatus = "starting" | "preparing" | "running" | "succeeded" | "blocked" | "failed";
+
+export interface ArtifactMeta {
+  filename: string;
+  title: string;
+  size_bytes: number;
+  host_path: string;
+  sandbox_path?: string;
+}
+
+export interface RunState {
+  run_id: string;
+  status: RunStatus;
+  repo_url: string;
+  goal: string;
+  started_at: string;
+  finished_at?: string;
+  sandbox_id?: string;
+  /** Streaming transcript — appended to as the agent works. */
+  transcript: TranscriptEvent[];
+  /** Whatever the agent exported via sandbox_export_artifact. */
+  artifacts: ArtifactMeta[];
+  /** Set when status is `blocked` or `failed`. */
+  error?: string;
+}
+
+export interface TranscriptEvent {
+  at: string;
+  kind: "log" | "agent" | "tool_call" | "error";
+  text: string;
+}
+
+export interface OrchestratorOptions {
+  run_id: string;
+  repo_url: string;
+  goal: string;
+  /**
+   * Optional URL to fetch into /sandbox/inputs/ before the agent
+   * runs. Useful for "operate on this PDF" type goals. The agent
+   * is told the resulting in-sandbox path in its system prompt.
+   */
+  input_url?: string;
+  input_filename?: string;
+  /** Path to the `claude` CLI binary. Defaults to "claude" on PATH. */
+  claude_bin?: string;
+  /** Caps the agent's spend per run. Default $2. */
+  max_budget_usd?: number;
+  /** Hard wall-clock cap on the whole run. Default 600s. */
+  max_runtime_seconds?: number;
+  /**
+   * Path to the sandbox MCP server entrypoint (the JS or TS file).
+   * Default: `tsx <repoRoot>/packages/sandbox/src/mcp-server.ts`.
+   */
+  mcp_server_command?: { command: string; args: string[] };
+  /** Callback fired every time RunState changes. */
+  on_state?: (state: RunState) => void;
+}
+
+const DEFAULT_PROMPT_HEADER = `\
+You are a Beevibe sandbox child agent running inside a fresh Docker container.
+
+You have ONLY these five MCP tools to touch the container. They are in your
+tool list as deferred MCP tools — you MUST load each one via ToolSearch
+before using it. ToolSearch's "select:" form only accepts ONE tool name per
+call, so make five separate calls at the very start of your work:
+
+  ToolSearch({ "query": "select:mcp__beevibe-sandbox__sandbox_exec", "max_results": 1 })
+  ToolSearch({ "query": "select:mcp__beevibe-sandbox__sandbox_read_file", "max_results": 1 })
+  ToolSearch({ "query": "select:mcp__beevibe-sandbox__sandbox_write_file", "max_results": 1 })
+  ToolSearch({ "query": "select:mcp__beevibe-sandbox__sandbox_list", "max_results": 1 })
+  ToolSearch({ "query": "select:mcp__beevibe-sandbox__sandbox_export_artifact", "max_results": 1 })
+
+After those five ToolSearch calls, you may invoke the MCP tools directly:
+
+  mcp__beevibe-sandbox__sandbox_exec(cmd, cwd?, timeout_seconds?)
+  mcp__beevibe-sandbox__sandbox_read_file(path, max_bytes?)
+  mcp__beevibe-sandbox__sandbox_write_file(path, content)
+  mcp__beevibe-sandbox__sandbox_list(path)
+  mcp__beevibe-sandbox__sandbox_export_artifact(sandbox_path, title?)
+
+You have NO Bash, NO Read, NO Edit, NO Write tool — those will return errors.
+
+The container has Python 3.12, git, and curl pre-installed. Operate inside
+/sandbox. Use a project-local venv at /sandbox/venv.
+
+Your job: use the external repo the user gives you to produce a real artifact
+for the goal. Plan, install, run, verify, export. You succeed by exporting at
+least one artifact under /sandbox/artifacts/ via sandbox_export_artifact. Stop
+as soon as you've exported something useful — don't keep exploring. If you
+can't, write REASON.txt explaining why and export that.`;
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export async function runRepoAgent(opts: OrchestratorOptions): Promise<RunState> {
+  const state: RunState = {
+    run_id: opts.run_id,
+    status: "starting",
+    repo_url: opts.repo_url,
+    goal: opts.goal,
+    started_at: nowIso(),
+    transcript: [],
+    artifacts: [],
+  };
+  const emit = (): void => opts.on_state?.({ ...state, transcript: state.transcript.slice(), artifacts: state.artifacts.slice() });
+  const log = (kind: TranscriptEvent["kind"], text: string): void => {
+    state.transcript.push({ at: nowIso(), kind, text });
+    emit();
+  };
+
+  let sandbox: Sandbox | null = null;
+  try {
+    log("log", "Creating sandbox container…");
+    state.status = "preparing";
+    emit();
+    sandbox = await createSandbox({ label: `bv-run-${opts.run_id}` });
+    state.sandbox_id = sandbox.id;
+    log("log", `Sandbox ${sandbox.id} created (image ${sandbox.image}).`);
+
+    log("log", "Installing git + curl in the sandbox base image…");
+    await prepareBaseEnvironment(sandbox);
+    log("log", "Base environment ready.");
+
+    if (opts.input_url) {
+      const filename = opts.input_filename ?? "input.bin";
+      log("log", `Fetching input into /sandbox/inputs/${filename}…`);
+      const r = await sandboxExec(
+        sandbox,
+        `mkdir -p /sandbox/inputs && curl -fsSL ${shellQuote(opts.input_url)} -o /sandbox/inputs/${shellQuote(filename)}`,
+        { timeout_seconds: 120 },
+      );
+      if (r.exit_code !== 0) {
+        throw new Error(`input fetch failed: ${r.stderr.trim().slice(0, 400)}`);
+      }
+      log("log", "Input file ready.");
+    }
+
+    // Write the MCP config the claude CLI will load.
+    const mcpServerCommand = opts.mcp_server_command ?? defaultMcpServerCommand();
+    const mcpConfigPath = join(sandbox.artifact_dir, "mcp-config.json");
+    const mcpConfig = {
+      mcpServers: {
+        "beevibe-sandbox": {
+          command: mcpServerCommand.command,
+          args: mcpServerCommand.args,
+          env: {
+            BEEVIBE_SANDBOX_ID: sandbox.id,
+            BEEVIBE_SANDBOX_ARTIFACTS: sandbox.artifact_dir,
+          },
+        },
+      },
+    };
+    await writeFile(mcpConfigPath, JSON.stringify(mcpConfig, null, 2), "utf8");
+    log("log", `MCP config written: ${mcpConfigPath}`);
+
+    // Build the prompt for the child agent.
+    const userPrompt = buildUserPrompt(opts);
+    const systemPromptAppend = DEFAULT_PROMPT_HEADER;
+
+    state.status = "running";
+    log("log", "Spawning child claude session…");
+    emit();
+
+    const claudeResult = await runClaude({
+      claudeBin: opts.claude_bin ?? "claude",
+      mcpConfigPath,
+      systemPromptAppend,
+      userPrompt,
+      maxBudgetUsd: opts.max_budget_usd ?? 2,
+      timeoutSeconds: opts.max_runtime_seconds ?? 600,
+      onTranscript: (kind, text) => log(kind, text),
+    });
+
+    if (claudeResult.exit_code !== 0 && claudeResult.exit_code !== null) {
+      log(
+        "error",
+        `Child claude exited with code ${claudeResult.exit_code}: ${claudeResult.stderr.slice(-500)}`,
+      );
+      state.status = "failed";
+      state.error = `claude exit ${claudeResult.exit_code}`;
+      state.finished_at = nowIso();
+      emit();
+      return state;
+    }
+
+    log("log", "Child claude exited cleanly. Collecting artifacts…");
+    state.artifacts = await collectArtifacts(sandbox);
+    if (state.artifacts.length === 0) {
+      state.status = "blocked";
+      state.error = "agent produced no artifacts";
+    } else {
+      state.status = "succeeded";
+    }
+    state.finished_at = nowIso();
+    emit();
+    return state;
+  } catch (err) {
+    log("error", err instanceof Error ? err.message : String(err));
+    state.status = "failed";
+    state.error = err instanceof Error ? err.message : String(err);
+    state.finished_at = nowIso();
+    emit();
+    return state;
+  } finally {
+    if (sandbox) {
+      try {
+        log("log", `Destroying sandbox ${sandbox.id}…`);
+        await destroySandbox(sandbox);
+      } catch (err) {
+        log(
+          "error",
+          `Destroy failed (continuing): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+  }
+}
+
+function buildUserPrompt(opts: OrchestratorOptions): string {
+  const lines = [
+    `Goal: ${opts.goal}`,
+    `Repo: ${opts.repo_url}`,
+  ];
+  if (opts.input_url) {
+    lines.push(`Input file (pre-fetched): /sandbox/inputs/${opts.input_filename ?? "input.bin"}`);
+  }
+  lines.push("");
+  lines.push("Work inside /sandbox. Clone the repo to /sandbox/repo. Install in a venv. ");
+  lines.push("Produce at least one artifact under /sandbox/artifacts/, then call ");
+  lines.push("sandbox_export_artifact() on each one with a short, human-readable title. ");
+  lines.push("Stop as soon as you've exported a useful artifact — don't keep exploring.");
+  return lines.join("\n");
+}
+
+const ALLOWED_TOOLS = [
+  "mcp__beevibe-sandbox__sandbox_exec",
+  "mcp__beevibe-sandbox__sandbox_read_file",
+  "mcp__beevibe-sandbox__sandbox_write_file",
+  "mcp__beevibe-sandbox__sandbox_list",
+  "mcp__beevibe-sandbox__sandbox_export_artifact",
+];
+
+const DISALLOWED_TOOLS = ["Bash", "Read", "Edit", "Write", "BashOutput", "KillBash"];
+
+interface ClaudeRunResult {
+  exit_code: number | null;
+  stdout: string;
+  stderr: string;
+  timed_out: boolean;
+}
+
+function runClaude(args: {
+  claudeBin: string;
+  mcpConfigPath: string;
+  systemPromptAppend: string;
+  userPrompt: string;
+  maxBudgetUsd: number;
+  timeoutSeconds: number;
+  onTranscript: (kind: TranscriptEvent["kind"], text: string) => void;
+}): Promise<ClaudeRunResult> {
+  return new Promise((resolve) => {
+    const cliArgs = [
+      "--print",
+      "--mcp-config",
+      args.mcpConfigPath,
+      "--allowed-tools",
+      ALLOWED_TOOLS.join(","),
+      "--disallowed-tools",
+      DISALLOWED_TOOLS.join(","),
+      "--append-system-prompt",
+      args.systemPromptAppend,
+      "--max-budget-usd",
+      String(args.maxBudgetUsd),
+      "--output-format",
+      "stream-json",
+      "--verbose",
+    ];
+
+    const proc = spawn(args.claudeBin, cliArgs, {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env },
+      // Detach the child from the parent's process group so claude
+      // doesn't inherit signals sent to the API server's request
+      // handlers (Next.js dev mode in particular forwards SIGTERM
+      // to children of route handlers when the request completes).
+      detached: true,
+    });
+    // Don't keep the parent waiting on the child's stdio after the
+    // child exits.
+    proc.unref();
+
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    let stdoutBuffer = "";
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      proc.kill("SIGTERM");
+      setTimeout(() => proc.kill("SIGKILL"), 5000);
+    }, args.timeoutSeconds * 1000);
+
+    proc.stdout.on("data", (chunk: Buffer) => {
+      const s = chunk.toString("utf8");
+      stdout += s;
+      stdoutBuffer += s;
+      // Stream-json emits newline-delimited JSON. Parse what we can and
+      // surface human-readable transcript events; preserve the buffer
+      // for partial lines.
+      let nl;
+      while ((nl = stdoutBuffer.indexOf("\n")) !== -1) {
+        const line = stdoutBuffer.slice(0, nl);
+        stdoutBuffer = stdoutBuffer.slice(nl + 1);
+        if (line.trim().length === 0) continue;
+        try {
+          const evt = JSON.parse(line) as unknown;
+          // Surface the init event's MCP server status + tool list
+          // explicitly so connection failures are obvious.
+          if (
+            evt &&
+            typeof evt === "object" &&
+            (evt as Record<string, unknown>).type === "system" &&
+            (evt as Record<string, unknown>).subtype === "init"
+          ) {
+            const init = evt as Record<string, unknown>;
+            const servers = init.mcp_servers as Array<{ name: string; status: string }> | undefined;
+            if (servers) {
+              for (const sv of servers) {
+                args.onTranscript("log", `mcp server ${sv.name}: ${sv.status}`);
+              }
+            }
+            const tools = init.tools as string[] | undefined;
+            const mcpTools = (tools ?? []).filter((t) => t.startsWith("mcp__beevibe-sandbox__"));
+            args.onTranscript(
+              "log",
+              `mcp tools exposed: ${mcpTools.length ? mcpTools.join(", ") : "none"}`,
+            );
+          }
+          handleStreamEvent(evt, args.onTranscript);
+        } catch {
+          // Not JSON yet — could be a noise line, skip.
+        }
+      }
+    });
+    proc.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    proc.on("error", (err) => {
+      clearTimeout(timer);
+      args.onTranscript("error", `claude spawn error: ${err.message}`);
+      resolve({ exit_code: -1, stdout, stderr, timed_out: timedOut });
+    });
+    proc.on("close", (code) => {
+      clearTimeout(timer);
+      // Surface stderr tail on non-zero exits so the orchestrator's
+      // error message is actionable instead of "exit 143".
+      if (code !== 0 && code !== null) {
+        const tail = stderr.slice(-800).trim();
+        if (tail) {
+          args.onTranscript("error", `claude stderr tail: ${tail}`);
+        }
+      }
+      resolve({ exit_code: code, stdout, stderr, timed_out: timedOut });
+    });
+
+    // Pipe the user prompt in via stdin (no risk of arg quoting issues).
+    proc.stdin.write(args.userPrompt);
+    proc.stdin.end();
+  });
+}
+
+/**
+ * Translate a stream-json event from claude CLI into a transcript line.
+ * stream-json events have many shapes; we surface assistant text, tool
+ * calls, and results in a tight way without dumping the raw JSON.
+ */
+function handleStreamEvent(
+  evt: unknown,
+  emit: (kind: TranscriptEvent["kind"], text: string) => void,
+): void {
+  if (!evt || typeof evt !== "object") return;
+  const e = evt as Record<string, unknown>;
+  const t = e.type as string | undefined;
+  if (t === "assistant" || t === "assistant_message") {
+    // Try to extract the text content
+    const message = e.message as Record<string, unknown> | undefined;
+    if (message && Array.isArray(message.content)) {
+      for (const item of message.content) {
+        if (!item || typeof item !== "object") continue;
+        const it = item as Record<string, unknown>;
+        if (it.type === "text" && typeof it.text === "string") {
+          emit("agent", it.text);
+        } else if (it.type === "tool_use") {
+          const name = String(it.name ?? "unknown");
+          const input = it.input ? compactJson(it.input) : "";
+          emit("tool_call", `${name}(${input})`);
+        }
+      }
+    } else if (typeof e.content === "string") {
+      emit("agent", e.content);
+    }
+  } else if (t === "user" || t === "user_message") {
+    // Tool result blocks come back inside user messages. Surface a compact
+    // form so the transcript reads as a real interleaving of calls + results.
+    const message = e.message as Record<string, unknown> | undefined;
+    if (message && Array.isArray(message.content)) {
+      for (const item of message.content) {
+        if (!item || typeof item !== "object") continue;
+        const it = item as Record<string, unknown>;
+        if (it.type === "tool_result") {
+          const content = it.content;
+          let text: string;
+          if (typeof content === "string") {
+            text = content;
+          } else if (Array.isArray(content)) {
+            text = content
+              .map((c) =>
+                c && typeof c === "object" && typeof (c as Record<string, unknown>).text === "string"
+                  ? ((c as Record<string, unknown>).text as string)
+                  : "",
+              )
+              .filter(Boolean)
+              .join(" ");
+          } else {
+            text = JSON.stringify(content ?? null);
+          }
+          const isErr = (it as Record<string, unknown>).is_error === true;
+          emit(isErr ? "error" : "tool_call", `→ ${text.slice(0, 300)}${text.length > 300 ? "…" : ""}`);
+        }
+      }
+    }
+  } else if (t === "result" && typeof e.result === "string") {
+    emit("agent", e.result);
+  } else if (t === "error") {
+    emit("error", typeof e.message === "string" ? e.message : "claude error");
+  }
+}
+
+function compactJson(v: unknown): string {
+  try {
+    const s = JSON.stringify(v);
+    return s.length > 200 ? s.slice(0, 200) + "…" : s;
+  } catch {
+    return "?";
+  }
+}
+
+/**
+ * Scan the sandbox's artifact dir for files exported via
+ * sandbox_export_artifact. Reads any sidecar `.meta.json` files the MCP
+ * server wrote so the artifact title shows up in the UI.
+ */
+async function collectArtifacts(sandbox: Sandbox): Promise<ArtifactMeta[]> {
+  const out: ArtifactMeta[] = [];
+  await mkdir(sandbox.artifact_dir, { recursive: true });
+  const entries = await readdir(sandbox.artifact_dir);
+  const sidecars = new Map<string, Record<string, unknown>>();
+  for (const e of entries) {
+    if (e.endsWith(".meta.json")) {
+      try {
+        const raw = await readFile(join(sandbox.artifact_dir, e), "utf8");
+        sidecars.set(e.replace(/\.meta\.json$/, ""), JSON.parse(raw));
+      } catch {
+        // Skip bad sidecars.
+      }
+    }
+  }
+  for (const e of entries) {
+    if (e.endsWith(".meta.json") || e === "mcp-config.json") continue;
+    const hostPath = join(sandbox.artifact_dir, e);
+    const stat = await readFile(hostPath).then(
+      (b) => ({ size: b.byteLength }),
+      () => null,
+    );
+    if (!stat) continue;
+    const meta = sidecars.get(e);
+    out.push({
+      filename: e,
+      title:
+        (typeof meta?.title === "string" && meta.title) || e.replace(/\.[^.]+$/, ""),
+      size_bytes: stat.size,
+      host_path: hostPath,
+      sandbox_path:
+        (typeof meta?.sandbox_path === "string" && meta.sandbox_path) || undefined,
+    });
+  }
+  return out;
+}
+
+function defaultMcpServerCommand(): { command: string; args: string[] } {
+  // The MCP server is spawned by claude (as a child of the orchestrator),
+  // which inherits claude's own cwd — not ours. Use an absolute path so
+  // it always resolves regardless of who launched claude. This file
+  // resolves from /packages/sandbox/dist/orchestrator.js when built, and
+  // /packages/sandbox/src/orchestrator.ts when run via tsx — both
+  // siblings of mcp-server.{js,ts}, so we just compute the path relative
+  // to this module.
+  const here = dirname(fileURLToPath(import.meta.url));
+  const isTsxRun = here.endsWith("/src");
+  const mcpServerPath = resolve(
+    here,
+    isTsxRun ? "./mcp-server.ts" : "./mcp-server.js",
+  );
+  return isTsxRun
+    ? { command: "npx", args: ["--no-install", "tsx", mcpServerPath] }
+    : { command: "node", args: ["--enable-source-maps", mcpServerPath] };
+}
+
+function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}

--- a/packages/sandbox/src/scripts/orchestrate-pdfplumber.ts
+++ b/packages/sandbox/src/scripts/orchestrate-pdfplumber.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * Real end-to-end demo: a child claude session, inside a sandbox,
+ * uses pdfplumber to extract tables from a sample PDF. No
+ * deterministic install commands — the agent figures it out.
+ *
+ * Run: pnpm --filter @beevibe/sandbox exec tsx src/scripts/orchestrate-pdfplumber.ts
+ */
+import { runRepoAgent } from "../orchestrator.js";
+
+const CLAUDE_BIN =
+  process.env.BEEVIBE_CLAUDE_BIN ??
+  "/Users/weijiasong/.vscode/extensions/anthropic.claude-code-2.1.140-darwin-arm64/resources/native-binary/claude";
+
+async function main(): Promise<void> {
+  const state = await runRepoAgent({
+    run_id: `demo-${Date.now()}`,
+    repo_url: "https://github.com/jsvine/pdfplumber",
+    goal:
+      "Extract the tables from the bundled sample PDF " +
+      "(tests/pdfs/federal-register-2020-17221.pdf in the repo) into " +
+      "structured JSON. Export the JSON as the artifact for the user.",
+    claude_bin: CLAUDE_BIN,
+    max_budget_usd: 3,
+    max_runtime_seconds: 600,
+    on_state: (s) => {
+      // Print a single-line marker each time state advances.
+      const last = s.transcript[s.transcript.length - 1];
+      if (!last) return;
+      const head = last.text.split("\n")[0]?.slice(0, 140) ?? "";
+      process.stdout.write(`[${s.status}] ${last.kind}: ${head}\n`);
+    },
+  });
+
+  process.stdout.write(`\n=== FINAL ===\nstatus: ${state.status}\n`);
+  if (state.error) process.stdout.write(`error: ${state.error}\n`);
+  process.stdout.write(`artifacts (${state.artifacts.length}):\n`);
+  for (const a of state.artifacts) {
+    process.stdout.write(
+      `  - ${a.title} (${a.size_bytes} bytes) → ${a.host_path}\n`,
+    );
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`[orchestrate] FAILED: ${err.message ?? err}\n`);
+  process.exit(1);
+});

--- a/packages/sandbox/src/scripts/reap.ts
+++ b/packages/sandbox/src/scripts/reap.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * Reap orphan sandbox containers from earlier crashed/aborted runs.
+ *
+ * Usage:
+ *   pnpm --filter @beevibe/sandbox exec tsx src/scripts/reap.ts [--older-than-minutes <N>]
+ *
+ * Default: removes any `bv-run-*` or `bv-sbx-*` / `smoke-*` container
+ * older than 30 minutes. Useful in dev when Docker piles up after
+ * a failed orchestrator run or a force-quit Next.js dev server.
+ */
+import { spawn } from "node:child_process";
+
+interface Args {
+  olderThanMinutes: number;
+}
+
+function parseArgs(): Args {
+  const args = process.argv.slice(2);
+  let olderThanMinutes = 30;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--older-than-minutes" && args[i + 1]) {
+      const n = Number(args[i + 1]);
+      if (!Number.isFinite(n) || n < 0) {
+        throw new Error(`bad --older-than-minutes value: ${args[i + 1]}`);
+      }
+      olderThanMinutes = n;
+      i++;
+    }
+  }
+  return { olderThanMinutes };
+}
+
+async function docker(args: string[]): Promise<{ stdout: string; code: number }> {
+  return new Promise((resolve) => {
+    const proc = spawn("docker", args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    proc.stdout.on("data", (c: Buffer) => {
+      stdout += c.toString("utf8");
+    });
+    proc.on("close", (code) => resolve({ stdout, code: code ?? -1 }));
+    proc.on("error", () => resolve({ stdout, code: -1 }));
+  });
+}
+
+async function main(): Promise<void> {
+  const { olderThanMinutes } = parseArgs();
+  const cutoffMs = Date.now() - olderThanMinutes * 60 * 1000;
+
+  const { stdout, code } = await docker([
+    "ps",
+    "-a",
+    "--format",
+    "{{.Names}}\t{{.CreatedAt}}",
+  ]);
+  if (code !== 0) {
+    process.stderr.write("docker ps failed — is Docker running?\n");
+    process.exit(1);
+  }
+
+  const candidates: string[] = [];
+  for (const line of stdout.split("\n")) {
+    if (!line.trim()) continue;
+    const [name, createdAt] = line.split("\t");
+    if (!name || !createdAt) continue;
+    if (!/^(bv-(run|sbx)-|smoke-)/.test(name)) continue;
+    const created = new Date(createdAt).getTime();
+    if (!Number.isFinite(created)) continue;
+    if (created < cutoffMs) candidates.push(name);
+  }
+
+  if (candidates.length === 0) {
+    process.stdout.write(`No orphan sandbox containers older than ${olderThanMinutes} min.\n`);
+    return;
+  }
+
+  process.stdout.write(`Reaping ${candidates.length} container(s):\n`);
+  for (const name of candidates) {
+    process.stdout.write(`  - ${name}\n`);
+  }
+  const r = await docker(["rm", "-f", ...candidates]);
+  if (r.code !== 0) {
+    process.stderr.write(`docker rm failed: ${r.stdout}\n`);
+    process.exit(1);
+  }
+  process.stdout.write("done.\n");
+}
+
+main().catch((err) => {
+  process.stderr.write(`reap failed: ${err.message ?? err}\n`);
+  process.exit(1);
+});

--- a/packages/sandbox/src/scripts/smoke.ts
+++ b/packages/sandbox/src/scripts/smoke.ts
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * End-to-end sandbox smoke test (no agent, just the primitives).
+ *
+ * Proves: docker is reachable, a container spawns, git clone works,
+ * pip install works, pdfplumber extracts tables from a real PDF, and
+ * the artifact comes back to the host.
+ *
+ * Run: pnpm --filter @beevibe/sandbox smoke
+ */
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  createSandbox,
+  destroySandbox,
+  exec,
+  exportArtifact,
+  listDir,
+  prepareBaseEnvironment,
+  readFileIn,
+  writeFileIn,
+} from "../docker.js";
+
+async function main(): Promise<void> {
+  let sandbox = null as Awaited<ReturnType<typeof createSandbox>> | null;
+  try {
+    log("creating sandbox…");
+    sandbox = await createSandbox({ label: "smoke-pdfplumber" });
+    log(`sandbox ${sandbox.id} created (image ${sandbox.image})`);
+    log(`artifact dir: ${sandbox.artifact_dir}`);
+
+    log("installing git + curl + ca-certificates inside sandbox…");
+    await prepareBaseEnvironment(sandbox);
+    log("base prep done");
+
+    log("verifying tool availability…");
+    const versions = await exec(sandbox, "python --version && git --version && pip --version");
+    log(versions.stdout.trim());
+    if (versions.exit_code !== 0) throw new Error("base tools missing");
+
+    log("cloning pdfplumber…");
+    const clone = await exec(
+      sandbox,
+      "git clone --depth 1 https://github.com/jsvine/pdfplumber.git /sandbox/repo",
+    );
+    if (clone.exit_code !== 0) throw new Error(`clone failed: ${clone.stderr}`);
+    log("clone done");
+
+    log("creating venv and installing pdfplumber…");
+    const install = await exec(
+      sandbox,
+      "python -m venv /sandbox/venv && . /sandbox/venv/bin/activate && pip install --quiet -e /sandbox/repo",
+      { timeout_seconds: 300 },
+    );
+    if (install.exit_code !== 0) {
+      throw new Error(
+        `install failed (exit ${install.exit_code}): ${install.stderr.slice(-1000)}`,
+      );
+    }
+    log("install done");
+
+    log("listing bundled sample PDFs…");
+    const pdfs = await exec(
+      sandbox,
+      "ls /sandbox/repo/tests/pdfs | grep -E 'example|table|federal' | head -5",
+    );
+    log(pdfs.stdout.trim());
+
+    log("writing extraction glue script (agent would do this)…");
+    await writeFileIn(
+      sandbox,
+      "/sandbox/extract.py",
+      [
+        "import json, sys",
+        "import pdfplumber",
+        "path = sys.argv[1]",
+        "out = sys.argv[2]",
+        "with pdfplumber.open(path) as pdf:",
+        "    tables = []",
+        "    for i, page in enumerate(pdf.pages):",
+        "        for t in page.extract_tables():",
+        "            tables.append({'page': i + 1, 'rows': t})",
+        "with open(out, 'w') as f:",
+        "    json.dump({'tables': tables, 'page_count': len(pdf.pages)}, f, indent=2)",
+        "print(f'wrote {out} with {len(tables)} table(s)')",
+      ].join("\n"),
+    );
+
+    log("running extraction…");
+    const run = await exec(
+      sandbox,
+      ". /sandbox/venv/bin/activate && python /sandbox/extract.py /sandbox/repo/tests/pdfs/federal-register-2020-17221.pdf /sandbox/artifacts/result.json",
+    );
+    log(run.stdout.trim());
+    if (run.exit_code !== 0) {
+      throw new Error(`extract failed (exit ${run.exit_code}): ${run.stderr}`);
+    }
+
+    log("artifact list inside sandbox:");
+    const arts = await listDir(sandbox, "/sandbox/artifacts");
+    for (const a of arts) log(`  ${a}`);
+
+    log("reading first 200 chars of result.json from inside sandbox:");
+    const preview = await readFileIn(sandbox, "/sandbox/artifacts/result.json");
+    log(preview.slice(0, 200) + (preview.length > 200 ? "…" : ""));
+
+    log("exporting result.json to host…");
+    const exported = await exportArtifact(sandbox, "/sandbox/artifacts/result.json");
+    log(`exported ${exported.size_bytes} bytes to ${exported.host_path}`);
+
+    log("smoke OK ✓");
+  } finally {
+    if (sandbox) {
+      log(`destroying sandbox ${sandbox.id}…`);
+      await destroySandbox(sandbox);
+      log("destroyed");
+    }
+  }
+}
+
+function log(msg: string): void {
+  process.stdout.write(`[smoke] ${msg}\n`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[smoke] FAILED: ${err.message ?? err}\n`);
+  process.exit(1);
+});

--- a/packages/sandbox/tsconfig.json
+++ b/packages/sandbox/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
+++ b/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
@@ -21,6 +21,8 @@ import { DetailShell } from "@/components/detail/detail-shell";
 import { FooterField } from "@/components/detail/footer-field";
 import { Metric } from "@/components/detail/metric";
 import { cn } from "@/lib/utils";
+import { AgentSavedToolsSection } from "@/components/repo-runs/saved-skills";
+import { getSavedToolsForAgentHierarchy } from "@/lib/fixtures/repo-runs";
 import type { AgentDetail } from "@/lib/api/types";
 import type { RecentSession } from "@/lib/types/agents";
 import type { ReviewPolicy } from "@beevibe/core";
@@ -192,6 +194,10 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
               </div>
             )}
           </section>
+
+          <AgentSavedToolsSection
+            tools={getSavedToolsForAgentHierarchy(agent.hierarchy)}
+          />
 
           <section>
             <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-3 font-medium">

--- a/packages/web/app/(authed)/tasks/[id]/task-detail-client.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/task-detail-client.tsx
@@ -26,6 +26,8 @@ import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
 import { richTextToMarkdown } from "@/components/rich-text";
 import { formatRelativeTime, shortId } from "@/lib/format";
+import { RepoRunsSection } from "@/components/repo-runs/repo-runs-section";
+import { getRunsForTask } from "@/lib/fixtures/repo-runs";
 import type { TaskDetail, TaskDetailSessionRow } from "@/lib/api/types";
 import type { WorkProduct } from "@beevibe/core";
 
@@ -232,6 +234,12 @@ function TaskDetailLoaded({ task }: { task: TaskDetail }) {
               </div>
             </section>
           ) : null}
+
+          <RepoRunsSection
+            runs={getRunsForTask(task.id)}
+            taskId={task.id}
+            heading="Tool runs"
+          />
 
           <section>
             <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-3 font-medium">

--- a/packages/web/app/(authed)/tools/page.tsx
+++ b/packages/web/app/(authed)/tools/page.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from "next";
+import { ToolsClient } from "./tools-client";
+
+export const metadata: Metadata = { title: "Tools" };
+
+export default function ToolsPage() {
+  return <ToolsClient />;
+}

--- a/packages/web/app/(authed)/tools/tools-client.tsx
+++ b/packages/web/app/(authed)/tools/tools-client.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useState } from "react";
-import { Box, Info } from "lucide-react";
+import { Box } from "lucide-react";
 import { DetailShell } from "@/components/detail/detail-shell";
 import { DiscoveryPanel } from "@/components/repo-runs/discovery-panel";
 import { LiveRunCard } from "@/components/repo-runs/live-run";
 import { ToolRunRow } from "@/components/repo-runs/repo-runs-section";
+import { RunFromPromptForm } from "@/components/repo-runs/run-from-prompt";
 import { SavedToolCard } from "@/components/repo-runs/saved-skills";
 import {
   FIXTURE_RUNS,
@@ -13,12 +14,11 @@ import {
 } from "@/lib/fixtures/repo-runs";
 
 /**
- * Tools — the product moment. Pick a goal, the agent picks a repo and
- * uses it inside a sandbox, the artifact appears here. Below the
- * discovery panel: live runs the user has just kicked off (real
- * sandboxed work, polled from `/api/tools/runs/[id]`). Below that:
- * fixture rows kept as design examples of what a finished run looks
- * like, until enough live runs accumulate to drop them.
+ * Tools — point at a repo, the agent uses it inside a sandbox, the
+ * artifact appears here. Primary path is the "Run a repo" form; the
+ * discovery panel below it stays as a quick-start affordance. Fixture
+ * sections at the bottom serve as design reference until enough live
+ * runs accumulate.
  */
 export function ToolsClient() {
   const [liveRunIds, setLiveRunIds] = useState<string[]>([]);
@@ -26,6 +26,8 @@ export function ToolsClient() {
   const launch = async (input: {
     repo_url: string;
     goal: string;
+    input_url?: string;
+    input_filename?: string;
   }): Promise<string | null> => {
     const r = await fetch("/api/tools/use-repo", {
       method: "POST",
@@ -57,14 +59,14 @@ export function ToolsClient() {
           </span>
         </div>
         <p className="text-sm text-muted-foreground max-w-2xl">
-          Tell us what you want done. We&apos;ll find a repo that can do it,
-          try it safely in a sandbox, and bring back the result. Save the
-          ones worth keeping for next time.
+          Point at a GitHub repo and tell the agent what you want done.
+          We clone, install, and run it inside a sandbox; the result
+          comes back here. Your machine stays clean.
         </p>
       </header>
 
       <div className="space-y-8">
-        <DiscoveryPanel onLaunch={launch} />
+        <RunFromPromptForm onLaunch={launch} />
 
         {liveRunIds.length > 0 ? (
           <section>
@@ -82,14 +84,14 @@ export function ToolsClient() {
               ))}
             </ul>
           </section>
-        ) : (
-          <p className="text-[11px] text-muted-foreground inline-flex items-center gap-1.5 px-1">
-            <Info className="h-3 w-3" />
-            Click <span className="font-medium text-foreground/85">Run this</span> on a
-            real candidate above and the live sandbox run shows up here with the agent&apos;s
-            transcript and exported artifacts.
-          </p>
-        )}
+        ) : null}
+
+        <section>
+          <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-3 font-medium">
+            Or try a starter
+          </h2>
+          <DiscoveryPanel onLaunch={launch} />
+        </section>
 
         <section>
           <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-3 font-medium">

--- a/packages/web/app/(authed)/tools/tools-client.tsx
+++ b/packages/web/app/(authed)/tools/tools-client.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { Box } from "lucide-react";
+import { useState } from "react";
+import { Box, Info } from "lucide-react";
 import { DetailShell } from "@/components/detail/detail-shell";
 import { DiscoveryPanel } from "@/components/repo-runs/discovery-panel";
+import { LiveRunCard } from "@/components/repo-runs/live-run";
 import { ToolRunRow } from "@/components/repo-runs/repo-runs-section";
 import { SavedToolCard } from "@/components/repo-runs/saved-skills";
 import {
@@ -11,11 +13,39 @@ import {
 } from "@/lib/fixtures/repo-runs";
 
 /**
- * Tools — the product moment for "let agents borrow open-source repos
- * to do real work." One panel to start something, one list of what's
- * been done, and the saved ones the team kept around for next time.
+ * Tools — the product moment. Pick a goal, the agent picks a repo and
+ * uses it inside a sandbox, the artifact appears here. Below the
+ * discovery panel: live runs the user has just kicked off (real
+ * sandboxed work, polled from `/api/tools/runs/[id]`). Below that:
+ * fixture rows kept as design examples of what a finished run looks
+ * like, until enough live runs accumulate to drop them.
  */
 export function ToolsClient() {
+  const [liveRunIds, setLiveRunIds] = useState<string[]>([]);
+
+  const launch = async (input: {
+    repo_url: string;
+    goal: string;
+  }): Promise<string | null> => {
+    const r = await fetch("/api/tools/use-repo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input),
+    });
+    if (!r.ok) {
+      // eslint-disable-next-line no-console
+      console.error("use-repo failed", r.status, await r.text());
+      return null;
+    }
+    const { run_id } = (await r.json()) as { run_id: string };
+    setLiveRunIds((prev) => [run_id, ...prev]);
+    return run_id;
+  };
+
+  const dismiss = (run_id: string): void => {
+    setLiveRunIds((prev) => prev.filter((id) => id !== run_id));
+  };
+
   return (
     <DetailShell>
       <header className="mb-6">
@@ -28,19 +58,47 @@ export function ToolsClient() {
         </div>
         <p className="text-sm text-muted-foreground max-w-2xl">
           Tell us what you want done. We&apos;ll find a repo that can do it,
-          try it safely in a sandbox, and bring back the result. Save the ones
-          worth keeping for next time.
+          try it safely in a sandbox, and bring back the result. Save the
+          ones worth keeping for next time.
         </p>
       </header>
 
       <div className="space-y-8">
-        <DiscoveryPanel />
+        <DiscoveryPanel onLaunch={launch} />
+
+        {liveRunIds.length > 0 ? (
+          <section>
+            <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-3 font-medium">
+              Live runs{" "}
+              <span className="text-muted-foreground/70 tabular-nums">
+                {liveRunIds.length}
+              </span>
+            </h2>
+            <ul className="space-y-2">
+              {liveRunIds.map((id) => (
+                <li key={id}>
+                  <LiveRunCard runId={id} onDismiss={() => dismiss(id)} />
+                </li>
+              ))}
+            </ul>
+          </section>
+        ) : (
+          <p className="text-[11px] text-muted-foreground inline-flex items-center gap-1.5 px-1">
+            <Info className="h-3 w-3" />
+            Click <span className="font-medium text-foreground/85">Run this</span> on a
+            real candidate above and the live sandbox run shows up here with the agent&apos;s
+            transcript and exported artifacts.
+          </p>
+        )}
 
         <section>
           <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-3 font-medium">
-            Recent work{" "}
+            Example runs{" "}
             <span className="text-muted-foreground/70 tabular-nums">
               {FIXTURE_RUNS.length}
+            </span>
+            <span className="ml-2 text-[10px] text-muted-foreground/70 italic font-normal">
+              fixture — design reference
             </span>
           </h2>
           <ul className="space-y-2">

--- a/packages/web/app/(authed)/tools/tools-client.tsx
+++ b/packages/web/app/(authed)/tools/tools-client.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { Box } from "lucide-react";
+import { DetailShell } from "@/components/detail/detail-shell";
+import { DiscoveryPanel } from "@/components/repo-runs/discovery-panel";
+import { ToolRunRow } from "@/components/repo-runs/repo-runs-section";
+import { SavedToolCard } from "@/components/repo-runs/saved-skills";
+import {
+  FIXTURE_RUNS,
+  FIXTURE_SAVED_TOOLS,
+} from "@/lib/fixtures/repo-runs";
+
+/**
+ * Tools — the product moment for "let agents borrow open-source repos
+ * to do real work." One panel to start something, one list of what's
+ * been done, and the saved ones the team kept around for next time.
+ */
+export function ToolsClient() {
+  return (
+    <DetailShell>
+      <header className="mb-6">
+        <div className="flex items-center gap-2 mb-1.5">
+          <Box className="h-5 w-5 text-muted-foreground" />
+          <h1 className="text-2xl font-semibold leading-tight">Tools</h1>
+          <span className="ml-2 inline-flex items-center rounded border border-border/60 bg-secondary/40 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground font-medium">
+            POC
+          </span>
+        </div>
+        <p className="text-sm text-muted-foreground max-w-2xl">
+          Tell us what you want done. We&apos;ll find a repo that can do it,
+          try it safely in a sandbox, and bring back the result. Save the ones
+          worth keeping for next time.
+        </p>
+      </header>
+
+      <div className="space-y-8">
+        <DiscoveryPanel />
+
+        <section>
+          <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-3 font-medium">
+            Recent work{" "}
+            <span className="text-muted-foreground/70 tabular-nums">
+              {FIXTURE_RUNS.length}
+            </span>
+          </h2>
+          <ul className="space-y-2">
+            {FIXTURE_RUNS.map((r, i) => (
+              <ToolRunRow
+                key={r.id}
+                run={r}
+                taskId={r.task_id}
+                initiallyOpen={i === 0}
+              />
+            ))}
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-3 font-medium">
+            Saved for next time{" "}
+            <span className="text-muted-foreground/70 tabular-nums">
+              {FIXTURE_SAVED_TOOLS.length}
+            </span>
+          </h2>
+          {FIXTURE_SAVED_TOOLS.length === 0 ? (
+            <p className="text-sm text-muted-foreground italic">
+              Nothing saved yet. Successful runs can be saved as team tools
+              from the row above.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {FIXTURE_SAVED_TOOLS.map((t) => (
+                <SavedToolCard key={t.name} tool={t} />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </DetailShell>
+  );
+}

--- a/packages/web/app/api/tools/runs/[id]/artifacts/[name]/route.ts
+++ b/packages/web/app/api/tools/runs/[id]/artifacts/[name]/route.ts
@@ -1,0 +1,53 @@
+/**
+ * Serve a single artifact file from a completed run.
+ *
+ * GET /api/tools/runs/[id]/artifacts/[name]
+ */
+import { readFile } from "node:fs/promises";
+import { extname } from "node:path";
+import { NextResponse } from "next/server";
+import { getRun } from "@/lib/tools/run-store";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const MIME: Record<string, string> = {
+  ".md": "text/markdown; charset=utf-8",
+  ".txt": "text/plain; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".csv": "text/csv; charset=utf-8",
+  ".html": "text/html; charset=utf-8",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".mp4": "video/mp4",
+  ".pdf": "application/pdf",
+};
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { id: string; name: string } },
+): Promise<NextResponse> {
+  const state = getRun(params.id);
+  if (!state) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+  const decoded = decodeURIComponent(params.name);
+  const meta = state.artifacts.find((a) => a.filename === decoded);
+  if (!meta) {
+    return NextResponse.json({ error: "artifact_not_found" }, { status: 404 });
+  }
+  try {
+    const data = await readFile(meta.host_path);
+    const mime = MIME[extname(meta.filename).toLowerCase()] ?? "application/octet-stream";
+    return new NextResponse(data, {
+      status: 200,
+      headers: {
+        "Content-Type": mime,
+        "Content-Disposition": `inline; filename="${meta.filename}"`,
+      },
+    });
+  } catch {
+    return NextResponse.json({ error: "read_failed" }, { status: 500 });
+  }
+}

--- a/packages/web/app/api/tools/runs/[id]/route.ts
+++ b/packages/web/app/api/tools/runs/[id]/route.ts
@@ -1,0 +1,31 @@
+/**
+ * Poll endpoint for an in-flight or completed sandboxed tool run.
+ * Returns the full RunState — transcript + artifact metadata.
+ *
+ * GET /api/tools/runs/[id]
+ */
+import { NextResponse } from "next/server";
+import { getRun } from "@/lib/tools/run-store";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { id: string } },
+): Promise<NextResponse> {
+  const state = getRun(params.id);
+  if (!state) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+  // Don't ship host_path to clients (filesystem leak); replace with a
+  // public artifact route the UI can fetch.
+  const artifacts = state.artifacts.map((a) => ({
+    filename: a.filename,
+    title: a.title,
+    size_bytes: a.size_bytes,
+    sandbox_path: a.sandbox_path,
+    href: `/api/tools/runs/${state.run_id}/artifacts/${encodeURIComponent(a.filename)}`,
+  }));
+  return NextResponse.json({ ...state, artifacts });
+}

--- a/packages/web/app/api/tools/use-repo/route.ts
+++ b/packages/web/app/api/tools/use-repo/route.ts
@@ -1,0 +1,106 @@
+/**
+ * POC: kick off a sandboxed tool run.
+ *
+ * POST { repo_url, goal, input_url?, input_filename? } → 202 + { run_id }
+ *
+ * The orchestrator runs async in the same Next.js server process; clients
+ * poll `/api/tools/runs/[run_id]` for status + artifacts. State lives
+ * in-memory in `@/lib/tools/run-store`.
+ *
+ * Lives under `app/api/*` for the POC only (M8 normally forbids it).
+ * See `lib/tools/run-store.ts` for the deviation rationale.
+ */
+import { NextResponse } from "next/server";
+import { runRepoAgent } from "@beevibe/sandbox/orchestrator";
+import { generateRunId, upsertRun } from "@/lib/tools/run-store";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+// Default to a VS Code extension copy of the claude binary. Override via
+// BEEVIBE_CLAUDE_BIN. Falls back to whatever `claude` resolves to via PATH.
+const DEFAULT_CLAUDE_BIN =
+  "/Users/weijiasong/.vscode/extensions/anthropic.claude-code-2.1.140-darwin-arm64/resources/native-binary/claude";
+
+interface Body {
+  repo_url?: unknown;
+  goal?: unknown;
+  input_url?: unknown;
+  input_filename?: unknown;
+  max_runtime_seconds?: unknown;
+  max_budget_usd?: unknown;
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  let body: Body;
+  try {
+    body = (await request.json()) as Body;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const repo_url = typeof body.repo_url === "string" ? body.repo_url.trim() : "";
+  const goal = typeof body.goal === "string" ? body.goal.trim() : "";
+  if (!repo_url || !goal) {
+    return NextResponse.json(
+      { error: "missing_fields", message: "repo_url and goal are required" },
+      { status: 400 },
+    );
+  }
+
+  const input_url =
+    typeof body.input_url === "string" && body.input_url.trim().length > 0
+      ? body.input_url.trim()
+      : undefined;
+  const input_filename =
+    typeof body.input_filename === "string" && body.input_filename.trim().length > 0
+      ? body.input_filename.trim()
+      : undefined;
+  const max_runtime_seconds =
+    typeof body.max_runtime_seconds === "number" ? body.max_runtime_seconds : 600;
+  const max_budget_usd =
+    typeof body.max_budget_usd === "number" ? body.max_budget_usd : 3;
+
+  const run_id = generateRunId();
+
+  // Kick off the orchestrator async. Persist state on every update.
+  upsertRun({
+    run_id,
+    status: "starting",
+    repo_url,
+    goal,
+    started_at: new Date().toISOString(),
+    transcript: [],
+    artifacts: [],
+  });
+
+  void runRepoAgent({
+    run_id,
+    repo_url,
+    goal,
+    input_url,
+    input_filename,
+    claude_bin: process.env.BEEVIBE_CLAUDE_BIN ?? DEFAULT_CLAUDE_BIN,
+    max_runtime_seconds,
+    max_budget_usd,
+    on_state: (s) => upsertRun(s),
+  }).then(
+    (final) => upsertRun(final),
+    (err) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      upsertRun({
+        run_id,
+        status: "failed",
+        repo_url,
+        goal,
+        started_at: new Date().toISOString(),
+        finished_at: new Date().toISOString(),
+        transcript: [],
+        artifacts: [],
+        error: msg,
+      });
+    },
+  );
+
+  return NextResponse.json({ run_id }, { status: 202 });
+}

--- a/packages/web/components/repo-runs/artifact-preview.tsx
+++ b/packages/web/components/repo-runs/artifact-preview.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState } from "react";
+import { FileCode, FileJson, FileText, Image as ImageIcon, FileQuestion } from "lucide-react";
+import type { Artifact } from "@/lib/fixtures/repo-runs";
+import { formatBytes } from "@/lib/fixtures/repo-runs";
+import { ChatMarkdown } from "@/components/chat/markdown";
+import { cn } from "@/lib/utils";
+
+const KIND_ICON = {
+  markdown: FileText,
+  json: FileJson,
+  text: FileCode,
+  image: ImageIcon,
+  binary: FileQuestion,
+} as const;
+
+export function ArtifactPreview({ artifacts }: { artifacts: Artifact[] }) {
+  const [openId, setOpenId] = useState<string | null>(
+    artifacts[0]?.id ?? null,
+  );
+
+  if (artifacts.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground italic">
+        No artifacts produced.
+      </p>
+    );
+  }
+
+  const open = artifacts.find((a) => a.id === openId) ?? artifacts[0];
+
+  return (
+    <div className="grid grid-cols-[200px_1fr] gap-3">
+      <ul className="space-y-1">
+        {artifacts.map((a) => {
+          const Icon = KIND_ICON[a.kind];
+          const active = a.id === open.id;
+          return (
+            <li key={a.id}>
+              <button
+                type="button"
+                onClick={() => setOpenId(a.id)}
+                className={cn(
+                  "w-full text-left flex items-center gap-2 rounded px-2 py-1.5 transition-colors cursor-pointer",
+                  active
+                    ? "bg-secondary text-foreground"
+                    : "hover:bg-secondary/40 text-muted-foreground hover:text-foreground",
+                )}
+              >
+                <Icon className="h-3.5 w-3.5 shrink-0" />
+                <span className="flex-1 min-w-0 truncate text-xs">
+                  {a.title}
+                </span>
+                <span className="text-[10px] tabular-nums text-muted-foreground/70 shrink-0">
+                  {formatBytes(a.size_bytes)}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      <div className="min-w-0 rounded-lg border border-border bg-card p-4">
+        <div className="flex items-center justify-between gap-3 mb-3 pb-2 border-b border-border/60">
+          <div className="flex items-center gap-2 min-w-0">
+            <span className="text-sm font-medium truncate">{open.title}</span>
+            <span className="font-mono text-[10px] text-muted-foreground truncate">
+              {open.path}
+            </span>
+          </div>
+          <span className="text-[10px] uppercase tracking-wider text-muted-foreground shrink-0">
+            {open.kind}
+          </span>
+        </div>
+
+        <ArtifactBody artifact={open} />
+      </div>
+    </div>
+  );
+}
+
+function ArtifactBody({ artifact }: { artifact: Artifact }) {
+  if (artifact.preview === null) {
+    return (
+      <p className="text-xs text-muted-foreground italic">
+        Binary artifact — preview unavailable. Download to inspect.
+      </p>
+    );
+  }
+
+  if (artifact.kind === "markdown") {
+    return (
+      <div className="text-foreground/90">
+        <ChatMarkdown content={artifact.preview} />
+      </div>
+    );
+  }
+
+  if (artifact.kind === "json") {
+    return (
+      <pre className="text-xs leading-relaxed font-mono text-foreground/85 overflow-x-auto">
+        {artifact.preview}
+      </pre>
+    );
+  }
+
+  return (
+    <pre className="text-xs leading-relaxed font-mono text-foreground/85 whitespace-pre-wrap break-words">
+      {artifact.preview}
+    </pre>
+  );
+}

--- a/packages/web/components/repo-runs/discovery-panel.tsx
+++ b/packages/web/components/repo-runs/discovery-panel.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useState } from "react";
+import { ExternalLink, PlayCircle, Sparkles } from "lucide-react";
+import {
+  FIXTURE_GOALS,
+  fitLabel,
+  getGoalBySlug,
+  historyLine,
+  nextLabel,
+  type Candidate,
+  type DiscoveryResult,
+  type Fit,
+} from "@/lib/fixtures/discovery";
+import { shortRepoLabel } from "@/lib/fixtures/repo-runs";
+import { cn } from "@/lib/utils";
+
+/**
+ * "What do you need done?" — the entry point. User picks a goal from a
+ * starter chip, we show 2–3 candidate repos with a one-line description
+ * and a Run button. No score chips, no signal panels, no regime banners
+ * surfaced to the user. The scoring that the agent does happens server-
+ * side; this panel just renders the picks.
+ */
+export function DiscoveryPanel() {
+  const [slug, setSlug] = useState<string>(FIXTURE_GOALS[0]!.slug);
+  const [dispatched, setDispatched] = useState<Set<string>>(new Set());
+  const goal = getGoalBySlug(slug);
+
+  return (
+    <section className="rounded-lg border border-border bg-card">
+      <header className="p-4 border-b border-border/60">
+        <h2 className="text-sm font-medium leading-tight mb-1">
+          What do you need done?
+        </h2>
+        <p className="text-xs text-muted-foreground mb-3">
+          Pick a starter or type a goal. We&apos;ll find a repo that can do
+          it, try it safely, and bring back the result.
+        </p>
+        <div className="flex flex-wrap gap-1.5">
+          {FIXTURE_GOALS.map((g) => (
+            <GoalChip
+              key={g.slug}
+              label={g.goal}
+              active={g.slug === slug}
+              onClick={() => setSlug(g.slug)}
+            />
+          ))}
+        </div>
+      </header>
+
+      {goal ? (
+        <CandidatesList
+          goal={goal}
+          dispatched={dispatched}
+          onDispatch={(id) =>
+            setDispatched((prev) => {
+              const next = new Set(prev);
+              next.add(id);
+              return next;
+            })
+          }
+        />
+      ) : null}
+    </section>
+  );
+}
+
+function GoalChip({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "rounded-full border px-3 py-1 text-[11px] transition-colors cursor-pointer",
+        active
+          ? "border-primary/50 bg-primary/10 text-foreground"
+          : "border-border bg-secondary/30 text-muted-foreground hover:text-foreground hover:bg-secondary/60",
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+function CandidatesList({
+  goal,
+  dispatched,
+  onDispatch,
+}: {
+  goal: DiscoveryResult;
+  dispatched: Set<string>;
+  onDispatch: (id: string) => void;
+}) {
+  return (
+    <ul className="divide-y divide-border/60">
+      {goal.candidates.map((c) => (
+        <li key={c.id}>
+          <CandidateRow
+            candidate={c}
+            dispatched={dispatched.has(c.id)}
+            onDispatch={() => onDispatch(c.id)}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+const FIT_DOT: Record<Fit, string> = {
+  high: "bg-status-done",
+  medium: "bg-status-review",
+  low: "bg-status-failed",
+};
+
+function CandidateRow({
+  candidate: c,
+  dispatched,
+  onDispatch,
+}: {
+  candidate: Candidate;
+  dispatched: boolean;
+  onDispatch: () => void;
+}) {
+  return (
+    <div className="p-4 flex items-start gap-4">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-0.5">
+          <h3 className="text-sm font-medium">{c.display_name}</h3>
+          <span className="font-mono text-[10px] text-muted-foreground truncate">
+            {shortRepoLabel(c.repo_url)}
+          </span>
+          <span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground">
+            <span className={cn("h-1.5 w-1.5 rounded-full", FIT_DOT[c.fit])} aria-hidden />
+            {fitLabel(c.fit)}
+          </span>
+        </div>
+        <p className="text-xs text-foreground/85 mb-1">
+          {c.short_description}
+        </p>
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
+          {c.prior_team_uses > 0 ? (
+            <span className="inline-flex items-center gap-1 text-status-done">
+              <Sparkles className="h-3 w-3" />
+              {historyLine(c)}
+            </span>
+          ) : (
+            <span>{historyLine(c)}</span>
+          )}
+          <span>·</span>
+          <span>{c.license}</span>
+          <a
+            href={c.repo_url}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 hover:text-foreground transition-colors"
+          >
+            view on GitHub
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        </div>
+      </div>
+      <div className="shrink-0 pt-1">
+        {dispatched ? (
+          <span className="inline-flex items-center gap-1.5 text-[11px] text-status-done">
+            <PlayCircle className="h-3.5 w-3.5" />
+            Started
+          </span>
+        ) : (
+          <button
+            type="button"
+            onClick={onDispatch}
+            className={cn(
+              "h-8 px-3 rounded text-xs font-medium transition-colors cursor-pointer inline-flex items-center gap-1.5",
+              c.next === "run"
+                ? "bg-primary text-primary-foreground hover:opacity-90"
+                : "border border-border bg-card hover:bg-secondary",
+            )}
+          >
+            <PlayCircle className="h-3.5 w-3.5" />
+            {nextLabel(c.next)}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/repo-runs/discovery-panel.tsx
+++ b/packages/web/components/repo-runs/discovery-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ExternalLink, PlayCircle, Sparkles } from "lucide-react";
+import { ExternalLink, Loader2, PlayCircle, Sparkles } from "lucide-react";
 import {
   FIXTURE_GOALS,
   fitLabel,
@@ -16,16 +16,37 @@ import { shortRepoLabel } from "@/lib/fixtures/repo-runs";
 import { cn } from "@/lib/utils";
 
 /**
- * "What do you need done?" — the entry point. User picks a goal from a
- * starter chip, we show 2–3 candidate repos with a one-line description
- * and a Run button. No score chips, no signal panels, no regime banners
- * surfaced to the user. The scoring that the agent does happens server-
- * side; this panel just renders the picks.
+ * "What do you need done?" — the entry point. Real `Run this` on
+ * candidates with `real_repo: true` (currently just pdfplumber); demo-
+ * only on the others until they're wired to live repos.
  */
-export function DiscoveryPanel() {
+export function DiscoveryPanel({
+  onLaunch,
+}: {
+  /** POSTs the run to the backend and returns the run_id. Parent surfaces it. */
+  onLaunch: (input: {
+    repo_url: string;
+    goal: string;
+    candidate: Candidate;
+  }) => Promise<string | null>;
+}) {
   const [slug, setSlug] = useState<string>(FIXTURE_GOALS[0]!.slug);
-  const [dispatched, setDispatched] = useState<Set<string>>(new Set());
+  const [launching, setLaunching] = useState<string | null>(null);
   const goal = getGoalBySlug(slug);
+
+  const launch = async (cand: Candidate, goalText: string): Promise<void> => {
+    if (!cand.real_repo) return;
+    setLaunching(cand.id);
+    try {
+      await onLaunch({
+        repo_url: cand.repo_url,
+        goal: cand.goal_override ?? goalText,
+        candidate: cand,
+      });
+    } finally {
+      setLaunching(null);
+    }
+  };
 
   return (
     <section className="rounded-lg border border-border bg-card">
@@ -52,14 +73,8 @@ export function DiscoveryPanel() {
       {goal ? (
         <CandidatesList
           goal={goal}
-          dispatched={dispatched}
-          onDispatch={(id) =>
-            setDispatched((prev) => {
-              const next = new Set(prev);
-              next.add(id);
-              return next;
-            })
-          }
+          launchingId={launching}
+          onLaunch={(cand) => launch(cand, goal.goal)}
         />
       ) : null}
     </section>
@@ -93,12 +108,12 @@ function GoalChip({
 
 function CandidatesList({
   goal,
-  dispatched,
-  onDispatch,
+  launchingId,
+  onLaunch,
 }: {
   goal: DiscoveryResult;
-  dispatched: Set<string>;
-  onDispatch: (id: string) => void;
+  launchingId: string | null;
+  onLaunch: (cand: Candidate) => void;
 }) {
   return (
     <ul className="divide-y divide-border/60">
@@ -106,8 +121,8 @@ function CandidatesList({
         <li key={c.id}>
           <CandidateRow
             candidate={c}
-            dispatched={dispatched.has(c.id)}
-            onDispatch={() => onDispatch(c.id)}
+            launching={launchingId === c.id}
+            onLaunch={() => onLaunch(c)}
           />
         </li>
       ))}
@@ -123,12 +138,12 @@ const FIT_DOT: Record<Fit, string> = {
 
 function CandidateRow({
   candidate: c,
-  dispatched,
-  onDispatch,
+  launching,
+  onLaunch,
 }: {
   candidate: Candidate;
-  dispatched: boolean;
-  onDispatch: () => void;
+  launching: boolean;
+  onLaunch: () => void;
 }) {
   return (
     <div className="p-4 flex items-start gap-4">
@@ -169,15 +184,22 @@ function CandidateRow({
         </div>
       </div>
       <div className="shrink-0 pt-1">
-        {dispatched ? (
-          <span className="inline-flex items-center gap-1.5 text-[11px] text-status-done">
-            <PlayCircle className="h-3.5 w-3.5" />
-            Started
+        {!c.real_repo ? (
+          <span
+            className="inline-flex items-center gap-1 text-[11px] text-muted-foreground/70"
+            title="Wired up in a later PR — for the first POC only pdfplumber runs for real."
+          >
+            demo only
+          </span>
+        ) : launching ? (
+          <span className="inline-flex items-center gap-1.5 text-[11px] text-status-running">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            Starting…
           </span>
         ) : (
           <button
             type="button"
-            onClick={onDispatch}
+            onClick={onLaunch}
             className={cn(
               "h-8 px-3 rounded text-xs font-medium transition-colors cursor-pointer inline-flex items-center gap-1.5",
               c.next === "run"

--- a/packages/web/components/repo-runs/live-run.tsx
+++ b/packages/web/components/repo-runs/live-run.tsx
@@ -1,0 +1,337 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  CircleCheck,
+  CircleX,
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+  XCircle,
+} from "lucide-react";
+import { ChatMarkdown } from "@/components/chat/markdown";
+import { formatRelativeTime } from "@/lib/format";
+import { cn } from "@/lib/utils";
+
+/**
+ * A real, live sandboxed tool run. Polls `/api/tools/runs/[id]` until
+ * the orchestrator finishes. Renders transcript events as they stream
+ * in and artifacts after the run completes.
+ *
+ * Backed by Next.js API routes (POC-only deviation from the no-app/api
+ * rule — see lib/tools/run-store.ts for context).
+ */
+export type LiveRunStatus =
+  | "starting"
+  | "preparing"
+  | "running"
+  | "succeeded"
+  | "blocked"
+  | "failed";
+
+interface TranscriptEvent {
+  at: string;
+  kind: "log" | "agent" | "tool_call" | "error";
+  text: string;
+}
+
+interface ArtifactDescriptor {
+  filename: string;
+  title: string;
+  size_bytes: number;
+  sandbox_path?: string;
+  href: string;
+}
+
+interface RunResponse {
+  run_id: string;
+  status: LiveRunStatus;
+  repo_url: string;
+  goal: string;
+  started_at: string;
+  finished_at?: string;
+  transcript: TranscriptEvent[];
+  artifacts: ArtifactDescriptor[];
+  error?: string;
+}
+
+const STATUS_TONE: Record<LiveRunStatus, { dot: string; text: string; label: string; Icon: typeof CircleCheck }> = {
+  starting: { dot: "bg-status-running animate-pulse-breathe", text: "text-status-running", label: "Starting", Icon: Loader2 },
+  preparing: { dot: "bg-status-running animate-pulse-breathe", text: "text-status-running", label: "Preparing sandbox", Icon: Loader2 },
+  running: { dot: "bg-status-running animate-pulse-breathe", text: "text-status-running", label: "Agent working", Icon: Loader2 },
+  succeeded: { dot: "bg-status-done", text: "text-status-done", label: "Done", Icon: CircleCheck },
+  blocked: { dot: "bg-status-blocked", text: "text-status-blocked", label: "Couldn't finish", Icon: XCircle },
+  failed: { dot: "bg-status-failed", text: "text-status-failed", label: "Failed", Icon: CircleX },
+};
+
+export function LiveRunCard({
+  runId,
+  onDismiss,
+}: {
+  runId: string;
+  onDismiss?: () => void;
+}) {
+  const { data, isError } = useQuery<RunResponse>({
+    queryKey: ["tools", "run", runId],
+    queryFn: async () => {
+      const r = await fetch(`/api/tools/runs/${runId}`, { cache: "no-store" });
+      if (!r.ok) throw new Error(`run ${runId} not found`);
+      return (await r.json()) as RunResponse;
+    },
+    // Poll fast while in flight, slowly when done.
+    refetchInterval: (q) => {
+      const s = (q.state.data as RunResponse | undefined)?.status;
+      if (!s || s === "succeeded" || s === "blocked" || s === "failed") {
+        return false;
+      }
+      return 1500;
+    },
+  });
+
+  if (isError || !data) {
+    return (
+      <article className="rounded-lg border border-status-failed/40 bg-card p-4 text-sm text-status-failed">
+        Couldn&apos;t load run {runId}. Check the server logs.
+      </article>
+    );
+  }
+
+  return <LiveRunBody run={data} onDismiss={onDismiss} />;
+}
+
+function LiveRunBody({
+  run,
+  onDismiss,
+}: {
+  run: RunResponse;
+  onDismiss?: () => void;
+}) {
+  const tone = STATUS_TONE[run.status];
+  const StatusIcon = tone.Icon;
+  const inFlight =
+    run.status === "starting" ||
+    run.status === "preparing" ||
+    run.status === "running";
+
+  const [transcriptOpen, setTranscriptOpen] = useState(inFlight);
+  // Auto-expand transcript when in-flight, collapse when finished and
+  // there are artifacts to focus on.
+  useEffect(() => {
+    if (!inFlight && run.artifacts.length > 0) setTranscriptOpen(false);
+  }, [inFlight, run.artifacts.length]);
+
+  return (
+    <article className="rounded-lg border border-border bg-card overflow-hidden">
+      <header className="p-3 flex items-start gap-3 border-b border-border/60">
+        <StatusIcon
+          className={cn(
+            "h-4 w-4 mt-0.5 shrink-0",
+            tone.text,
+            inFlight ? "animate-spin" : "",
+          )}
+        />
+        <div className="flex-1 min-w-0">
+          <p className="text-sm text-foreground/90 leading-snug">
+            <span className={cn("font-medium", tone.text)}>{tone.label}</span>
+            <span className="text-muted-foreground"> — </span>
+            <span className="text-foreground/85">{run.goal}</span>
+          </p>
+          <p className="text-[11px] text-muted-foreground font-mono mt-0.5">
+            {shortRepoLabel(run.repo_url)} · {formatRelativeTime(run.started_at)}
+          </p>
+        </div>
+        {onDismiss ? (
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="text-muted-foreground hover:text-foreground transition-colors cursor-pointer shrink-0"
+            aria-label="Dismiss"
+          >
+            ×
+          </button>
+        ) : null}
+      </header>
+
+      {run.error ? (
+        <p className="text-[11px] text-status-failed px-3 py-2 border-b border-border/60">
+          {run.error}
+        </p>
+      ) : null}
+
+      {run.artifacts.length > 0 ? (
+        <div className="p-3 border-b border-border/60">
+          <h3 className="text-[10px] uppercase tracking-wider text-muted-foreground mb-2 font-medium">
+            Artifacts
+          </h3>
+          <ArtifactList artifacts={run.artifacts} />
+        </div>
+      ) : null}
+
+      <div className="p-3">
+        <button
+          type="button"
+          onClick={() => setTranscriptOpen((v) => !v)}
+          className="text-[11px] text-muted-foreground hover:text-foreground transition-colors cursor-pointer inline-flex items-center gap-1"
+        >
+          {transcriptOpen ? (
+            <ChevronDown className="h-3 w-3" />
+          ) : (
+            <ChevronRight className="h-3 w-3" />
+          )}
+          {transcriptOpen ? "Hide" : "Show"} agent log
+          <span className="text-muted-foreground/70 tabular-nums">
+            ({run.transcript.length})
+          </span>
+        </button>
+        {transcriptOpen ? <Transcript events={run.transcript} /> : null}
+      </div>
+    </article>
+  );
+}
+
+function Transcript({ events }: { events: TranscriptEvent[] }) {
+  return (
+    <ul className="mt-2 space-y-1 max-h-[420px] overflow-auto rounded border border-border/40 bg-background/50 p-2 font-mono text-[11px]">
+      {events.length === 0 ? (
+        <li className="text-muted-foreground/70 italic">…waiting…</li>
+      ) : null}
+      {events.map((e, i) => {
+        const tone =
+          e.kind === "error"
+            ? "text-status-failed"
+            : e.kind === "agent"
+              ? "text-foreground/90"
+              : e.kind === "tool_call"
+                ? "text-status-running"
+                : "text-muted-foreground";
+        return (
+          <li key={i} className={cn("leading-tight whitespace-pre-wrap break-words", tone)}>
+            <span className="text-muted-foreground/50 mr-1.5">
+              {e.kind === "agent"
+                ? "▸"
+                : e.kind === "tool_call"
+                  ? "·"
+                  : e.kind === "error"
+                    ? "!"
+                    : "—"}
+            </span>
+            {e.text}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function ArtifactList({ artifacts }: { artifacts: ArtifactDescriptor[] }) {
+  const [openId, setOpenId] = useState<string | null>(artifacts[0]?.filename ?? null);
+  const open = useMemo(
+    () => artifacts.find((a) => a.filename === openId) ?? artifacts[0],
+    [artifacts, openId],
+  );
+  return (
+    <div className="grid grid-cols-[200px_1fr] gap-3">
+      <ul className="space-y-1">
+        {artifacts.map((a) => {
+          const active = a.filename === open?.filename;
+          return (
+            <li key={a.filename}>
+              <button
+                type="button"
+                onClick={() => setOpenId(a.filename)}
+                className={cn(
+                  "w-full text-left flex items-center gap-2 rounded px-2 py-1.5 transition-colors cursor-pointer",
+                  active
+                    ? "bg-secondary text-foreground"
+                    : "hover:bg-secondary/40 text-muted-foreground hover:text-foreground",
+                )}
+              >
+                <span className="flex-1 min-w-0 truncate text-xs">{a.title}</span>
+                <span className="text-[10px] tabular-nums text-muted-foreground/70 shrink-0">
+                  {formatSize(a.size_bytes)}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+      {open ? <ArtifactBody artifact={open} /> : null}
+    </div>
+  );
+}
+
+function ArtifactBody({ artifact }: { artifact: ArtifactDescriptor }) {
+  const [content, setContent] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    setContent(null);
+    setErr(null);
+    fetch(artifact.href, { cache: "no-store" })
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`status ${r.status}`);
+        return r.text();
+      })
+      .then((text) => {
+        if (!cancelled) setContent(text);
+      })
+      .catch((e) => {
+        if (!cancelled) setErr(e instanceof Error ? e.message : String(e));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [artifact.href]);
+
+  const ext = artifact.filename.split(".").pop()?.toLowerCase() ?? "";
+  return (
+    <div className="min-w-0 rounded border border-border bg-background/40 p-3">
+      <div className="flex items-center justify-between gap-3 mb-2 pb-1.5 border-b border-border/60">
+        <span className="text-sm font-medium truncate">{artifact.title}</span>
+        <a
+          href={artifact.href}
+          download={artifact.filename}
+          className="text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+        >
+          download
+        </a>
+      </div>
+      {err ? (
+        <p className="text-[11px] text-status-failed italic">{err}</p>
+      ) : content === null ? (
+        <p className="text-[11px] text-muted-foreground italic">loading…</p>
+      ) : ext === "md" ? (
+        <div className="text-foreground/90">
+          <ChatMarkdown content={content} />
+        </div>
+      ) : ext === "json" ? (
+        <pre className="text-xs leading-relaxed font-mono text-foreground/85 overflow-x-auto whitespace-pre-wrap">
+          {prettyJson(content)}
+        </pre>
+      ) : (
+        <pre className="text-xs leading-relaxed font-mono text-foreground/85 whitespace-pre-wrap break-words">
+          {content.length > 4000 ? content.slice(0, 4000) + "\n…[truncated]" : content}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function shortRepoLabel(repoUrl: string): string {
+  return repoUrl.replace(/^https?:\/\/github\.com\//, "");
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function prettyJson(s: string): string {
+  try {
+    return JSON.stringify(JSON.parse(s), null, 2);
+  } catch {
+    return s;
+  }
+}

--- a/packages/web/components/repo-runs/repo-runs-section.tsx
+++ b/packages/web/components/repo-runs/repo-runs-section.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import {
+  Bookmark,
+  BookmarkCheck,
+  ChevronDown,
+  ChevronRight,
+  Terminal,
+} from "lucide-react";
+import type { ToolRun } from "@/lib/fixtures/repo-runs";
+import {
+  formatDiskMb,
+  formatDurationMinutes,
+  shortRepoLabel,
+} from "@/lib/fixtures/repo-runs";
+import { formatRelativeTime } from "@/lib/format";
+import { ArtifactPreview } from "./artifact-preview";
+import { RunStatusPill } from "./run-status-pill";
+
+/**
+ * "Recent work" — a list of sandboxed tool runs. Each row reads as a
+ * sentence about what an agent did. Technical detail (commit, install
+ * attempts, disk, network) lives behind a "Show details" disclosure so
+ * the default view stays product-clean.
+ */
+export function RepoRunsSection({
+  runs,
+  taskId,
+  heading = "Recent work",
+  defaultOpenFirst = false,
+}: {
+  runs: ToolRun[];
+  taskId: string;
+  heading?: string;
+  defaultOpenFirst?: boolean;
+}) {
+  if (runs.length === 0) return null;
+  return (
+    <section>
+      <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-3 font-medium">
+        {heading}{" "}
+        <span className="text-muted-foreground/70 tabular-nums">
+          {runs.length}
+        </span>
+      </h2>
+      <ul className="space-y-2">
+        {runs.map((run, i) => (
+          <ToolRunRow
+            key={run.id}
+            run={run}
+            taskId={taskId}
+            initiallyOpen={defaultOpenFirst && i === 0}
+          />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export function ToolRunRow({
+  run,
+  taskId,
+  initiallyOpen = false,
+}: {
+  run: ToolRun;
+  taskId: string;
+  initiallyOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(initiallyOpen);
+  const [saved, setSaved] = useState(Boolean(run.saved));
+  const ChevronIcon = open ? ChevronDown : ChevronRight;
+  const canSave = run.has_draft_skill && run.status === "succeeded";
+
+  return (
+    <li className="rounded-lg border border-border bg-card overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="w-full text-left p-3 hover:bg-secondary/30 transition-colors cursor-pointer"
+        aria-expanded={open}
+      >
+        <div className="flex items-start gap-2.5">
+          <ChevronIcon className="h-3.5 w-3.5 text-muted-foreground mt-0.5 shrink-0" />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm text-foreground/90 leading-snug">
+              <span className="text-muted-foreground">{run.agent_label}</span>{" "}
+              {phrasing(run.status)}{" "}
+              <span className="font-mono text-xs">{run.repo_short_name}</span>{" "}
+              <span className="text-muted-foreground">to</span>{" "}
+              {lowerFirst(run.goal)}
+            </p>
+            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground tabular-nums">
+              <span>
+                {run.artifacts.length}{" "}
+                {run.artifacts.length === 1 ? "artifact" : "artifacts"}
+              </span>
+              <span>·</span>
+              <span>{formatDurationMinutes(run.details.elapsed_minutes)}</span>
+              <span>·</span>
+              <span>{formatRelativeTime(run.started_at)}</span>
+              {saved ? (
+                <span className="inline-flex items-center gap-1 text-status-done">
+                  <BookmarkCheck className="h-3 w-3" />
+                  saved
+                </span>
+              ) : null}
+            </div>
+          </div>
+          <RunStatusPill status={run.status} className="shrink-0" />
+        </div>
+
+        {run.status === "blocked" && run.blocked_reason ? (
+          <p className="ml-6 mt-2 rounded border border-status-blocked/30 bg-status-blocked/5 text-status-blocked text-[11px] px-2 py-1.5">
+            {run.blocked_reason}
+          </p>
+        ) : null}
+      </button>
+
+      {open ? (
+        <div className="border-t border-border/60 p-3 bg-background/40 space-y-3">
+          <p className="text-xs text-foreground/85">{run.summary}</p>
+
+          <ArtifactPreview artifacts={run.artifacts} />
+
+          <div className="flex items-center justify-between gap-3 pt-2 border-t border-border/40">
+            <Link
+              href={`/tasks/${taskId}/sessions/${run.session_short_id}`}
+              onClick={(e) => e.stopPropagation()}
+              className="inline-flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <Terminal className="h-3 w-3" />
+              <span className="font-mono">{run.session_short_id}</span>
+            </Link>
+            {canSave ? (
+              <SaveButton saved={saved} onToggle={() => setSaved((v) => !v)} />
+            ) : null}
+          </div>
+
+          <Details run={run} />
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
+function Details({ run }: { run: ToolRun }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="text-[11px]">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="text-muted-foreground/70 hover:text-foreground transition-colors cursor-pointer inline-flex items-center gap-1"
+      >
+        {open ? (
+          <ChevronDown className="h-3 w-3" />
+        ) : (
+          <ChevronRight className="h-3 w-3" />
+        )}
+        {open ? "Hide details" : "Show details"}
+      </button>
+      {open ? (
+        <dl className="mt-1.5 grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 text-muted-foreground">
+          <dt>Repo</dt>
+          <dd className="font-mono">
+            <a
+              href={run.repo_url}
+              target="_blank"
+              rel="noreferrer"
+              className="hover:text-foreground transition-colors"
+            >
+              {shortRepoLabel(run.repo_url)} @{" "}
+              {run.details.pinned_commit.slice(0, 7)}
+            </a>
+          </dd>
+          <dt>Install attempts</dt>
+          <dd className="tabular-nums">{run.details.install_attempts}</dd>
+          <dt>Disk used</dt>
+          <dd className="tabular-nums">{formatDiskMb(run.details.disk_mb)}</dd>
+          <dt>Network after clone</dt>
+          <dd>{run.details.network_after_clone_used ? "yes" : "no"}</dd>
+        </dl>
+      ) : null}
+    </div>
+  );
+}
+
+function SaveButton({
+  saved,
+  onToggle,
+}: {
+  saved: boolean;
+  onToggle: () => void;
+}) {
+  if (saved) {
+    return (
+      <button
+        type="button"
+        onClick={onToggle}
+        className="inline-flex items-center gap-1.5 text-[11px] text-status-done hover:opacity-80 transition-opacity cursor-pointer"
+      >
+        <BookmarkCheck className="h-3.5 w-3.5" />
+        Saved as team tool
+      </button>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className="h-7 px-3 rounded text-[11px] font-medium border border-border bg-card hover:bg-secondary transition-colors cursor-pointer inline-flex items-center gap-1"
+    >
+      <Bookmark className="h-3 w-3" />
+      Save as team tool
+    </button>
+  );
+}
+
+/** Turn the status into a sentence verb for the row's one-line summary. */
+function phrasing(status: ToolRun["status"]): string {
+  switch (status) {
+    case "running":
+      return "is using";
+    case "succeeded":
+      return "used";
+    case "partial":
+      return "partially used";
+    case "blocked":
+      return "tried to use";
+    case "failed":
+      return "couldn't use";
+  }
+}
+
+function lowerFirst(s: string): string {
+  if (!s) return s;
+  return s.charAt(0).toLowerCase() + s.slice(1);
+}

--- a/packages/web/components/repo-runs/run-from-prompt.tsx
+++ b/packages/web/components/repo-runs/run-from-prompt.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2, PlayCircle, AlertCircle } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Free-form "Run a repo" form. Primary path on `/tools`: type a repo
+ * URL and a goal, optionally a sample input, hit Run in sandbox. The
+ * parent wires `onLaunch` to POST to `/api/tools/use-repo` and surface
+ * the run id back as a LiveRunCard.
+ *
+ * No discovery, no ranking, no fixture coupling — proves the
+ * sandbox primitive is general, not a hardcoded pdfplumber demo.
+ */
+export function RunFromPromptForm({
+  onLaunch,
+}: {
+  onLaunch: (input: {
+    repo_url: string;
+    goal: string;
+    input_url?: string;
+    input_filename?: string;
+  }) => Promise<string | null>;
+}) {
+  const [repoUrl, setRepoUrl] = useState("");
+  const [goal, setGoal] = useState("");
+  const [inputUrl, setInputUrl] = useState("");
+  const [inputFilename, setInputFilename] = useState("");
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const repoLooksValid =
+    /^https?:\/\/github\.com\/[\w.-]+\/[\w.-]+/i.test(repoUrl.trim());
+  const goalLooksValid = goal.trim().length > 0;
+  const inputUrlLooksValid =
+    inputUrl.trim().length === 0 ||
+    /^https?:\/\//i.test(inputUrl.trim());
+  const canSubmit =
+    repoLooksValid && goalLooksValid && inputUrlLooksValid && !submitting;
+
+  const submit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setError(null);
+    setSubmitting(true);
+    try {
+      const run_id = await onLaunch({
+        repo_url: repoUrl.trim(),
+        goal: goal.trim(),
+        input_url: inputUrl.trim() || undefined,
+        input_filename:
+          inputFilename.trim() ||
+          (inputUrl.trim() ? deriveFilename(inputUrl.trim()) : undefined),
+      });
+      if (run_id) {
+        // Clear the goal so it's clear we accepted, but keep the repo
+        // URL so the user can iterate with a different goal.
+        setGoal("");
+        setInputUrl("");
+        setInputFilename("");
+      } else {
+        setError("Couldn't start the run. Check the server logs.");
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-4">
+      <header className="mb-3">
+        <h2 className="text-sm font-medium leading-tight mb-1">Run a repo</h2>
+        <p className="text-xs text-muted-foreground">
+          Point at a GitHub repo and tell the agent what to do with it. We&apos;ll
+          clone it inside a sandbox, install what&apos;s needed, run it, and bring
+          back the artifact.
+        </p>
+      </header>
+
+      <form onSubmit={submit} className="space-y-3">
+        <div>
+          <label
+            htmlFor="repo-url"
+            className="block text-[10px] uppercase tracking-wider text-muted-foreground mb-1 font-medium"
+          >
+            Repo URL
+          </label>
+          <input
+            id="repo-url"
+            type="url"
+            value={repoUrl}
+            onChange={(e) => setRepoUrl(e.target.value)}
+            placeholder="https://github.com/jsvine/pdfplumber"
+            className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-ring"
+          />
+          {repoUrl.length > 0 && !repoLooksValid ? (
+            <p className="mt-1 text-[11px] text-status-failed inline-flex items-center gap-1">
+              <AlertCircle className="h-3 w-3" />
+              Needs to look like https://github.com/&lt;owner&gt;/&lt;repo&gt;
+            </p>
+          ) : null}
+        </div>
+
+        <div>
+          <label
+            htmlFor="run-goal"
+            className="block text-[10px] uppercase tracking-wider text-muted-foreground mb-1 font-medium"
+          >
+            Goal
+          </label>
+          <textarea
+            id="run-goal"
+            value={goal}
+            onChange={(e) => setGoal(e.target.value)}
+            placeholder="Extract the tables from tests/pdfs/federal-register-2020-17221.pdf into JSON."
+            rows={3}
+            className="w-full rounded border border-border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring resize-y"
+          />
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            Describe the outcome you want, in one or two sentences. The agent
+            reads the repo&apos;s README to figure out the install + invocation.
+          </p>
+        </div>
+
+        <div>
+          <button
+            type="button"
+            onClick={() => setAdvancedOpen((v) => !v)}
+            className="text-[11px] text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+          >
+            {advancedOpen ? "Hide" : "Show"} input file (optional)
+          </button>
+          {advancedOpen ? (
+            <div className="mt-2 grid grid-cols-[1fr_auto] gap-2">
+              <input
+                type="url"
+                value={inputUrl}
+                onChange={(e) => setInputUrl(e.target.value)}
+                placeholder="https://example.com/sample.pdf"
+                className="rounded border border-border bg-background px-2 py-1.5 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-ring"
+              />
+              <input
+                type="text"
+                value={inputFilename}
+                onChange={(e) => setInputFilename(e.target.value)}
+                placeholder="filename"
+                className="w-32 rounded border border-border bg-background px-2 py-1.5 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-ring"
+              />
+              {inputUrl.length > 0 && !inputUrlLooksValid ? (
+                <p className="col-span-2 text-[11px] text-status-failed inline-flex items-center gap-1">
+                  <AlertCircle className="h-3 w-3" />
+                  Input URL must start with http(s)://
+                </p>
+              ) : (
+                <p className="col-span-2 text-[11px] text-muted-foreground">
+                  We curl this into <span className="font-mono">/sandbox/inputs/</span>{" "}
+                  before the agent runs. Leave blank if the repo provides its own samples.
+                </p>
+              )}
+            </div>
+          ) : null}
+        </div>
+
+        {error ? (
+          <p className="text-[11px] text-status-failed inline-flex items-center gap-1">
+            <AlertCircle className="h-3 w-3" />
+            {error}
+          </p>
+        ) : null}
+
+        <div className="flex justify-end">
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            className={cn(
+              "h-9 px-4 rounded text-sm font-medium transition-opacity cursor-pointer inline-flex items-center gap-2",
+              canSubmit
+                ? "bg-primary text-primary-foreground hover:opacity-90"
+                : "bg-secondary text-muted-foreground cursor-not-allowed",
+            )}
+          >
+            {submitting ? (
+              <>
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                Starting…
+              </>
+            ) : (
+              <>
+                <PlayCircle className="h-3.5 w-3.5" />
+                Run in sandbox
+              </>
+            )}
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}
+
+function deriveFilename(url: string): string {
+  try {
+    const u = new URL(url);
+    const last = u.pathname.split("/").filter(Boolean).pop();
+    return last && last.length > 0 ? last : "input.bin";
+  } catch {
+    return "input.bin";
+  }
+}

--- a/packages/web/components/repo-runs/run-status-pill.tsx
+++ b/packages/web/components/repo-runs/run-status-pill.tsx
@@ -1,0 +1,56 @@
+import type { RunStatus } from "@/lib/fixtures/repo-runs";
+import { cn } from "@/lib/utils";
+
+const STATUS: Record<
+  RunStatus,
+  { dot: string; text: string; label: string }
+> = {
+  running: {
+    dot: "bg-status-running animate-pulse-breathe",
+    text: "text-status-running",
+    label: "Running",
+  },
+  succeeded: {
+    dot: "bg-status-done",
+    text: "text-status-done",
+    label: "Done",
+  },
+  partial: {
+    dot: "bg-status-review",
+    text: "text-status-review",
+    label: "Partial",
+  },
+  blocked: {
+    dot: "bg-status-blocked",
+    text: "text-status-blocked",
+    label: "Couldn't run",
+  },
+  failed: {
+    dot: "bg-status-failed",
+    text: "text-status-failed",
+    label: "Failed",
+  },
+};
+
+export function RunStatusPill({
+  status,
+  className,
+}: {
+  status: RunStatus;
+  className?: string;
+}) {
+  const s = STATUS[status];
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-medium",
+        "bg-card border border-border/60",
+        s.text,
+        className,
+      )}
+    >
+      <span className={cn("h-1.5 w-1.5 rounded-full", s.dot)} aria-hidden />
+      {s.label}
+    </span>
+  );
+}

--- a/packages/web/components/repo-runs/saved-skills.tsx
+++ b/packages/web/components/repo-runs/saved-skills.tsx
@@ -1,0 +1,66 @@
+import { BookmarkCheck, ExternalLink } from "lucide-react";
+import type { SavedTool } from "@/lib/fixtures/repo-runs";
+import { shortRepoLabel } from "@/lib/fixtures/repo-runs";
+import { formatRelativeTime } from "@/lib/format";
+
+/**
+ * "Saved tools" on the agent detail page. Rendered only when the agent
+ * has at least one — keeps the page quiet for agents with none.
+ */
+export function AgentSavedToolsSection({
+  tools,
+}: {
+  tools: SavedTool[];
+}) {
+  if (tools.length === 0) return null;
+  return (
+    <section>
+      <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-3 font-medium">
+        Saved tools{" "}
+        <span className="text-muted-foreground/70 tabular-nums">
+          {tools.length}
+        </span>
+      </h2>
+      <div className="space-y-2">
+        {tools.map((t) => (
+          <SavedToolCard key={t.name} tool={t} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function SavedToolCard({ tool }: { tool: SavedTool }) {
+  return (
+    <article className="rounded-lg border border-border bg-card p-4">
+      <div className="flex items-start gap-3">
+        <BookmarkCheck className="h-4 w-4 text-status-done mt-0.5 shrink-0" />
+        <div className="flex-1 min-w-0">
+          <h3 className="text-sm font-medium leading-tight mb-0.5">
+            {tool.display_name}
+          </h3>
+          <p className="text-xs text-muted-foreground mb-2">
+            {tool.description}
+          </p>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground tabular-nums">
+            <a
+              href={tool.repo_url}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 hover:text-foreground transition-colors"
+            >
+              <span className="font-mono">
+                {shortRepoLabel(tool.repo_url)}
+              </span>
+              <ExternalLink className="h-3 w-3" />
+            </a>
+            <span>·</span>
+            <span>used {tool.use_count}×</span>
+            <span>·</span>
+            <span>last {formatRelativeTime(tool.last_used_at)}</span>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/packages/web/lib/fixtures/discovery.ts
+++ b/packages/web/lib/fixtures/discovery.ts
@@ -28,6 +28,19 @@ export interface Candidate {
   /** Number of times the org has used it (used for cold-start signal). */
   prior_org_uses: number;
   next: NextStep;
+  /**
+   * POC marker: when true, clicking `Run this` dispatches a real sandboxed
+   * run through the orchestrator. When false, the candidate is in the
+   * discovery list as a design demo only — clicking is disabled.
+   * The first POC only wires up `pdfplumber`.
+   */
+  real_repo?: boolean;
+  /**
+   * If the agent needs an explicit goal phrasing — e.g. "extract tables
+   * from THIS sample PDF" — set it here. The orchestrator gets this
+   * over the bare goal-chip text.
+   */
+  goal_override?: string;
 }
 
 export interface DiscoveryResult {
@@ -55,6 +68,9 @@ export const FIXTURE_GOALS: DiscoveryResult[] = [
         prior_team_uses: 0,
         prior_org_uses: 0,
         next: "run",
+        real_repo: true,
+        goal_override:
+          "Extract tables from the bundled sample PDF (tests/pdfs/federal-register-2020-17221.pdf in the repo) into structured JSON. Export the JSON as the artifact.",
       },
       {
         id: "tabula-py",

--- a/packages/web/lib/fixtures/discovery.ts
+++ b/packages/web/lib/fixtures/discovery.ts
@@ -1,0 +1,187 @@
+/**
+ * Fixture data for the discovery half of the tools POC.
+ *
+ * Hand-authored candidate lists per goal — when the backend ships, this
+ * module shrinks to type re-exports and the hooks switch to an MCP-backed
+ * React Query call.
+ *
+ * Kept deliberately small: the UI shows a name, a short description, a
+ * single qualitative fit label, and one human-readable line about the
+ * team's history with it. Anything richer (scores, weights, signal
+ * vectors) is an internal scoring detail and not surfaced.
+ */
+export type Fit = "high" | "medium" | "low";
+export type NextStep = "run" | "inspect_first" | "ask";
+
+export interface Candidate {
+  id: string;
+  repo_url: string;
+  display_name: string;
+  /** One sentence — what this repo does, in plain language. */
+  short_description: string;
+  fit: Fit;
+  /** One-line reason, shown under the row when expanded. */
+  reason: string;
+  license: string;
+  /** Number of times the caller's team has used this repo successfully. 0 = first time. */
+  prior_team_uses: number;
+  /** Number of times the org has used it (used for cold-start signal). */
+  prior_org_uses: number;
+  next: NextStep;
+}
+
+export interface DiscoveryResult {
+  /** Slug the page uses for routing/lookups. */
+  slug: string;
+  /** Plain-language goal, shown as a chip. */
+  goal: string;
+  candidates: Candidate[];
+}
+
+export const FIXTURE_GOALS: DiscoveryResult[] = [
+  {
+    slug: "pdf-tables",
+    goal: "Extract tables from PDFs",
+    candidates: [
+      {
+        id: "pdfplumber",
+        repo_url: "https://github.com/jsvine/pdfplumber",
+        display_name: "pdfplumber",
+        short_description:
+          "Pure-Python PDF text and table extraction with a clean CLI.",
+        fit: "high",
+        reason: "Clean CLI, MIT, examples directory, no system deps.",
+        license: "MIT",
+        prior_team_uses: 0,
+        prior_org_uses: 0,
+        next: "run",
+      },
+      {
+        id: "tabula-py",
+        repo_url: "https://github.com/chezou/tabula-py",
+        display_name: "tabula-py",
+        short_description: "Strong on bordered tables. Needs a JVM.",
+        fit: "medium",
+        reason: "Good accuracy but adds ~300MB of Java install.",
+        license: "MIT",
+        prior_team_uses: 0,
+        prior_org_uses: 0,
+        next: "inspect_first",
+      },
+      {
+        id: "camelot",
+        repo_url: "https://github.com/atlanhq/camelot",
+        display_name: "camelot",
+        short_description: "Tuned for complex layouts. Needs Ghostscript.",
+        fit: "medium",
+        reason: "System packages required; OK if the layout demands it.",
+        license: "MIT",
+        prior_team_uses: 0,
+        prior_org_uses: 0,
+        next: "inspect_first",
+      },
+    ],
+  },
+  {
+    slug: "gtm-launch",
+    goal: "Draft launch artifacts for a product update",
+    candidates: [
+      {
+        id: "gtm-playbook",
+        repo_url: "https://github.com/beevibe-ai/gtm-playbook-example",
+        display_name: "gtm-playbook",
+        short_description:
+          "Generates blog, checklist, social thread, and email from a brief.",
+        fit: "high",
+        reason: "Your team has used this 7 times and saved it.",
+        license: "MIT",
+        prior_team_uses: 7,
+        prior_org_uses: 14,
+        next: "run",
+      },
+      {
+        id: "launch-doc-generator",
+        repo_url: "https://github.com/example/launch-doc-generator",
+        display_name: "launch-doc-generator",
+        short_description: "LLM-backed launch document generator.",
+        fit: "medium",
+        reason: "Better long-form prose but needs an OpenAI key.",
+        license: "Apache-2.0",
+        prior_team_uses: 0,
+        prior_org_uses: 1,
+        next: "ask",
+      },
+    ],
+  },
+  {
+    slug: "json-to-mp4",
+    goal: "Render an MP4 from a JSON scene",
+    candidates: [
+      {
+        id: "videolib",
+        repo_url: "https://github.com/example/videolib",
+        display_name: "videolib",
+        short_description:
+          "JSON-driven 2D scene renderer with an offline CLI.",
+        fit: "high",
+        reason: "Used once before for this kind of task — worked cleanly.",
+        license: "MIT",
+        prior_team_uses: 1,
+        prior_org_uses: 1,
+        next: "run",
+      },
+      {
+        id: "manimcli",
+        repo_url: "https://github.com/example/manimcli",
+        display_name: "manimcli",
+        short_description: "Mathematical animation engine. Heavy install.",
+        fit: "low",
+        reason: "Wrong input shape (Python class, not JSON) and bulky deps.",
+        license: "MIT",
+        prior_team_uses: 0,
+        prior_org_uses: 0,
+        next: "ask",
+      },
+    ],
+  },
+];
+
+/* ── small helpers used by the panel ── */
+
+export function getGoalBySlug(slug: string): DiscoveryResult | undefined {
+  return FIXTURE_GOALS.find((g) => g.slug === slug);
+}
+
+/**
+ * Human-readable history line for a candidate. Returns a neutral string
+ * when there's nothing to say (cold start).
+ */
+export function historyLine(c: Candidate): string {
+  if (c.prior_team_uses > 0) {
+    return `Your team has used this ${c.prior_team_uses}×`;
+  }
+  if (c.prior_org_uses > 0) {
+    return `Used ${c.prior_org_uses}× across your org`;
+  }
+  return "First time trying this kind of task";
+}
+
+const FIT_LABEL: Record<Fit, string> = {
+  high: "Good fit",
+  medium: "Worth trying",
+  low: "Probably not",
+};
+
+export function fitLabel(fit: Fit): string {
+  return FIT_LABEL[fit];
+}
+
+const NEXT_LABEL: Record<NextStep, string> = {
+  run: "Run this",
+  inspect_first: "Try this",
+  ask: "Try anyway",
+};
+
+export function nextLabel(next: NextStep): string {
+  return NEXT_LABEL[next];
+}

--- a/packages/web/lib/fixtures/repo-runs.ts
+++ b/packages/web/lib/fixtures/repo-runs.ts
@@ -1,0 +1,351 @@
+/**
+ * Fixture data for the "tool run" half of the tools POC.
+ *
+ * A "tool run" = one sandboxed `use_repo` call: a child agent borrowed an
+ * external repo, tried to accomplish a goal, and either produced artifacts
+ * or stopped cheaply. A "saved tool" = a run the team chose to keep as a
+ * reusable skill.
+ *
+ * Types stay shallow on purpose — what's not surfaced in the UI doesn't
+ * need to be in the fixture. Anything technical (pinned commits, install
+ * attempts, network flags) lives in a single `details` sub-object that the
+ * UI only renders behind a "Show details" disclosure.
+ */
+export type ArtifactKind = "markdown" | "json" | "text" | "image" | "binary";
+
+export interface Artifact {
+  id: string;
+  /** Sandbox path, e.g. `artifacts/launch-v2/blog-post.md`. */
+  path: string;
+  kind: ArtifactKind;
+  title: string;
+  size_bytes: number;
+  /** Inline preview body. Null for binary / oversized artifacts. */
+  preview: string | null;
+}
+
+export type RunStatus = "running" | "succeeded" | "partial" | "blocked" | "failed";
+
+export interface RunDetails {
+  pinned_commit: string;
+  elapsed_minutes: number;
+  install_attempts: number;
+  disk_mb: number;
+  network_after_clone_used: boolean;
+}
+
+export interface ToolRun {
+  id: string;
+  task_id: string;
+  session_short_id: string;
+  agent_label: string;
+  repo_url: string;
+  /** Short name shown in the UI — e.g. `gtm-playbook`. */
+  repo_short_name: string;
+  /** Goal in the user's words. */
+  goal: string;
+  status: RunStatus;
+  started_at: string;
+  finished_at: string | null;
+  /** Plain summary of what came out of the run. */
+  summary: string;
+  /** Set when the run was blocked or failed. */
+  blocked_reason: string | null;
+  artifacts: Artifact[];
+  details: RunDetails;
+  /** True if the child drafted a reusable skill (i.e. there's something to save). */
+  has_draft_skill: boolean;
+  /** Local POC state — true once the user clicked "Save as team tool." */
+  saved?: boolean;
+}
+
+export interface SavedTool {
+  /** Slug, e.g. `gtm-playbook-example`. */
+  name: string;
+  display_name: string;
+  /** What the tool does, in one sentence. */
+  description: string;
+  repo_url: string;
+  use_count: number;
+  last_used_at: string;
+}
+
+/* ───────────── fixtures ───────────── */
+
+const GTM_TASK_ID = "task_demo_gtm_launch_analytics_v2";
+const HARNESS_TASK_ID = "task_demo_cli_harness_for_videolib";
+const BLOCKED_TASK_ID = "task_demo_blocked_repo_use";
+
+export const FIXTURE_RUNS: ToolRun[] = [
+  {
+    id: "run_2026_05_12_001",
+    task_id: GTM_TASK_ID,
+    session_short_id: "snd-4ab9c2",
+    agent_label: "GTM Captain",
+    repo_url: "https://github.com/beevibe-ai/gtm-playbook-example",
+    repo_short_name: "gtm-playbook",
+    goal: "Draft launch artifacts for analytics dashboard v2",
+    status: "succeeded",
+    started_at: "2026-05-12T17:42:00Z",
+    finished_at: "2026-05-12T17:48:21Z",
+    summary: "Produced 4 markdown drafts: checklist, blog, social thread, customer email.",
+    blocked_reason: null,
+    has_draft_skill: true,
+    saved: true,
+    details: {
+      pinned_commit: "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678",
+      elapsed_minutes: 6,
+      install_attempts: 1,
+      disk_mb: 412,
+      network_after_clone_used: false,
+    },
+    artifacts: [
+      {
+        id: "art_001",
+        path: "artifacts/launch-v2/launch-checklist.md",
+        kind: "markdown",
+        title: "Launch checklist",
+        size_bytes: 1820,
+        preview: [
+          "# Analytics Dashboard v2 — Launch Checklist",
+          "",
+          "## T-7 days",
+          "- [ ] Lock final feature set and changelog",
+          "- [ ] Brief support team on the top 5 expected questions",
+          "- [ ] Pre-record 60s product demo loop",
+          "",
+          "## Launch day",
+          "- [ ] Publish blog at 7:55am PT",
+          "- [ ] Post social thread at 8:00am PT",
+          "- [ ] Submit to HN at 8:05am PT",
+          "- [ ] Customer email at 9:00am PT",
+          "- [ ] Reply to first 50 HN comments inside 4h",
+        ].join("\n"),
+      },
+      {
+        id: "art_002",
+        path: "artifacts/launch-v2/blog-post.md",
+        kind: "markdown",
+        title: "Blog post",
+        size_bytes: 4210,
+        preview: [
+          "# Analytics Dashboard v2: same answers, half the clicks",
+          "",
+          "When we shipped v1, the most common piece of feedback wasn't \"add",
+          "this metric.\" It was \"I know the answer is in here somewhere, but",
+          "I have to click through three filters to find it.\"",
+          "",
+          "Today we're shipping v2 — a rebuilt query layer, saved views that",
+          "remember the right things, and a faster path from question to chart.",
+          "",
+          "## What's new",
+          "- Saved views remember filters AND time range.",
+          "- Inline drill-downs — click a datapoint, see the underlying rows.",
+          "- Query layer rewrite cuts median load from 1.8s to 380ms.",
+        ].join("\n"),
+      },
+      {
+        id: "art_003",
+        path: "artifacts/launch-v2/social-thread.md",
+        kind: "markdown",
+        title: "Social thread",
+        size_bytes: 980,
+        preview: [
+          "1/ analytics dashboard v2 is live — rebuilt query layer cuts",
+          "median load from 1.8s to 380ms 🚀",
+          "",
+          "2/ the #1 piece of v1 feedback was \"i know the answer is here,",
+          "i just can't find it fast.\" v2 is our answer.",
+          "",
+          "3/ saved views now remember filters AND time range. inline",
+          "drill-downs let you click into a datapoint without leaving",
+          "the chart.",
+          "",
+          "4/ live for all teams today. would love to hear what feels",
+          "faster and what's still slow 👇",
+        ].join("\n"),
+      },
+      {
+        id: "art_004",
+        path: "artifacts/launch-v2/customer-email.md",
+        kind: "markdown",
+        title: "Customer email",
+        size_bytes: 720,
+        preview: [
+          "Subject: Your dashboard just got 4× faster (Analytics v2 is live)",
+          "",
+          "Hi {first_name},",
+          "",
+          "Analytics Dashboard v2 is live starting today. The biggest change",
+          "is speed — median dashboard loads dropped from ~1.8s to ~380ms.",
+          "Saved views also now remember filters AND time range (the #1",
+          "thing we heard people wanted from v1).",
+          "",
+          "Nothing to migrate. Your existing dashboards are already on v2.",
+          "",
+          "— The beevibe team",
+        ].join("\n"),
+      },
+    ],
+  },
+  {
+    id: "run_2026_05_13_001",
+    task_id: HARNESS_TASK_ID,
+    session_short_id: "snd-7c2d10",
+    agent_label: "Captain",
+    repo_url: "https://github.com/example/videolib",
+    repo_short_name: "videolib",
+    goal: "Render an MP4 from a JSON scene description",
+    status: "succeeded",
+    started_at: "2026-05-13T02:14:00Z",
+    finished_at: "2026-05-13T02:22:48Z",
+    summary:
+      "Generated a CLI harness, then rendered a 2-second fixture clip to verify it works end-to-end.",
+    blocked_reason: null,
+    has_draft_skill: true,
+    saved: false,
+    details: {
+      pinned_commit: "9f8e7d6c5b4a39281706f5e4d3c2b1a09876fedc",
+      elapsed_minutes: 8,
+      install_attempts: 1,
+      disk_mb: 1830,
+      network_after_clone_used: true,
+    },
+    artifacts: [
+      {
+        id: "art_h1",
+        path: "artifacts/cli-harness/README.md",
+        kind: "markdown",
+        title: "Generated harness README",
+        size_bytes: 1380,
+        preview: [
+          "# videolib harness",
+          "",
+          "Use:",
+          "",
+          "```bash",
+          "videolib-harness render --input scene.json --output clip.mp4",
+          "```",
+          "",
+          "Inputs: a videolib scene JSON. Outputs: H.264 MP4, ≤ 60s.",
+          "Sandbox only. No GPU. ~2GB disk recommended.",
+        ].join("\n"),
+      },
+      {
+        id: "art_h2",
+        path: "artifacts/cli-harness/fixture-render.mp4",
+        kind: "binary",
+        title: "Fixture render",
+        size_bytes: 624_000,
+        preview: null,
+      },
+      {
+        id: "art_h3",
+        path: "artifacts/cli-harness/run-summary.json",
+        kind: "json",
+        title: "Run summary",
+        size_bytes: 380,
+        preview: JSON.stringify(
+          {
+            repo: "example/videolib",
+            harness_commands: ["render", "probe"],
+            fixture_render_seconds: 2,
+            artifact_size_bytes: 624000,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+  },
+  {
+    id: "run_2026_05_13_002",
+    task_id: BLOCKED_TASK_ID,
+    session_short_id: "snd-aa1b22",
+    agent_label: "Captain",
+    repo_url: "https://github.com/example/headless-suite",
+    repo_short_name: "headless-suite",
+    goal: "Run the headless-suite test pack on our e2e fixtures",
+    status: "blocked",
+    started_at: "2026-05-13T03:01:00Z",
+    finished_at: "2026-05-13T03:09:40Z",
+    summary: "Couldn't install — needed kernel features and a GPU the sandbox doesn't grant.",
+    blocked_reason:
+      "Repo requires privileged kernel features and a CUDA-capable GPU.",
+    has_draft_skill: false,
+    saved: false,
+    details: {
+      pinned_commit: "11223344556677889900aabbccddeeff00112233",
+      elapsed_minutes: 9,
+      install_attempts: 2,
+      disk_mb: 740,
+      network_after_clone_used: true,
+    },
+    artifacts: [
+      {
+        id: "art_b1",
+        path: "logs/install-attempt-1.log",
+        kind: "text",
+        title: "Install attempt 1 — tail",
+        size_bytes: 420,
+        preview: [
+          "+ pip install -e .",
+          "  error: requires kernel feature `userns` (privileged)",
+          "ERROR: Failed building wheel for headless-runner",
+        ].join("\n"),
+      },
+    ],
+  },
+];
+
+export const FIXTURE_SAVED_TOOLS: SavedTool[] = [
+  {
+    name: "gtm-playbook-example",
+    display_name: "GTM Launch Playbook",
+    description:
+      "Drafts a launch package (blog, checklist, social, email) from a product brief.",
+    repo_url: "https://github.com/beevibe-ai/gtm-playbook-example",
+    use_count: 7,
+    last_used_at: "2026-05-13T01:18:00Z",
+  },
+];
+
+/* ───────────── helpers used by the components ───────────── */
+
+export function getRunsForTask(taskId: string): ToolRun[] {
+  return FIXTURE_RUNS.filter((r) => r.task_id === taskId);
+}
+
+export function getSavedToolsForAgentHierarchy(
+  // hierarchy is accepted so the call site reads cleanly; in the POC the
+  // saved-tool list isn't actually scoped per role yet.
+  hierarchy: "ic" | "team" | "org",
+): SavedTool[] {
+  void hierarchy;
+  return FIXTURE_SAVED_TOOLS;
+}
+
+/* ─── tiny formatters (keep these in one place so the UI stays terse) ─── */
+
+export function shortRepoLabel(repoUrl: string): string {
+  return repoUrl.replace(/^https?:\/\/github\.com\//, "");
+}
+
+export function formatDurationMinutes(minutes: number): string {
+  if (minutes < 1) return "<1 min";
+  if (minutes < 60) return `${Math.round(minutes)} min`;
+  const h = Math.floor(minutes / 60);
+  const m = Math.round(minutes % 60);
+  return m === 0 ? `${h}h` : `${h}h ${m}m`;
+}
+
+export function formatDiskMb(mb: number): string {
+  if (mb >= 1024) return `${(mb / 1024).toFixed(1)} GB`;
+  return `${Math.round(mb)} MB`;
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}

--- a/packages/web/lib/tools/run-store.ts
+++ b/packages/web/lib/tools/run-store.ts
@@ -1,0 +1,46 @@
+/**
+ * Server-side in-memory store for sandboxed tool runs.
+ *
+ * POC NOTE: M8 locked "no app/api routes" — the production home for
+ * `use_repo` is the api package (MCP tool surface). For this POC we
+ * keep the run state co-located with the Next.js process so the demo
+ * is self-contained and doesn't require running the full beevibe
+ * api + daemon + postgres stack. Once the sandbox broker integrates
+ * with the existing daemon path, this module disappears.
+ *
+ * The store is parked on `globalThis` so it survives Next.js dev-mode
+ * HMR (which otherwise re-evaluates this module per route file and
+ * gives each route its own private Map — POST writes, GET reads,
+ * neither sees the other).
+ */
+import type { RunState } from "@beevibe/sandbox/orchestrator";
+
+const GLOBAL_KEY = "__beevibe_tools_run_store__";
+
+interface GlobalShape {
+  [GLOBAL_KEY]?: Map<string, RunState>;
+}
+
+const g = globalThis as unknown as GlobalShape;
+if (!g[GLOBAL_KEY]) {
+  g[GLOBAL_KEY] = new Map<string, RunState>();
+}
+const STORE: Map<string, RunState> = g[GLOBAL_KEY]!;
+
+export function upsertRun(state: RunState): void {
+  STORE.set(state.run_id, state);
+}
+
+export function getRun(run_id: string): RunState | undefined {
+  return STORE.get(run_id);
+}
+
+export function listRuns(): RunState[] {
+  return Array.from(STORE.values()).sort((a, b) =>
+    (b.started_at ?? "").localeCompare(a.started_at ?? ""),
+  );
+}
+
+export function generateRunId(): string {
+  return `run_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@beevibe/api": "workspace:*",
     "@beevibe/core": "workspace:*",
+    "@beevibe/sandbox": "workspace:*",
     "@tanstack/react-query": "^5.59.0",
     "@tanstack/react-query-devtools": "^5.59.0",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,22 @@ importers:
         specifier: ^8.5.13
         version: 8.18.1
 
+  packages/sandbox:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.0.0
+        version: 1.29.0(zod@4.4.1)
+    devDependencies:
+      '@types/node':
+        specifier: ^20.16.0
+        version: 20.19.39
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@20.19.39)(happy-dom@15.11.7)
+
   packages/scheduler:
     dependencies:
       '@beevibe/core':
@@ -162,6 +178,9 @@ importers:
       '@beevibe/core':
         specifier: workspace:*
         version: link:../core
+      '@beevibe/sandbox':
+        specifier: workspace:*
+        version: link:../sandbox
       '@tanstack/react-query':
         specifier: ^5.59.0
         version: 5.100.5(react@18.3.1)
@@ -4586,14 +4605,6 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@20.19.39))':
-    dependencies:
-      '@vitest/spy': 2.1.9
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 5.4.21(@types/node@20.19.39)
-
   '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@25.6.0))':
     dependencies:
       '@vitest/spy': 2.1.9
@@ -7492,7 +7503,7 @@ snapshots:
   vitest@2.1.9(@types/node@20.19.39)(happy-dom@15.11.7):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.39))
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@25.6.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9

--- a/skills/beevibe-discover-repo/SKILL.md
+++ b/skills/beevibe-discover-repo/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: beevibe-discover-repo
+description: >
+  Find a GitHub repo that can plausibly accomplish a goal. Read-only metadata
+  work — no clone, install, or run. Returns a short ranked list. Pairs with
+  beevibe-use-repo, which borrows the chosen repo in a sandbox.
+---
+
+# Discover Repo
+
+You pick the candidate repo. You do not trust any of them — `use_repo` runs
+the chosen one inside a sandbox, where the trust boundary actually lives.
+
+```text
+discover_repos(goal, hints?)
+```
+
+Run inside a sandbox: parsing READMEs and package manifests is hostile input.
+You may hit GitHub + package registries + Beevibe's own success history.
+Export only the candidate list back to the parent.
+
+## Inputs
+
+- `goal` — what the parent wants done, in plain language.
+- optional `hints.preferred_language`, `hints.required_runtime` (`cli` /
+  `library` / `service`), `hints.license_must_allow`,
+  `hints.exclude_repos`, `hints.max_candidates` (default `5`),
+  `hints.scope` (`team` or `org` for prior-success lookups).
+
+If `goal` is missing, return an empty result with `reason: "no goal"`.
+
+## How to pick
+
+For each candidate, judge:
+
+1. **Has the team used it before for a similar goal?** If yes, this almost
+   always wins — prior success is the strongest signal we have. Surface the
+   count.
+2. **Will it work for an agent?** Prefer repos with a CLI or library API,
+   structured I/O, a quickstart, no required API keys for first-use, no
+   human-in-loop prompts, non-privileged dependencies. Stars are a spam
+   filter, not a quality signal.
+3. **Does the license permit the intended use?** Hard gate. Skip otherwise.
+4. **Can it install cheaply?** Penalize required system packages, GPU,
+   privileged container flags, postinstall scripts.
+
+If no candidate clears the bar, return an empty list with a reason. Better
+than guessing.
+
+## Result
+
+Return 3–5 candidates, highest fit first.
+
+```json
+{
+  "goal": "extract tables from PDFs",
+  "candidates": [
+    {
+      "repo_url": "https://github.com/jsvine/pdfplumber",
+      "display_name": "pdfplumber",
+      "short_description": "Pure-Python PDF text + table extraction with CLI and JSON output.",
+      "fit": "high",
+      "reason": "Clean CLI, MIT, examples directory, no system deps.",
+      "license": "MIT",
+      "estimated_setup_minutes": 5,
+      "prior_team_uses": 0,
+      "next": "use_repo"
+    }
+  ],
+  "reason": null
+}
+```
+
+`fit` is one of `high` / `medium` / `low` — a single qualitative judgement,
+not a number. `next` is `use_repo` (good to try) or `inspect_first` (worth
+trying but install is non-trivial) or `ask_human` (top candidate isn't
+confident enough — surface the list).
+
+Every successful `use_repo` run feeds back into `prior_team_uses` for future
+discovery calls. That is the loop.

--- a/skills/beevibe-use-repo/SKILL.md
+++ b/skills/beevibe-use-repo/SKILL.md
@@ -16,6 +16,21 @@ do the work.
 use_repo(repo_url, goal, inputs?, limits?)
 ```
 
+The sandbox is reached through five MCP tools. Your host `Bash` / `Read` /
+`Edit` / `Write` tools are denied — every shell command and every file
+operation goes through:
+
+  - `mcp__beevibe-sandbox__sandbox_exec(cmd, cwd?, timeout_seconds?)`
+  - `mcp__beevibe-sandbox__sandbox_read_file(path, max_bytes?)`
+  - `mcp__beevibe-sandbox__sandbox_write_file(path, content)`
+  - `mcp__beevibe-sandbox__sandbox_list(path)`
+  - `mcp__beevibe-sandbox__sandbox_export_artifact(sandbox_path, title?)`
+
+These tools are exposed by the per-run MCP server in `@beevibe/sandbox`.
+In claude-code's tool budgeting they ship as deferred tools — at the
+start of your work you may need to call `ToolSearch` once per tool with
+`select:<full-mcp-name>` to load them before invoking them.
+
 ## Inputs
 
 - `repo_url`, `goal` — required.

--- a/skills/beevibe-use-repo/SKILL.md
+++ b/skills/beevibe-use-repo/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: beevibe-use-repo
+description: >
+  Use an external GitHub repo as a temporary sandboxed tool to produce an
+  artifact for the parent's goal. Repo dependencies never touch the user's
+  host workspace. Pairs with beevibe-discover-repo, which picks the repo.
+---
+
+# Use Repo
+
+You are a child agent in a fresh sandbox. Borrow the repo, produce a real
+artifact, return it. Don't review the repo. The proof is that it helps you
+do the work.
+
+```text
+use_repo(repo_url, goal, inputs?, limits?)
+```
+
+## Inputs
+
+- `repo_url`, `goal` — required.
+- optional `inputs` — files, URLs, fixtures, params the goal needs.
+- optional `limits.wall_clock_minutes` (default `20`),
+  `limits.max_install_attempts` (default `2`),
+  `limits.disk_mb`,
+  `limits.allow_network_after_clone` (default `false`),
+  `capture_skill` — draft a reusable skill if the run works.
+
+If `repo_url` or `goal` is missing, return `blocked`.
+
+## Trust boundary
+
+The sandbox runtime enforces:
+
+- no host workspace mount; no user secrets unless explicitly granted
+- network gated after the initial clone
+- wall-clock, install-attempt, and disk budgets
+- artifact-only export back to the parent
+
+Installation runs untrusted code (`pip install` runs `setup.py`, etc.). The
+sandbox contains the blast radius; your job is to observe and report, not to
+defend against it.
+
+## Protocol
+
+1. **Clone** the repo into `./repo` and record the pinned commit.
+
+2. **Read enough to use it** — README, manifests, examples, scripts.
+   Don't audit; find the shortest path to the goal.
+
+3. **Install** the least invasive way that works:
+   - existing command → project-local venv/deps → container install →
+     install script (only when docs demand it).
+   - Capture logs. Stop at `max_install_attempts`. Stop early if the wall
+     clock or disk is exhausted, or if the repo can't plausibly do the goal.
+
+4. **Run it.** Save outputs under `artifacts/<short-slug>/`. Prefer
+   machine-checkable outputs (files, JSON, structured stdout).
+
+5. **Verify.** Run a small check (parse the output, list files, run
+   `--help`, render a tiny fixture). Not a full test suite.
+
+6. **Capture skill (optional).** If `capture_skill` is true and the run
+   succeeded, draft `artifacts/skill/SKILL.md` with the install recipe,
+   inputs, invocation, and known limits. Don't let this block the main
+   result.
+
+## Result
+
+```json
+{
+  "status": "succeeded",
+  "repo_url": "https://github.com/org/repo",
+  "pinned_commit": "40-char-sha",
+  "goal": "what the parent asked for",
+  "artifact_paths": ["artifacts/example/output.json"],
+  "summary": "what was produced",
+  "verification": [{ "name": "artifact exists", "passed": true }],
+  "limits_used": {
+    "elapsed_minutes": 6,
+    "install_attempts": 1,
+    "network_after_clone_used": true
+  },
+  "blocked_reason": null,
+  "generated_skill_path": "artifacts/skill/SKILL.md"
+}
+```
+
+Statuses: `succeeded` · `partial` · `blocked` · `failed`. Use `blocked` for
+budget / access / dependency / platform issues — the repo didn't get a fair
+chance. Use `failed` when execution itself broke.
+
+A failed run is still useful — return the classified reason instead of
+nothing.


### PR DESCRIPTION
## What this does

An agent picks up a GitHub repo, uses it inside a sandbox, and brings back the artifact. Your machine never touches the repo's code.

Type a repo URL and a goal on `/tools`. A real Beevibe child agent spawns in a fresh Docker container, clones the repo, installs whatever it needs, writes glue scripts, runs them, verifies the output, and exports the file back to the UI. The agent figures out the install + invocation from the repo's README — there are no hardcoded commands.

The advice-vs-agency difference: not *"you could use pdfplumber to extract those tables"* but *"I extracted them — here's the JSON."*

## End to end

```text
You: paste repo + goal in /tools
  → POST /api/tools/use-repo returns a run_id immediately
  → orchestrator creates a fresh Docker sandbox
  → spawns `claude --print` with Bash/Read/Edit/Write denied and
    only mcp__beevibe-sandbox__* allowed
  → child agent reads the repo, installs, runs, exports
  → /tools polls and renders the live transcript + artifact preview
  → sandbox is torn down; the host machine stayed clean
```

Verified locally just before this PR was pushed: `pdfplumber` against the federal-register sample PDF, ~60s wall-clock, $0.30 of tokens, a real 818-byte `tables.json` with the actual labor/parts/cost rows from the PDF.

## What's in this PR

**`@beevibe/sandbox`** — new package, three layers:
- `docker.ts`: primitives wrapping `docker run` / `exec` / `cp` / `rm`. Pinned `python:3.12-slim`, non-root in-container user, CPU/memory/disk caps, bind-mounted artifact dir.
- `mcp-server.ts`: per-run stdio MCP server exposing five tools — `sandbox_exec`, `sandbox_read_file`, `sandbox_write_file`, `sandbox_list`, `sandbox_export_artifact`. Bound to one sandbox via env.
- `orchestrator.ts`: `runRepoAgent({ repo_url, goal, … })`. Creates sandbox, writes MCP config, spawns `claude` with strict tool allow-list, streams stream-json transcript, collects exported artifacts, tears down.

**Stabilization** (this round):
- Transcript capped at 500 events × 4KB each; synthetic truncation notice when the cap fires.
- Friendly errors for Docker-not-running, docker-CLI-missing, out-of-disk, claude-binary-missing, wall-clock-budget-hit.
- Cleanup failures don't change the run outcome.
- Orphan reaper script (`pnpm --filter @beevibe/sandbox exec tsx src/scripts/reap.ts`).
- Gated e2e test (`BEEVIBE_E2E_DOCKER=1`) exercising the docker primitives end-to-end against a real daemon (~5s with cached image).

**Backend wiring** (Next.js API routes — POC-only deviation from M8's no-app/api decision; production home is the api package's MCP surface, documented in [`run-store.ts`](packages/web/lib/tools/run-store.ts)):
- `POST /api/tools/use-repo` — kicks off async, returns `run_id`.
- `GET /api/tools/runs/[id]` — full run state + artifact descriptors.
- `GET /api/tools/runs/[id]/artifacts/[name]` — serves a single artifact file with a sensible Content-Type.

**`/tools` UI**:
- **Run a repo** form at the top — Repo URL, Goal, optional Input file. Submits to the orchestrator.
- **Live runs** card list — polls the API, renders agent transcript and artifact preview inline (markdown via ChatMarkdown, JSON pretty-printed).
- **Or try a starter** — the discovery panel demoted; pdfplumber-and-friends as quick-start chips.
- **Example runs** + **Saved for next time** — fixture sections, kept as design reference.

**Skills** (operational, no essays):
- [`beevibe-discover-repo`](skills/beevibe-discover-repo/SKILL.md) — pick a candidate from a goal + team history. (Fixtures only in this PR — real GitHub search is later.)
- [`beevibe-use-repo`](skills/beevibe-use-repo/SKILL.md) — child agent contract. Updated to reference the MCP tool names and the one-time ToolSearch bootstrap the child has to do.

## Local prerequisites

- Docker Desktop running
- The `claude` CLI binary (defaults to the VS Code extension's bundled binary at `~/.vscode/extensions/anthropic.claude-code-…/resources/native-binary/claude`; override via `BEEVIBE_CLAUDE_BIN`)
- Anthropic auth via OAuth or `ANTHROPIC_API_KEY`. Each demo run costs ~$0.10–$0.30 in tokens.

Run: `pnpm dev` from `packages/web`, open `http://localhost:3000/tools`, type a repo + goal, hit Run.

## Intentionally not in this PR

Per-step scope discipline:
- Real GitHub search for discovery (fixtures only).
- Persistent run history / saved-as-team-skill (in-memory, dies on restart).
- MCP tool registration for `use_repo` on the parent agent's surface (no parent integration yet — `/tools` is the only entry point).
- Daemon integration — the orchestrator runs inside Next.js instead of via `packages/daemon`.
- Reusable container images — every run installs from scratch.
- Remote sandbox providers — local Docker only.
- License auditing as a separate flow.
- Production sandbox hardening (rootless docker, seccomp, no-new-privileges, disk-quota cgroups, network allowlists per phase).

## Test plan

- [x] Typecheck clean across `@beevibe/sandbox` and `@beevibe/web`
- [x] Lint clean
- [x] 141/141 web tests passing
- [x] `BEEVIBE_E2E_DOCKER=1 pnpm --filter @beevibe/sandbox test` — docker primitives against real daemon
- [x] `pnpm --filter @beevibe/sandbox smoke` — end-to-end primitives + pdfplumber install + table extraction
- [x] `pnpm --filter @beevibe/sandbox exec tsx src/scripts/orchestrate-pdfplumber.ts` — full agent-driven run, no UI in the loop
- [x] `POST /api/tools/use-repo` → poll → fetch artifact bytes — verified on this branch
- [ ] Manual click-through on `/tools`: type a non-pdfplumber repo + goal, watch the live transcript, verify the artifact renders
- [ ] Migrate backend to the `packages/api` MCP surface as the daemon integration lands
- [ ] Production hardening pass on the sandbox runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)