### PR TITLE
fix(agents): split runtime/model fields in AgentDisplay

### DIFF
--- a/packages/api/src/views/agents.test.ts
+++ b/packages/api/src/views/agents.test.ts
@@ -27,7 +27,31 @@ describe("listAgents", () => {
     expect(agents[0]?.hierarchy).toBe("org");
     expect(agents[0]?.sessions_count).toBe(12);
     expect(agents[0]?.facts_learned).toBe(4);
-    expect(agents[0]?.runtime).toBe("opus");
+    expect(agents[0]?.runtime).toBe("claude");
+    expect(agents[0]?.model).toBe("opus");
+  });
+
+  it("returns undefined model when runtime_config has no model set", async () => {
+    const pool = makeMockPool([
+      [
+        {
+          id: "agt_x",
+          name: "NoModel",
+          owner_id: "per_w",
+          parent_agent_id: null,
+          hierarchy_level: "ic",
+          review_policy: null,
+          runtime_config: { type: "claude" },
+          created_at: new Date(),
+          updated_at: new Date(),
+          sessions_count: 0,
+          facts_learned: 0,
+        },
+      ],
+    ]);
+    const agents = await listAgents(pool);
+    expect(agents[0]?.runtime).toBe("claude");
+    expect(agents[0]?.model).toBeUndefined();
   });
 });
 

--- a/packages/api/src/views/agents.ts
+++ b/packages/api/src/views/agents.ts
@@ -59,7 +59,12 @@ ORDER BY
 `;
 
 function rowToAgentDisplay(row: AgentRow): AgentDisplay {
-  const runtime = (row.runtime_config?.model as string | undefined) ?? "claude";
+  // `runtime` is the CLI tool name; `model` is the LLM alias passed to it.
+  // Previously this view returned `runtime_config.model` under the `runtime`
+  // key, conflating the two — see https://github.com/beevibe-ai/beevibe/issues
+  // for the diagnosis. Now they're separate fields.
+  const runtime = (row.runtime_config?.type as string | undefined) ?? "claude";
+  const model = row.runtime_config?.model as string | undefined;
   return {
     id: row.id,
     name: row.name,
@@ -73,6 +78,7 @@ function rowToAgentDisplay(row: AgentRow): AgentDisplay {
     sessions_count: Number(row.sessions_count),
     facts_learned: Number(row.facts_learned),
     runtime,
+    model,
     review_policy: row.review_policy ?? undefined,
     preferred_runtime_id: row.preferred_runtime_id ?? undefined,
     archived_at: row.archived_at ? row.archived_at.toISOString() : undefined,

--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -95,7 +95,13 @@ export interface AgentDisplay
   merge_events?: number;
   specialization?: string;
   themes?: string[];
+  /** CLI tool the agent uses — derived from `runtime_config.type`. */
   runtime?: string;
+  /**
+   * Model alias passed to the CLI (e.g. "opus", "sonnet"). Undefined when
+   * the agent uses the CLI's user-configured default model.
+   */
+  model?: string;
   review_policy?: string;
   /**
    * The agent's pinned `runtime` row id. The Runtimes panel uses this to

--- a/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
+++ b/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
@@ -226,6 +226,7 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
         </FooterField>
         <FooterField label="Hierarchy">{agent.hierarchy}</FooterField>
         {agent.runtime ? <FooterField label="Runtime">{agent.runtime}</FooterField> : null}
+        <FooterField label="Model">{agent.model ?? "CLI default"}</FooterField>
         {agent.review_policy ? (
           <FooterField label="Review policy">{agent.review_policy}</FooterField>
         ) : null}


### PR DESCRIPTION
## Summary

Issue #4 from the agents-config diagnosis. The agent detail page's \"Runtime\" footer was displaying the model name (\"opus\") instead of the runtime/CLI tool (\"claude\") because \`rowToAgentDisplay\` read \`runtime_config.model\` and surfaced it under the \`runtime\` key.

## What changed

- \`AgentDisplay.runtime\` now reflects \`runtime_config.type\` (the CLI tool — \"claude\")
- New \`AgentDisplay.model\` field carries \`runtime_config.model\` (e.g. \"opus\", or undefined when the agent uses the CLI's user-configured default)
- Agent detail page footer renders both: \`Runtime: claude\`, \`Model: opus\` (or \`Model: CLI default\` when undefined)

## Test plan

- [x] Existing test that asserted \`runtime === \"opus\"\` now asserts \`runtime === \"claude\"\` AND \`model === \"opus\"\`
- [x] New test: \`runtime_config\` without a \`model\` key → \`agent.model\` is undefined
- [x] Typecheck + lint clean on both api and web
- [ ] Manual UI smoke after merge — agent detail footer renders both fields correctly

## Follow-ups (separate PRs)

- Drop \`model: \"opus\"\` from \`DEFAULT_RUNTIME_CONFIG\` so new agents use the CLI default
- Add a per-agent model edit affordance in the agent detail page
- Both follow this PR; this is the view-layer foundation they build on

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)