### PR TITLE
fix(agents): drop model="opus" from DEFAULT_RUNTIME_CONFIG

### DIFF
--- a/packages/core/src/domain/agent.ts
+++ b/packages/core/src/domain/agent.ts
@@ -21,7 +21,10 @@ export interface RuntimeConfig {
 
 export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
   type: "claude",
-  model: "opus",
+  // `model` intentionally omitted so the CLI uses its user-configured
+  // default (`~/.claude/config`). Per-agent overrides land via the
+  // agent settings UI; nothing here should force a specific model on
+  // every new agent.
 };
 
 export interface Agent {


### PR DESCRIPTION
## Summary

Issue #2 from the agents-config diagnosis. \`DEFAULT_RUNTIME_CONFIG\` set \`model: \"opus\"\` on every new agent, overriding whatever model the user had configured in their CLI (\`~/.claude/config\`). The \`model\` field's own doc says *\"Optional: when unset, the CLI uses its own default\"* — the default was contradicting that.

## What changed

One line in \`packages/core/src/domain/agent.ts\`:

\`\`\`ts
export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
  type: \"claude\",
  // model intentionally omitted — CLI uses its user-configured default
};
\`\`\`

New agents now get \`runtime_config.model === undefined\` → CLI picks user's configured default. Existing agents are unaffected (their persisted \`runtime_config\` is unchanged).

## What's NOT in this PR

- **No backfill** — agents currently set to \`opus\` keep that. Users who explicitly chose opus shouldn't have it cleared on their behalf; per-agent overrides land via the agent settings UI in a follow-up PR.
- **No model edit UI** — separate PR (#3 in the diagnosis list)

## Test plan

- [x] Core build + tests pass (440 tests)
- [x] API tests pass (289 tests) — existing tests using \`DEFAULT_RUNTIME_CONFIG\` as a fixture still work; nothing relies on \`model\` being \"opus\"
- [ ] Manual smoke after merge: provisioning a new user via \`pnpm seed-demo\` or signup produces an agent with \`runtime_config = { type: \"claude\" }\` (no \`model\` key)

## Depends on

- PR #96 makes the agent detail page correctly render \`Model: CLI default\` when \`model\` is undefined. Land #96 first so the new agents look right immediately.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)