### PR TITLE
feat(memory): per-block descriptions + tag_line + persistent-specialist framing

### DIFF
--- a/migrations/1780400000000_add-core-memory-block-description.sql
+++ b/migrations/1780400000000_add-core-memory-block-description.sql
@@ -1,0 +1,73 @@
+-- Add `description` field to core memory blocks — first-person guidance
+-- the agent reads to decide WHAT belongs in each block. Surface in the
+-- <core_memory> system-prompt render + as tool-call guidance for
+-- update_core_memory / create_subordinate_agent.
+--
+-- Per the agent-as-persistent-specialist framing (issue diagnosis), each
+-- block has a narrow purpose: identity stays in persona/domain/tag_line;
+-- project context goes in active_context; rules in constraints. The
+-- description column is the single source of truth for these per-block
+-- semantics.
+--
+-- Also seed `tag_line` block for every existing agent — used by the UI's
+-- agent-card "specialization" line and as the agent's enduring headline.
+
+ALTER TABLE core_memory_block
+  ADD COLUMN description TEXT NOT NULL DEFAULT '';
+
+-- Backfill descriptions on existing blocks. Hand-coded per (level,
+-- block_name) pair so the migration is reproducible without a runtime
+-- read of the JS template constant. Keep in lockstep with
+-- packages/core/src/domain/core-memory.ts:DEFAULT_BLOCK_TEMPLATES.
+
+UPDATE core_memory_block b
+SET description = CASE b.block_name
+  WHEN 'persona' THEN
+    'Who I am and how I work — my role and working style, persistent across every project I touch. 1-3 sentences in first person. Update when my self-conception genuinely shifts. NOT my current project (that''s `active_context`), NOT my domain scope (that''s `domain`).'
+  WHEN 'domain' THEN
+    'The areas I specialize in ACROSS all projects — my enduring expertise. As I work on more projects in my domain, this can deepen (becoming truly expert in narrower sub-areas). Bullet format. NOT project-specific paths (those go in `active_context`). NOT the rules I follow (those go in `constraints`).'
+  WHEN 'active_context' THEN
+    'What I''m currently working on — the specific project and its in-flight details. Bullet format. Transient — rewrite when the project changes. This is where ALL project/codebase-specific details live, NOT in `domain`.'
+  WHEN 'constraints' THEN
+    'Hard rules I follow — non-negotiable conventions and coordination boundaries. Mix of persistent rules and project-specific rules. Bullet format. Reference docs by path, not content.'
+  WHEN 'team_members' THEN
+    'Roster of my direct reports — for each: name, agent_id, specialization (NOT project assignment). Bullet format. Update when subordinates are spawned/archived/reassigned.'
+  WHEN 'active_work' THEN
+    'What my team is currently working on — the active project + high-level work in flight across specialists. Bullet format. Transient — rewrite on project shifts.'
+  WHEN 'patterns' THEN
+    'Cross-project patterns I''ve observed in how my team operates — what works, what trips them up. Persistent. NOT specific findings about a codebase (those go in archival memory via save_memory).'
+  WHEN 'teams' THEN
+    'Teams under my oversight — for each: name, team-lead agent_id, scope. Persistent identity. Bullet format.'
+  WHEN 'strategy' THEN
+    'Cross-project / cross-team direction I''m driving. Higher-level than active_work.'
+  WHEN 'decisions' THEN
+    'Cross-team decisions I''ve resolved — bullet log. Each entry: what was decided, when, why.'
+  ELSE description
+END
+WHERE description = '';
+
+-- Seed `tag_line` block for every existing agent that doesn't already
+-- have one. The content stays empty; the UI's "specialization" line
+-- falls back to the agent's persona/domain first-line when tag_line is
+-- blank. Agents will fill in tag_line on their next session via
+-- update_core_memory guidance.
+
+INSERT INTO core_memory_block (id, agent_id, block_name, content, char_limit, is_system, description)
+SELECT
+  'blk_' || substr(replace(gen_random_uuid()::text, '-', ''), 1, 12),
+  a.id,
+  'tag_line',
+  '',
+  100,
+  TRUE,
+  CASE a.hierarchy_level
+    WHEN 'ic' THEN 'One-line headline of my enduring specialization — shown on agent cards in the UI. Describes what I''m an expert in, not what project I''m currently on. Max 100 chars.'
+    WHEN 'team' THEN 'One-line headline of my enduring role — shown on agent cards. Describes the team I lead, not the project we''re on. Max 100 chars.'
+    WHEN 'org' THEN 'One-line headline of my org-level role — shown on agent cards. Describes the scope I oversee, not the current project. Max 100 chars.'
+  END
+FROM agent a
+WHERE a.archived_at IS NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM core_memory_block b2
+    WHERE b2.agent_id = a.id AND b2.block_name = 'tag_line'
+  );

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "bootstrap": "tsx scripts/init.ts",
     "provision-user": "tsx scripts/provision-user.ts",
     "seed-demo": "tsx scripts/seed-demo.ts",
+    "sync-core-memory": "tsx scripts/sync-core-memory-descriptions.ts",
     "daemon": "tsx packages/daemon/src/main.ts"
   },
   "devDependencies": {

--- a/packages/api/src/tools/assemble.ts
+++ b/packages/api/src/tools/assemble.ts
@@ -111,7 +111,10 @@ export function assembleTools(
       { factStore: services.factStore },
     ),
     createUpdateCoreMemoryTool(
-      { agentId: ctx.caller.agentId },
+      {
+        agentId: ctx.caller.agentId,
+        hierarchyLevel: ctx.caller.hierarchyLevel,
+      },
       { coreMemory: services.coreMemory },
     ),
   ];

--- a/packages/api/src/tools/hierarchy.ts
+++ b/packages/api/src/tools/hierarchy.ts
@@ -22,6 +22,7 @@
 import {
   DEFAULT_RUNTIME_CONFIG,
   TASK_PRIORITIES,
+  DEFAULT_BLOCK_TEMPLATES,
   TASK_STATUSES,
   WORK_PRODUCT_TYPES,
   agentId as makeAgentId,
@@ -1011,16 +1012,23 @@ function createSubordinateAgentTool(
   ctx: HierarchyToolContext,
   services: HierarchyToolServices,
 ): AgentTool {
+  // Pull field descriptions from the IC tier's block templates so the
+  // tool's per-field guidance and the agent-facing <core_memory> block
+  // descriptions stay in lockstep. Same source of truth.
+  const icBlocks = new Map(
+    DEFAULT_BLOCK_TEMPLATES.ic.map((t) => [t.block_name, t.description]),
+  );
+
   return {
     name: "create_subordinate_agent",
     description:
       "Spawn an IC specialist agent under you. Use this during onboarding " +
       "(after the user describes their codebase / problem) to assemble a " +
       "small team — typically 2–3 specialists chosen for the actual stack. " +
-      "Each new agent gets a persona block (who they are, how they work) " +
-      "and a domain block (what they know about the codebase / area). After " +
-      "creating them, use create_task to give each one a concrete first " +
-      "task. Returns the new agent_id so you can immediately reference it.",
+      "Each field below becomes the correspondingly-named core memory " +
+      "block on the new agent. After creating them, use create_task to " +
+      "give each one a concrete first task. Returns the new agent_id so " +
+      "you can immediately reference it.",
     schema: {
       type: "object",
       properties: {
@@ -1029,20 +1037,28 @@ function createSubordinateAgentTool(
           description:
             "Short human-readable label, e.g. 'Backend specialist', 'Auth/SSO expert'.",
         },
+        tag_line: {
+          type: "string",
+          description: icBlocks.get("tag_line") ?? "",
+        },
         persona: {
           type: "string",
-          description:
-            "Who this agent is and how they should work. Becomes the persona " +
-            "core-memory block. 1–4 sentences.",
+          description: icBlocks.get("persona") ?? "",
         },
         domain: {
           type: "string",
-          description:
-            "What this agent knows / owns: stack, files/dirs, conventions, " +
-            "constraints. Becomes the domain core-memory block. Be specific.",
+          description: icBlocks.get("domain") ?? "",
+        },
+        active_context: {
+          type: "string",
+          description: icBlocks.get("active_context") ?? "",
+        },
+        constraints: {
+          type: "string",
+          description: icBlocks.get("constraints") ?? "",
         },
       },
-      required: ["name", "persona", "domain"],
+      required: ["name", "tag_line", "persona", "domain"],
     },
     handler: async (input) => {
       try {
@@ -1058,11 +1074,29 @@ function createSubordinateAgentTool(
         }
 
         const name = String(input.name ?? "").trim();
+        const tagLine = String(input.tag_line ?? "").trim();
         const persona = String(input.persona ?? "").trim();
         const domain = String(input.domain ?? "").trim();
-        if (!name || !persona || !domain) {
+        const activeContext = String(input.active_context ?? "").trim();
+        const constraints = String(input.constraints ?? "").trim();
+        if (!name || !tagLine || !persona || !domain) {
           return {
-            content: { error: "name, persona, and domain are all required" },
+            content: {
+              error: "missing_required_fields",
+              message: "name, tag_line, persona, and domain are all required",
+            },
+            isError: true,
+          };
+        }
+        // Soft-enforce the tag_line limit so the UI's agent card line stays
+        // legible. Hard limit is the column char_limit.
+        if (tagLine.length > 100) {
+          return {
+            content: {
+              error: "tag_line_too_long",
+              message: "tag_line must be ≤100 chars",
+              actual: tagLine.length,
+            },
             isError: true,
           };
         }
@@ -1137,13 +1171,28 @@ function createSubordinateAgentTool(
           },
         );
 
-        // Seed the IC's persona + domain blocks. provisionAgent's initDefaults
-        // creates them empty; overwrite with the briefing the parent supplied
-        // so the IC's first turn has its identity baked in.
-        await Promise.all([
+        // Seed the IC's identity-bearing blocks. provisionAgent's
+        // initDefaults creates them empty; overwrite with the briefing
+        // the parent supplied so the IC's first turn has its identity
+        // baked in. Optional blocks (active_context, constraints) only
+        // get written if the parent provided content — empty blocks
+        // stay empty and the IC can fill them in as it works.
+        const seeds: Promise<unknown>[] = [
+          services.coreMemoryRepo.updateContent(agent.id, "tag_line", tagLine),
           services.coreMemoryRepo.updateContent(agent.id, "persona", persona),
           services.coreMemoryRepo.updateContent(agent.id, "domain", domain),
-        ]);
+        ];
+        if (activeContext) {
+          seeds.push(
+            services.coreMemoryRepo.updateContent(agent.id, "active_context", activeContext),
+          );
+        }
+        if (constraints) {
+          seeds.push(
+            services.coreMemoryRepo.updateContent(agent.id, "constraints", constraints),
+          );
+        }
+        await Promise.all(seeds);
 
         // Phase 9 audit log row — backs the daily cap query above + the
         // /agents/[id] audit panel ("spawned by X on D, persona was Y").

--- a/packages/api/src/tools/update-core-memory.test.ts
+++ b/packages/api/src/tools/update-core-memory.test.ts
@@ -21,7 +21,7 @@ function fakeCoreMemory(): { coreMemory: CoreMemory; calls: Array<{ args: unknow
 describe("update_core_memory tool", () => {
   it("delegates an append operation to coreMemory.applyUpdate", async () => {
     const { coreMemory, calls } = fakeCoreMemory();
-    const tool = createUpdateCoreMemoryTool({ agentId: "agent_a" }, { coreMemory });
+    const tool = createUpdateCoreMemoryTool({ agentId: "agent_a", hierarchyLevel: "ic" }, { coreMemory });
 
     const result = await tool.handler({
       block_name: "persona",
@@ -43,7 +43,7 @@ describe("update_core_memory tool", () => {
 
   it("delegates a replace operation with old_content", async () => {
     const { coreMemory, calls } = fakeCoreMemory();
-    const tool = createUpdateCoreMemoryTool({ agentId: "agent_a" }, { coreMemory });
+    const tool = createUpdateCoreMemoryTool({ agentId: "agent_a", hierarchyLevel: "ic" }, { coreMemory });
 
     const result = await tool.handler({
       block_name: "domain",
@@ -64,7 +64,7 @@ describe("update_core_memory tool", () => {
 
   it("rejects replace without old_content", async () => {
     const { coreMemory, calls } = fakeCoreMemory();
-    const tool = createUpdateCoreMemoryTool({ agentId: "agent_a" }, { coreMemory });
+    const tool = createUpdateCoreMemoryTool({ agentId: "agent_a", hierarchyLevel: "ic" }, { coreMemory });
 
     const result = await tool.handler({
       block_name: "domain",
@@ -79,7 +79,7 @@ describe("update_core_memory tool", () => {
 
   it("rejects unknown operation", async () => {
     const { coreMemory, calls } = fakeCoreMemory();
-    const tool = createUpdateCoreMemoryTool({ agentId: "agent_a" }, { coreMemory });
+    const tool = createUpdateCoreMemoryTool({ agentId: "agent_a", hierarchyLevel: "ic" }, { coreMemory });
 
     const result = await tool.handler({
       block_name: "persona",
@@ -95,13 +95,13 @@ describe("update_core_memory tool", () => {
   it("surfaces service errors as isError responses", async () => {
     const coreMemory = {
       applyUpdate: vi.fn(async () => {
-        throw new Error("Block \"unknown\" not found for agent agent_a — initDefaults first");
+        throw new Error("Block \"persona\" not found for agent agent_a — initDefaults first");
       }),
     } as unknown as CoreMemory;
-    const tool = createUpdateCoreMemoryTool({ agentId: "agent_a" }, { coreMemory });
+    const tool = createUpdateCoreMemoryTool({ agentId: "agent_a", hierarchyLevel: "ic" }, { coreMemory });
 
     const result = await tool.handler({
-      block_name: "unknown",
+      block_name: "persona",
       operation: "append",
       content: "x",
     });
@@ -111,9 +111,21 @@ describe("update_core_memory tool", () => {
     expect(String((result.content as { message: string }).message)).toMatch(/not found/);
   });
 
+  it("rejects block_name not in the agent's tier template", async () => {
+    const { coreMemory } = fakeCoreMemory();
+    const tool = createUpdateCoreMemoryTool({ agentId: "agent_a", hierarchyLevel: "ic" }, { coreMemory });
+    const result = await tool.handler({
+      block_name: "team_members",
+      operation: "append",
+      content: "x",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "unknown_block" });
+  });
+
   it("tool descriptor exposes JSON schema with required fields", () => {
     const { coreMemory } = fakeCoreMemory();
-    const tool = createUpdateCoreMemoryTool({ agentId: "agent_a" }, { coreMemory });
+    const tool = createUpdateCoreMemoryTool({ agentId: "agent_a", hierarchyLevel: "ic" }, { coreMemory });
     expect(tool.name).toBe("update_core_memory");
     expect(tool.schema.required).toEqual(["block_name", "operation", "content"]);
   });

--- a/packages/api/src/tools/update-core-memory.ts
+++ b/packages/api/src/tools/update-core-memory.ts
@@ -1,38 +1,30 @@
 import type { CoreMemory, CoreMemoryOperation } from "@beevibe/core/services/memory";
+import type { HierarchyLevel } from "@beevibe/core";
+import { DEFAULT_BLOCK_TEMPLATES } from "@beevibe/core";
 import type { AgentTool } from "./types.js";
 
 const OPERATIONS: readonly CoreMemoryOperation[] = ["append", "replace"];
 
-const UPDATE_CORE_MEMORY_SCHEMA = {
-  type: "object",
-  properties: {
-    block_name: {
-      type: "string",
-      description:
-        "Which core-memory block to edit. ICs typically have: persona, " +
-        "domain, constraints, learnings.",
-    },
-    operation: {
-      type: "string",
-      enum: OPERATIONS,
-      description:
-        "append: add new content at the end of the existing block. " +
-        "replace: substitute old_content with content (old_content required).",
-    },
-    content: {
-      type: "string",
-      description:
-        "The new content. For append: appended verbatim. For replace: replaces old_content.",
-    },
-    old_content: {
-      type: "string",
-      description:
-        "Required for replace. The exact substring to substitute. Must match " +
-        "exactly (verbatim) somewhere in the existing block.",
-    },
-  },
-  required: ["block_name", "operation", "content"],
-} as const;
+/**
+ * Compose per-block guidance for the agent's `block_name` enum. Reads
+ * straight from DEFAULT_BLOCK_TEMPLATES so this stays in lockstep with
+ * the same descriptions the agent sees on its <core_memory> render and
+ * via create_subordinate_agent's field descriptions — single source of
+ * truth for block semantics.
+ */
+function buildBlockNameDescription(level: HierarchyLevel): string {
+  const templates = DEFAULT_BLOCK_TEMPLATES[level];
+  const blockList = templates
+    .map((t) => `- **${t.block_name}**: ${t.description}`)
+    .join("\n");
+  return (
+    "Which core-memory block to edit. Each block has a narrow purpose — " +
+    "content for one block doesn't belong in another. Read the block's " +
+    "`description` attribute in your <core_memory> render before writing.\n\n" +
+    "Available blocks at your tier:\n" +
+    blockList
+  );
+}
 
 export interface UpdateCoreMemoryServices {
   coreMemory: CoreMemory;
@@ -40,30 +32,69 @@ export interface UpdateCoreMemoryServices {
 
 export interface UpdateCoreMemoryContext {
   agentId: string;
+  hierarchyLevel: HierarchyLevel;
 }
 
 /**
  * Build the `update_core_memory` MCP tool. Delegates to M3's
  * `CoreMemory.applyUpdate` which validates block existence + operation
  * shape (e.g. replace requires old_content match).
+ *
+ * The `block_name` enum is tier-aware: an IC agent sees ic blocks
+ * (persona/domain/active_context/constraints/tag_line), team agents see
+ * team blocks (persona/team_members/active_work/patterns/tag_line),
+ * etc. — prevents writes to non-existent blocks at the protocol level.
  */
 export function createUpdateCoreMemoryTool(
   ctx: UpdateCoreMemoryContext,
   services: UpdateCoreMemoryServices,
 ): AgentTool {
+  const tierBlocks = DEFAULT_BLOCK_TEMPLATES[ctx.hierarchyLevel].map(
+    (t) => t.block_name,
+  );
+
+  const schema = {
+    type: "object",
+    properties: {
+      block_name: {
+        type: "string",
+        enum: tierBlocks,
+        description: buildBlockNameDescription(ctx.hierarchyLevel),
+      },
+      operation: {
+        type: "string",
+        enum: OPERATIONS,
+        description:
+          "append: add new content at the end of the existing block. " +
+          "replace: substitute old_content with content (old_content required).",
+      },
+      content: {
+        type: "string",
+        description:
+          "The new content. For append: appended verbatim. For replace: replaces old_content.",
+      },
+      old_content: {
+        type: "string",
+        description:
+          "Required for replace. The exact substring to substitute. Must match " +
+          "exactly (verbatim) somewhere in the existing block.",
+      },
+    },
+    required: ["block_name", "operation", "content"],
+  } as const;
+
   return {
     name: "update_core_memory",
     description:
-      "Edit one of your core-memory blocks (persona/domain/constraints/" +
-      "learnings/etc). These appear in every future session's briefing — " +
-      "treat as expensive real estate. Use ONLY for stable, durable shifts " +
-      "that should appear in every future briefing: persona changes, " +
-      "long-term constraint changes, patterns confirmed across multiple " +
-      "sessions. NOT for one-shot facts (use save_memory instead). If " +
-      "unsure between core and archival, use save_memory; promote to core " +
-      "later if the fact recurs across sessions. Use append to add a " +
-      "paragraph, replace to substitute a specific passage.",
-    schema: UPDATE_CORE_MEMORY_SCHEMA as Record<string, unknown>,
+      "Edit one of your core-memory blocks. These appear in every future " +
+      "session's briefing — treat as expensive real estate. Use ONLY for " +
+      "stable, durable shifts that should appear in every future briefing: " +
+      "persona changes, long-term constraint changes, patterns confirmed " +
+      "across multiple sessions. NOT for one-shot facts (use save_memory " +
+      "instead). If unsure between core and archival, use save_memory; " +
+      "promote to core later if the fact recurs across sessions. Use " +
+      "append to add a paragraph, replace to substitute a specific passage.",
+    schema: schema as Record<string, unknown>,
     handler: async (input) => {
       const blockName = input.block_name;
       const operation = input.operation;
@@ -73,6 +104,15 @@ export function createUpdateCoreMemoryTool(
       if (typeof blockName !== "string" || !blockName.trim()) {
         return {
           content: { error: "invalid_block_name", message: "block_name must be a non-empty string" },
+          isError: true,
+        };
+      }
+      if (!tierBlocks.includes(blockName)) {
+        return {
+          content: {
+            error: "unknown_block",
+            message: `block_name must be one of: ${tierBlocks.join(", ")}`,
+          },
           isError: true,
         };
       }

--- a/packages/api/src/views/agents.ts
+++ b/packages/api/src/views/agents.ts
@@ -31,6 +31,8 @@ interface AgentRow {
   updated_at: Date;
   sessions_count: string;
   facts_learned: string;
+  tag_line: string | null;
+  domain_content: string | null;
 }
 
 const LIST_SQL = /* sql */ `
@@ -39,7 +41,9 @@ SELECT
   a.review_policy, a.runtime_config, a.preferred_runtime_id, a.archived_at,
   a.created_at, a.updated_at,
   COALESCE(sc.n, 0)::int  AS sessions_count,
-  COALESCE(fc.n, 0)::int  AS facts_learned
+  COALESCE(fc.n, 0)::int  AS facts_learned,
+  tl.content              AS tag_line,
+  dm.content              AS domain_content
 FROM agent a
 LEFT JOIN (
   SELECT agent_id, COUNT(*)::int AS n
@@ -51,6 +55,8 @@ LEFT JOIN (
   FROM memory_fact
   GROUP BY agent_id
 ) fc ON fc.agent_id = a.id
+LEFT JOIN core_memory_block tl ON tl.agent_id = a.id AND tl.block_name = 'tag_line'
+LEFT JOIN core_memory_block dm ON dm.agent_id = a.id AND dm.block_name = 'domain'
 WHERE ($1::text IS NULL OR a.owner_id = $1)
   AND a.archived_at IS NULL
 ORDER BY
@@ -61,10 +67,13 @@ ORDER BY
 function rowToAgentDisplay(row: AgentRow): AgentDisplay {
   // `runtime` is the CLI tool name; `model` is the LLM alias passed to it.
   // Previously this view returned `runtime_config.model` under the `runtime`
-  // key, conflating the two — see https://github.com/beevibe-ai/beevibe/issues
-  // for the diagnosis. Now they're separate fields.
+  // key, conflating the two — PR #96 split them. PR #99 adds specialization,
+  // sourced from the `tag_line` core memory block (≤100 chars), falling
+  // back to the first non-empty line of `domain` for legacy agents whose
+  // tag_line is still empty.
   const runtime = (row.runtime_config?.type as string | undefined) ?? "claude";
   const model = row.runtime_config?.model as string | undefined;
+  const specialization = firstNonEmptyLine(row.tag_line) ?? firstNonEmptyLine(row.domain_content);
   return {
     id: row.id,
     name: row.name,
@@ -79,10 +88,20 @@ function rowToAgentDisplay(row: AgentRow): AgentDisplay {
     facts_learned: Number(row.facts_learned),
     runtime,
     model,
+    specialization,
     review_policy: row.review_policy ?? undefined,
     preferred_runtime_id: row.preferred_runtime_id ?? undefined,
     archived_at: row.archived_at ? row.archived_at.toISOString() : undefined,
   };
+}
+
+function firstNonEmptyLine(content: string | null | undefined): string | undefined {
+  if (!content) return undefined;
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed) return trimmed;
+  }
+  return undefined;
 }
 
 export async function listAgents(
@@ -99,7 +118,11 @@ SELECT
   a.review_policy, a.runtime_config, a.preferred_runtime_id, a.archived_at,
   a.created_at, a.updated_at,
   (SELECT COUNT(*)::int FROM session       WHERE agent_id = a.id) AS sessions_count,
-  (SELECT COUNT(*)::int FROM memory_fact   WHERE agent_id = a.id) AS facts_learned
+  (SELECT COUNT(*)::int FROM memory_fact   WHERE agent_id = a.id) AS facts_learned,
+  (SELECT content FROM core_memory_block
+    WHERE agent_id = a.id AND block_name = 'tag_line' LIMIT 1) AS tag_line,
+  (SELECT content FROM core_memory_block
+    WHERE agent_id = a.id AND block_name = 'domain'   LIMIT 1) AS domain_content
 FROM agent a
 WHERE a.id = $1
 LIMIT 1

--- a/packages/core/src/adapters/postgres/core-memory-repo.ts
+++ b/packages/core/src/adapters/postgres/core-memory-repo.ts
@@ -35,15 +35,24 @@ export class PostgresCoreMemoryRepository implements CoreMemoryBlockRepository {
   async upsert(input: NewCoreMemoryBlock): Promise<CoreMemoryBlock> {
     const { rows } = await this.pool.query<CoreMemoryBlockRow>(
       `INSERT INTO core_memory_block (
-         id, agent_id, block_name, content, char_limit, is_system
-       ) VALUES ($1, $2, $3, $4, $5, $6)
+         id, agent_id, block_name, content, char_limit, is_system, description
+       ) VALUES ($1, $2, $3, $4, $5, $6, $7)
        ON CONFLICT (agent_id, block_name) DO UPDATE SET
-         content    = EXCLUDED.content,
-         char_limit = EXCLUDED.char_limit,
-         is_system  = EXCLUDED.is_system,
-         updated_at = NOW()
+         content     = EXCLUDED.content,
+         char_limit  = EXCLUDED.char_limit,
+         is_system   = EXCLUDED.is_system,
+         description = EXCLUDED.description,
+         updated_at  = NOW()
        RETURNING *`,
-      [input.id, input.agent_id, input.block_name, input.content, input.char_limit, input.is_system],
+      [
+        input.id,
+        input.agent_id,
+        input.block_name,
+        input.content,
+        input.char_limit,
+        input.is_system,
+        input.description ?? "",
+      ],
     );
     return rowToBlock(rows[0]!);
   }
@@ -86,7 +95,7 @@ export class PostgresCoreMemoryRepository implements CoreMemoryBlockRepository {
     const values: unknown[] = [];
     let i = 1;
     for (const tmpl of templates) {
-      tuples.push(`($${i++}, $${i++}, $${i++}, $${i++}, $${i++}, $${i++})`);
+      tuples.push(`($${i++}, $${i++}, $${i++}, $${i++}, $${i++}, $${i++}, $${i++})`);
       values.push(
         blockId(),
         agentId,
@@ -94,15 +103,20 @@ export class PostgresCoreMemoryRepository implements CoreMemoryBlockRepository {
         tmpl.initial_content,
         tmpl.char_limit,
         tmpl.is_system,
+        tmpl.description,
       );
     }
 
+    // ON CONFLICT updates `description` so re-running initDefaults on an
+    // existing agent (e.g. after a template description was tightened in
+    // code) refreshes the agent-facing guidance. Content is preserved.
     const { rows } = await this.pool.query<CoreMemoryBlockRow>(
       `INSERT INTO core_memory_block (
-         id, agent_id, block_name, content, char_limit, is_system
+         id, agent_id, block_name, content, char_limit, is_system, description
        ) VALUES ${tuples.join(", ")}
        ON CONFLICT (agent_id, block_name) DO UPDATE SET
-         updated_at = NOW()
+         description = EXCLUDED.description,
+         updated_at  = NOW()
        RETURNING *`,
       values,
     );
@@ -118,6 +132,7 @@ function rowToBlock(row: CoreMemoryBlockRow): CoreMemoryBlock {
     content: row.content,
     char_limit: row.char_limit,
     is_system: row.is_system,
+    description: row.description ?? "",
     created_at: row.created_at,
     updated_at: row.updated_at,
   };

--- a/packages/core/src/adapters/postgres/row-types.ts
+++ b/packages/core/src/adapters/postgres/row-types.ts
@@ -83,6 +83,7 @@ export interface CoreMemoryBlockRow {
   content: string;
   char_limit: number;
   is_system: boolean;
+  description: string;
   created_at: Date;
   updated_at: Date;
 }

--- a/packages/core/src/auth/auth.integration.test.ts
+++ b/packages/core/src/auth/auth.integration.test.ts
@@ -77,13 +77,13 @@ describe("auth — integration", () => {
     expect(fetched?.id).toBe(alice.person.id);
   });
 
-  it("provisionAgent mints a bv_a_ key, stores it, and seeds 4 default blocks", async () => {
+  it("provisionAgent mints a bv_a_ key, stores it, and seeds 5 default blocks", async () => {
     const alice = await makeAlice();
     const team = await makeTeamAgentFor(alice.person.id);
 
     expect(team.apiKey).toMatch(/^bv_a_[0-9A-Za-z]{24}$/);
     expect(team.agent.api_key).toBe(team.apiKey);
-    expect(team.blocks).toHaveLength(4);
+    expect(team.blocks).toHaveLength(5);
 
     const fetched = await agentRepo.findByApiKey(team.apiKey);
     expect(fetched?.id).toBe(team.agent.id);

--- a/packages/core/src/auth/provision.test.ts
+++ b/packages/core/src/auth/provision.test.ts
@@ -13,13 +13,14 @@ import {
 } from "./test-fakes.js";
 
 function makeBlocks(agentId: string): CoreMemoryBlock[] {
-  return ["persona", "domain", "active_context", "constraints"].map((name) => ({
+  return ["tag_line", "persona", "domain", "active_context", "constraints"].map((name) => ({
     id: `block_${name}`,
     agent_id: agentId,
     block_name: name,
     content: "",
-    char_limit: 2000,
+    char_limit: name === "tag_line" ? 100 : 2000,
     is_system: true,
+    description: "",
     created_at: new Date(),
     updated_at: new Date(),
   }));
@@ -62,7 +63,7 @@ describe("provisionAgent", () => {
     expect(out.apiKey).toMatch(/^bv_a_[0-9A-Za-z]{24}$/);
     expect(out.agent.api_key).toBe(out.apiKey);
     expect(out.agent.id).toBe("agent_1");
-    expect(out.blocks).toHaveLength(4);
+    expect(out.blocks).toHaveLength(5);
 
     expect(agentRepo.create).toHaveBeenCalledWith(
       expect.objectContaining({ id: "agent_1", api_key: out.apiKey }),

--- a/packages/core/src/domain/core-memory.ts
+++ b/packages/core/src/domain/core-memory.ts
@@ -52,6 +52,15 @@ export interface BlockTemplate {
  * stable identity (persona, domain, tag_line) survives across every
  * project they touch. Project context (active_context, active_work) is
  * transient and gets rewritten when the agent shifts to a new codebase.
+ *
+ * THIS CONSTANT IS THE SOURCE OF TRUTH for block descriptions. New
+ * agents inherit descriptions via `coreMemoryRepo.initDefaults` (which
+ * reads this constant). To propagate description edits to EXISTING
+ * agents, run `pnpm sync-core-memory` — that script re-runs initDefaults
+ * per agent, and `ON CONFLICT` updates the description column to the
+ * latest template value. The migration's initial backfill is a snapshot
+ * that may drift if the template is edited later; the sync script is
+ * how we reconcile.
  */
 export const DEFAULT_BLOCK_TEMPLATES: Record<HierarchyLevel, readonly BlockTemplate[]> = {
   ic: [

--- a/packages/core/src/domain/core-memory.ts
+++ b/packages/core/src/domain/core-memory.ts
@@ -6,6 +6,7 @@ export interface CoreMemoryBlock {
   block_name: string;
   content: string;
   char_limit: number;
+  description: string;
   is_system: boolean;
   created_at: Date;
   updated_at: Date;
@@ -13,6 +14,10 @@ export interface CoreMemoryBlock {
 
 export const TOTAL_BLOCK_CHAR_LIMIT = 50_000;
 
+/**
+ * Blocks consulted when deciding whether to route a request to a peer/sub
+ * (i.e., "does this agent know about X?"). Per-tier subset.
+ */
 export const ROUTING_BLOCKS: Record<HierarchyLevel, readonly string[]> = {
   ic: ["persona", "domain"],
   team: ["persona", "team_members"],
@@ -24,25 +29,208 @@ export interface BlockTemplate {
   char_limit: number;
   is_system: boolean;
   initial_content: string;
+  /**
+   * First-person guidance ("Who I am…", "What I'm currently working on…")
+   * that the agent reads to decide HOW and WHEN to update this block.
+   * Per Letta's pattern: the description is the single source of truth for
+   * the block's purpose, and is surfaced to the agent in three places:
+   *   1. As an attribute on the `<core_memory>` XML in the system prompt
+   *   2. As the `block_name` enum's per-value guidance on `update_core_memory`
+   *   3. As field descriptions on `create_subordinate_agent` for the parent
+   * Keep these in sync — they're all read by the same agent at different
+   * moments in the same session.
+   */
+  description: string;
 }
 
+/**
+ * Core memory blocks per hierarchy tier. Each block has a narrow,
+ * non-overlapping purpose; the description is what tells the agent which
+ * content belongs where.
+ *
+ * Framing: agents are persistent SPECIALISTS, not project-bound. The
+ * stable identity (persona, domain, tag_line) survives across every
+ * project they touch. Project context (active_context, active_work) is
+ * transient and gets rewritten when the agent shifts to a new codebase.
+ */
 export const DEFAULT_BLOCK_TEMPLATES: Record<HierarchyLevel, readonly BlockTemplate[]> = {
   ic: [
-    { block_name: "persona", char_limit: 2000, is_system: true, initial_content: "" },
-    { block_name: "domain", char_limit: 2000, is_system: true, initial_content: "" },
-    { block_name: "active_context", char_limit: 2000, is_system: true, initial_content: "" },
-    { block_name: "constraints", char_limit: 2000, is_system: true, initial_content: "" },
+    {
+      block_name: "tag_line",
+      char_limit: 100,
+      is_system: true,
+      initial_content: "",
+      description:
+        "One-line headline of my enduring specialization — shown on agent " +
+        "cards in the UI. Describes what I'm an expert in, not what " +
+        "project I'm currently on. Examples: 'Go backend specialist " +
+        "(Chi/sqlc, websockets)', 'Next.js + React UI lead'. Max 100 " +
+        "chars. Update only when my specialization itself shifts.",
+    },
+    {
+      block_name: "persona",
+      char_limit: 2000,
+      is_system: true,
+      initial_content: "",
+      description:
+        "Who I am and how I work — my role and working style, persistent " +
+        "across every project I touch. 1-3 sentences in first person. " +
+        "Update when my self-conception genuinely shifts (acquired a " +
+        "major capability, refined my approach). NOT my current project " +
+        "(that's `active_context`), NOT my domain scope (that's `domain`).",
+    },
+    {
+      block_name: "domain",
+      char_limit: 2000,
+      is_system: true,
+      initial_content: "",
+      description:
+        "The areas I specialize in ACROSS all projects — my enduring " +
+        "expertise. As I work on more projects in my domain, this can " +
+        "deepen (becoming truly expert in narrower sub-areas). Bullet " +
+        "format. Example: 'Go backend services: HTTP via Chi/echo, DB " +
+        "via sqlc, websockets via gorilla, distribution via goreleaser.' " +
+        "NOT project-specific paths (those go in `active_context`). NOT " +
+        "the rules I follow (those go in `constraints`).",
+    },
+    {
+      block_name: "active_context",
+      char_limit: 2000,
+      is_system: true,
+      initial_content: "",
+      description:
+        "What I'm currently working on — the specific project and its " +
+        "in-flight details. Bullet format. Example: 'Project: " +
+        "github.com/multica-ai/multica. Local clone: /tmp/multica-repo. " +
+        "Owned paths in this project: server/cmd/**, server/internal/**. " +
+        "Current task: task_xfQpuEHWjbvk.' Transient — rewrite when the " +
+        "project changes. This is where ALL project/codebase-specific " +
+        "details live, NOT in `domain`.",
+    },
+    {
+      block_name: "constraints",
+      char_limit: 2000,
+      is_system: true,
+      initial_content: "",
+      description:
+        "Hard rules I follow — non-negotiable conventions and " +
+        "coordination boundaries. Mix of persistent rules ('queries " +
+        "always via sqlc — never hand-write the DB layer') and " +
+        "project-specific rules ('read /CLAUDE.md before changes in " +
+        "this codebase'). Bullet format. Reference docs by path, not " +
+        "content.",
+    },
   ],
   team: [
-    { block_name: "persona", char_limit: 2000, is_system: true, initial_content: "" },
-    { block_name: "team_members", char_limit: 3000, is_system: true, initial_content: "" },
-    { block_name: "active_work", char_limit: 2000, is_system: true, initial_content: "" },
-    { block_name: "patterns", char_limit: 2000, is_system: true, initial_content: "" },
+    {
+      block_name: "tag_line",
+      char_limit: 100,
+      is_system: true,
+      initial_content: "",
+      description:
+        "One-line headline of my enduring role — shown on agent cards. " +
+        "Describes the team I lead, not the project we're on. Examples: " +
+        "'Daniel's team — orchestrates 3 backend/frontend/platform " +
+        "specialists', 'Solo lead — driving a small team for hire'. " +
+        "Max 100 chars.",
+    },
+    {
+      block_name: "persona",
+      char_limit: 2000,
+      is_system: true,
+      initial_content: "",
+      description:
+        "Who I am as a team lead — my orchestration style and how I " +
+        "delegate. 1-3 sentences in first person. Persistent across " +
+        "projects. NOT my team roster (that's `team_members`), NOT the " +
+        "current work (that's `active_work`).",
+    },
+    {
+      block_name: "team_members",
+      char_limit: 3000,
+      is_system: true,
+      initial_content: "",
+      description:
+        "Roster of my direct reports — for each: name, agent_id, " +
+        "specialization (NOT project assignment — same agents stay over " +
+        "time as we work different projects). Bullet format. Update " +
+        "when subordinates are spawned/archived/reassigned.",
+    },
+    {
+      block_name: "active_work",
+      char_limit: 2000,
+      is_system: true,
+      initial_content: "",
+      description:
+        "What my team is currently working on — the active project + " +
+        "high-level work in flight across specialists. Bullet format. " +
+        "Example: 'Project: github.com/multica-ai/multica. Backend " +
+        "specialist running CLI audit (task_xfQpuEHWjbvk); Frontend on " +
+        "standby.' Transient — rewrite on project shifts.",
+    },
+    {
+      block_name: "patterns",
+      char_limit: 2000,
+      is_system: true,
+      initial_content: "",
+      description:
+        "Cross-project patterns I've observed in how my team operates — " +
+        "what works, what trips them up. Persistent. Example: 'When I " +
+        "assign an audit task, the IC tends to produce thorough work " +
+        "products but forgets to save_memory mid-pass.' NOT specific " +
+        "findings about a codebase (those go in archival memory via " +
+        "save_memory).",
+    },
   ],
   org: [
-    { block_name: "persona", char_limit: 2000, is_system: true, initial_content: "" },
-    { block_name: "teams", char_limit: 3000, is_system: true, initial_content: "" },
-    { block_name: "strategy", char_limit: 2000, is_system: true, initial_content: "" },
-    { block_name: "decisions", char_limit: 2000, is_system: true, initial_content: "" },
+    {
+      block_name: "tag_line",
+      char_limit: 100,
+      is_system: true,
+      initial_content: "",
+      description:
+        "One-line headline of my org-level role — shown on agent cards. " +
+        "Describes the scope I oversee, not the current project. " +
+        "Examples: 'Eng org lead — 3 teams (product/platform/infra)'. " +
+        "Max 100 chars.",
+    },
+    {
+      block_name: "persona",
+      char_limit: 2000,
+      is_system: true,
+      initial_content: "",
+      description:
+        "Who I am as an org leader — my decision style and how I balance " +
+        "across teams. 1-3 sentences. Persistent.",
+    },
+    {
+      block_name: "teams",
+      char_limit: 3000,
+      is_system: true,
+      initial_content: "",
+      description:
+        "Teams under my oversight — for each: name, team-lead agent_id, " +
+        "scope. Persistent identity. Bullet format.",
+    },
+    {
+      block_name: "strategy",
+      char_limit: 2000,
+      is_system: true,
+      initial_content: "",
+      description:
+        "Cross-project / cross-team direction I'm driving. Higher-level " +
+        "than active_work. Examples: 'Q2 focus: ship Multica self-host " +
+        "v1', 'Hiring: prioritize backend over frontend this quarter'.",
+    },
+    {
+      block_name: "decisions",
+      char_limit: 2000,
+      is_system: true,
+      initial_content: "",
+      description:
+        "Cross-team decisions I've resolved — bullet log. Each entry: " +
+        "what was decided, when, why. Persistent record so the same " +
+        "question doesn't come back up.",
+    },
   ],
 };

--- a/packages/core/src/services/memory/memory-agent.ts
+++ b/packages/core/src/services/memory/memory-agent.ts
@@ -190,8 +190,15 @@ function composeBriefing(
   const blockSnapshots: SessionBriefingSnapshot["blocks"] = [];
   let charTotal = 0;
   for (const b of blocks) {
+    // Description attribute is first-person guidance the agent reads
+    // to decide WHAT belongs in this block. Surfaced alongside content
+    // so the agent sees scope right next to the data it's about to
+    // (potentially) edit. See packages/core/src/domain/core-memory.ts.
+    const descAttr = b.description
+      ? ` description="${escapeAttr(b.description)}"`
+      : "";
     blockLines.push(
-      `  <block name="${escapeAttr(b.block_name)}">${escapeText(b.content)}</block>`,
+      `  <block name="${escapeAttr(b.block_name)}"${descAttr}>${escapeText(b.content)}</block>`,
     );
     blockSnapshots.push({
       name: b.block_name,

--- a/packages/core/src/services/spawn-prep.ts
+++ b/packages/core/src/services/spawn-prep.ts
@@ -87,8 +87,25 @@ When to update memory (proactively, mid-session):
 - You resolved something tricky → save_memory(rationale, "decision")
 - You hit a non-obvious gotcha → save_memory(...., "gotcha")
 - You found a pattern that worked → save_memory(..., "pattern")
-- A user/teammate stated a preference → save_memory(..., "preference")
-- Your role/domain shifted → update_core_memory(persona/constraints, ...)
+- A user/teammate stated a DURABLE preference ("always do X", "from
+  now on") → save_memory(..., "preference")
+- Your role/domain shifted → update_core_memory(persona/domain, ...)
+
+DO NOT save_memory("preference") for one-off requests ("can you do X
+this time", "for this task"). Those are session-scoped instructions,
+not preferences worth carrying forward.
+
+Before writing to a core memory block, READ THE BLOCK'S "description"
+attribute in your <core_memory> render. Each block has a narrow purpose
+— content for one block doesn't belong in another. Common mistakes:
+- Project-specific paths/repos → "active_context", NOT "domain"
+- Hard rules / conventions → "constraints", NOT "persona"
+- Codebase findings → archival memory (save_memory), NOT "domain"
+
+Agents are persistent SPECIALISTS — they work across multiple projects
+over time. The "domain" block holds enduring cross-project expertise;
+"active_context" holds the CURRENT project's specifics (rewrite on
+project shifts). Don't conflate the two.
 
 Before searching: check if the answer is already in your <core_memory>
 blocks or the <archival_memory> block from your session-start briefing —
@@ -148,8 +165,19 @@ Your job over the next few turns:
    "Frontend specialist (covers \`packages/web\`, Next.js, design
    system)". Concrete > generic — name the actual files / dirs each
    agent owns. Confirm with the user, then call
-   \`create_subordinate_agent\` once per specialist with a focused
-   \`persona\` and \`domain\` block.
+   \`create_subordinate_agent\` once per specialist. Fill each
+   block-shaped field with content that fits THAT block's purpose:
+   - \`tag_line\`: ≤100 char UI headline ("Go backend specialist
+     (Chi/sqlc)")
+   - \`persona\`: 1-2 sentences on role + working style. NO project
+     details.
+   - \`domain\`: cross-project expertise — areas this specialist owns
+     across any codebase. NOT project-specific paths.
+   - \`active_context\` (optional): CURRENT project's specifics —
+     repo URL, owned paths, reference docs (e.g. /CLAUDE.md).
+   - \`constraints\` (optional): hard rules + coordination boundaries.
+   Don't dump everything into one block. Each block has a narrow
+   purpose; read its description.
 
 5. **Mint a real first task for at least one specialist.** Use
    \`create_task\` with a tightly-scoped intent the user agreed on
@@ -157,10 +185,17 @@ Your job over the next few turns:
    packages/web"). Reference the resulting \`task_*\` id in your reply —
    the UI hydrates it as a clickable card.
 
-6. **Use \`update_core_memory\`** as you go to record what you learned
-   about the user, the codebase, and the team you assembled. The user
-   sees those writes happen in real time — that's how they know you're
-   actually listening, not just LLM-stalling.
+6. **Use \`update_core_memory\` per BLOCK** as you go. Each block has
+   a narrow purpose — read the block's \`description\` attribute in
+   your <core_memory> before writing. For a team agent in onboarding,
+   typical writes are:
+   - \`team_members\`: append the new specialist's name + agent_id +
+     specialization
+   - \`active_work\`: the codebase you're now focused on
+   - \`patterns\` (later): cross-project observations about how your
+     team operates
+   Don't write project-specific details into persona or domain — those
+   are persistent identity blocks. Project state goes in active_work.
 
 7. **End every turn with 2–4 \`<suggest_action>\` chips** that give the
    user concrete next moves (especially during onboarding). Examples

--- a/scripts/sync-core-memory-descriptions.ts
+++ b/scripts/sync-core-memory-descriptions.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env tsx
+/**
+ * Sync core memory block descriptions across all agents from the TS
+ * template (DEFAULT_BLOCK_TEMPLATES). Run after editing block
+ * descriptions in `packages/core/src/domain/core-memory.ts` to propagate
+ * the change to existing agents.
+ *
+ * The TS template is the single source of truth for block descriptions.
+ * `initDefaults` writes the template description on each call (its
+ * `ON CONFLICT … description = EXCLUDED.description` clause), so iterating
+ * every agent and calling initDefaults is the propagation primitive.
+ *
+ * Idempotent: safe to re-run. Only the `description` column is rewritten;
+ * `content`, `char_limit`, and `is_system` are preserved by the ON CONFLICT
+ * branch.
+ *
+ * Usage:
+ *   pnpm sync-core-memory
+ */
+
+import { config as loadEnv } from "dotenv";
+import { Pool } from "pg";
+import { PostgresAgentRepository } from "@beevibe/core/adapters/postgres";
+import { PostgresCoreMemoryRepository } from "@beevibe/core/adapters/postgres";
+
+async function main(): Promise<void> {
+  loadEnv();
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    throw new Error("DATABASE_URL not set");
+  }
+
+  const pool = new Pool({ connectionString: url });
+  const agents = new PostgresAgentRepository(pool);
+  const blocks = new PostgresCoreMemoryRepository(pool);
+
+  const { rows } = await pool.query<{ id: string; hierarchy_level: string }>(
+    `SELECT id, hierarchy_level FROM agent WHERE archived_at IS NULL`,
+  );
+
+  console.log(`[sync] syncing core memory descriptions for ${rows.length} agents…`);
+
+  let synced = 0;
+  for (const row of rows) {
+    try {
+      await blocks.initDefaults(row.id, row.hierarchy_level as "ic" | "team" | "org");
+      synced += 1;
+    } catch (err) {
+      console.error(
+        `[sync] failed for agent ${row.id}:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+
+  console.log(`[sync] done — ${synced}/${rows.length} agents updated`);
+  await pool.end();
+  // agents variable is read for typing — used implicitly via the import
+  void agents;
+}
+
+main().catch((err: unknown) => {
+  console.error("[sync] fatal:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Issue #5 from the agents-config diagnosis. Letta-style block design where each core memory block carries a first-person \`description\` field that's the single source of truth for the block's purpose. Surfaced at read-time (in \`<core_memory>\` XML), at write-time (in \`update_core_memory\` tool's block_name enum), and at spawn-time (in \`create_subordinate_agent\` field descriptions) — all three pull from \`DEFAULT_BLOCK_TEMPLATES\` so they can't drift.

## Reframes block scope around agents-as-persistent-specialists

Agents work across multiple projects over time. Identity persists; project context is transient. Each block has a narrow, non-overlapping purpose:

| Block (IC tier) | Purpose |
|---|---|
| \`tag_line\` (NEW, ≤100 char) | UI headline of enduring specialization |
| \`persona\` | Role + working style, persistent |
| \`domain\` | Cross-project expertise (not project paths) |
| \`active_context\` | CURRENT project's specifics (transient) |
| \`constraints\` | Hard rules + coordination boundaries |

(Team / org tiers get parallel splits — \`team_members\` vs \`active_work\`, etc.)

The Multica smoke that surfaced this (#90) wouldn't happen under this design: the team agent was dumping project-specific paths into IC's \`domain\` block, but the new description explicitly redirects that content to \`active_context\`.

## What changed

- **Block templates** (\`packages/core/src/domain/core-memory.ts\`): added \`description\` to \`BlockTemplate\` + \`CoreMemoryBlock\`; filled descriptions per (tier, block); added \`tag_line\` block to all three tiers (100 char limit).
- **Migration** (\`migrations/1780400000000_add-core-memory-block-description.sql\`): adds \`description TEXT NOT NULL DEFAULT ''\`; backfills descriptions on existing rows (CASE per block_name); seeds an empty \`tag_line\` for every existing agent.
- **Repo adapter** (\`core-memory-repo.ts\`, \`row-types.ts\`): wire \`description\` through upsert / initDefaults / rowToBlock.
- **Briefing render** (\`memory-agent.composeBriefing\`): render \`description=\"...\"\` attribute on each \`<block>\` in \`<core_memory>\`.
- **\`update_core_memory\` tool**: \`block_name\` is now a tier-aware enum; description auto-generated by listing per-block (name, description) pairs. Rejects cross-tier writes at the protocol level (e.g. IC agent trying to write \`team_members\`).
- **\`create_subordinate_agent\` tool**: input schema expanded with \`tag_line\` (required), \`active_context\` (optional), \`constraints\` (optional). Field descriptions pulled from IC block templates.
- **View** (\`packages/api/src/views/agents.ts\`): \`specialization\` view field now populated from the \`tag_line\` block (fallback: first non-empty line of \`domain\`). Fixes the UI's \"No domain set\" rendering.
- **Directives** (\`spawn-prep.ts\`): \`BEEVIBE_MEMORY_REMINDER\` gains \"read block description before editing\" + per-block-purpose guidance + persistent-specialist framing + \"DURABLE preference vs one-off request\" rule. \`ONBOARDING_DIRECTIVES\` step 4 gets per-block field guidance for create_subordinate_agent; step 6 gets per-block guidance for update_core_memory.

## Test plan

- [x] Core tests pass (440)
- [x] API tests pass (290, +1 new for cross-tier block rejection)
- [x] Web typecheck + test pass
- [x] Migration applied locally; existing agents got a \`tag_line\` block seeded + their other blocks got descriptions backfilled
- [ ] Manual: spawn a new IC subordinate, verify all 5 blocks created with descriptions visible in the dashboard's core memory panel

## Source design

- [Letta persona.mdx](https://github.com/letta-ai/letta-code/blob/main/src/agent/prompts/persona.mdx) — first-person block description pattern
- [Letta memory-blocks docs](https://docs.letta.com/guides/core-concepts/memory/memory-blocks/) — single source of truth for block semantics

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)