### PR TITLE
fix(agents): split identity (system_prompt_addition) from description (persona block)

### DIFF
--- a/packages/api/src/tools/hierarchy.ts
+++ b/packages/api/src/tools/hierarchy.ts
@@ -1141,13 +1141,13 @@ function createSubordinateAgentTool(
         }
 
         // Inherit the parent's runtime so all the user's agents share the
-        // same Claude auth + model. Carry the user-supplied persona into
-        // the system prompt as a short addition (the heavyweight context
-        // lives in core memory, which the runtime injects on every turn).
+        // same Claude auth + model. `system_prompt_addition` carries the
+        // name only — the persona description lives in core memory (seeded
+        // below) and shouldn't be duplicated into the system prompt.
         const runtime_config = {
           ...DEFAULT_RUNTIME_CONFIG,
           ...parent.runtime_config,
-          system_prompt_addition: `You are ${name}. ${persona}`,
+          system_prompt_addition: `You are ${name}.`,
         };
 
         const { agent } = await provisionAgent(
@@ -1177,6 +1177,8 @@ function createSubordinateAgentTool(
         // baked in. Optional blocks (active_context, constraints) only
         // get written if the parent provided content — empty blocks
         // stay empty and the IC can fill them in as it works.
+        // The agent's name lives in runtime_config.system_prompt_addition
+        // ("You are X."); persona block is the description only.
         const seeds: Promise<unknown>[] = [
           services.coreMemoryRepo.updateContent(agent.id, "tag_line", tagLine),
           services.coreMemoryRepo.updateContent(agent.id, "persona", persona),


### PR DESCRIPTION
## Summary

Issue #1 of the 5-issue agent-creation cleanup. `create_subordinate_agent` was writing `\`You are \${name}. \${persona}\`` into BOTH `runtime_config.system_prompt_addition` AND the persona core-memory block — real byte-level duplication of the same string on every turn.

## Approach

Split the two concerns into single sources of truth:

- **`system_prompt_addition: \`You are \${name}.\`\`** — name only. Stable identity stamp; agent always knows what it's called. Lives in the system prompt because the agent's name is never edited via core memory and shouldn't render in `<core_memory>` either.
- **persona block: `persona`** — description only. Parent-supplied briefing (skills, tone, approach). Rendered in `<core_memory>` on every turn; editable via `update_core_memory`.

## Why not put the name in the persona block?

The persona block's purpose (per PR #99's block-description framing) is the description of *what kind of specialist* the agent is. The agent's name is metadata — closer to the agent's hierarchy level or owner_id than to its persona content. Keeping the name in the system prompt also means the agent reads it once at session start, not every time it scans core memory.

## Why not drop the name entirely?

Today (post-#99 in flight), there is no place the agent's human-readable name reaches the system prompt other than via `system_prompt_addition`. `BEEVIBE_LIFECYCLE_REMINDER` references `BEEVIBE_AGENT_ID` (opaque) and core memory blocks are content-only. Without this line, agents wouldn't know their own name and couldn't self-identify in chat or sign work products.

## Test plan
- [x] `pnpm --filter @beevibe/api typecheck` green
- [x] `pnpm --filter @beevibe/api test` — 290 tests pass
- [x] `pnpm --filter @beevibe/core test` — 440 tests pass
- [ ] Manual smoke: parent calls `create_subordinate_agent({name:"Alice", persona:"backend specialist focused on Python testing", domain:"…"})` → child's system prompt contains `You are Alice.` exactly once → persona core-memory block is just `backend specialist focused on Python testing` (no "You are Alice." prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)