### PR TITLE
fix(web): make agent detail read-only when caller doesn't own the agent

### DIFF
--- a/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
+++ b/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, AlertTriangle, Bot, Archive } from "lucide-react";
 import { useAgent } from "@/lib/hooks/use-agents";
+import { useMe } from "@/lib/hooks/use-me";
 import { isApiConfigured } from "@/lib/api/config";
 import { api, type RuntimesListResponse } from "@/lib/api/client";
 import { queryKeys } from "@/lib/hooks/keys";
@@ -98,6 +99,13 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
     },
   });
   const archived = Boolean(agent.archived_at);
+  // Cross-user discovery is allowed (GET /agent/:id ungated for mesh
+  // visibility), but every mutation route checks owner_id. Reflect that
+  // in the UI: hide pickers + archive when the caller doesn't own the
+  // agent. The footer still surfaces runtime/model/review-policy as
+  // read-only metadata.
+  const me = useMe();
+  const isOwner = me.data?.person.id === agent.owner_id;
 
   return (
     <DetailShell nav={<AgentsBackLink />}>
@@ -119,7 +127,7 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
             ) : null}
           </div>
           <div className="shrink-0 flex items-center gap-2">
-            {!archived ? (
+            {!archived && isOwner ? (
               confirming ? (
                 <>
                   <button
@@ -175,7 +183,7 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
             ) : (
               <div className="space-y-3">
                 {agent.core_blocks.map((b) => (
-                  <CoreBlockCard key={b.id} block={b} />
+                  <CoreBlockCard key={b.id} block={b} editable={isOwner} />
                 ))}
               </div>
             )}
@@ -201,9 +209,13 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
         </div>
 
         <aside className="col-span-1 space-y-4">
-          <RuntimePicker agent={agent} />
-          <ModelPicker agent={agent} />
-          <ReviewPolicyPicker agent={agent} />
+          {isOwner ? (
+            <>
+              <RuntimePicker agent={agent} />
+              <ModelPicker agent={agent} />
+              <ReviewPolicyPicker agent={agent} />
+            </>
+          ) : null}
           {agent.outgoing_mesh_hints.length ? (
             <section className="rounded-lg border border-border bg-card p-4">
               <h3 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-2 font-medium">
@@ -230,6 +242,9 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
         <FooterField label="Hierarchy">{agent.hierarchy}</FooterField>
         {agent.runtime ? <FooterField label="Runtime">{agent.runtime}</FooterField> : null}
         <FooterField label="Model">{agent.model ?? "CLI default"}</FooterField>
+        <FooterField label="Review policy">
+          {agent.review_policy === "require_human" ? "require human" : "auto-done"}
+        </FooterField>
         {agent.archived_at ? (
           <FooterField label="Archived">
             {new Date(agent.archived_at).toLocaleString()}

--- a/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
+++ b/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
@@ -6,8 +6,9 @@ import { useRouter } from "next/navigation";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, AlertTriangle, Bot, Archive } from "lucide-react";
 import { useAgent } from "@/lib/hooks/use-agents";
-import { useMe } from "@/lib/hooks/use-me";
+import { useIsOwner } from "@/lib/hooks/use-me";
 import { isApiConfigured } from "@/lib/api/config";
+import { formatReviewPolicy } from "@/lib/format";
 import { api, type RuntimesListResponse } from "@/lib/api/client";
 import { queryKeys } from "@/lib/hooks/keys";
 import { Avatar } from "@/components/avatar";
@@ -100,12 +101,15 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
   });
   const archived = Boolean(agent.archived_at);
   // Cross-user discovery is allowed (GET /agent/:id ungated for mesh
-  // visibility), but every mutation route checks owner_id. Reflect that
-  // in the UI: hide pickers + archive when the caller doesn't own the
-  // agent. The footer still surfaces runtime/model/review-policy as
-  // read-only metadata.
-  const me = useMe();
-  const isOwner = me.data?.person.id === agent.owner_id;
+  // visibility), but every mutation route checks owner_id. Hide pickers
+  // + archive when the caller doesn't own the agent. Tri-state — `null`
+  // while /me loads so the cold-mount render doesn't briefly hide owner
+  // controls before resolving.
+  const isOwner = useIsOwner(agent.owner_id);
+  // Aside only renders when it has content. For non-owners with no
+  // outgoing mesh, we'd otherwise reserve 1/3 of the grid for an empty
+  // column — main expands to full width in that case.
+  const showAside = isOwner === true || agent.outgoing_mesh_hints.length > 0;
 
   return (
     <DetailShell nav={<AgentsBackLink />}>
@@ -127,7 +131,7 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
             ) : null}
           </div>
           <div className="shrink-0 flex items-center gap-2">
-            {!archived && isOwner ? (
+            {!archived && isOwner === true ? (
               confirming ? (
                 <>
                   <button
@@ -169,8 +173,8 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
         </div>
       </header>
 
-      <div className="grid grid-cols-3 gap-6">
-        <div className="col-span-2 space-y-5">
+      <div className={cn("grid gap-6", showAside ? "grid-cols-3" : "grid-cols-1")}>
+        <div className={cn("space-y-5", showAside ? "col-span-2" : "col-span-1")}>
           <section>
             <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-3 font-medium">
               Core memory{" "}
@@ -183,7 +187,7 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
             ) : (
               <div className="space-y-3">
                 {agent.core_blocks.map((b) => (
-                  <CoreBlockCard key={b.id} block={b} editable={isOwner} />
+                  <CoreBlockCard key={b.id} block={b} editable={isOwner === true} />
                 ))}
               </div>
             )}
@@ -208,31 +212,33 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
           </section>
         </div>
 
-        <aside className="col-span-1 space-y-4">
-          {isOwner ? (
-            <>
-              <RuntimePicker agent={agent} />
-              <ModelPicker agent={agent} />
-              <ReviewPolicyPicker agent={agent} />
-            </>
-          ) : null}
-          {agent.outgoing_mesh_hints.length ? (
-            <section className="rounded-lg border border-border bg-card p-4">
-              <h3 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-2 font-medium">
-                Outgoing mesh
-              </h3>
-              <ul className="space-y-2">
-                {agent.outgoing_mesh_hints.map((hint, i) => (
-                  <li key={i} className="text-xs">
-                    <span className="text-foreground/85">{hint.target}</span>{" "}
-                    <span className="text-muted-foreground/70">· {hint.age}</span>
-                    <p className="text-muted-foreground line-clamp-1">{hint.intent}</p>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          ) : null}
-        </aside>
+        {showAside ? (
+          <aside className="col-span-1 space-y-4">
+            {isOwner === true ? (
+              <>
+                <RuntimePicker agent={agent} />
+                <ModelPicker agent={agent} />
+                <ReviewPolicyPicker agent={agent} />
+              </>
+            ) : null}
+            {agent.outgoing_mesh_hints.length ? (
+              <section className="rounded-lg border border-border bg-card p-4">
+                <h3 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-2 font-medium">
+                  Outgoing mesh
+                </h3>
+                <ul className="space-y-2">
+                  {agent.outgoing_mesh_hints.map((hint, i) => (
+                    <li key={i} className="text-xs">
+                      <span className="text-foreground/85">{hint.target}</span>{" "}
+                      <span className="text-muted-foreground/70">· {hint.age}</span>
+                      <p className="text-muted-foreground line-clamp-1">{hint.intent}</p>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ) : null}
+          </aside>
+        ) : null}
       </div>
 
       <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
@@ -243,7 +249,7 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
         {agent.runtime ? <FooterField label="Runtime">{agent.runtime}</FooterField> : null}
         <FooterField label="Model">{agent.model ?? "CLI default"}</FooterField>
         <FooterField label="Review policy">
-          {agent.review_policy === "require_human" ? "require human" : "auto-done"}
+          {formatReviewPolicy(agent.review_policy)}
         </FooterField>
         {agent.archived_at ? (
           <FooterField label="Archived">

--- a/packages/web/components/agents/agent-detail-panel.tsx
+++ b/packages/web/components/agents/agent-detail-panel.tsx
@@ -11,7 +11,8 @@ import { HierChip } from "@/components/hier-chip";
 import { Skeleton } from "@/components/skeleton";
 import { isApiConfigured } from "@/lib/api/config";
 import { useAgent } from "@/lib/hooks/use-agents";
-import { useMe } from "@/lib/hooks/use-me";
+import { useIsOwner } from "@/lib/hooks/use-me";
+import { formatReviewPolicy } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import type { AgentDetail } from "@/lib/api/types";
 import type { RecentSession } from "@/lib/types/agents";
@@ -148,8 +149,7 @@ function PanelBody({ agentId }: { agentId: string }) {
 }
 
 function PanelLoaded({ agent }: { agent: AgentDetail }) {
-  const me = useMe();
-  const isOwner = me.data?.person.id === agent.owner_id;
+  const isOwner = useIsOwner(agent.owner_id);
   const initial = agent.display_name.charAt(0).toUpperCase();
   const presence = agent.metrics.sessions > 0 ? "idle" : "off";
 
@@ -196,7 +196,7 @@ function PanelLoaded({ agent }: { agent: AgentDetail }) {
         {agent.core_blocks.length > 0 ? (
           <div className="space-y-2.5">
             {agent.core_blocks.map((b) => (
-              <CoreBlockCard key={b.id} block={b} editable={isOwner} />
+              <CoreBlockCard key={b.id} block={b} editable={isOwner === true} />
             ))}
           </div>
         ) : null}
@@ -240,9 +240,9 @@ function PanelLoaded({ agent }: { agent: AgentDetail }) {
         {agent.runtime ? (
           <PanelFooterField label="Runtime">{agent.runtime}</PanelFooterField>
         ) : null}
-        {agent.review_policy ? (
-          <PanelFooterField label="Review">{agent.review_policy}</PanelFooterField>
-        ) : null}
+        <PanelFooterField label="Review">
+          {formatReviewPolicy(agent.review_policy)}
+        </PanelFooterField>
       </footer>
     </div>
   );

--- a/packages/web/components/agents/agent-detail-panel.tsx
+++ b/packages/web/components/agents/agent-detail-panel.tsx
@@ -11,6 +11,7 @@ import { HierChip } from "@/components/hier-chip";
 import { Skeleton } from "@/components/skeleton";
 import { isApiConfigured } from "@/lib/api/config";
 import { useAgent } from "@/lib/hooks/use-agents";
+import { useMe } from "@/lib/hooks/use-me";
 import { cn } from "@/lib/utils";
 import type { AgentDetail } from "@/lib/api/types";
 import type { RecentSession } from "@/lib/types/agents";
@@ -147,6 +148,8 @@ function PanelBody({ agentId }: { agentId: string }) {
 }
 
 function PanelLoaded({ agent }: { agent: AgentDetail }) {
+  const me = useMe();
+  const isOwner = me.data?.person.id === agent.owner_id;
   const initial = agent.display_name.charAt(0).toUpperCase();
   const presence = agent.metrics.sessions > 0 ? "idle" : "off";
 
@@ -193,7 +196,7 @@ function PanelLoaded({ agent }: { agent: AgentDetail }) {
         {agent.core_blocks.length > 0 ? (
           <div className="space-y-2.5">
             {agent.core_blocks.map((b) => (
-              <CoreBlockCard key={b.id} block={b} />
+              <CoreBlockCard key={b.id} block={b} editable={isOwner} />
             ))}
           </div>
         ) : null}

--- a/packages/web/components/agents/core-block-card.tsx
+++ b/packages/web/components/agents/core-block-card.tsx
@@ -16,16 +16,27 @@ import type { CoreBlockDisplay } from "@/lib/types/core-memory-blocks";
  * treatment it deserves; anything we don't recognize falls back to a
  * markdown-rendered prose block. Never a wall of unparsed asterisks.
  */
-export function CoreBlockCard({ block }: { block: CoreBlockDisplay }) {
+/**
+ * `editable` gates the inline Edit pencil. False for non-owner viewers
+ * (the backend would reject the eventual `update_core_memory` call
+ * anyway; the UI surface just hides the affordance up front).
+ */
+export function CoreBlockCard({
+  block,
+  editable = true,
+}: {
+  block: CoreBlockDisplay;
+  editable?: boolean;
+}) {
   switch (block.block_name) {
     case "persona":
-      return <PersonaBlock block={block} />;
+      return <PersonaBlock block={block} editable={editable} />;
     case "active_work":
-      return <ActiveWorkBlock block={block} />;
+      return <ActiveWorkBlock block={block} editable={editable} />;
     case "team_members":
-      return <TeamMembersBlock block={block} />;
+      return <TeamMembersBlock block={block} editable={editable} />;
     default:
-      return <ProseBlock block={block} />;
+      return <ProseBlock block={block} editable={editable} />;
   }
 }
 
@@ -53,9 +64,11 @@ function BlockShell({
 function BlockHeader({
   block,
   kindLabel,
+  editable,
 }: {
   block: CoreBlockDisplay;
   kindLabel?: string;
+  editable: boolean;
 }) {
   // The kind label is the human-readable name ("Identity", "Active
   // work"); the raw `block_name` (persona, active_work) sits next to
@@ -78,12 +91,14 @@ function BlockHeader({
         <span className="text-[10px] text-muted-foreground/50 tabular-nums opacity-0 group-hover:opacity-100 transition-opacity">
           {formatCount(block.char_count)} / {formatCount(block.char_limit)}
         </span>
-        <button
-          aria-label={`Edit ${block.block_name} block`}
-          className="h-5 w-5 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary opacity-0 group-hover:opacity-100 transition-opacity"
-        >
-          <Pencil className="h-3 w-3" />
-        </button>
+        {editable ? (
+          <button
+            aria-label={`Edit ${block.block_name} block`}
+            className="h-5 w-5 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary opacity-0 group-hover:opacity-100 transition-opacity"
+          >
+            <Pencil className="h-3 w-3" />
+          </button>
+        ) : null}
       </div>
     </div>
   );
@@ -96,13 +111,13 @@ function formatCount(n: number): string {
 
 // ── Persona — identity prose ─────────────────────────────────────────
 
-function PersonaBlock({ block }: { block: CoreBlockDisplay }) {
+function PersonaBlock({ block, editable }: { block: CoreBlockDisplay; editable: boolean }) {
   // Persona is short by nature (~400 chars), so no collapse — show the
   // whole identity statement at once. Primary left accent stripe makes
   // it read as a quote / mission-statement instead of a config field.
   return (
     <BlockShell accent="primary">
-      <BlockHeader block={block} kindLabel="Identity" />
+      <BlockHeader block={block} kindLabel="Identity" editable={editable} />
       <div className="text-sm text-foreground/85 italic">
         <ChatMarkdown content={block.content} />
       </div>
@@ -117,7 +132,7 @@ interface ActiveWorkUpdate {
   content: string;
 }
 
-function ActiveWorkBlock({ block }: { block: CoreBlockDisplay }) {
+function ActiveWorkBlock({ block, editable }: { block: CoreBlockDisplay; editable: boolean }) {
   const { current, updates } = parseActiveWork(block.content);
   const [showAll, setShowAll] = useState(false);
 
@@ -127,7 +142,7 @@ function ActiveWorkBlock({ block }: { block: CoreBlockDisplay }) {
 
   return (
     <BlockShell>
-      <BlockHeader block={block} kindLabel="Active work" />
+      <BlockHeader block={block} kindLabel="Active work" editable={editable} />
 
       {current ? (
         <div className="text-sm text-foreground/90">
@@ -220,16 +235,16 @@ interface TeamMember {
   description: string;
 }
 
-function TeamMembersBlock({ block }: { block: CoreBlockDisplay }) {
+function TeamMembersBlock({ block, editable }: { block: CoreBlockDisplay; editable: boolean }) {
   const members = parseTeamMembers(block.content);
   if (members.length === 0) {
     // Parsing fell apart — don't lose the data, render as prose so
     // the user still sees what's there.
-    return <ProseBlock block={block} kindLabel="Team members" />;
+    return <ProseBlock block={block} kindLabel="Team members" editable={editable} />;
   }
   return (
     <BlockShell>
-      <BlockHeader block={block} kindLabel="Team members" />
+      <BlockHeader block={block} kindLabel="Team members" editable={editable} />
       <ul className="space-y-2.5">
         {members.map((m) => (
           <TeamMemberRow key={m.agentId} member={m} />
@@ -296,9 +311,11 @@ const COLLAPSE_THRESHOLD = 400;
 function ProseBlock({
   block,
   kindLabel,
+  editable,
 }: {
   block: CoreBlockDisplay;
   kindLabel?: string;
+  editable: boolean;
 }) {
   const long = block.content.length > COLLAPSE_THRESHOLD;
   const [expanded, setExpanded] = useState(!long);
@@ -308,7 +325,7 @@ function ProseBlock({
       : block.content;
   return (
     <BlockShell>
-      <BlockHeader block={block} kindLabel={kindLabel} />
+      <BlockHeader block={block} kindLabel={kindLabel} editable={editable} />
       <div className="text-sm text-foreground/85">
         <ChatMarkdown content={visible} />
       </div>

--- a/packages/web/components/agents/core-block-card.tsx
+++ b/packages/web/components/agents/core-block-card.tsx
@@ -19,14 +19,15 @@ import type { CoreBlockDisplay } from "@/lib/types/core-memory-blocks";
 /**
  * `editable` gates the inline Edit pencil. False for non-owner viewers
  * (the backend would reject the eventual `update_core_memory` call
- * anyway; the UI surface just hides the affordance up front).
+ * anyway; the UI surface just hides the affordance up front). Required
+ * so every callsite has to think about ownership — no fail-open default.
  */
 export function CoreBlockCard({
   block,
-  editable = true,
+  editable,
 }: {
   block: CoreBlockDisplay;
-  editable?: boolean;
+  editable: boolean;
 }) {
   switch (block.block_name) {
     case "persona":

--- a/packages/web/lib/format.ts
+++ b/packages/web/lib/format.ts
@@ -83,3 +83,14 @@ export function formatDurationLabel(
   const hrs = hr % 24;
   return hrs ? `${days}d ${hrs}h` : `${days}d`;
 }
+
+/**
+ * Display label for an agent's `review_policy`. Anything other than the
+ * `require_human` sentinel renders as "auto-done" — covers null/undefined
+ * legacy agents (pre-PR #102) AND the explicit "auto_done" value. The
+ * input is widened to `string | null | undefined` because the AgentDisplay
+ * view shape stringifies the column for JSON serialization.
+ */
+export function formatReviewPolicy(policy: string | null | undefined): string {
+  return policy === "require_human" ? "require human" : "auto-done";
+}

--- a/packages/web/lib/hooks/use-me.ts
+++ b/packages/web/lib/hooks/use-me.ts
@@ -19,6 +19,18 @@ export function useMe() {
   });
 }
 
+/**
+ * Tri-state ownership check: `true`/`false` once `useMe` resolves, `null`
+ * while loading. Callers gate edit affordances on `=== true` so the
+ * loading state shows neither owner UI nor read-only UI — avoids the
+ * flicker of owners briefly seeing the read-only layout on cold mount.
+ */
+export function useIsOwner(ownerId: string | undefined): boolean | null {
+  const me = useMe();
+  if (!me.data) return null;
+  return me.data.person.id === ownerId;
+}
+
 export function useLlmHealth(enabled = true) {
   return useQuery<HealthResponse>({
     queryKey: queryKeys.me.health(),


### PR DESCRIPTION
## Problem

`GET /agent/:id` is intentionally ungated (mesh visibility — agents discover each other across users), but the UI surfaced editable controls regardless of who's viewing:

- Runtime, Model, Review-policy pickers in the right rail
- Archive button in the header
- Per-block Edit pencil on Core Memory cards

Every mutation route (`POST /agent/:id/runtime|model|review-policy|archive`, `update_core_memory` MCP tool) already gates on `owner_id`, so non-owners submitting changes get 403. But there's no point showing controls that always fail.

Also, the runtime picker lists `GET /runtimes` which filters by **caller**'s daemons — when viewing someone else's agent, the dropdown would show *your* runtimes instead of the agent owner's. Misleading.

## Fix

Compute `isOwner = useMe().data?.person.id === agent.owner_id` and gate UI on it.

- **Pickers** (`RuntimePicker`, `ModelPicker`, `ReviewPolicyPicker`) render only when `isOwner`. Eliminates the wrong-runtimes dropdown problem entirely — the picker only renders when caller == owner == agent owner.
- **Archive button** renders only when `isOwner` (and not already archived).
- **Core memory Edit pencil**: `CoreBlockCard` gains an `editable` prop (default `true` for back-compat), threaded through `PersonaBlock` / `ActiveWorkBlock` / `TeamMembersBlock` / `ProseBlock` → `BlockHeader`, which hides the Pencil when false. Both `agent-detail-client.tsx` and the `AgentDetailPanel` peek pass `isOwner`.
- **Review-policy** now shown in the footer alongside Runtime + Model, so non-owners can see all three as read-only metadata. Matches the existing pattern; owners see picker + footer (same redundancy as Runtime / Model).

## Server-side: nothing to change

The "agent can only pick runtimes on daemons owned by its owner" requirement is already enforced by `POST /agent/:id/runtime` checking both:
- `existing.owner_id === caller.personId`
- `runtime.daemon.owner_person_id === caller.personId`

Hiding the picker for non-owners eliminates the only remaining wrong-data path (caller's runtimes shown for an agent they don't own).

## Test plan

- [x] `pnpm --filter @beevibe/web typecheck` green
- [x] `pnpm --filter @beevibe/web test` — 113 tests pass
- [x] `pnpm --filter @beevibe/core test` — 441 pass
- [x] `pnpm --filter @beevibe/api test` — 291 pass
- [ ] Manual smoke: sign in as user A, navigate to /agents/<bob's agent id> → no pickers, no archive button, no edit pencil; runtime/model/review-policy visible in footer as text. Navigate to /agents/<my agent id> → pickers + archive + pencil all present
- [ ] Peek panel (click an agent on /agent-network) for someone else's agent → no edit pencil

🤖 Generated with [Claude Code](https://claude.com/claude-code)