### PR TITLE
chore(scripts): add `db:reset` for one-command local DB reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "migrate": "node-pg-migrate --envPath .env",
     "migrate:deploy": "node-pg-migrate",
     "migrate:test": "node-pg-migrate --envPath .env -d DATABASE_URL_TEST",
+    "db:reset": "docker compose down -v && docker compose up -d --wait postgres && pnpm migrate up && pnpm seed-demo",
     "install-skills": "tsx scripts/install-skills.ts",
     "bootstrap": "tsx scripts/init.ts",
     "provision-user": "tsx scripts/provision-user.ts",


### PR DESCRIPTION
## Summary

Adds \`pnpm db:reset\` — destroys the postgres volume, starts a fresh container, applies all migrations, seeds demo data. One command instead of four.

## Why

When local dev DB drifts from main (renamed migrations, cross-branch work, timestamp collisions like the one fixed in #105), the recovery is:

\`\`\`bash
docker compose down -v
docker compose up -d --wait postgres
pnpm migrate up
pnpm seed-demo
\`\`\`

Easy to forget the order; easy to skip \`--wait\` and hit a race on a cold postgres. Wrapping it as a script makes the recovery path discoverable in \`pnpm run\` output and removes the memorization tax.

## Test plan

- [x] Run \`pnpm db:reset\` locally → postgres rebuilt, 32 migrations applied, 12 agents + 31 facts + 11 tasks seeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)