### PR TITLE
Add OpenCode runtime

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -9,6 +9,11 @@ deployment needs:
 - `@beevibe/web`
 - one local `beevibe-daemon` per user machine that should run agent sessions
 
+Daemons register every supported CLI they find on `PATH`. `claude` is the
+default high-reliability runtime. `opencode` is the open/free model path: it
+can route through OpenRouter, Ollama, and OpenAI-compatible providers using
+OpenCode's own provider configuration.
+
 ## Required Environment
 
 Copy [`.env.example`](./.env.example) and set the values for your host.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ For the deeper version, see the package docs:
 
 - **Database:** Postgres 16 + `pgvector`
 - **Runtime:** Node.js 20, TypeScript, pnpm workspaces, Turborepo
-- **Agents:** Claude Code CLI + Model Context Protocol
+- **Agents:** Claude Code CLI, OpenCode, Codex detection, Model Context Protocol
 - **Memory:** OpenAI embeddings + Anthropic/OpenAI LLM providers
 - **Web:** Next.js, React Query, Tailwind CSS, Server-Sent Events
 

--- a/packages/api/src/runtime/router.test.ts
+++ b/packages/api/src/runtime/router.test.ts
@@ -314,6 +314,7 @@ describe("/runtime — integration", () => {
         agent_id: a.agent.id,
         agent_api_key: a.agent.api_key,
         agent_hierarchy_level: "team",
+        runtime_type: "claude",
         type: "chat",
         mcp_server_url: "http://api.test/mcp",
         env: { BEEVIBE_SESSION_ID: sid, BEEVIBE_AGENT_ID: a.agent.id },
@@ -511,4 +512,3 @@ describe("/runtime — integration", () => {
     });
   });
 });
-

--- a/packages/api/src/runtime/router.ts
+++ b/packages/api/src/runtime/router.ts
@@ -1,26 +1,24 @@
 import { createHash } from "node:crypto";
 import { promises as fs } from "node:fs";
 import { join, relative } from "node:path";
-import { Router, type Request, type RequestHandler, type Response } from "express";
+import { Router, type RequestHandler } from "express";
 import {
   daemonId as newDaemonId,
   runtimeId as newRuntimeId,
   sessionEventId as newSessionEventId,
   isTerminalSessionStatus,
   type AgentRepository,
+  type DaemonRepository,
   type PersonRepository,
   type Session,
   type SessionEventRepository,
   type SessionRepository,
+  type RuntimeRepository,
 } from "@beevibe/core";
 import {
   generateDaemonApiKey,
   hashDaemonToken,
 } from "@beevibe/core/auth";
-import type {
-  DaemonRepository,
-  RuntimeRepository,
-} from "@beevibe/core";
 import type { MemoryAgent } from "@beevibe/core/services/memory";
 import {
   composeIntent,
@@ -452,6 +450,7 @@ async function composeDispatchPayload(
     agent_id: agent.id,
     agent_api_key: agent.api_key,
     agent_hierarchy_level: agent.hierarchy_level,
+    runtime_type: agent.runtime_config.type,
     intent: composeIntent(session.intent, briefing.userMessagePrefix),
     system_prompt_append: composeSystemPromptAppend(
       agent.runtime_config.system_prompt_addition,
@@ -550,4 +549,3 @@ async function assertDaemonOwnsSessions(
   const owned = await deps.sessionRepo.countOwnedByDaemon(daemonId, ids);
   return owned === ids.length;
 }
-

--- a/packages/api/src/runtime/types.ts
+++ b/packages/api/src/runtime/types.ts
@@ -7,6 +7,7 @@
 
 import type {
   HierarchyLevel,
+  KnownCli,
   SessionEventKind,
   SessionStatus,
   SessionType,
@@ -61,6 +62,8 @@ export interface DispatchPayload {
    * sync. Pulled from agent.hierarchy_level at claim time.
    */
   agent_hierarchy_level: HierarchyLevel;
+  /** CLI runtime to spawn. Mirrors `agent.runtime_config.type`. */
+  runtime_type: KnownCli;
   intent: string;
   system_prompt_append: string;
   /** When set, daemon spawns with `--resume <cli_session_id>`. */

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -35,6 +35,7 @@ Tree-shake-friendly subpaths via the `exports` map in `package.json`:
 | `@beevibe/core/auth` | API-key validation, `ResolvedCaller`, `provisionAgent` |
 | `@beevibe/core/adapters/postgres` | All 10 repository implementations + `createPool` |
 | `@beevibe/core/adapters/claude-code` | `ClaudeCodeRuntime` (spawns `claude` CLI) |
+| `@beevibe/core/adapters/opencode` | `OpenCodeRuntime` (spawns `opencode` CLI for OpenRouter, Ollama, and OpenAI-compatible providers) |
 | `@beevibe/core/adapters/openai` | `OpenAIEmbeddingService`, `OpenAILlmProvider` |
 | `@beevibe/core/adapters/anthropic` | `AnthropicLlmProvider` |
 | `@beevibe/core/adapters/local-workspace` | `LocalWorkspaceManager` |
@@ -112,6 +113,7 @@ Every external dependency lives behind a port. New runtimes (e.g., a different C
 |---|---|---|
 | `postgres/` | All 10 repos + `createPool` | Raw `pg` driver, no ORM. Schema in [`/migrations/`](../../migrations). |
 | `claude-code/` | `AgentRuntime` | Spawns `claude` CLI as subprocess, parses stream-JSON output, captures cache tokens. |
+| `opencode/` | `AgentRuntime` | Spawns `opencode run --format json`; delegates provider/model plumbing to OpenCode for OpenRouter, Ollama, and OpenAI-compatible endpoints. |
 | `openai/` | `EmbeddingService`, `LlmProvider` | `text-embedding-3-small` (1536 dims), GPT-4o for fact merging. |
 | `anthropic/` | `LlmProvider` | Claude Sonnet for fact promotion (native JSON schema output). |
 | `local-workspace/` | `WorkspaceManager` | Per-agent dirs under `~/.beevibe/workspaces/<agent_id>/`, manages `mcp-config.json`. |

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,10 @@
       "types": "./dist/adapters/claude-code/index.d.ts",
       "default": "./dist/adapters/claude-code/index.js"
     },
+    "./adapters/opencode": {
+      "types": "./dist/adapters/opencode/index.d.ts",
+      "default": "./dist/adapters/opencode/index.js"
+    },
     "./adapters/local-workspace": {
       "types": "./dist/adapters/local-workspace/index.d.ts",
       "default": "./dist/adapters/local-workspace/index.js"

--- a/packages/core/src/adapters/local-workspace/manager.test.ts
+++ b/packages/core/src/adapters/local-workspace/manager.test.ts
@@ -132,6 +132,37 @@ describe("LocalWorkspaceManager", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("calls runtime.prepareWorkspace before syncing skills", async () => {
+    const calls: string[] = [];
+    const runtime = {
+      type: "opencode",
+      prepareWorkspace: ({ workspace }: { workspace: Workspace }) => {
+        calls.push(`prepare:${workspace.path}`);
+        writeFileSync(join(workspace.path, "opencode.json"), "{}\n");
+      },
+      skillsDir: (workspace: Workspace) => {
+        calls.push(`skills:${workspace.path}`);
+        return join(workspace.path, ".opencode", "skills");
+      },
+    } as unknown as AgentRuntime;
+    const m = new LocalWorkspaceManager({
+      workspaceRoot,
+      mcpServerUrl: MCP_URL,
+      runtimeRegistry: { opencode: runtime },
+      skillsSourceDir,
+    });
+
+    const ws = await m.ensureWorkspace({
+      agent: makeAgent({
+        id: "agent_opencode",
+        runtime_config: { type: "opencode", model: "openrouter/qwen/qwen3-coder" },
+      }),
+    });
+
+    expect(existsSync(join(ws.path, "opencode.json"))).toBe(true);
+    expect(calls).toEqual([`prepare:${ws.path}`, `skills:${ws.path}`]);
+  });
+
   it("different agents get isolated dirs", async () => {
     const a = await manager.ensureWorkspace({ agent: makeAgent({ id: "agent_a" }) });
     const b = await manager.ensureWorkspace({ agent: makeAgent({ id: "agent_b" }) });

--- a/packages/core/src/adapters/local-workspace/manager.ts
+++ b/packages/core/src/adapters/local-workspace/manager.ts
@@ -91,6 +91,18 @@ export class LocalWorkspaceManager implements WorkspaceManager {
         `No runtime registered for agent ${agent.id} (runtime_config.type='${agent.runtime_config.type}')`,
       );
     }
+    if (runtime.prepareWorkspace) {
+      if (!agent.api_key) {
+        throw new Error(
+          `Cannot prepare workspace for agent ${agent.id}: agent.api_key is missing`,
+        );
+      }
+      await runtime.prepareWorkspace({
+        workspace,
+        agentApiKey: agent.api_key,
+        mcpServerUrl: this.config.mcpServerUrl,
+      });
+    }
     await syncSkills({
       sourceDir: this.config.skillsSourceDir,
       targetDir: runtime.skillsDir(workspace),

--- a/packages/core/src/adapters/opencode/index.ts
+++ b/packages/core/src/adapters/opencode/index.ts
@@ -1,0 +1,2 @@
+export { OpenCodeRuntime } from "./runtime.js";
+export type { OpenCodeRuntimeConfig } from "./runtime.js";

--- a/packages/core/src/adapters/opencode/runtime.test.ts
+++ b/packages/core/src/adapters/opencode/runtime.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeContext, RuntimeStep } from "../../ports/runtime.js";
+import { OpenCodeRuntime, buildOpenCodeConfig } from "./runtime.js";
+import type { CliProcessOptions, CliProcessResult } from "../claude-code/spawn.js";
+import * as spawnModule from "../claude-code/spawn.js";
+
+const MOCK_OK: CliProcessResult = {
+  stdout:
+    JSON.stringify({
+      type: "result",
+      session_id: "opencode_sess_mock",
+      output: "done",
+      model: "openrouter/qwen/qwen3-coder",
+      usage: { input_tokens: 100, output_tokens: 50, cost_usd: 0 },
+    }) + "\n",
+  stderr: "",
+  exitCode: 0,
+  timedOut: false,
+  aborted: false,
+  pid: 9999,
+  process_group_id: 9999,
+  truncated: false,
+};
+
+let runCliSpy: ReturnType<typeof vi.spyOn>;
+let lastOptions: CliProcessOptions | undefined;
+
+function mockRunCli(result: CliProcessResult = MOCK_OK): void {
+  runCliSpy.mockImplementation(async (options) => {
+    lastOptions = options;
+    if (result.pid !== null) {
+      options.onSpawn?.({ pid: result.pid, process_group_id: result.process_group_id ?? result.pid });
+    }
+    if (result.stdout) options.onLog?.("stdout", result.stdout);
+    return result;
+  });
+}
+
+function ctx(overrides: Partial<RuntimeContext> = {}): RuntimeContext {
+  return {
+    intent: "do a thing",
+    workspace: { path: "/tmp/beevibe-opencode-test-ws" },
+    system_prompt_append: "",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  lastOptions = undefined;
+  runCliSpy = vi.spyOn(spawnModule, "runCliProcess");
+});
+
+afterEach(() => {
+  runCliSpy.mockRestore();
+});
+
+describe("OpenCodeRuntime.execute", () => {
+  it("runs opencode non-interactively with raw JSON events", async () => {
+    mockRunCli();
+    await new OpenCodeRuntime().execute(ctx({ workspace: { path: "/sandbox/agent_op" } }));
+    expect(lastOptions?.cwd).toBe("/sandbox/agent_op");
+    expect(lastOptions?.args?.slice(0, 4)).toEqual([
+      "run",
+      "--format",
+      "json",
+      "--dangerously-skip-permissions",
+    ]);
+  });
+
+  it("passes context.model as --model in provider/model form", async () => {
+    mockRunCli();
+    await new OpenCodeRuntime({ model: "fallback/model" }).execute(
+      ctx({ model: "openrouter/qwen/qwen3-coder" }),
+    );
+    const idx = lastOptions!.args!.indexOf("--model");
+    expect(lastOptions!.args![idx + 1]).toBe("openrouter/qwen/qwen3-coder");
+  });
+
+  it("passes --session when context.resume_session_id is set", async () => {
+    mockRunCli();
+    await new OpenCodeRuntime().execute(ctx({ resume_session_id: "opencode_prev" }));
+    const idx = lastOptions!.args!.indexOf("--session");
+    expect(lastOptions!.args![idx + 1]).toBe("opencode_prev");
+  });
+
+  it("folds system_prompt_append into the prompt because OpenCode has no append-system flag", async () => {
+    mockRunCli();
+    await new OpenCodeRuntime().execute(
+      ctx({ intent: "fix bug", system_prompt_append: "<core>memory</core>" }),
+    );
+    const prompt = lastOptions!.args!.at(-1)!;
+    expect(prompt).toContain("<beevibe_system_context>");
+    expect(prompt).toContain("<core>memory</core>");
+    expect(prompt).toContain("fix bug");
+  });
+
+  it("merges context.env into the spawned process env", async () => {
+    mockRunCli();
+    await new OpenCodeRuntime().execute(
+      ctx({ env: { BEEVIBE_SESSION_ID: "sess_test_123" } }),
+    );
+    expect(lastOptions!.env!.BEEVIBE_SESSION_ID).toBe("sess_test_123");
+  });
+
+  it("parses result events into RuntimeResult", async () => {
+    mockRunCli();
+    const result = await new OpenCodeRuntime().execute(ctx());
+    expect(result.status).toBe("completed");
+    expect(result.output).toBe("done");
+    expect(result.cli_session_id).toBe("opencode_sess_mock");
+    expect(result.usage).toEqual({
+      input_tokens: 100,
+      output_tokens: 50,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+      cost_usd: 0,
+      model: "openrouter/qwen/qwen3-coder",
+    });
+  });
+
+  it("emits tool steps from flexible JSON event shapes", async () => {
+    const steps: RuntimeStep[] = [];
+    runCliSpy.mockImplementation(async (options) => {
+      options.onLog?.(
+        "stdout",
+        JSON.stringify({
+          type: "tool_call",
+          tool: "read",
+          input: { file_path: "/src/x.ts" },
+        }) + "\n",
+      );
+      return MOCK_OK;
+    });
+    await new OpenCodeRuntime().execute(ctx({ onStep: (step) => steps.push(step) }));
+    expect(steps).toHaveLength(1);
+    expect(steps[0]!.kind).toBe("tool_call");
+    expect(steps[0]!.tool).toBe("read");
+    expect(steps[0]!.description).toBe("/src/x.ts");
+  });
+
+  it("maps aborted result to cancelled", async () => {
+    mockRunCli({ ...MOCK_OK, aborted: true, stdout: "" });
+    const result = await new OpenCodeRuntime().execute(ctx());
+    expect(result.status).toBe("cancelled");
+  });
+});
+
+describe("OpenCodeRuntime.healthCheck", () => {
+  it("runs opencode --version", async () => {
+    mockRunCli({ ...MOCK_OK, stdout: "", exitCode: 0 });
+    const health = await new OpenCodeRuntime().healthCheck();
+    expect(health.healthy).toBe(true);
+    expect(lastOptions!.args).toEqual(["--version"]);
+    expect(lastOptions!.timeoutMs).toBe(5000);
+    expect(lastOptions!.graceMs).toBe(0);
+  });
+});
+
+describe("buildOpenCodeConfig", () => {
+  it("writes a remote Beevibe MCP server using the session env placeholder", () => {
+    const parsed = JSON.parse(buildOpenCodeConfig("bv_a_test", "http://api.test/mcp"));
+    expect(parsed.mcp.beevibe).toMatchObject({
+      type: "remote",
+      url: "http://api.test/mcp",
+      enabled: true,
+      oauth: false,
+    });
+    expect(parsed.mcp.beevibe.headers.Authorization).toBe("Bearer bv_a_test");
+    expect(parsed.mcp.beevibe.headers["X-Beevibe-Session"]).toBe(
+      "{env:BEEVIBE_SESSION_ID}",
+    );
+  });
+});

--- a/packages/core/src/adapters/opencode/runtime.ts
+++ b/packages/core/src/adapters/opencode/runtime.ts
@@ -1,0 +1,315 @@
+import { existsSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+  AgentRuntime,
+  RuntimeContext,
+  RuntimeHealth,
+  RuntimeResult,
+  RuntimeStep,
+  RuntimeWorkspaceContext,
+  Workspace,
+} from "../../ports/runtime.js";
+import { runCliProcess } from "../claude-code/spawn.js";
+
+export interface OpenCodeRuntimeConfig {
+  /** Override CLI command (defaults to "opencode" on PATH). */
+  command?: string;
+  /** OpenCode model id in provider/model form. Omit to use OpenCode's default. */
+  model?: string;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+/**
+ * OpenCode CLI subprocess runtime.
+ *
+ * OpenCode is the multi-provider runtime: it delegates provider/model
+ * plumbing to OpenCode itself, so Beevibe can support OpenRouter, Ollama,
+ * Groq, Cerebras, LM Studio, vLLM, and other OpenAI-compatible endpoints
+ * through one CLI adapter.
+ */
+export class OpenCodeRuntime implements AgentRuntime {
+  readonly type = "opencode";
+
+  constructor(private config: OpenCodeRuntimeConfig = {}) {}
+
+  async execute(context: RuntimeContext): Promise<RuntimeResult> {
+    const args = [
+      "run",
+      "--format",
+      "json",
+      "--dangerously-skip-permissions",
+    ];
+    const model = context.model ?? this.config.model;
+    if (model) args.push("--model", model);
+    if (context.resume_session_id) args.push("--session", context.resume_session_id);
+    args.push(composePrompt(context));
+
+    const env: Record<string, string | undefined> = { ...process.env };
+    if (context.env) Object.assign(env, context.env);
+
+    const events: JsonRecord[] = [];
+    let pending = "";
+    const handleLine = (line: string): void => {
+      const evt = parseJsonLine(line);
+      if (!evt) return;
+      events.push(evt);
+      const step = eventToStep(evt);
+      if (step) context.onStep?.(step);
+    };
+
+    const result = await runCliProcess({
+      command: this.config.command ?? "opencode",
+      args,
+      cwd: context.workspace.path,
+      env,
+      abortSignal: context.abort_signal,
+      onSpawn: ({ pid, process_group_id }) => {
+        context.onSpawn?.({ process_pid: pid, process_group_id });
+      },
+      onLog: (stream, chunk) => {
+        if (stream !== "stdout") return;
+        pending += chunk;
+        let nl: number;
+        while ((nl = pending.indexOf("\n")) !== -1) {
+          handleLine(pending.slice(0, nl));
+          pending = pending.slice(nl + 1);
+        }
+      },
+    });
+    if (pending) handleLine(pending);
+
+    if (result.truncated) {
+      console.warn(
+        "[OpenCodeRuntime] stdout truncated at 4MB — result parsing may be incomplete",
+      );
+    }
+
+    if (result.aborted) {
+      return {
+        status: "cancelled",
+        output: "Session cancelled.",
+        process_pid: result.pid ?? undefined,
+        process_group_id: result.process_group_id ?? undefined,
+      };
+    }
+
+    const parsed = parseOpenCodeEvents(events, result.stdout, result.exitCode);
+    return {
+      ...parsed,
+      process_pid: result.pid ?? undefined,
+      process_group_id: result.process_group_id ?? undefined,
+    };
+  }
+
+  async healthCheck(): Promise<RuntimeHealth> {
+    try {
+      const result = await runCliProcess({
+        command: this.config.command ?? "opencode",
+        args: ["--version"],
+        cwd: tmpdir(),
+        timeoutMs: 5_000,
+        graceMs: 0,
+      });
+      return { healthy: result.exitCode === 0 };
+    } catch {
+      return {
+        healthy: false,
+        error: `Command not found: ${this.config.command ?? "opencode"}`,
+      };
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    /* stateless — each session is a separate process */
+  }
+
+  skillsDir(workspace: Workspace): string {
+    return join(workspace.path, ".opencode", "skills");
+  }
+
+  prepareWorkspace(context: RuntimeWorkspaceContext): void {
+    const configPath = join(context.workspace.path, "opencode.json");
+    if (existsSync(configPath)) return;
+    writeFileSync(configPath, buildOpenCodeConfig(context.agentApiKey, context.mcpServerUrl), {
+      mode: 0o600,
+    });
+  }
+}
+
+function composePrompt(context: RuntimeContext): string {
+  if (context.system_prompt_append.length === 0) return context.intent;
+  return [
+    "<beevibe_system_context>",
+    context.system_prompt_append,
+    "</beevibe_system_context>",
+    "",
+    context.intent,
+  ].join("\n");
+}
+
+export function buildOpenCodeConfig(apiKey: string, mcpServerUrl: string): string {
+  return (
+    JSON.stringify(
+      {
+        "$schema": "https://opencode.ai/config.json",
+        mcp: {
+          beevibe: {
+            type: "remote",
+            url: mcpServerUrl,
+            enabled: true,
+            oauth: false,
+            headers: {
+              Authorization: `Bearer ${apiKey}`,
+              "X-Beevibe-Session": "{env:BEEVIBE_SESSION_ID}",
+            },
+          },
+        },
+      },
+      null,
+      2,
+    ) + "\n"
+  );
+}
+
+function parseJsonLine(line: string): JsonRecord | undefined {
+  const trimmed = line.trim();
+  if (!trimmed) return undefined;
+  try {
+    const value = JSON.parse(trimmed);
+    return isRecord(value) ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function eventToStep(evt: JsonRecord): RuntimeStep | undefined {
+  const type = String(evt.type ?? evt.event ?? evt.kind ?? "").toLowerCase();
+  const tool = pickString(evt, ["tool", "tool_name", "name"]);
+  if (type.includes("tool") || tool) {
+    return {
+      kind: type.includes("result") ? "tool_result" : "tool_call",
+      tool,
+      description: summarizeTool(evt),
+      timestamp: new Date().toISOString(),
+    };
+  }
+  const text = pickText(evt);
+  if (text && (type.includes("message") || type.includes("assistant") || type.includes("text"))) {
+    return {
+      kind: "agent",
+      description: text,
+      timestamp: new Date().toISOString(),
+    };
+  }
+  return undefined;
+}
+
+function parseOpenCodeEvents(
+  events: JsonRecord[],
+  stdout: string,
+  exitCode: number | null,
+): Omit<RuntimeResult, "process_pid" | "process_group_id"> {
+  const assistantText = events.map(pickText).filter(Boolean).join("\n").trim();
+  const final = [...events].reverse().find((evt) => {
+    const type = String(evt.type ?? evt.event ?? evt.kind ?? "").toLowerCase();
+    return type.includes("result") || type.includes("done") || type.includes("complete");
+  });
+  const output = (final && pickText(final)) || assistantText || fallbackText(stdout);
+  return {
+    status: exitCode === 0 ? "completed" : "failed",
+    output: output || (exitCode === 0 ? "OpenCode completed." : "OpenCode failed."),
+    transcript: stdout || undefined,
+    usage: parseUsage(events),
+    cli_session_id: parseSessionId(events),
+  };
+}
+
+function parseUsage(events: JsonRecord[]): RuntimeResult["usage"] {
+  for (const evt of [...events].reverse()) {
+    const usage = evt.usage;
+    if (!isRecord(usage)) continue;
+    const input = pickNumber(usage, ["input_tokens", "inputTokens", "prompt_tokens", "promptTokens"]);
+    const output = pickNumber(usage, ["output_tokens", "outputTokens", "completion_tokens", "completionTokens"]);
+    const cost = pickNumber(usage, ["cost_usd", "costUSD", "cost"]);
+    const model = pickString(usage, ["model"]) ?? pickString(evt, ["model"]);
+    if (input === undefined && output === undefined && cost === undefined && model === undefined) {
+      continue;
+    }
+    return {
+      input_tokens: input ?? 0,
+      output_tokens: output ?? 0,
+      cache_creation_input_tokens: pickNumber(usage, ["cache_creation_input_tokens"]) ?? 0,
+      cache_read_input_tokens: pickNumber(usage, ["cache_read_input_tokens"]) ?? 0,
+      cost_usd: cost,
+      model,
+    };
+  }
+  const model = [...events].reverse().map((evt) => pickString(evt, ["model"])).find(Boolean);
+  return model ? { input_tokens: 0, output_tokens: 0, model } : undefined;
+}
+
+function parseSessionId(events: JsonRecord[]): string | undefined {
+  for (const evt of [...events].reverse()) {
+    const id =
+      pickString(evt, ["session_id", "sessionID", "sessionId"]) ??
+      (isRecord(evt.session) ? pickString(evt.session, ["id", "session_id"]) : undefined);
+    if (id) return id;
+  }
+  return undefined;
+}
+
+function pickText(evt: JsonRecord): string {
+  const direct = pickString(evt, ["output", "text", "content", "message"]);
+  if (direct) return direct;
+  if (isRecord(evt.message)) {
+    return pickString(evt.message, ["content", "text"]) ?? "";
+  }
+  return "";
+}
+
+function summarizeTool(evt: JsonRecord): string {
+  const input = evt.input ?? evt.arguments ?? evt.args ?? evt.params;
+  if (typeof input === "string") return input.slice(0, 300);
+  if (isRecord(input)) {
+    const path = pickString(input, ["file_path", "path", "file"]);
+    const command = pickString(input, ["command", "cmd"]);
+    if (path) return path;
+    if (command) return command;
+    return JSON.stringify(input).slice(0, 300);
+  }
+  return pickText(evt) || "tool call";
+}
+
+function fallbackText(stdout: string): string {
+  return stdout
+    .split("\n")
+    .map((line) => {
+      const parsed = parseJsonLine(line);
+      return parsed ? pickText(parsed) : line;
+    })
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+}
+
+function pickString(obj: JsonRecord, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+function pickNumber(obj: JsonRecord, keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+  }
+  return undefined;
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/core/src/adapters/runtime-registry.test.ts
+++ b/packages/core/src/adapters/runtime-registry.test.ts
@@ -8,6 +8,12 @@ describe("createDefaultRuntimeRegistry", () => {
     expect(registry["claude"]!.type).toBe("claude");
   });
 
+  it("registers opencode", () => {
+    const registry = createDefaultRuntimeRegistry();
+    expect(registry["opencode"]).toBeDefined();
+    expect(registry["opencode"]!.type).toBe("opencode");
+  });
+
   it("every registry value's .type matches its registry key (sanity check against typos)", () => {
     const registry = createDefaultRuntimeRegistry();
     for (const [key, runtime] of Object.entries(registry)) {

--- a/packages/core/src/adapters/runtime-registry.ts
+++ b/packages/core/src/adapters/runtime-registry.ts
@@ -1,5 +1,6 @@
 import type { RuntimeRegistry } from "../ports/runtime.js";
 import { ClaudeCodeRuntime } from "./claude-code/runtime.js";
+import { OpenCodeRuntime } from "./opencode/runtime.js";
 
 /**
  * Default registry with all production runtimes wired.
@@ -18,5 +19,6 @@ import { ClaudeCodeRuntime } from "./claude-code/runtime.js";
 export function createDefaultRuntimeRegistry(): RuntimeRegistry {
   return {
     claude: new ClaudeCodeRuntime({}),
+    opencode: new OpenCodeRuntime({}),
   };
 }

--- a/packages/core/src/ports/runtime.ts
+++ b/packages/core/src/ports/runtime.ts
@@ -32,6 +32,14 @@ export interface AgentRuntime {
    * sync the tier-filtered SKILL.md files.
    */
   skillsDir(workspace: Workspace): string;
+
+  /**
+   * Optional runtime-specific workspace provisioning hook. Called after the
+   * generic workspace + Claude-compatible mcp-config.json are present and
+   * before skills are synced. Runtimes use this for config files that must
+   * live in the workspace root, for example OpenCode's `opencode.json`.
+   */
+  prepareWorkspace?(context: RuntimeWorkspaceContext): Promise<void> | void;
 }
 
 /**
@@ -42,6 +50,12 @@ export interface AgentRuntime {
 export interface Workspace {
   /** Absolute path to the agent's home dir. E.g. "~/.beevibe/workspaces/agent_XXX/". */
   path: string;
+}
+
+export interface RuntimeWorkspaceContext {
+  workspace: Workspace;
+  agentApiKey: string;
+  mcpServerUrl: string;
 }
 
 /**

--- a/packages/daemon/src/claimer.ts
+++ b/packages/daemon/src/claimer.ts
@@ -12,6 +12,7 @@
  */
 
 import WebSocket from "ws";
+import type { RuntimeRegistry } from "@beevibe/core";
 import type { LocalWorkspaceManager } from "@beevibe/core/adapters/local-workspace";
 import type { ApiClient } from "./api-client.js";
 import type { Supervisor } from "./supervisor.js";
@@ -21,6 +22,7 @@ export interface ClaimerConfig {
   api: ApiClient;
   supervisor: Supervisor;
   workspaceManager: LocalWorkspaceManager;
+  runtimeRegistry: RuntimeRegistry;
   runtimeIds: string[];
   /** Default 30_000ms. */
   pollIntervalMs?: number;
@@ -179,7 +181,11 @@ export class Claimer {
       if (!payload) return;
       const ctrl = this.cfg.supervisor.start(payload.session_id);
       void runDispatch(
-        { api: this.cfg.api, workspaceManager: this.cfg.workspaceManager },
+        {
+          api: this.cfg.api,
+          workspaceManager: this.cfg.workspaceManager,
+          runtimeRegistry: this.cfg.runtimeRegistry,
+        },
         payload,
         ctrl.signal,
       )

--- a/packages/daemon/src/spawner.test.ts
+++ b/packages/daemon/src/spawner.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AgentRuntime, RuntimeContext, RuntimeResult, RuntimeRegistry, Workspace } from "@beevibe/core";
+import { runDispatch, type DispatchPayload } from "./spawner.js";
+
+function payload(overrides: Partial<DispatchPayload> = {}): DispatchPayload {
+  return {
+    session_id: "sess_123",
+    agent_id: "agent_123",
+    agent_api_key: "bv_a_test",
+    agent_hierarchy_level: "team",
+    runtime_type: "opencode",
+    intent: "do work",
+    system_prompt_append: "<core />",
+    model: "openrouter/qwen/qwen3-coder",
+    max_turns: 3,
+    env: { BEEVIBE_SESSION_ID: "sess_123", BEEVIBE_AGENT_ID: "agent_123" },
+    type: "task",
+    mcp_server_url: "http://api.test/mcp",
+    ...overrides,
+  };
+}
+
+describe("runDispatch", () => {
+  it("uses payload.runtime_type for workspace provisioning and runtime execution", async () => {
+    let ensuredAgentRuntimeType: string | undefined;
+    let runtimeContext: RuntimeContext | undefined;
+    const runtime: AgentRuntime = {
+      type: "opencode",
+      execute: vi.fn(async (ctx: RuntimeContext): Promise<RuntimeResult> => {
+        runtimeContext = ctx;
+        ctx.onStep?.({
+          kind: "tool_call",
+          tool: "read",
+          description: "README.md",
+          timestamp: new Date().toISOString(),
+        });
+        return {
+          status: "completed",
+          output: "done",
+          cli_session_id: "opencode_sess_1",
+          usage: { input_tokens: 1, output_tokens: 2 },
+        };
+      }),
+      healthCheck: vi.fn(),
+      shutdown: vi.fn(),
+      skillsDir: (workspace: Workspace) => `${workspace.path}/.opencode/skills`,
+    };
+    const posts: Array<{ path: string; body: unknown }> = [];
+    const api = {
+      post: vi.fn(async (path: string, body: unknown) => {
+        posts.push({ path, body });
+      }),
+    };
+    const workspaceManager = {
+      ensureWorkspace: vi.fn(async ({ agent }) => {
+        ensuredAgentRuntimeType = agent.runtime_config.type;
+        return { path: "/tmp/ws-opencode" };
+      }),
+    };
+
+    await runDispatch(
+      {
+        api: api as never,
+        workspaceManager: workspaceManager as never,
+        runtimeRegistry: { opencode: runtime } as RuntimeRegistry,
+      },
+      payload(),
+    );
+
+    expect(ensuredAgentRuntimeType).toBe("opencode");
+    expect(runtime.execute).toHaveBeenCalledOnce();
+    expect(runtimeContext?.model).toBe("openrouter/qwen/qwen3-coder");
+    expect(posts.some((p) => p.path === "/runtime/events")).toBe(true);
+    const done = posts.find((p) => p.path === "/runtime/done")!.body as {
+      status: string;
+      cli_session_id: string;
+    };
+    expect(done.status).toBe("succeeded");
+    expect(done.cli_session_id).toBe("opencode_sess_1");
+  });
+});

--- a/packages/daemon/src/spawner.ts
+++ b/packages/daemon/src/spawner.ts
@@ -9,8 +9,15 @@
  * `<workspace>/.claude/skills/`).
  */
 
-import { ClaudeCodeRuntime } from "@beevibe/core/adapters/claude-code";
-import type { Agent, RuntimeStep, RuntimeResult, TerminalSessionStatus } from "@beevibe/core";
+import { createDefaultRuntimeRegistry } from "@beevibe/core/adapters/runtime-registry";
+import type {
+  Agent,
+  KnownCli,
+  RuntimeRegistry,
+  RuntimeStep,
+  RuntimeResult,
+  TerminalSessionStatus,
+} from "@beevibe/core";
 import type { LocalWorkspaceManager } from "@beevibe/core/adapters/local-workspace";
 import type { ApiClient } from "./api-client.js";
 
@@ -19,6 +26,7 @@ export interface DispatchPayload {
   agent_id: string;
   agent_api_key: string;
   agent_hierarchy_level: "ic" | "team" | "org";
+  runtime_type: KnownCli;
   intent: string;
   system_prompt_append: string;
   resume_session_id?: string;
@@ -32,8 +40,8 @@ export interface DispatchPayload {
 export interface SpawnDeps {
   api: ApiClient;
   workspaceManager: LocalWorkspaceManager;
-  /** Default ClaudeCodeRuntime; tests inject a fake. */
-  runtime?: ClaudeCodeRuntime;
+  /** Default registry; tests inject fakes. */
+  runtimeRegistry?: RuntimeRegistry;
 }
 
 /**
@@ -54,11 +62,15 @@ export async function runDispatch(
     id: payload.agent_id,
     api_key: payload.agent_api_key,
     hierarchy_level: payload.agent_hierarchy_level,
-    runtime_config: { type: "claude" as const },
+    runtime_config: { type: payload.runtime_type },
   } as unknown as Agent;
   const ws = await deps.workspaceManager.ensureWorkspace({ agent: syntheticAgent });
 
-  const runtime = deps.runtime ?? new ClaudeCodeRuntime();
+  const registry = deps.runtimeRegistry ?? createDefaultRuntimeRegistry();
+  const runtime = registry[payload.runtime_type];
+  if (!runtime) {
+    throw new Error(`No runtime registered for dispatch payload type '${payload.runtime_type}'`);
+  }
 
   // Buffer events so the daemon doesn't fire one POST per token. Flushed
   // every BATCH_INTERVAL_MS or when the buffer hits BATCH_MAX. Final

--- a/packages/daemon/src/start.ts
+++ b/packages/daemon/src/start.ts
@@ -49,6 +49,7 @@ export async function runStart(): Promise<void> {
     api,
     supervisor,
     workspaceManager,
+    runtimeRegistry,
     runtimeIds: cfg.runtimes.map((r) => r.id),
   });
   claimer.start();


### PR DESCRIPTION
## Summary
- add an OpenCode AgentRuntime adapter using `opencode run --format json`
- generate workspace-local `opencode.json` with Beevibe remote MCP config
- pass runtime type through daemon claims so daemons dispatch the selected CLI instead of hardcoding Claude
- register OpenCode in the default runtime registry and document it as the open/free model path

## Verification
- `pnpm --filter @beevibe/core typecheck`
- `pnpm --filter @beevibe/core build`
- `pnpm --filter @beevibe/daemon typecheck`
- `pnpm --filter @beevibe/api typecheck`
- `pnpm --filter @beevibe/core test -- opencode/runtime.test.ts runtime-registry.test.ts local-workspace/manager.test.ts`
- `pnpm --filter @beevibe/daemon test -- spawner.test.ts`
- `pnpm --filter @beevibe/core lint`
- `pnpm --filter @beevibe/daemon lint` (warnings only: existing WebSocket import/no-named-as-default)
- `pnpm --filter @beevibe/api lint` (warning only: existing unused workProductRepo in escalation.test.ts)