### PR TITLE
feat(web): owner can edit agent core memory blocks via UI

### DIFF
--- a/packages/api/src/bootstrap.ts
+++ b/packages/api/src/bootstrap.ts
@@ -321,6 +321,7 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
     agentRepo,
     runtimeRepo,
     daemonRepo,
+    coreMemory,
   });
   server.getApp().use(viewRouter);
 

--- a/packages/api/src/routes/view.ts
+++ b/packages/api/src/routes/view.ts
@@ -33,6 +33,7 @@ import {
   type RuntimeRepository,
 } from "@beevibe/core";
 import { requireHuman } from "../auth/middleware.js";
+import type { CoreMemory } from "@beevibe/core/services/memory";
 import { listTasks, getTask, type TaskListFilter } from "../views/tasks.js";
 import {
   TASK_STATUSES_BY_LIFECYCLE,
@@ -57,6 +58,8 @@ export interface ViewRoutesDeps {
   runtimeRepo: RuntimeRepository;
   /** Backs `POST /agent/:id/runtime` (cross-tenant guard). */
   daemonRepo: DaemonRepository;
+  /** Backs `POST /agent/:id/core-memory/:blockName` (owner block edits). */
+  coreMemory: CoreMemory;
 }
 
 const LIFECYCLES = new Set<Lifecycle>(
@@ -341,6 +344,60 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
       res.json({ ok: true, review_policy: updated.review_policy });
     } catch (err) {
       handleError(err, res, "agent review_policy update");
+    }
+  });
+
+  router.post("/agent/:id/core-memory/:blockName", async (req, res) => {
+    if (!requireHuman(req, res)) return;
+    const id = req.params.id;
+    const blockName = req.params.blockName;
+    if (!id || !blockName) {
+      res.status(400).json({ error: "missing_param" });
+      return;
+    }
+    const body = req.body as { content?: unknown } | undefined;
+    if (typeof body?.content !== "string") {
+      res.status(400).json({
+        error: "invalid_body",
+        message: "expected { content: string }",
+      });
+      return;
+    }
+    try {
+      const existing = await deps.agentRepo.findById(id);
+      if (!existing) {
+        res.status(404).json({ error: "agent_not_found" });
+        return;
+      }
+      if (existing.owner_id !== req.caller.personId) {
+        res.status(403).json({ error: "not_owner" });
+        return;
+      }
+      // CoreMemory.setContent handles block-exists + char_limit guards;
+      // surface those as 4xx instead of leaking as 500.
+      try {
+        const updated = await deps.coreMemory.setContent(id, blockName, body.content);
+        res.json({
+          ok: true,
+          block_name: updated.block_name,
+          char_count: updated.content.length,
+          char_limit: updated.char_limit,
+          updated_at: updated.updated_at.toISOString(),
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes("not found")) {
+          res.status(404).json({ error: "block_not_found", message: msg });
+          return;
+        }
+        if (msg.includes("char_limit")) {
+          res.status(400).json({ error: "char_limit_exceeded", message: msg });
+          return;
+        }
+        throw err;
+      }
+    } catch (err) {
+      handleError(err, res, "agent core_memory update");
     }
   });
 

--- a/packages/api/src/routes/view.ts
+++ b/packages/api/src/routes/view.ts
@@ -33,7 +33,11 @@ import {
   type RuntimeRepository,
 } from "@beevibe/core";
 import { requireHuman } from "../auth/middleware.js";
-import type { CoreMemory } from "@beevibe/core/services/memory";
+import {
+  BlockCharLimitExceededError,
+  BlockNotFoundError,
+  type CoreMemory,
+} from "@beevibe/core/services/memory";
 import { listTasks, getTask, type TaskListFilter } from "../views/tasks.js";
 import {
   TASK_STATUSES_BY_LIFECYCLE,
@@ -373,30 +377,17 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
         res.status(403).json({ error: "not_owner" });
         return;
       }
-      // CoreMemory.setContent handles block-exists + char_limit guards;
-      // surface those as 4xx instead of leaking as 500.
-      try {
-        const updated = await deps.coreMemory.setContent(id, blockName, body.content);
-        res.json({
-          ok: true,
-          block_name: updated.block_name,
-          char_count: updated.content.length,
-          char_limit: updated.char_limit,
-          updated_at: updated.updated_at.toISOString(),
-        });
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        if (msg.includes("not found")) {
-          res.status(404).json({ error: "block_not_found", message: msg });
-          return;
-        }
-        if (msg.includes("char_limit")) {
-          res.status(400).json({ error: "char_limit_exceeded", message: msg });
-          return;
-        }
-        throw err;
-      }
+      await deps.coreMemory.setContent(id, blockName, body.content);
+      res.json({ ok: true });
     } catch (err) {
+      if (err instanceof BlockNotFoundError) {
+        res.status(404).json({ error: "block_not_found", message: err.message });
+        return;
+      }
+      if (err instanceof BlockCharLimitExceededError) {
+        res.status(400).json({ error: "char_limit_exceeded", message: err.message });
+        return;
+      }
       handleError(err, res, "agent core_memory update");
     }
   });

--- a/packages/core/src/services/memory/core-memory.ts
+++ b/packages/core/src/services/memory/core-memory.ts
@@ -72,4 +72,30 @@ export class CoreMemory {
 
     return this.deps.repo.updateContent(agentId, blockName, nextContent);
   }
+
+  /**
+   * Owner-driven full-block overwrite. Where `applyUpdate` is the agent's
+   * append/replace-substring path, this is the human's "rewrite the whole
+   * block" path — used by the agent detail page's Edit affordance. Same
+   * char_limit + block-existence guards.
+   */
+  async setContent(
+    agentId: string,
+    blockName: string,
+    content: string,
+  ): Promise<CoreMemoryBlock> {
+    const block = await this.deps.repo.findOne(agentId, blockName);
+    if (!block) {
+      throw new Error(
+        `Block "${blockName}" not found for agent ${agentId} — initDefaults first`,
+      );
+    }
+    if (content.length > block.char_limit) {
+      throw new Error(
+        `Block "${blockName}" would exceed char_limit ${block.char_limit} ` +
+          `(new length ${content.length})`,
+      );
+    }
+    return this.deps.repo.updateContent(agentId, blockName, content);
+  }
 }

--- a/packages/core/src/services/memory/core-memory.ts
+++ b/packages/core/src/services/memory/core-memory.ts
@@ -78,6 +78,10 @@ export class CoreMemory {
    * append/replace-substring path, this is the human's "rewrite the whole
    * block" path — used by the agent detail page's Edit affordance. Same
    * char_limit + block-existence guards.
+   *
+   * Throws {@link BlockNotFoundError} or {@link BlockCharLimitExceededError}
+   * so HTTP callers can map to 4xx via `instanceof` (mirrors the
+   * TaskNotFoundError / InvalidTaskTransitionError pattern in task-service).
    */
   async setContent(
     agentId: string,
@@ -86,16 +90,27 @@ export class CoreMemory {
   ): Promise<CoreMemoryBlock> {
     const block = await this.deps.repo.findOne(agentId, blockName);
     if (!block) {
-      throw new Error(
-        `Block "${blockName}" not found for agent ${agentId} — initDefaults first`,
-      );
+      throw new BlockNotFoundError(agentId, blockName);
     }
     if (content.length > block.char_limit) {
-      throw new Error(
-        `Block "${blockName}" would exceed char_limit ${block.char_limit} ` +
-          `(new length ${content.length})`,
-      );
+      throw new BlockCharLimitExceededError(blockName, block.char_limit, content.length);
     }
     return this.deps.repo.updateContent(agentId, blockName, content);
+  }
+}
+
+export class BlockNotFoundError extends Error {
+  constructor(agentId: string, blockName: string) {
+    super(`Block "${blockName}" not found for agent ${agentId} — initDefaults first`);
+    this.name = "BlockNotFoundError";
+  }
+}
+
+export class BlockCharLimitExceededError extends Error {
+  constructor(blockName: string, limit: number, attempted: number) {
+    super(
+      `Block "${blockName}" would exceed char_limit ${limit} (new length ${attempted})`,
+    );
+    this.name = "BlockCharLimitExceededError";
   }
 }

--- a/packages/core/src/services/memory/index.ts
+++ b/packages/core/src/services/memory/index.ts
@@ -1,4 +1,8 @@
-export { CoreMemory } from "./core-memory.js";
+export {
+  BlockCharLimitExceededError,
+  BlockNotFoundError,
+  CoreMemory,
+} from "./core-memory.js";
 export type { CoreMemoryDeps, CoreMemoryOperation } from "./core-memory.js";
 
 export { FactStore } from "./fact-store.js";

--- a/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
+++ b/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
@@ -187,7 +187,12 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
             ) : (
               <div className="space-y-3">
                 {agent.core_blocks.map((b) => (
-                  <CoreBlockCard key={b.id} block={b} editable={isOwner === true} />
+                  <CoreBlockCard
+                    key={b.id}
+                    agentId={agent.id}
+                    block={b}
+                    editable={isOwner === true}
+                  />
                 ))}
               </div>
             )}

--- a/packages/web/components/agents/agent-detail-panel.tsx
+++ b/packages/web/components/agents/agent-detail-panel.tsx
@@ -196,7 +196,12 @@ function PanelLoaded({ agent }: { agent: AgentDetail }) {
         {agent.core_blocks.length > 0 ? (
           <div className="space-y-2.5">
             {agent.core_blocks.map((b) => (
-              <CoreBlockCard key={b.id} block={b} editable={isOwner === true} />
+              <CoreBlockCard
+                key={b.id}
+                agentId={agent.id}
+                block={b}
+                editable={isOwner === true}
+              />
             ))}
           </div>
         ) : null}

--- a/packages/web/components/agents/core-block-card.tsx
+++ b/packages/web/components/agents/core-block-card.tsx
@@ -38,7 +38,7 @@ export function CoreBlockCard({
   const [editing, setEditing] = useState(false);
   if (editing) {
     return (
-      <BlockShell accent={block.block_name === "persona" ? "primary" : undefined}>
+      <BlockShell accent={blockAccent(block.block_name)}>
         <BlockEditor
           agentId={agentId}
           block={block}
@@ -108,7 +108,7 @@ function BlockEditor({
       <div className="flex items-center gap-2 justify-end">
         {mutation.isError ? (
           <span className="mr-auto text-xs text-destructive">
-            {mutation.error instanceof Error ? mutation.error.message : "Save failed"}
+            {mutation.error?.message ?? "Save failed"}
           </span>
         ) : null}
         <button
@@ -206,12 +206,21 @@ function formatCount(n: number): string {
 
 // ── Persona — identity prose ─────────────────────────────────────────
 
+/**
+ * Map a block_name to its visual accent. Persona gets the primary left
+ * stripe to read as a quote / mission-statement; others use the default
+ * border. Centralised so the edit-mode shell (CoreBlockCard) and the
+ * view-mode block components don't drift.
+ */
+function blockAccent(blockName: string): "primary" | undefined {
+  return blockName === "persona" ? "primary" : undefined;
+}
+
 function PersonaBlock({ block, onEdit }: { block: CoreBlockDisplay; onEdit?: () => void }) {
   // Persona is short by nature (~400 chars), so no collapse — show the
-  // whole identity statement at once. Primary left accent stripe makes
-  // it read as a quote / mission-statement instead of a config field.
+  // whole identity statement at once.
   return (
-    <BlockShell accent="primary">
+    <BlockShell accent={blockAccent(block.block_name)}>
       <BlockHeader block={block} kindLabel="Identity" onEdit={onEdit} />
       <div className="text-sm text-foreground/85 italic">
         <ChatMarkdown content={block.content} />

--- a/packages/web/components/agents/core-block-card.tsx
+++ b/packages/web/components/agents/core-block-card.tsx
@@ -2,8 +2,11 @@
 
 import { useState } from "react";
 import { Pencil } from "lucide-react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Avatar } from "@/components/avatar";
 import { ChatMarkdown } from "@/components/chat/markdown";
+import { api } from "@/lib/api/client";
+import { queryKeys } from "@/lib/hooks/keys";
 import { cn } from "@/lib/utils";
 import type { CoreBlockDisplay } from "@/lib/types/core-memory-blocks";
 
@@ -18,27 +21,115 @@ import type { CoreBlockDisplay } from "@/lib/types/core-memory-blocks";
  */
 /**
  * `editable` gates the inline Edit pencil. False for non-owner viewers
- * (the backend would reject the eventual `update_core_memory` call
- * anyway; the UI surface just hides the affordance up front). Required
- * so every callsite has to think about ownership — no fail-open default.
+ * (the backend would reject anyway; UI just hides the affordance). The
+ * agent's own append/replace-substring is via the `update_core_memory`
+ * MCP tool; this UI is the human owner's full-block overwrite path.
+ * `agentId` lets the editor call POST /agent/:id/core-memory/:block.
  */
 export function CoreBlockCard({
+  agentId,
   block,
   editable,
 }: {
+  agentId: string;
   block: CoreBlockDisplay;
   editable: boolean;
 }) {
+  const [editing, setEditing] = useState(false);
+  if (editing) {
+    return (
+      <BlockShell accent={block.block_name === "persona" ? "primary" : undefined}>
+        <BlockEditor
+          agentId={agentId}
+          block={block}
+          onDone={() => setEditing(false)}
+        />
+      </BlockShell>
+    );
+  }
+  const onEdit = editable ? () => setEditing(true) : undefined;
   switch (block.block_name) {
     case "persona":
-      return <PersonaBlock block={block} editable={editable} />;
+      return <PersonaBlock block={block} onEdit={onEdit} />;
     case "active_work":
-      return <ActiveWorkBlock block={block} editable={editable} />;
+      return <ActiveWorkBlock block={block} onEdit={onEdit} />;
     case "team_members":
-      return <TeamMembersBlock block={block} editable={editable} />;
+      return <TeamMembersBlock block={block} onEdit={onEdit} />;
     default:
-      return <ProseBlock block={block} editable={editable} />;
+      return <ProseBlock block={block} onEdit={onEdit} />;
   }
+}
+
+function BlockEditor({
+  agentId,
+  block,
+  onDone,
+}: {
+  agentId: string;
+  block: CoreBlockDisplay;
+  onDone: () => void;
+}) {
+  const [value, setValue] = useState(block.content);
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: (content: string) => api.agents.setCoreBlock(agentId, block.block_name, content),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agentId) });
+      onDone();
+    },
+  });
+  const tooLong = value.length > block.char_limit;
+  const unchanged = value === block.content;
+  return (
+    <div className="space-y-2">
+      <div className="flex items-baseline gap-2">
+        <span className="text-[10px] uppercase tracking-wider font-semibold text-foreground/85">
+          Editing
+        </span>
+        <span className="font-mono text-[10px] text-muted-foreground/80">
+          {block.block_name}
+        </span>
+        <span
+          className={cn(
+            "ml-auto text-[10px] tabular-nums",
+            tooLong ? "text-destructive" : "text-muted-foreground/70",
+          )}
+        >
+          {value.length} / {block.char_limit}
+        </span>
+      </div>
+      <textarea
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        disabled={mutation.isPending}
+        rows={Math.min(16, Math.max(4, value.split("\n").length + 1))}
+        className="w-full text-sm rounded border border-border bg-background px-2 py-1.5 font-mono disabled:opacity-50"
+      />
+      <div className="flex items-center gap-2 justify-end">
+        {mutation.isError ? (
+          <span className="mr-auto text-xs text-destructive">
+            {mutation.error instanceof Error ? mutation.error.message : "Save failed"}
+          </span>
+        ) : null}
+        <button
+          type="button"
+          onClick={onDone}
+          disabled={mutation.isPending}
+          className="h-7 px-3 rounded text-xs font-medium border border-border hover:bg-secondary transition-colors cursor-pointer disabled:opacity-50"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={() => mutation.mutate(value)}
+          disabled={mutation.isPending || tooLong || unchanged}
+          className="h-7 px-3 rounded text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50"
+        >
+          {mutation.isPending ? "Saving…" : "Save"}
+        </button>
+      </div>
+    </div>
+  );
 }
 
 // ── Shared chrome ────────────────────────────────────────────────────
@@ -65,11 +156,12 @@ function BlockShell({
 function BlockHeader({
   block,
   kindLabel,
-  editable,
+  onEdit,
 }: {
   block: CoreBlockDisplay;
   kindLabel?: string;
-  editable: boolean;
+  /** Click handler for the inline edit pencil. Omit to hide it (non-owner). */
+  onEdit?: () => void;
 }) {
   // The kind label is the human-readable name ("Identity", "Active
   // work"); the raw `block_name` (persona, active_work) sits next to
@@ -92,10 +184,12 @@ function BlockHeader({
         <span className="text-[10px] text-muted-foreground/50 tabular-nums opacity-0 group-hover:opacity-100 transition-opacity">
           {formatCount(block.char_count)} / {formatCount(block.char_limit)}
         </span>
-        {editable ? (
+        {onEdit ? (
           <button
+            type="button"
+            onClick={onEdit}
             aria-label={`Edit ${block.block_name} block`}
-            className="h-5 w-5 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary opacity-0 group-hover:opacity-100 transition-opacity"
+            className="h-5 w-5 rounded inline-flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-secondary opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
           >
             <Pencil className="h-3 w-3" />
           </button>
@@ -112,13 +206,13 @@ function formatCount(n: number): string {
 
 // ── Persona — identity prose ─────────────────────────────────────────
 
-function PersonaBlock({ block, editable }: { block: CoreBlockDisplay; editable: boolean }) {
+function PersonaBlock({ block, onEdit }: { block: CoreBlockDisplay; onEdit?: () => void }) {
   // Persona is short by nature (~400 chars), so no collapse — show the
   // whole identity statement at once. Primary left accent stripe makes
   // it read as a quote / mission-statement instead of a config field.
   return (
     <BlockShell accent="primary">
-      <BlockHeader block={block} kindLabel="Identity" editable={editable} />
+      <BlockHeader block={block} kindLabel="Identity" onEdit={onEdit} />
       <div className="text-sm text-foreground/85 italic">
         <ChatMarkdown content={block.content} />
       </div>
@@ -133,7 +227,7 @@ interface ActiveWorkUpdate {
   content: string;
 }
 
-function ActiveWorkBlock({ block, editable }: { block: CoreBlockDisplay; editable: boolean }) {
+function ActiveWorkBlock({ block, onEdit }: { block: CoreBlockDisplay; onEdit?: () => void }) {
   const { current, updates } = parseActiveWork(block.content);
   const [showAll, setShowAll] = useState(false);
 
@@ -143,7 +237,7 @@ function ActiveWorkBlock({ block, editable }: { block: CoreBlockDisplay; editabl
 
   return (
     <BlockShell>
-      <BlockHeader block={block} kindLabel="Active work" editable={editable} />
+      <BlockHeader block={block} kindLabel="Active work" onEdit={onEdit} />
 
       {current ? (
         <div className="text-sm text-foreground/90">
@@ -236,16 +330,16 @@ interface TeamMember {
   description: string;
 }
 
-function TeamMembersBlock({ block, editable }: { block: CoreBlockDisplay; editable: boolean }) {
+function TeamMembersBlock({ block, onEdit }: { block: CoreBlockDisplay; onEdit?: () => void }) {
   const members = parseTeamMembers(block.content);
   if (members.length === 0) {
     // Parsing fell apart — don't lose the data, render as prose so
     // the user still sees what's there.
-    return <ProseBlock block={block} kindLabel="Team members" editable={editable} />;
+    return <ProseBlock block={block} kindLabel="Team members" onEdit={onEdit} />;
   }
   return (
     <BlockShell>
-      <BlockHeader block={block} kindLabel="Team members" editable={editable} />
+      <BlockHeader block={block} kindLabel="Team members" onEdit={onEdit} />
       <ul className="space-y-2.5">
         {members.map((m) => (
           <TeamMemberRow key={m.agentId} member={m} />
@@ -312,11 +406,11 @@ const COLLAPSE_THRESHOLD = 400;
 function ProseBlock({
   block,
   kindLabel,
-  editable,
+  onEdit,
 }: {
   block: CoreBlockDisplay;
   kindLabel?: string;
-  editable: boolean;
+  onEdit?: () => void;
 }) {
   const long = block.content.length > COLLAPSE_THRESHOLD;
   const [expanded, setExpanded] = useState(!long);
@@ -326,7 +420,7 @@ function ProseBlock({
       : block.content;
   return (
     <BlockShell>
-      <BlockHeader block={block} kindLabel={kindLabel} editable={editable} />
+      <BlockHeader block={block} kindLabel={kindLabel} onEdit={onEdit} />
       <div className="text-sm text-foreground/85">
         <ChatMarkdown content={visible} />
       </div>

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -404,6 +404,23 @@ export const api = {
         `/agent/${encodeURIComponent(id)}/review-policy`,
         { method: "POST", body: { review_policy: policy } },
       ),
+    /**
+     * Owner-only full-block overwrite. The agent's own `update_core_memory`
+     * MCP tool handles append/replace-substring; this is the human's
+     * "rewrite the whole block" path. Server-side guards: block must
+     * exist for the agent and content.length ≤ block.char_limit.
+     */
+    setCoreBlock: (id: string, blockName: string, content: string) =>
+      fetchJson<{
+        ok: true;
+        block_name: string;
+        char_count: number;
+        char_limit: number;
+        updated_at: string;
+      }>(
+        `/agent/${encodeURIComponent(id)}/core-memory/${encodeURIComponent(blockName)}`,
+        { method: "POST", body: { content } },
+      ),
   },
   runtimes: {
     list: (opts: ReadOptions = {}) =>

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -408,16 +408,13 @@ export const api = {
      * Owner-only full-block overwrite. The agent's own `update_core_memory`
      * MCP tool handles append/replace-substring; this is the human's
      * "rewrite the whole block" path. Server-side guards: block must
-     * exist for the agent and content.length ≤ block.char_limit.
+     * exist for the agent and content.length ≤ block.char_limit. Caller
+     * invalidates `queryKeys.agents.detail(id)` on success to pick up
+     * the new content + updated_at — no fields need to flow through the
+     * response, matching the `setReviewPolicy` / `setModel` minimalism.
      */
     setCoreBlock: (id: string, blockName: string, content: string) =>
-      fetchJson<{
-        ok: true;
-        block_name: string;
-        char_count: number;
-        char_limit: number;
-        updated_at: string;
-      }>(
+      fetchJson<{ ok: true }>(
         `/agent/${encodeURIComponent(id)}/core-memory/${encodeURIComponent(blockName)}`,
         { method: "POST", body: { content } },
       ),


### PR DESCRIPTION
## Problem

The Edit pencil on `CoreBlockCard` was decorative — no `onClick`, no backend route. The only path to edit core memory was the agent's own `update_core_memory` MCP tool (append / replace-substring); owners had no way to correct a wrong persona, tighten a constraints block, or rewrite domain context from the web UI.

## Fix

### Backend
- **`CoreMemory.setContent(agentId, blockName, content)`** — new service method. Sibling of `applyUpdate` (the agent's append/replace-substring path); this is the human owner's "rewrite the whole block" path. Same block-exists + `char_limit` guards.
- **`POST /agent/:id/core-memory/:blockName`** — new route. Owner-gated (mirrors `/runtime`, `/model`, `/review-policy`). Body `{ content: string }`. Validation errors mapped to 4xx instead of leaking as 500: missing block → `404 block_not_found`; content over `char_limit` → `400 char_limit_exceeded`.
- `ViewRoutesDeps` gains `coreMemory`; bootstrap threads the existing `CoreMemory` instance through.

### Frontend
- **`CoreBlockCard`** owns an `editing` state. When false, dispatches to type-specific renders (`PersonaBlock` / `ActiveWorkBlock` / `TeamMembersBlock` / `ProseBlock`) with an `onEdit` callback. When true, renders `BlockEditor` inside the same `BlockShell` for visual continuity.
- **`BlockEditor`** — textarea + live char counter + Save/Cancel. Save calls `api.agents.setCoreBlock` and invalidates `queryKeys.agents.detail`. Save disabled while pending, over `char_limit`, or unchanged. Inline error surface for save failures.
- **`BlockHeader`** signature flipped from `editable: boolean` to `onEdit?: () => void` — single source of truth. Pencil renders iff handler is provided.
- **`agentId`** now a required prop on `CoreBlockCard`; both call sites (full detail page + peek panel) pass it.

Non-owners still see block content; they just get no pencil (`onEdit = undefined`) — symmetric with the existing hide-pickers-for-non-owners pattern from PR #104.

## Test plan
- [x] `pnpm --filter @beevibe/core test` — 447 pass
- [x] `pnpm --filter @beevibe/api test` — 308 pass
- [x] `pnpm --filter @beevibe/web typecheck` + `test` — 141 pass
- [ ] Manual smoke: as owner, hover any block → pencil appears → click → textarea pre-filled with current content → save with a small edit → block re-renders with new content; char counter turns red when over limit; Save disabled when unchanged
- [ ] Cross-user check: navigate to another user's agent → no pencil on any block; same behavior in the peek panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)