### PR TITLE
feat(agents): show owner on agent detail page and side panel

### DIFF
--- a/packages/api/src/views/agents.test.ts
+++ b/packages/api/src/views/agents.test.ts
@@ -10,6 +10,7 @@ describe("listAgents", () => {
           id: "agt_org",
           name: "Atlas",
           owner_id: "per_w",
+          owner_label: "Wendy",
           parent_agent_id: null,
           hierarchy_level: "org",
           review_policy: null,
@@ -29,6 +30,7 @@ describe("listAgents", () => {
     expect(agents[0]?.facts_learned).toBe(4);
     expect(agents[0]?.runtime).toBe("claude");
     expect(agents[0]?.model).toBe("opus");
+    expect(agents[0]?.owner_label).toBe("Wendy");
   });
 
   it("returns undefined model when runtime_config has no model set", async () => {
@@ -38,6 +40,7 @@ describe("listAgents", () => {
           id: "agt_x",
           name: "NoModel",
           owner_id: "per_w",
+          owner_label: "Wendy",
           parent_agent_id: null,
           hierarchy_level: "ic",
           review_policy: null,
@@ -68,6 +71,7 @@ describe("getAgent", () => {
           id: "agt_team",
           name: "Beta",
           owner_id: "per_w",
+          owner_label: "Wendy",
           parent_agent_id: "agt_org",
           hierarchy_level: "team",
           review_policy: "auto_done",
@@ -123,5 +127,6 @@ describe("getAgent", () => {
     expect(detail?.recent_sessions[0]?.title).toBe("Bill rewrite");
     expect(detail?.outgoing_mesh_hints).toHaveLength(1);
     expect(detail?.outgoing_mesh_hints[0]?.target).toBe("Charlie");
+    expect(detail?.owner_label).toBe("Wendy");
   });
 });

--- a/packages/api/src/views/agents.ts
+++ b/packages/api/src/views/agents.ts
@@ -21,6 +21,7 @@ interface AgentRow {
   id: string;
   name: string;
   owner_id: string;
+  owner_label: string | null;
   parent_agent_id: string | null;
   hierarchy_level: HierarchyLevel;
   review_policy: string | null;
@@ -40,11 +41,13 @@ SELECT
   a.id, a.name, a.owner_id, a.parent_agent_id, a.hierarchy_level,
   a.review_policy, a.runtime_config, a.preferred_runtime_id, a.archived_at,
   a.created_at, a.updated_at,
+  p.name                  AS owner_label,
   COALESCE(sc.n, 0)::int  AS sessions_count,
   COALESCE(fc.n, 0)::int  AS facts_learned,
   tl.content              AS tag_line,
   dm.content              AS domain_content
 FROM agent a
+LEFT JOIN person p ON p.id = a.owner_id
 LEFT JOIN (
   SELECT agent_id, COUNT(*)::int AS n
   FROM session
@@ -78,6 +81,7 @@ function rowToAgentDisplay(row: AgentRow): AgentDisplay {
     id: row.id,
     name: row.name,
     owner_id: row.owner_id,
+    owner_label: row.owner_label ?? undefined,
     parent_agent_id: row.parent_agent_id ?? undefined,
     hierarchy_level: row.hierarchy_level,
     created_at: row.created_at,
@@ -117,6 +121,7 @@ SELECT
   a.id, a.name, a.owner_id, a.parent_agent_id, a.hierarchy_level,
   a.review_policy, a.runtime_config, a.preferred_runtime_id, a.archived_at,
   a.created_at, a.updated_at,
+  p.name AS owner_label,
   (SELECT COUNT(*)::int FROM session       WHERE agent_id = a.id) AS sessions_count,
   (SELECT COUNT(*)::int FROM memory_fact   WHERE agent_id = a.id) AS facts_learned,
   (SELECT content FROM core_memory_block
@@ -124,6 +129,7 @@ SELECT
   (SELECT content FROM core_memory_block
     WHERE agent_id = a.id AND block_name = 'domain'   LIMIT 1) AS domain_content
 FROM agent a
+LEFT JOIN person p ON p.id = a.owner_id
 WHERE a.id = $1
 LIMIT 1
 `;

--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -86,6 +86,8 @@ export interface AgentDisplay
     Agent,
     "id" | "name" | "owner_id" | "parent_agent_id" | "hierarchy_level" | "created_at" | "updated_at"
   > {
+  /** Human-readable owner name (joined from person.name). */
+  owner_label?: string;
   /** Defaults to `name` but the UI may want a different display string. */
   display_name: string;
   hierarchy: HierarchyLevel;

--- a/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
+++ b/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
@@ -245,6 +245,7 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
         <FooterField label="ID">
           <ClickToCopyId id={agent.id} />
         </FooterField>
+        <FooterField label="Owner">{agent.owner_label ?? "—"}</FooterField>
         <FooterField label="Hierarchy">{agent.hierarchy}</FooterField>
         {agent.runtime ? <FooterField label="Runtime">{agent.runtime}</FooterField> : null}
         <FooterField label="Model">{agent.model ?? "CLI default"}</FooterField>

--- a/packages/web/components/agents/agent-detail-panel.tsx
+++ b/packages/web/components/agents/agent-detail-panel.tsx
@@ -236,6 +236,7 @@ function PanelLoaded({ agent }: { agent: AgentDetail }) {
         <PanelFooterField label="ID">
           <ClickToCopyId id={agent.id} />
         </PanelFooterField>
+        <PanelFooterField label="Owner">{agent.owner_label ?? "—"}</PanelFooterField>
         <PanelFooterField label="Hierarchy">{agent.hierarchy}</PanelFooterField>
         {agent.runtime ? (
           <PanelFooterField label="Runtime">{agent.runtime}</PanelFooterField>


### PR DESCRIPTION
## Summary
- Join `person.name` onto the agent list + detail views as `owner_label`
- Render an **Owner** field in the footer of the full agent detail page
- Render an **Owner** field in the footer of the peek-panel side tab

## Test plan
- [x] `packages/api/src/views/agents.test.ts` updated with `owner_label` fixtures + assertions — 4/4 pass
- [x] Full API unit suite green (232 pass; 6 pre-existing integration-test failures require a live DB and are unrelated)
- [x] Web test suite green (141/141)
- [x] Web typecheck clean
- [ ] Visual check that the owner shows up on `/agents/[id]` and in the peek panel against a live DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)