### PR TITLE
fix(runtimes): share install instructions and refresh presence on WS connect

### DIFF
--- a/packages/api/src/runtime/ws-server.test.ts
+++ b/packages/api/src/runtime/ws-server.test.ts
@@ -113,12 +113,20 @@ describe("RuntimeWsServer", () => {
 
   it("upgrades a valid daemon caller and registers it on the hub", async () => {
     const fx = await setupFixture();
+    expect((await runtimeRepo.findById(fx.runtimeId))?.last_heartbeat).toBeUndefined();
+
     const { ws } = await connect(`/runtime/ws?runtime_ids=${fx.runtimeId}`, {
       Authorization: `Bearer ${fx.daemonToken}`,
     });
     expect(ws).toBeDefined();
     expect(hub.size()).toBe(1);
     expect(hub.hasRuntime(fx.runtimeId)).toBe(true);
+
+    // Connect-time heartbeat bumps last_heartbeat so the DB trigger fires
+    // `runtime.updated` SSE and the web's online dot updates immediately
+    // instead of waiting for the next HTTP heartbeat.
+    await new Promise((r) => setTimeout(r, 30));
+    expect((await runtimeRepo.findById(fx.runtimeId))?.last_heartbeat).toBeInstanceOf(Date);
 
     // Notify reaches the live socket.
     const received = new Promise<string>((resolve) => ws!.once("message", (data) => {

--- a/packages/api/src/runtime/ws-server.test.ts
+++ b/packages/api/src/runtime/ws-server.test.ts
@@ -122,11 +122,14 @@ describe("RuntimeWsServer", () => {
     expect(hub.size()).toBe(1);
     expect(hub.hasRuntime(fx.runtimeId)).toBe(true);
 
-    // Connect-time heartbeat bumps last_heartbeat so the DB trigger fires
-    // `runtime.updated` SSE and the web's online dot updates immediately
-    // instead of waiting for the next HTTP heartbeat.
-    await new Promise((r) => setTimeout(r, 30));
-    expect((await runtimeRepo.findById(fx.runtimeId))?.last_heartbeat).toBeInstanceOf(Date);
+    // Connect-time heartbeat is fire-and-forget, so poll until the row
+    // reflects it. Bump on WS connect feeds the DB trigger that fires
+    // `runtime.updated` SSE — without it the web waits for the next HTTP
+    // heartbeat (~30s) to flip the online dot.
+    const heartbeatAt = await waitFor(
+      async () => (await runtimeRepo.findById(fx.runtimeId))?.last_heartbeat,
+    );
+    expect(heartbeatAt).toBeInstanceOf(Date);
 
     // Notify reaches the live socket.
     const received = new Promise<string>((resolve) => ws!.once("message", (data) => {
@@ -200,3 +203,16 @@ describe("RuntimeWsServer", () => {
   });
 
 });
+
+async function waitFor<T>(
+  check: () => Promise<T | undefined>,
+  { timeoutMs = 500, intervalMs = 10 }: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<T | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const v = await check();
+    if (v !== undefined) return v;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  return check();
+}

--- a/packages/api/src/runtime/ws-server.ts
+++ b/packages/api/src/runtime/ws-server.ts
@@ -120,11 +120,9 @@ export class RuntimeWsServer {
       },
     };
     this.options.hub.register(client);
-    // Bump last_heartbeat for every runtime this client just subscribed to.
-    // The DB trigger on `runtime.last_heartbeat` fires `runtime.updated` SSE,
-    // which invalidates the web's `/runtimes` cache so the online dot
-    // updates immediately instead of waiting up to ~30s for the next HTTP
-    // heartbeat or the staleTime to expire.
+    // Bump last_heartbeat so the DB trigger fires `runtime.updated` SSE and
+    // the web's online dot flips immediately, not after the next ~30s HTTP
+    // heartbeat / React Query staleTime window.
     void this.touchHeartbeats(runtimeIds);
     ws.on("pong", () => {
       client.alive = true;

--- a/packages/api/src/runtime/ws-server.ts
+++ b/packages/api/src/runtime/ws-server.ts
@@ -120,6 +120,12 @@ export class RuntimeWsServer {
       },
     };
     this.options.hub.register(client);
+    // Bump last_heartbeat for every runtime this client just subscribed to.
+    // The DB trigger on `runtime.last_heartbeat` fires `runtime.updated` SSE,
+    // which invalidates the web's `/runtimes` cache so the online dot
+    // updates immediately instead of waiting up to ~30s for the next HTTP
+    // heartbeat or the staleTime to expire.
+    void this.touchHeartbeats(runtimeIds);
     ws.on("pong", () => {
       client.alive = true;
     });
@@ -145,6 +151,21 @@ export class RuntimeWsServer {
     };
     ws.on("close", cleanup);
     ws.on("error", cleanup);
+  }
+
+  private async touchHeartbeats(runtimeIds: readonly string[]): Promise<void> {
+    await Promise.all(
+      runtimeIds.map(async (rid) => {
+        try {
+          await this.options.runtimeRepo.heartbeat(rid);
+        } catch (err) {
+          console.warn("[runtime/ws] heartbeat on connect failed", {
+            runtimeId: rid,
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }),
+    );
   }
 }
 

--- a/packages/web/app/(authed)/runtimes/runtimes-client.tsx
+++ b/packages/web/app/(authed)/runtimes/runtimes-client.tsx
@@ -16,11 +16,11 @@ import {
   type RuntimePanelEntry,
   type RuntimesListResponse,
 } from "@/lib/api/client";
-import { apiBaseUrl, getUserKey, isApiConfigured } from "@/lib/api/config";
+import { isApiConfigured } from "@/lib/api/config";
 import { describeError } from "@/lib/api/http";
 import { queryKeys } from "@/lib/hooks/keys";
 import { formatRelativeTime } from "@/lib/format";
-import { CommandBlock } from "@/components/command-block";
+import { DaemonInstallInstructions } from "@/components/daemon-install";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
 import { cn } from "@/lib/utils";
@@ -308,19 +308,5 @@ function AddAnotherMachine() {
 }
 
 function InstallSnippet() {
-  const userKey = typeof window !== "undefined" ? getUserKey() : null;
-  const apiUrl = apiBaseUrl ?? "http://localhost:3000";
-  const setupCmd = `pnpm daemon setup --api ${apiUrl} --user-token ${userKey ?? "<your-key>"}`;
-  const startCmd = `pnpm daemon start`;
-  return (
-    <div className="w-full max-w-xl space-y-2">
-      <CommandBlock label="1. Register" command={setupCmd} />
-      <CommandBlock label="2. Start (long-running)" command={startCmd} />
-      <p className="text-[11px] text-muted-foreground/80 leading-snug pt-1">
-        Run from a checkout of the beevibe repo. A published{" "}
-        <span className="font-mono">npx @beevibe/daemon</span> / brew tap
-        is on the roadmap so users can install without the repo.
-      </p>
-    </div>
-  );
+  return <DaemonInstallInstructions className="w-full max-w-xl" />;
 }

--- a/packages/web/app/welcome/welcome-client.tsx
+++ b/packages/web/app/welcome/welcome-client.tsx
@@ -16,9 +16,9 @@ import {
   MessageSquare,
   Sparkles,
 } from "lucide-react";
-import { apiBaseUrl, getUserKey, isApiConfigured } from "@/lib/api/config";
+import { isApiConfigured } from "@/lib/api/config";
 import { api, type RuntimesListResponse } from "@/lib/api/client";
-import { CommandBlock } from "@/components/command-block";
+import { DaemonInstallInstructions } from "@/components/daemon-install";
 import { queryKeys } from "@/lib/hooks/keys";
 import { useMe } from "@/lib/hooks/use-me";
 import { cn } from "@/lib/utils";
@@ -176,107 +176,7 @@ function IntroStep({ onNext }: { onNext: () => void }) {
 
 // ── Step 2: install daemon — show command, poll until it appears ──────
 
-type InstallChannel = "brew" | "npx" | "direct";
-
-interface InstallOption {
-  id: InstallChannel;
-  label: string;
-  /** Short subtitle shown under the label in the tab strip. */
-  hint: string;
-}
-
-const INSTALL_OPTIONS: readonly InstallOption[] = [
-  { id: "brew", label: "Homebrew", hint: "macOS" },
-  { id: "npx", label: "npx", hint: "any platform with Node" },
-  { id: "direct", label: "Direct download", hint: "advanced" },
-];
-
-const RELEASES_URL = "https://github.com/beevibe-ai/beevibe/releases/latest";
-const NPX_BIN = "npx -y @beevibe/daemon@latest";
-const LOCAL_BIN = "beevibe-daemon";
-
-interface InstallStepSpec {
-  /** Short imperative — number is prepended at render time. */
-  label: string;
-  command: string;
-}
-
-interface InstallBundle {
-  /** Optional helper text rendered before the command list. */
-  prelude?: React.ReactNode;
-  steps: readonly InstallStepSpec[];
-}
-
-function buildInstallBundle(channel: InstallChannel, setupArgs: string): InstallBundle {
-  switch (channel) {
-    case "brew":
-      return {
-        steps: [
-          { label: "Install via Homebrew", command: "brew install beevibe-ai/tap/beevibe-daemon" },
-          { label: "Register", command: `${LOCAL_BIN} ${setupArgs}` },
-          { label: "Start (long-running)", command: `${LOCAL_BIN} start` },
-        ],
-      };
-    case "npx":
-      return {
-        steps: [
-          {
-            label: "Register (downloads daemon on first run)",
-            command: `${NPX_BIN} ${setupArgs}`,
-          },
-          { label: "Start (long-running)", command: `${NPX_BIN} start` },
-        ],
-      };
-    case "direct":
-      return {
-        prelude: (
-          <p className="text-xs text-muted-foreground leading-relaxed">
-            Pick the binary that matches your platform from{" "}
-            <a
-              href={RELEASES_URL}
-              target="_blank"
-              rel="noreferrer noopener"
-              className="underline hover:text-foreground"
-            >
-              the latest GitHub release
-            </a>
-            {" "}— darwin-arm64, darwin-x64, linux-x64, or linux-arm64. Then:
-          </p>
-        ),
-        steps: [
-          {
-            label: "Download (substitute your platform)",
-            command:
-              `curl -fsSL -o ~/.local/bin/${LOCAL_BIN} \\\n` +
-              `  "${RELEASES_URL}/download/${LOCAL_BIN}-darwin-arm64" \\\n` +
-              `  && chmod +x ~/.local/bin/${LOCAL_BIN}`,
-          },
-          { label: "Register", command: `${LOCAL_BIN} ${setupArgs}` },
-          { label: "Start (long-running)", command: `${LOCAL_BIN} start` },
-        ],
-      };
-  }
-}
-
-/**
- * Detect the user's OS from navigator.userAgent so we default the tab
- * to whatever is most natural for them. Falls back to `npx` (universal).
- * Runs once on mount — userAgent doesn't change for the page lifetime.
- */
-function detectDefaultChannel(): InstallChannel {
-  if (typeof navigator === "undefined") return "npx";
-  if (/Mac OS X|Macintosh/i.test(navigator.userAgent)) return "brew";
-  return "npx";
-}
-
 function InstallStep({ onDaemonReady }: { onDaemonReady: () => void }) {
-  const userKey = typeof window !== "undefined" ? getUserKey() : null;
-  const apiUrl = apiBaseUrl ?? "http://localhost:3000";
-  const keyOrPlaceholder = userKey ?? "<your-key>";
-  const setupArgs = `setup --api ${apiUrl} --user-token ${keyOrPlaceholder}`;
-
-  const [channel, setChannel] = useState<InstallChannel>(() => detectDefaultChannel());
-
   // Poll /runtimes every 3s until at least one daemon shows up.
   const query = useQuery<RuntimesListResponse>({
     queryKey: queryKeys.runtimes.list(),
@@ -297,28 +197,7 @@ function InstallStep({ onDaemonReady }: { onDaemonReady: () => void }) {
         </p>
       </div>
 
-      <div className="max-w-xl mx-auto space-y-3">
-        <div className="flex gap-1 rounded-lg border border-border bg-card p-1">
-          {INSTALL_OPTIONS.map((opt) => (
-            <button
-              key={opt.id}
-              type="button"
-              onClick={() => setChannel(opt.id)}
-              className={cn(
-                "flex-1 rounded px-3 py-1.5 text-xs font-medium transition-colors cursor-pointer",
-                channel === opt.id
-                  ? "bg-primary text-primary-foreground"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-            >
-              <div>{opt.label}</div>
-              <div className="text-[10px] font-normal opacity-80 mt-0.5">{opt.hint}</div>
-            </button>
-          ))}
-        </div>
-
-        <InstallStepList bundle={buildInstallBundle(channel, setupArgs)} />
-      </div>
+      <DaemonInstallInstructions className="max-w-xl mx-auto" />
 
       <div
         className={cn(
@@ -356,17 +235,6 @@ function InstallStep({ onDaemonReady }: { onDaemonReady: () => void }) {
         (<span className="font-mono">npm i -g @anthropic/claude-code</span>) and
         run <span className="font-mono">claude login</span>.
       </p>
-    </div>
-  );
-}
-
-function InstallStepList({ bundle }: { bundle: InstallBundle }) {
-  return (
-    <div className="space-y-2">
-      {bundle.prelude}
-      {bundle.steps.map((step, i) => (
-        <CommandBlock key={i} label={`${i + 1}. ${step.label}`} command={step.command} />
-      ))}
     </div>
   );
 }

--- a/packages/web/components/daemon-install.tsx
+++ b/packages/web/components/daemon-install.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { apiBaseUrl, getUserKey } from "@/lib/api/config";
+import { CommandBlock } from "@/components/command-block";
+import { cn } from "@/lib/utils";
+
+export type InstallChannel = "brew" | "npx" | "direct";
+
+interface InstallOption {
+  id: InstallChannel;
+  label: string;
+  hint: string;
+}
+
+const INSTALL_OPTIONS: readonly InstallOption[] = [
+  { id: "brew", label: "Homebrew", hint: "macOS" },
+  { id: "npx", label: "npx", hint: "any platform with Node" },
+  { id: "direct", label: "Direct download", hint: "advanced" },
+];
+
+const RELEASES_URL = "https://github.com/beevibe-ai/beevibe/releases/latest";
+const NPX_BIN = "npx -y @beevibe/daemon@latest";
+const LOCAL_BIN = "beevibe-daemon";
+
+interface InstallStepSpec {
+  label: string;
+  command: string;
+}
+
+interface InstallBundle {
+  prelude?: ReactNode;
+  steps: readonly InstallStepSpec[];
+}
+
+function buildInstallBundle(channel: InstallChannel, setupArgs: string): InstallBundle {
+  switch (channel) {
+    case "brew":
+      return {
+        steps: [
+          { label: "Install via Homebrew", command: "brew install beevibe-ai/tap/beevibe-daemon" },
+          { label: "Register", command: `${LOCAL_BIN} ${setupArgs}` },
+          { label: "Start (long-running)", command: `${LOCAL_BIN} start` },
+        ],
+      };
+    case "npx":
+      return {
+        steps: [
+          {
+            label: "Register (downloads daemon on first run)",
+            command: `${NPX_BIN} ${setupArgs}`,
+          },
+          { label: "Start (long-running)", command: `${NPX_BIN} start` },
+        ],
+      };
+    case "direct":
+      return {
+        prelude: (
+          <p className="text-xs text-muted-foreground leading-relaxed">
+            Pick the binary that matches your platform from{" "}
+            <a
+              href={RELEASES_URL}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="underline hover:text-foreground"
+            >
+              the latest GitHub release
+            </a>
+            {" "}— darwin-arm64, darwin-x64, linux-x64, or linux-arm64. Then:
+          </p>
+        ),
+        steps: [
+          {
+            label: "Download (substitute your platform)",
+            command:
+              `curl -fsSL -o ~/.local/bin/${LOCAL_BIN} \\\n` +
+              `  "${RELEASES_URL}/download/${LOCAL_BIN}-darwin-arm64" \\\n` +
+              `  && chmod +x ~/.local/bin/${LOCAL_BIN}`,
+          },
+          { label: "Register", command: `${LOCAL_BIN} ${setupArgs}` },
+          { label: "Start (long-running)", command: `${LOCAL_BIN} start` },
+        ],
+      };
+  }
+}
+
+// Runs once on mount — userAgent doesn't change for the page lifetime.
+function detectDefaultChannel(): InstallChannel {
+  if (typeof navigator === "undefined") return "npx";
+  if (/Mac OS X|Macintosh/i.test(navigator.userAgent)) return "brew";
+  return "npx";
+}
+
+export function DaemonInstallInstructions({ className }: { className?: string }) {
+  const userKey = typeof window !== "undefined" ? getUserKey() : null;
+  const apiUrl = apiBaseUrl ?? "http://localhost:3000";
+  const keyOrPlaceholder = userKey ?? "<your-key>";
+  const setupArgs = `setup --api ${apiUrl} --user-token ${keyOrPlaceholder}`;
+
+  const [channel, setChannel] = useState<InstallChannel>(() => detectDefaultChannel());
+  const bundle = buildInstallBundle(channel, setupArgs);
+
+  return (
+    <div className={cn("space-y-3", className)}>
+      <div className="flex gap-1 rounded-lg border border-border bg-card p-1">
+        {INSTALL_OPTIONS.map((opt) => (
+          <button
+            key={opt.id}
+            type="button"
+            onClick={() => setChannel(opt.id)}
+            className={cn(
+              "flex-1 rounded px-3 py-1.5 text-xs font-medium transition-colors cursor-pointer",
+              channel === opt.id
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            <div>{opt.label}</div>
+            <div className="text-[10px] font-normal opacity-80 mt-0.5">{opt.hint}</div>
+          </button>
+        ))}
+      </div>
+      <div className="space-y-2">
+        {bundle.prelude}
+        {bundle.steps.map((step, i) => (
+          <CommandBlock key={i} label={`${i + 1}. ${step.label}`} command={step.command} />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Runtimes tab setup snippet**: the install commands were still the pre-publish `pnpm daemon …` block. Extracted the welcome flow's channel picker (Homebrew / npx / direct download) into a shared `<DaemonInstallInstructions>` and rendered it in both the welcome wizard and the Runtimes tab so the two screens stay in sync.
- **Daemon presence stuck offline after WS reconnect**: `RuntimeWsServer.onConnect` only touched the in-memory hub, so the DB trigger that fires `runtime.updated` SSE never ran. The Runtimes tab and the agent detail runtime picker stayed on the offline icon until the next HTTP heartbeat (~30s) or the React Query staleTime expired. Now we call `runtimeRepo.heartbeat()` for each subscribed runtime when the upgrade completes; the existing trigger broadcasts SSE and the web invalidates `queryKeys.runtimes.all` immediately.

## Test plan
- [x] `pnpm --filter @beevibe/api test` — 232/232 unit tests pass; the 6 failures are pre-existing live-DB integration tests unrelated to this change.
- [x] `pnpm --filter @beevibe/api typecheck` — clean.
- [x] `pnpm --filter @beevibe/web typecheck` — clean.
- [x] `pnpm --filter @beevibe/web test` — 141/141 pass.
- [x] `pnpm --filter @beevibe/web lint` — clean.
- [x] Updated `ws-server.test.ts` to assert `last_heartbeat` is stamped after WS upgrade (runs in CI with the live DB).
- [ ] Visual check that the Runtimes tab shows the new channel picker and that a daemon flipping online refreshes the dot without a manual reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)