### PR TITLE
fix(agent-network): show every owner's team, not just shared-room peers

### DIFF
--- a/packages/api/src/views/agent-network.ts
+++ b/packages/api/src/views/agent-network.ts
@@ -1,17 +1,17 @@
 /**
- * Agent network view — the caller's own team plus peer teams they
- * collaborate with through shared rooms.
+ * Agent network view — the caller's own team plus every other user's
+ * team-and-tree shown as peer orbits.
  *
  * The pitch is "teams of specialists working alongside other teams";
- * the data model already supports it (agents have owner_id, rooms link
- * agents from multiple owners), but the /agent list endpoint scopes
- * to the caller's tree. This view is the explicit cross-owner surface.
+ * the agent graph is the discovery surface for that. The previous
+ * room-membership gate left new users (and anyone who hadn't created
+ * rooms yet) invisible to each other — bootstrapping a collaboration
+ * required already knowing the other person, which defeats the point.
  *
- * Peer set is derived from co-membership in rooms: for every room the
- * caller is a member of, every agent member of that room whose owner
- * isn't the caller becomes a peer-network anchor. We then rope in that
- * peer's full agent tree (their team + ICs) so the UI can render a
- * complete satellite orbit.
+ * Today the cross-owner surface is open: every non-archived agent
+ * belonging to someone other than the caller is a potential peer. The
+ * UI still groups by owner so the rendering reads as "Daniel's team"
+ * rather than a flat list.
  *
  * `owner_label` is the person's name; rendered next to the team agent
  * avatar so peer orbits read as "Daniel's team", not just "Roadmap".
@@ -32,27 +32,18 @@ LEFT JOIN (SELECT agent_id, COUNT(*)::int AS n FROM session GROUP BY agent_id) s
 LEFT JOIN (SELECT agent_id, COUNT(*)::int AS n FROM memory_fact GROUP BY agent_id) fc
   ON fc.agent_id = a.id
 WHERE a.owner_id = $1
+  AND a.archived_at IS NULL
 ORDER BY
   CASE a.hierarchy_level WHEN 'org' THEN 0 WHEN 'team' THEN 1 ELSE 2 END,
   a.name ASC
 `;
 
-// Peer agents — every agent in any room the caller co-attends, scoped
-// to OTHER owners so the caller's own agents don't appear twice. Walks
-// room_member from caller (kind=person) → shared rooms → agent
-// members. Returns the full tree per peer owner so the UI can render
-// each peer team's specialists, not just the top-level avatar.
+// Peer agents — every non-archived agent owned by someone other than
+// the caller. The UI groups by owner_id (preserved by ORDER BY) so each
+// peer team renders as one satellite orbit; team rows come first within
+// each owner bucket so the orbit's centre is the team agent and ICs
+// trail.
 const PEERS_SQL = /* sql */ `
-WITH peer_owners AS (
-  SELECT DISTINCT a.owner_id
-  FROM room_member me
-  JOIN room_member rm  ON rm.room_id = me.room_id
-  JOIN agent       a   ON a.id = rm.agent_id
-  WHERE me.kind = 'person'
-    AND me.person_id = $1
-    AND rm.kind = 'agent'
-    AND a.owner_id <> $1
-)
 SELECT
   a.id, a.name, a.owner_id, a.parent_agent_id, a.hierarchy_level,
   a.review_policy, a.runtime_config, a.created_at, a.updated_at,
@@ -60,12 +51,13 @@ SELECT
   COALESCE(sc.n, 0)::int  AS sessions_count,
   COALESCE(fc.n, 0)::int  AS facts_learned
 FROM agent a
-JOIN peer_owners po ON po.owner_id = a.owner_id
-JOIN person p       ON p.id = a.owner_id
+JOIN person p ON p.id = a.owner_id
 LEFT JOIN (SELECT agent_id, COUNT(*)::int AS n FROM session GROUP BY agent_id) sc
   ON sc.agent_id = a.id
 LEFT JOIN (SELECT agent_id, COUNT(*)::int AS n FROM memory_fact GROUP BY agent_id) fc
   ON fc.agent_id = a.id
+WHERE a.owner_id <> $1
+  AND a.archived_at IS NULL
 ORDER BY a.owner_id,
   CASE a.hierarchy_level WHEN 'org' THEN 0 WHEN 'team' THEN 1 ELSE 2 END,
   a.name ASC
@@ -90,7 +82,12 @@ interface PeerRow extends AgentRow {
 }
 
 function rowToAgentDisplay(row: AgentRow): AgentDisplay {
-  const runtime = (row.runtime_config?.model as string | undefined) ?? "claude-code";
+  // PR #96 split runtime (CLI tool) from model (LLM alias). This view
+  // was previously surfacing `runtime_config.model` as `runtime` — same
+  // conflation. Match `agents.ts` so the network UI shows "claude" not
+  // "claude-opus-4-7" under the Runtime label.
+  const runtime = (row.runtime_config?.type as string | undefined) ?? "claude";
+  const model = row.runtime_config?.model as string | undefined;
   return {
     id: row.id,
     name: row.name,
@@ -104,6 +101,7 @@ function rowToAgentDisplay(row: AgentRow): AgentDisplay {
     sessions_count: Number(row.sessions_count),
     facts_learned: Number(row.facts_learned),
     runtime,
+    model,
     review_policy: (row.review_policy ?? undefined) as AgentDisplay["review_policy"],
   };
 }

--- a/packages/api/src/views/agent-network.ts
+++ b/packages/api/src/views/agent-network.ts
@@ -18,7 +18,15 @@
  */
 
 import type { Pool } from "@beevibe/core/adapters/postgres";
+import type { RuntimeConfig } from "@beevibe/core";
 import type { AgentDisplay, AgentNetwork, AgentPeerOwner } from "./types.js";
+
+// Defensive cap on the peer fetch. The agent graph is one orbit per
+// owner (~5 agents each); 500 rows covers roughly 100 owners' trees.
+// Beyond that we'd want owner-level pagination, but cutting at row
+// level here is fine as a tripwire — payload size stays bounded and
+// the UI is unusable with 100+ orbits anyway.
+const PEERS_LIMIT = 500;
 
 const SELF_SQL = /* sql */ `
 SELECT
@@ -61,6 +69,7 @@ WHERE a.owner_id <> $1
 ORDER BY a.owner_id,
   CASE a.hierarchy_level WHEN 'org' THEN 0 WHEN 'team' THEN 1 ELSE 2 END,
   a.name ASC
+LIMIT ${PEERS_LIMIT}
 `;
 
 interface AgentRow {
@@ -70,7 +79,7 @@ interface AgentRow {
   parent_agent_id: string | null;
   hierarchy_level: "ic" | "team" | "org";
   review_policy: string | null;
-  runtime_config: Record<string, unknown>;
+  runtime_config: RuntimeConfig;
   created_at: Date;
   updated_at: Date;
   sessions_count: string | number;
@@ -86,8 +95,8 @@ function rowToAgentDisplay(row: AgentRow): AgentDisplay {
   // was previously surfacing `runtime_config.model` as `runtime` — same
   // conflation. Match `agents.ts` so the network UI shows "claude" not
   // "claude-opus-4-7" under the Runtime label.
-  const runtime = (row.runtime_config?.type as string | undefined) ?? "claude";
-  const model = row.runtime_config?.model as string | undefined;
+  const runtime = row.runtime_config.type ?? "claude";
+  const model = row.runtime_config.model;
   return {
     id: row.id,
     name: row.name,


### PR DESCRIPTION
## Diagnosis

The agent graph at `/agent-network` (and the data behind it) gates peer visibility on **room co-membership**. From `packages/api/src/views/agent-network.ts:45-72`:

\`\`\`sql
WITH peer_owners AS (
  SELECT DISTINCT a.owner_id
  FROM room_member me
  JOIN room_member rm ON rm.room_id = me.room_id
  JOIN agent       a  ON a.id = rm.agent_id
  WHERE me.kind = 'person'
    AND me.person_id = $1
    AND rm.kind = 'agent'
    AND a.owner_id <> $1
)
\`\`\`

For Alice to see Bob's team agent: Alice must be a `person`-member of room R **and** Bob's agent must be an `agent`-member of the same R. Without that wiring, Bob's agent stays invisible — even though `agent.owner_id = bob` is sitting in the DB.

Onboarding state correlates (a user who hasn't onboarded hasn't built rooms) but isn't the gate. The gate is `room_member` co-attendance. It's a discovery bootstrap problem: you can't see anyone to invite them into a room, but a room is what makes them visible.

## Fix

Drop the room CTE. Peer set is now "every non-archived agent owned by someone other than the caller." The UI still groups by `owner_id` (preserved by `ORDER BY`) so each peer team renders as one satellite orbit; team rows precede ICs within each bucket so orbits read centre-out.

## Bonus fixes in the same file

While I was in there, two adjacent bugs from earlier PRs:
- **`SELF_SQL` archived filter** — added `AND a.archived_at IS NULL` so archived agents stop polluting the graph. Matches `/agent` list (`agents.ts:64`).
- **`runtime` / `model` conflation** — `rowToAgentDisplay` was returning `runtime_config.model` under the `runtime` key (the PR #96 fix didn't reach this view). Fixed: `runtime` now reads `.type`, `.model` is surfaced separately. Matches `agents.ts:73-78`.

## Test plan
- [x] `pnpm --filter @beevibe/api test` — 308 pass (mock-pool tests verify row mapping + per-owner grouping; SQL change is opaque to them)
- [x] `pnpm --filter @beevibe/api build` green
- [x] `pnpm --filter @beevibe/web typecheck` green
- [ ] Manual smoke: sign in as user A → /agent-network → see user B's team agent as a peer orbit even when there are no shared rooms. Archived agents do not appear. Runtime field shows "claude" not "claude-opus-4-7".

🤖 Generated with [Claude Code](https://claude.com/claude-code)