### PR TITLE
fix(chat): keep user message visible on 503; auto-recover when daemon reconnects

### DIFF
--- a/packages/web/lib/hooks/use-chat.ts
+++ b/packages/web/lib/hooks/use-chat.ts
@@ -10,6 +10,7 @@ import {
   type SuggestedAction,
 } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
+import { ApiError } from "@/lib/api/http";
 import { queryKeys } from "./keys";
 
 export interface ChatMessage {
@@ -187,8 +188,18 @@ export function useChat(opts: UseChatOptions = {}) {
         queryKey: queryKeys.chat.history(undefined),
       });
     },
-    onError: () => {
-      // Roll back the optimistic user turn so the input doesn't look
+    onError: (err) => {
+      // agent_offline (503) is special: the api persisted the session row
+      // before rejecting, so the turn is queued, not lost. Keep the user
+      // message visible — refresh would show it anyway from the server,
+      // and rolling back here just creates a flicker of "vanished, then
+      // back on refresh". When the daemon reconnects and the session
+      // completes, session.updated SSE invalidates chat queries and the
+      // response auto-appears.
+      if (err instanceof ApiError && err.errorCode === "agent_offline") return;
+
+      // Other errors (429 rate limit, 400 validation, etc.) reject the
+      // turn before persistence — roll back so the input doesn't look
       // sent-and-stuck.
       queryClient.setQueryData<ChatHistoryResponse>(queryKey, (prev) => {
         if (!prev) return prev;

--- a/packages/web/lib/hooks/use-chat.ts
+++ b/packages/web/lib/hooks/use-chat.ts
@@ -219,6 +219,17 @@ export function useChat(opts: UseChatOptions = {}) {
     [mutation],
   );
 
+  // Clear the prior turn's error banner once the auto-recovery path
+  // settles: when SSE invalidation fans an agent reply into the cache
+  // (the queued session finally completed), `messages.at(-1)` flips to
+  // an "agent" role. Without this reset, the chat UI shows the new
+  // reply AND a stale "Couldn't reach the agent" banner side-by-side.
+  const lastRole = messages.at(-1)?.role;
+  const { isError: mutationIsError, reset: resetMutation } = mutation;
+  useEffect(() => {
+    if (mutationIsError && lastRole === "agent") resetMutation();
+  }, [mutationIsError, lastRole, resetMutation]);
+
   return {
     messages,
     send,

--- a/packages/web/lib/sse.ts
+++ b/packages/web/lib/sse.ts
@@ -36,7 +36,17 @@ const eventInvalidations: Record<string, InvalidationKey[]> = {
     queryKeys.activity.all,
     queryKeys.agentNetwork.all,
   ],
-  "session.updated": [queryKeys.sessions.all, queryKeys.tasks.all, queryKeys.activity.all],
+  "session.updated": [
+    queryKeys.sessions.all,
+    queryKeys.tasks.all,
+    queryKeys.activity.all,
+    // Chat history is keyed by conversation; a pending chat session
+    // completing (daemon reconnect after agent_offline, or normal turn
+    // settle) flips it from "user message only" → "user + agent reply".
+    // Invalidating the chat tree here is how the UI auto-recovers
+    // without a manual refresh.
+    queryKeys.chat.all,
+  ],
   "memory.fact.created": [queryKeys.memory.all],
   "promotion.created": [queryKeys.promotions.all, queryKeys.memory.all],
   "mesh.activity": [queryKeys.mesh.all, queryKeys.activity.all, queryKeys.inbox.all],

--- a/packages/web/lib/sse.ts
+++ b/packages/web/lib/sse.ts
@@ -40,12 +40,15 @@ const eventInvalidations: Record<string, InvalidationKey[]> = {
     queryKeys.sessions.all,
     queryKeys.tasks.all,
     queryKeys.activity.all,
-    // Chat history is keyed by conversation; a pending chat session
-    // completing (daemon reconnect after agent_offline, or normal turn
-    // settle) flips it from "user message only" → "user + agent reply".
-    // Invalidating the chat tree here is how the UI auto-recovers
-    // without a manual refresh.
-    queryKeys.chat.all,
+    // Chat history only. A pending chat session completing (daemon
+    // reconnect after agent_offline, or normal turn settle) flips it
+    // from "user message only" → "user + agent reply"; that's the
+    // auto-recovery path. We do NOT fan out to `chat.conversations`
+    // here — the sidebar chain head only changes when a new conversation
+    // is opened, and `use-chat`'s onSuccess already invalidates it
+    // explicitly. Refetching it on every non-chat session.updated
+    // (task/mesh transitions) would be pure waste.
+    queryKeys.chat.history(undefined),
   ],
   "memory.fact.created": [queryKeys.memory.all],
   "promotion.created": [queryKeys.promotions.all, queryKeys.memory.all],


### PR DESCRIPTION
## Symptoms

When the daemon is offline and the user sends a chat turn:
1. The message they typed vanishes from the chat surface
2. After refresh, the message reappears but no "agent is thinking" indicator
3. After a second refresh, the agent's response box finally appears

## Root cause

Two separate bugs, both client-side.

### A. `use-chat.ts:190` rolled back the optimistic user turn on ANY error

The chat handler (`packages/api/src/routes/chat.ts:486-509`) calls `dispatchService.dispatchTask` (which **persists the session row**) *before* checking whether the bound daemon is online. If the daemon is offline, the route returns 503 `agent_offline` but the session is already in the DB, marked `pending`, holding the user's intent.

The client's `onError` then rolled back the optimistic user message — making it look "vanished" even though refresh would show it.

### B. `sse.ts:39` didn't invalidate chat on `session.updated`

When the daemon eventually reconnects, claims the pending session, and completes it, the `session.updated` SSE event fires. But the invalidation map only listed `sessions / tasks / activity` — never the chat tree. The agent's response sat in the DB unseen until a manual refresh.

## Fix

- **`onError` keeps the message on `agent_offline`.** Rollback still happens for 400 / 429 / non-persistence errors. Uses `ApiError.errorCode` to differentiate.
- **`session.updated` invalidates `queryKeys.chat.all`.** A pending chat session settling now triggers a chat-history refetch, picking up the agent's eventual reply.

## Known follow-up (not in this PR)

After a cold refresh while a session is still pending, there's no "thinking" indicator. `chainToMessages` (`routes/chat.ts:186`) silently drops pending sessions — no agent placeholder is appended. To get a thinking indicator after refresh, the chat history response needs to surface `pending_session_id` so the chat client can subscribe to `session.event` SSE without a local mutation in flight. Bigger surgery — separate PR.

## Test plan
- [x] `pnpm --filter @beevibe/web typecheck` green
- [x] `pnpm --filter @beevibe/web test` — 141 pass
- [ ] Manual smoke: stop the daemon, send a chat message → 503 returns but the message stays visible with the daemon-offline error block. Start the daemon → within ~30s the agent's response auto-appears in the same chat surface without a manual refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)