### PR TITLE
fix(hub): isOnline considers heartbeat freshness, not just WS push

### DIFF
--- a/packages/api/src/bootstrap.ts
+++ b/packages/api/src/bootstrap.ts
@@ -170,11 +170,14 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
         daemonHub.notify(session.runtime_id, session.id);
       }
     },
-    // Mesh-typed dispatches whose preferred runtime isn't currently
-    // connected get demoted to server_fallback_mesh — the server-fallback
-    // worker picks them up with a restricted tool surface so cross-team
-    // asks don't silently break when the target's daemon is offline.
-    isRuntimeOnline: (runtimeId) => daemonHub.hasRuntime(runtimeId),
+    // Mesh-typed dispatches whose preferred runtime isn't reachable get
+    // demoted to server_fallback_mesh — the server-fallback worker picks
+    // them up with a restricted tool surface so cross-team asks don't
+    // silently break when the target's daemon is offline. Use `isOnline`
+    // (WS or fresh heartbeat) rather than the narrow `hasRuntime` (WS
+    // only); a daemon mid-WS-blip is still reachable via the HTTP claim
+    // poll within ~30s, no need to demote.
+    isRuntimeOnline: (runtimeId) => daemonHub.isOnline(runtimeId),
   });
 
   // M6.4 escalation service: DB-only writes for the resolution + dispatch

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -499,7 +499,7 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
     // pending forever and the user gets a clear error rather than a
     // 90-second timeout. Null runtime_id (legacy executor fallback) is
     // fine — the in-process executor claims within ≤30s.
-    if (dispatchResult.runtime_id && !deps.hub.hasRuntime(dispatchResult.runtime_id)) {
+    if (dispatchResult.runtime_id && !deps.hub.isOnline(dispatchResult.runtime_id)) {
       rateOutcome.release();
       res.status(503).json({
         error: "agent_offline",

--- a/packages/api/src/routes/runtimes.ts
+++ b/packages/api/src/routes/runtimes.ts
@@ -92,7 +92,7 @@ export function createRuntimesRouter(deps: RuntimesRoutesDeps): Router {
           external_id: d.external_id,
           last_seen_at: d.last_seen_at ? d.last_seen_at.toISOString() : null,
           created_at: d.created_at.toISOString(),
-          runtimes: runtimes.map((r) => projectRuntime(r, deps.hub.hasRuntime(r.id))),
+          runtimes: runtimes.map((r) => projectRuntime(r, deps.hub.isOnline(r.id))),
         };
       }),
     );

--- a/packages/api/src/runtime/hub.test.ts
+++ b/packages/api/src/runtime/hub.test.ts
@@ -157,3 +157,44 @@ describe("DaemonHub.hasRuntime", () => {
     expect(hub.hasRuntime("rt_x")).toBe(false);
   });
 });
+
+describe("DaemonHub.isOnline", () => {
+  it("is true while a WS client is subscribed (mirrors hasRuntime)", () => {
+    const a = makeClient("dmn_a", ["rt_x"]);
+    hub.register(a);
+    expect(hub.isOnline("rt_x")).toBe(true);
+    hub.unregister(a);
+    // No HTTP heartbeat after unregister, but the register itself
+    // bumped lastSeen — within freshness window it's still online.
+    expect(hub.isOnline("rt_x")).toBe(true);
+  });
+
+  it("falls back to heartbeat freshness when no WS client is connected", () => {
+    const t0 = 1_000_000;
+    hub.bumpLastSeen("rt_x", t0);
+    // No register — purely an HTTP-heartbeat-only daemon.
+    expect(hub.hasRuntime("rt_x")).toBe(false);
+    expect(hub.isOnline("rt_x", t0 + 15_000)).toBe(true);
+    // 30s freshness window: at exactly 30s still online; past that, offline.
+    expect(hub.isOnline("rt_x", t0 + 30_000)).toBe(true);
+    expect(hub.isOnline("rt_x", t0 + 30_001)).toBe(false);
+  });
+
+  it("returns false for a runtime we've never heard from", () => {
+    expect(hub.isOnline("rt_never")).toBe(false);
+  });
+
+  it("survives a WS drop when heartbeats keep arriving", () => {
+    const t0 = 1_000_000;
+    const a = makeClient("dmn_a", ["rt_x"]);
+    hub.register(a); // bumps lastSeen at t=t0
+    hub.unregister(a);
+    // 25s later — past nothing yet, well within freshness even without
+    // a heartbeat top-up. (Real daemons heartbeat at 15s, so they'd
+    // refresh long before this.)
+    expect(hub.isOnline("rt_x", t0 + 25_000)).toBe(true);
+    // A heartbeat at t=29s extends the window.
+    hub.bumpLastSeen("rt_x", t0 + 29_000);
+    expect(hub.isOnline("rt_x", t0 + 50_000)).toBe(true);
+  });
+});

--- a/packages/api/src/runtime/hub.ts
+++ b/packages/api/src/runtime/hub.ts
@@ -29,12 +29,36 @@ export interface DaemonClient {
 
 const DEDUP_CAP = 128;
 
+/**
+ * How recently we need to have heard from a daemon (HTTP heartbeat OR
+ * WS upgrade) for its runtimes to count as "online". Daemons heartbeat
+ * every 15s (DEFAULT_HEARTBEAT_MS in packages/daemon/src/claimer.ts), so
+ * 30s allows one missed beat before we flip offline.
+ *
+ * Why this matters: `hasRuntime` only knows about WS pushes — a daemon
+ * whose WebSocket briefly dropped but is still heartbeating via HTTP
+ * looks "offline" to anyone checking `hasRuntime`, even though chat
+ * dispatches would land on the next 30s HTTP claim poll. `isOnline`
+ * adds the heartbeat fallback so the chat 503 fast-fail and the UI's
+ * online dot don't false-negative on WS blips.
+ */
+const ONLINE_FRESHNESS_MS = 30_000;
+
 export class DaemonHub {
   private readonly byRuntimeId = new Map<string, Set<DaemonClient>>();
   private readonly byDaemonId = new Map<string, Set<DaemonClient>>();
   private readonly dedup = new WeakMap<DaemonClient, Set<string>>();
+  /**
+   * Last time we heard from each runtime, via WS upgrade or HTTP
+   * heartbeat. Read by `isOnline`. Bumped from `bumpLastSeen` (called
+   * by the heartbeat HTTP handler) and from `register` (called by
+   * RuntimeWsServer.onConnect). Process-local; lost on api restart,
+   * which is fine — the next heartbeat (within 15s) refills it.
+   */
+  private readonly lastSeen = new Map<string, number>();
 
   register(client: DaemonClient): void {
+    const now = Date.now();
     for (const rid of client.runtimeIds) {
       let bucket = this.byRuntimeId.get(rid);
       if (!bucket) {
@@ -42,6 +66,7 @@ export class DaemonHub {
         this.byRuntimeId.set(rid, bucket);
       }
       bucket.add(client);
+      this.lastSeen.set(rid, now);
     }
     let dbucket = this.byDaemonId.get(client.daemonId);
     if (!dbucket) {
@@ -108,9 +133,35 @@ export class DaemonHub {
     return n;
   }
 
-  /** Is this runtime currently online (≥1 client subscribed)? */
+  /**
+   * Is this runtime currently WS-subscribed? Narrow — true only when a
+   * push-channel client is connected RIGHT NOW. Use this for things
+   * that need an immediate-delivery guarantee (`hub.notify` internal
+   * fan-out). For "is the daemon reachable at all," prefer `isOnline`.
+   */
   hasRuntime(runtimeId: string): boolean {
     return (this.byRuntimeId.get(runtimeId)?.size ?? 0) > 0;
+  }
+
+  /**
+   * Is this runtime reachable via any channel — WS push OR recent HTTP
+   * heartbeat? Broader than `hasRuntime`; this is what user-facing
+   * surfaces (chat 503 fast-fail, online dot) should use so a WS blip
+   * doesn't false-negative against a daemon that's still heartbeating.
+   */
+  isOnline(runtimeId: string, now: number = Date.now()): boolean {
+    if (this.hasRuntime(runtimeId)) return true;
+    const seen = this.lastSeen.get(runtimeId);
+    return seen !== undefined && now - seen <= ONLINE_FRESHNESS_MS;
+  }
+
+  /**
+   * Note a liveness signal for a runtime. Called by the HTTP heartbeat
+   * route so `isOnline` includes daemons whose WS dropped but are still
+   * heartbeating. WS register also bumps this implicitly.
+   */
+  bumpLastSeen(runtimeId: string, now: number = Date.now()): void {
+    this.lastSeen.set(runtimeId, now);
   }
 
   private deliver(

--- a/packages/api/src/runtime/hub.ts
+++ b/packages/api/src/runtime/hub.ts
@@ -16,6 +16,8 @@
  *     10 concern (pg_notify('runtime_wakeup', json) + per-instance hubs).
  */
 
+import { RUNTIME_HEARTBEAT_INTERVAL_MS } from "@beevibe/core";
+
 export type DaemonPushPayload =
   | { type: "task_available"; runtime_id: string; session_id: string }
   | { type: "cancel"; session_id: string };
@@ -31,9 +33,9 @@ const DEDUP_CAP = 128;
 
 /**
  * How recently we need to have heard from a daemon (HTTP heartbeat OR
- * WS upgrade) for its runtimes to count as "online". Daemons heartbeat
- * every 15s (DEFAULT_HEARTBEAT_MS in packages/daemon/src/claimer.ts), so
- * 30s allows one missed beat before we flip offline.
+ * WS upgrade) for its runtimes to count as "online". Derived from the
+ * shared `RUNTIME_HEARTBEAT_INTERVAL_MS` so the two values can't drift —
+ * 2× gives one missed-beat of slack before flipping offline.
  *
  * Why this matters: `hasRuntime` only knows about WS pushes — a daemon
  * whose WebSocket briefly dropped but is still heartbeating via HTTP
@@ -42,7 +44,7 @@ const DEDUP_CAP = 128;
  * adds the heartbeat fallback so the chat 503 fast-fail and the UI's
  * online dot don't false-negative on WS blips.
  */
-const ONLINE_FRESHNESS_MS = 30_000;
+const ONLINE_FRESHNESS_MS = 2 * RUNTIME_HEARTBEAT_INTERVAL_MS;
 
 export class DaemonHub {
   private readonly byRuntimeId = new Map<string, Set<DaemonClient>>();
@@ -66,7 +68,10 @@ export class DaemonHub {
         this.byRuntimeId.set(rid, bucket);
       }
       bucket.add(client);
-      this.lastSeen.set(rid, now);
+      // WS upgrade counts as a liveness signal — route through the same
+      // method as the HTTP heartbeat handler so there's one canonical
+      // path for "we just heard from this runtime."
+      this.bumpLastSeen(rid, now);
     }
     let dbucket = this.byDaemonId.get(client.daemonId);
     if (!dbucket) {

--- a/packages/api/src/runtime/router.ts
+++ b/packages/api/src/runtime/router.ts
@@ -125,13 +125,16 @@ export function createRuntimeRouter(deps: RuntimeRouterDeps): Router {
       res.status(400).json({ error: "invalid_body", message: "runtime_ids required" });
       return;
     }
+    const runtimeIds = body.runtime_ids.filter(
+      (id): id is string => typeof id === "string",
+    );
     try {
       await deps.daemonRepo.touchLastSeen(req.caller!.daemonId);
-      await Promise.all(
-        body.runtime_ids
-          .filter((id): id is string => typeof id === "string")
-          .map((id) => deps.runtimeRepo.heartbeat(id)),
-      );
+      await Promise.all(runtimeIds.map((id) => deps.runtimeRepo.heartbeat(id)));
+      // Mirror the DB heartbeat into the in-memory hub so `isOnline`
+      // (used by chat 503 + the runtimes panel dot) keeps returning
+      // true even if the WS push channel has dropped.
+      for (const id of runtimeIds) deps.hub.bumpLastSeen(id);
       res.status(204).send();
     } catch (err) {
       console.error("[runtime/heartbeat]", err);

--- a/packages/core/src/domain/runtime.ts
+++ b/packages/core/src/domain/runtime.ts
@@ -13,6 +13,15 @@ export function isKnownCli(v: unknown): v is KnownCli {
   return typeof v === "string" && (KNOWN_CLIS as readonly string[]).includes(v);
 }
 
+/**
+ * Daemon → api heartbeat cadence. Single source of truth so the
+ * server-side freshness window can derive from it (see `DaemonHub`'s
+ * ONLINE_FRESHNESS_MS = 2× this) and the daemon's claimer uses the
+ * same default. Don't drift these two — the hub's "1 missed beat OK"
+ * tolerance assumes the daemon ships at exactly this cadence.
+ */
+export const RUNTIME_HEARTBEAT_INTERVAL_MS = 15_000;
+
 export interface Runtime {
   id: string;
   daemon_id: string;

--- a/packages/daemon/src/claimer.ts
+++ b/packages/daemon/src/claimer.ts
@@ -12,6 +12,7 @@
  */
 
 import WebSocket from "ws";
+import { RUNTIME_HEARTBEAT_INTERVAL_MS } from "@beevibe/core";
 import type { LocalWorkspaceManager } from "@beevibe/core/adapters/local-workspace";
 import type { ApiClient } from "./api-client.js";
 import type { Supervisor } from "./supervisor.js";
@@ -31,7 +32,6 @@ export interface ClaimerConfig {
 }
 
 const DEFAULT_POLL_MS = 30_000;
-const DEFAULT_HEARTBEAT_MS = 15_000;
 const DEFAULT_WS_RECONNECT_MAX_MS = 30_000;
 
 interface PushPayload {
@@ -53,7 +53,7 @@ export class Claimer {
 
   constructor(private readonly cfg: ClaimerConfig) {
     this.pollIntervalMs = cfg.pollIntervalMs ?? DEFAULT_POLL_MS;
-    this.heartbeatIntervalMs = cfg.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_MS;
+    this.heartbeatIntervalMs = cfg.heartbeatIntervalMs ?? RUNTIME_HEARTBEAT_INTERVAL_MS;
     this.wsReconnectMaxDelayMs =
       cfg.wsReconnectMaxDelayMs ?? DEFAULT_WS_RECONNECT_MAX_MS;
   }


### PR DESCRIPTION
## Diagnosis

`hub.hasRuntime(runtime_id)` was load-bearing for three "is the daemon online?" checks:

| Caller | File | Purpose |
|---|---|---|
| Chat 503 fast-fail | `chat.ts:502` | Bail before awaiting resolver if no daemon listening |
| Runtimes panel online dot | `runtimes.ts:95` | UI green/gray indicator |
| Mesh server-fallback demotion | `bootstrap.ts:177` → `dispatch-service.ts:111` | Fall back to in-process restricted-tools spawn when target's daemon is offline |

But `hasRuntime` only knows about **WebSocket push channels**. A daemon whose WS dropped (network blip, proxy reset) but is still heartbeating via HTTP every 15s returns `false` — so we false-503 the chat, flip the dot gray, and demote mesh asks, all while the daemon would have claimed the work on its next 30s HTTP poll.

This is the broader version of #114: that PR fixed the WS reconnect signal so the dot updates fast; this PR fixes the **semantics** of "online" so the dot (and chat, and mesh) don't false-negative in the first place.

## Fix

New `hub.isOnline(runtime_id)` returns true when EITHER:
1. A WS push client is currently subscribed (the existing `hasRuntime` check), OR
2. The runtime's `lastSeen` timestamp is within `ONLINE_FRESHNESS_MS = 30_000` (2× the daemon's 15s heartbeat cadence)

The hub keeps a `lastSeen: Map<runtime_id, number>` bumped from:
- `register()` — WS upgrade implicitly counts as a liveness signal
- `bumpLastSeen()` — called from the HTTP heartbeat handler (one new line in `runtime/router.ts`)

`hasRuntime` stays as-is for `hub.notify` internals (where we genuinely need an active WS client to send to). All three user-facing checks switch to `isOnline`.

## Why not query `runtime.last_heartbeat` in the DB?

Two reasons:
1. **Cost** — every chat POST, every /runtimes load, every mesh dispatch would add a DB roundtrip just to read a single timestamp. The in-memory map gives O(1) lookup with the same accuracy (it's bumped from the same place that writes the DB row).
2. **No new staleness** — the hub map is process-local and lost on api restart, but the next heartbeat (≤15s later) refills it. During the gap, callers get `false` instead of `true` — fail-closed, which is the safer direction.

## Test plan
- [x] `pnpm --filter @beevibe/api test` — 312 pass (4 new tests for `isOnline` cover WS-only, heartbeat-only, freshness-edge, expiry-past-30s, WS-drop-with-heartbeats)
- [x] `pnpm --filter @beevibe/api build` green
- [ ] Manual smoke: kill the daemon's WS (e.g. block port to ws-server) while HTTP heartbeats keep flowing — runtimes dot stays green, chat dispatches succeed (waiting up to 30s for HTTP claim), mesh asks don't demote to server-fallback

## Relationship to other PRs
- **#114** fixed the WS reconnect → DB heartbeat write so `runtime.updated` SSE fires. The dot now updates in ms instead of waiting for the next HTTP heartbeat. This PR fixes what the dot's `online` flag *means* — addresses the case where heartbeat is fine but WS isn't.
- **#116** (open) — chat 503 client-side handling. This PR reduces how often the 503 fires in the first place; #116 makes the cases where it does fire less jarring. They're complementary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)