### PR TITLE
fix(memory): per-fact-type descriptions surface failure-mode guards (issue #90 part 1)

### DIFF
--- a/packages/api/src/tools/save-memory.ts
+++ b/packages/api/src/tools/save-memory.ts
@@ -65,13 +65,10 @@ export function createSaveMemoryTool(
       "retrieval across all future sessions. Store self-contained facts that " +
       "stand alone when retrieved later (no \"we\", \"the user\", \"recently\" " +
       "— name specific entities and use definite language). One sentence per " +
-      "call; for multiple facts, call the tool multiple times. See the " +
-      "`fact_type` parameter for per-type guidance — each type has a narrow " +
-      "purpose, and if no type fits cleanly you probably shouldn't save the " +
-      "fact. The save date is auto-stamped — future retrievals show " +
-      "saved=YYYY-MM-DD so old facts can be judged for staleness. Persists " +
-      "across sessions; retrievable via the briefing's vector recall and via " +
-      "search_context.",
+      "call; for multiple facts, call the tool multiple times. The save date " +
+      "is auto-stamped — future retrievals show saved=YYYY-MM-DD so old facts " +
+      "can be judged for staleness. Persists across sessions; retrievable via " +
+      "the briefing's vector recall and via search_context.",
     schema: SAVE_MEMORY_SCHEMA as Record<string, unknown>,
     handler: async (input) => {
       const content = input.content;

--- a/packages/api/src/tools/save-memory.ts
+++ b/packages/api/src/tools/save-memory.ts
@@ -1,6 +1,24 @@
 import type { FactStore } from "@beevibe/core/services/memory";
-import { FACT_TYPES, type FactType } from "@beevibe/core";
+import { FACT_TYPES, FACT_TYPE_DESCRIPTIONS, type FactType } from "@beevibe/core";
 import type { AgentTool } from "./types.js";
+
+/**
+ * Render the per-fact-type guidance for the tool's `fact_type` enum
+ * description. Reads from FACT_TYPE_DESCRIPTIONS so this stays in
+ * lockstep with the same guidance the agent sees in its briefing —
+ * mirrors `buildBlockNameDescription` in update-core-memory.ts.
+ */
+function buildFactTypeDescription(): string {
+  const typeList = FACT_TYPES.map(
+    (t) => `- **${t}**: ${FACT_TYPE_DESCRIPTIONS[t]}`,
+  ).join("\n");
+  return (
+    "What kind of fact this is. Each type has a narrow purpose — content for " +
+    "one type doesn't belong under another. Read the type guidance before " +
+    "writing; if no type fits cleanly, you probably shouldn't save the fact.\n\n" +
+    typeList
+  );
+}
 
 const SAVE_MEMORY_SCHEMA = {
   type: "object",
@@ -14,10 +32,7 @@ const SAVE_MEMORY_SCHEMA = {
     fact_type: {
       type: "string",
       enum: FACT_TYPES,
-      description:
-        "What kind of fact: belief (a position you hold), pattern (a recurring " +
-        "observation), gotcha (a thing-that-bites if forgotten), preference " +
-        "(your or the team's stated preference), decision (a chosen path with rationale).",
+      description: buildFactTypeDescription(),
     },
   },
   required: ["content", "fact_type"],
@@ -47,17 +62,16 @@ export function createSaveMemoryTool(
     name: "save_memory",
     description:
       "Save a fact, learning, or insight to long-term archival memory for " +
-      "retrieval across all future sessions. Best practices: store " +
-      "self-contained facts or summaries that stand alone when retrieved " +
-      "later (no 'we', 'the user', 'recently' — name specific entities and " +
-      "use definite language). One sentence per call; for multiple facts, " +
-      "call the tool multiple times. Pick fact_type to match provenance: " +
-      "decision rationale → 'decision', non-obvious thing-that-bites → " +
-      "'gotcha', recurring observation → 'pattern', stated preference → " +
-      "'preference', position you hold → 'belief'. The save date is auto-" +
-      "stamped — future retrievals show saved=YYYY-MM-DD so old facts can " +
-      "be judged for staleness. Persists across sessions; retrievable via " +
-      "the briefing's vector recall and via search_context.",
+      "retrieval across all future sessions. Store self-contained facts that " +
+      "stand alone when retrieved later (no \"we\", \"the user\", \"recently\" " +
+      "— name specific entities and use definite language). One sentence per " +
+      "call; for multiple facts, call the tool multiple times. See the " +
+      "`fact_type` parameter for per-type guidance — each type has a narrow " +
+      "purpose, and if no type fits cleanly you probably shouldn't save the " +
+      "fact. The save date is auto-stamped — future retrievals show " +
+      "saved=YYYY-MM-DD so old facts can be judged for staleness. Persists " +
+      "across sessions; retrievable via the briefing's vector recall and via " +
+      "search_context.",
     schema: SAVE_MEMORY_SCHEMA as Record<string, unknown>,
     handler: async (input) => {
       const content = input.content;

--- a/packages/core/src/domain/memory.ts
+++ b/packages/core/src/domain/memory.ts
@@ -12,6 +12,44 @@ export const FACT_TYPES: readonly FactType[] = [
   "decision",
 ] as const;
 
+/**
+ * Per-fact-type guidance. Single source of truth — surfaced inside the
+ * `save_memory` tool's `fact_type` enum description so the agent sees
+ * the intent + the "don't save this" guards at decision time, before
+ * it writes. Mirrors the role of `BlockTemplate.description` for core
+ * memory.
+ *
+ * The failure-mode guards encoded here come from issue #90: agents
+ * over-saved (a) one-off scoped requests as durable preferences and
+ * (b) self-referential meta-patterns about their own search/save
+ * behavior. Each description names the trap explicitly.
+ */
+export const FACT_TYPE_DESCRIPTIONS: Record<FactType, string> = {
+  belief:
+    "A position you hold based on multiple sessions of evidence. A lasting view, " +
+    "not a fleeting reaction to one session.",
+  pattern:
+    "A recurring observation about the codebase or the domain you work in — " +
+    "knowledge another agent could reuse. NOT a pattern about your own behavior " +
+    "(your search habits, your memory-keeping, how you should have responded next " +
+    "time). Save the thing you learned about the world, not a note-to-self about " +
+    "how to behave.",
+  gotcha:
+    "A non-obvious thing-that-bites — a footgun that's easy to step on, where the " +
+    "surprise itself is the value. Concrete and reusable across future tasks in " +
+    "the same area.",
+  preference:
+    "A user's stated durable rule. Trigger words: \"always\", \"from now on\", " +
+    "\"every time\", \"as a default\", \"going forward\". Do NOT save preferences " +
+    "for one-off requests scoped to a specific task, session, or work-product " +
+    "(\"after this task\", \"for this audit\", \"now\"). When in doubt, just do the " +
+    "thing once without saving — the user can restate it if they want it to stick.",
+  decision:
+    "A chosen path with rationale. The \"why\" that future-you (or another agent) " +
+    "needs to understand why the codebase / approach looks the way it does — not " +
+    "the mechanical \"what\" (read the code for that).",
+};
+
 export interface MemoryFact {
   id: string;
   agent_id: string;

--- a/packages/core/src/services/spawn-prep.ts
+++ b/packages/core/src/services/spawn-prep.ts
@@ -138,16 +138,13 @@ top-k hits arrive in your USER prompt as <archival_memory>...</archival_memory>)
   patterns, niche facts. Cheap; default home.
 
 When to update memory (proactively, mid-session):
-- You resolved something tricky → save_memory(rationale, "decision")
-- You hit a non-obvious gotcha → save_memory(...., "gotcha")
-- You found a pattern that worked → save_memory(..., "pattern")
-- A user/teammate stated a DURABLE preference ("always do X", "from
-  now on") → save_memory(..., "preference")
-- Your role/domain shifted → update_core_memory(persona/domain, ...)
-
-DO NOT save_memory("preference") for one-off requests ("can you do X
-this time", "for this task"). Those are session-scoped instructions,
-not preferences worth carrying forward.
+- You resolved something tricky, hit a gotcha, or found a transferable
+  pattern about the codebase/domain → save_memory. Pick fact_type per
+  the tool's enum description — each type has explicit "don't save
+  this" guards (e.g. preference only for durable rules, not one-off
+  requests; pattern only for transferable knowledge, not notes-to-self
+  about your own behavior).
+- Your role/domain shifted → update_core_memory(persona/domain, ...).
 
 Before writing to a core memory block, READ THE BLOCK'S "description"
 attribute in your <core_memory> render. Each block has a narrow purpose

--- a/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
+++ b/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
@@ -14,6 +14,7 @@ import { queryKeys } from "@/lib/hooks/keys";
 import { Avatar } from "@/components/avatar";
 import { HierChip } from "@/components/hier-chip";
 import { CoreBlockCard } from "@/components/agents/core-block-card";
+import { RecentSessionRow } from "@/components/agents/recent-session-row";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
@@ -22,14 +23,7 @@ import { FooterField } from "@/components/detail/footer-field";
 import { Metric } from "@/components/detail/metric";
 import { cn } from "@/lib/utils";
 import type { AgentDetail } from "@/lib/api/types";
-import type { RecentSession } from "@/lib/types/agents";
 import type { ReviewPolicy } from "@beevibe/core";
-
-const RECENT_SESSION_DOT: Record<RecentSession["status"], string> = {
-  running: "bg-status-running animate-pulse-breathe",
-  review: "bg-status-review",
-  succeeded: "bg-status-done",
-};
 
 const AgentsBackLink = () => (
   <Link
@@ -210,7 +204,11 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
             ) : (
               <ul className="space-y-2">
                 {agent.recent_sessions.map((s, i) => (
-                  <RecentSessionRow key={s.short_id ?? i} session={s} />
+                  <RecentSessionRow
+                    key={s.short_id ?? i}
+                    session={s}
+                    variant="comfortable"
+                  />
                 ))}
               </ul>
             )}
@@ -264,44 +262,6 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
         ) : null}
       </footer>
     </DetailShell>
-  );
-}
-
-function RecentSessionRow({ session }: { session: RecentSession }) {
-  const rowInner = (
-    <>
-      <span
-        className={cn("h-1.5 w-1.5 rounded-full", RECENT_SESSION_DOT[session.status])}
-        aria-hidden
-      />
-      <span className="flex-1 min-w-0 truncate">{session.title}</span>
-      {session.short_id ? (
-        <span className="font-mono text-xs text-muted-foreground">{session.short_id}</span>
-      ) : null}
-      <span className="text-xs text-muted-foreground tabular-nums shrink-0">{session.age}</span>
-    </>
-  );
-
-  // Without a short_id we can't route anywhere — render unlinked so we
-  // don't ship a dead <Link>. RecentSession.short_id is currently always
-  // populated in practice; this is defensive against future shapes.
-  if (!session.short_id) {
-    return (
-      <li className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-sm">
-        {rowInner}
-      </li>
-    );
-  }
-
-  return (
-    <li>
-      <Link
-        href={`/sessions/${session.short_id}`}
-        className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-sm hover:bg-secondary/50 hover:border-border/80 transition-colors cursor-pointer"
-      >
-        {rowInner}
-      </Link>
-    </li>
   );
 }
 

--- a/packages/web/components/agents/agent-detail-panel.tsx
+++ b/packages/web/components/agents/agent-detail-panel.tsx
@@ -6,6 +6,7 @@ import { AlertTriangle, Bot, ExternalLink, X } from "lucide-react";
 import { Avatar } from "@/components/avatar";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { CoreBlockCard } from "@/components/agents/core-block-card";
+import { RecentSessionRow } from "@/components/agents/recent-session-row";
 import { EmptyState } from "@/components/empty-state";
 import { HierChip } from "@/components/hier-chip";
 import { Skeleton } from "@/components/skeleton";
@@ -13,15 +14,7 @@ import { isApiConfigured } from "@/lib/api/config";
 import { useAgent } from "@/lib/hooks/use-agents";
 import { useIsOwner } from "@/lib/hooks/use-me";
 import { formatReviewPolicy } from "@/lib/format";
-import { cn } from "@/lib/utils";
 import type { AgentDetail } from "@/lib/api/types";
-import type { RecentSession } from "@/lib/types/agents";
-
-const RECENT_SESSION_DOT: Record<RecentSession["status"], string> = {
-  running: "bg-status-running animate-pulse-breathe",
-  review: "bg-status-review",
-  succeeded: "bg-status-done",
-};
 
 /**
  * Notion-style peek panel for an agent. Anchored to the right of the
@@ -215,7 +208,7 @@ function PanelLoaded({ agent }: { agent: AgentDetail }) {
         {agent.recent_sessions.length > 0 ? (
           <ul className="space-y-1.5">
             {agent.recent_sessions.map((s, i) => (
-              <RecentSessionRow key={s.short_id ?? i} session={s} />
+              <RecentSessionRow key={s.short_id ?? i} session={s} variant="compact" />
             ))}
           </ul>
         ) : null}
@@ -308,45 +301,3 @@ function PanelFooterField({
   );
 }
 
-function RecentSessionRow({ session }: { session: RecentSession }) {
-  const rowInner = (
-    <>
-      <span
-        className={cn("h-1.5 w-1.5 rounded-full shrink-0", RECENT_SESSION_DOT[session.status])}
-        aria-hidden
-      />
-      <span className="flex-1 min-w-0 truncate">{session.title}</span>
-      {session.short_id ? (
-        <span className="font-mono text-[10px] text-muted-foreground shrink-0">
-          {session.short_id}
-        </span>
-      ) : null}
-      <span className="text-[10px] text-muted-foreground tabular-nums shrink-0">
-        {session.age}
-      </span>
-    </>
-  );
-
-  const rowClassName =
-    "flex items-center gap-2 rounded-md border border-border/70 bg-background/40 px-2.5 py-1.5 text-xs";
-
-  // Without a short_id we can't route — render unlinked. Matches the
-  // full /agents/[id] page's defensive handling.
-  if (!session.short_id) {
-    return <li className={rowClassName}>{rowInner}</li>;
-  }
-
-  return (
-    <li>
-      <Link
-        href={`/sessions/${session.short_id}`}
-        className={cn(
-          rowClassName,
-          "hover:bg-secondary/50 hover:border-border transition-colors cursor-pointer",
-        )}
-      >
-        {rowInner}
-      </Link>
-    </li>
-  );
-}

--- a/packages/web/components/agents/agent-detail-panel.tsx
+++ b/packages/web/components/agents/agent-detail-panel.tsx
@@ -309,8 +309,8 @@ function PanelFooterField({
 }
 
 function RecentSessionRow({ session }: { session: RecentSession }) {
-  return (
-    <li className="flex items-center gap-2 rounded-md border border-border/70 bg-background/40 px-2.5 py-1.5 text-xs">
+  const rowInner = (
+    <>
       <span
         className={cn("h-1.5 w-1.5 rounded-full shrink-0", RECENT_SESSION_DOT[session.status])}
         aria-hidden
@@ -324,6 +324,29 @@ function RecentSessionRow({ session }: { session: RecentSession }) {
       <span className="text-[10px] text-muted-foreground tabular-nums shrink-0">
         {session.age}
       </span>
+    </>
+  );
+
+  const rowClassName =
+    "flex items-center gap-2 rounded-md border border-border/70 bg-background/40 px-2.5 py-1.5 text-xs";
+
+  // Without a short_id we can't route — render unlinked. Matches the
+  // full /agents/[id] page's defensive handling.
+  if (!session.short_id) {
+    return <li className={rowClassName}>{rowInner}</li>;
+  }
+
+  return (
+    <li>
+      <Link
+        href={`/sessions/${session.short_id}`}
+        className={cn(
+          rowClassName,
+          "hover:bg-secondary/50 hover:border-border transition-colors cursor-pointer",
+        )}
+      >
+        {rowInner}
+      </Link>
     </li>
   );
 }

--- a/packages/web/components/agents/recent-session-row.tsx
+++ b/packages/web/components/agents/recent-session-row.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+import type { RecentSession } from "@/lib/types/agents";
+
+/**
+ * Status → dot color/animation map. `running` gets the breathing pulse
+ * to read as live; `review` uses the review accent; everything else
+ * (`succeeded`) lands on the muted "done" green.
+ */
+const RECENT_SESSION_DOT: Record<RecentSession["status"], string> = {
+  running: "bg-status-running animate-pulse-breathe",
+  review: "bg-status-review",
+  succeeded: "bg-status-done",
+};
+
+/**
+ * `compact` — peek panel (520px right rail): tighter padding, smaller
+ *   text + meta, lighter background to fit the panel's nested context.
+ * `comfortable` — full agent detail page: roomier padding, base text,
+ *   solid card background.
+ *
+ * Both wrap the row in a Link when `short_id` is present (always in
+ * practice; the unlinked branch is defense against future shapes).
+ */
+type Variant = "compact" | "comfortable";
+
+const VARIANT_STYLES: Record<Variant, { row: string; meta: string }> = {
+  compact: {
+    row: "flex items-center gap-2 rounded-md border border-border/70 bg-background/40 px-2.5 py-1.5 text-xs",
+    meta: "text-[10px]",
+  },
+  comfortable: {
+    row: "flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-sm",
+    meta: "text-xs",
+  },
+};
+
+const LINKED_HOVER =
+  "hover:bg-secondary/50 hover:border-border/80 transition-colors cursor-pointer";
+
+export function RecentSessionRow({
+  session,
+  variant,
+}: {
+  session: RecentSession;
+  variant: Variant;
+}) {
+  const styles = VARIANT_STYLES[variant];
+  const inner = (
+    <>
+      <span
+        className={cn("h-1.5 w-1.5 rounded-full shrink-0", RECENT_SESSION_DOT[session.status])}
+        aria-hidden
+      />
+      <span className="flex-1 min-w-0 truncate">{session.title}</span>
+      {session.short_id ? (
+        <span className={cn("font-mono text-muted-foreground shrink-0", styles.meta)}>
+          {session.short_id}
+        </span>
+      ) : null}
+      <span className={cn("text-muted-foreground tabular-nums shrink-0", styles.meta)}>
+        {session.age}
+      </span>
+    </>
+  );
+
+  if (!session.short_id) {
+    return <li className={styles.row}>{inner}</li>;
+  }
+
+  return (
+    <li>
+      <Link href={`/sessions/${session.short_id}`} className={cn(styles.row, LINKED_HOVER)}>
+        {inner}
+      </Link>
+    </li>
+  );
+}


### PR DESCRIPTION
Addresses the foundation of [issue #90](https://github.com/beevibe-ai/beevibe/issues/90): agents over-saved one-off scoped requests as durable `preference` facts and self-referential meta-`pattern` facts about their own behavior. Before the prompt tuning + FactPromoter heuristics + UI affordance fixes, the data model needs to follow the core-memory design from PR #99 — descriptions as the single source of truth, surfaced where the agent decides what to save.

## What changed

- **New `FACT_TYPE_DESCRIPTIONS: Record<FactType, string>`** in `packages/core/src/domain/memory.ts`. Each description encodes the type's intent + the explicit "don't save THIS" guard inline. TS `Record<FactType, _>` enforces coverage at compile time.
- **`save-memory.ts` builds the enum description from the SOT** via `buildFactTypeDescription()` — mirrors `buildBlockNameDescription` in `update-core-memory.ts`. Tool's main description trimmed of the now-redundant inline per-type guidance.

## Failure-mode guards now inline in the SOT

- **`preference`**: "Trigger words: \"always\", \"from now on\", \"every time\", \"as a default\", \"going forward\". Do NOT save preferences for one-off requests scoped to a specific task, session, or work-product (\"after this task\", \"for this audit\", \"now\"). When in doubt, just do the thing once without saving."
- **`pattern`**: "Knowledge another agent could reuse. NOT a pattern about your own behavior (your search habits, your memory-keeping, how you should have responded next time). Save the thing you learned about the world, not a note-to-self about how to behave."

Both directly target the failure modes documented in issue #90:
- `fact_xxx` team agent saved as `preference` with content about "this task AND FUTURE TASKS" — would now hit the "don't save preferences for one-off scoped requests" guard.
- `fact_qdtoVj8RkXNE` IC agent saved as `pattern` about "save_memory mid-task for each non-obvious finding" — would now hit the "NOT a pattern about your own behavior" guard.

## Why follow PR #99's pattern

PR #99 established the precedent: descriptions live in `DEFAULT_BLOCK_TEMPLATES` (one place), get surfaced into `update_core_memory`'s `block_name` enum + the agent's `<core_memory>` render via the same map. The agent reads the same guidance everywhere the topic comes up. Doing the same for fact_type ensures future drift between core-memory and archival-memory documentation styles stays minimal.

## Out of scope (separate PRs per issue #90)

- **B**: IC re-read work-product prompt (failure mode 3 — memory is a cache, work product is source of truth)
- **C**: FactPromoter demote heuristics for self-referential / mis-scoped facts
- **D**: Memory delete UI affordance + `DELETE /memory/facts/:id` endpoint
- **Cleanup**: the two facts saved in the original incident (`fact_qdtoVj8RkXNE` + the team agent's preference) will be cleaned up via D's UI affordance once it lands

## Test plan
- [x] `pnpm --filter @beevibe/core build && test` — 447 pass
- [x] `pnpm --filter @beevibe/api build && test` — 312 pass (existing save-memory.test.ts assertions on handler behavior still hold)
- [ ] Manual smoke: reproduce a one-off "after this task" request to a team agent — agent should now see the explicit "do NOT save preferences for one-off scoped requests" guard in the fact_type description and skip the save_memory call (or pick a different type)

🤖 Generated with [Claude Code](https://claude.com/claude-code)