### PR TITLE
fix(memory): fact scope reflects saver's hierarchy_level, not hardcoded 'ic'

### DIFF
--- a/packages/api/src/routes/mcp.test.ts
+++ b/packages/api/src/routes/mcp.test.ts
@@ -219,9 +219,10 @@ describe.skipIf(!HAS_LIVE_API_KEYS)("/mcp router — integration", () => {
       });
       expect(result.isError).toBeFalsy();
 
-      // addOrMerge writes facts at scope='ic' initially; promotion to team/org
-      // happens later via FactPromoter.onTaskComplete (not exercised here).
-      const facts = await factRepo.listByAgentScope(team.agent.id, "ic");
+      // addOrMerge stamps the fact's scope from the saver's hierarchy_level.
+      // The caller here is a team-tier human, so the fact lands at scope='team'.
+      // FactPromoter.onTaskComplete can elevate to 'org' later if it recurs.
+      const facts = await factRepo.listByAgentScope(team.agent.id, "team");
       expect(facts).toHaveLength(1);
       expect(facts[0]?.content).toContain("green");
       expect(facts[0]?.fact_type).toBe("preference");

--- a/packages/api/src/tools/assemble.ts
+++ b/packages/api/src/tools/assemble.ts
@@ -107,7 +107,11 @@ export function assembleTools(
 ): AgentTool[] {
   const memoryTools: AgentTool[] = [
     createSaveMemoryTool(
-      { agentId: ctx.caller.agentId, sessionId: ctx.beevibeSid },
+      {
+        agentId: ctx.caller.agentId,
+        sessionId: ctx.beevibeSid,
+        hierarchyLevel: ctx.caller.hierarchyLevel,
+      },
       { factStore: services.factStore },
     ),
     createUpdateCoreMemoryTool(

--- a/packages/api/src/tools/save-memory.test.ts
+++ b/packages/api/src/tools/save-memory.test.ts
@@ -11,7 +11,7 @@ function fakeFactStore(): { factStore: FactStore; calls: Array<{ args: unknown[]
       return {
         id: "fact_minted",
         agent_id: args[0],
-        scope: "ic",
+        scope: args[4],
         category: "archival",
         fact_type: args[3],
         content: args[2],
@@ -26,7 +26,7 @@ describe("save_memory tool", () => {
   it("delegates to factStore.addOrMerge with caller agentId + sessionId from context", async () => {
     const { factStore, calls } = fakeFactStore();
     const tool = createSaveMemoryTool(
-      { agentId: "agent_a", sessionId: "sess_1" },
+      { agentId: "agent_a", sessionId: "sess_1", hierarchyLevel: "ic" },
       { factStore },
     );
 
@@ -41,19 +41,37 @@ describe("save_memory tool", () => {
       "sess_1",
       "Prefers pnpm over npm.",
       "preference",
+      "ic",
     ]);
     expect(result.isError).toBeFalsy();
     expect(result.content).toMatchObject({
       saved: true,
       fact_id: "fact_minted",
       fact_type: "preference",
+      scope: "ic",
     });
+  });
+
+  it("passes the caller's hierarchyLevel through as the fact scope", async () => {
+    const { factStore, calls } = fakeFactStore();
+    const tool = createSaveMemoryTool(
+      { agentId: "agent_team", sessionId: "sess_1", hierarchyLevel: "team" },
+      { factStore },
+    );
+
+    await tool.handler({
+      content: "Team-wide convention: branch names use kebab-case.",
+      fact_type: "pattern",
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.args[4]).toBe("team");
   });
 
   it("returns isError for empty content", async () => {
     const { factStore, calls } = fakeFactStore();
     const tool = createSaveMemoryTool(
-      { agentId: "agent_a", sessionId: "sess_1" },
+      { agentId: "agent_a", sessionId: "sess_1", hierarchyLevel: "ic" },
       { factStore },
     );
 
@@ -67,7 +85,7 @@ describe("save_memory tool", () => {
   it("returns isError for unknown fact_type", async () => {
     const { factStore, calls } = fakeFactStore();
     const tool = createSaveMemoryTool(
-      { agentId: "agent_a", sessionId: "sess_1" },
+      { agentId: "agent_a", sessionId: "sess_1", hierarchyLevel: "ic" },
       { factStore },
     );
 
@@ -81,7 +99,7 @@ describe("save_memory tool", () => {
   it("tool descriptor exposes JSON schema with required fields", () => {
     const { factStore } = fakeFactStore();
     const tool = createSaveMemoryTool(
-      { agentId: "agent_a", sessionId: "sess_1" },
+      { agentId: "agent_a", sessionId: "sess_1", hierarchyLevel: "ic" },
       { factStore },
     );
 

--- a/packages/api/src/tools/save-memory.ts
+++ b/packages/api/src/tools/save-memory.ts
@@ -1,5 +1,11 @@
 import type { FactStore } from "@beevibe/core/services/memory";
-import { FACT_TYPES, FACT_TYPE_DESCRIPTIONS, type FactType } from "@beevibe/core";
+import {
+  FACT_TYPES,
+  FACT_TYPE_DESCRIPTIONS,
+  type FactType,
+  type HierarchyLevel,
+  type MemoryScope,
+} from "@beevibe/core";
 import type { AgentTool } from "./types.js";
 
 /**
@@ -47,6 +53,12 @@ export interface SaveMemoryContext {
   agentId: string;
   /** Beevibe session id for `source_session_ids` provenance. */
   sessionId: string;
+  /**
+   * Saver's tier — also the scope the fact is created at. HierarchyLevel
+   * and MemoryScope share the same string values (`"ic" | "team" | "org"`),
+   * so the cast at the call site is identity at runtime.
+   */
+  hierarchyLevel: HierarchyLevel;
 }
 
 /**
@@ -93,9 +105,10 @@ export function createSaveMemoryTool(
         ctx.sessionId,
         content,
         factType as FactType,
+        ctx.hierarchyLevel as MemoryScope,
       );
       return {
-        content: { saved: true, fact_id: fact.id, fact_type: factType },
+        content: { saved: true, fact_id: fact.id, fact_type: factType, scope: fact.scope },
       };
     },
   };

--- a/packages/api/src/tools/save-memory.ts
+++ b/packages/api/src/tools/save-memory.ts
@@ -2,9 +2,9 @@ import type { FactStore } from "@beevibe/core/services/memory";
 import {
   FACT_TYPES,
   FACT_TYPE_DESCRIPTIONS,
+  hierarchyToScope,
   type FactType,
   type HierarchyLevel,
-  type MemoryScope,
 } from "@beevibe/core";
 import type { AgentTool } from "./types.js";
 
@@ -53,11 +53,7 @@ export interface SaveMemoryContext {
   agentId: string;
   /** Beevibe session id for `source_session_ids` provenance. */
   sessionId: string;
-  /**
-   * Saver's tier — also the scope the fact is created at. HierarchyLevel
-   * and MemoryScope share the same string values (`"ic" | "team" | "org"`),
-   * so the cast at the call site is identity at runtime.
-   */
+  /** Saver's tier — converted to the fact's scope via `hierarchyToScope`. */
   hierarchyLevel: HierarchyLevel;
 }
 
@@ -105,8 +101,11 @@ export function createSaveMemoryTool(
         ctx.sessionId,
         content,
         factType as FactType,
-        ctx.hierarchyLevel as MemoryScope,
+        hierarchyToScope(ctx.hierarchyLevel),
       );
+      // Echo `scope` because the agent didn't supply it — it was derived
+      // from the caller's tier. Surfaces the resulting visibility so the
+      // agent knows whether a fact is IC-private or team-/org-visible.
       return {
         content: { saved: true, fact_id: fact.id, fact_type: factType, scope: fact.scope },
       };

--- a/packages/core/src/domain/memory.ts
+++ b/packages/core/src/domain/memory.ts
@@ -1,6 +1,21 @@
+import type { HierarchyLevel } from "./agent.js";
+
 export type MemoryScope = "ic" | "team" | "org";
 
 export const MEMORY_SCOPES: readonly MemoryScope[] = ["ic", "team", "org"] as const;
+
+/**
+ * Identity converter from HierarchyLevel → MemoryScope. The two unions
+ * share the same string values today (`"ic" | "team" | "org"`) but are
+ * intentionally distinct nominal types: HierarchyLevel describes an
+ * agent's tier; MemoryScope describes a fact's visibility. Using this
+ * helper instead of a raw `as MemoryScope` cast documents the
+ * equivalence in code and gives us one place to revisit if the two
+ * sets ever diverge (e.g., a future "domain" memory scope below ic).
+ */
+export function hierarchyToScope(level: HierarchyLevel): MemoryScope {
+  return level;
+}
 
 export type FactType = "belief" | "pattern" | "gotcha" | "preference" | "decision";
 

--- a/packages/core/src/services/memory/fact-store.test.ts
+++ b/packages/core/src/services/memory/fact-store.test.ts
@@ -62,6 +62,7 @@ describe("FactStore.addOrMerge — create path", () => {
       "sess_new",
       "Prefers pnpm over npm",
       "preference",
+      "ic",
     );
 
     expect(repo.searchByVector).toHaveBeenCalledWith({
@@ -83,6 +84,23 @@ describe("FactStore.addOrMerge — create path", () => {
     expect(createInput.source_session_ids).toEqual(["sess_new"]);
     expect(llm.complete).not.toHaveBeenCalled();
     expect(fact.content).toBe("Prefers pnpm over npm");
+  });
+
+  it("stamps the scope from the caller (team agent → team-scoped fact)", async () => {
+    vi.mocked(embed.embed).mockResolvedValue(new Array<number>(1536).fill(0.1));
+    vi.mocked(repo.searchByVector).mockResolvedValue([]);
+    vi.mocked(repo.create).mockImplementation(async (input) => ({
+      ...input,
+      created_at: new Date(),
+    }));
+
+    await store.addOrMerge("agent_team", "sess_new", "Team prefers X", "preference", "team");
+
+    expect(repo.searchByVector).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: "team" }),
+    );
+    const createInput = vi.mocked(repo.create).mock.calls[0]![0];
+    expect(createInput.scope).toBe("team");
   });
 });
 
@@ -110,6 +128,7 @@ describe("FactStore.addOrMerge — merge path", () => {
       "sess_B",
       "Prefers pnpm and won't use npm",
       "preference",
+      "ic",
     );
 
     expect(llm.complete).toHaveBeenCalledOnce();
@@ -142,7 +161,7 @@ describe("FactStore.addOrMerge — merge path", () => {
       ...patch,
     }));
 
-    await store.addOrMerge("agent_1", "sess_B", "same session again", "preference");
+    await store.addOrMerge("agent_1", "sess_B", "same session again", "preference", "ic");
 
     const updatePatch = vi.mocked(repo.update).mock.calls[0]![1];
     expect(updatePatch.source_session_ids).toEqual(["sess_A", "sess_B"]);
@@ -161,7 +180,7 @@ describe("FactStore.addOrMerge — merge path", () => {
       ...patch,
     }));
 
-    await store.addOrMerge("agent_1", "sess_new", "new content", "preference");
+    await store.addOrMerge("agent_1", "sess_new", "new content", "preference", "ic");
     expect(vi.mocked(repo.update).mock.calls[0]![1].content).toBe("merged text");
   });
 });

--- a/packages/core/src/services/memory/fact-store.ts
+++ b/packages/core/src/services/memory/fact-store.ts
@@ -33,23 +33,31 @@ export class FactStore {
 
   /**
    * Embed the new content; if its nearest neighbor (same fact_type, same
-   * agent, scope=ic) is above SIMILARITY_MERGE_THRESHOLD, LLM-merge the two
-   * and update the existing row with the merged content, re-embed, and the
-   * union of source_session_ids. Otherwise insert a new fact.
+   * agent, same scope) is above SIMILARITY_MERGE_THRESHOLD, LLM-merge the
+   * two and update the existing row with the merged content, re-embed, and
+   * the union of source_session_ids. Otherwise insert a new fact.
    *
-   * Facts are always created at scope="ic"; promotion to team/org happens
-   * post-session via FactPromoter.
+   * `scope` reflects the saving agent's tier: an IC agent's facts start at
+   * `ic`, a team agent's at `team`, an org agent's at `org`. Promotion
+   * UPWARD (e.g. `team` → `org`) still happens post-session via
+   * FactPromoter when a fact recurs across enough sessions.
+   *
+   * Dedup-merge is scoped: a team agent saving something near-identical to
+   * an existing `ic` fact creates a fresh `team` row rather than merging
+   * across scopes — the two facts live in different conceptual universes
+   * (one is IC-private, the other is team-wide knowledge).
    */
   async addOrMerge(
     agentId: string,
     sessionId: string,
     content: string,
     fact_type: FactType,
+    scope: MemoryScope,
   ): Promise<MemoryFact> {
     const embedding = await this.deps.embed.embed(content);
     const [neighbor] = await this.deps.repo.searchByVector({
       agent_id: agentId,
-      scope: "ic",
+      scope,
       embedding,
       limit: 1,
       min_similarity: SIMILARITY_MERGE_THRESHOLD,
@@ -60,7 +68,7 @@ export class FactStore {
       return this.deps.repo.create({
         id: factId(),
         agent_id: agentId,
-        scope: "ic",
+        scope,
         fact_type,
         content,
         embedding,


### PR DESCRIPTION
## Bug

`FactStore.addOrMerge` hardcoded `scope: 'ic'` on every fact creation. The justification was that `FactPromoter` would later elevate worthy facts to `team`/`org`. In practice that means a team agent's `save_memory` writes a team-level insight as an `ic` fact — the saver's tier doesn't reach the DB until something happens to promote it (which may never happen for many legitimate team-level facts). Reading-side queries union all scopes so the agent can still find its own writes, but the `scope` column in the DB lies about who reasoned the fact into existence.

## Fix

- **`FactStore.addOrMerge`** gains a required `scope: MemoryScope` param. The row is created at that scope, and the dedup-merge `searchByVector` runs at the same scope (cross-scope merging would conflate IC-private and team-wide observations into one row).
- **save-memory MCP tool's `SaveMemoryContext`** gains `hierarchyLevel: HierarchyLevel` and passes it through as the scope. `HierarchyLevel` and `MemoryScope` share the same string values (`\"ic\" | \"team\" | \"org\"`), so the cast at the call site is identity at runtime.
- **`assemble.ts`** threads `ctx.caller.hierarchyLevel` through to `createSaveMemoryTool` (same pattern as `createUpdateCoreMemoryTool`).
- **Tool response shape** gains `scope` so the agent can confirm where the fact landed.

`FactPromoter` is unchanged. It still operates on whatever the fact's current scope is and proposes valid upward transitions via `isValidUpward`. A team-scoped fact can still be promoted to org; an org-scoped fact short-circuits with `promoted=false`.

## Data migration

None needed. The recall query at `MemoryAgent.prepareBriefing` already unions `ic+team+org` so existing `ic`-scoped facts remain visible. The change is forward-only for new saves.

## Test plan

- [x] `pnpm --filter @beevibe/core test` — 448 pass (new \"team agent → team-scoped fact\" case + updated existing tests)
- [x] `pnpm --filter @beevibe/api test` — 313 pass (new save-memory team-tier coverage; the team-caller integration test in `mcp.test.ts` now asserts scope='team' with the comment updated)
- [x] `pnpm --filter @beevibe/api build && core build` green
- [ ] Manual smoke: as a team agent in chat, save_memory(...) → verify the fact's scope column is 'team' in the DB and the response payload includes `scope: \"team\"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)