### PR TITLE
fix(agents): specialization comes from tag_line only, no domain fallback

### DIFF
--- a/packages/api/src/views/agent-network.ts
+++ b/packages/api/src/views/agent-network.ts
@@ -19,6 +19,7 @@
 
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import type { RuntimeConfig } from "@beevibe/core";
+import { firstNonEmptyLine } from "./format.js";
 import type { AgentDisplay, AgentNetwork, AgentPeerOwner } from "./types.js";
 
 // Defensive cap on the peer fetch. The agent graph is one orbit per
@@ -119,15 +120,6 @@ function rowToAgentDisplay(row: AgentRow): AgentDisplay {
     specialization,
     review_policy: (row.review_policy ?? undefined) as AgentDisplay["review_policy"],
   };
-}
-
-function firstNonEmptyLine(content: string | null | undefined): string | undefined {
-  if (!content) return undefined;
-  for (const line of content.split("\n")) {
-    const trimmed = line.trim();
-    if (trimmed) return trimmed;
-  }
-  return undefined;
 }
 
 export async function getAgentNetwork(

--- a/packages/api/src/views/agent-network.ts
+++ b/packages/api/src/views/agent-network.ts
@@ -33,12 +33,14 @@ SELECT
   a.id, a.name, a.owner_id, a.parent_agent_id, a.hierarchy_level,
   a.review_policy, a.runtime_config, a.created_at, a.updated_at,
   COALESCE(sc.n, 0)::int  AS sessions_count,
-  COALESCE(fc.n, 0)::int  AS facts_learned
+  COALESCE(fc.n, 0)::int  AS facts_learned,
+  tl.content              AS tag_line
 FROM agent a
 LEFT JOIN (SELECT agent_id, COUNT(*)::int AS n FROM session GROUP BY agent_id) sc
   ON sc.agent_id = a.id
 LEFT JOIN (SELECT agent_id, COUNT(*)::int AS n FROM memory_fact GROUP BY agent_id) fc
   ON fc.agent_id = a.id
+LEFT JOIN core_memory_block tl ON tl.agent_id = a.id AND tl.block_name = 'tag_line'
 WHERE a.owner_id = $1
   AND a.archived_at IS NULL
 ORDER BY
@@ -57,13 +59,15 @@ SELECT
   a.review_policy, a.runtime_config, a.created_at, a.updated_at,
   p.name AS owner_label,
   COALESCE(sc.n, 0)::int  AS sessions_count,
-  COALESCE(fc.n, 0)::int  AS facts_learned
+  COALESCE(fc.n, 0)::int  AS facts_learned,
+  tl.content              AS tag_line
 FROM agent a
 JOIN person p ON p.id = a.owner_id
 LEFT JOIN (SELECT agent_id, COUNT(*)::int AS n FROM session GROUP BY agent_id) sc
   ON sc.agent_id = a.id
 LEFT JOIN (SELECT agent_id, COUNT(*)::int AS n FROM memory_fact GROUP BY agent_id) fc
   ON fc.agent_id = a.id
+LEFT JOIN core_memory_block tl ON tl.agent_id = a.id AND tl.block_name = 'tag_line'
 WHERE a.owner_id <> $1
   AND a.archived_at IS NULL
 ORDER BY a.owner_id,
@@ -84,6 +88,7 @@ interface AgentRow {
   updated_at: Date;
   sessions_count: string | number;
   facts_learned: string | number;
+  tag_line: string | null;
 }
 
 interface PeerRow extends AgentRow {
@@ -91,12 +96,12 @@ interface PeerRow extends AgentRow {
 }
 
 function rowToAgentDisplay(row: AgentRow): AgentDisplay {
-  // PR #96 split runtime (CLI tool) from model (LLM alias). This view
-  // was previously surfacing `runtime_config.model` as `runtime` — same
-  // conflation. Match `agents.ts` so the network UI shows "claude" not
-  // "claude-opus-4-7" under the Runtime label.
+  // PR #96 split runtime (CLI tool) from model (LLM alias). Match `agents.ts`
+  // so the network UI shows "claude" not "claude-opus-4-7" under the Runtime
+  // label.
   const runtime = row.runtime_config.type ?? "claude";
   const model = row.runtime_config.model;
+  const specialization = firstNonEmptyLine(row.tag_line);
   return {
     id: row.id,
     name: row.name,
@@ -111,8 +116,18 @@ function rowToAgentDisplay(row: AgentRow): AgentDisplay {
     facts_learned: Number(row.facts_learned),
     runtime,
     model,
+    specialization,
     review_policy: (row.review_policy ?? undefined) as AgentDisplay["review_policy"],
   };
+}
+
+function firstNonEmptyLine(content: string | null | undefined): string | undefined {
+  if (!content) return undefined;
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed) return trimmed;
+  }
+  return undefined;
 }
 
 export async function getAgentNetwork(

--- a/packages/api/src/views/agents.ts
+++ b/packages/api/src/views/agents.ts
@@ -7,7 +7,7 @@
 
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import type { HierarchyLevel, SessionStatus } from "@beevibe/core";
-import { deriveShortId, formatRelativeShort } from "./format.js";
+import { deriveShortId, firstNonEmptyLine, formatRelativeShort } from "./format.js";
 import type {
   AgentDisplay,
   AgentDetail,
@@ -94,15 +94,6 @@ function rowToAgentDisplay(row: AgentRow): AgentDisplay {
     preferred_runtime_id: row.preferred_runtime_id ?? undefined,
     archived_at: row.archived_at ? row.archived_at.toISOString() : undefined,
   };
-}
-
-function firstNonEmptyLine(content: string | null | undefined): string | undefined {
-  if (!content) return undefined;
-  for (const line of content.split("\n")) {
-    const trimmed = line.trim();
-    if (trimmed) return trimmed;
-  }
-  return undefined;
 }
 
 export async function listAgents(

--- a/packages/api/src/views/agents.ts
+++ b/packages/api/src/views/agents.ts
@@ -33,7 +33,6 @@ interface AgentRow {
   sessions_count: string;
   facts_learned: string;
   tag_line: string | null;
-  domain_content: string | null;
 }
 
 const LIST_SQL = /* sql */ `
@@ -44,8 +43,7 @@ SELECT
   p.name                  AS owner_label,
   COALESCE(sc.n, 0)::int  AS sessions_count,
   COALESCE(fc.n, 0)::int  AS facts_learned,
-  tl.content              AS tag_line,
-  dm.content              AS domain_content
+  tl.content              AS tag_line
 FROM agent a
 LEFT JOIN person p ON p.id = a.owner_id
 LEFT JOIN (
@@ -59,7 +57,6 @@ LEFT JOIN (
   GROUP BY agent_id
 ) fc ON fc.agent_id = a.id
 LEFT JOIN core_memory_block tl ON tl.agent_id = a.id AND tl.block_name = 'tag_line'
-LEFT JOIN core_memory_block dm ON dm.agent_id = a.id AND dm.block_name = 'domain'
 WHERE ($1::text IS NULL OR a.owner_id = $1)
   AND a.archived_at IS NULL
 ORDER BY
@@ -69,14 +66,14 @@ ORDER BY
 
 function rowToAgentDisplay(row: AgentRow): AgentDisplay {
   // `runtime` is the CLI tool name; `model` is the LLM alias passed to it.
-  // Previously this view returned `runtime_config.model` under the `runtime`
-  // key, conflating the two — PR #96 split them. PR #99 adds specialization,
-  // sourced from the `tag_line` core memory block (≤100 chars), falling
-  // back to the first non-empty line of `domain` for legacy agents whose
-  // tag_line is still empty.
+  // PR #96 split them. `specialization` is the first non-empty line of the
+  // `tag_line` core memory block (≤100 chars by template). No fallback to
+  // `domain` — that block is for the agent's enduring expertise prose, not
+  // a UI headline; mixing the two confused agents with set tag_lines whose
+  // cards still showed the domain text.
   const runtime = (row.runtime_config?.type as string | undefined) ?? "claude";
   const model = row.runtime_config?.model as string | undefined;
-  const specialization = firstNonEmptyLine(row.tag_line) ?? firstNonEmptyLine(row.domain_content);
+  const specialization = firstNonEmptyLine(row.tag_line);
   return {
     id: row.id,
     name: row.name,
@@ -125,9 +122,7 @@ SELECT
   (SELECT COUNT(*)::int FROM session       WHERE agent_id = a.id) AS sessions_count,
   (SELECT COUNT(*)::int FROM memory_fact   WHERE agent_id = a.id) AS facts_learned,
   (SELECT content FROM core_memory_block
-    WHERE agent_id = a.id AND block_name = 'tag_line' LIMIT 1) AS tag_line,
-  (SELECT content FROM core_memory_block
-    WHERE agent_id = a.id AND block_name = 'domain'   LIMIT 1) AS domain_content
+    WHERE agent_id = a.id AND block_name = 'tag_line' LIMIT 1) AS tag_line
 FROM agent a
 LEFT JOIN person p ON p.id = a.owner_id
 WHERE a.id = $1

--- a/packages/api/src/views/format.ts
+++ b/packages/api/src/views/format.ts
@@ -71,3 +71,18 @@ export function formatDurationLabel(
   const hrs = hr % 24;
   return hrs ? `${days}d ${hrs}h` : `${days}d`;
 }
+
+/**
+ * First non-empty line of a multi-line block content. Used to derive a
+ * one-liner UI headline (e.g. `specialization` from a core-memory
+ * tag_line block) from text that might be empty / whitespace-only /
+ * multi-line. Returns undefined when there is nothing renderable.
+ */
+export function firstNonEmptyLine(content: string | null | undefined): string | undefined {
+  if (!content) return undefined;
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed) return trimmed;
+  }
+  return undefined;
+}

--- a/packages/web/components/agents/agent-detail-panel.tsx
+++ b/packages/web/components/agents/agent-detail-panel.tsx
@@ -168,7 +168,7 @@ function PanelLoaded({ agent }: { agent: AgentDetail }) {
                 {agent.specialization}
               </p>
             ) : (
-              <p className="text-xs text-muted-foreground/60 italic">No domain set</p>
+              <p className="text-xs text-muted-foreground/60 italic">No tagline yet</p>
             )}
           </div>
         </div>

--- a/packages/web/components/team-orbit.tsx
+++ b/packages/web/components/team-orbit.tsx
@@ -291,7 +291,7 @@ function SpecialistCard({
               agent.specialization ? "text-muted-foreground" : "text-muted-foreground/60 italic",
             )}
           >
-            {agent.specialization ?? "No domain set"}
+            {agent.specialization ?? "No tagline yet"}
           </p>
         ) : null}
       </div>


### PR DESCRIPTION
## Two issues

### 1. Agent network view never queried `tag_line`

`agent-network.ts` (powers the team graph at `/agents` — self orbit + peer orbits) didn't JOIN the tag_line block. Its `rowToAgentDisplay` never set `specialization`. So every card showed the "No domain set" placeholder regardless of whether a tag_line was set — the field literally didn't reach the UI.

### 2. Agents list view fell back to `domain` when tag_line was empty

`agents.ts` did `specialization = firstNonEmptyLine(tag_line) ?? firstNonEmptyLine(domain_content)`. Confused users with a domain set but no tag_line: the card showed domain prose instead of looking unset (and prompting them to set a tag_line).

## Fix

- **`agent-network.ts`** SELF_SQL + PEERS_SQL JOIN `core_memory_block` on `tag_line`; `rowToAgentDisplay` emits `specialization` from the first non-empty line. Mirrors the agents.ts approach exactly.
- **`agents.ts`** (list + detail) drops the `?? firstNonEmptyLine(domain_content)` fallback. Domain is enduring expertise prose, not a UI headline — mixing the two confused agents with set tag_lines whose cards still showed domain text. Also removes the now-unused `domain_content` from LIST_SQL + DETAIL_SQL_AGENT.
- **UI placeholder text** changes from `"No domain set"` → `"No tagline yet"` in:
  - `team-orbit.tsx:294` (the orbit card)
  - `agent-detail-panel.tsx:171` (the peek panel header)

The detail page (`agent-detail-client.tsx:123`) already conditionally hides the specialization paragraph when undefined — no change there.

## Test plan
- [x] `pnpm --filter @beevibe/api build && test` — 313 pass
- [x] `pnpm --filter @beevibe/web typecheck && test` — 141 pass
- [ ] Manual smoke: open `/agents`, edit an agent's tag_line via the core-block editor → save → card refreshes with the new tag_line (no longer "No domain set"). Clear the tag_line back to empty → card flips to "No tagline yet" (not the domain text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)