### PR TITLE
docs: restructure root README around positioning + one-command quickstart

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,95 @@ welcome but please skim this first.
 Be kind. Disagreement is fine; rudeness is not. The maintainers will close
 issues / PRs that don't meet this bar.
 
+## Local development
+
+The container stack in [docker-compose.quickstart.yml](./docker-compose.quickstart.yml)
+is the right answer for "I just want to try it." For an iterative dev loop
+with file watching, hot reload, and breakpoints, run the services on the
+host instead.
+
+### Prerequisites
+
+- Node.js v20+ — [nodejs.org](https://nodejs.org/)
+- pnpm v9 — `corepack enable && corepack prepare pnpm@9.12.0 --activate`
+- Docker — for the local Postgres
+- Claude Code CLI on `PATH` — [claude.ai/code](https://claude.ai/code).
+  Run `claude login` once before dispatching real agent work.
+- Provider keys: `OPENAI_API_KEY` (embeddings) + `ANTHROPIC_API_KEY` (LLM).
+
+### First-run setup
+
+```bash
+git clone https://github.com/beevibe-ai/beevibe.git && cd beevibe
+pnpm install
+pnpm bootstrap
+```
+
+`pnpm bootstrap` writes `.env` from `.env.example` (prompting for provider
+keys), starts local Postgres via docker-compose, runs migrations, and
+provisions an admin person + team agent. Re-running is safe — it detects
+existing setup and skips.
+
+### Daily loop
+
+```bash
+pnpm dev                                # postgres + api + scheduler
+pnpm --filter @beevibe/web dev -- -p 3030   # in a second terminal
+```
+
+Open <http://localhost:3030>. Edit code; api/scheduler use `tsx watch` and
+web uses Next dev — both restart on save.
+
+### Minting a `bv_u_` token for the daemon
+
+`pnpm bootstrap` creates an admin and writes its `bv_u_` key into both
+root `.env` and `packages/web/.env.local`. To mint another user (or a
+clean demo topology):
+
+```bash
+pnpm provision-user                       # one extra person + team agent
+pnpm tsx scripts/provision-demo.ts        # captain + 2 ICs + paste-ready mcp.json
+```
+
+Then register your daemon against the dev api:
+
+```bash
+pnpm tsx packages/daemon/src/main.ts setup \
+  --api http://localhost:3000 --user-token <bv_u_…>
+pnpm tsx packages/daemon/src/main.ts start
+```
+
+### Common commands
+
+```bash
+pnpm build              # build all packages (turbo)
+pnpm typecheck          # TypeScript across the workspace
+pnpm lint               # ESLint
+pnpm test               # unit + integration (CI runs this)
+pnpm migrate up         # apply migrations to DATABASE_URL
+pnpm db:reset           # wipe + recreate the local DB
+pnpm install-skills     # sync /skills/* into ~/.claude/skills/
+pnpm sync-core-memory   # re-sync core memory block descriptions
+```
+
+### Monorepo layout
+
+```text
+packages/
+├── api/         MCP tools, REST API, SSE, chat, mesh broker, /runtime
+├── core/        domain types, ports, services, adapters, auth
+├── daemon/      local process that claims sessions and spawns CLIs
+├── scheduler/   server-side fallback claimant + orphan reaper
+└── web/         Next.js dashboard
+
+infra/railway/   Dockerfiles + Railway config-as-code per service
+migrations/      node-pg-migrate SQL migrations
+scripts/         dev orchestration + provisioning + skills sync
+skills/          shipped Anthropic Agent Skills (synced into workspaces)
+```
+
+Each `packages/<name>/README.md` is the source of truth for that subsystem.
+
 ## How to contribute
 
 1. **Open an issue first** for non-trivial work (anything beyond a typo,

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -60,25 +60,40 @@ spawn their local CLI sessions.
 
 ## Docker
 
+The repo ships a self-contained compose stack — postgres + api + scheduler +
+web in one command, no Node or pnpm on the host.
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-… \
+OPENAI_API_KEY=sk-…       \
+docker compose -f docker-compose.quickstart.yml up -d --build
+```
+
+Visit `http://localhost:3030` for the dashboard. To shut down + wipe the
+local db volume:
+
+```bash
+docker compose -f docker-compose.quickstart.yml down -v
+```
+
+The stack runs migrations as a one-shot service before api starts, so no
+separate migrate step is needed. The compose file is annotated with the
+non-obvious wiring — see the `BEEVIBE_MCP_SERVER_URL` comments for why api
+and scheduler resolve the api differently.
+
+For per-image manual control (custom networking, sidecars, separate hosts
+per service), build and run the images individually:
+
 ```bash
 docker build -f infra/railway/Dockerfile.api -t beevibe-api .
 docker build -f infra/railway/Dockerfile.scheduler -t beevibe-scheduler .
 docker build -f infra/railway/Dockerfile.web \
   --build-arg NEXT_PUBLIC_BV_API_URL=http://localhost:3000 \
   -t beevibe-web .
-
-docker compose up -d postgres
-
-docker run --rm --network host \
-  -e DATABASE_URL=postgresql://beevibe:beevibe@localhost:5433/beevibe \
-  beevibe-api pnpm migrate:deploy up
-
-docker run -p 3000:3000 --network host --env-file .env beevibe-api
-docker run --network host --env-file .env beevibe-scheduler
-docker run -p 8080:3000 --env-file .env beevibe-web
 ```
 
-Visit `http://localhost:8080` for the dashboard.
+Then run with your own env file. See the Dockerfile headers for the
+required runtime envs per service.
 
 ## Bare Node
 
@@ -98,6 +113,8 @@ The daemon is installed and run on the machine that should execute agent CLI
 sessions.
 
 ```bash
+brew install beevibe-ai/tap/beevibe-daemon
+
 beevibe-daemon setup \
   --api https://your-api.example.com \
   --user-token <bv_u_token>

--- a/README.md
+++ b/README.md
@@ -168,20 +168,13 @@ To actually dispatch agent work after the stack is up, install the daemon
 on the machine where Claude Code lives and point it at the api:
 
 ```bash
+brew install beevibe-ai/tap/beevibe-daemon
 beevibe-daemon setup --api http://localhost:3000 --user-token <bv_u_…>
 beevibe-daemon start
 ```
 
 The `bv_u_` token is created by `pnpm provision-user` (see
 [CONTRIBUTING.md](./CONTRIBUTING.md#minting-a-bv_u_-token-for-the-daemon)).
-
-## Project status
-
-Single-tenant self-hosted is the v1 scope. Cross-instance api federation
-(running multiple api replicas in front of the same Postgres) is on the
-roadmap — for now the mesh and chat resolvers are in-process maps, so both
-halves of a long-held request need to reach the same api process. See
-[DEPLOYMENT.md → Production Notes](./DEPLOYMENT.md#production-notes).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -50,17 +50,6 @@ compounds.
 - **BYO CLI.** Each user runs their own Claude Code (or other) CLI on their
   own machine via a local daemon — your tools, your files, your tokens.
 
-## The Bet
-
-Beevibe is betting against the AGI-in-a-box future. The next phase of AI at
-work is not one giant generalist. It's a team of bounded specialists with
-persistent identity, lasting roles, and enough shared structure to ask each
-other for help.
-
-Once you make that bet, the primitives change: memory has an `agent_id`,
-the workspace has an org chart, and the most important command is no longer
-*"do this task"* but *"ask the right teammate."*
-
 ## Architecture
 
 ```text

--- a/README.md
+++ b/README.md
@@ -2,104 +2,114 @@
 
 # Beevibe
 
-## The agent-native operating system for companies.
+### The agent-native operating system for companies.
 
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
-[![Node.js](https://img.shields.io/badge/node-%3E%3D20-43853d.svg)](./package.json)
-[![pnpm](https://img.shields.io/badge/pnpm-9-F69220.svg)](./package.json)
+[![GitHub stars](https://img.shields.io/github/stars/beevibe-ai/beevibe?style=social)](https://github.com/beevibe-ai/beevibe)
 
-Beevibe is a shared workspace where a team's people and AI agents work side by
-side. Agents hold lasting roles, build bounded domain memory, ask the right
-teammate when their context runs out, and escalate blockers back to humans.
-
-[Quick Start](#quick-start) | [Architecture](#architecture) |
-[Deployment](./DEPLOYMENT.md)
+[Architecture](#architecture) · [Concepts](#core-concepts) · [Quick Start](#quick-start) · [Deploy](./DEPLOYMENT.md) · [Contributing](./CONTRIBUTING.md)
 
 </div>
+
+---
+
+## What is Beevibe?
+
+Beevibe is a shared workspace where a team's people and AI agents work side
+by side. Agents hold lasting roles, build bounded domain memory, ask the
+right teammate when their context runs out, and escalate blockers back to
+humans.
+
+It's the missing layer between your AI tools and your team. Slack, Notion,
+and Linear are how humans coordinate. Beevibe is the same surface for the
+AI side of the team — so the same context isn't re-explained dozens of
+times a week and the same answer isn't learned and forgotten across
+different engineers.
+
+Beevibe is **self-hosted**. You own the Postgres database, the Node
+services, the local daemon processes, and the CLI binaries doing the work.
 
 ## Why Beevibe?
 
 Every engineer now works with AI all day: Claude Code, Cursor, Codex, and
-whatever comes next. Individually, they are faster than ever. Then the team
+whatever comes next. Individually, they're faster than ever. Then the team
 gets in a room together and coordination is still stuck at 2019 speed.
 
-The problem is not that the agents are too weak. The problem is that each
-person's AI work lives in a private bubble. The same context gets re-explained
-dozens of times a week, the same answer gets learned and forgotten across
-different engineers, and no shared intelligence compounds.
+The problem isn't that the agents are too weak. The problem is that each
+person's AI work lives in a private bubble, and no shared intelligence
+compounds.
 
-Teams solved this for humans with Slack, Notion, and Linear. Beevibe is that
-missing layer for the AI side of the team.
-
-- **Shared AI workspace.** People and agents work in the same team graph,
+- **Shared AI workspace.** People and agents work in the same team graph
   with tasks, ownership, review, handoffs, and escalation.
 - **Persistent specialists.** Each agent has an identity, domain, hierarchy
   level, and bounded memory that deepens across sessions.
-- **Agent-to-agent coordination.** When an agent leaves its domain, it can ask
-  another specialist for context or negotiate toward a solution.
-- **Human-in-the-loop control.** Humans review, redirect, revise, cancel, and
-  resolve blockers from the dashboard.
-
-Beevibe is self-hosted. You own the Postgres database, the Node services, the
-local daemon processes, and the CLI binaries doing the work.
-
-## Quick Start
-
-Prerequisites: Node.js 20+, pnpm 9, Docker, the Claude Code CLI on `PATH`,
-and provider keys for `OPENAI_API_KEY` and `ANTHROPIC_API_KEY`. Run
-`claude login` once before dispatching real agent work.
-
-```bash
-git clone https://github.com/beevibe-ai/beevibe.git && cd beevibe
-pnpm install && pnpm bootstrap
-pnpm dev
-```
-
-In a second terminal, start the dashboard:
-
-```bash
-pnpm --filter @beevibe/web dev -- -p 3030
-```
-
-Open `http://localhost:3030`.
-
-`pnpm bootstrap` creates `.env`, starts local Postgres, runs migrations, and
-provisions an admin user plus a team agent. `pnpm dev` starts the API,
-scheduler, Postgres, and an optional Cloudflare tunnel when `cloudflared` is
-installed.
+- **Agent-to-agent coordination.** When an agent leaves its domain, it can
+  ask another specialist for context or negotiate toward a solution.
+- **Human-in-the-loop control.** Humans review, redirect, revise, cancel,
+  and resolve blockers from the dashboard.
+- **BYO CLI.** Each user runs their own Claude Code (or other) CLI on their
+  own machine via a local daemon — your tools, your files, your tokens.
 
 ## The Bet
 
 Beevibe is betting against the AGI-in-a-box future. The next phase of AI at
-work is not one giant generalist. It is a team of bounded specialists with
+work is not one giant generalist. It's a team of bounded specialists with
 persistent identity, lasting roles, and enough shared structure to ask each
 other for help.
 
-Once you make that bet, the primitives change: memory has an `agent_id`, the
-workspace has an org chart, and the most important command is not "do this
-task" but "ask the right teammate."
+Once you make that bet, the primitives change: memory has an `agent_id`,
+the workspace has an org chart, and the most important command is no longer
+*"do this task"* but *"ask the right teammate."*
 
-## The Mental Model
+## Architecture
 
 ```text
-Company workspace
-  |
-  +-- People
-  |     +-- engineers review, redirect, and hand off work
-  |
-  +-- Team agents
-        +-- backend specialist
-        +-- frontend specialist
-        +-- infrastructure specialist
-        +-- product specialist
-
-Task -> right agent -> asks peers when needed -> human review
+                  Humans                            Agents
+                  ──────                            ──────
+   ┌──────────────────────────┐         ┌──────────────────────────┐
+   │   Web dashboard          │         │   Claude Code CLI        │
+   │   (Next.js)              │         │   (one per agent run)    │
+   └────────────┬─────────────┘         └────────────┬─────────────┘
+                │ REST + SSE                         │ MCP tools
+                │                                    │ (HTTPS)
+                ▼                                    ▼
+        ┌─────────────────────────────────────────────────┐
+        │                @beevibe/api                     │
+        │  control plane: REST · SSE · MCP · /runtime · WSS │
+        └─────────┬─────────────────────────┬─────────────┘
+                  │                         │
+                  │ SQL                     │ WS push +
+                  │                         │ HTTP claim
+                  ▼                         ▼
+       ┌──────────────────────┐    ┌─────────────────────┐
+       │ Postgres + pgvector  │    │  beevibe-daemon     │
+       │ shared state, mesh,  │    │  (your laptop)      │
+       │ memory, sessions     │    │                     │
+       └──────────┬───────────┘    │  spawns the local   │
+                  │ poll for       │  Claude CLI for     │
+                  │ fallback claim │  every session      │
+                  ▼                │  pinned to this     │
+       ┌──────────────────────┐    │  machine            │
+       │  @beevibe/scheduler  │    └─────────────────────┘
+       │  server-side spawn   │
+       │  (offline daemons)   │
+       │  + orphan reaping    │
+       └──────────────────────┘
 ```
 
-Agents are not disposable chat sessions. They are persistent teammates with
-domains. They can delegate through hierarchy, ask peers for missing context,
-negotiate when plans conflict, and escalate to a human when a decision needs
-judgment.
+The **api** is the control plane. **Postgres** is the shared coordination
+and memory layer. **Local daemons** run the actual CLI sessions where each
+user's tools and files live. The **scheduler** is a server-side fallback
+for mesh asks targeting agents whose daemon is offline, plus the orphan
+reaper for crashed sessions.
+
+For a deeper version of any layer, see the package READMEs:
+
+- [packages/api](./packages/api/README.md) — MCP tools, REST, SSE, MeshServer, daemon control plane
+- [packages/core](./packages/core/README.md) — domain types, ports, services, adapters
+- [packages/daemon](./packages/daemon/README.md) — local CLI claimer + spawner
+- [packages/scheduler](./packages/scheduler/README.md) — server-side fallback claimant
+- [packages/web](./packages/web/README.md) — Next.js dashboard
 
 ## Core Concepts
 
@@ -109,94 +119,83 @@ judgment.
 | **Agent** | A persistent domain expert with a role, hierarchy level, memory, API key, and preferred runtime. |
 | **Task** | A unit of team work assigned to a person or agent. Tasks can spawn child tasks and move through review. |
 | **Mesh** | The agent-to-agent layer for asking the right teammate, negotiating, responding, and escalating. |
-| **Memory** | Durable per-agent memory plus vector-searchable facts that compound across team work. |
+| **Memory** | Durable per-agent core memory blocks plus vector-searchable facts that compound across team work. |
 | **Runtime** | A registered `(daemon, CLI)` pair, usually a user's local `claude` binary. |
 | **Daemon** | A local process that claims sessions and spawns CLI runs on a user's machine. |
 
-## Architecture
+## Quick Start
 
-```text
-                 +------------------+
-                 |   Web dashboard  |
-                 +--------+---------+
-                          |
-                          v
-People + agents  -->  Beevibe API  <-- MCP tool calls from Claude
-                          |
-                          v
-                    Postgres + pgvector
-                          ^
-                          |
-              +-----------+------------+
-              |                        |
-        Local daemons              Scheduler
-       spawn CLI runs          fallback + reaping
-```
+Two paths — pick whichever matches what you're trying to do.
 
-The API is the control plane. Postgres is the shared coordination and memory
-layer. Local daemons run the actual CLI sessions where each user's tools and
-files live.
+### One-click deploy (Railway)
 
-For the deeper version, see the package docs:
-
-- [packages/api](./packages/api/README.md)
-- [packages/core](./packages/core/README.md)
-- [packages/web](./packages/web/README.md)
-
-## Tech Stack
-
-- **Database:** Postgres 16 + `pgvector`
-- **Runtime:** Node.js 20, TypeScript, pnpm workspaces, Turborepo
-- **Agents:** Claude Code CLI + Model Context Protocol
-- **Memory:** OpenAI embeddings + Anthropic/OpenAI LLM providers
-- **Web:** Next.js, React Query, Tailwind CSS, Server-Sent Events
-
-## Deployment
+Spins up Postgres + api + scheduler + web on Railway. Each user still
+installs `beevibe-daemon` on their own machine to actually run agent CLI
+sessions; the hosted api doesn't spawn local CLIs.
 
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/beevibe)
 
-Beevibe can run on Railway, Docker, bare Node, or any container host with
-Postgres 16 and `pgvector`.
+After the template finishes provisioning, set `ANTHROPIC_API_KEY` +
+`OPENAI_API_KEY` on the api and scheduler services, then point
+`BEEVIBE_CORS_ORIGINS` (api) and `NEXT_PUBLIC_BV_API_URL` (web build arg)
+at the public URLs Railway assigned. Full notes in
+[DEPLOYMENT.md](./DEPLOYMENT.md).
 
-See [DEPLOYMENT.md](./DEPLOYMENT.md) for Railway notes, Docker commands,
-production configuration, and current self-hosting limitations.
+### Local Docker
 
-## Development
-
-Common commands:
+Brings up the whole stack — Postgres + api + scheduler + web — in
+containers from the repo root. No Node, no pnpm, no migrations to run by
+hand.
 
 ```bash
-pnpm build              # build all packages
-pnpm typecheck          # TypeScript checks
-pnpm lint               # ESLint
-pnpm test               # unit + integration tests
-pnpm migrate up         # apply migrations to DATABASE_URL
-pnpm db:reset           # reset local DB and apply migrations
+git clone https://github.com/beevibe-ai/beevibe.git && cd beevibe
+
+ANTHROPIC_API_KEY=sk-ant-… \
+OPENAI_API_KEY=sk-…       \
+docker compose -f docker-compose.quickstart.yml up -d --build
 ```
 
-Monorepo layout:
+Then open <http://localhost:3030>.
 
-```text
-packages/
-+-- api/         MCP tools, REST API, SSE, chat, mesh broker
-+-- core/        domain types, ports, services, adapters, auth
-+-- daemon/      local process that claims sessions and spawns CLIs
-+-- scheduler/   server-side fallback claimant and orphan reaper
-+-- web/         Next.js dashboard
+The compose file builds the three Node images from `infra/railway/`, runs
+migrations as a one-shot, and starts the stack. To shut it down:
+
+```bash
+docker compose -f docker-compose.quickstart.yml down -v
 ```
+
+To actually dispatch agent work after the stack is up, install the daemon
+on the machine where Claude Code lives and point it at the api:
+
+```bash
+beevibe-daemon setup --api http://localhost:3000 --user-token <bv_u_…>
+beevibe-daemon start
+```
+
+The `bv_u_` token is created by `pnpm provision-user` (see
+[CONTRIBUTING.md](./CONTRIBUTING.md#minting-a-bv_u_-token-for-the-daemon)).
+
+## Project status
+
+Single-tenant self-hosted is the v1 scope. Cross-instance api federation
+(running multiple api replicas in front of the same Postgres) is on the
+roadmap — for now the mesh and chat resolvers are in-process maps, so both
+halves of a long-held request need to reach the same api process. See
+[DEPLOYMENT.md → Production Notes](./DEPLOYMENT.md#production-notes).
 
 ## Contributing
 
 Issues and PRs are welcome. For larger changes, open an issue first so the
-direction is clear before implementation.
-
-Please include a `Signed-off-by:` trailer on commits. See
-[CONTRIBUTING.md](./CONTRIBUTING.md) for the DCO details.
+direction is clear before implementation. See
+[CONTRIBUTING.md](./CONTRIBUTING.md) for local development setup, the DCO
+sign-off requirement, and the contribution license terms.
 
 ## License
 
-The Beevibe source code is licensed under the [Apache License 2.0](./LICENSE).
+The Beevibe source code is licensed under the
+[Apache License 2.0](./LICENSE).
 
-The Beevibe name and logo are project trademarks. Apache 2.0 grants rights to
-the source code; it does not grant rights to use the project's name or marks.
-Forks and derivative works are welcome under names that are not "Beevibe."
+The Beevibe name and logo are project trademarks. Apache 2.0 grants rights
+to the source code; it does not grant rights to use the project's name or
+marks. Forks and derivative works are welcome under names that are not
+"Beevibe."

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -60,6 +60,10 @@ services:
     restart: unless-stopped
     environment:
       DATABASE_URL: postgresql://beevibe:beevibe@postgres:5432/beevibe
+      # api bakes this URL into mcp-config.json when it preps a workspace for
+      # a daemon-claimed session. The daemon writes that file on the user's
+      # host and spawns the CLI there — so the URL must resolve from the
+      # host, hence the published port (not the in-network DNS name).
       BEEVIBE_MCP_SERVER_URL: http://localhost:3000/mcp
       BEEVIBE_API_PORT: "3000"
       BEEVIBE_CORS_ORIGINS: http://localhost:3030
@@ -80,6 +84,9 @@ services:
     restart: unless-stopped
     environment:
       DATABASE_URL: postgresql://beevibe:beevibe@postgres:5432/beevibe
+      # scheduler-spawned (server-fallback-mesh) CLIs run inside THIS
+      # container's network namespace, so they reach api via the docker DNS
+      # name, not the host's published port.
       BEEVIBE_MCP_SERVER_URL: http://api:3000/mcp
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:?ANTHROPIC_API_KEY must be set}
       OPENAI_API_KEY: ${OPENAI_API_KEY:?OPENAI_API_KEY must be set}

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -1,0 +1,106 @@
+# Self-contained quickstart: postgres + api + scheduler + web in containers.
+#
+# Usage:
+#   ANTHROPIC_API_KEY=… OPENAI_API_KEY=… docker compose \
+#     -f docker-compose.quickstart.yml up -d --build
+#
+# Then open http://localhost:3030.
+#
+# Differences from the dev-focused docker-compose.yml (postgres-only):
+#   - Builds + runs the three Node services from the Railway Dockerfiles.
+#   - Migrations run as a one-shot `migrate` service before api starts.
+#   - No bind mount of source — this is a "try it" stack, not a dev loop.
+#     For an iterative dev loop run `pnpm dev` instead (see CONTRIBUTING.md).
+#
+# End users still install + run `beevibe-daemon` on their own machine to
+# actually spawn agent CLI sessions; the api/scheduler containers do not
+# spawn local CLIs themselves.
+
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    container_name: beevibe-quickstart-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: beevibe
+      POSTGRES_PASSWORD: beevibe
+      POSTGRES_DB: beevibe
+    volumes:
+      - quickstart_pg_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U beevibe -d beevibe"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # One-shot: applies all migrations to the postgres above, then exits.
+  # Uses npx so we don't have to bake node-pg-migrate into the api image.
+  migrate:
+    image: node:20-slim
+    working_dir: /app
+    volumes:
+      - ./migrations:/app/migrations:ro
+    environment:
+      DATABASE_URL: postgresql://beevibe:beevibe@postgres:5432/beevibe
+    command:
+      - sh
+      - -c
+      - "npx -y node-pg-migrate@7 -m /app/migrations up"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  api:
+    build:
+      context: .
+      dockerfile: infra/railway/Dockerfile.api
+    container_name: beevibe-quickstart-api
+    restart: unless-stopped
+    environment:
+      DATABASE_URL: postgresql://beevibe:beevibe@postgres:5432/beevibe
+      BEEVIBE_MCP_SERVER_URL: http://localhost:3000/mcp
+      BEEVIBE_API_PORT: "3000"
+      BEEVIBE_CORS_ORIGINS: http://localhost:3030
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:?ANTHROPIC_API_KEY must be set}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:?OPENAI_API_KEY must be set}
+      BEEVIBE_SIGNUP_ENABLED: "1"
+    ports:
+      - "3000:3000"
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+
+  scheduler:
+    build:
+      context: .
+      dockerfile: infra/railway/Dockerfile.scheduler
+    container_name: beevibe-quickstart-scheduler
+    restart: unless-stopped
+    environment:
+      DATABASE_URL: postgresql://beevibe:beevibe@postgres:5432/beevibe
+      BEEVIBE_MCP_SERVER_URL: http://api:3000/mcp
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:?ANTHROPIC_API_KEY must be set}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:?OPENAI_API_KEY must be set}
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+
+  web:
+    build:
+      context: .
+      dockerfile: infra/railway/Dockerfile.web
+      args:
+        NEXT_PUBLIC_BV_API_URL: http://localhost:3000
+    container_name: beevibe-quickstart-web
+    restart: unless-stopped
+    environment:
+      PORT: "3030"
+    ports:
+      - "3030:3030"
+    depends_on:
+      - api
+
+volumes:
+  quickstart_pg_data:


### PR DESCRIPTION
## Summary

The old README led with the local-dev quickstart (\`pnpm bootstrap\` + \`pnpm dev\`), buried the architecture, and duplicated dev commands that belonged in CONTRIBUTING. Restructure following the [multica](https://github.com/multica-ai/multica) + [paperclip](https://github.com/paperclipai/paperclip) format: positioning first, architecture early, real quickstart late with two paths.

## README changes

- **Drop badge noise** (Node, pnpm) — Apache + GitHub stars only.
- **New ordering:** What is → Why → The Bet → Architecture (rich ASCII) → Core Concepts → Quick Start → Project status → Contributing → License.
- **Architecture diagram redrawn** to show humans/agents entering through different surfaces, daemon ↔ api over WS, scheduler as the postgres-poll fallback for offline-target mesh asks.
- **Quick Start moved to the lower half**, two paths:
  1. Railway one-click button.
  2. Local Docker — \`docker compose -f docker-compose.quickstart.yml up -d --build\` brings up postgres + api + scheduler + web in one command (no Node, no pnpm, no manual migrations).
- **Drop the Tech Stack section** per request.
- **Drop the Development section** — moved to CONTRIBUTING.
- **Add a Project status callout** for the v1 single-instance constraint.

## docker-compose.quickstart.yml (new)

Self-contained four-service stack: postgres (pgvector) + one-shot migrate + api + scheduler + web.

- Migrations run via \`npx -y node-pg-migrate@7\` against bind-mounted \`/migrations\` so we don't have to bake node-pg-migrate into the api image (it's a root devDep). One slow first-run pull, then cached.
- \`\${ANTHROPIC_API_KEY:?…}\` / \`\${OPENAI_API_KEY:?…}\` fail-fast at boot if either env var is unset.
- Distinct from the existing \`docker-compose.yml\` (postgres-only, used by \`pnpm dev\`); chosen via \`-f\` so neither workflow steps on the other.

## CONTRIBUTING.md additions

New **Local development** section before the contribution workflow: prerequisites (Node 20+, pnpm 9, Docker, claude CLI, provider keys), first-run setup (\`pnpm bootstrap\`), daily loop (\`pnpm dev\` + web port), minting a \`bv_u_\` token + registering a daemon against the dev api, common commands, and the monorepo layout. README now points users here for "I'm hacking on this."

## Test plan

- [x] \`docker compose -f docker-compose.quickstart.yml config\` validates
- [x] No source code changes; build/test status unchanged
- [ ] Manual end-to-end: \`docker compose -f docker-compose.quickstart.yml up -d --build\` on a clean machine, confirm <http://localhost:3030> renders
- [ ] Visual review of the rendered README on GitHub