### PR TITLE
fix(chat): thinking indicator survives nav-away and clears after response

### DIFF
--- a/packages/web/lib/hooks/keys.ts
+++ b/packages/web/lib/hooks/keys.ts
@@ -67,6 +67,8 @@ export const queryKeys = {
     /** Per-conversation history. `undefined` = the most recent conversation. */
     history: (conversationId?: string) =>
       ["chat", "history", conversationId ?? "<latest>"] as const,
+    /** Prefix that matches every per-conversation history slot at once. */
+    historyAll: ["chat", "history"] as const,
     conversations: () => ["chat", "conversations"] as const,
   },
 } as const;

--- a/packages/web/lib/hooks/use-chat.ts
+++ b/packages/web/lib/hooks/use-chat.ts
@@ -142,8 +142,12 @@ export function useChat(opts: UseChatOptions = {}) {
         session_id: sessionId,
         prior_session_id: priorSessionId,
       }),
-    onMutate: ({ message }) => {
-      // Optimistically append the user's turn so it shows up instantly.
+    onMutate: ({ message, sessionId }) => {
+      // Optimistically append the user's turn AND stamp in_flight_session_id
+      // into the cache so the thinking indicator survives nav-away-and-back:
+      // if the hook unmounts mid-mutation, local `mutation.isPending` state
+      // is gone, and `serverInFlightSessionId` is the only signal left for
+      // the next mount to honor.
       queryClient.setQueryData<ChatHistoryResponse>(queryKey, (prev) => {
         const base = prev ?? FRESH_HISTORY;
         return {
@@ -152,11 +156,15 @@ export function useChat(opts: UseChatOptions = {}) {
             ...base.messages,
             { id: localId(), role: "user", content: message },
           ],
+          in_flight_session_id: sessionId,
         };
       });
     },
     onSuccess: (data) => {
-      // Append the agent turn and advance the chain pointer in-place.
+      // Append the agent turn, advance the chain pointer, AND clear
+      // in_flight_session_id. Without the explicit clear the thinking
+      // indicator persists (the spread preserves whatever onMutate
+      // stamped) — manifesting as "agent replied but UI still spinning."
       queryClient.setQueryData<ChatHistoryResponse>(queryKey, (prev) => {
         const base = prev ?? FRESH_HISTORY;
         const agentMessage: ChatHistoryMessage = {
@@ -172,6 +180,7 @@ export function useChat(opts: UseChatOptions = {}) {
           ...base,
           messages: [...base.messages, agentMessage],
           prior_session_id: data.session_id,
+          in_flight_session_id: undefined,
         };
       });
       // First turn of a brand-new conversation can flip the server's
@@ -191,21 +200,23 @@ export function useChat(opts: UseChatOptions = {}) {
     onError: (err) => {
       // agent_offline (503) is special: the api persisted the session row
       // before rejecting, so the turn is queued, not lost. Keep the user
-      // message visible — refresh would show it anyway from the server,
-      // and rolling back here just creates a flicker of "vanished, then
-      // back on refresh". When the daemon reconnects and the session
-      // completes, session.updated SSE invalidates chat queries and the
-      // response auto-appears.
+      // message AND in_flight_session_id visible — refresh would show
+      // them anyway from the server, and rolling back here creates a
+      // flicker of "vanished, then back on refresh". When the daemon
+      // reconnects and the session completes, session.updated SSE
+      // invalidates chat queries and the response auto-appears.
       if (err instanceof ApiError && err.errorCode === "agent_offline") return;
 
       // Other errors (429 rate limit, 400 validation, etc.) reject the
-      // turn before persistence — roll back so the input doesn't look
+      // turn before persistence — roll back the optimistic user message
+      // AND clear in_flight_session_id so the input doesn't look
       // sent-and-stuck.
       queryClient.setQueryData<ChatHistoryResponse>(queryKey, (prev) => {
         if (!prev) return prev;
         const last = prev.messages[prev.messages.length - 1];
-        if (last?.role !== "user") return prev;
-        return { ...prev, messages: prev.messages.slice(0, -1) };
+        const messages =
+          last?.role === "user" ? prev.messages.slice(0, -1) : prev.messages;
+        return { ...prev, messages, in_flight_session_id: undefined };
       });
     },
   });

--- a/packages/web/lib/sse.ts
+++ b/packages/web/lib/sse.ts
@@ -43,14 +43,14 @@ const eventInvalidations: Record<string, InvalidationKey[]> = {
     // Match ALL chat history slots, not just the `<latest>` one. A user
     // viewing a specific conversation (cacheId = conv head) needs the
     // same auto-recovery: when their pending chat session completes, the
-    // cache slot for that conversation has to refetch. Using the
-    // `["chat", "history"]` prefix invalidates every per-conversation
-    // slot under it. We do NOT fan out to `chat.conversations` — the
-    // sidebar chain head only changes when a new conversation is opened,
-    // and `use-chat`'s onSuccess already invalidates it explicitly.
-    // Refetching it on every non-chat session.updated (task/mesh
-    // transitions) would be pure waste.
-    ["chat", "history"],
+    // cache slot for that conversation has to refetch. The `historyAll`
+    // prefix invalidates every per-conversation slot under it. We do NOT
+    // fan out to `chat.conversations` — the sidebar chain head only
+    // changes when a new conversation is opened, and `use-chat`'s
+    // onSuccess already invalidates it explicitly. Refetching it on
+    // every non-chat session.updated (task/mesh transitions) would be
+    // pure waste.
+    queryKeys.chat.historyAll,
   ],
   "memory.fact.created": [queryKeys.memory.all],
   "memory.fact.deleted": [queryKeys.memory.all],

--- a/packages/web/lib/sse.ts
+++ b/packages/web/lib/sse.ts
@@ -40,15 +40,17 @@ const eventInvalidations: Record<string, InvalidationKey[]> = {
     queryKeys.sessions.all,
     queryKeys.tasks.all,
     queryKeys.activity.all,
-    // Chat history only. A pending chat session completing (daemon
-    // reconnect after agent_offline, or normal turn settle) flips it
-    // from "user message only" → "user + agent reply"; that's the
-    // auto-recovery path. We do NOT fan out to `chat.conversations`
-    // here — the sidebar chain head only changes when a new conversation
-    // is opened, and `use-chat`'s onSuccess already invalidates it
-    // explicitly. Refetching it on every non-chat session.updated
-    // (task/mesh transitions) would be pure waste.
-    queryKeys.chat.history(undefined),
+    // Match ALL chat history slots, not just the `<latest>` one. A user
+    // viewing a specific conversation (cacheId = conv head) needs the
+    // same auto-recovery: when their pending chat session completes, the
+    // cache slot for that conversation has to refetch. Using the
+    // `["chat", "history"]` prefix invalidates every per-conversation
+    // slot under it. We do NOT fan out to `chat.conversations` — the
+    // sidebar chain head only changes when a new conversation is opened,
+    // and `use-chat`'s onSuccess already invalidates it explicitly.
+    // Refetching it on every non-chat session.updated (task/mesh
+    // transitions) would be pure waste.
+    ["chat", "history"],
   ],
   "memory.fact.created": [queryKeys.memory.all],
   "memory.fact.deleted": [queryKeys.memory.all],


### PR DESCRIPTION
Two related bugs from the cache wiring after PR #123.

## Bug A — navigate away from /chat mid-turn and back, thinking box gone until manual refresh

**Cause:** \`onMutate\` (use-chat.ts:145) writes the optimistic user message into the cache but never writes \`in_flight_session_id\`. While the hook is mounted, local mutation state (\`mutation.isPending\` → \`localSendingSessionId\`) shows the indicator. Navigate away → hook unmounts → mutation state gone (the mutation continues in the background, but its hooks detach). Navigate back → fresh hook → \`localSendingSessionId = undefined\`, cache still has \`in_flight_session_id = undefined\` (no one ever wrote it) → indicator missing.

**Fix:** \`onMutate\` now stamps \`in_flight_session_id: sessionId\` into the cache. Survives unmount.

## Bug B — agent finishes responding but thinking box persists until manual refresh

**Cause** (two contributing factors):

1. \`onSuccess\` returns \`{...base, messages: [..., agent], …}\`. The spread preserves \`in_flight_session_id\` from \`base\`. With Bug A's fix in place \`onMutate\` now stamps it, so \`onSuccess\` would leak the stale value forever without an explicit clear.
2. SSE invalidation in \`lib/sse.ts\` only matched \`chat.history(undefined)\` — the \`<latest>\` slot. When the user is viewing a specific conversation slot (\`cacheId = conversation head\`), \`session.updated\` SSE never refetches that slot, so even server-side completion couldn't recover the cache.

**Fix:**
- \`onSuccess\` now writes \`in_flight_session_id: undefined\` explicitly.
- \`onError\` (non-\`agent_offline\`) clears it too on rollback.
- \`onError\` (\`agent_offline\`) deliberately **keeps** it — the session is persisted server-side and the eventual SSE refetch will land the response. Clearing locally would re-show "ready to send" and then re-show thinking when SSE arrives, a worse flicker.
- \`lib/sse.ts\` \`session.updated\` invalidation now uses the \`["chat", "history"]\` prefix so all per-conversation slots refetch.

## Test plan

- [x] \`pnpm --filter @beevibe/web typecheck\` green
- [x] \`pnpm --filter @beevibe/web test\` green (141 tests)
- [ ] Manual: send message → thinking shown; navigate to /agents and back → thinking still shown.
- [ ] Manual: send message; agent finishes while on /chat → response shown immediately, thinking gone.
- [ ] Manual: send message on \`/chat?c=<old conv>\`; agent finishes → response shown immediately on the specific-conversation view (the slot-prefix fix).
- [ ] Manual: trigger 503 \`agent_offline\` (kill daemon mid-send) → thinking persists; bring daemon back → response auto-appears via SSE.

## Related

- Builds on #123 (added \`in_flight_session_id\` to the GET /chat response). #123 wired the read side; this PR wires the write side and broadens the SSE invalidation prefix.