### PR TITLE
feat(agents): show CLI-to-MCP setup on the team agent detail page

### DIFF
--- a/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
+++ b/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
@@ -6,12 +6,13 @@ import { useRouter } from "next/navigation";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, AlertTriangle, Bot, Archive } from "lucide-react";
 import { useAgent } from "@/lib/hooks/use-agents";
-import { useIsOwner } from "@/lib/hooks/use-me";
+import { useIsOwner, useMe } from "@/lib/hooks/use-me";
 import { isApiConfigured } from "@/lib/api/config";
 import { formatReviewPolicy } from "@/lib/format";
 import { api, type RuntimesListResponse } from "@/lib/api/client";
 import { queryKeys } from "@/lib/hooks/keys";
 import { Avatar } from "@/components/avatar";
+import { CliMcpInstructions } from "@/components/cli-mcp-instructions";
 import { HierChip } from "@/components/hier-chip";
 import { CoreBlockCard } from "@/components/agents/core-block-card";
 import { RecentSessionRow } from "@/components/agents/recent-session-row";
@@ -100,6 +101,13 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
   // while /me loads so the cold-mount render doesn't briefly hide owner
   // controls before resolving.
   const isOwner = useIsOwner(agent.owner_id);
+  // The human MCP route keys off the caller's user token and dispatches
+  // to whatever `findTopLevelForOwner` returns — i.e. the caller's
+  // primary agent. Surfacing "Connect your CLI" anywhere else would be
+  // misleading: pointing your CLI at /mcp won't reach that agent.
+  const { data: me } = useMe();
+  const isPrimaryAgent =
+    isOwner === true && me?.primary_agent?.id === agent.id;
   // Aside only renders when it has content. For non-owners with no
   // outgoing mesh, we'd otherwise reserve 1/3 of the grid for an empty
   // column — main expands to full width in that case.
@@ -213,6 +221,19 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
               </ul>
             )}
           </section>
+
+          {isPrimaryAgent ? (
+            <section>
+              <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-3 font-medium">
+                Connect your CLI
+              </h2>
+              <p className="text-xs text-muted-foreground mb-3 max-w-prose">
+                Pipe your local CLI through the human MCP endpoint so you can
+                drive this team agent from a terminal session.
+              </p>
+              <CliMcpInstructions />
+            </section>
+          ) : null}
         </div>
 
         {showAside ? (

--- a/packages/web/components/cli-mcp-instructions.tsx
+++ b/packages/web/components/cli-mcp-instructions.tsx
@@ -20,6 +20,8 @@ const CHANNEL_OPTIONS: readonly ChannelOption[] = [
   { id: "manual", label: "Manual", hint: "raw URL + token" },
 ];
 
+const MCP_SERVER_NAME = "beevibe";
+
 interface SetupStep {
   label: string;
   command: string;
@@ -42,9 +44,9 @@ function buildBundle(channel: CliChannel, mcpUrl: string, token: string): SetupB
         ),
         steps: [
           {
-            label: "Register the beevibe MCP server",
+            label: `Register the ${MCP_SERVER_NAME} MCP server`,
             command:
-              `claude mcp add --transport http beevibe ${mcpUrl} \\\n` +
+              `claude mcp add --transport http ${MCP_SERVER_NAME} ${mcpUrl} \\\n` +
               `  --header "Authorization: Bearer ${token}"`,
           },
         ],
@@ -67,9 +69,9 @@ function buildBundle(channel: CliChannel, mcpUrl: string, token: string): SetupB
           {
             label: "Add the MCP server block",
             command:
-              `[mcp_servers.beevibe]\n` +
+              `[mcp_servers.${MCP_SERVER_NAME}]\n` +
               `url = "${mcpUrl}"\n\n` +
-              `[mcp_servers.beevibe.headers]\n` +
+              `[mcp_servers.${MCP_SERVER_NAME}.headers]\n` +
               `Authorization = "Bearer ${token}"`,
           },
         ],
@@ -84,7 +86,7 @@ function buildBundle(channel: CliChannel, mcpUrl: string, token: string): SetupB
       return {
         prelude: (
           <p className="text-xs text-muted-foreground leading-relaxed">
-            Add a <span className="font-mono">mcp.beevibe</span> entry to{" "}
+            Add a <span className="font-mono">mcp.{MCP_SERVER_NAME}</span> entry to{" "}
             <span className="font-mono">~/.config/opencode/opencode.json</span>{" "}
             (or your project&apos;s <span className="font-mono">opencode.json</span>):
           </p>
@@ -95,7 +97,7 @@ function buildBundle(channel: CliChannel, mcpUrl: string, token: string): SetupB
             command: JSON.stringify(
               {
                 mcp: {
-                  beevibe: {
+                  [MCP_SERVER_NAME]: {
                     type: "remote",
                     url: mcpUrl,
                     headers: { Authorization: `Bearer ${token}` },

--- a/packages/web/components/cli-mcp-instructions.tsx
+++ b/packages/web/components/cli-mcp-instructions.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { apiBaseUrl, getUserKey } from "@/lib/api/config";
+import { CommandBlock } from "@/components/command-block";
+import { cn } from "@/lib/utils";
+
+export type CliChannel = "claude" | "codex" | "opencode" | "manual";
+
+interface ChannelOption {
+  id: CliChannel;
+  label: string;
+  hint: string;
+}
+
+const CHANNEL_OPTIONS: readonly ChannelOption[] = [
+  { id: "claude", label: "Claude Code", hint: "claude mcp add" },
+  { id: "codex", label: "Codex", hint: "config.toml" },
+  { id: "opencode", label: "opencode", hint: "opencode.json" },
+  { id: "manual", label: "Manual", hint: "raw URL + token" },
+];
+
+interface SetupStep {
+  label: string;
+  command: string;
+}
+
+interface SetupBundle {
+  prelude?: ReactNode;
+  steps: readonly SetupStep[];
+  epilogue?: ReactNode;
+}
+
+function buildBundle(channel: CliChannel, mcpUrl: string, token: string): SetupBundle {
+  switch (channel) {
+    case "claude":
+      return {
+        prelude: (
+          <p className="text-xs text-muted-foreground leading-relaxed">
+            One-shot — Claude Code persists the entry in <span className="font-mono">~/.claude.json</span>.
+          </p>
+        ),
+        steps: [
+          {
+            label: "Register the beevibe MCP server",
+            command:
+              `claude mcp add --transport http beevibe ${mcpUrl} \\\n` +
+              `  --header "Authorization: Bearer ${token}"`,
+          },
+        ],
+        epilogue: (
+          <p className="text-[11px] text-muted-foreground/80 leading-snug pt-1">
+            Then start <span className="font-mono">claude</span> in any directory and ask your
+            team agent something (e.g. <span className="font-mono">/mcp</span> to verify the
+            connection, then &ldquo;what tasks do I have open?&rdquo;).
+          </p>
+        ),
+      };
+    case "codex":
+      return {
+        prelude: (
+          <p className="text-xs text-muted-foreground leading-relaxed">
+            Append to <span className="font-mono">~/.codex/config.toml</span>:
+          </p>
+        ),
+        steps: [
+          {
+            label: "Add the MCP server block",
+            command:
+              `[mcp_servers.beevibe]\n` +
+              `url = "${mcpUrl}"\n\n` +
+              `[mcp_servers.beevibe.headers]\n` +
+              `Authorization = "Bearer ${token}"`,
+          },
+        ],
+        epilogue: (
+          <p className="text-[11px] text-muted-foreground/80 leading-snug pt-1">
+            Requires a Codex build with HTTP MCP transport support. Restart{" "}
+            <span className="font-mono">codex</span> after editing the file.
+          </p>
+        ),
+      };
+    case "opencode":
+      return {
+        prelude: (
+          <p className="text-xs text-muted-foreground leading-relaxed">
+            Add a <span className="font-mono">mcp.beevibe</span> entry to{" "}
+            <span className="font-mono">~/.config/opencode/opencode.json</span>{" "}
+            (or your project&apos;s <span className="font-mono">opencode.json</span>):
+          </p>
+        ),
+        steps: [
+          {
+            label: "Register the remote MCP server",
+            command: JSON.stringify(
+              {
+                mcp: {
+                  beevibe: {
+                    type: "remote",
+                    url: mcpUrl,
+                    headers: { Authorization: `Bearer ${token}` },
+                    enabled: true,
+                  },
+                },
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+        epilogue: (
+          <p className="text-[11px] text-muted-foreground/80 leading-snug pt-1">
+            Restart <span className="font-mono">opencode</span> to pick up the new server.
+          </p>
+        ),
+      };
+    case "manual":
+      return {
+        prelude: (
+          <p className="text-xs text-muted-foreground leading-relaxed">
+            Wire any MCP-capable client to these. Transport is HTTP
+            (<span className="font-mono">StreamableHTTPServerTransport</span>); auth is a bearer header.
+          </p>
+        ),
+        steps: [
+          { label: "Server URL", command: mcpUrl },
+          { label: "Auth header", command: `Authorization: Bearer ${token}` },
+        ],
+      };
+  }
+}
+
+export function CliMcpInstructions({ className }: { className?: string }) {
+  const userKey = typeof window !== "undefined" ? getUserKey() : null;
+  const base = apiBaseUrl ?? "http://localhost:3000";
+  const mcpUrl = `${base}/mcp`;
+  const token = userKey ?? "<your-key>";
+
+  const [channel, setChannel] = useState<CliChannel>("claude");
+  const bundle = buildBundle(channel, mcpUrl, token);
+
+  return (
+    <div className={cn("space-y-3", className)}>
+      <div className="flex gap-1 rounded-lg border border-border bg-card p-1">
+        {CHANNEL_OPTIONS.map((opt) => (
+          <button
+            key={opt.id}
+            type="button"
+            onClick={() => setChannel(opt.id)}
+            className={cn(
+              "flex-1 rounded px-3 py-1.5 text-xs font-medium transition-colors cursor-pointer",
+              channel === opt.id
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            <div>{opt.label}</div>
+            <div className="text-[10px] font-normal opacity-80 mt-0.5">{opt.hint}</div>
+          </button>
+        ))}
+      </div>
+      <div className="space-y-2">
+        {bundle.prelude}
+        {bundle.steps.map((step, i) => (
+          <CommandBlock
+            key={i}
+            label={bundle.steps.length > 1 ? `${i + 1}. ${step.label}` : step.label}
+            command={step.command}
+          />
+        ))}
+        {bundle.epilogue}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a **Connect your CLI** section to the agent detail page so a user can copy a ready-made snippet that wires their local CLI into beevibe's `/mcp` endpoint and drive the team agent from a terminal session.
- New shared component `packages/web/components/cli-mcp-instructions.tsx` mirroring the existing `DaemonInstallInstructions` pattern: tabbed channel picker → labeled `CommandBlock`s.

## Where it shows up
The `/mcp` route resolves by the caller's `bv_u_` token to whatever `agentRepo.findTopLevelForOwner(personId)` returns — i.e. the user's **primary agent**. Surfacing the snippet anywhere else would be misleading: pointing your CLI at `/mcp` won't reach a non-primary agent.

So the section is gated to `isOwner && agent.id === me.primary_agent.id`. It appears in the main column right after **Recent sessions**.

## Channels
| Tab | Output |
|---|---|
| Claude Code | `claude mcp add --transport http beevibe <api>/mcp --header "Authorization: Bearer <token>"` |
| Codex | `[mcp_servers.beevibe]` TOML block for `~/.codex/config.toml` |
| opencode | `mcp.beevibe` JSON entry for `~/.config/opencode/opencode.json` |
| Manual | raw server URL + `Authorization: Bearer …` header for any other MCP-capable client |

URL is `${apiBaseUrl}/mcp`. Token comes from `getUserKey()` with the same `<your-key>` fallback the daemon-install snippet uses when no key is in localStorage.

## Test plan
- [x] `pnpm --filter @beevibe/web typecheck` — clean.
- [x] `pnpm --filter @beevibe/web lint` — clean.
- [x] `pnpm --filter @beevibe/web test --run` — 141/141 pass.
- [x] `pnpm --filter @beevibe/web build` — green.
- [ ] Visual check that the section renders only on the user's primary agent page (not on other agents or non-owners), and that each tab's snippet copy/pastes cleanly.
- [ ] Verify the snippet wires the corresponding CLI end-to-end (Claude Code is the most likely to "just work" — Codex/opencode depend on their MCP-HTTP support).

🤖 Generated with [Claude Code](https://claude.com/claude-code)