### PR TITLE
fix(daemon): WORKSPACE_ROOT footgun + diagnostics + UI failure mapping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,9 +34,10 @@ BEEVIBE_API_PORT=3000
 BEEVIBE_CORS_ORIGINS=
 
 # ─── Scheduler ─────────────────────────────────────────────────────────
-# Workspace root for each agent's sandbox + mcp-config.json. Defaults to
-# ~/.beevibe/workspaces if unset.
-WORKSPACE_ROOT=
+# Workspace root for each agent's sandbox + mcp-config.json. Defaults
+# to ~/.beevibe/workspaces when unset. Uncomment to point at a custom
+# absolute path.
+# WORKSPACE_ROOT=/absolute/path/to/workspaces
 # Health endpoint port (GET /health → 200/503). Default 3001.
 BEEVIBE_SCHEDULER_HEALTH_PORT=3001
 ORG_ID=beevibe

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -184,10 +184,42 @@ export function groupIntoConversations(
   return chains;
 }
 
+/**
+ * The bare "CLI exited with code N" message from parseClaudeMessages tells
+ * the user nothing actionable — the daemon now also surfaces the CLI's
+ * stderr tail (`session.error`), so prefer that when it's something other
+ * than the same bare line. If neither holds anything useful, fall back to
+ * a daemon-pointer message instead of "(turn failed — no response)".
+ */
+const BARE_CLI_EXIT_RE = /^CLI exited with code (-?\d+|null)\.?$/;
+const DAEMON_LOG_POINTER =
+  "Couldn't reach your team agent. Check the terminal where you ran " +
+  "`beevibe-daemon start` for the failure detail.";
+
+function failureMessageFor(s: {
+  result_summary?: string | null;
+  error?: string | null;
+}): string {
+  const error = s.error?.trim();
+  if (error && !BARE_CLI_EXIT_RE.test(error)) return error;
+  const summary = s.result_summary?.trim();
+  if (summary && !BARE_CLI_EXIT_RE.test(summary)) return summary;
+  return DAEMON_LOG_POINTER;
+}
+
 function chainToMessages(chain: ConversationChain): HistoryMessage[] {
   const messages: HistoryMessage[] = [];
   for (const s of chain.sessions) {
     messages.push({ id: `u_${s.id}`, role: "user", content: s.intent });
+    if (s.status === "failed") {
+      messages.push({
+        id: `a_${s.id}`,
+        role: "agent",
+        content: failureMessageFor(s),
+        session_id: s.id,
+      });
+      continue;
+    }
     const summary = s.result_summary ?? "";
     if (summary) {
       const { visible, view_refs, open_view, suggested_actions } = processResponse(summary);
@@ -199,13 +231,6 @@ function chainToMessages(chain: ConversationChain): HistoryMessage[] {
         ...(view_refs.length > 0 ? { view_refs } : {}),
         ...(open_view ? { open_view } : {}),
         ...(suggested_actions ? { suggested_actions } : {}),
-      });
-    } else if (s.status === "failed") {
-      messages.push({
-        id: `a_${s.id}`,
-        role: "agent",
-        content: s.error || "(turn failed — no response)",
-        session_id: s.id,
       });
     }
   }
@@ -253,11 +278,15 @@ function toChatTurnResponse(
   const { visible, view_refs, open_view, suggested_actions } = processResponse(
     session.result_summary ?? "",
   );
+  // Failed turns get the same friendlier-than-"CLI exited with code 1"
+  // treatment as chat history. Success path stays unchanged.
+  const response =
+    session.status === "failed" ? failureMessageFor(session) : visible || session.error || "";
   return {
     ok: true,
     agent: { id: agent.id, name: agent.name, hierarchy: agent.hierarchy_level },
     session_id: session.id,
-    response: visible || session.error || "",
+    response,
     status: session.status,
     view_refs,
     ...(open_view ? { open_view } : {}),

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -31,6 +31,7 @@ import {
 } from "@beevibe/core";
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
 import type { ResumeReason } from "@beevibe/core/services/agent-session";
+import { isBareCliExitMessage } from "@beevibe/core/adapters/claude-code";
 import { requireHuman } from "../auth/middleware.js";
 import type { ChatResolver } from "../runtime/chat-resolver.js";
 import type { DaemonHub } from "../runtime/hub.js";
@@ -190,20 +191,22 @@ export function groupIntoConversations(
  * stderr tail (`session.error`), so prefer that when it's something other
  * than the same bare line. If neither holds anything useful, fall back to
  * a daemon-pointer message instead of "(turn failed — no response)".
+ *
+ * Exported so non-chat surfaces that render failed sessions (e.g. rooms)
+ * can apply the same mapping rather than each site re-implementing it.
  */
-const BARE_CLI_EXIT_RE = /^CLI exited with code (-?\d+|null)\.?$/;
 const DAEMON_LOG_POINTER =
   "Couldn't reach your team agent. Check the terminal where you ran " +
   "`beevibe-daemon start` for the failure detail.";
 
-function failureMessageFor(s: {
+export function failureMessageFor(s: {
   result_summary?: string | null;
   error?: string | null;
 }): string {
   const error = s.error?.trim();
-  if (error && !BARE_CLI_EXIT_RE.test(error)) return error;
+  if (error && !isBareCliExitMessage(error)) return error;
   const summary = s.result_summary?.trim();
-  if (summary && !BARE_CLI_EXIT_RE.test(summary)) return summary;
+  if (summary && !isBareCliExitMessage(summary)) return summary;
   return DAEMON_LOG_POINTER;
 }
 

--- a/packages/api/src/routes/room.ts
+++ b/packages/api/src/routes/room.ts
@@ -26,6 +26,7 @@ import {
   type AgentSessionDeps,
   teamAgentRoutingDirective,
 } from "@beevibe/core/services/agent-session";
+import { failureMessageFor } from "./chat.js";
 import {
   roomId as makeRoomId,
   roomMessageId as makeRoomMessageId,
@@ -599,13 +600,20 @@ async function runMentionedAgents(
           .filter((s) => s.length > 0)
           .join("\n\n"),
       });
-      const visible = session.result_summary ?? "";
+      // Failed sessions used to surface the raw "CLI exited with code N"
+      // string to other room members. Route through the same mapper the
+      // chat surface uses so rooms get the daemon-pointer or stderr tail
+      // instead of an opaque exit code.
+      const content =
+        session.status === "failed"
+          ? failureMessageFor({ result_summary: session.result_summary, error: session.error })
+          : session.result_summary ?? "";
       await deps.roomRepo.appendMessage({
         id: makeRoomMessageId(),
         room_id: roomId,
         kind: "agent",
         sender_agent_id: agent.id,
-        content: visible,
+        content,
         session_id: session.id,
       });
     } catch (err) {

--- a/packages/core/src/adapters/claude-code/index.ts
+++ b/packages/core/src/adapters/claude-code/index.ts
@@ -6,5 +6,7 @@ export {
   parseStreamJsonLine,
   extractStepEvents,
   parseClaudeStreamJson,
+  bareCliExitMessage,
+  isBareCliExitMessage,
 } from "./stream-json.js";
 export type { StreamJsonMessage } from "./stream-json.js";

--- a/packages/core/src/adapters/claude-code/runtime.ts
+++ b/packages/core/src/adapters/claude-code/runtime.ts
@@ -153,10 +153,21 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     }
 
     const parsed = parseClaudeMessages(messages, result.exitCode);
+    // Surface the CLI's stderr tail on failure so operators / users get
+    // the actual diagnostic instead of just "CLI exited with code N".
+    // Capped at 4KB — most useful info is at the end (final error +
+    // stacktrace), so tail-slice rather than head.
+    const STDERR_TAIL_BYTES = 4096;
+    const stderrTail =
+      parsed.status === "failed" && result.stderr
+        ? result.stderr.slice(-STDERR_TAIL_BYTES)
+        : undefined;
     return {
       ...parsed,
       process_pid: result.pid ?? undefined,
       process_group_id: result.process_group_id ?? undefined,
+      exit_code: result.exitCode,
+      ...(stderrTail ? { stderr: stderrTail } : {}),
     };
   }
 

--- a/packages/core/src/adapters/claude-code/stream-json.ts
+++ b/packages/core/src/adapters/claude-code/stream-json.ts
@@ -260,11 +260,32 @@ export function parseClaudeMessages(
 
   return {
     status: succeeded ? "completed" : "failed",
-    output: output || (succeeded ? "Session completed." : `CLI exited with code ${exitCode}`),
+    output: output || (succeeded ? "Session completed." : bareCliExitMessage(exitCode)),
     transcript: transcript || undefined,
     usage,
     cli_session_id: sessionId,
   };
+}
+
+/**
+ * The placeholder message `parseClaudeMessages` returns when the CLI
+ * exited non-zero with no final-result message to surface. Exported so
+ * downstream consumers (e.g. the chat route's user-facing failure
+ * mapping) can detect this exact string and replace it with something
+ * more actionable instead of pattern-matching across package boundaries.
+ */
+export function bareCliExitMessage(exitCode: number | null): string {
+  return `CLI exited with code ${exitCode}`;
+}
+
+/**
+ * Matches strings produced by `bareCliExitMessage` — the only "useless"
+ * stand-in this layer emits on failure. Consumers that want to swap a
+ * bare exit for a friendlier diagnostic gate on this predicate so the
+ * coupling stays in one place.
+ */
+export function isBareCliExitMessage(s: string): boolean {
+  return /^CLI exited with code (-?\d+|null)$/.test(s);
 }
 
 /**

--- a/packages/core/src/adapters/local-workspace/manager.test.ts
+++ b/packages/core/src/adapters/local-workspace/manager.test.ts
@@ -119,6 +119,35 @@ describe("LocalWorkspaceManager", () => {
     expect(root).toMatch(/\/\.beevibe\/workspaces$/);
   });
 
+  // Regression: previously the constructor used `??` which only checks for
+  // null/undefined — an empty-string workspaceRoot (leaked from a stray
+  // `WORKSPACE_ROOT=` in .env via Bun's auto-load) slipped through, and
+  // downstream `join("", agent.id)` produced a relative path that spawn
+  // resolved off the daemon's cwd. The fix uses `||` so any falsy value
+  // (empty string included) falls through to the homedir default.
+  it("falsy workspaceRoot (empty string) falls back to the homedir default", () => {
+    const m = new LocalWorkspaceManager({
+      workspaceRoot: "",
+      mcpServerUrl: MCP_URL,
+      runtimeRegistry: fakeRuntimeRegistry,
+      skillsSourceDir,
+    });
+    const root = (m as unknown as { root: string }).root;
+    expect(root).toMatch(/\/\.beevibe\/workspaces$/);
+  });
+
+  it("throws on a relative workspaceRoot (fail-fast belt-and-suspenders)", () => {
+    expect(
+      () =>
+        new LocalWorkspaceManager({
+          workspaceRoot: "relative/path",
+          mcpServerUrl: MCP_URL,
+          runtimeRegistry: fakeRuntimeRegistry,
+          skillsSourceDir,
+        }),
+    ).toThrow(/must be absolute/);
+  });
+
   it("removeWorkspace deletes the dir and all contents", async () => {
     const ws = await manager.ensureWorkspace({ agent: makeAgent({ id: "agent_rm" }) });
     writeFileSync(join(ws.path, "file.txt"), "x");
@@ -191,7 +220,7 @@ describe("LocalWorkspaceManager", () => {
       expect(existsSync(configPath)).toBe(true);
     });
 
-    it("new instance with different mcpServerUrl does NOT auto-refresh a stale file (documented limitation)", async () => {
+    it("new instance with different mcpServerUrl auto-refreshes the stale file", async () => {
       await manager.ensureWorkspace({ agent: makeAgent({ id: "agent_stale" }) });
       const configPath = join(workspaceRoot, "agent_stale", "mcp-config.json");
       const original = readFileSync(configPath, "utf-8");
@@ -204,11 +233,27 @@ describe("LocalWorkspaceManager", () => {
       });
       await different.ensureWorkspace({ agent: makeAgent({ id: "agent_stale" }) });
 
-      // File persists unchanged — operator must rm to force refresh.
+      // File now rewrites on URL drift — operator no longer has to `rm`
+      // to switch a workspace from localhost to a hosted api after deploy.
       const after = readFileSync(configPath, "utf-8");
-      expect(after).toBe(original);
-      expect(after).toContain(MCP_URL);
-      expect(after).not.toContain("different.example");
+      expect(after).not.toBe(original);
+      expect(after).not.toContain(MCP_URL);
+      expect(after).toContain("different.example");
+    });
+
+    it("auto-refreshes when agent.api_key rotates", async () => {
+      await manager.ensureWorkspace({
+        agent: makeAgent({ id: "agent_rotate", api_key: "bv_a_oldkey" }),
+      });
+      const configPath = join(workspaceRoot, "agent_rotate", "mcp-config.json");
+      expect(readFileSync(configPath, "utf-8")).toContain("Bearer bv_a_oldkey");
+
+      await manager.ensureWorkspace({
+        agent: makeAgent({ id: "agent_rotate", api_key: "bv_a_newkey" }),
+      });
+      const after = readFileSync(configPath, "utf-8");
+      expect(after).toContain("Bearer bv_a_newkey");
+      expect(after).not.toContain("bv_a_oldkey");
     });
 
     it("throws when agent has no api_key", async () => {

--- a/packages/core/src/adapters/local-workspace/manager.ts
+++ b/packages/core/src/adapters/local-workspace/manager.ts
@@ -1,6 +1,6 @@
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import type { Agent } from "../../domain/agent.js";
 import type { RuntimeRegistry, Workspace } from "../../ports/runtime.js";
 import type { WorkspaceManager } from "../../ports/workspace.js";
@@ -56,7 +56,20 @@ export class LocalWorkspaceManager implements WorkspaceManager {
   private readonly root: string;
 
   constructor(private config: LocalWorkspaceManagerConfig) {
-    this.root = config.workspaceRoot ?? join(homedir(), ".beevibe", "workspaces");
+    // `||` not `??` — an empty-string `workspaceRoot` (e.g. leaked from a
+    // stray `WORKSPACE_ROOT=` line in .env via Bun's auto-load) is a bug
+    // disguised as "configured": `?? ` would accept it and downstream
+    // `join("", agent.id)` produces a relative path that spawn resolves
+    // off the daemon's cwd. Force the homedir fallback for any falsy
+    // value so the workspace always lands at a known absolute path.
+    this.root = config.workspaceRoot || join(homedir(), ".beevibe", "workspaces");
+    // Belt-and-suspenders: if someone constructs us with a relative root,
+    // fail fast at construction time instead of mid-spawn.
+    if (!isAbsolute(this.root)) {
+      throw new Error(
+        `LocalWorkspaceManager: workspaceRoot must be absolute, got "${this.root}"`,
+      );
+    }
   }
 
   async ensureWorkspace({ agent }: { agent: Agent }): Promise<Workspace> {
@@ -66,16 +79,22 @@ export class LocalWorkspaceManager implements WorkspaceManager {
     // their current permissions, which is the right semantic (idempotent).
     mkdirSync(path, { recursive: true, mode: 0o700 });
 
+    if (!agent.api_key) {
+      throw new Error(
+        `Cannot write mcp-config.json for agent ${agent.id}: agent.api_key is missing`,
+      );
+    }
     const configPath = join(path, "mcp-config.json");
-    if (!existsSync(configPath)) {
-      if (!agent.api_key) {
-        throw new Error(
-          `Cannot write mcp-config.json for agent ${agent.id}: agent.api_key is missing`,
-        );
-      }
-      writeFileSync(configPath, buildMcpConfig(agent.api_key, this.config.mcpServerUrl), {
-        mode: 0o600,
-      });
+    const expected = buildMcpConfig(agent.api_key, this.config.mcpServerUrl);
+    // Auto-refresh on drift: previously this was guarded by a bare
+    // `existsSync` and a stale URL or rotated bv_a_ would persist until
+    // the operator manually rm'd the file (documented but undiscoverable).
+    // Compare-and-rewrite catches api_url switches (e.g. localhost → hosted
+    // after deploy) and key rotations on the next ensureWorkspace call.
+    const needsWrite =
+      !existsSync(configPath) || readFileSync(configPath, "utf-8") !== expected;
+    if (needsWrite) {
+      writeFileSync(configPath, expected, { mode: 0o600 });
     }
 
     const workspace: Workspace = { path };

--- a/packages/core/src/ports/runtime.ts
+++ b/packages/core/src/ports/runtime.ts
@@ -164,6 +164,22 @@ export interface RuntimeResult {
 
   /** Process-group id (for killing the whole tree) — maps to session.process_group_id. */
   process_group_id?: number;
+
+  /**
+   * Tail of the CLI's stderr (truncated to ~4KB), populated only when
+   * `status === 'failed'`. Lets the daemon surface the real diagnostic
+   * to /runtime/done instead of the user staring at a useless
+   * "CLI exited with code N". `undefined` on success or cancel.
+   */
+  stderr?: string;
+
+  /**
+   * Raw exit code of the CLI subprocess. Distinct from `status`: a
+   * non-zero code maps to `status='failed'`, null (spawn never settled)
+   * also maps to failed but tells us something different (ENOENT, fork
+   * failed, etc.).
+   */
+  exit_code?: number | null;
 }
 
 /** Result of `healthCheck()`. */

--- a/packages/daemon/scripts/build-binaries.sh
+++ b/packages/daemon/scripts/build-binaries.sh
@@ -46,8 +46,16 @@ for entry in "${TARGETS[@]}"; do
   target="${entry%%:*}"
   outname="${entry##*:}"
   echo "==> Building $outname ($target)"
+  # --no-compile-autoload-dotenv / --no-compile-autoload-bunfig (Bun
+  # ≥1.3.3): standalone executables normally auto-load .env + bunfig.toml
+  # from the cwd at startup. The daemon's own config lives in
+  # ~/.beevibe/config.json — a repo-checkout .env has no business
+  # leaking in. Disable both at build time so launching the daemon from
+  # any directory is deterministic.
   bun build src/main.ts \
     --compile \
+    --no-compile-autoload-dotenv \
+    --no-compile-autoload-bunfig \
     --target="$target" \
     --outfile="$OUTDIR/$outname" \
     --define "BEEVIBE_DAEMON_VERSION=\"$VERSION\""

--- a/packages/daemon/src/claimer.ts
+++ b/packages/daemon/src/claimer.ts
@@ -177,6 +177,12 @@ export class Claimer {
     while (this.running && this.cfg.supervisor.hasCapacity()) {
       const payload = await this.cfg.api.claim<DispatchPayload>(runtimeId);
       if (!payload) return;
+      // Visibility: every claim shows up in the daemon's stdout. The
+      // spawner logs the matching cwd + exit lines so one session id
+      // can be grep'd end-to-end.
+      console.log(
+        `[daemon/claim] sess=${payload.session_id} agent=${payload.agent_id} runtime=${runtimeId}`,
+      );
       const ctrl = this.cfg.supervisor.start(payload.session_id);
       void runDispatch(
         { api: this.cfg.api, workspaceManager: this.cfg.workspaceManager },

--- a/packages/daemon/src/main.ts
+++ b/packages/daemon/src/main.ts
@@ -4,6 +4,12 @@
  *   - setup --api <url> --user-token <bv_u_…> [--device-name <name>]
  *   - start
  *   - update [--yes]
+ *
+ * The daemon owns its own config (~/.beevibe/config.json) and has no
+ * legitimate reason to read a local .env. Compiled binaries are built
+ * with `--no-compile-autoload-dotenv --no-compile-autoload-bunfig`
+ * (see packages/daemon/scripts/build-binaries.sh) so launching from
+ * inside a beevibe checkout doesn't silently slurp the repo's .env.
  */
 
 import { runSetup } from "./setup.js";

--- a/packages/daemon/src/spawner.ts
+++ b/packages/daemon/src/spawner.ts
@@ -58,10 +58,9 @@ export async function runDispatch(
   } as unknown as Agent;
   const ws = await deps.workspaceManager.ensureWorkspace({ agent: syntheticAgent });
 
-  // Hot-path log so the daemon's stdout shows what it's actually doing.
-  // Previously this path was silent — "CLI exited with code 1" with no
-  // way to tell which session it was, what cwd was used, or whether
-  // anything was even spawned.
+  // One log line per spawn, same `sess=` token as claimer.ts and the
+  // exit line below, so one session id grep'd from a daemon log shows
+  // the full lifecycle.
   console.log(
     `[daemon/spawn] sess=${payload.session_id} agent=${payload.agent_id} type=${payload.type} cwd=${ws.path}`,
   );
@@ -159,16 +158,15 @@ export async function runDispatch(
     status,
     cli_session_id: result?.cli_session_id,
     result_summary: result?.output ?? "",
-    // Real exit code (when we got one) — beats the previous hardcoded
-    // 0/1. The api uses this to distinguish exit-1 (CLI ran and failed)
-    // from exit-null (spawn never settled — ENOENT etc.).
-    exit_code: result?.exit_code ?? (status === "succeeded" ? 0 : null),
+    // Real exit code when the spawn actually ran; null on the runError
+    // path means "spawn never settled" (ENOENT etc.) — the api can use
+    // that to distinguish "CLI ran and failed" from "we never got to
+    // run it." Previously hardcoded 0/1, which threw away that info.
+    exit_code: result?.exit_code ?? null,
     error: errorDetail,
     usage: result?.usage,
   };
 
-  // Hot-path log — same line for spawn end as for spawn start. Operator
-  // can grep one session id and see the full lifecycle in one place.
   if (status === "succeeded") {
     console.log(`[daemon/spawn] sess=${payload.session_id} exit=0`);
   } else {

--- a/packages/daemon/src/spawner.ts
+++ b/packages/daemon/src/spawner.ts
@@ -58,6 +58,14 @@ export async function runDispatch(
   } as unknown as Agent;
   const ws = await deps.workspaceManager.ensureWorkspace({ agent: syntheticAgent });
 
+  // Hot-path log so the daemon's stdout shows what it's actually doing.
+  // Previously this path was silent — "CLI exited with code 1" with no
+  // way to tell which session it was, what cwd was used, or whether
+  // anything was even spawned.
+  console.log(
+    `[daemon/spawn] sess=${payload.session_id} agent=${payload.agent_id} type=${payload.type} cwd=${ws.path}`,
+  );
+
   const runtime = deps.runtime ?? new ClaudeCodeRuntime();
 
   // Buffer events so the daemon doesn't fire one POST per token. Flushed
@@ -138,15 +146,38 @@ export async function runDispatch(
       : result?.status === "cancelled"
         ? "cancelled"
         : "failed";
+
+  // Build the error string from the most informative source available:
+  // 1. A spawn-side throw (workspace mkdir, ENOENT on `claude`, …) — runError.
+  // 2. The CLI's own stderr tail when it ran but exited non-zero — result.stderr.
+  // Plain "CLI exited with code N" is no longer the user's only signal
+  // when something goes wrong.
+  const errorDetail = runError?.message ?? result?.stderr;
+
   const done = {
     session_id: payload.session_id,
     status,
     cli_session_id: result?.cli_session_id,
     result_summary: result?.output ?? "",
-    exit_code: status === "succeeded" ? 0 : 1,
-    error: runError?.message,
+    // Real exit code (when we got one) — beats the previous hardcoded
+    // 0/1. The api uses this to distinguish exit-1 (CLI ran and failed)
+    // from exit-null (spawn never settled — ENOENT etc.).
+    exit_code: result?.exit_code ?? (status === "succeeded" ? 0 : null),
+    error: errorDetail,
     usage: result?.usage,
   };
+
+  // Hot-path log — same line for spawn end as for spawn start. Operator
+  // can grep one session id and see the full lifecycle in one place.
+  if (status === "succeeded") {
+    console.log(`[daemon/spawn] sess=${payload.session_id} exit=0`);
+  } else {
+    console.error(
+      `[daemon/spawn] sess=${payload.session_id} status=${status} exit=${done.exit_code}` +
+        (errorDetail ? `\n  error:\n    ${errorDetail.split("\n").join("\n    ")}` : ""),
+    );
+  }
+
   try {
     await deps.api.post("/runtime/done", done);
   } catch (err) {


### PR DESCRIPTION
Eight fixes from a debug report where the daemon silently spawned `claude` with a relative cwd (workspace under `./<agent_id>` instead of `~/.beevibe/workspaces/<agent_id>`), claude couldn't open the non-existent mcp-config path, `--strict-mcp-config` made it fatal, every chat replied "CLI exited with code 1" with no diagnostic.

## What broke

1. Daemon binary built with Bun auto-loads `.env` from cwd at startup.
2. Repo's `.env.example` shipped `WORKSPACE_ROOT=` (empty value), copied into `.env`.
3. `manager.ts` used `??`: `"" ?? default` returns `""`, not the default.
4. `join("", agent_id)` → relative path → spawn cwd is relative → mcp-config path is relative → claude can't find it → `--strict-mcp-config` → exit 1.
5. Daemon discards claude's stderr, so the user-facing chat message is the useless string `"CLI exited with code 1"`.

## Fixes (ranked by impact on the next user who hits this)

| # | Where | What |
|---|---|---|
| 1 | `manager.ts:59` | `??` → `\|\|` for `workspaceRoot`. Belt-and-suspenders: throw on non-absolute root in constructor. + regression tests for `workspaceRoot: ""` and `"relative/path"`. |
| 2 | `.env.example` | Drop the empty `WORKSPACE_ROOT=` line; document the var as commented-out with an example path. |
| 3 | `build-binaries.sh` | Pass `--no-compile-autoload-dotenv --no-compile-autoload-bunfig` (Bun ≥1.3.3). Compiled binary no longer reads the cwd's `.env`. Daemon has its own config in `~/.beevibe/config.json`; repo vars have no business leaking in. |
| 4 | `manager.ts` ensureWorkspace | Compare `mcp-config.json` content vs what it would write; rewrite on drift. Catches api_url switches (localhost → hosted after deploy) and rotated `bv_a_` keys. Existing "documented limitation" test flipped to assert auto-refresh. |
| 5 | `claimer.ts` + `spawner.ts` | Hot-path one-line logs per claim / spawn-start / spawn-exit. Same `sess=…` token in every line so one session can be grep'd end-to-end. |
| 6 | `runtime.ts` + `ports/runtime.ts` + `spawner.ts` | Add `stderr` (tail, ~4KB) and `exit_code` to `RuntimeResult`. ClaudeCodeRuntime populates them on failure. Daemon spawner forwards `stderr` into `/runtime/done.error` AND `console.error`s it inline. The actual claude error message now reaches both the session row and the daemon's stdout. |
| 7 | (folded into #1) | `LocalWorkspaceManager` constructor throws if the resolved root isn't absolute. Bug surfaces at construction, not mid-spawn. |
| 9 | `chat.ts` | New `failureMessageFor()` helper: when failed-session text is the bare `"CLI exited with code N"`, prefer the stderr tail (now in `session.error` via #6), or fall back to `"Couldn't reach your team agent. Check the terminal where you ran \`beevibe-daemon start\` for the failure detail."`. Used for both chat history and live response. |

#8 (`beevibe-daemon doctor` subcommand) and #10 (resume-pinning fallback to `agent.preferred_runtime_id` when prior runtime is offline) intentionally deferred per the report's bug list.

## Test plan

- [x] `pnpm build` — all 5 packages
- [x] `pnpm test` — 141 web + 7-package suite + 22 scripts; all green
- [x] New regression tests: `workspaceRoot: ""` → defaults to homedir; `"relative/path"` → throws; auto-refresh on URL drift; auto-refresh on api_key rotation
- [ ] Manual: clean checkout → `pnpm bootstrap` → `beevibe-daemon setup` → first chat. Workspace lands at `~/.beevibe/workspaces/<agent_id>/`. Daemon stdout shows `[daemon/claim]` + `[daemon/spawn] cwd=…` + `[daemon/spawn] exit=0`.
- [ ] Manual: simulate failure (kill claude binary path) → daemon spawn exit≠0 → UI shows stderr-derived message (not "CLI exited with code 1") → daemon stdout shows full stderr.

## Sources

Bun's `--no-compile-autoload-dotenv` flag confirmed via [Jarred Sumner's announcement](https://x.com/jarredsumner/status/1990538844194910695) and the [Bun v1.3.3 release notes](https://bun.com/blog/bun-v1.3.3).