### PR TITLE
fix(mesh): reject caller's ask/negotiate fast when callee session fails

### DIFF
--- a/packages/api/src/bootstrap.ts
+++ b/packages/api/src/bootstrap.ts
@@ -33,6 +33,7 @@ import { TaskService } from "@beevibe/core/services/task-service";
 import { EscalationService } from "@beevibe/core/services/escalation-service";
 import { DispatchService } from "@beevibe/core/services/dispatch-service";
 import { DaemonOrphanReaper } from "@beevibe/core/services/orphan-reaper";
+import type { Session } from "@beevibe/core";
 import { MeshServer } from "./mesh/server.js";
 import { BeevibeApiServer } from "./server.js";
 import { SessionCache } from "./session-cache.js";
@@ -228,6 +229,24 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
     makeMemoryAgent,
   });
 
+  // Shared between `onSessionComplete` (graceful failed/cancelled) and
+  // `onSessionReaped` (daemon-orphan reaps). If a mesh callee terminates
+  // without ever calling respond_ask / respond_negotiate, the waiting
+  // caller would otherwise sit out the 5-min resolver timeout and surface
+  // as a generic MCP "transport dropped" error. The mesh-failure paths
+  // call this so the caller's promise rejects within a tick. Success path
+  // is unaffected — respondAsk/respondNegotiate fired `fireResolver` and
+  // drained the index before this ever runs. Blocker sessions are
+  // fire-and-forget, no resolver to reject.
+  const failMeshCalleeIfTerminal = (session: Session, fallbackReason: string) => {
+    if (
+      (session.type === "mesh_ask" || session.type === "mesh_negotiate") &&
+      (session.status === "failed" || session.status === "cancelled")
+    ) {
+      mesh.failResolverForCalleeSession(session.id, session.error ?? fallbackReason);
+    }
+  };
+
   /**
    * The session cache's onEvict needs to call `onTaskComplete(beevibeSid)`,
    * but `onTaskComplete` lives on a per-agent MemoryAgent. We don't know
@@ -349,22 +368,7 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
       if (session.type === "chat") {
         chatResolver.resolve(session.id, session);
       }
-      // If a mesh callee terminates without ever calling respond_ask /
-      // respond_negotiate, the waiting caller would otherwise sit out the
-      // 5-min resolver timeout and surface as a generic MCP "transport
-      // dropped" error. Reject fast with the session's recorded error so
-      // the caller sees a useful reason within a tick of the row going
-      // terminal. Success path is unaffected: respondAsk/respondNegotiate
-      // already fired `fireResolver` and drained the index.
-      if (
-        (session.type === "mesh_ask" || session.type === "mesh_negotiate") &&
-        (session.status === "failed" || session.status === "cancelled")
-      ) {
-        mesh.failResolverForCalleeSession(
-          session.id,
-          session.error ?? session.status,
-        );
-      }
+      failMeshCalleeIfTerminal(session, session.status);
     },
   });
   server.getApp().use("/runtime", runtimeRouter);
@@ -444,19 +448,7 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
       if (session.type === "chat") {
         chatResolver.resolve(session.id, session);
       }
-      // Same fast-fail path as `onSessionComplete` above — when the
-      // daemon-orphan reaper marks a callee session failed, drop the
-      // caller's mesh resolver immediately instead of waiting for the
-      // 5-min timeout.
-      if (
-        (session.type === "mesh_ask" || session.type === "mesh_negotiate") &&
-        session.status === "failed"
-      ) {
-        mesh.failResolverForCalleeSession(
-          session.id,
-          session.error ?? "daemon_orphaned",
-        );
-      }
+      failMeshCalleeIfTerminal(session, "daemon_orphaned");
     },
   });
   void daemonOrphanReaper.start();

--- a/packages/api/src/bootstrap.ts
+++ b/packages/api/src/bootstrap.ts
@@ -349,8 +349,22 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
       if (session.type === "chat") {
         chatResolver.resolve(session.id, session);
       }
-      // Future: mesh resolver for cross-instance mesh, post-dispatch
-      // hook for parent-task rollup, etc.
+      // If a mesh callee terminates without ever calling respond_ask /
+      // respond_negotiate, the waiting caller would otherwise sit out the
+      // 5-min resolver timeout and surface as a generic MCP "transport
+      // dropped" error. Reject fast with the session's recorded error so
+      // the caller sees a useful reason within a tick of the row going
+      // terminal. Success path is unaffected: respondAsk/respondNegotiate
+      // already fired `fireResolver` and drained the index.
+      if (
+        (session.type === "mesh_ask" || session.type === "mesh_negotiate") &&
+        (session.status === "failed" || session.status === "cancelled")
+      ) {
+        mesh.failResolverForCalleeSession(
+          session.id,
+          session.error ?? session.status,
+        );
+      }
     },
   });
   server.getApp().use("/runtime", runtimeRouter);
@@ -430,7 +444,19 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
       if (session.type === "chat") {
         chatResolver.resolve(session.id, session);
       }
-      // Mesh waiters time out via their own awaitResolver; no fanout here.
+      // Same fast-fail path as `onSessionComplete` above — when the
+      // daemon-orphan reaper marks a callee session failed, drop the
+      // caller's mesh resolver immediately instead of waiting for the
+      // 5-min timeout.
+      if (
+        (session.type === "mesh_ask" || session.type === "mesh_negotiate") &&
+        session.status === "failed"
+      ) {
+        mesh.failResolverForCalleeSession(
+          session.id,
+          session.error ?? "daemon_orphaned",
+        );
+      }
     },
   });
   void daemonOrphanReaper.start();

--- a/packages/api/src/mesh/server.test.ts
+++ b/packages/api/src/mesh/server.test.ts
@@ -1,0 +1,106 @@
+/**
+ * MeshServer unit tests. Focused on the failure-propagation path —
+ * when a callee session terminates non-success, the caller's pending
+ * `ask`/`negotiate` promise must reject within a tick instead of sitting
+ * through the 5-minute resolver timeout (which surfaces to the MCP layer
+ * as a generic "transport dropped" error).
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type {
+  AgentRepository,
+  NegotiationRepository,
+  NegotiationRoundRepository,
+  RuntimeRegistry,
+  SessionEventRepository,
+  SessionRepository,
+  WorkspaceManager,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import { MeshServer } from "./server.js";
+
+function makeMesh() {
+  const dispatchCalls: Array<{ agentId: string; sessionIdOverride?: string }> = [];
+  const dispatchService = {
+    dispatchTask: vi.fn(async (opts: { agentId: string; sessionIdOverride?: string }) => {
+      dispatchCalls.push(opts);
+      // Return a minimal shape that satisfies the type — MeshServer
+      // discards the return via `void`, so values don't matter.
+      return {} as Awaited<ReturnType<DispatchService["dispatchTask"]>>;
+    }),
+  } as unknown as DispatchService;
+
+  const mesh = new MeshServer({
+    agentRepo: {
+      findById: vi.fn(async (id: string) => ({
+        id,
+        name: id,
+        owner_id: "per_1",
+        hierarchy_level: "team" as const,
+        max_mesh_sessions: 5,
+        max_negotiation_rounds: 5,
+        runtime_config: { type: "claude" as const },
+      })),
+    } as unknown as AgentRepository,
+    sessionRepo: {
+      countRunningByAgent: vi.fn(async () => 0),
+    } as unknown as SessionRepository,
+    sessionEventRepo: {} as SessionEventRepository,
+    negotiationRepo: {} as NegotiationRepository,
+    negotiationRoundRepo: {} as NegotiationRoundRepository,
+    workspaceManager: {} as WorkspaceManager,
+    runtimeRegistry: {} as RuntimeRegistry,
+    dispatchService,
+    makeMemoryAgent: () => ({}) as never,
+  });
+
+  return { mesh, dispatchCalls };
+}
+
+describe("MeshServer.failResolverForCalleeSession", () => {
+  it("rejects an ask waiter as soon as the callee session is marked failed", async () => {
+    const { mesh, dispatchCalls } = makeMesh();
+    const ask = mesh.sendAsk("req_1", "agent_caller", "agent_callee", "hello?");
+
+    // sendAsk awaits capacity checks before kicking off the spawn — wait
+    // a full event-loop tick so the pre-minted sessionId reaches the spy.
+    await new Promise((r) => setImmediate(r));
+    const calleeSid = dispatchCalls[0]?.sessionIdOverride;
+    expect(calleeSid).toBeDefined();
+
+    mesh.failResolverForCalleeSession(calleeSid!, "process_lost");
+
+    await expect(ask).rejects.toThrow(/mesh callee session failed: process_lost/);
+  });
+
+  it("is a no-op when the callee session has no pending waiter", () => {
+    const { mesh } = makeMesh();
+    // Should not throw; no resolver is registered for this id.
+    expect(() => mesh.failResolverForCalleeSession("sess_unknown", "x")).not.toThrow();
+  });
+
+  it("does not interfere with the success path", async () => {
+    const { mesh, dispatchCalls } = makeMesh();
+    const ask = mesh.sendAsk("req_2", "agent_caller", "agent_callee", "ping?");
+
+    await new Promise((r) => setImmediate(r));
+    const calleeSid = dispatchCalls[0]?.sessionIdOverride;
+    expect(calleeSid).toBeDefined();
+
+    mesh.respondAsk("req_2", {
+      request_id: "req_2",
+      from_agent_id: "agent_callee",
+      answer: "pong",
+    });
+
+    await expect(ask).resolves.toEqual({
+      request_id: "req_2",
+      from_agent_id: "agent_callee",
+      answer: "pong",
+    });
+
+    // After the success path drains the reverse index, a stale failure
+    // signal for the same session is a no-op (idempotency).
+    expect(() => mesh.failResolverForCalleeSession(calleeSid!, "late")).not.toThrow();
+  });
+});

--- a/packages/api/src/mesh/server.ts
+++ b/packages/api/src/mesh/server.ts
@@ -87,12 +87,30 @@ interface ResolverEntry<T> {
   resolve: (response: T) => void;
   reject: (err: Error) => void;
   timer: ReturnType<typeof setTimeout>;
+  /**
+   * Callee session this resolver is waiting on. When that session ends in a
+   * terminal failure state, `failResolverForCalleeSession` looks the
+   * resolver up via the reverse `pendingByCalleeSession` index and rejects
+   * fast — otherwise the resolver would sit out the full ASK / NEGOTIATE
+   * timeout (5 min) and the caller's MCP transport would eventually drop
+   * with a generic "transport dropped" error instead of a useful reason.
+   */
+  calleeSessionId?: string;
 }
 
 type AskOrNegotiate = AskResponse | NegotiateResponse | EscalatedSentinel;
 
 export class MeshServer {
   private readonly resolvers = new Map<string, ResolverEntry<AskOrNegotiate>>();
+  /**
+   * Reverse index: callee session id → resolver keys waiting on it.
+   * Populated by `awaitResolver` when a `calleeSessionId` is passed and
+   * drained by `fireResolver`/`failResolverForCalleeSession`. One callee
+   * session can have ≥1 waiters across its lifetime (negotiate flips
+   * between initiator and responder keys as rounds alternate, all tied to
+   * the same B-resident session).
+   */
+  private readonly pendingByCalleeSession = new Map<string, Set<string>>();
 
   constructor(private readonly deps: MeshServerDeps) {}
 
@@ -121,14 +139,26 @@ export class MeshServer {
       `Read the question, search relevant context if needed, and respond by calling respond_ask(request_id="${requestId}", answer="..."). The answer is delivered to the asker via that tool — replying in chat alone does NOT reach them. After respond_ask returns, exit.\n` +
       `</context>`;
 
+    // Pre-mint the callee session id so we can index the asker's resolver
+    // by it. If the callee session fails before calling respond_ask, the
+    // bootstrap hooks invoke `failResolverForCalleeSession(sid, ...)` and
+    // the asker gets a clear error fast instead of waiting out the 5-min
+    // resolver timeout.
+    const calleeSid = makeSessionId();
+
     void this.spawnTargetSession({
       targetAgentId: toAgentId,
       type: "mesh_ask",
       intent,
+      sessionId: calleeSid,
       callerAgentId: fromAgentId,
     });
 
-    return this.awaitResolver<AskResponse>(`${requestId}:asker`, DEFAULT_ASK_TIMEOUT_MS);
+    return this.awaitResolver<AskResponse>(
+      `${requestId}:asker`,
+      DEFAULT_ASK_TIMEOUT_MS,
+      calleeSid,
+    );
   }
 
   /**
@@ -231,6 +261,7 @@ export class MeshServer {
     return this.awaitResolver<NegotiateResponse | EscalatedSentinel>(
       `${neg.id}:initiator`,
       DEFAULT_NEGOTIATE_TIMEOUT_MS,
+      counterpartySid,
     );
   }
 
@@ -343,9 +374,13 @@ export class MeshServer {
     // key from whichever was just resolved (or the initiator key if this
     // was B's first response to round 1).
     const myKey = initiatorEntry ? responderKey : initiatorKey;
+    // Across the negotiation's lifetime both initiator and responder
+    // waiters are tied to the same B-resident session, so failing that
+    // session must reject whichever side is currently blocked.
     return this.awaitResolver<NegotiateResponse | EscalatedSentinel>(
       myKey,
       DEFAULT_NEGOTIATE_TIMEOUT_MS,
+      neg.counterparty_session_id ?? undefined,
     );
   }
 
@@ -467,10 +502,13 @@ export class MeshServer {
   private awaitResolver<T extends AskOrNegotiate>(
     key: string,
     timeoutMs: number,
+    calleeSessionId?: string,
   ): Promise<T> {
     return new Promise<T>((resolve, reject) => {
       const timer = setTimeout(() => {
-        if (this.resolvers.delete(key)) {
+        const entry = this.resolvers.get(key);
+        if (entry && this.resolvers.delete(key)) {
+          this.untrackResolverKey(key, entry.calleeSessionId);
           reject(new Error(`mesh resolver timeout (${timeoutMs}ms) for ${key}`));
         }
       }, timeoutMs);
@@ -478,7 +516,16 @@ export class MeshServer {
         resolve: resolve as (response: AskOrNegotiate) => void,
         reject,
         timer,
+        calleeSessionId,
       });
+      if (calleeSessionId) {
+        let keys = this.pendingByCalleeSession.get(calleeSessionId);
+        if (!keys) {
+          keys = new Set();
+          this.pendingByCalleeSession.set(calleeSessionId, keys);
+        }
+        keys.add(key);
+      }
     });
   }
 
@@ -487,8 +534,40 @@ export class MeshServer {
     if (!entry) return false;
     clearTimeout(entry.timer);
     this.resolvers.delete(key);
+    this.untrackResolverKey(key, entry.calleeSessionId);
     entry.resolve(response);
     return true;
+  }
+
+  private untrackResolverKey(key: string, calleeSessionId: string | undefined): void {
+    if (!calleeSessionId) return;
+    const keys = this.pendingByCalleeSession.get(calleeSessionId);
+    if (!keys) return;
+    keys.delete(key);
+    if (keys.size === 0) this.pendingByCalleeSession.delete(calleeSessionId);
+  }
+
+  /**
+   * Reject every resolver currently waiting on `calleeSessionId`. Called
+   * from the bootstrap session-terminal hooks (`onSessionComplete` for
+   * graceful failures + `onSessionReaped` for daemon-orphan reaps) so a
+   * caller's `ask`/`negotiate` promise rejects within a heartbeat of the
+   * callee session entering a terminal failure state, instead of sitting
+   * through the 5-minute resolver timeout. Idempotent — no-op when the
+   * session has no registered waiters (success path or unrelated session).
+   */
+  failResolverForCalleeSession(calleeSessionId: string, reason: string): void {
+    const keys = this.pendingByCalleeSession.get(calleeSessionId);
+    if (!keys || keys.size === 0) return;
+    // Snapshot before mutating: rejecting drains via `untrackResolverKey`.
+    for (const key of [...keys]) {
+      const entry = this.resolvers.get(key);
+      if (!entry) continue;
+      clearTimeout(entry.timer);
+      this.resolvers.delete(key);
+      entry.reject(new Error(`mesh callee session failed: ${reason}`));
+    }
+    this.pendingByCalleeSession.delete(calleeSessionId);
   }
 }
 

--- a/packages/api/src/mesh/server.ts
+++ b/packages/api/src/mesh/server.ts
@@ -506,9 +506,7 @@ export class MeshServer {
   ): Promise<T> {
     return new Promise<T>((resolve, reject) => {
       const timer = setTimeout(() => {
-        const entry = this.resolvers.get(key);
-        if (entry && this.resolvers.delete(key)) {
-          this.untrackResolverKey(key, entry.calleeSessionId);
+        if (this.removeResolver(key)) {
           reject(new Error(`mesh resolver timeout (${timeoutMs}ms) for ${key}`));
         }
       }, timeoutMs);
@@ -530,21 +528,31 @@ export class MeshServer {
   }
 
   private fireResolver(key: string, response: AskOrNegotiate): boolean {
-    const entry = this.resolvers.get(key);
+    const entry = this.removeResolver(key);
     if (!entry) return false;
-    clearTimeout(entry.timer);
-    this.resolvers.delete(key);
-    this.untrackResolverKey(key, entry.calleeSessionId);
     entry.resolve(response);
     return true;
   }
 
-  private untrackResolverKey(key: string, calleeSessionId: string | undefined): void {
-    if (!calleeSessionId) return;
-    const keys = this.pendingByCalleeSession.get(calleeSessionId);
-    if (!keys) return;
-    keys.delete(key);
-    if (keys.size === 0) this.pendingByCalleeSession.delete(calleeSessionId);
+  /**
+   * Single source of truth for resolver cleanup: clears the timer, drops
+   * the entry from both `resolvers` and the reverse `pendingByCalleeSession`
+   * index, and returns the entry so the caller can resolve/reject it.
+   * Returns `undefined` if no entry was registered (idempotent).
+   */
+  private removeResolver(key: string): ResolverEntry<AskOrNegotiate> | undefined {
+    const entry = this.resolvers.get(key);
+    if (!entry) return undefined;
+    clearTimeout(entry.timer);
+    this.resolvers.delete(key);
+    if (entry.calleeSessionId) {
+      const keys = this.pendingByCalleeSession.get(entry.calleeSessionId);
+      if (keys) {
+        keys.delete(key);
+        if (keys.size === 0) this.pendingByCalleeSession.delete(entry.calleeSessionId);
+      }
+    }
+    return entry;
   }
 
   /**
@@ -559,15 +567,14 @@ export class MeshServer {
   failResolverForCalleeSession(calleeSessionId: string, reason: string): void {
     const keys = this.pendingByCalleeSession.get(calleeSessionId);
     if (!keys || keys.size === 0) return;
-    // Snapshot before mutating: rejecting drains via `untrackResolverKey`.
+    // Snapshot the key set first: an entry.reject() can synchronously
+    // resume awaiters that re-enter mesh code, and removeResolver mutates
+    // the same set as it drains. Iterating the live set is unsafe.
     for (const key of [...keys]) {
-      const entry = this.resolvers.get(key);
+      const entry = this.removeResolver(key);
       if (!entry) continue;
-      clearTimeout(entry.timer);
-      this.resolvers.delete(key);
       entry.reject(new Error(`mesh callee session failed: ${reason}`));
     }
-    this.pendingByCalleeSession.delete(calleeSessionId);
   }
 }
 

--- a/packages/core/src/services/agent-session.test.ts
+++ b/packages/core/src/services/agent-session.test.ts
@@ -255,6 +255,44 @@ describe("AgentSession.run", () => {
     expect(failPatch![1].error).toContain("spawn ENOENT");
   });
 
+  it("fires onSessionComplete with the failed row when the runtime throws", async () => {
+    // Spawn/CLI exceptions used to skip the hook — only graceful failures
+    // fired it — which left mesh resolvers waiting out the 5-min timeout.
+    // Verifies the in-catch fire so failResolverForCalleeSession runs fast.
+    const onSessionComplete = vi
+      .fn<NonNullable<AgentSessionDeps["onSessionComplete"]>>()
+      .mockResolvedValue();
+    const local = new AgentSession({
+      agentRepo,
+      sessionRepo,
+      sessionEventRepo,
+      runtime,
+      memoryAgent,
+      onSessionComplete,
+    });
+    vi.mocked(agentRepo.findById).mockResolvedValue(makeAgent());
+    vi.mocked(sessionRepo.create).mockImplementation(async (i) => makeSession(i.id));
+    vi.mocked(memoryAgent.prepareBriefing).mockResolvedValue({
+      systemPromptAppend: "",
+      userMessagePrefix: "",
+      snapshot: { block_count: 0, fact_count: 0, token_count: 0, blocks: [], facts: [] },
+    });
+    vi.mocked(runtime.execute).mockRejectedValue(new Error("spawn ENOENT"));
+    vi.mocked(sessionRepo.update).mockImplementation(async (id, patch) =>
+      makeSession(id, patch as Partial<Session>),
+    );
+
+    await expect(
+      local.run({ agentId: "agent_1", intent: "x", workspace: WORKSPACE }),
+    ).rejects.toThrow(/spawn ENOENT/);
+
+    // Allow the fire-and-forget hook to settle before asserting.
+    await new Promise((r) => setImmediate(r));
+    expect(onSessionComplete).toHaveBeenCalledTimes(1);
+    expect(onSessionComplete.mock.calls[0]![0].status).toBe("failed");
+    expect(onSessionComplete.mock.calls[0]![0].error).toContain("spawn ENOENT");
+  });
+
   it("passes agent.runtime_config.model + max_turns into RuntimeContext (per-agent override)", async () => {
     vi.mocked(agentRepo.findById).mockResolvedValue(
       makeAgent({

--- a/packages/core/src/services/agent-session.ts
+++ b/packages/core/src/services/agent-session.ts
@@ -227,11 +227,26 @@ export class AgentSession {
         },
       });
     } catch (err) {
-      await this.deps.sessionRepo.update(sid, {
+      const failedSession = await this.deps.sessionRepo.update(sid, {
         status: "failed",
         error: (err as Error).message,
         completed_at: new Date(),
       });
+      // Fire onSessionComplete on the in-catch failure path too. Without
+      // this, exceptions thrown out of `executor.execute` (spawn errors,
+      // CLI crashes) update the row to status=failed but skip the hook
+      // that the graceful failure path on line ~272 fires — leaving mesh
+      // resolvers blocked until their 5-min timeout. The hook is
+      // fire-and-forget; we still rethrow so the dispatcher sees the
+      // original error and can mark the daemon's claim as failed.
+      if (!input.skipOnComplete) {
+        void this.deps.onSessionComplete?.(failedSession).catch((hookErr) =>
+          console.error(
+            "[AgentSession] onSessionComplete (catch path) failed:",
+            (hookErr as Error).message,
+          ),
+        );
+      }
       throw err;
     }
 


### PR DESCRIPTION
## Summary
When a mesh `ask` / `negotiate` callee terminates without ever calling `respond_ask` / `respond_negotiate` (CLI crash, spawn error, daemon-orphan reap, generic failure), the caller's MCP tool used to sit through MeshServer's 5-minute resolver timeout. Claude's MCP transport drops first, surfacing to the asking agent as the opaque `MCP server "beevibe" transport dropped mid-call` error. The transcript in the bug report (`b37fcf70-18c1-4d75-8382-8b4e3a4cc360`) shows two ~7–10 min waits producing exactly this message.

This wires callee-session failure → resolver rejection so the caller's promise rejects **within a tick** of the row going terminal, with the session's recorded error string instead of a generic transport error.

## How
1. **`MeshServer`** keeps a reverse index `pendingByCalleeSession: Map<sessionId, Set<resolverKey>>`, populated by `awaitResolver` when a `calleeSessionId` is supplied; drained by `fireResolver`.
2. **`sendAsk`** now pre-mints the callee session id (parallels `sendNegotiate`'s existing `counterpartySid` pattern) and threads it through `awaitResolver`. `sendNegotiate` does the same for both the initiator and per-round responder waiters — they're all tied to B's resident session.
3. New public method **`MeshServer.failResolverForCalleeSession(sessionId, reason)`** rejects every resolver still waiting on that session. Idempotent.
4. **`bootstrap.ts`** wires the call from two existing terminal-state hooks:
   - `onSessionComplete` — graceful `failed`/`cancelled` mesh sessions.
   - `daemonOrphanReaper.onSessionReaped` — daemon-orphan reaps.
   - Closes the `// Future: mesh resolver` TODO at `bootstrap.ts:352`.
5. **`AgentSession.run`** catch-and-rethrow path now also fires `onSessionComplete` for the failed row. Without this, exceptions thrown out of `executor.execute` (spawn errors, CLI crashes) wrote `status=failed` but skipped the hook that the graceful failure path fires, defeating fix #4 for the most common CLI-crash flavor.

## Test plan
- [x] `mesh/server.test.ts` (new): rejects with the callee's recorded reason, is a no-op for unknown sessions, and the success path is unaffected (3/3 pass).
- [x] `agent-session.test.ts`: new case asserts `onSessionComplete` fires with the failed row when `runtime.execute` throws (24/24 pass).
- [x] Full core service suite — 163/163 pass.
- [x] Full API suite — 240/240 unit tests pass; 6 pre-existing live-DB integration failures are unrelated.
- [x] `typecheck` + `lint` clean on api, core, web.
- [ ] End-to-end: kill a callee mid-`ask` (e.g. `SIGKILL` the daemon mid-spawn) and confirm the caller's MCP tool errors within ~1s with `mesh callee session failed: <reason>` instead of waiting for the transport drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)