### PR TITLE
fix(memory): stable scope-tab counts via dedicated counts endpoint

### DIFF
--- a/packages/api/src/routes/view.ts
+++ b/packages/api/src/routes/view.ts
@@ -46,7 +46,7 @@ import {
 } from "../views/tasks-grouping.js";
 import { listAgents, getAgent } from "../views/agents.js";
 import { getSessionByShortId, AmbiguousShortIdError } from "../views/sessions.js";
-import { listMemoryFacts } from "../views/memory.js";
+import { listMemoryFactCounts, listMemoryFacts } from "../views/memory.js";
 import { getDashboardSummary } from "../views/dashboard.js";
 import { getMeshOverview } from "../views/mesh.js";
 import { listPromotions } from "../views/promotions.js";
@@ -503,6 +503,16 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
       res.json(facts);
     } catch (err) {
       handleError(err, res, "memory fact list");
+    }
+  });
+
+  router.get("/memory/fact/counts", async (req, res) => {
+    if (!requireHuman(req, res)) return;
+    try {
+      const counts = await listMemoryFactCounts(deps.pool, req.caller.personId);
+      res.json(counts);
+    } catch (err) {
+      handleError(err, res, "memory fact counts");
     }
   });
 

--- a/packages/api/src/views/memory.test.ts
+++ b/packages/api/src/views/memory.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { listMemoryFacts } from "./memory.js";
+import { listMemoryFactCounts, listMemoryFacts } from "./memory.js";
 import { makeMockPool } from "./test-helpers.js";
 
 describe("listMemoryFacts", () => {
@@ -69,5 +69,26 @@ describe("listMemoryFacts", () => {
     expect(facts[1]?.merge_origin).toBe("merged");
     expect(facts[1]?.source_session_count).toBe(2);
     expect(facts[1]?.agent_label).toBe("Alice");
+  });
+});
+
+describe("listMemoryFactCounts", () => {
+  it("returns zeros for every scope when the owner has no facts", async () => {
+    const pool = makeMockPool([]);
+    const counts = await listMemoryFactCounts(pool, "per_w");
+    expect(counts).toEqual({ total: 0, ic: 0, team: 0, org: 0 });
+    expect(pool._spy).toHaveBeenCalledWith(expect.any(String), ["per_w"]);
+  });
+
+  it("aggregates per-scope rows and computes total", async () => {
+    // Mirror the GROUP BY result shape: one row per non-empty scope. The
+    // mapper must zero-fill scopes missing from the result so the UI can
+    // unconditionally read counts.ic / counts.team / counts.org.
+    const pool = makeMockPool([
+      { scope: "ic", n: 7 },
+      { scope: "team", n: 3 },
+    ]);
+    const counts = await listMemoryFactCounts(pool, "per_w");
+    expect(counts).toEqual({ total: 10, ic: 7, team: 3, org: 0 });
   });
 });

--- a/packages/api/src/views/memory.ts
+++ b/packages/api/src/views/memory.ts
@@ -9,7 +9,10 @@
 
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import type { FactType, MemoryScope } from "@beevibe/core";
+import { MEMORY_SCOPES } from "@beevibe/core";
 import type { MemoryFactCounts, MemoryFactDisplay, MergeOrigin } from "./types.js";
+
+const MEMORY_SCOPE_SET = new Set<string>(MEMORY_SCOPES);
 
 interface FactRow {
   id: string;
@@ -87,6 +90,10 @@ export async function listMemoryFactCounts(
   const { rows } = await pool.query<CountsRow>(COUNTS_SQL, [ownerId]);
   const counts: MemoryFactCounts = { total: 0, ic: 0, team: 0, org: 0 };
   for (const row of rows) {
+    // Defensive: if a future migration adds a new MemoryScope and this
+    // query runs before the DTO/UI catch up, ignore the unknown bucket
+    // rather than corrupting the result with a stray property.
+    if (!MEMORY_SCOPE_SET.has(row.scope)) continue;
     counts[row.scope] = row.n;
     counts.total += row.n;
   }

--- a/packages/api/src/views/memory.ts
+++ b/packages/api/src/views/memory.ts
@@ -9,7 +9,7 @@
 
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import type { FactType, MemoryScope } from "@beevibe/core";
-import type { MemoryFactDisplay, MergeOrigin } from "./types.js";
+import type { MemoryFactCounts, MemoryFactDisplay, MergeOrigin } from "./types.js";
 
 interface FactRow {
   id: string;
@@ -59,6 +59,38 @@ export async function listMemoryFacts(
     limit,
   ]);
   return rows.map(rowToMemoryFactDisplay);
+}
+
+/**
+ * Per-scope fact counts for the memory page's scope tabs. Owner-scoped
+ * and unconditional — the tab counts must stay stable regardless of
+ * which scope filter is active on `/memory/fact`, otherwise switching
+ * tabs makes the other tabs' badges flash to 0.
+ */
+const COUNTS_SQL = /* sql */ `
+SELECT f.scope, COUNT(*)::int AS n
+FROM memory_fact f
+JOIN agent a ON a.id = f.agent_id
+WHERE a.owner_id = $1
+GROUP BY f.scope
+`;
+
+interface CountsRow {
+  scope: MemoryScope;
+  n: number;
+}
+
+export async function listMemoryFactCounts(
+  pool: Pool,
+  ownerId: string,
+): Promise<MemoryFactCounts> {
+  const { rows } = await pool.query<CountsRow>(COUNTS_SQL, [ownerId]);
+  const counts: MemoryFactCounts = { total: 0, ic: 0, team: 0, org: 0 };
+  for (const row of rows) {
+    counts[row.scope] = row.n;
+    counts.total += row.n;
+  }
+  return counts;
 }
 
 function rowToMemoryFactDisplay(row: FactRow): MemoryFactDisplay {

--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -283,6 +283,18 @@ export interface MemoryFactDisplay {
   promotion_origin_scope?: MemoryScope;
 }
 
+/**
+ * Per-scope fact counts for the /memory page's tab badges. Owner-scoped
+ * and unfiltered — the badges have to stay stable regardless of which
+ * scope tab is currently selected on the page.
+ */
+export interface MemoryFactCounts {
+  total: number;
+  ic: number;
+  team: number;
+  org: number;
+}
+
 // ── Dashboard ───────────────────────────────────────────────────────────────
 //
 // The dashboard DTO is intentionally pure data. The web composes display

--- a/packages/web/app/(authed)/memory/memory-client.tsx
+++ b/packages/web/app/(authed)/memory/memory-client.tsx
@@ -22,7 +22,7 @@ import { FactRowSkeleton } from "@/components/skeletons";
 import { FactTypeTag } from "@/components/fact-type-tag";
 import { ScopeChip } from "@/components/scope-chip";
 import { RichTextRender } from "@/components/rich-text";
-import { useMemoryFacts } from "@/lib/hooks/use-memory";
+import { useMemoryFactCounts, useMemoryFacts } from "@/lib/hooks/use-memory";
 import { useSlashFocus } from "@/lib/hooks/use-slash-focus";
 import { isApiConfigured } from "@/lib/api/config";
 import { api } from "@/lib/api/client";
@@ -41,9 +41,13 @@ export function MemoryClient() {
 
   const filterScope: MemoryScope | undefined = scope === "all" ? undefined : scope;
   const { data, isLoading, isError } = useMemoryFacts({ scope: filterScope });
+  // Counts come from a separate endpoint so the tab badges stay stable
+  // when the scope filter narrows the list below. Deriving counts from
+  // the filtered `data` would zero out the inactive tabs.
+  const { data: countsData } = useMemoryFactCounts();
 
   const facts = data ?? EMPTY_FACTS;
-  const counts = useMemo(() => deriveCounts(facts), [facts]);
+  const counts = countsData ?? EMPTY_COUNTS;
   const haystacks = useMemo(() => buildHaystacks(facts), [facts]);
   const filtered = useMemo(() => applyFilter(facts, haystacks, query), [facts, haystacks, query]);
 
@@ -264,13 +268,6 @@ function FilterButton({ label }: { label: string }) {
       <ChevronDown className="h-3 w-3" />
     </button>
   );
-}
-
-function deriveCounts(facts: MemoryFactDisplay[]): FactCounts {
-  if (facts.length === 0) return EMPTY_COUNTS;
-  const counts: FactCounts = { total: facts.length, ic: 0, team: 0, org: 0 };
-  for (const f of facts) counts[f.scope] += 1;
-  return counts;
 }
 
 function buildHaystacks(facts: MemoryFactDisplay[]): string[] {

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -9,7 +9,7 @@ import type { TaskListItem } from "@/lib/types/tasks";
 import type { AgentDisplay } from "@/lib/types/agents";
 import type { AgentNetwork } from "@/lib/types/agent-network";
 import type { SessionDisplay } from "@/lib/types/sessions";
-import type { MemoryFactDisplay } from "@/lib/types/memory-facts";
+import type { FactCounts, MemoryFactDisplay } from "@/lib/types/memory-facts";
 import type { PromotionEvent } from "@/lib/types/promotion-events";
 import type { InboxItem } from "@/lib/types/inbox";
 import type {
@@ -451,6 +451,14 @@ export const api = {
         query: { ...filter },
         signal: opts.signal,
       }),
+    /**
+     * Per-scope counts for the memory page's tab badges. Driven by a
+     * separate endpoint so the badges stay stable across scope changes —
+     * deriving counts from a scope-filtered list would zero out the
+     * inactive tabs.
+     */
+    factCounts: (opts: ReadOptions = {}) =>
+      fetchJson<FactCounts>("/memory/fact/counts", { signal: opts.signal }),
     /**
      * Owner-driven delete. Lets users correct over-saved facts (issue
      * #90 fix D) without waiting for FactPromoter or running SQL. The

--- a/packages/web/lib/hooks/keys.ts
+++ b/packages/web/lib/hooks/keys.ts
@@ -19,6 +19,7 @@ export const queryKeys = {
   memory: {
     all: ["memory"] as const,
     facts: (filter: { scope?: MemoryScope }) => ["memory", "facts", filter] as const,
+    counts: () => ["memory", "counts"] as const,
   },
   promotions: {
     all: ["promotions"] as const,

--- a/packages/web/lib/hooks/use-memory.ts
+++ b/packages/web/lib/hooks/use-memory.ts
@@ -2,12 +2,29 @@ import { useQuery } from "@tanstack/react-query";
 import type { MemoryScope } from "@beevibe/core";
 import { api } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
+import type { FactCounts } from "@/lib/types/memory-facts";
 import { queryKeys } from "./keys";
 
 export function useMemoryFacts(filter: { scope?: MemoryScope } = {}) {
   return useQuery({
     queryKey: queryKeys.memory.facts(filter),
     queryFn: ({ signal }) => api.memory.listFacts(filter, { signal }),
+    enabled: isApiConfigured,
+  });
+}
+
+/**
+ * Per-scope counts for the memory page's tab badges. Owner-scoped on
+ * the server and independent of the active scope filter, so the badges
+ * keep showing the true cardinality of each scope while the list below
+ * narrows. Shares the `["memory"]` invalidation prefix with the facts
+ * query so `memory.fact.created` / `memory.fact.deleted` SSE refresh
+ * both at once.
+ */
+export function useMemoryFactCounts() {
+  return useQuery<FactCounts>({
+    queryKey: queryKeys.memory.counts(),
+    queryFn: ({ signal }) => api.memory.factCounts({ signal }),
     enabled: isApiConfigured,
   });
 }

--- a/packages/web/lib/types/memory-facts.ts
+++ b/packages/web/lib/types/memory-facts.ts
@@ -1,8 +1,5 @@
-export type { MemoryFactDisplay, MergeOrigin } from "@beevibe/api/views/types";
-
-export interface FactCounts {
-  total: number;
-  ic: number;
-  team: number;
-  org: number;
-}
+export type {
+  MemoryFactDisplay,
+  MergeOrigin,
+  MemoryFactCounts as FactCounts,
+} from "@beevibe/api/views/types";


### PR DESCRIPTION
## Summary
When the user clicked a different scope tab on `/memory`, the inactive tabs' badges dropped to 0. Each tab change re-fetched `/memory/fact?scope=<tab>`, the response held only that scope's facts, and `deriveCounts` ran against the filtered array — so the result was `<active>=N, others=0`.

This PR moves counts to a dedicated, owner-scoped endpoint that's independent of the active scope filter, so the badges stay stable while the list below narrows.

## Changes

**Backend**
- `GET /memory/fact/counts` returns `{ total, ic, team, org }`. Runs a `GROUP BY scope` joined through `agent.owner_id` so it's owner-scoped (matches the read-side filter on `/memory/fact`).
- `listMemoryFactCounts` zero-fills scopes that don't appear in the GROUP BY result, so the client can read `counts.ic` / `counts.team` / `counts.org` unconditionally.
- New `MemoryFactCounts` DTO in `views/types.ts`.

**Frontend**
- New `useMemoryFactCounts()` hook + `queryKeys.memory.counts()`. Existing SSE wiring already invalidates the `["memory"]` prefix on `memory.fact.created` / `memory.fact.deleted`, so counts and list refresh together with no extra plumbing.
- `MemoryClient` reads counts from the new hook. The buggy `deriveCounts` helper is gone.

## Test plan
- [x] `pnpm --filter @beevibe/api test --run src/views/memory.test.ts` — 6/6 pass, including two new cases (zero-fill on empty owner, aggregation + total for a multi-scope result).
- [x] API build + typecheck — clean.
- [x] Web typecheck + lint — clean.
- [x] Full web test suite — 140/140 pass.
- [ ] Visual: on `/memory`, switch scope tabs and confirm each tab badge keeps its real count (no zeros on inactive tabs). After creating or deleting a fact, both the list and the badges should refresh together via SSE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)