### PR TITLE
fix(tasks): drop the expandable archived lane, keep just the header badge

### DIFF
--- a/packages/web/app/(authed)/tasks/tasks-client.test.tsx
+++ b/packages/web/app/(authed)/tasks/tasks-client.test.tsx
@@ -138,7 +138,7 @@ describe("TasksClient — lane rendering", () => {
     expect(counts).toEqual(["2", "1", "1", "1", "1"]);
   });
 
-  it("hides cancelled+failed by default and surfaces the archive toggle", async () => {
+  it("omits cancelled+failed from the board and surfaces their count as a header badge", async () => {
     listMock.mockResolvedValue([
       makeTask({ id: "d1", status: "done", title: "done one" }),
       makeTask({ id: "f1", status: "failed", title: "failed one" }),
@@ -147,17 +147,16 @@ describe("TasksClient — lane rendering", () => {
     renderClient();
 
     expect(await screen.findByText("done one")).toBeInTheDocument();
-    // Failed + cancelled are off by default.
+    // Failed + cancelled are never rendered on the board — the badge is
+    // informational only.
     expect(screen.queryByText("failed one")).not.toBeInTheDocument();
     expect(screen.queryByText("cancel one")).not.toBeInTheDocument();
-    // Toggle pill exposes the count. Accessible name = its text
-    // content ("2 archived") since the button has no aria-label.
-    const toggle = screen.getByRole("button", { name: /\d+ archived/i });
-    expect(toggle).toHaveTextContent("2 archived");
-    // Click expands the Archived lane.
-    await userEvent.click(toggle);
-    expect(await screen.findByText("failed one")).toBeInTheDocument();
-    expect(screen.getByText("cancel one")).toBeInTheDocument();
+    // Read-only badge shows the count. No button role: there's nothing
+    // to toggle anymore.
+    expect(screen.getByText("2 archived")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /\d+ archived/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("calls the task list endpoint without a view filter (no My tasks tab)", async () => {

--- a/packages/web/app/(authed)/tasks/tasks-client.tsx
+++ b/packages/web/app/(authed)/tasks/tasks-client.tsx
@@ -24,11 +24,6 @@ export function TasksClient() {
   const selectedTaskId = searchParams?.get("p") ?? undefined;
 
   const [query, setQuery] = useState("");
-  // Cancelled + failed are noise on the default board — agents fail
-  // more than humans intend, and a "Cancelled" column always-visible
-  // would dominate the board. Default closed; surface count + toggle
-  // in the header so the morgue stays accessible without dominating.
-  const [showArchived, setShowArchived] = useState(false);
 
   const openTask = useCallback(
     (taskId: string) => {
@@ -53,10 +48,7 @@ export function TasksClient() {
   }, [data, query]);
 
   const archivedCount = useMemo(() => countArchivedTasks(filtered), [filtered]);
-  const lanes = useMemo(
-    () => groupTasks(filtered, { showArchived }),
-    [filtered, showArchived],
-  );
+  const lanes = useMemo(() => groupTasks(filtered), [filtered]);
   const emptyMessage = pickEmptyMessage({
     isApiConfigured,
     isError,
@@ -77,8 +69,6 @@ export function TasksClient() {
         query={query}
         onQueryChange={setQuery}
         archivedCount={archivedCount}
-        showArchived={showArchived}
-        onToggleArchived={() => setShowArchived((v) => !v)}
       />
 
       {fullScreenEmpty ? (

--- a/packages/web/components/tasks/view-tabs.tsx
+++ b/packages/web/components/tasks/view-tabs.tsx
@@ -2,7 +2,6 @@
 
 import { useRef } from "react";
 import { Archive, Search } from "lucide-react";
-import { cn } from "@/lib/utils";
 import { useSlashFocus } from "@/lib/hooks/use-slash-focus";
 
 // Header for /tasks. The earlier strip had "All tasks / My tasks"
@@ -19,8 +18,6 @@ interface Props {
   onQueryChange: (value: string) => void;
   /** Number of failed+cancelled tasks under the current filter. */
   archivedCount: number;
-  showArchived: boolean;
-  onToggleArchived: () => void;
 }
 
 export function ViewTabs({
@@ -28,8 +25,6 @@ export function ViewTabs({
   query,
   onQueryChange,
   archivedCount,
-  showArchived,
-  onToggleArchived,
 }: Props) {
   return (
     <div className="flex items-center gap-3 px-6 pt-5 pb-4 border-b border-border/60">
@@ -39,46 +34,26 @@ export function ViewTabs({
       </p>
 
       <div className="shrink-0 flex items-center gap-2">
-        {/* Archive toggle — always rendered so the affordance is
-            discoverable even when there's nothing archived yet. Failed
-            and cancelled tasks would otherwise dominate Done, so they're
-            hidden by default behind this toggle. */}
-        <ArchiveToggle
-          count={archivedCount}
-          showing={showArchived}
-          onToggle={onToggleArchived}
-        />
+        {/* Read-only badge. Failed + cancelled aren't rendered as a
+            lane on the board (Done is reserved for "this shipped"); the
+            badge just surfaces the count so the user knows the morgue
+            isn't empty without dedicating a column to it. */}
+        <ArchiveBadge count={archivedCount} />
         <SearchBox query={query} onChange={onQueryChange} onFocus={onSearch} />
       </div>
     </div>
   );
 }
 
-function ArchiveToggle({
-  count,
-  showing,
-  onToggle,
-}: {
-  count: number;
-  showing: boolean;
-  onToggle: () => void;
-}) {
+function ArchiveBadge({ count }: { count: number }) {
   return (
-    <button
-      type="button"
-      onClick={onToggle}
-      aria-pressed={showing}
-      title={showing ? "Hide archived (failed + cancelled)" : "Show archived (failed + cancelled)"}
-      className={cn(
-        "h-7 inline-flex items-center gap-1.5 px-2 rounded text-[11px] font-medium border transition-colors cursor-pointer tabular-nums",
-        showing
-          ? "border-border bg-secondary text-foreground"
-          : "border-transparent text-muted-foreground hover:text-foreground hover:bg-secondary/60",
-      )}
+    <span
+      title="Archived (failed + cancelled). Not shown on the board."
+      className="h-7 inline-flex items-center gap-1.5 px-2 rounded text-[11px] font-medium text-muted-foreground tabular-nums"
     >
       <Archive className="h-3 w-3" />
       <span>{count} archived</span>
-    </button>
+    </span>
   );
 }
 

--- a/packages/web/components/tasks/view-tabs.tsx
+++ b/packages/web/components/tasks/view-tabs.tsx
@@ -52,7 +52,7 @@ function ArchiveBadge({ count }: { count: number }) {
       className="h-7 inline-flex items-center gap-1.5 px-2 rounded text-[11px] font-medium text-muted-foreground tabular-nums"
     >
       <Archive className="h-3 w-3" />
-      <span>{count} archived</span>
+      {count} archived
     </span>
   );
 }

--- a/packages/web/lib/tasks-grouping.test.ts
+++ b/packages/web/lib/tasks-grouping.test.ts
@@ -21,7 +21,9 @@ function makeTask(id: string, status: TaskStatus): TaskListItem {
   };
 }
 
-const EXPECTED_LIFECYCLE: Record<TaskStatus, Lifecycle> = {
+// `null` = omitted from the board; the header's archived badge surfaces
+// the count instead. Only failed + cancelled get this treatment today.
+const EXPECTED_LIFECYCLE: Record<TaskStatus, Lifecycle | null> = {
   pending: "pending",
   assigned: "pending",
   in_progress: "in_progress",
@@ -30,12 +32,12 @@ const EXPECTED_LIFECYCLE: Record<TaskStatus, Lifecycle> = {
   review: "in_review",
   blocked: "blocked",
   done: "done",
-  failed: "archived",
-  cancelled: "archived",
+  failed: null,
+  cancelled: null,
 };
 
 describe("groupTasks", () => {
-  it("returns five lanes in workflow order by default (no archived)", () => {
+  it("returns five lanes in workflow order", () => {
     const lanes = groupTasks([]);
     expect(lanes.map((l) => l.key)).toEqual([
       "pending",
@@ -47,28 +49,20 @@ describe("groupTasks", () => {
     expect(lanes.every((l) => l.count === 0 && l.tasks.length === 0)).toBe(true);
   });
 
-  it("appends an archived lane when showArchived is true", () => {
-    const lanes = groupTasks([], { showArchived: true });
-    expect(lanes.map((l) => l.key)).toEqual([
-      "pending",
-      "in_progress",
-      "blocked",
-      "in_review",
-      "done",
-      "archived",
-    ]);
-  });
-
   it("maps every TaskStatus exhaustively (no status falls through to a wrong lane)", () => {
     for (const status of TASK_STATUSES) {
-      const [task] = [makeTask("t1", status)];
-      const lanes = groupTasks([task], { showArchived: true });
+      const lanes = groupTasks([makeTask("t1", status)]);
       const populated = lanes.find((l) => l.tasks.length === 1);
-      expect(populated?.key, `status=${status}`).toBe(EXPECTED_LIFECYCLE[status]);
+      const expected = EXPECTED_LIFECYCLE[status];
+      if (expected === null) {
+        expect(populated, `status=${status}`).toBeUndefined();
+      } else {
+        expect(populated?.key, `status=${status}`).toBe(expected);
+      }
     }
   });
 
-  it("hides failed + cancelled tasks when showArchived is false", () => {
+  it("hides failed + cancelled tasks from the board", () => {
     const tasks: TaskListItem[] = [
       makeTask("a", "pending"),
       makeTask("b", "failed"),
@@ -103,7 +97,7 @@ describe("groupTasks", () => {
       makeTask("g", "assigned"),
       makeTask("h", "needs_revision"),
     ];
-    const lanes = groupTasks(tasks, { showArchived: true });
+    const lanes = groupTasks(tasks);
     const byKey = Object.fromEntries(lanes.map((l) => [l.key, l]));
 
     expect(byKey.pending.tasks.map((t) => t.id)).toEqual(["a", "g"]);
@@ -111,11 +105,12 @@ describe("groupTasks", () => {
     expect(byKey.blocked.tasks.map((t) => t.id)).toEqual(["c"]);
     expect(byKey.in_review.tasks.map((t) => t.id)).toEqual(["d"]);
     expect(byKey.done.tasks.map((t) => t.id)).toEqual(["e"]);
-    expect(byKey.archived.tasks.map((t) => t.id)).toEqual(["f"]);
+    // "f" is failed → omitted from the board.
+    expect(lanes.some((l) => l.tasks.some((t) => t.id === "f"))).toBe(false);
   });
 
   it("attaches a non-empty dot class and label to each lane", () => {
-    const lanes = groupTasks([], { showArchived: true });
+    const lanes = groupTasks([]);
     for (const lane of lanes) {
       expect(lane.dot).toMatch(/^bg-/);
       expect(lane.label.length).toBeGreaterThan(0);

--- a/packages/web/lib/tasks-grouping.ts
+++ b/packages/web/lib/tasks-grouping.ts
@@ -53,6 +53,16 @@ const VISIBLE_LANES: LaneTemplate[] = [
   { key: "done", label: "Done", dot: "bg-status-done" },
 ];
 
+/**
+ * "Archived" = any status that's terminal-non-success. Derived from
+ * `LIFECYCLE_OF` so the badge count and the board filter stay in sync —
+ * if a future status maps to `null` (omit from board), it automatically
+ * counts toward the archived badge too.
+ */
+export function isArchivedStatus(status: TaskStatus): boolean {
+  return LIFECYCLE_OF[status] === null;
+}
+
 export function groupTasks(tasks: TaskListItem[]): BoardLane[] {
   const buckets: Record<Lifecycle, TaskListItem[]> = {
     pending: [],
@@ -72,11 +82,11 @@ export function groupTasks(tasks: TaskListItem[]): BoardLane[] {
   }));
 }
 
-/** Count of failed+cancelled tasks — drives the archived badge in the header. */
+/** Count of archived (terminal-non-success) tasks — drives the header badge. */
 export function countArchivedTasks(tasks: TaskListItem[]): number {
   let n = 0;
   for (const t of tasks) {
-    if (t.status === "failed" || t.status === "cancelled") n += 1;
+    if (isArchivedStatus(t.status)) n += 1;
   }
   return n;
 }

--- a/packages/web/lib/tasks-grouping.ts
+++ b/packages/web/lib/tasks-grouping.ts
@@ -7,22 +7,22 @@ export type Lifecycle =
   | "in_progress"
   | "blocked"
   | "in_review"
-  | "done"
-  | "archived";
+  | "done";
 
 /**
- * Status → lifecycle lane.
+ * Status → lifecycle lane (or `null` to omit from the board entirely).
  *
- * - `blocked` lives in its own lane (was previously folded into
- *   In review). Blocked = waiting on an external dependency, semantically
- *   different from "waiting on a human verdict." Different action by the
- *   human reading the board, so different column.
- * - `failed` and `cancelled` are terminal states that aren't success.
- *   They go into the `archived` lane, hidden by default — `Done` should
- *   read as "this shipped." Archive toggle exposes them when the user
- *   wants to see what didn't ship.
+ * `blocked` lives in its own lane (was previously folded into In review).
+ * Blocked = waiting on an external dependency, semantically different from
+ * "waiting on a human verdict" — different action by the human reading
+ * the board, so different column.
+ *
+ * `failed` and `cancelled` are terminal non-success statuses. They are
+ * omitted from the board so `Done` reads as "this shipped." The header's
+ * archived badge surfaces the count for awareness, but the board itself
+ * stays focused on in-flight + shipped work.
  */
-const LIFECYCLE_OF: Record<TaskStatus, Lifecycle> = {
+const LIFECYCLE_OF: Record<TaskStatus, Lifecycle | null> = {
   pending: "pending",
   assigned: "pending",
   in_progress: "in_progress",
@@ -31,8 +31,8 @@ const LIFECYCLE_OF: Record<TaskStatus, Lifecycle> = {
   review: "in_review",
   blocked: "blocked",
   done: "done",
-  failed: "archived",
-  cancelled: "archived",
+  failed: null,
+  cancelled: null,
 };
 
 interface LaneTemplate {
@@ -53,41 +53,26 @@ const VISIBLE_LANES: LaneTemplate[] = [
   { key: "done", label: "Done", dot: "bg-status-done" },
 ];
 
-const ARCHIVED_LANE: LaneTemplate = {
-  key: "archived",
-  label: "Archived",
-  dot: "bg-muted-foreground/40",
-};
-
-interface GroupOptions {
-  /** Append the Archived lane (failed + cancelled). Default: false. */
-  showArchived?: boolean;
-}
-
-export function groupTasks(
-  tasks: TaskListItem[],
-  options: GroupOptions = {},
-): BoardLane[] {
+export function groupTasks(tasks: TaskListItem[]): BoardLane[] {
   const buckets: Record<Lifecycle, TaskListItem[]> = {
     pending: [],
     in_progress: [],
     blocked: [],
     in_review: [],
     done: [],
-    archived: [],
   };
-  for (const t of tasks) buckets[LIFECYCLE_OF[t.status]].push(t);
-  const template = options.showArchived
-    ? [...VISIBLE_LANES, ARCHIVED_LANE]
-    : VISIBLE_LANES;
-  return template.map((l) => ({
+  for (const t of tasks) {
+    const lane = LIFECYCLE_OF[t.status];
+    if (lane) buckets[lane].push(t);
+  }
+  return VISIBLE_LANES.map((l) => ({
     ...l,
     count: buckets[l.key].length,
     tasks: buckets[l.key],
   }));
 }
 
-/** Count of failed+cancelled tasks — drives the "X archived" toggle. */
+/** Count of failed+cancelled tasks — drives the archived badge in the header. */
 export function countArchivedTasks(tasks: TaskListItem[]): number {
   let n = 0;
   for (const t of tasks) {


### PR DESCRIPTION
## Summary
Followup on #136. The always-visible archive toggle was working but the panel it expanded was unwanted — failed + cancelled tasks shouldn't get their own board lane. This keeps the icon + count as a read-only header badge so the user knows the morgue isn't empty, but removes the lane entirely.

## Changes
- `tasks-grouping.ts` — drop the `archived` Lifecycle key, the `ARCHIVED_LANE` template, and the `showArchived` option. `LIFECYCLE_OF` now maps `failed` / `cancelled` to `null` so they're silently omitted from the board. `groupTasks(tasks)` is the only shape — always five lanes.
- `view-tabs.tsx` — replace `ArchiveToggle` (button) with `ArchiveBadge` (read-only `<span>` with title hint). Drop `showArchived` + `onToggleArchived` from `Props`. `cn` is no longer used here.
- `tasks-client.tsx` — drop the `showArchived` state and the toggle pass-through.
- Tests — replace the "click toggle → expand lane" assertions with "badge renders the count, no button role". Update the grouping fixture to expect `null` for failed/cancelled (omitted from the board) instead of an `"archived"` lane.

## Test plan
- [x] `pnpm --filter @beevibe/web test --run` — 139/139 pass.
- [x] `pnpm --filter @beevibe/web typecheck` + `lint` — clean.
- [ ] Visual: confirm the `[N archived]` badge still shows in the header (or `0 archived` when empty), with no hover/click behavior, and no extra lane on the board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)