### PR TITLE
fix(mesh): fast-fail across processes via session.updated pg_notify

### DIFF
--- a/packages/api/src/bootstrap.ts
+++ b/packages/api/src/bootstrap.ts
@@ -466,6 +466,29 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
     databaseUrl: cfg.databaseUrl,
     manager: sseManager,
     ownerLookup,
+    // Cross-process mesh fast-fail. The api server's `onSessionComplete`
+    // hook only fires for sessions claimed via /runtime/done (daemon path).
+    // `spawn_mode='server_fallback_mesh'` callees run inside the scheduler
+    // binary, so a failure there never reaches MeshServer through the
+    // in-process callback. Subscribe to the existing `session.updated`
+    // pg_notify and fast-fail any pending caller waiting on that row.
+    // Guard with `hasPendingCalleeSession` so we skip the DB fetch for
+    // the 99% case (every chat / task / unrelated session.updated).
+    onEvent: (event) => {
+      if (event.event !== "session.updated") return;
+      if (!mesh.hasPendingCalleeSession(event.id)) return;
+      void sessionRepo
+        .findById(event.id)
+        .then((session) => {
+          if (session) failMeshCalleeIfTerminal(session, session.status);
+        })
+        .catch((err: unknown) => {
+          console.error(
+            "[sse] mesh-fail lookup failed:",
+            err instanceof Error ? err.message : err,
+          );
+        });
+    },
   });
   sseListener.start();
   const streamRouter = createStreamRouter({

--- a/packages/api/src/bootstrap.ts
+++ b/packages/api/src/bootstrap.ts
@@ -462,33 +462,36 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
   // /api/stream pushes to subscribed browsers.
   const sseManager = new SseManager();
   const ownerLookup = new OwnerLookup(pool);
+
+  // Cross-process mesh fast-fail. The api server's `onSessionComplete`
+  // hook only fires for sessions claimed via /runtime/done (daemon path).
+  // `spawn_mode='server_fallback_mesh'` callees run inside the scheduler
+  // binary, so a failure there never reaches MeshServer through the
+  // in-process callback. Subscribe to the existing `session.updated`
+  // pg_notify and fast-fail any pending caller waiting on that row. The
+  // `hasPendingCalleeSession` guard short-circuits the 99% case (every
+  // chat / task / unrelated session.updated) before touching the DB.
+  const forwardMeshFailFromSession = (event: { event: string; id: string }) => {
+    if (event.event !== "session.updated") return;
+    if (!mesh.hasPendingCalleeSession(event.id)) return;
+    void sessionRepo
+      .findById(event.id)
+      .then((session) => {
+        if (session) failMeshCalleeIfTerminal(session, session.status);
+      })
+      .catch((err: unknown) => {
+        console.error(
+          "[sse] mesh-fail lookup failed:",
+          err instanceof Error ? err.message : err,
+        );
+      });
+  };
+
   const sseListener = new SseListener({
     databaseUrl: cfg.databaseUrl,
     manager: sseManager,
     ownerLookup,
-    // Cross-process mesh fast-fail. The api server's `onSessionComplete`
-    // hook only fires for sessions claimed via /runtime/done (daemon path).
-    // `spawn_mode='server_fallback_mesh'` callees run inside the scheduler
-    // binary, so a failure there never reaches MeshServer through the
-    // in-process callback. Subscribe to the existing `session.updated`
-    // pg_notify and fast-fail any pending caller waiting on that row.
-    // Guard with `hasPendingCalleeSession` so we skip the DB fetch for
-    // the 99% case (every chat / task / unrelated session.updated).
-    onEvent: (event) => {
-      if (event.event !== "session.updated") return;
-      if (!mesh.hasPendingCalleeSession(event.id)) return;
-      void sessionRepo
-        .findById(event.id)
-        .then((session) => {
-          if (session) failMeshCalleeIfTerminal(session, session.status);
-        })
-        .catch((err: unknown) => {
-          console.error(
-            "[sse] mesh-fail lookup failed:",
-            err instanceof Error ? err.message : err,
-          );
-        });
-    },
+    onEvent: forwardMeshFailFromSession,
   });
   sseListener.start();
   const streamRouter = createStreamRouter({

--- a/packages/api/src/mesh/server.test.ts
+++ b/packages/api/src/mesh/server.test.ts
@@ -79,6 +79,22 @@ describe("MeshServer.failResolverForCalleeSession", () => {
     expect(() => mesh.failResolverForCalleeSession("sess_unknown", "x")).not.toThrow();
   });
 
+  it("hasPendingCalleeSession tracks the in-flight reverse index", async () => {
+    const { mesh, dispatchCalls } = makeMesh();
+    expect(mesh.hasPendingCalleeSession("sess_unknown")).toBe(false);
+
+    const ask = mesh.sendAsk("req_3", "agent_caller", "agent_callee", "yo?");
+    await new Promise((r) => setImmediate(r));
+    const calleeSid = dispatchCalls[0]?.sessionIdOverride;
+    expect(calleeSid).toBeDefined();
+    expect(mesh.hasPendingCalleeSession(calleeSid!)).toBe(true);
+
+    // Drains on fast-fail.
+    mesh.failResolverForCalleeSession(calleeSid!, "x");
+    await expect(ask).rejects.toThrow();
+    expect(mesh.hasPendingCalleeSession(calleeSid!)).toBe(false);
+  });
+
   it("does not interfere with the success path", async () => {
     const { mesh, dispatchCalls } = makeMesh();
     const ask = mesh.sendAsk("req_2", "agent_caller", "agent_callee", "ping?");

--- a/packages/api/src/mesh/server.ts
+++ b/packages/api/src/mesh/server.ts
@@ -576,6 +576,18 @@ export class MeshServer {
       entry.reject(new Error(`mesh callee session failed: ${reason}`));
     }
   }
+
+  /**
+   * Cheap predicate the `session.updated` SSE listener uses to decide
+   * whether a session-row change is worth a DB fetch. Returns true iff
+   * an `ask`/`negotiate` caller is currently blocked waiting on this
+   * specific callee session. False for every other session id in the
+   * system — chats, tasks, mesh sessions whose caller already resolved,
+   * etc. — so the listener can short-circuit before reading the row.
+   */
+  hasPendingCalleeSession(calleeSessionId: string): boolean {
+    return this.pendingByCalleeSession.has(calleeSessionId);
+  }
 }
 
 function escapeAttr(s: string): string {

--- a/packages/api/src/sse/listener.ts
+++ b/packages/api/src/sse/listener.ts
@@ -15,6 +15,15 @@ export interface SseListenerConfig {
   databaseUrl: string;
   manager: SseManager;
   ownerLookup: OwnerLookup;
+  /**
+   * Synchronous side-channel for in-process subscribers. Fires for every
+   * parsed `bv_event` BEFORE the async owner-lookup + SseManager fan-out
+   * so cross-process signal handlers don't wait on the DB owner query.
+   * Used by MeshServer to fast-fail callers when their mesh callee
+   * session (possibly running in the scheduler binary) terminates.
+   * Listener throws are caught and logged; they never break the fan-out.
+   */
+  onEvent?: (event: BvEvent) => void;
   /** Default 5s. */
   reconnectDelayMs?: number;
 }
@@ -75,6 +84,16 @@ export class SseListener {
       if (msg.channel !== "bv_event" || !msg.payload) return;
       const parsed = parseEvent(msg.payload);
       if (!parsed) return;
+      if (this.config.onEvent) {
+        try {
+          this.config.onEvent(parsed);
+        } catch (err) {
+          console.error(
+            "[SseListener] onEvent subscriber threw:",
+            (err as Error).message,
+          );
+        }
+      }
       void this.config.ownerLookup.ownersOf(parsed).then((owners) => {
         this.config.manager.publish(parsed, owners);
       });


### PR DESCRIPTION
## Summary
Followup on #135. That PR closed the fast-fail gap for **daemon-claimed** mesh callees, but `spawn_mode='server_fallback_mesh'` callees run in the **scheduler binary** — a separate process whose `onSessionComplete` hook never reaches the api's `MeshServer` instance. The transcript `b37fcf70` shows this scenario:

- Server-fallback callee exited with `CLI exited with code null, exit code = 1`.
- API's resolver sat through its 5-min `DEFAULT_ASK_TIMEOUT_MS` timeout.
- Claude's MCP transport surfaced `MCP server "beevibe" transport dropped mid-call` after ~6.5 min.

This closes the gap via the existing `session.updated` pg_notify pipeline.

## How
1. **`MeshServer.hasPendingCalleeSession(sessionId)`** — public predicate over the existing `pendingByCalleeSession` reverse-index map. No new state.
2. **`SseListener.onEvent` hook** — fires synchronously for every parsed `bv_event` BEFORE the async owner-lookup + SseManager fan-out, so cross-process signal handlers don't wait on a DB owner query. Listener throws are caught and logged.
3. **`bootstrap.ts`** wires the hook: filter to `event === "session.updated"`, guard with `mesh.hasPendingCalleeSession(event.id)` (so we skip the DB fetch for the 99% of events where no caller is waiting), `sessionRepo.findById`, then call the existing `failMeshCalleeIfTerminal` helper.

## Per-event cost
- No waiter for that session: one `Map.has` lookup, done.
- Waiter exists: one indexed `findById` (PK), then the existing `failResolverForCalleeSession` path.

The 5-min resolver timeout from #135 still acts as a backstop if the SSE listener misses an event during a reconnect window.

## Test plan
- [x] `pnpm --filter @beevibe/api test --run src/mesh src/sse` — 23/23 pass, including a new `hasPendingCalleeSession` case asserting the reverse index drains on fast-fail.
- [x] API typecheck + build clean.
- [x] API lint — 0 errors (only pre-existing warnings in router.ts).
- [ ] End-to-end: trigger a server-fallback mesh-ask whose callee fails (e.g. send to an offline-daemon team, have the executor crash mid-spawn), confirm the caller's MCP tool errors within ~1s with `mesh callee session failed: <reason>` instead of waiting the full 5+ min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)