### PR TITLE
fix(tasks): map 'assigned' to In progress lane (was Pending)

### DIFF
--- a/packages/web/app/(authed)/tasks/tasks-client.test.tsx
+++ b/packages/web/app/(authed)/tasks/tasks-client.test.tsx
@@ -135,7 +135,9 @@ describe("TasksClient — lane rendering", () => {
         return countNode?.textContent;
       },
     );
-    expect(counts).toEqual(["2", "1", "1", "1", "1"]);
+    // Pending=1 (p1), In progress=2 (p2 assigned + ip1 in_progress),
+    // Blocked=1, In review=1, Done=1. `assigned` lives in In progress.
+    expect(counts).toEqual(["1", "2", "1", "1", "1"]);
   });
 
   it("hides cancelled+failed by default and surfaces the archive toggle", async () => {

--- a/packages/web/lib/tasks-grouping.test.ts
+++ b/packages/web/lib/tasks-grouping.test.ts
@@ -23,7 +23,11 @@ function makeTask(id: string, status: TaskStatus): TaskListItem {
 
 const EXPECTED_LIFECYCLE: Record<TaskStatus, Lifecycle> = {
   pending: "pending",
-  assigned: "pending",
+  // `assigned` lives in In progress — see LIFECYCLE_OF doc-comment.
+  // The brief INSERT-then-UPDATE window after agent-side create_task
+  // (where status is `assigned` before dispatchService bumps it to
+  // `in_progress`) shouldn't visibly bounce the card across lanes.
+  assigned: "in_progress",
   in_progress: "in_progress",
   revision: "in_progress",
   needs_revision: "in_progress",
@@ -106,8 +110,8 @@ describe("groupTasks", () => {
     const lanes = groupTasks(tasks, { showArchived: true });
     const byKey = Object.fromEntries(lanes.map((l) => [l.key, l]));
 
-    expect(byKey.pending.tasks.map((t) => t.id)).toEqual(["a", "g"]);
-    expect(byKey.in_progress.tasks.map((t) => t.id)).toEqual(["b", "h"]);
+    expect(byKey.pending.tasks.map((t) => t.id)).toEqual(["a"]);
+    expect(byKey.in_progress.tasks.map((t) => t.id)).toEqual(["b", "g", "h"]);
     expect(byKey.blocked.tasks.map((t) => t.id)).toEqual(["c"]);
     expect(byKey.in_review.tasks.map((t) => t.id)).toEqual(["d"]);
     expect(byKey.done.tasks.map((t) => t.id)).toEqual(["e"]);

--- a/packages/web/lib/tasks-grouping.ts
+++ b/packages/web/lib/tasks-grouping.ts
@@ -13,6 +13,13 @@ export type Lifecycle =
 /**
  * Status → lifecycle lane.
  *
+ * - `assigned` lives in In progress, not Pending. Agent-created tasks
+ *   land at `assigned` for the brief window between INSERT and the
+ *   dispatchService UPDATE that transitions them to `in_progress` (and
+ *   if the daemon takes a moment to claim, they sit at `assigned` for
+ *   longer). From the user's mental model "this task has been routed
+ *   to an agent" = active work, not waiting-for-someone-to-pick-it-up.
+ *   `pending` stays for human-created tasks with no assignee.
  * - `blocked` lives in its own lane (was previously folded into
  *   In review). Blocked = waiting on an external dependency, semantically
  *   different from "waiting on a human verdict." Different action by the
@@ -24,7 +31,7 @@ export type Lifecycle =
  */
 const LIFECYCLE_OF: Record<TaskStatus, Lifecycle> = {
   pending: "pending",
-  assigned: "pending",
+  assigned: "in_progress",
   in_progress: "in_progress",
   revision: "in_progress",
   needs_revision: "in_progress",


### PR DESCRIPTION
## What was happening

> "once a task is assigned, when I go to the task panel, it is not showing in in progress, I had to refresh the page to show it"

Diagnosed: not a cache or SSE bug. The web's task-board categorizer mapped \`assigned\` → **Pending** lane.

The agent-side \`create_task\` MCP tool inserts the task at \`status='assigned'\` (\`hierarchy.ts:647\`), then \`dispatchService.dispatchTask\` immediately UPDATEs it to \`in_progress\` (\`dispatch-service.ts:131-134\`). Two SSE events fire (\`task.created\` then \`task.updated\`), but in the gap — anywhere from <100ms to ~30s if the daemon is slow to claim — the task sits at \`assigned\`.

User flow:
1. Agent calls \`create_task\` → task lands at \`assigned\`.
2. Web sees \`task.created\` SSE → invalidates → refetches → renders task in **Pending** column.
3. User looks at "In progress", doesn't see it, refreshes.
4. By then daemon claimed → status flipped to \`in_progress\` → task moves to **In progress** column.

The "had to refresh" was really "I refreshed because I was looking in the wrong column."

## Fix

Map \`assigned\` → \`in_progress\` lane. From a user's mental model, "this task has been routed to an agent" = active work, not "waiting for someone to pick it up." \`pending\` stays for human-created tasks with no assignee yet.

\`packages/web/lib/tasks-grouping.ts:27\`:
\`\`\`diff
- assigned: "pending",
+ assigned: "in_progress",
\`\`\`

## Test changes

Two tests asserted the old categorization:
- \`tasks-grouping.test.ts\`: \`EXPECTED_LIFECYCLE.assigned\` flipped, lane-counting test moves task \`g\` (assigned) from pending to in_progress
- \`tasks-client.test.tsx\`: lane-count assertion flips from \`["2","1","1","1","1"]\` to \`["1","2","1","1","1"]\`

## Test plan

- [x] \`pnpm --filter @beevibe/web test\` — 140 tests green
- [x] \`pnpm --filter @beevibe/web typecheck\`
- [ ] Manual: chat with team agent → ask it to delegate a task → switch to /tasks → task appears in **In progress** immediately, no refresh needed

## Related

The few-second delay between task pill flipping to \`cancelled\` and session pill flipping to \`cancelled\` (PR #137 follow-up) is a different story — that's a structural intent-vs-work-stopped asymmetry, not a categorization bug. Worth a small UX polish (transient "cancelling…" state on the session pill during the gap) — would file as a separate issue.