### PR TITLE
fix(tasks): suppress 'No tasks yet' during background refetch

### DIFF
--- a/packages/web/app/(authed)/tasks/tasks-client.test.tsx
+++ b/packages/web/app/(authed)/tasks/tasks-client.test.tsx
@@ -96,6 +96,47 @@ describe("TasksClient — empty-state branches", () => {
     ).toBeInTheDocument();
   });
 
+  // Regression: previously, navigating /chat → /tasks after an SSE
+  // invalidation that marked a cached `[]` as stale would briefly flash
+  // the "No tasks yet" empty state until the background refetch settled
+  // (typically ~200ms). User perception: "the task didn't show up; I
+  // had to refresh." Hard refresh worked because isLoading=true on
+  // initial mount correctly suppresses the empty state. Background
+  // refetches on a stale-empty cache had isLoading=false and so fell
+  // through to the misleading empty state.
+  it("does NOT render the no-results empty state while a background refetch is in flight on a stale-empty cache", async () => {
+    // Resolver we control so the refetch stays in-flight while we
+    // assert. This is the window the bug-fix targets.
+    let resolveRefetch: (tasks: TaskListItem[]) => void = () => {};
+    listMock.mockImplementation(
+      () => new Promise((resolve) => { resolveRefetch = resolve; }),
+    );
+
+    // Pre-seed the cache as if a previous /tasks visit returned [], then
+    // invalidate it to simulate the SSE task.created handler. This puts
+    // useTasks in the exact state we want on mount: cached empty data,
+    // stale, refetch about to fire.
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    client.setQueryData(["tasks", "list", {}], []);
+    await client.invalidateQueries({ queryKey: ["tasks"] });
+
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+    render(<TasksClient />, { wrapper: Wrapper });
+
+    // Refetch is in flight. With the bug, "No tasks yet" would be in
+    // the DOM right now. With the fix, isFetching=true suppresses it.
+    await waitFor(() => expect(listMock).toHaveBeenCalled());
+    expect(screen.queryByText("No tasks yet")).not.toBeInTheDocument();
+
+    // Refetch settles with a real task — the lane shows the task and
+    // the empty state stays absent.
+    resolveRefetch([makeTask({ id: "new1", status: "in_progress", title: "freshly minted" })]);
+    expect(await screen.findByText("freshly minted")).toBeInTheDocument();
+    expect(screen.queryByText("No tasks yet")).not.toBeInTheDocument();
+  });
+
   it("renders the no-matching-search empty state when query has no matches", async () => {
     listMock.mockResolvedValue([makeTask({ title: "alpha" }), makeTask({ id: "t2", title: "beta" })]);
     renderClient();

--- a/packages/web/app/(authed)/tasks/tasks-client.tsx
+++ b/packages/web/app/(authed)/tasks/tasks-client.tsx
@@ -43,7 +43,7 @@ export function TasksClient() {
     router.push("/tasks", { scroll: false });
   }, [router]);
 
-  const { data, isLoading, isError } = useTasks({});
+  const { data, isLoading, isFetching, isError } = useTasks({});
 
   const filtered = useMemo(() => {
     if (!data) return [];
@@ -61,6 +61,7 @@ export function TasksClient() {
     isApiConfigured,
     isError,
     isLoading,
+    isFetching,
     hasResults: filtered.length > 0,
     hasQuery: query.length > 0,
   });
@@ -121,6 +122,7 @@ function pickEmptyMessage(state: {
   isApiConfigured: boolean;
   isError: boolean;
   isLoading: boolean;
+  isFetching: boolean;
   hasResults: boolean;
   hasQuery: boolean;
 }): EmptyMessage | null {
@@ -139,7 +141,13 @@ function pickEmptyMessage(state: {
       description: "Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load tasks.",
     };
   }
-  if (state.isLoading || state.hasResults) return null;
+  // Suppress the empty state while ANY fetch is in flight — including a
+  // background refetch where `data === []` is cached. Without this guard,
+  // navigating /chat → /tasks after an SSE-triggered cache invalidation
+  // briefly shows "No tasks yet" until the refetch settles, even though
+  // the api is about to return the new task. `isLoading` only catches
+  // the initial-fetch case (no data yet); `isFetching` covers refetches.
+  if (state.isLoading || state.isFetching || state.hasResults) return null;
   if (state.hasQuery) {
     return {
       icon: ListChecks,

--- a/packages/web/lib/hooks/use-tasks.ts
+++ b/packages/web/lib/hooks/use-tasks.ts
@@ -8,6 +8,17 @@ export function useTasks(filter: TaskListFilter = {}) {
     queryKey: queryKeys.tasks.list(filter),
     queryFn: ({ signal }) => api.tasks.list(filter, { signal }),
     enabled: isApiConfigured,
+    // Always refetch when the user lands on /tasks. The default
+    // staleTime: 30_000 (providers.tsx) combined with mount-with-cached-
+    // data semantics means /chat → /tasks could render the previous
+    // empty-or-stale list without firing a fetch. SSE invalidation
+    // *should* mark the cache stale and trigger a refetch, but a missed
+    // event (proxy buffering, brief disconnect, race between SSE connect
+    // and task creation) leaves the user staring at an empty board.
+    // Treat /tasks navigation as a "give me the latest" signal — one
+    // SQL query per visit is negligible and the freshness guarantee
+    // matters more on this surface than the cache hit.
+    refetchOnMount: "always",
   });
 }
 


### PR DESCRIPTION
## What was happening

> "once a task is assigned, when I go to the task panel, it is not showing in in progress, I had to refresh the page to show it"

Initially I guessed this was a categorization bug (`assigned` → Pending lane vs In progress). Wrong. The user confirmed:

> "I see from the chat ui that the task is in_progress but went to the task panel, and no task is on there. After I refresh, it shows up in in progress."

Real bug: the `tasks-client` renders the **"No tasks yet"** full-screen empty state during a stale-cache background refetch, hiding the in-flight refresh from the user. By the time they refresh, the refetch has settled and the task appears.

## Root cause

`tasks-client.tsx:46` destructures only `{data, isLoading, isError}` from `useTasks`. With `staleTime: 30_000` (`providers.tsx:19`) and cache-on-unmount semantics, this failure mode is fully reproducible:

1. User opens /tasks early in session — fetch returns `[]` (no tasks yet). Cached.
2. User goes to /chat. Cache persists.
3. Agent creates task → SSE `task.created` fires → `invalidateQueries(["tasks"])` → cache marked stale.
4. User navigates back to /tasks → `useTasks` mounts with cached `data=[]`.
5. **`isLoading=false`** (we have data, even if empty), `hasResults=false`. `pickEmptyMessage` falls through to the "No tasks yet" branch.
6. Background refetch settles ~200ms later → `data=[{new task}]` → `hasResults=true` → empty state goes away → task renders.

Hard refresh works because `isLoading=true` on a cold mount, which suppresses the empty state until the fetch settles.

## Fix

Read `isFetching` too. Suppress the empty state during ANY fetch in flight (initial OR background refetch), not just the initial one.

```diff
- const { data, isLoading, isError } = useTasks({});
+ const { data, isLoading, isFetching, isError } = useTasks({});

- if (state.isLoading || state.hasResults) return null;
+ if (state.isLoading || state.isFetching || state.hasResults) return null;
```

The categorization of `assigned` (Pending lane) stays as it was — a previous attempt to "fix" by moving it to In progress was based on the wrong root-cause guess (PR #141, closed).

## Regression test

Added a focused test that pre-seeds the cache with `[]`, invalidates it (simulating the SSE `task.created` handler), then mounts the component and asserts the empty state is NOT in the DOM while the refetch is in-flight (and stays hidden after the refetch settles with a real task).

## Test plan

- [x] `pnpm --filter @beevibe/web typecheck`
- [x] `pnpm --filter @beevibe/web test` — 141 tests green (was 140, +1 regression)
- [ ] Manual: open /tasks with empty state → switch to /chat → ask team agent to delegate a task → switch back to /tasks → no "No tasks yet" flash; task appears in **Pending** lane (status='assigned') then moves to In progress when daemon claims.

## Related

- Closed PR #141 — wrong fix. The categorization mapping (`assigned` → Pending) is correct.