### PR TITLE
fix(inbox): scope task branches by owner, not direct-person-creator

### DIFF
--- a/packages/api/src/views/inbox.ts
+++ b/packages/api/src/views/inbox.ts
@@ -29,12 +29,15 @@ const TITLE_TRUNCATE = 120;
  * the same column set (id / kind / title / detail / href / age_at)
  * so the application layer maps a uniform row shape to InboxItem.
  *
- * Branch 1 — tasks awaiting the caller's review/unblock decision.
- *   Filter: status IN ('review','blocked') AND creator_id = $1.
- *   `detail` carries the assignee's name (or "(unassigned)") when in
- *   review, the blocker's reason when blocked.
+ * Branches 1 + 2 — tasks awaiting the caller's review/unblock decision.
+ *   Scoped via assignee or creator-agent ownership (matching the
+ *   `/task` list scope in views/tasks.ts). Humans don't create tasks
+ *   directly — the `create_task` MCP tool stamps `creator_type='agent'`
+ *   — so a `creator_type='person' AND creator_id=$1` filter (which is
+ *   what this query used to do) misses every real task in the system.
+ *   Detail: assignee name when in review, blocker reason when blocked.
  *
- * Branch 2 — escalations awaiting a human resolver. Walked from
+ * Branch 3 — escalations awaiting a human resolver. Walked from
  *   negotiation → both agents to find any owned by the caller; one
  *   row per escalation regardless of which side the caller owns.
  */
@@ -44,14 +47,18 @@ WITH inbox AS (
     'task_review:' || t.id          AS id,
     'task_review'::text             AS kind,
     LEFT(t.title, ${TITLE_TRUNCATE}) AS title,
-    COALESCE(a.name, '(unassigned)') AS detail,
+    COALESCE(asg.name, '(unassigned)') AS detail,
     '/tasks/' || t.id               AS href,
     t.updated_at                    AS age_at
   FROM task t
-  LEFT JOIN agent a ON a.id = t.assignee_id
-  WHERE t.creator_id = $1
-    AND t.creator_type = 'person'
-    AND t.status = 'review'
+  LEFT JOIN agent asg   ON asg.id   = t.assignee_id
+  LEFT JOIN agent crt_a ON crt_a.id = t.creator_id  AND t.creator_type = 'agent'
+  WHERE t.status = 'review'
+    AND (
+      asg.owner_id = $1
+      OR crt_a.owner_id = $1
+      OR (t.creator_type = 'person' AND t.creator_id = $1)
+    )
 
   UNION ALL
 
@@ -63,9 +70,14 @@ WITH inbox AS (
     '/tasks/' || t.id                    AS href,
     t.updated_at                         AS age_at
   FROM task t
-  WHERE t.creator_id = $1
-    AND t.creator_type = 'person'
-    AND t.status = 'blocked'
+  LEFT JOIN agent asg   ON asg.id   = t.assignee_id
+  LEFT JOIN agent crt_a ON crt_a.id = t.creator_id  AND t.creator_type = 'agent'
+  WHERE t.status = 'blocked'
+    AND (
+      asg.owner_id = $1
+      OR crt_a.owner_id = $1
+      OR (t.creator_type = 'person' AND t.creator_id = $1)
+    )
 
   UNION ALL
 


### PR DESCRIPTION
## Summary
The `/inbox` task branches (`task_review`, `task_blocked`) gated on `creator_id = \$personId AND creator_type = 'person'` — i.e. tasks the human **created directly**. But humans don't have a direct create-task surface; they chat with their team agent, which calls `create_task` MCP and stamps `creator_type: 'agent'` (`hierarchy.ts:651`). So in practice every real task has `creator_type='agent'`, and the inbox showed **zero** task items even when the user had a task sitting in `review` waiting for sign-off — exactly the symptom reported ("the task is in the review panel correctly" but "Inbox Zero even after several refresh").

## Fix
Mirror the `/task` list owner-scope (already shipped in #136) on both task branches: a task lands in the inbox iff the caller
- owns the assignee agent (`asg.owner_id = \$1`), OR
- owns the creator agent (`crt_a.owner_id = \$1` when `creator_type='agent'`), OR
- created the task directly (defensive third arm for any future direct-create surface).

Adds the matching `LEFT JOIN agent asg` + `LEFT JOIN agent crt_a` to both branches. Escalation branch was already owner-scoped — left untouched.

## Test plan
- [x] `pnpm --filter @beevibe/api test --run src/views/inbox.test.ts` — 6/6 pass (existing tests verify param forwarding + row mapping; SQL itself contract-tested by route integration tests).
- [x] `pnpm --filter @beevibe/api build` + `typecheck` + `lint` — clean.
- [ ] Visual: a task in `review` status whose assignee or creator agent is owned by the caller should now appear in the sidebar inbox under `task_review`. Same for `blocked`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)