### PR TITLE
fix(task): human revise dispatches the revision session

### DIFF
--- a/packages/api/src/bootstrap.ts
+++ b/packages/api/src/bootstrap.ts
@@ -305,6 +305,7 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
     taskService,
     sessionRepo,
     runtimeRepo,
+    dispatchService,
     hub: daemonHub,
     pool,
   });

--- a/packages/api/src/routes/task.test.ts
+++ b/packages/api/src/routes/task.test.ts
@@ -18,6 +18,7 @@ import {
 } from "@beevibe/core/adapters/postgres";
 import { provisionAgent, provisionUser } from "@beevibe/core/auth";
 import { TaskService } from "@beevibe/core/services/task-service";
+import { DispatchService } from "@beevibe/core/services/dispatch-service";
 import { DEFAULT_RUNTIME_CONFIG, agentId, personId, taskId } from "@beevibe/core";
 import { createTestPool, truncateAll } from "@beevibe/core/test-helpers";
 import { createAuthMiddleware } from "../auth/middleware.js";
@@ -34,6 +35,7 @@ describe("task routes — integration", () => {
   let taskRepo: PostgresTaskRepository;
   let workProductRepo: PostgresWorkProductRepository;
   let taskService: TaskService;
+  let dispatchService: DispatchService;
   let hub: DaemonHub;
 
   beforeAll(() => {
@@ -46,6 +48,7 @@ describe("task routes — integration", () => {
     taskRepo = new PostgresTaskRepository(pool);
     workProductRepo = new PostgresWorkProductRepository(pool);
     taskService = new TaskService({ taskRepo, workProductRepo, agentRepo, sessionRepo });
+    dispatchService = new DispatchService({ agentRepo, sessionRepo, taskRepo });
     hub = new DaemonHub();
   });
 
@@ -68,6 +71,7 @@ describe("task routes — integration", () => {
         taskService,
         sessionRepo,
         runtimeRepo,
+        dispatchService,
         hub,
         pool,
       }),
@@ -134,7 +138,7 @@ describe("task routes — integration", () => {
     expect(res.body.task.status).toBe("cancelled");
   });
 
-  it("revise: review → needs_revision + stamps next_dispatch_context", async () => {
+  it("revise: review → revision + stamps next_dispatch_context + dispatches a session", async () => {
     const { owner, agent } = await setupHuman();
     const task = await seedTask("review", agent.agent.id);
 
@@ -144,16 +148,31 @@ describe("task routes — integration", () => {
       .send({ feedback: "please add error handling" });
 
     expect(res.status).toBe(200);
-    expect(res.body.task.status).toBe("needs_revision");
+    // The route reviseTask + dispatchService.dispatchTask: reviseTask
+    // moves the task to 'needs_revision' and stamps the dispatch
+    // context; dispatchService then transitions it to 'revision' and
+    // inserts a pending session row. Without the dispatch, the task
+    // would sit at needs_revision forever — no daemon would claim it.
+    expect(res.body.task.status).toBe("revision");
 
     const refetched = await taskRepo.findById(task.id);
-    expect(refetched?.status).toBe("needs_revision");
+    expect(refetched?.status).toBe("revision");
     expect(refetched?.next_dispatch_context?.kind).toBe("revision");
     if (refetched?.next_dispatch_context?.kind === "revision") {
       expect(refetched.next_dispatch_context.feedback).toBe("please add error handling");
       expect(refetched.next_dispatch_context.source).toBe("human");
       expect(refetched.next_dispatch_context.from_status).toBe("review");
     }
+
+    // Regression: assert the pending session row exists. Previously
+    // the route called reviseTask but skipped dispatchTask, so the task
+    // was re-queued in DB but no session was ever created — the daemon
+    // had nothing to claim and the task stayed stuck.
+    const sessions = await sessionRepo.listForTask(task.id);
+    expect(sessions.length).toBe(1);
+    expect(sessions[0]?.status).toBe("pending");
+    expect(sessions[0]?.type).toBe("task");
+    expect(sessions[0]?.agent_id).toBe(agent.agent.id);
   });
 
   it("revise: missing feedback → 400", async () => {

--- a/packages/api/src/routes/task.ts
+++ b/packages/api/src/routes/task.ts
@@ -33,6 +33,8 @@ import {
   InvalidTaskTransitionError,
   TaskNotFoundError,
 } from "@beevibe/core/services/task-service";
+import { buildIntent, type ResumeReason } from "@beevibe/core/services/agent-session";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
 import { requireHuman } from "../auth/middleware.js";
 import type { DaemonHub } from "../runtime/hub.js";
 
@@ -53,6 +55,12 @@ export interface TaskRoutesDeps {
   taskService: TaskService;
   sessionRepo: SessionRepository;
   runtimeRepo: RuntimeRepository;
+  /**
+   * Required to dispatch the revision session after `POST /task/:id/revise`.
+   * Without it, the task lands at `needs_revision` and just sits — no
+   * session row exists for the daemon to claim.
+   */
+  dispatchService: DispatchService;
   /** Push cancel frames over WS to daemon-bound running sessions. */
   hub: DaemonHub;
   /** For pg_notify('cancel_task', task_id) — server-fallback path only. */
@@ -189,11 +197,37 @@ export function createTaskRouter(deps: TaskRoutesDeps): Router {
       const updated = await deps.taskService.reviseTask(id, feedback, {
         source: "human",
       });
+
+      // Mirror the parent_agent revise_task MCP tool path
+      // (hierarchy.ts:824-840): reviseTask just stamps the task with
+      // status='needs_revision' + next_dispatch_context. Without an
+      // explicit dispatch, no session row exists and no daemon claims
+      // the task — it sits at needs_revision until manual intervention.
+      // The MCP tool dispatched; this route forgot to.
+      let dispatchedStatus: TaskStatus = updated.status;
+      if (updated.next_dispatch_context?.kind === "revision" && updated.assignee_id) {
+        const reason: ResumeReason = updated.next_dispatch_context;
+        const intent = buildIntent(
+          { id: updated.id, title: updated.title, description: updated.description },
+          reason,
+        );
+        await deps.dispatchService.dispatchTask({
+          task: updated,
+          agentId: updated.assignee_id,
+          intent,
+          reason,
+          type: "task",
+        });
+        // dispatchService transitions needs_revision → revision and
+        // inserts a pending session pinned to the agent's runtime.
+        dispatchedStatus = "revision";
+      }
+
       res.json({
         ok: true,
         task: {
           id: updated.id,
-          status: updated.status,
+          status: dispatchedStatus,
           next_dispatch_context: updated.next_dispatch_context,
         },
       });


### PR DESCRIPTION
## What was broken

> "For a review task, after add revise and the task changed to needs revision, no daemon claim on the task from either ws notify or http polling, the task stays needs revision."

\`POST /task/:id/revise\` called \`taskService.reviseTask\` but never dispatched. \`reviseTask\` only stamps the task with \`status='needs_revision'\` + \`next_dispatch_context.kind='revision'\` — it doesn't create a session row. The daemon claims **sessions**, not tasks. Without a pending session, there's nothing to claim, and the task sits at \`needs_revision\` indefinitely.

## How the MCP path got it right

The \`revise_task\` MCP tool (\`hierarchy.ts:824-840\`) does the dispatch:

\`\`\`ts
const updated = await services.taskService.reviseTask(taskId, feedback, { source: "parent_agent", ... });
if (updated.next_dispatch_context?.kind === "revision") {
  const reason: ResumeReason = updated.next_dispatch_context;
  const intent = buildIntent({ id, title, description }, reason);
  await services.dispatchService.dispatchTask({
    task: updated,
    agentId: updated.assignee_id!,
    intent,
    reason,
    type: "task",
  });
}
\`\`\`

The human REST route was missing the dispatch half. Mirroring the same pattern fixes it — same \`buildIntent\` + \`dispatchService.dispatchTask\` flow, same handling of the prior-session runtime pinning, same daemon WS wakeup hook.

## Changes

- \`packages/api/src/routes/task.ts\`: import \`buildIntent\` + \`DispatchService\`; add \`dispatchService\` to \`TaskRoutesDeps\`; call \`dispatchTask\` after \`reviseTask\`. Response \`task.status\` becomes \`'revision'\` (post-dispatch state) instead of \`'needs_revision'\`.
- \`packages/api/src/bootstrap.ts\`: pass \`dispatchService\` into \`createTaskRouter\`.
- \`packages/api/src/routes/task.test.ts\`: wire \`DispatchService\` in test setup; update the revise test to assert the post-dispatch state (status='revision', exactly one pending session row for the assignee).

## Test plan

- [x] \`pnpm build\` — green (5 packages)
- [x] \`pnpm test\` — green (existing 14 task-route tests + the regression assertion on session creation)
- [ ] Manual: open a task in review status → click "Request revision" with feedback → daemon log shows \`[daemon/claim] sess=… agent=…\` within seconds → task transitions to \`revision\` then \`in_progress\` → agent works on the revision.

## Related

The \`reviseTask + dispatch\` pair is now duplicated in two call sites (MCP tool + REST route). Worth a small extraction to a single helper later — flagging as follow-up rather than blocking this fix.