### PR TITLE
fix(inbox): invalidate inbox cache on task approve/reject/revise/cancel

### DIFF
--- a/packages/web/components/mode-sidebars.tsx
+++ b/packages/web/components/mode-sidebars.tsx
@@ -6,12 +6,10 @@ import { useQuery } from "@tanstack/react-query";
 import {
   AlertCircle,
   Bot,
-  Check,
   CheckCircle2,
   Cpu,
   GaugeCircle,
   Inbox,
-  Loader2,
   Network,
   ShieldAlert,
   Sparkles,
@@ -25,7 +23,6 @@ import {
 } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
 import { useInbox } from "@/lib/hooks/use-inbox";
-import { useApproveTask } from "@/lib/hooks/use-task-mutations";
 import { queryKeys } from "@/lib/hooks/keys";
 import { formatRelativeTime } from "@/lib/format";
 import { cn } from "@/lib/utils";
@@ -253,15 +250,14 @@ export function TasksAttentionSidebar({
 function AttentionRow({ item, active }: { item: InboxItem; active: boolean }) {
   const meta = INBOX_KIND_META[item.kind];
   const Icon = meta.icon;
-  const taskId = inboxTaskId(item);
   return (
     <li
       className={cn(
-        "group/row mx-1 my-0.5 rounded flex items-stretch transition-colors",
+        "mx-1 my-0.5 rounded transition-colors",
         active ? "bg-secondary" : "hover:bg-secondary/60",
       )}
     >
-      <Link href={inboxRowHref(item)} className="flex-1 min-w-0 px-3 py-1.5">
+      <Link href={inboxRowHref(item)} className="block px-3 py-1.5">
         <div className="flex items-baseline gap-1.5">
           <Icon
             className={cn("h-3 w-3 shrink-0 self-center", meta.iconClass)}
@@ -283,39 +279,7 @@ function AttentionRow({ item, active }: { item: InboxItem; active: boolean }) {
           {item.detail}
         </div>
       </Link>
-      {item.kind === "task_review" && taskId ? (
-        <ApproveButton taskId={taskId} />
-      ) : null}
     </li>
-  );
-}
-
-function ApproveButton({ taskId }: { taskId: string }) {
-  const approve = useApproveTask(taskId);
-  return (
-    <button
-      type="button"
-      title="Approve"
-      aria-label="Approve task"
-      disabled={approve.isPending}
-      onClick={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        approve.mutate({});
-      }}
-      className={cn(
-        "shrink-0 mr-1 my-0.5 px-1.5 inline-flex items-center justify-center rounded text-status-done/80 hover:bg-status-done/15 hover:text-status-done transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed",
-        // Reveal on row hover so the rail stays calm when nothing's
-        // hovered. Keyboard focus (focus-within on the li) also reveals.
-        "opacity-0 group-hover/row:opacity-100 focus-visible:opacity-100",
-      )}
-    >
-      {approve.isPending ? (
-        <Loader2 className="h-3.5 w-3.5 animate-spin" />
-      ) : (
-        <Check className="h-3.5 w-3.5" />
-      )}
-    </button>
   );
 }
 

--- a/packages/web/components/sidebar.tsx
+++ b/packages/web/components/sidebar.tsx
@@ -233,10 +233,11 @@ function renderModePanel(args: ModePanelArgs): React.ReactNode {
     return <RoomsSidebar activeRoomId={extractIdFromPath(pathname, "/rooms/")} />;
   }
   // /tasks rail surfaces the human-attention inbox: review +
-  // blocked + escalation rows with inline approve. It's NOT a
-  // duplicate of the kanban (the old TasksSidebar was). Different
-  // axis: kanban = "all work in flight," inbox = "things waiting
-  // on you specifically."
+  // blocked + escalation rows. It's NOT a duplicate of the kanban
+  // (the old TasksSidebar was). Different axis: kanban = "all work
+  // in flight," inbox = "things waiting on you specifically." Clicking
+  // a row opens the task detail (or escalation surface) where the
+  // human can review and decide — no inline approve.
   if (pathname.startsWith("/tasks")) {
     return (
       <TasksAttentionSidebar

--- a/packages/web/lib/hooks/use-task-mutations.test.tsx
+++ b/packages/web/lib/hooks/use-task-mutations.test.tsx
@@ -71,6 +71,11 @@ describe("useApproveTask", () => {
         queryKeys.tasks.detail("t_1"),
         queryKeys.tasks.all,
         queryKeys.dashboard.all,
+        // Approve transitions the task out of `review`, which is the
+        // entire population of the inbox's task_review branch. Without
+        // this invalidation the row lingers in the sidebar until the
+        // user navigates away and back.
+        queryKeys.inbox.all,
       ]),
     );
   });

--- a/packages/web/lib/hooks/use-task-mutations.ts
+++ b/packages/web/lib/hooks/use-task-mutations.ts
@@ -15,6 +15,12 @@ function useTaskMutationInvalidations(taskId: string) {
     client.invalidateQueries({ queryKey: queryKeys.tasks.detail(taskId) });
     client.invalidateQueries({ queryKey: queryKeys.tasks.all });
     client.invalidateQueries({ queryKey: queryKeys.dashboard.all });
+    // Approve/reject/revise transition tasks out of `review`/`blocked`,
+    // which is the entire population of the inbox's task branches.
+    // Without this, the row lingers in the sidebar until SSE delivers
+    // `task.updated` (already wired, but unreliable behind buffering
+    // proxies) or the user navigates and remounts.
+    client.invalidateQueries({ queryKey: queryKeys.inbox.all });
   };
 }
 
@@ -49,6 +55,9 @@ export function useCancelTask(taskId: string) {
     onSuccess: () => {
       client.invalidateQueries({ queryKey: queryKeys.tasks.detail(taskId) });
       client.invalidateQueries({ queryKey: queryKeys.tasks.all });
+      // Cancelled tasks leave both the `review` and `blocked` inbox
+      // branches; refresh so the row disappears immediately.
+      client.invalidateQueries({ queryKey: queryKeys.inbox.all });
     },
   });
 }


### PR DESCRIPTION
## Summary
Two related fixes to the sidebar inbox UX:

### 1. Invalidate the inbox cache on task mutations
After clicking Approve, the row stayed visible — same for any local task transition out of `review`/`blocked`. `useTaskMutationInvalidations` (and `useCancelTask`) invalidated tasks + dashboard caches but **not the inbox cache**, so the sidebar held on to stale data until SSE eventually delivered `task.updated` (unreliable behind buffering proxies) or the user navigated away and remounted. Adds `queryKeys.inbox.all` to both invalidation sites. The SSE path is already wired correctly (`sse.ts:22-27`); this just makes the click-side feel instant.

### 2. Drop the inline approve button, route through the task detail page
The inline Approve button let users approve a review task without seeing the task body or work products — a tiny check icon and the task title was the entire decision surface. Cheap to misclick, hard to undo. Removed `ApproveButton` from `mode-sidebars.tsx`; clicking any inbox row now navigates to the task detail (already the existing `<Link>` behavior), where the human can review and decide with full context. The cache-invalidation fix above still earns its keep — the task detail's Approve button uses the same `useTaskMutationInvalidations` helper, so its click also refreshes the sidebar inbox immediately.

## Test plan
- [x] `pnpm --filter @beevibe/web test --run` — 141/141 pass; the approve-mutation test now asserts `queryKeys.inbox.all` is in the invalidation set as a regression guard.
- [x] `pnpm --filter @beevibe/web typecheck` + `lint` — clean.
- [ ] Visual: click an inbox row → arrives at the task detail page; click Approve on the detail page → the sidebar inbox row disappears within a tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)