### PR TITLE
feat(runtime): recover pluggable runtimes and add codex

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -9,6 +9,11 @@ deployment needs:
 - `@beevibe/web`
 - one local `beevibe-daemon` per user machine that should run agent sessions
 
+Daemons register every supported CLI they find on `PATH`. `claude` is the
+default high-reliability runtime. `opencode` is the open/free model path: it
+can route through OpenRouter, Ollama, and OpenAI-compatible providers using
+OpenCode's own provider configuration.
+
 ## Required Environment
 
 Copy [`.env.example`](./.env.example) and set the values for your host.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ For a deeper version of any layer, see the package READMEs:
 | **Task** | A unit of team work assigned to a person or agent. Tasks can spawn child tasks and move through review. |
 | **Mesh** | The agent-to-agent layer for asking the right teammate, negotiating, responding, and escalating. |
 | **Memory** | Durable per-agent core memory blocks plus vector-searchable facts that compound across team work. |
-| **Runtime** | A registered `(daemon, CLI)` pair, usually a user's local `claude` binary. |
+| **Runtime** | A registered `(daemon, CLI)` pair, such as a user's local `claude`, `codex`, or `opencode` binary. |
 | **Daemon** | A local process that claims sessions and spawns CLI runs on a user's machine. |
 
 ## Quick Start

--- a/packages/api/src/bootstrap.ts
+++ b/packages/api/src/bootstrap.ts
@@ -399,6 +399,7 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
     authMiddleware: server.getAuthMiddleware(),
     agentRepo,
     personRepo,
+    runtimeRepo,
     sessionRepo,
     dispatchService,
     chatResolver,

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -107,6 +107,7 @@ export interface ChatSession {
   status: string;
   error?: string;
   created_at: Date;
+  runtime_id?: string;
 }
 
 export interface ConversationChain {
@@ -271,6 +272,23 @@ interface ChatTurnAgent {
   id: string;
   name: string;
   hierarchy_level: string;
+}
+
+async function resolvePinnedRuntimeCli(
+  deps: Pick<ChatRoutesDeps, "runtimeRepo">,
+  sessions: readonly ChatSession[],
+): Promise<KnownCli | undefined> {
+  // Walk newest → oldest so we surface the most recent claim. Legacy
+  // sessions with no runtime_id are skipped; if none in the chain ever
+  // ran on a runtime, the conversation isn't pinned.
+  for (let i = sessions.length - 1; i >= 0; i -= 1) {
+    const runtimeId = sessions[i]?.runtime_id;
+    if (!runtimeId) continue;
+    const runtime = await deps.runtimeRepo.findById(runtimeId);
+    if (runtime && isKnownCli(runtime.cli)) return runtime.cli;
+    return undefined;
+  }
+  return undefined;
 }
 
 async function resolveRuntimeOverride(
@@ -534,6 +552,10 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
     // present but the agent reply slot is empty until SSE auto-recovery
     // (PR #116) lands the response.
     const inFlightSessionId = isInFlightSessionStatus(latest.status) ? latest.id : undefined;
+    // Surface the CLI this conversation is pinned to so the composer can
+    // lock its runtime picker — otherwise the user can pick a different
+    // CLI mid-chat and the next send 409s.
+    const pinnedRuntimeCli = await resolvePinnedRuntimeCli(deps, chain.sessions);
 
     res.json({
       ok: true,
@@ -542,6 +564,7 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
       prior_session_id: latest.id,
       conversation_id: chain.head_id,
       in_flight_session_id: inFlightSessionId,
+      pinned_runtime_cli: pinnedRuntimeCli,
     });
   });
 

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -25,8 +25,12 @@ import { randomUUID } from "node:crypto";
 import { Router, type RequestHandler, type Response } from "express";
 import {
   isInFlightSessionStatus,
+  isKnownCli,
+  KNOWN_CLIS,
   type AgentRepository,
+  type KnownCli,
   type PersonRepository,
+  type RuntimeRepository,
   type SessionRepository,
 } from "@beevibe/core";
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
@@ -42,6 +46,7 @@ export interface ChatRoutesDeps {
   authMiddleware: RequestHandler;
   agentRepo: AgentRepository;
   personRepo: PersonRepository;
+  runtimeRepo: RuntimeRepository;
   sessionRepo: SessionRepository;
   /**
    * Phase 4 daemon-first chat path: dispatchService inserts a pending
@@ -268,6 +273,73 @@ interface ChatTurnAgent {
   hierarchy_level: string;
 }
 
+async function resolveRuntimeOverride(
+  deps: Pick<ChatRoutesDeps, "runtimeRepo" | "sessionRepo" | "hub">,
+  ownerPersonId: string,
+  runtimeType: KnownCli | undefined,
+  priorSessionId: string | undefined,
+): Promise<
+  | { ok: true; runtimeIdOverride?: string }
+  | { ok: false; status: number; body: Record<string, unknown> }
+> {
+  if (!runtimeType) return { ok: true };
+
+  if (priorSessionId) {
+    const prior = await deps.sessionRepo.findById(priorSessionId);
+    if (prior?.runtime_id) {
+      const priorRuntime = await deps.runtimeRepo.findById(prior.runtime_id);
+      if (priorRuntime?.cli !== runtimeType) {
+        return {
+          ok: false,
+          status: 409,
+          body: {
+            error: "runtime_switch_requires_new_chat",
+            message:
+              "This conversation is already pinned to another runtime. Start a new chat to switch runtimes.",
+          },
+        };
+      }
+      if (!deps.hub.isOnline(prior.runtime_id)) {
+        return {
+          ok: false,
+          status: 503,
+          body: {
+            error: "runtime_offline",
+            message: `The ${runtimeType} runtime for this conversation is offline. Start the same daemon to resume it.`,
+          },
+        };
+      }
+      return { ok: true, runtimeIdOverride: prior.runtime_id };
+    }
+  }
+
+  const runtimes = await deps.runtimeRepo.listByOwnerAndCli(ownerPersonId, runtimeType);
+  if (runtimes.length === 0) {
+    return {
+      ok: false,
+      status: 400,
+      body: {
+        error: "runtime_not_registered",
+        message: `No ${runtimeType} runtime is registered for this account.`,
+      },
+    };
+  }
+
+  const online = runtimes.find((r) => deps.hub.isOnline(r.id));
+  if (!online) {
+    return {
+      ok: false,
+      status: 503,
+      body: {
+        error: "runtime_offline",
+        message: `No online ${runtimeType} runtime is available. Start beevibe-daemon on a machine with ${runtimeType}.`,
+      },
+    };
+  }
+
+  return { ok: true, runtimeIdOverride: online.id };
+}
+
 /**
  * Build the response body for a chat turn — used by both the live
  * POST success path and the idempotent-replay path. `replayed: true`
@@ -487,6 +559,16 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
     }
     const priorSessionId =
       typeof body.prior_session_id === "string" ? body.prior_session_id : undefined;
+    const runtimeTypeRaw = body.runtime_type;
+    const runtimeType =
+      runtimeTypeRaw === undefined ? undefined : isKnownCli(runtimeTypeRaw) ? runtimeTypeRaw : null;
+    if (runtimeType === null) {
+      res.status(400).json({
+        error: "invalid_runtime_type",
+        message: `runtime_type must be one of: ${KNOWN_CLIS.join(", ")}`,
+      });
+      return;
+    }
     const callerSessionId =
       typeof body.session_id === "string" && /^sess_[A-Za-z0-9]{12}$/.test(body.session_id)
         ? body.session_id
@@ -513,6 +595,10 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
     // another Claude Code subprocess. Each turn is real $$; this
     // collapses double-submits, browser-cache POST replays, and
     // network-blip retries to a single charge.
+    //
+    // Check this BEFORE resolving the runtime override — the original
+    // turn already validated and pinned a runtime, so a replay doesn't
+    // need to revalidate, and skipping it spares 1-2 DB hits on retries.
     if (callerSessionId) {
       const replay = await tryReplay(deps, agent, callerSessionId);
       if (replay) {
@@ -521,6 +607,17 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
           return;
         }
       }
+    }
+
+    const runtimeOverride = await resolveRuntimeOverride(
+      deps,
+      req.caller.personId,
+      runtimeType,
+      priorSessionId,
+    );
+    if (!runtimeOverride.ok) {
+      res.status(runtimeOverride.status).json(runtimeOverride.body);
+      return;
     }
 
     // Per-person rate limit (concurrent + sliding window). Compromised
@@ -556,6 +653,7 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
         intent: messageRaw,
         reason,
         type: "chat",
+        runtimeIdOverride: runtimeOverride.runtimeIdOverride,
       });
     } catch (err) {
       rateOutcome.release();

--- a/packages/api/src/routes/mcp.ts
+++ b/packages/api/src/routes/mcp.ts
@@ -67,8 +67,10 @@ interface ActiveMcpSession {
  * adaptations for beevibe:
  *   - No OAuth bridge (Bearer auth via M4's `lookupApiKey` only).
  *   - Per-session beevibe sid: agents pass `X-Beevibe-Session` header (set
- *     before they were spawned); humans get a fresh chat session row + sid
- *     created at initialize, with the cache mapping `mcpSid → beevibeSid`.
+ *     before they were spawned). Runtimes that cannot set custom MCP headers
+ *     may pass `?beevibe_session=...` on the MCP URL instead. Humans get a
+ *     fresh chat session row + sid created at initialize, with the cache
+ *     mapping `mcpSid → beevibeSid`.
  *   - Tools are assembled fresh per session via `assembleTools(ctx, services)`,
  *     closed over the resolved caller + sid (no async-storage threading).
  *
@@ -186,16 +188,23 @@ async function handleMcpRequest(
   let beevibeSid: string;
   if (caller.source === "agent") {
     const fromHeader = req.headers["x-beevibe-session"];
-    if (typeof fromHeader !== "string" || !fromHeader) {
+    const fromQuery = req.query.beevibe_session;
+    const sid =
+      typeof fromHeader === "string" && fromHeader
+        ? fromHeader
+        : typeof fromQuery === "string" && fromQuery
+          ? fromQuery
+          : undefined;
+    if (!sid) {
       res.status(400).json({
         error: "agent_caller_missing_x_beevibe_session",
         message:
-          "Agent callers must pass the X-Beevibe-Session header (set via " +
-          "env-var interpolation in mcp-config.json by the spawner).",
+          "Agent callers must pass the X-Beevibe-Session header or " +
+          "?beevibe_session=... on the MCP URL.",
       });
       return;
     }
-    beevibeSid = fromHeader;
+    beevibeSid = sid;
   } else {
     // Human: mint a fresh chat session row.
     beevibeSid = makeBeevibeSid();

--- a/packages/api/src/runtime/router.test.ts
+++ b/packages/api/src/runtime/router.test.ts
@@ -314,6 +314,7 @@ describe("/runtime — integration", () => {
         agent_id: a.agent.id,
         agent_api_key: a.agent.api_key,
         agent_hierarchy_level: "team",
+        runtime_type: "claude",
         type: "chat",
         mcp_server_url: "http://api.test/mcp",
         env: { BEEVIBE_SESSION_ID: sid, BEEVIBE_AGENT_ID: a.agent.id },
@@ -511,4 +512,3 @@ describe("/runtime — integration", () => {
     });
   });
 });
-

--- a/packages/api/src/runtime/router.ts
+++ b/packages/api/src/runtime/router.ts
@@ -1,26 +1,24 @@
 import { createHash } from "node:crypto";
 import { promises as fs } from "node:fs";
 import { join, relative } from "node:path";
-import { Router, type Request, type RequestHandler, type Response } from "express";
+import { Router, type RequestHandler } from "express";
 import {
   daemonId as newDaemonId,
   runtimeId as newRuntimeId,
   sessionEventId as newSessionEventId,
   isTerminalSessionStatus,
   type AgentRepository,
+  type DaemonRepository,
   type PersonRepository,
   type Session,
   type SessionEventRepository,
   type SessionRepository,
+  type RuntimeRepository,
 } from "@beevibe/core";
 import {
   generateDaemonApiKey,
   hashDaemonToken,
 } from "@beevibe/core/auth";
-import type {
-  DaemonRepository,
-  RuntimeRepository,
-} from "@beevibe/core";
 import type { MemoryAgent } from "@beevibe/core/services/memory";
 import {
   composeIntent,
@@ -455,6 +453,7 @@ async function composeDispatchPayload(
     agent_id: agent.id,
     agent_api_key: agent.api_key,
     agent_hierarchy_level: agent.hierarchy_level,
+    runtime_type: agent.runtime_config.type,
     intent: composeIntent(session.intent, briefing.userMessagePrefix),
     system_prompt_append: composeSystemPromptAppend(
       agent.runtime_config.system_prompt_addition,
@@ -553,4 +552,3 @@ async function assertDaemonOwnsSessions(
   const owned = await deps.sessionRepo.countOwnedByDaemon(daemonId, ids);
   return owned === ids.length;
 }
-

--- a/packages/api/src/runtime/router.ts
+++ b/packages/api/src/runtime/router.ts
@@ -7,6 +7,7 @@ import {
   runtimeId as newRuntimeId,
   sessionEventId as newSessionEventId,
   isTerminalSessionStatus,
+  isKnownCli,
   type AgentRepository,
   type DaemonRepository,
   type PersonRepository,
@@ -408,6 +409,12 @@ async function composeDispatchPayload(
 ): Promise<DispatchPayload | null> {
   const agent = await deps.agentRepo.findById(session.agent_id);
   if (!agent || !agent.api_key) return null;
+  const claimedRuntime = session.runtime_id
+    ? await deps.runtimeRepo.findById(session.runtime_id)
+    : undefined;
+  const runtimeType = isKnownCli(claimedRuntime?.cli)
+    ? claimedRuntime.cli
+    : agent.runtime_config.type;
 
   const memoryAgent = deps.makeMemoryAgent(agent.id);
   const isChat = session.type === "chat";
@@ -453,7 +460,7 @@ async function composeDispatchPayload(
     agent_id: agent.id,
     agent_api_key: agent.api_key,
     agent_hierarchy_level: agent.hierarchy_level,
-    runtime_type: agent.runtime_config.type,
+    runtime_type: runtimeType,
     intent: composeIntent(session.intent, briefing.userMessagePrefix),
     system_prompt_append: composeSystemPromptAppend(
       agent.runtime_config.system_prompt_addition,

--- a/packages/api/src/runtime/types.ts
+++ b/packages/api/src/runtime/types.ts
@@ -7,6 +7,7 @@
 
 import type {
   HierarchyLevel,
+  KnownCli,
   SessionEventKind,
   SessionStatus,
   SessionType,
@@ -61,6 +62,8 @@ export interface DispatchPayload {
    * sync. Pulled from agent.hierarchy_level at claim time.
    */
   agent_hierarchy_level: HierarchyLevel;
+  /** CLI runtime to spawn. Mirrors `agent.runtime_config.type`. */
+  runtime_type: KnownCli;
   intent: string;
   system_prompt_append: string;
   /** When set, daemon spawns with `--resume <cli_session_id>`. */

--- a/packages/api/src/runtime/types.ts
+++ b/packages/api/src/runtime/types.ts
@@ -62,7 +62,7 @@ export interface DispatchPayload {
    * sync. Pulled from agent.hierarchy_level at claim time.
    */
   agent_hierarchy_level: HierarchyLevel;
-  /** CLI runtime to spawn. Mirrors `agent.runtime_config.type`. */
+  /** CLI runtime to spawn. Mirrors the claimed `session.runtime_id` when pinned. */
   runtime_type: KnownCli;
   intent: string;
   system_prompt_append: string;

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -37,6 +37,7 @@ Tree-shake-friendly subpaths via the `exports` map in `package.json`:
 | `@beevibe/core/auth/constants` | Browser-safe constants (`PASSWORD_MIN_LENGTH`, …) |
 | `@beevibe/core/adapters/postgres` | All 15 repository implementations + `createPool` |
 | `@beevibe/core/adapters/claude-code` | `ClaudeCodeRuntime` (spawns `claude` CLI) |
+| `@beevibe/core/adapters/opencode` | `OpenCodeRuntime` (spawns `opencode` CLI for OpenRouter, Ollama, and OpenAI-compatible providers) |
 | `@beevibe/core/adapters/openai` | `OpenAIEmbeddingService`, `OpenAILlmProvider` |
 | `@beevibe/core/adapters/anthropic` | `AnthropicLlmProvider` |
 | `@beevibe/core/adapters/local-workspace` | `LocalWorkspaceManager` |
@@ -122,6 +123,7 @@ Every external dependency lives behind a port. New runtimes (e.g., a different C
 |---|---|---|
 | `postgres/` | All 15 repos + `createPool` | Raw `pg` driver, no ORM. Schema in [`/migrations/`](../../migrations). |
 | `claude-code/` | `AgentRuntime` | Spawns `claude` CLI as subprocess, parses stream-JSON output, captures cache tokens. |
+| `opencode/` | `AgentRuntime` | Spawns `opencode run --format json`; delegates provider/model plumbing to OpenCode for OpenRouter, Ollama, and OpenAI-compatible endpoints. |
 | `openai/` | `EmbeddingService`, `LlmProvider` | `text-embedding-3-small` (1536 dims), GPT-4o for fact merging. |
 | `anthropic/` | `LlmProvider` | Claude Sonnet for fact promotion (native JSON schema output). |
 | `local-workspace/` | `WorkspaceManager` | Per-agent dirs under `~/.beevibe/workspaces/<agent_id>/`, manages `mcp-config.json`. |

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,14 @@
       "types": "./dist/adapters/claude-code/index.d.ts",
       "default": "./dist/adapters/claude-code/index.js"
     },
+    "./adapters/codex": {
+      "types": "./dist/adapters/codex/index.d.ts",
+      "default": "./dist/adapters/codex/index.js"
+    },
+    "./adapters/opencode": {
+      "types": "./dist/adapters/opencode/index.d.ts",
+      "default": "./dist/adapters/opencode/index.js"
+    },
     "./adapters/local-workspace": {
       "types": "./dist/adapters/local-workspace/index.d.ts",
       "default": "./dist/adapters/local-workspace/index.js"

--- a/packages/core/src/adapters/codex/index.ts
+++ b/packages/core/src/adapters/codex/index.ts
@@ -1,0 +1,1 @@
+export * from "./runtime.js";

--- a/packages/core/src/adapters/codex/index.ts
+++ b/packages/core/src/adapters/codex/index.ts
@@ -1,1 +1,10 @@
-export * from "./runtime.js";
+export { CodexRuntime } from "./runtime.js";
+export type { CodexRuntimeConfig } from "./runtime.js";
+export {
+  CODEX_EVENT_TYPE,
+  CODEX_ITEM_TYPE,
+  parseCodexEventLine,
+  extractCodexStepEvents,
+  parseCodexEvents,
+} from "./stream-json.js";
+export type { CodexEvent, CodexItem } from "./stream-json.js";

--- a/packages/core/src/adapters/codex/runtime.test.ts
+++ b/packages/core/src/adapters/codex/runtime.test.ts
@@ -3,22 +3,38 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import type { RuntimeContext, RuntimeStep } from "../../ports/runtime.js";
 import { CodexRuntime } from "./runtime.js";
+import { CODEX_EVENT_TYPE, CODEX_ITEM_TYPE } from "./stream-json.js";
 import type { CliProcessOptions, CliProcessResult } from "../claude-code/spawn.js";
 import * as spawnModule from "../claude-code/spawn.js";
 
+/**
+ * Canonical stdout for a clean codex turn — fixtures match the schema in
+ * codex-rs/exec/src/exec_events.rs. The parser unit tests in
+ * ./stream-json.test.ts cover edge cases; this file exercises the
+ * end-to-end runtime wiring (args + env + last-message file + step
+ * streaming) on top of those fixtures.
+ */
+const CANONICAL_STDOUT =
+  JSON.stringify({ type: CODEX_EVENT_TYPE.ThreadStarted, thread_id: "thread_abc" }) +
+  "\n" +
+  JSON.stringify({
+    type: CODEX_EVENT_TYPE.ItemCompleted,
+    item: { id: "item_1", type: CODEX_ITEM_TYPE.AgentMessage, text: "done" },
+  }) +
+  "\n" +
+  JSON.stringify({
+    type: CODEX_EVENT_TYPE.TurnCompleted,
+    usage: {
+      input_tokens: 100,
+      cached_input_tokens: 60,
+      output_tokens: 40,
+      reasoning_output_tokens: 10,
+    },
+  }) +
+  "\n";
+
 const MOCK_OK: CliProcessResult = {
-  stdout:
-    JSON.stringify({
-      type: "thread.started",
-      thread_id: "codex_thread_mock",
-    }) +
-    "\n" +
-    JSON.stringify({
-      type: "item.completed",
-      item: { type: "agent_message", text: "done" },
-      usage: { input_tokens: 100, output_tokens: 50, model: "gpt-5.5" },
-    }) +
-    "\n",
+  stdout: CANONICAL_STDOUT,
   stderr: "",
   exitCode: 0,
   timedOut: false,
@@ -51,7 +67,7 @@ function mockRunCli(result: CliProcessResult = MOCK_OK): void {
 function ctx(overrides: Partial<RuntimeContext> = {}): RuntimeContext {
   return {
     intent: "do a thing",
-    workspace: { path: "/tmp/beevibe-codex-test-ws" },
+    workspace: { path: `/tmp/beevibe-codex-test-${Math.random()}` },
     system_prompt_append: "",
     ...overrides,
   };
@@ -117,11 +133,16 @@ describe("CodexRuntime.execute", () => {
     mockRunCli();
     const runtime = new CodexRuntime();
     runtime.prepareWorkspace({
-      workspace: { path: "/tmp/beevibe-codex-test-ws" },
+      workspace: { path: "/tmp/beevibe-codex-test-mcp" },
       agentApiKey: "bv_a_test",
       mcpServerUrl: "http://api.test/mcp",
     });
-    await runtime.execute(ctx({ env: { BEEVIBE_SESSION_ID: "sess_test_123" } }));
+    await runtime.execute(
+      ctx({
+        workspace: { path: "/tmp/beevibe-codex-test-mcp" },
+        env: { BEEVIBE_SESSION_ID: "sess_test_123" },
+      }),
+    );
     expect(lastOptions!.env!.BEEVIBE_AGENT_API_KEY).toBe("bv_a_test");
     expect(lastOptions!.args).toContain(
       'mcp_servers.beevibe.url="http://api.test/mcp?beevibe_session=sess_test_123"',
@@ -129,41 +150,95 @@ describe("CodexRuntime.execute", () => {
     expect(lastOptions!.args).toContain(
       'mcp_servers.beevibe.bearer_token_env_var="BEEVIBE_AGENT_API_KEY"',
     );
+    // Regression: codex's --ask-for-approval never doesn't extend to MCP
+    // tool calls; without this override every tool call fails with
+    // "user cancelled MCP tool call" in headless exec mode.
+    expect(lastOptions!.args).toContain(
+      'mcp_servers.beevibe.default_tools_approval_mode="approve"',
+    );
   });
 
-  it("parses result events into RuntimeResult and prefers output-last-message", async () => {
+  it("strips OPENAI_API_KEY / OPENAI_AUTH_TOKEN from the spawned env to preserve subscription auth", async () => {
+    mockRunCli();
+    const prior = {
+      OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+      OPENAI_AUTH_TOKEN: process.env.OPENAI_AUTH_TOKEN,
+    };
+    process.env.OPENAI_API_KEY = "sk-leaked";
+    process.env.OPENAI_AUTH_TOKEN = "token-leaked";
+    try {
+      await new CodexRuntime().execute(ctx());
+    } finally {
+      if (prior.OPENAI_API_KEY === undefined) delete process.env.OPENAI_API_KEY;
+      else process.env.OPENAI_API_KEY = prior.OPENAI_API_KEY;
+      if (prior.OPENAI_AUTH_TOKEN === undefined) delete process.env.OPENAI_AUTH_TOKEN;
+      else process.env.OPENAI_AUTH_TOKEN = prior.OPENAI_AUTH_TOKEN;
+    }
+    expect(lastOptions!.env!.OPENAI_API_KEY).toBeUndefined();
+    expect(lastOptions!.env!.OPENAI_AUTH_TOKEN).toBeUndefined();
+  });
+
+  it("warns when stdout was truncated at the spawn cap", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockRunCli({ ...MOCK_OK, truncated: true });
+    await new CodexRuntime().execute(ctx());
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("stdout truncated at 4MB"),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("parses canonical event stream into RuntimeResult and prefers output-last-message", async () => {
     mockRunCli();
     const result = await new CodexRuntime().execute(ctx());
     expect(result.status).toBe("completed");
     expect(result.output).toBe("last message from file");
-    expect(result.cli_session_id).toBe("codex_thread_mock");
+    expect(result.cli_session_id).toBe("thread_abc");
     expect(result.usage).toEqual({
       input_tokens: 100,
       output_tokens: 50,
       cache_creation_input_tokens: 0,
-      cache_read_input_tokens: 0,
-      model: "gpt-5.5",
+      cache_read_input_tokens: 60,
     });
   });
 
-  it("emits tool steps from JSON event shapes", async () => {
+  it("streams tool steps from mcp_tool_call items (started → tool_call, completed → tool_result)", async () => {
     const steps: RuntimeStep[] = [];
     runCliSpy.mockImplementation(async (options) => {
-      options.onLog?.(
-        "stdout",
+      const stdout =
         JSON.stringify({
-          type: "tool_call",
-          tool: "shell",
-          input: { command: "ls" },
-        }) + "\n",
-      );
-      return MOCK_OK;
+          type: CODEX_EVENT_TYPE.ItemStarted,
+          item: {
+            id: "item_t",
+            type: CODEX_ITEM_TYPE.McpToolCall,
+            server: "beevibe",
+            tool: "create_task",
+            arguments: { title: "fix" },
+            status: "in_progress",
+          },
+        }) +
+        "\n" +
+        JSON.stringify({
+          type: CODEX_EVENT_TYPE.ItemCompleted,
+          item: {
+            id: "item_t",
+            type: CODEX_ITEM_TYPE.McpToolCall,
+            server: "beevibe",
+            tool: "create_task",
+            arguments: { title: "fix" },
+            result: { content: [{ type: "text", text: "ok" }] },
+            status: "completed",
+          },
+        }) +
+        "\n";
+      options.onLog?.("stdout", stdout);
+      return { ...MOCK_OK, stdout };
     });
-    await new CodexRuntime().execute(ctx({ onStep: (step) => steps.push(step) }));
-    expect(steps).toHaveLength(1);
-    expect(steps[0]!.kind).toBe("tool_call");
-    expect(steps[0]!.tool).toBe("shell");
-    expect(steps[0]!.description).toBe("ls");
+    await new CodexRuntime().execute(ctx({ onStep: (s) => steps.push(s) }));
+    expect(steps).toEqual([
+      expect.objectContaining({ kind: "tool_call", tool: "create_task" }),
+      expect.objectContaining({ kind: "tool_result", tool: "create_task" }),
+    ]);
   });
 
   it("maps aborted result to cancelled", async () => {
@@ -172,51 +247,26 @@ describe("CodexRuntime.execute", () => {
     expect(result.status).toBe("cancelled");
   });
 
-  it("drops non-JSON log noise from stdout when no assistant text was extracted", async () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("surfaces stderr tail on failure so /runtime/done has something actionable", async () => {
     runCliSpy.mockImplementation(async (options) => {
       lastOptions = options;
-      // Codex's Rust binary prints `tracing` WARN lines to stdout
-      // alongside JSON events. With no assistant message in events
-      // and no last-message file, the old fallback dumped these
-      // warnings as the chat reply.
-      const stdout =
-        "2026-05-16T16:50:34Z WARN codex_core_skills::loader: ignoring interface.icon_small: icon path must not contain '..'\n" +
-        JSON.stringify({ type: "thread.started", thread_id: "codex_t1" }) +
-        "\n";
-      options.onLog?.("stdout", stdout);
-      return { ...MOCK_OK, stdout, exitCode: 0 };
+      return {
+        ...MOCK_OK,
+        stdout: "",
+        stderr: "Error: rate limited\n",
+        exitCode: 1,
+      };
     });
-    // Unique workspace so a sibling test's last-message file (which
-    // shares a directory and a millisecond-precision filename) can't
-    // bleed in.
-    const result = await new CodexRuntime().execute(
-      ctx({ workspace: { path: `/tmp/beevibe-codex-noise-${Math.random()}` } }),
-    );
-    expect(result.output).toBe("Codex completed.");
-    expect(result.output).not.toContain("WARN");
-    warnSpy.mockRestore();
-  });
-
-  it("extracts text from nested delta objects", async () => {
-    runCliSpy.mockImplementation(async (options) => {
-      lastOptions = options;
-      const stdout =
-        JSON.stringify({ type: "item.delta", delta: { text: "hello world" } }) + "\n";
-      options.onLog?.("stdout", stdout);
-      return { ...MOCK_OK, stdout, exitCode: 0 };
-    });
-    const result = await new CodexRuntime().execute(
-      ctx({ workspace: { path: `/tmp/beevibe-codex-delta-${Math.random()}` } }),
-    );
-    expect(result.output).toBe("hello world");
+    const result = await new CodexRuntime().execute(ctx());
+    expect(result.status).toBe("failed");
+    expect(result.stderr).toBe("Error: rate limited\n");
   });
 
   it("prefers structured Codex errors over noisy stderr", async () => {
     runCliSpy.mockImplementation(async (options) => {
       lastOptions = options;
       const stdout =
-        JSON.stringify({ type: "error", message: "You've hit your usage limit." }) +
+        JSON.stringify({ type: CODEX_EVENT_TYPE.Error, message: "You've hit your usage limit." }) +
         "\n";
       options.onLog?.("stdout", stdout);
       return {
@@ -229,7 +279,6 @@ describe("CodexRuntime.execute", () => {
     const result = await new CodexRuntime().execute(ctx());
     expect(result.status).toBe("failed");
     expect(result.output).toBe("You've hit your usage limit.");
-    expect(result.stderr).toBeUndefined();
   });
 });
 

--- a/packages/core/src/adapters/codex/runtime.test.ts
+++ b/packages/core/src/adapters/codex/runtime.test.ts
@@ -171,6 +171,66 @@ describe("CodexRuntime.execute", () => {
     const result = await new CodexRuntime().execute(ctx());
     expect(result.status).toBe("cancelled");
   });
+
+  it("drops non-JSON log noise from stdout when no assistant text was extracted", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    runCliSpy.mockImplementation(async (options) => {
+      lastOptions = options;
+      // Codex's Rust binary prints `tracing` WARN lines to stdout
+      // alongside JSON events. With no assistant message in events
+      // and no last-message file, the old fallback dumped these
+      // warnings as the chat reply.
+      const stdout =
+        "2026-05-16T16:50:34Z WARN codex_core_skills::loader: ignoring interface.icon_small: icon path must not contain '..'\n" +
+        JSON.stringify({ type: "thread.started", thread_id: "codex_t1" }) +
+        "\n";
+      options.onLog?.("stdout", stdout);
+      return { ...MOCK_OK, stdout, exitCode: 0 };
+    });
+    // Unique workspace so a sibling test's last-message file (which
+    // shares a directory and a millisecond-precision filename) can't
+    // bleed in.
+    const result = await new CodexRuntime().execute(
+      ctx({ workspace: { path: `/tmp/beevibe-codex-noise-${Math.random()}` } }),
+    );
+    expect(result.output).toBe("Codex completed.");
+    expect(result.output).not.toContain("WARN");
+    warnSpy.mockRestore();
+  });
+
+  it("extracts text from nested delta objects", async () => {
+    runCliSpy.mockImplementation(async (options) => {
+      lastOptions = options;
+      const stdout =
+        JSON.stringify({ type: "item.delta", delta: { text: "hello world" } }) + "\n";
+      options.onLog?.("stdout", stdout);
+      return { ...MOCK_OK, stdout, exitCode: 0 };
+    });
+    const result = await new CodexRuntime().execute(
+      ctx({ workspace: { path: `/tmp/beevibe-codex-delta-${Math.random()}` } }),
+    );
+    expect(result.output).toBe("hello world");
+  });
+
+  it("prefers structured Codex errors over noisy stderr", async () => {
+    runCliSpy.mockImplementation(async (options) => {
+      lastOptions = options;
+      const stdout =
+        JSON.stringify({ type: "error", message: "You've hit your usage limit." }) +
+        "\n";
+      options.onLog?.("stdout", stdout);
+      return {
+        ...MOCK_OK,
+        stdout,
+        stderr: "WARN plugin noise",
+        exitCode: 1,
+      };
+    });
+    const result = await new CodexRuntime().execute(ctx());
+    expect(result.status).toBe("failed");
+    expect(result.output).toBe("You've hit your usage limit.");
+    expect(result.stderr).toBeUndefined();
+  });
 });
 
 describe("CodexRuntime.healthCheck", () => {

--- a/packages/core/src/adapters/codex/runtime.test.ts
+++ b/packages/core/src/adapters/codex/runtime.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import type { RuntimeContext, RuntimeStep } from "../../ports/runtime.js";
+import { CodexRuntime } from "./runtime.js";
+import type { CliProcessOptions, CliProcessResult } from "../claude-code/spawn.js";
+import * as spawnModule from "../claude-code/spawn.js";
+
+const MOCK_OK: CliProcessResult = {
+  stdout:
+    JSON.stringify({
+      type: "thread.started",
+      thread_id: "codex_thread_mock",
+    }) +
+    "\n" +
+    JSON.stringify({
+      type: "item.completed",
+      item: { type: "agent_message", text: "done" },
+      usage: { input_tokens: 100, output_tokens: 50, model: "gpt-5.5" },
+    }) +
+    "\n",
+  stderr: "",
+  exitCode: 0,
+  timedOut: false,
+  aborted: false,
+  pid: 9999,
+  process_group_id: 9999,
+  truncated: false,
+};
+
+let runCliSpy: ReturnType<typeof vi.spyOn>;
+let lastOptions: CliProcessOptions | undefined;
+
+function mockRunCli(result: CliProcessResult = MOCK_OK): void {
+  runCliSpy.mockImplementation(async (options) => {
+    lastOptions = options;
+    if (result.pid !== null) {
+      options.onSpawn?.({ pid: result.pid, process_group_id: result.process_group_id ?? result.pid });
+    }
+    if (result.stdout) options.onLog?.("stdout", result.stdout);
+    const outputIdx = options.args?.indexOf("--output-last-message") ?? -1;
+    const outputPath = outputIdx >= 0 ? options.args?.[outputIdx + 1] : undefined;
+    if (outputPath) {
+      mkdirSync(dirname(outputPath), { recursive: true });
+      writeFileSync(outputPath, "last message from file", "utf8");
+    }
+    return result;
+  });
+}
+
+function ctx(overrides: Partial<RuntimeContext> = {}): RuntimeContext {
+  return {
+    intent: "do a thing",
+    workspace: { path: "/tmp/beevibe-codex-test-ws" },
+    system_prompt_append: "",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  lastOptions = undefined;
+  runCliSpy = vi.spyOn(spawnModule, "runCliProcess");
+});
+
+afterEach(() => {
+  runCliSpy.mockRestore();
+});
+
+describe("CodexRuntime.execute", () => {
+  it("runs codex exec non-interactively with JSON events", async () => {
+    mockRunCli();
+    await new CodexRuntime().execute(ctx({ workspace: { path: "/tmp/agent_codex" } }));
+    expect(lastOptions?.cwd).toBe("/tmp/agent_codex");
+    expect(lastOptions?.args?.slice(0, 8)).toEqual([
+      "--sandbox",
+      "workspace-write",
+      "--ask-for-approval",
+      "never",
+      "--cd",
+      "/tmp/agent_codex",
+      "exec",
+      "--json",
+    ]);
+  });
+
+  it("passes context.model as --model", async () => {
+    mockRunCli();
+    await new CodexRuntime({ model: "fallback" }).execute(ctx({ model: "gpt-5.5" }));
+    const idx = lastOptions!.args!.indexOf("--model");
+    expect(lastOptions!.args![idx + 1]).toBe("gpt-5.5");
+  });
+
+  it("uses exec resume when context.resume_session_id is set", async () => {
+    mockRunCli();
+    await new CodexRuntime().execute(ctx({ resume_session_id: "codex_prev" }));
+    const execIdx = lastOptions!.args!.indexOf("exec");
+    expect(lastOptions!.args!.slice(execIdx, execIdx + 3)).toEqual([
+      "exec",
+      "resume",
+      "--json",
+    ]);
+    expect(lastOptions!.args).toContain("codex_prev");
+  });
+
+  it("folds system_prompt_append into the prompt", async () => {
+    mockRunCli();
+    await new CodexRuntime().execute(
+      ctx({ intent: "fix bug", system_prompt_append: "<core>memory</core>" }),
+    );
+    const prompt = lastOptions!.args!.at(-1)!;
+    expect(prompt).toContain("<beevibe_system_context>");
+    expect(prompt).toContain("<core>memory</core>");
+    expect(prompt).toContain("fix bug");
+  });
+
+  it("adds Beevibe MCP config overrides after workspace preparation", async () => {
+    mockRunCli();
+    const runtime = new CodexRuntime();
+    runtime.prepareWorkspace({
+      workspace: { path: "/tmp/beevibe-codex-test-ws" },
+      agentApiKey: "bv_a_test",
+      mcpServerUrl: "http://api.test/mcp",
+    });
+    await runtime.execute(ctx({ env: { BEEVIBE_SESSION_ID: "sess_test_123" } }));
+    expect(lastOptions!.env!.BEEVIBE_AGENT_API_KEY).toBe("bv_a_test");
+    expect(lastOptions!.args).toContain(
+      'mcp_servers.beevibe.url="http://api.test/mcp?beevibe_session=sess_test_123"',
+    );
+    expect(lastOptions!.args).toContain(
+      'mcp_servers.beevibe.bearer_token_env_var="BEEVIBE_AGENT_API_KEY"',
+    );
+  });
+
+  it("parses result events into RuntimeResult and prefers output-last-message", async () => {
+    mockRunCli();
+    const result = await new CodexRuntime().execute(ctx());
+    expect(result.status).toBe("completed");
+    expect(result.output).toBe("last message from file");
+    expect(result.cli_session_id).toBe("codex_thread_mock");
+    expect(result.usage).toEqual({
+      input_tokens: 100,
+      output_tokens: 50,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+      model: "gpt-5.5",
+    });
+  });
+
+  it("emits tool steps from JSON event shapes", async () => {
+    const steps: RuntimeStep[] = [];
+    runCliSpy.mockImplementation(async (options) => {
+      options.onLog?.(
+        "stdout",
+        JSON.stringify({
+          type: "tool_call",
+          tool: "shell",
+          input: { command: "ls" },
+        }) + "\n",
+      );
+      return MOCK_OK;
+    });
+    await new CodexRuntime().execute(ctx({ onStep: (step) => steps.push(step) }));
+    expect(steps).toHaveLength(1);
+    expect(steps[0]!.kind).toBe("tool_call");
+    expect(steps[0]!.tool).toBe("shell");
+    expect(steps[0]!.description).toBe("ls");
+  });
+
+  it("maps aborted result to cancelled", async () => {
+    mockRunCli({ ...MOCK_OK, aborted: true, stdout: "" });
+    const result = await new CodexRuntime().execute(ctx());
+    expect(result.status).toBe("cancelled");
+  });
+});
+
+describe("CodexRuntime.healthCheck", () => {
+  it("runs codex --version", async () => {
+    mockRunCli({ ...MOCK_OK, stdout: "", exitCode: 0 });
+    const health = await new CodexRuntime().healthCheck();
+    expect(health.healthy).toBe(true);
+    expect(lastOptions!.args).toEqual(["--version"]);
+    expect(lastOptions!.timeoutMs).toBe(5000);
+    expect(lastOptions!.graceMs).toBe(0);
+  });
+});

--- a/packages/core/src/adapters/codex/runtime.ts
+++ b/packages/core/src/adapters/codex/runtime.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type {
@@ -6,11 +6,16 @@ import type {
   RuntimeContext,
   RuntimeHealth,
   RuntimeResult,
-  RuntimeStep,
   RuntimeWorkspaceContext,
   Workspace,
 } from "../../ports/runtime.js";
 import { runCliProcess } from "../claude-code/spawn.js";
+import {
+  extractCodexStepEvents,
+  parseCodexEventLine,
+  parseCodexEvents,
+  type CodexEvent,
+} from "./stream-json.js";
 
 export interface CodexRuntimeConfig {
   /** Override CLI command (defaults to "codex" on PATH). */
@@ -19,7 +24,15 @@ export interface CodexRuntimeConfig {
   model?: string;
 }
 
-type JsonRecord = Record<string, unknown>;
+/**
+ * OpenAI auth env vars stripped from the spawned Codex subprocess so it
+ * authenticates via its own `~/.codex/` credentials (ChatGPT subscription
+ * when the user has run `codex login`). Mirrors `ANTHROPIC_AUTH_VARS` in
+ * ClaudeCodeRuntime: without this, an `OPENAI_API_KEY` set in the
+ * daemon's shell (or leaked from a stray `.env`) silently overrides
+ * the subscription auth the user had configured and forces API-key billing.
+ */
+const OPENAI_AUTH_VARS = ["OPENAI_API_KEY", "OPENAI_AUTH_TOKEN"] as const;
 
 interface PreparedWorkspace {
   agentApiKey: string;
@@ -29,11 +42,13 @@ interface PreparedWorkspace {
 /**
  * Codex CLI subprocess runtime.
  *
- * This adapter is intentionally small: it proves Beevibe's runtime registry
- * can route sessions to Codex while preserving the existing RuntimeResult /
- * RuntimeStep contract. Codex's own CLI owns tool execution and JSONL event
- * streaming; Beevibe owns workspace provisioning, MCP policy, persistence,
- * and task/session lifecycle.
+ * Spawns `codex exec --json`, parses the typed event stream documented in
+ * `codex-rs/exec/src/exec_events.rs`, and maps the result to RuntimeResult.
+ * Per-event step parsing lives in `./stream-json.ts` — the runtime itself
+ * just owns process lifecycle, MCP wiring, and workspace handoff.
+ *
+ * Stateless; no cleanup required beyond removing the per-spawn
+ * `--output-last-message` file (codex leaves it behind otherwise).
  */
 export class CodexRuntime implements AgentRuntime {
   readonly type = "codex";
@@ -62,6 +77,15 @@ export class CodexRuntime implements AgentRuntime {
         `mcp_servers.beevibe.url=${tomlString(withBeevibeSession(prepared.mcpServerUrl, sid))}`,
         "-c",
         `mcp_servers.beevibe.bearer_token_env_var=${tomlString("BEEVIBE_AGENT_API_KEY")}`,
+        // Auto-approve every beevibe MCP tool. `--ask-for-approval never`
+        // + `--sandbox workspace-write` does NOT bypass codex's MCP
+        // approval flow — codex auto-approves MCP only when sandbox is
+        // `danger-full-access`. In headless `exec` mode there's no TTY to
+        // answer the elicitation, so the prompt resolves to "cancel" and
+        // every tool call fails with "user cancelled MCP tool call".
+        // Workspace-write keeps filesystem safety; this opens MCP only.
+        "-c",
+        `mcp_servers.beevibe.default_tools_approval_mode=${tomlString("approve")}`,
       );
     }
 
@@ -77,17 +101,20 @@ export class CodexRuntime implements AgentRuntime {
       : [...globalArgs, "exec", ...execArgs, composePrompt(context)];
 
     const env: Record<string, string | undefined> = { ...process.env };
+    for (const key of OPENAI_AUTH_VARS) delete env[key];
     if (context.env) Object.assign(env, context.env);
     if (prepared) env.BEEVIBE_AGENT_API_KEY = prepared.agentApiKey;
 
-    const events: JsonRecord[] = [];
+    const events: CodexEvent[] = [];
     let pending = "";
     const handleLine = (line: string): void => {
-      const evt = parseJsonLine(line);
+      const evt = parseCodexEventLine(line);
       if (!evt) return;
       events.push(evt);
-      const step = eventToStep(evt);
-      if (step) context.onStep?.(step);
+      if (!context.onStep) return;
+      for (const step of extractCodexStepEvents(evt)) {
+        context.onStep(step);
+      }
     };
 
     const result = await runCliProcess({
@@ -111,7 +138,14 @@ export class CodexRuntime implements AgentRuntime {
     });
     if (pending) handleLine(pending);
 
+    if (result.truncated) {
+      console.warn(
+        "[CodexRuntime] stdout truncated at 4MB — result parsing may be incomplete",
+      );
+    }
+
     if (result.aborted) {
+      removeIfExists(lastMessagePath);
       return {
         status: "cancelled",
         output: "Session cancelled.",
@@ -120,13 +154,20 @@ export class CodexRuntime implements AgentRuntime {
       };
     }
 
-    const parsed = parseCodexEvents(events, result.stdout, result.exitCode, lastMessagePath);
+    const lastMessage = readIfExists(lastMessagePath);
+    removeIfExists(lastMessagePath);
+    const parsed = parseCodexEvents(events, result.exitCode, lastMessage);
+    const STDERR_TAIL_BYTES = 4096;
+    const stderrTail =
+      parsed.status === "failed" && result.stderr
+        ? result.stderr.slice(-STDERR_TAIL_BYTES)
+        : undefined;
     return {
       ...parsed,
       process_pid: result.pid ?? undefined,
       process_group_id: result.process_group_id ?? undefined,
       exit_code: result.exitCode,
-      stderr: stderrForFailure(parsed, result.stderr),
+      ...(stderrTail ? { stderr: stderrTail } : {}),
     };
   }
 
@@ -167,19 +208,6 @@ export class CodexRuntime implements AgentRuntime {
   }
 }
 
-function stderrForFailure(
-  parsed: Omit<RuntimeResult, "process_pid" | "process_group_id">,
-  stderr: string,
-): string | undefined {
-  if (parsed.status !== "failed") return undefined;
-  const output = parsed.output.trim();
-  // Codex emits structured `error` events on stdout for user-actionable
-  // failures (usage limit, auth, etc.). Prefer that over stderr, which often
-  // contains noisy plugin / skill loader warnings.
-  if (output && output !== "Codex failed.") return undefined;
-  return stderr ? stderr.slice(-4_000) : undefined;
-}
-
 function buildGlobalArgs(context: RuntimeContext, config: CodexRuntimeConfig): string[] {
   const args = [
     "--sandbox",
@@ -215,79 +243,6 @@ function tomlString(value: string): string {
   return JSON.stringify(value);
 }
 
-function parseJsonLine(line: string): JsonRecord | undefined {
-  const trimmed = line.trim();
-  if (!trimmed) return undefined;
-  try {
-    const value = JSON.parse(trimmed);
-    return isRecord(value) ? value : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function eventToStep(evt: JsonRecord): RuntimeStep | undefined {
-  const type = String(evt.type ?? evt.event ?? evt.kind ?? "").toLowerCase();
-  const item = isRecord(evt.item) ? evt.item : undefined;
-  const tool =
-    pickString(evt, ["tool", "tool_name", "name"]) ??
-    (item ? pickString(item, ["tool", "tool_name", "name"]) : undefined);
-  if (type.includes("tool") || tool) {
-    return {
-      kind: type.includes("result") || type.includes("completed") ? "tool_result" : "tool_call",
-      tool,
-      description: summarizeTool(evt),
-      timestamp: new Date().toISOString(),
-    };
-  }
-  const text = pickText(evt);
-  if (text) {
-    return {
-      kind: "agent",
-      description: text,
-      timestamp: new Date().toISOString(),
-    };
-  }
-  return undefined;
-}
-
-function parseCodexEvents(
-  events: JsonRecord[],
-  stdout: string,
-  exitCode: number | null,
-  lastMessagePath: string,
-): Omit<RuntimeResult, "process_pid" | "process_group_id"> {
-  const lastMessage = readIfExists(lastMessagePath).trim();
-  const assistantText = events.map(pickText).filter(Boolean).join("\n").trim();
-  if (!lastMessage && !assistantText) {
-    // Neither source produced text. Log a sample so we can see what
-    // Codex actually emitted — the chat reply will be a generic
-    // "Codex completed./failed." fallback (or a `fallbackText` distill
-    // of any JSON events that lacked recognized text fields).
-    const sample = events.slice(0, 5).map((e) => ({
-      type: typeof e.type === "string" ? e.type : undefined,
-      keys: Object.keys(e).slice(0, 8),
-    }));
-    console.warn(
-      "[codex-adapter] no assistant text extracted: events=%d, lastMessageFileExists=%s, sample=%j",
-      events.length,
-      existsSync(lastMessagePath),
-      sample,
-    );
-  }
-  const output =
-    exitCode === 0
-      ? lastMessage || assistantText || fallbackText(stdout)
-      : assistantText || lastMessage || fallbackText(stdout);
-  return {
-    status: exitCode === 0 ? "completed" : "failed",
-    output: output || (exitCode === 0 ? "Codex completed." : "Codex failed."),
-    transcript: stdout || undefined,
-    usage: parseUsage(events),
-    cli_session_id: parseSessionId(events),
-  };
-}
-
 function readIfExists(path: string): string {
   try {
     return existsSync(path) ? readFileSync(path, "utf8") : "";
@@ -296,111 +251,10 @@ function readIfExists(path: string): string {
   }
 }
 
-function parseUsage(events: JsonRecord[]): RuntimeResult["usage"] {
-  for (const evt of [...events].reverse()) {
-    const usage = isRecord(evt.usage)
-      ? evt.usage
-      : isRecord(evt.token_usage)
-        ? evt.token_usage
-        : undefined;
-    if (!usage) continue;
-    const input = pickNumber(usage, ["input_tokens", "inputTokens", "prompt_tokens", "promptTokens"]);
-    const output = pickNumber(usage, ["output_tokens", "outputTokens", "completion_tokens", "completionTokens"]);
-    const cost = pickNumber(usage, ["cost_usd", "costUSD", "cost"]);
-    const model = pickString(usage, ["model"]) ?? pickString(evt, ["model"]);
-    if (input === undefined && output === undefined && cost === undefined && model === undefined) {
-      continue;
-    }
-    return {
-      input_tokens: input ?? 0,
-      output_tokens: output ?? 0,
-      cache_creation_input_tokens: pickNumber(usage, ["cache_creation_input_tokens"]) ?? 0,
-      cache_read_input_tokens: pickNumber(usage, ["cache_read_input_tokens"]) ?? 0,
-      cost_usd: cost,
-      model,
-    };
+function removeIfExists(path: string): void {
+  try {
+    if (existsSync(path)) unlinkSync(path);
+  } catch {
+    // Best-effort cleanup; leftover files don't affect correctness.
   }
-  return undefined;
-}
-
-function parseSessionId(events: JsonRecord[]): string | undefined {
-  for (const evt of [...events].reverse()) {
-    const id =
-      pickString(evt, ["session_id", "sessionID", "sessionId", "thread_id", "threadId"]) ??
-      (isRecord(evt.session) ? pickString(evt.session, ["id", "session_id"]) : undefined) ??
-      (isRecord(evt.thread) ? pickString(evt.thread, ["id", "thread_id"]) : undefined);
-    if (id) return id;
-  }
-  return undefined;
-}
-
-function pickText(evt: JsonRecord): string {
-  const direct = pickString(evt, ["output", "text", "content", "message", "delta"]);
-  if (direct) return direct;
-  const item = isRecord(evt.item) ? evt.item : undefined;
-  if (item) {
-    const itemText = pickString(item, ["text", "content", "message"]);
-    if (itemText) return itemText;
-  }
-  // Streaming shapes sometimes nest the chunk as { delta: { text: "..." } }
-  // rather than a flat string delta.
-  const delta = isRecord(evt.delta) ? evt.delta : undefined;
-  if (delta) {
-    const deltaText = pickString(delta, ["text", "content", "message"]);
-    if (deltaText) return deltaText;
-  }
-  if (isRecord(evt.message)) {
-    return pickString(evt.message, ["content", "text"]) ?? "";
-  }
-  return "";
-}
-
-function summarizeTool(evt: JsonRecord): string {
-  const item = isRecord(evt.item) ? evt.item : undefined;
-  const input = evt.input ?? evt.arguments ?? evt.args ?? evt.params ?? item?.input;
-  if (typeof input === "string") return input.slice(0, 300);
-  if (isRecord(input)) {
-    const path = pickString(input, ["file_path", "path", "file"]);
-    const command = pickString(input, ["command", "cmd"]);
-    if (path) return path;
-    if (command) return command;
-    return JSON.stringify(input).slice(0, 300);
-  }
-  return pickText(evt) || "tool call";
-}
-
-function fallbackText(stdout: string): string {
-  // Stdout is supposed to be NDJSON. Drop non-JSON lines — they're
-  // Codex's tracing/log output (skill loader warnings, plugin manifest
-  // diagnostics, etc.) and never legitimate model output. If we kept
-  // them, a turn that fails to surface an assistant message would dump
-  // the raw log noise into the chat reply.
-  return stdout
-    .split("\n")
-    .map(parseJsonLine)
-    .filter((evt): evt is JsonRecord => !!evt)
-    .map(pickText)
-    .filter(Boolean)
-    .join("\n")
-    .trim();
-}
-
-function pickString(obj: JsonRecord, keys: string[]): string | undefined {
-  for (const key of keys) {
-    const value = obj[key];
-    if (typeof value === "string" && value.length > 0) return value;
-  }
-  return undefined;
-}
-
-function pickNumber(obj: JsonRecord, keys: string[]): number | undefined {
-  for (const key of keys) {
-    const value = obj[key];
-    if (typeof value === "number" && Number.isFinite(value)) return value;
-  }
-  return undefined;
-}
-
-function isRecord(value: unknown): value is JsonRecord {
-  return !!value && typeof value === "object" && !Array.isArray(value);
 }

--- a/packages/core/src/adapters/codex/runtime.ts
+++ b/packages/core/src/adapters/codex/runtime.ts
@@ -126,7 +126,7 @@ export class CodexRuntime implements AgentRuntime {
       process_pid: result.pid ?? undefined,
       process_group_id: result.process_group_id ?? undefined,
       exit_code: result.exitCode,
-      stderr: parsed.status === "failed" ? result.stderr.slice(-4_000) : undefined,
+      stderr: stderrForFailure(parsed, result.stderr),
     };
   }
 
@@ -165,6 +165,19 @@ export class CodexRuntime implements AgentRuntime {
       mcpServerUrl: context.mcpServerUrl,
     });
   }
+}
+
+function stderrForFailure(
+  parsed: Omit<RuntimeResult, "process_pid" | "process_group_id">,
+  stderr: string,
+): string | undefined {
+  if (parsed.status !== "failed") return undefined;
+  const output = parsed.output.trim();
+  // Codex emits structured `error` events on stdout for user-actionable
+  // failures (usage limit, auth, etc.). Prefer that over stderr, which often
+  // contains noisy plugin / skill loader warnings.
+  if (output && output !== "Codex failed.") return undefined;
+  return stderr ? stderr.slice(-4_000) : undefined;
 }
 
 function buildGlobalArgs(context: RuntimeContext, config: CodexRuntimeConfig): string[] {
@@ -246,7 +259,26 @@ function parseCodexEvents(
 ): Omit<RuntimeResult, "process_pid" | "process_group_id"> {
   const lastMessage = readIfExists(lastMessagePath).trim();
   const assistantText = events.map(pickText).filter(Boolean).join("\n").trim();
-  const output = lastMessage || assistantText || fallbackText(stdout);
+  if (!lastMessage && !assistantText) {
+    // Neither source produced text. Log a sample so we can see what
+    // Codex actually emitted — the chat reply will be a generic
+    // "Codex completed./failed." fallback (or a `fallbackText` distill
+    // of any JSON events that lacked recognized text fields).
+    const sample = events.slice(0, 5).map((e) => ({
+      type: typeof e.type === "string" ? e.type : undefined,
+      keys: Object.keys(e).slice(0, 8),
+    }));
+    console.warn(
+      "[codex-adapter] no assistant text extracted: events=%d, lastMessageFileExists=%s, sample=%j",
+      events.length,
+      existsSync(lastMessagePath),
+      sample,
+    );
+  }
+  const output =
+    exitCode === 0
+      ? lastMessage || assistantText || fallbackText(stdout)
+      : assistantText || lastMessage || fallbackText(stdout);
   return {
     status: exitCode === 0 ? "completed" : "failed",
     output: output || (exitCode === 0 ? "Codex completed." : "Codex failed."),
@@ -310,6 +342,13 @@ function pickText(evt: JsonRecord): string {
     const itemText = pickString(item, ["text", "content", "message"]);
     if (itemText) return itemText;
   }
+  // Streaming shapes sometimes nest the chunk as { delta: { text: "..." } }
+  // rather than a flat string delta.
+  const delta = isRecord(evt.delta) ? evt.delta : undefined;
+  if (delta) {
+    const deltaText = pickString(delta, ["text", "content", "message"]);
+    if (deltaText) return deltaText;
+  }
   if (isRecord(evt.message)) {
     return pickString(evt.message, ["content", "text"]) ?? "";
   }
@@ -331,12 +370,16 @@ function summarizeTool(evt: JsonRecord): string {
 }
 
 function fallbackText(stdout: string): string {
+  // Stdout is supposed to be NDJSON. Drop non-JSON lines — they're
+  // Codex's tracing/log output (skill loader warnings, plugin manifest
+  // diagnostics, etc.) and never legitimate model output. If we kept
+  // them, a turn that fails to surface an assistant message would dump
+  // the raw log noise into the chat reply.
   return stdout
     .split("\n")
-    .map((line) => {
-      const parsed = parseJsonLine(line);
-      return parsed ? pickText(parsed) : line;
-    })
+    .map(parseJsonLine)
+    .filter((evt): evt is JsonRecord => !!evt)
+    .map(pickText)
     .filter(Boolean)
     .join("\n")
     .trim();

--- a/packages/core/src/adapters/codex/runtime.ts
+++ b/packages/core/src/adapters/codex/runtime.ts
@@ -1,0 +1,363 @@
+import { existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+  AgentRuntime,
+  RuntimeContext,
+  RuntimeHealth,
+  RuntimeResult,
+  RuntimeStep,
+  RuntimeWorkspaceContext,
+  Workspace,
+} from "../../ports/runtime.js";
+import { runCliProcess } from "../claude-code/spawn.js";
+
+export interface CodexRuntimeConfig {
+  /** Override CLI command (defaults to "codex" on PATH). */
+  command?: string;
+  /** Codex model id. Omit to use Codex's configured default. */
+  model?: string;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+interface PreparedWorkspace {
+  agentApiKey: string;
+  mcpServerUrl: string;
+}
+
+/**
+ * Codex CLI subprocess runtime.
+ *
+ * This adapter is intentionally small: it proves Beevibe's runtime registry
+ * can route sessions to Codex while preserving the existing RuntimeResult /
+ * RuntimeStep contract. Codex's own CLI owns tool execution and JSONL event
+ * streaming; Beevibe owns workspace provisioning, MCP policy, persistence,
+ * and task/session lifecycle.
+ */
+export class CodexRuntime implements AgentRuntime {
+  readonly type = "codex";
+  private readonly prepared = new Map<string, PreparedWorkspace>();
+
+  constructor(private config: CodexRuntimeConfig = {}) {}
+
+  async execute(context: RuntimeContext): Promise<RuntimeResult> {
+    const prepared = this.prepared.get(context.workspace.path);
+    const sid = context.env?.BEEVIBE_SESSION_ID;
+    const lastMessagePath = join(
+      context.workspace.path,
+      `.beevibe-codex-last-message-${Date.now()}.txt`,
+    );
+
+    const globalArgs = buildGlobalArgs(context, this.config);
+    const execArgs = [
+      "--json",
+      "--skip-git-repo-check",
+      "--output-last-message",
+      lastMessagePath,
+    ];
+    if (prepared && sid) {
+      globalArgs.push(
+        "-c",
+        `mcp_servers.beevibe.url=${tomlString(withBeevibeSession(prepared.mcpServerUrl, sid))}`,
+        "-c",
+        `mcp_servers.beevibe.bearer_token_env_var=${tomlString("BEEVIBE_AGENT_API_KEY")}`,
+      );
+    }
+
+    const args = context.resume_session_id
+      ? [
+          ...globalArgs,
+          "exec",
+          "resume",
+          ...execArgs,
+          context.resume_session_id,
+          composePrompt(context),
+        ]
+      : [...globalArgs, "exec", ...execArgs, composePrompt(context)];
+
+    const env: Record<string, string | undefined> = { ...process.env };
+    if (context.env) Object.assign(env, context.env);
+    if (prepared) env.BEEVIBE_AGENT_API_KEY = prepared.agentApiKey;
+
+    const events: JsonRecord[] = [];
+    let pending = "";
+    const handleLine = (line: string): void => {
+      const evt = parseJsonLine(line);
+      if (!evt) return;
+      events.push(evt);
+      const step = eventToStep(evt);
+      if (step) context.onStep?.(step);
+    };
+
+    const result = await runCliProcess({
+      command: this.config.command ?? "codex",
+      args,
+      cwd: context.workspace.path,
+      env,
+      abortSignal: context.abort_signal,
+      onSpawn: ({ pid, process_group_id }) => {
+        context.onSpawn?.({ process_pid: pid, process_group_id });
+      },
+      onLog: (stream, chunk) => {
+        if (stream !== "stdout") return;
+        pending += chunk;
+        let nl: number;
+        while ((nl = pending.indexOf("\n")) !== -1) {
+          handleLine(pending.slice(0, nl));
+          pending = pending.slice(nl + 1);
+        }
+      },
+    });
+    if (pending) handleLine(pending);
+
+    if (result.aborted) {
+      return {
+        status: "cancelled",
+        output: "Session cancelled.",
+        process_pid: result.pid ?? undefined,
+        process_group_id: result.process_group_id ?? undefined,
+      };
+    }
+
+    const parsed = parseCodexEvents(events, result.stdout, result.exitCode, lastMessagePath);
+    return {
+      ...parsed,
+      process_pid: result.pid ?? undefined,
+      process_group_id: result.process_group_id ?? undefined,
+      exit_code: result.exitCode,
+      stderr: parsed.status === "failed" ? result.stderr.slice(-4_000) : undefined,
+    };
+  }
+
+  async healthCheck(): Promise<RuntimeHealth> {
+    try {
+      const result = await runCliProcess({
+        command: this.config.command ?? "codex",
+        args: ["--version"],
+        cwd: tmpdir(),
+        timeoutMs: 5_000,
+        graceMs: 0,
+      });
+      return {
+        healthy: result.exitCode === 0,
+        error: result.exitCode === 0 ? undefined : result.stderr.slice(-500),
+      };
+    } catch {
+      return {
+        healthy: false,
+        error: `Command not found: ${this.config.command ?? "codex"}`,
+      };
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    /* stateless — each session is a separate process */
+  }
+
+  skillsDir(workspace: Workspace): string {
+    return join(workspace.path, ".codex", "skills");
+  }
+
+  prepareWorkspace(context: RuntimeWorkspaceContext): void {
+    this.prepared.set(context.workspace.path, {
+      agentApiKey: context.agentApiKey,
+      mcpServerUrl: context.mcpServerUrl,
+    });
+  }
+}
+
+function buildGlobalArgs(context: RuntimeContext, config: CodexRuntimeConfig): string[] {
+  const args = [
+    "--sandbox",
+    "workspace-write",
+    "--ask-for-approval",
+    "never",
+    "--cd",
+    context.workspace.path,
+  ];
+  const model = context.model ?? config.model;
+  if (model) args.push("--model", model);
+  return args;
+}
+
+function composePrompt(context: RuntimeContext): string {
+  if (context.system_prompt_append.length === 0) return context.intent;
+  return [
+    "<beevibe_system_context>",
+    context.system_prompt_append,
+    "</beevibe_system_context>",
+    "",
+    context.intent,
+  ].join("\n");
+}
+
+function withBeevibeSession(mcpServerUrl: string, sid: string): string {
+  const url = new URL(mcpServerUrl);
+  url.searchParams.set("beevibe_session", sid);
+  return url.toString();
+}
+
+function tomlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function parseJsonLine(line: string): JsonRecord | undefined {
+  const trimmed = line.trim();
+  if (!trimmed) return undefined;
+  try {
+    const value = JSON.parse(trimmed);
+    return isRecord(value) ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function eventToStep(evt: JsonRecord): RuntimeStep | undefined {
+  const type = String(evt.type ?? evt.event ?? evt.kind ?? "").toLowerCase();
+  const item = isRecord(evt.item) ? evt.item : undefined;
+  const tool =
+    pickString(evt, ["tool", "tool_name", "name"]) ??
+    (item ? pickString(item, ["tool", "tool_name", "name"]) : undefined);
+  if (type.includes("tool") || tool) {
+    return {
+      kind: type.includes("result") || type.includes("completed") ? "tool_result" : "tool_call",
+      tool,
+      description: summarizeTool(evt),
+      timestamp: new Date().toISOString(),
+    };
+  }
+  const text = pickText(evt);
+  if (text) {
+    return {
+      kind: "agent",
+      description: text,
+      timestamp: new Date().toISOString(),
+    };
+  }
+  return undefined;
+}
+
+function parseCodexEvents(
+  events: JsonRecord[],
+  stdout: string,
+  exitCode: number | null,
+  lastMessagePath: string,
+): Omit<RuntimeResult, "process_pid" | "process_group_id"> {
+  const lastMessage = readIfExists(lastMessagePath).trim();
+  const assistantText = events.map(pickText).filter(Boolean).join("\n").trim();
+  const output = lastMessage || assistantText || fallbackText(stdout);
+  return {
+    status: exitCode === 0 ? "completed" : "failed",
+    output: output || (exitCode === 0 ? "Codex completed." : "Codex failed."),
+    transcript: stdout || undefined,
+    usage: parseUsage(events),
+    cli_session_id: parseSessionId(events),
+  };
+}
+
+function readIfExists(path: string): string {
+  try {
+    return existsSync(path) ? readFileSync(path, "utf8") : "";
+  } catch {
+    return "";
+  }
+}
+
+function parseUsage(events: JsonRecord[]): RuntimeResult["usage"] {
+  for (const evt of [...events].reverse()) {
+    const usage = isRecord(evt.usage)
+      ? evt.usage
+      : isRecord(evt.token_usage)
+        ? evt.token_usage
+        : undefined;
+    if (!usage) continue;
+    const input = pickNumber(usage, ["input_tokens", "inputTokens", "prompt_tokens", "promptTokens"]);
+    const output = pickNumber(usage, ["output_tokens", "outputTokens", "completion_tokens", "completionTokens"]);
+    const cost = pickNumber(usage, ["cost_usd", "costUSD", "cost"]);
+    const model = pickString(usage, ["model"]) ?? pickString(evt, ["model"]);
+    if (input === undefined && output === undefined && cost === undefined && model === undefined) {
+      continue;
+    }
+    return {
+      input_tokens: input ?? 0,
+      output_tokens: output ?? 0,
+      cache_creation_input_tokens: pickNumber(usage, ["cache_creation_input_tokens"]) ?? 0,
+      cache_read_input_tokens: pickNumber(usage, ["cache_read_input_tokens"]) ?? 0,
+      cost_usd: cost,
+      model,
+    };
+  }
+  return undefined;
+}
+
+function parseSessionId(events: JsonRecord[]): string | undefined {
+  for (const evt of [...events].reverse()) {
+    const id =
+      pickString(evt, ["session_id", "sessionID", "sessionId", "thread_id", "threadId"]) ??
+      (isRecord(evt.session) ? pickString(evt.session, ["id", "session_id"]) : undefined) ??
+      (isRecord(evt.thread) ? pickString(evt.thread, ["id", "thread_id"]) : undefined);
+    if (id) return id;
+  }
+  return undefined;
+}
+
+function pickText(evt: JsonRecord): string {
+  const direct = pickString(evt, ["output", "text", "content", "message", "delta"]);
+  if (direct) return direct;
+  const item = isRecord(evt.item) ? evt.item : undefined;
+  if (item) {
+    const itemText = pickString(item, ["text", "content", "message"]);
+    if (itemText) return itemText;
+  }
+  if (isRecord(evt.message)) {
+    return pickString(evt.message, ["content", "text"]) ?? "";
+  }
+  return "";
+}
+
+function summarizeTool(evt: JsonRecord): string {
+  const item = isRecord(evt.item) ? evt.item : undefined;
+  const input = evt.input ?? evt.arguments ?? evt.args ?? evt.params ?? item?.input;
+  if (typeof input === "string") return input.slice(0, 300);
+  if (isRecord(input)) {
+    const path = pickString(input, ["file_path", "path", "file"]);
+    const command = pickString(input, ["command", "cmd"]);
+    if (path) return path;
+    if (command) return command;
+    return JSON.stringify(input).slice(0, 300);
+  }
+  return pickText(evt) || "tool call";
+}
+
+function fallbackText(stdout: string): string {
+  return stdout
+    .split("\n")
+    .map((line) => {
+      const parsed = parseJsonLine(line);
+      return parsed ? pickText(parsed) : line;
+    })
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+}
+
+function pickString(obj: JsonRecord, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+function pickNumber(obj: JsonRecord, keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+  }
+  return undefined;
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/core/src/adapters/codex/stream-json.test.ts
+++ b/packages/core/src/adapters/codex/stream-json.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "vitest";
+import {
+  CODEX_EVENT_TYPE,
+  CODEX_ITEM_TYPE,
+  parseCodexEventLine,
+  extractCodexStepEvents,
+  parseCodexEvents,
+  type CodexEvent,
+} from "./stream-json.js";
+
+/**
+ * Fixtures match the canonical schema in codex-rs/exec/src/exec_events.rs.
+ * If codex changes its event shape, these tests are the first thing to flip
+ * red — that's the point. Generic shape-guessing would silently keep
+ * "passing" with garbage outputs.
+ */
+
+const THREAD_STARTED: CodexEvent = {
+  type: CODEX_EVENT_TYPE.ThreadStarted,
+  thread_id: "thread_abc123",
+};
+
+const TURN_COMPLETED: CodexEvent = {
+  type: CODEX_EVENT_TYPE.TurnCompleted,
+  usage: {
+    input_tokens: 120,
+    cached_input_tokens: 80,
+    output_tokens: 40,
+    reasoning_output_tokens: 10,
+  },
+};
+
+const AGENT_MESSAGE_COMPLETED: CodexEvent = {
+  type: CODEX_EVENT_TYPE.ItemCompleted,
+  item: {
+    id: "item_1",
+    type: CODEX_ITEM_TYPE.AgentMessage,
+    text: "Here is the fix.",
+  },
+};
+
+describe("parseCodexEventLine", () => {
+  it("parses valid NDJSON", () => {
+    const evt = parseCodexEventLine(JSON.stringify(THREAD_STARTED));
+    expect(evt).toEqual(THREAD_STARTED);
+  });
+
+  it("returns null for non-JSON lines (defensive — codex's stdout is supposed to be pure NDJSON)", () => {
+    expect(parseCodexEventLine("WARN something")).toBeNull();
+    expect(parseCodexEventLine("")).toBeNull();
+    expect(parseCodexEventLine("   ")).toBeNull();
+  });
+
+  it("returns null for malformed JSON", () => {
+    expect(parseCodexEventLine("{not json")).toBeNull();
+  });
+});
+
+describe("extractCodexStepEvents", () => {
+  it("emits an agent step on item.completed for agent_message", () => {
+    const steps = extractCodexStepEvents(AGENT_MESSAGE_COMPLETED);
+    expect(steps).toEqual([
+      expect.objectContaining({ kind: "agent", description: "Here is the fix." }),
+    ]);
+  });
+
+  it("emits NO agent step on item.started (agent text only flows on completion)", () => {
+    const steps = extractCodexStepEvents({
+      type: CODEX_EVENT_TYPE.ItemStarted,
+      item: { id: "item_1", type: CODEX_ITEM_TYPE.AgentMessage, text: "partial" },
+    });
+    expect(steps).toEqual([]);
+  });
+
+  it("emits tool_call on item.started + mcp_tool_call, tool_result on item.completed", () => {
+    const started = extractCodexStepEvents({
+      type: CODEX_EVENT_TYPE.ItemStarted,
+      item: {
+        id: "item_2",
+        type: CODEX_ITEM_TYPE.McpToolCall,
+        server: "beevibe",
+        tool: "create_task",
+        arguments: { title: "fix bug", description: "details" },
+        status: "in_progress",
+      },
+    });
+    expect(started).toEqual([
+      expect.objectContaining({ kind: "tool_call", tool: "create_task" }),
+    ]);
+
+    const completed = extractCodexStepEvents({
+      type: CODEX_EVENT_TYPE.ItemCompleted,
+      item: {
+        id: "item_2",
+        type: CODEX_ITEM_TYPE.McpToolCall,
+        server: "beevibe",
+        tool: "create_task",
+        arguments: { title: "fix bug" },
+        result: { content: [{ type: "text", text: "ok" }] },
+        status: "completed",
+      },
+    });
+    expect(completed).toEqual([
+      expect.objectContaining({ kind: "tool_result", tool: "create_task" }),
+    ]);
+  });
+
+  it("emits a shell tool_call for command_execution items", () => {
+    const steps = extractCodexStepEvents({
+      type: CODEX_EVENT_TYPE.ItemStarted,
+      item: {
+        id: "item_3",
+        type: CODEX_ITEM_TYPE.CommandExecution,
+        command: "ls -la",
+        status: "in_progress",
+      },
+    });
+    expect(steps).toEqual([
+      expect.objectContaining({ kind: "tool_call", tool: "shell", description: "ls -la" }),
+    ]);
+  });
+
+  it("skips reasoning items so they don't bloat the transcript or dupe assistant text", () => {
+    const steps = extractCodexStepEvents({
+      type: CODEX_EVENT_TYPE.ItemCompleted,
+      item: { id: "item_4", type: CODEX_ITEM_TYPE.Reasoning, text: "let me think" },
+    });
+    expect(steps).toEqual([]);
+  });
+
+  it("skips lifecycle events (thread.started / turn.*)", () => {
+    expect(extractCodexStepEvents(THREAD_STARTED)).toEqual([]);
+    expect(extractCodexStepEvents({ type: CODEX_EVENT_TYPE.TurnStarted })).toEqual([]);
+    expect(extractCodexStepEvents(TURN_COMPLETED)).toEqual([]);
+  });
+
+  it("picks the most informative input field for mcp_tool_call descriptions", () => {
+    const steps = extractCodexStepEvents({
+      type: CODEX_EVENT_TYPE.ItemStarted,
+      item: {
+        id: "item_5",
+        type: CODEX_ITEM_TYPE.McpToolCall,
+        tool: "read_file",
+        arguments: { file_path: "/repo/src/foo.ts", line: 10 },
+        status: "in_progress",
+      },
+    });
+    expect(steps[0]!.description).toBe("/repo/src/foo.ts");
+  });
+});
+
+describe("parseCodexEvents", () => {
+  it("returns success with last-message file content as output and pulls thread_id + usage", () => {
+    const events = [THREAD_STARTED, AGENT_MESSAGE_COMPLETED, TURN_COMPLETED];
+    const result = parseCodexEvents(events, 0, "Final answer from the last-message file.\n");
+    expect(result.status).toBe("completed");
+    expect(result.output).toBe("Final answer from the last-message file.");
+    expect(result.cli_session_id).toBe("thread_abc123");
+    expect(result.usage).toEqual({
+      input_tokens: 120,
+      // output_tokens is regular + reasoning summed so cross-runtime totals line up
+      output_tokens: 50,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 80,
+    });
+  });
+
+  it("falls back to the agent_message text when the last-message file is empty", () => {
+    const result = parseCodexEvents([THREAD_STARTED, AGENT_MESSAGE_COMPLETED], 0, "");
+    expect(result.output).toBe("Here is the fix.");
+  });
+
+  it("maps non-zero exit code to failed, prefers turn.failed message over assistant text", () => {
+    const events: CodexEvent[] = [
+      THREAD_STARTED,
+      AGENT_MESSAGE_COMPLETED,
+      {
+        type: CODEX_EVENT_TYPE.TurnFailed,
+        error: { message: "model overloaded; retry shortly" },
+      },
+    ];
+    const result = parseCodexEvents(events, 1, "");
+    expect(result.status).toBe("failed");
+    expect(result.output).toBe("model overloaded; retry shortly");
+  });
+
+  it("falls back to bareCliExitMessage when failure has no message — chat route's failureMessageFor can then swap it", () => {
+    const result = parseCodexEvents([], 137, "");
+    expect(result.status).toBe("failed");
+    expect(result.output).toBe("CLI exited with code 137");
+  });
+
+  it("treats top-level error events as failure even when exit code is 0", () => {
+    const events: CodexEvent[] = [
+      THREAD_STARTED,
+      { type: CODEX_EVENT_TYPE.Error, message: "rate limit hit" },
+    ];
+    const result = parseCodexEvents(events, 0, "");
+    expect(result.status).toBe("failed");
+    expect(result.output).toBe("rate limit hit");
+  });
+
+  it("builds a human-readable transcript with [assistant] + [tool_call] + [tool_result from X] entries", () => {
+    const events: CodexEvent[] = [
+      THREAD_STARTED,
+      {
+        type: CODEX_EVENT_TYPE.ItemCompleted,
+        item: {
+          id: "item_t1",
+          type: CODEX_ITEM_TYPE.McpToolCall,
+          tool: "create_task",
+          arguments: { title: "fix" },
+          result: { content: [{ type: "text", text: "task_abc" }] },
+          status: "completed",
+        },
+      },
+      AGENT_MESSAGE_COMPLETED,
+    ];
+    const result = parseCodexEvents(events, 0, "Here is the fix.");
+    expect(result.transcript).toContain("[tool_call] create_task");
+    expect(result.transcript).toContain("[tool_result from create_task] task_abc");
+    expect(result.transcript).toContain("[assistant] Here is the fix.");
+  });
+});

--- a/packages/core/src/adapters/codex/stream-json.ts
+++ b/packages/core/src/adapters/codex/stream-json.ts
@@ -1,0 +1,315 @@
+import type { RuntimeResult, RuntimeStep } from "../../ports/runtime.js";
+import { bareCliExitMessage } from "../claude-code/stream-json.js";
+
+/**
+ * Parser for `codex exec --json` output.
+ *
+ * Source: https://github.com/openai/codex/blob/main/codex-rs/exec/src/exec_events.rs
+ * The Rust `ThreadEvent` enum (`#[serde(tag = "type")]`) has 8 variants —
+ * the canonical surface for codex's NDJSON stdout. Stdout is strictly
+ * NDJSON per the contract at the top of `codex-rs/exec/src/lib.rs`:
+ *
+ *   "In --json mode, stdout must be valid JSONL, one event per line.
+ *    Any other output must be written to stderr."
+ *
+ * Streaming text deltas are NOT exposed via `exec --json` — only
+ * `item.started` / `item.updated` / `item.completed` snapshots. That's
+ * why this parser emits `agent` steps only on `item.completed` for
+ * `agent_message` items (and never tries to splice deltas).
+ */
+
+export const CODEX_EVENT_TYPE = {
+  ThreadStarted: "thread.started",
+  TurnStarted: "turn.started",
+  TurnCompleted: "turn.completed",
+  TurnFailed: "turn.failed",
+  ItemStarted: "item.started",
+  ItemUpdated: "item.updated",
+  ItemCompleted: "item.completed",
+  Error: "error",
+} as const;
+
+export const CODEX_ITEM_TYPE = {
+  AgentMessage: "agent_message",
+  Reasoning: "reasoning",
+  CommandExecution: "command_execution",
+  FileChange: "file_change",
+  McpToolCall: "mcp_tool_call",
+  CollabToolCall: "collab_tool_call",
+  WebSearch: "web_search",
+  TodoList: "todo_list",
+  Error: "error",
+} as const;
+
+/** Subset of codex `turn.completed.usage` we surface; cache+reasoning split is codex-specific. */
+interface CodexUsage {
+  input_tokens?: number;
+  cached_input_tokens?: number;
+  output_tokens?: number;
+  reasoning_output_tokens?: number;
+}
+
+/** Codex's `ThreadItem` — `{ id } & details` flattened, with details per `CODEX_ITEM_TYPE`. */
+export interface CodexItem {
+  id?: string;
+  type?: string;
+  /** agent_message + reasoning */
+  text?: string;
+  /** command_execution */
+  command?: string;
+  aggregated_output?: string;
+  exit_code?: number | null;
+  status?: string;
+  /** mcp_tool_call */
+  tool?: string;
+  server?: string;
+  arguments?: unknown;
+  result?: { content?: unknown[] } | null;
+  error?: { message?: string } | null;
+  /** web_search */
+  query?: string;
+  /** file_change */
+  changes?: Array<{ path?: string; kind?: string }>;
+  /** error item */
+  message?: string;
+}
+
+export interface CodexEvent {
+  type?: string;
+  /** thread.started */
+  thread_id?: string;
+  /** turn.completed */
+  usage?: CodexUsage;
+  /** turn.failed */
+  error?: { message?: string };
+  /** item.started / item.updated / item.completed */
+  item?: CodexItem;
+  /** top-level error event */
+  message?: string;
+}
+
+export function parseCodexEventLine(line: string): CodexEvent | null {
+  const trimmed = line.trim();
+  if (!trimmed || !trimmed.startsWith("{")) return null;
+  try {
+    return JSON.parse(trimmed) as CodexEvent;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Convert a parsed codex event into 0+ RuntimeSteps for the live transcript.
+ *
+ * - `item.completed` + `agent_message` → one `agent` step with the final text.
+ * - `item.started` + tool-ish items → `tool_call` step.
+ * - `item.completed` + tool-ish items → `tool_result` step.
+ * - `item.updated` → skipped (would dupe; codex emits started/updated/completed
+ *   triples for each item and `updated` carries no new info we want).
+ * - `reasoning` items → skipped (would bloat the transcript; reasoning is
+ *   already counted in `turn.completed.usage.reasoning_output_tokens`).
+ * - `turn.*` and `thread.*` → skipped (lifecycle events, not transcript content).
+ */
+export function extractCodexStepEvents(evt: CodexEvent): RuntimeStep[] {
+  const now = new Date().toISOString();
+  if (evt.type !== CODEX_EVENT_TYPE.ItemStarted && evt.type !== CODEX_EVENT_TYPE.ItemCompleted) {
+    return [];
+  }
+  const item = evt.item;
+  if (!item || !item.type) return [];
+  const isCompletion = evt.type === CODEX_EVENT_TYPE.ItemCompleted;
+
+  if (item.type === CODEX_ITEM_TYPE.AgentMessage) {
+    if (!isCompletion) return [];
+    const text = item.text?.trim();
+    if (!text) return [];
+    return [{ kind: "agent", description: text, timestamp: now }];
+  }
+
+  if (item.type === CODEX_ITEM_TYPE.McpToolCall) {
+    return [
+      {
+        kind: isCompletion ? "tool_result" : "tool_call",
+        tool: item.tool ?? "unknown",
+        description: describeCodexInput(item.arguments),
+        timestamp: now,
+      },
+    ];
+  }
+
+  if (item.type === CODEX_ITEM_TYPE.CommandExecution) {
+    return [
+      {
+        kind: isCompletion ? "tool_result" : "tool_call",
+        tool: "shell",
+        description: (item.command ?? "").slice(0, 200),
+        timestamp: now,
+      },
+    ];
+  }
+
+  if (item.type === CODEX_ITEM_TYPE.FileChange) {
+    const summary = (item.changes ?? [])
+      .map((c) => `${c.kind ?? "?"} ${c.path ?? ""}`)
+      .join(", ")
+      .slice(0, 200);
+    return [
+      {
+        kind: isCompletion ? "tool_result" : "tool_call",
+        tool: "file_change",
+        description: summary,
+        timestamp: now,
+      },
+    ];
+  }
+
+  if (item.type === CODEX_ITEM_TYPE.WebSearch) {
+    return [
+      {
+        kind: isCompletion ? "tool_result" : "tool_call",
+        tool: "web_search",
+        description: (item.query ?? "").slice(0, 200),
+        timestamp: now,
+      },
+    ];
+  }
+
+  return [];
+}
+
+/** Field-priority probe shared with claude's `describeToolInput` philosophy. */
+const PREFERRED_CODEX_FIELDS = [
+  "file_path",
+  "path",
+  "command",
+  "cmd",
+  "query",
+  "pattern",
+  "url",
+  "intent",
+] as const;
+
+function describeCodexInput(input: unknown): string {
+  if (typeof input === "string") return input.slice(0, 200);
+  if (!input || typeof input !== "object" || Array.isArray(input)) return "";
+  const obj = input as Record<string, unknown>;
+  for (const key of PREFERRED_CODEX_FIELDS) {
+    const v = obj[key];
+    if (typeof v === "string" && v.length > 0) return v.slice(0, 200);
+  }
+  return JSON.stringify(input).slice(0, 200);
+}
+
+/**
+ * Build a `RuntimeResult` from a parsed event stream + the codex-written
+ * `--output-last-message` file contents. Caller passes `exitCode` from the
+ * spawned process; non-zero or any `turn.failed` / top-level `error` event
+ * maps to `status: "failed"`.
+ *
+ * Codex usage shape → `SessionUsage`: codex reports only one cache bucket
+ * (`cached_input_tokens`, the cache-read total). We map it to
+ * `cache_read_input_tokens` and leave `cache_creation_input_tokens` at 0 —
+ * codex's API doesn't expose creation/read split the way Anthropic's does.
+ * `cost_usd` is omitted entirely (codex's exec surface doesn't surface cost;
+ * the dashboard does). `reasoning_output_tokens` is summed into output.
+ */
+export function parseCodexEvents(
+  events: CodexEvent[],
+  exitCode: number | null,
+  lastMessage: string,
+): Omit<RuntimeResult, "process_pid" | "process_group_id"> {
+  let threadId: string | undefined;
+  let usage: CodexUsage | undefined;
+  let assistantText = "";
+  let turnFailed: string | undefined;
+  let topLevelError: string | undefined;
+  const transcriptParts: string[] = [];
+
+  for (const evt of events) {
+    switch (evt.type) {
+      case CODEX_EVENT_TYPE.ThreadStarted:
+        if (evt.thread_id) threadId = evt.thread_id;
+        break;
+      case CODEX_EVENT_TYPE.TurnCompleted:
+        if (evt.usage) usage = evt.usage;
+        break;
+      case CODEX_EVENT_TYPE.TurnFailed:
+        turnFailed = evt.error?.message ?? turnFailed;
+        break;
+      case CODEX_EVENT_TYPE.Error:
+        topLevelError = evt.message ?? topLevelError;
+        if (evt.message) transcriptParts.push(`[error] ${evt.message}\n`);
+        break;
+      case CODEX_EVENT_TYPE.ItemCompleted: {
+        const item = evt.item;
+        if (!item || !item.type) break;
+        if (item.type === CODEX_ITEM_TYPE.AgentMessage && item.text) {
+          assistantText = item.text;
+          transcriptParts.push(`[assistant] ${item.text}\n`);
+        } else if (item.type === CODEX_ITEM_TYPE.McpToolCall) {
+          const tool = item.tool ?? "unknown";
+          transcriptParts.push(`[tool_call] ${tool}\n`);
+          const resultSummary = summarizeMcpResult(item.result);
+          if (resultSummary || item.error?.message) {
+            transcriptParts.push(
+              `[tool_result from ${tool}] ${item.error?.message ?? resultSummary}\n`,
+            );
+          }
+        } else if (item.type === CODEX_ITEM_TYPE.CommandExecution) {
+          transcriptParts.push(`[tool_call] shell ${(item.command ?? "").slice(0, 200)}\n`);
+          if (item.aggregated_output) {
+            transcriptParts.push(
+              `[tool_result from shell] ${item.aggregated_output.slice(0, 200).replace(/\n/g, " ")}\n`,
+            );
+          }
+        }
+        break;
+      }
+      // item.started + item.updated emit RuntimeSteps via extractCodexStepEvents
+      // but aren't included in the persisted transcript — only completions are.
+      default:
+        break;
+    }
+  }
+
+  const failed = exitCode !== 0 || !!turnFailed || !!topLevelError;
+  const trimmedLast = lastMessage.trim();
+  const failureMessage = turnFailed ?? topLevelError;
+  // Success: prefer the file-backed last message (codex writes the canonical
+  // final assistant text there); fall back to the event-stream's last
+  // agent_message; final fallback bareCliExitMessage so the chat-route's
+  // failure-mapping helper can swap it for stderr/daemon-pointer. `||`
+  // not `??` — empty assistantText must fall through to the next branch,
+  // not short-circuit there.
+  const output = failed
+    ? failureMessage || assistantText || bareCliExitMessage(exitCode)
+    : trimmedLast || assistantText || "Session completed.";
+
+  return {
+    status: failed ? "failed" : "completed",
+    output,
+    transcript: transcriptParts.join("") || undefined,
+    cli_session_id: threadId,
+    usage: usage
+      ? {
+          input_tokens: usage.input_tokens ?? 0,
+          output_tokens: (usage.output_tokens ?? 0) + (usage.reasoning_output_tokens ?? 0),
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: usage.cached_input_tokens ?? 0,
+        }
+      : undefined,
+  };
+}
+
+function summarizeMcpResult(result: { content?: unknown[] } | null | undefined): string {
+  if (!result || !Array.isArray(result.content)) return "";
+  // MCP result content is `[{ type: "text", text: string }, ...]`. Surface
+  // the first text block, trimmed; if none, fall back to a JSON snippet.
+  for (const block of result.content) {
+    if (block && typeof block === "object" && (block as { type?: unknown }).type === "text") {
+      const text = (block as { text?: unknown }).text;
+      if (typeof text === "string") return text.slice(0, 200).replace(/\n/g, " ");
+    }
+  }
+  return JSON.stringify(result.content).slice(0, 200);
+}

--- a/packages/core/src/adapters/local-workspace/manager.test.ts
+++ b/packages/core/src/adapters/local-workspace/manager.test.ts
@@ -161,6 +161,37 @@ describe("LocalWorkspaceManager", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("calls runtime.prepareWorkspace before syncing skills", async () => {
+    const calls: string[] = [];
+    const runtime = {
+      type: "opencode",
+      prepareWorkspace: ({ workspace }: { workspace: Workspace }) => {
+        calls.push(`prepare:${workspace.path}`);
+        writeFileSync(join(workspace.path, "opencode.json"), "{}\n");
+      },
+      skillsDir: (workspace: Workspace) => {
+        calls.push(`skills:${workspace.path}`);
+        return join(workspace.path, ".opencode", "skills");
+      },
+    } as unknown as AgentRuntime;
+    const m = new LocalWorkspaceManager({
+      workspaceRoot,
+      mcpServerUrl: MCP_URL,
+      runtimeRegistry: { opencode: runtime },
+      skillsSourceDir,
+    });
+
+    const ws = await m.ensureWorkspace({
+      agent: makeAgent({
+        id: "agent_opencode",
+        runtime_config: { type: "opencode", model: "openrouter/qwen/qwen3-coder" },
+      }),
+    });
+
+    expect(existsSync(join(ws.path, "opencode.json"))).toBe(true);
+    expect(calls).toEqual([`prepare:${ws.path}`, `skills:${ws.path}`]);
+  });
+
   it("different agents get isolated dirs", async () => {
     const a = await manager.ensureWorkspace({ agent: makeAgent({ id: "agent_a" }) });
     const b = await manager.ensureWorkspace({ agent: makeAgent({ id: "agent_b" }) });

--- a/packages/core/src/adapters/local-workspace/manager.ts
+++ b/packages/core/src/adapters/local-workspace/manager.ts
@@ -110,6 +110,18 @@ export class LocalWorkspaceManager implements WorkspaceManager {
         `No runtime registered for agent ${agent.id} (runtime_config.type='${agent.runtime_config.type}')`,
       );
     }
+    if (runtime.prepareWorkspace) {
+      if (!agent.api_key) {
+        throw new Error(
+          `Cannot prepare workspace for agent ${agent.id}: agent.api_key is missing`,
+        );
+      }
+      await runtime.prepareWorkspace({
+        workspace,
+        agentApiKey: agent.api_key,
+        mcpServerUrl: this.config.mcpServerUrl,
+      });
+    }
     await syncSkills({
       sourceDir: this.config.skillsSourceDir,
       targetDir: runtime.skillsDir(workspace),

--- a/packages/core/src/adapters/opencode/index.ts
+++ b/packages/core/src/adapters/opencode/index.ts
@@ -1,0 +1,2 @@
+export { OpenCodeRuntime } from "./runtime.js";
+export type { OpenCodeRuntimeConfig } from "./runtime.js";

--- a/packages/core/src/adapters/opencode/index.ts
+++ b/packages/core/src/adapters/opencode/index.ts
@@ -1,2 +1,9 @@
-export { OpenCodeRuntime } from "./runtime.js";
+export { OpenCodeRuntime, buildOpenCodeConfig } from "./runtime.js";
 export type { OpenCodeRuntimeConfig } from "./runtime.js";
+export {
+  OPENCODE_EVENT_TYPE,
+  parseOpenCodeEventLine,
+  extractOpenCodeStepEvents,
+  parseOpenCodeEvents,
+} from "./stream-json.js";
+export type { OpenCodeEvent, OpenCodePart } from "./stream-json.js";

--- a/packages/core/src/adapters/opencode/runtime.test.ts
+++ b/packages/core/src/adapters/opencode/runtime.test.ts
@@ -1,18 +1,50 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeContext, RuntimeStep } from "../../ports/runtime.js";
 import { OpenCodeRuntime, buildOpenCodeConfig } from "./runtime.js";
+import { OPENCODE_EVENT_TYPE } from "./stream-json.js";
 import type { CliProcessOptions, CliProcessResult } from "../claude-code/spawn.js";
 import * as spawnModule from "../claude-code/spawn.js";
 
+const SID = "ses_op_mock";
+
+/**
+ * Canonical stdout for a clean opencode turn. Wrapper shape matches
+ * opencode's run.ts `emit()` helper: every event carries top-level
+ * `sessionID`. The parser unit tests in ./stream-json.test.ts cover
+ * edge cases; this file exercises the runtime wiring on top of them.
+ */
+const CANONICAL_STDOUT =
+  JSON.stringify({
+    type: OPENCODE_EVENT_TYPE.Text,
+    timestamp: 1,
+    sessionID: SID,
+    part: {
+      id: "prt_t",
+      sessionID: SID,
+      messageID: "msg_1",
+      type: "text",
+      text: "done",
+      time: { start: 0, end: 1 },
+    },
+  }) +
+  "\n" +
+  JSON.stringify({
+    type: OPENCODE_EVENT_TYPE.StepFinish,
+    timestamp: 2,
+    sessionID: SID,
+    part: {
+      id: "prt_s",
+      sessionID: SID,
+      messageID: "msg_1",
+      type: "step-finish",
+      cost: 0,
+      tokens: { input: 100, output: 50, reasoning: 0, cache: { read: 0, write: 0 } },
+    },
+  }) +
+  "\n";
+
 const MOCK_OK: CliProcessResult = {
-  stdout:
-    JSON.stringify({
-      type: "result",
-      session_id: "opencode_sess_mock",
-      output: "done",
-      model: "openrouter/qwen/qwen3-coder",
-      usage: { input_tokens: 100, output_tokens: 50, cost_usd: 0 },
-    }) + "\n",
+  stdout: CANONICAL_STDOUT,
   stderr: "",
   exitCode: 0,
   timedOut: false,
@@ -55,16 +87,29 @@ afterEach(() => {
 });
 
 describe("OpenCodeRuntime.execute", () => {
-  it("runs opencode non-interactively with raw JSON events", async () => {
+  it("runs opencode non-interactively with the canonical JSON format flags", async () => {
     mockRunCli();
     await new OpenCodeRuntime().execute(ctx({ workspace: { path: "/sandbox/agent_op" } }));
     expect(lastOptions?.cwd).toBe("/sandbox/agent_op");
-    expect(lastOptions?.args?.slice(0, 4)).toEqual([
+    expect(lastOptions?.args?.slice(0, 6)).toEqual([
       "run",
       "--format",
       "json",
       "--dangerously-skip-permissions",
+      "--dir",
+      "/sandbox/agent_op",
     ]);
+  });
+
+  it("passes --dir to opencode so workspace opencode.json is actually loaded", async () => {
+    // Regression: without --dir, opencode run ignores the workspace
+    // opencode.json (the subprocess cwd alone doesn't drive config
+    // discovery), so the agent never sees the beevibe MCP server.
+    mockRunCli();
+    await new OpenCodeRuntime().execute(ctx({ workspace: { path: "/agents/foo" } }));
+    const dirIdx = lastOptions!.args!.indexOf("--dir");
+    expect(dirIdx).toBeGreaterThan(-1);
+    expect(lastOptions!.args![dirIdx + 1]).toBe("/agents/foo");
   });
 
   it("passes context.model as --model in provider/model form", async () => {
@@ -102,31 +147,38 @@ describe("OpenCodeRuntime.execute", () => {
     expect(lastOptions!.env!.BEEVIBE_SESSION_ID).toBe("sess_test_123");
   });
 
-  it("parses result events into RuntimeResult", async () => {
+  it("parses canonical wrapper events into a RuntimeResult", async () => {
     mockRunCli();
     const result = await new OpenCodeRuntime().execute(ctx());
     expect(result.status).toBe("completed");
     expect(result.output).toBe("done");
-    expect(result.cli_session_id).toBe("opencode_sess_mock");
+    expect(result.cli_session_id).toBe(SID);
     expect(result.usage).toEqual({
       input_tokens: 100,
       output_tokens: 50,
       cache_creation_input_tokens: 0,
       cache_read_input_tokens: 0,
       cost_usd: 0,
-      model: "openrouter/qwen/qwen3-coder",
     });
   });
 
-  it("emits tool steps from flexible JSON event shapes", async () => {
+  it("streams a tool_call step from a tool_use wrapper event", async () => {
     const steps: RuntimeStep[] = [];
     runCliSpy.mockImplementation(async (options) => {
       options.onLog?.(
         "stdout",
         JSON.stringify({
-          type: "tool_call",
-          tool: "read",
-          input: { file_path: "/src/x.ts" },
+          type: OPENCODE_EVENT_TYPE.ToolUse,
+          timestamp: 1,
+          sessionID: SID,
+          part: {
+            id: "prt_x",
+            sessionID: SID,
+            messageID: "msg_1",
+            type: "tool",
+            tool: "read",
+            state: { status: "running", input: { file_path: "/src/x.ts" } },
+          },
         }) + "\n",
       );
       return MOCK_OK;
@@ -142,6 +194,31 @@ describe("OpenCodeRuntime.execute", () => {
     mockRunCli({ ...MOCK_OK, aborted: true, stdout: "" });
     const result = await new OpenCodeRuntime().execute(ctx());
     expect(result.status).toBe("cancelled");
+  });
+
+  it("passes exit_code through so the daemon can persist real spawn outcome", async () => {
+    mockRunCli({ ...MOCK_OK, exitCode: 7, stdout: "" });
+    const result = await new OpenCodeRuntime().execute(ctx());
+    expect(result.exit_code).toBe(7);
+  });
+
+  it("surfaces stderr tail on failure so /runtime/done has something actionable", async () => {
+    mockRunCli({
+      ...MOCK_OK,
+      exitCode: 1,
+      stdout: "",
+      stderr: "Error: provider auth missing\n",
+    });
+    const result = await new OpenCodeRuntime().execute(ctx());
+    expect(result.status).toBe("failed");
+    expect(result.stderr).toBe("Error: provider auth missing\n");
+  });
+
+  it("does not surface stderr on success — only failures populate it", async () => {
+    mockRunCli({ ...MOCK_OK, stderr: "WARN harmless\n" });
+    const result = await new OpenCodeRuntime().execute(ctx());
+    expect(result.status).toBe("completed");
+    expect(result.stderr).toBeUndefined();
   });
 });
 

--- a/packages/core/src/adapters/opencode/runtime.test.ts
+++ b/packages/core/src/adapters/opencode/runtime.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeContext, RuntimeStep } from "../../ports/runtime.js";
+import { OpenCodeRuntime, buildOpenCodeConfig } from "./runtime.js";
+import type { CliProcessOptions, CliProcessResult } from "../claude-code/spawn.js";
+import * as spawnModule from "../claude-code/spawn.js";
+
+const MOCK_OK: CliProcessResult = {
+  stdout:
+    JSON.stringify({
+      type: "result",
+      session_id: "opencode_sess_mock",
+      output: "done",
+      model: "openrouter/qwen/qwen3-coder",
+      usage: { input_tokens: 100, output_tokens: 50, cost_usd: 0 },
+    }) + "\n",
+  stderr: "",
+  exitCode: 0,
+  timedOut: false,
+  aborted: false,
+  pid: 9999,
+  process_group_id: 9999,
+  truncated: false,
+};
+
+let runCliSpy: ReturnType<typeof vi.spyOn>;
+let lastOptions: CliProcessOptions | undefined;
+
+function mockRunCli(result: CliProcessResult = MOCK_OK): void {
+  runCliSpy.mockImplementation(async (options) => {
+    lastOptions = options;
+    if (result.pid !== null) {
+      options.onSpawn?.({ pid: result.pid, process_group_id: result.process_group_id ?? result.pid });
+    }
+    if (result.stdout) options.onLog?.("stdout", result.stdout);
+    return result;
+  });
+}
+
+function ctx(overrides: Partial<RuntimeContext> = {}): RuntimeContext {
+  return {
+    intent: "do a thing",
+    workspace: { path: "/tmp/beevibe-opencode-test-ws" },
+    system_prompt_append: "",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  lastOptions = undefined;
+  runCliSpy = vi.spyOn(spawnModule, "runCliProcess");
+});
+
+afterEach(() => {
+  runCliSpy.mockRestore();
+});
+
+describe("OpenCodeRuntime.execute", () => {
+  it("runs opencode non-interactively with raw JSON events", async () => {
+    mockRunCli();
+    await new OpenCodeRuntime().execute(ctx({ workspace: { path: "/sandbox/agent_op" } }));
+    expect(lastOptions?.cwd).toBe("/sandbox/agent_op");
+    expect(lastOptions?.args?.slice(0, 4)).toEqual([
+      "run",
+      "--format",
+      "json",
+      "--dangerously-skip-permissions",
+    ]);
+  });
+
+  it("passes context.model as --model in provider/model form", async () => {
+    mockRunCli();
+    await new OpenCodeRuntime({ model: "fallback/model" }).execute(
+      ctx({ model: "openrouter/qwen/qwen3-coder" }),
+    );
+    const idx = lastOptions!.args!.indexOf("--model");
+    expect(lastOptions!.args![idx + 1]).toBe("openrouter/qwen/qwen3-coder");
+  });
+
+  it("passes --session when context.resume_session_id is set", async () => {
+    mockRunCli();
+    await new OpenCodeRuntime().execute(ctx({ resume_session_id: "opencode_prev" }));
+    const idx = lastOptions!.args!.indexOf("--session");
+    expect(lastOptions!.args![idx + 1]).toBe("opencode_prev");
+  });
+
+  it("folds system_prompt_append into the prompt because OpenCode has no append-system flag", async () => {
+    mockRunCli();
+    await new OpenCodeRuntime().execute(
+      ctx({ intent: "fix bug", system_prompt_append: "<core>memory</core>" }),
+    );
+    const prompt = lastOptions!.args!.at(-1)!;
+    expect(prompt).toContain("<beevibe_system_context>");
+    expect(prompt).toContain("<core>memory</core>");
+    expect(prompt).toContain("fix bug");
+  });
+
+  it("merges context.env into the spawned process env", async () => {
+    mockRunCli();
+    await new OpenCodeRuntime().execute(
+      ctx({ env: { BEEVIBE_SESSION_ID: "sess_test_123" } }),
+    );
+    expect(lastOptions!.env!.BEEVIBE_SESSION_ID).toBe("sess_test_123");
+  });
+
+  it("parses result events into RuntimeResult", async () => {
+    mockRunCli();
+    const result = await new OpenCodeRuntime().execute(ctx());
+    expect(result.status).toBe("completed");
+    expect(result.output).toBe("done");
+    expect(result.cli_session_id).toBe("opencode_sess_mock");
+    expect(result.usage).toEqual({
+      input_tokens: 100,
+      output_tokens: 50,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+      cost_usd: 0,
+      model: "openrouter/qwen/qwen3-coder",
+    });
+  });
+
+  it("emits tool steps from flexible JSON event shapes", async () => {
+    const steps: RuntimeStep[] = [];
+    runCliSpy.mockImplementation(async (options) => {
+      options.onLog?.(
+        "stdout",
+        JSON.stringify({
+          type: "tool_call",
+          tool: "read",
+          input: { file_path: "/src/x.ts" },
+        }) + "\n",
+      );
+      return MOCK_OK;
+    });
+    await new OpenCodeRuntime().execute(ctx({ onStep: (step) => steps.push(step) }));
+    expect(steps).toHaveLength(1);
+    expect(steps[0]!.kind).toBe("tool_call");
+    expect(steps[0]!.tool).toBe("read");
+    expect(steps[0]!.description).toBe("/src/x.ts");
+  });
+
+  it("maps aborted result to cancelled", async () => {
+    mockRunCli({ ...MOCK_OK, aborted: true, stdout: "" });
+    const result = await new OpenCodeRuntime().execute(ctx());
+    expect(result.status).toBe("cancelled");
+  });
+});
+
+describe("OpenCodeRuntime.healthCheck", () => {
+  it("runs opencode --version", async () => {
+    mockRunCli({ ...MOCK_OK, stdout: "", exitCode: 0 });
+    const health = await new OpenCodeRuntime().healthCheck();
+    expect(health.healthy).toBe(true);
+    expect(lastOptions!.args).toEqual(["--version"]);
+    expect(lastOptions!.timeoutMs).toBe(5000);
+    expect(lastOptions!.graceMs).toBe(0);
+  });
+});
+
+describe("buildOpenCodeConfig", () => {
+  it("writes a remote Beevibe MCP server using the session env placeholder", () => {
+    const parsed = JSON.parse(buildOpenCodeConfig("bv_a_test", "http://api.test/mcp"));
+    expect(parsed.mcp.beevibe).toMatchObject({
+      type: "remote",
+      url: "http://api.test/mcp",
+      enabled: true,
+      oauth: false,
+    });
+    expect(parsed.mcp.beevibe.headers.Authorization).toBe("Bearer bv_a_test");
+    expect(parsed.mcp.beevibe.headers["X-Beevibe-Session"]).toBe(
+      "{env:BEEVIBE_SESSION_ID}",
+    );
+  });
+});

--- a/packages/core/src/adapters/opencode/runtime.ts
+++ b/packages/core/src/adapters/opencode/runtime.ts
@@ -6,11 +6,16 @@ import type {
   RuntimeContext,
   RuntimeHealth,
   RuntimeResult,
-  RuntimeStep,
   RuntimeWorkspaceContext,
   Workspace,
 } from "../../ports/runtime.js";
 import { runCliProcess } from "../claude-code/spawn.js";
+import {
+  extractOpenCodeStepEvents,
+  parseOpenCodeEventLine,
+  parseOpenCodeEvents,
+  type OpenCodeEvent,
+} from "./stream-json.js";
 
 export interface OpenCodeRuntimeConfig {
   /** Override CLI command (defaults to "opencode" on PATH). */
@@ -19,8 +24,6 @@ export interface OpenCodeRuntimeConfig {
   model?: string;
 }
 
-type JsonRecord = Record<string, unknown>;
-
 /**
  * OpenCode CLI subprocess runtime.
  *
@@ -28,6 +31,15 @@ type JsonRecord = Record<string, unknown>;
  * plumbing to OpenCode itself, so Beevibe can support OpenRouter, Ollama,
  * Groq, Cerebras, LM Studio, vLLM, and other OpenAI-compatible endpoints
  * through one CLI adapter.
+ *
+ * Per-event parsing lives in `./stream-json.ts` against the wrapper shape
+ * `emit()` produces in opencode's `run.ts` (`{ type, timestamp, sessionID,
+ * ...payload }`). The runtime itself just owns process lifecycle, MCP
+ * wiring, and workspace handoff.
+ *
+ * Provider auth env vars (OPENROUTER_API_KEY, OPENAI_API_KEY, etc.) are
+ * intentionally NOT stripped — opencode depends on them to know which
+ * provider to route to.
  */
 export class OpenCodeRuntime implements AgentRuntime {
   readonly type = "opencode";
@@ -40,6 +52,14 @@ export class OpenCodeRuntime implements AgentRuntime {
       "--format",
       "json",
       "--dangerously-skip-permissions",
+      // `--dir` tells opencode which directory to treat as the project
+      // root for config discovery (and file ops). Setting subprocess cwd
+      // alone is NOT enough — `opencode run` only loads the workspace
+      // `opencode.json` (where our MCP server config lives) when --dir
+      // points at it explicitly. Without this, opencode runs with zero
+      // MCP servers and the agent has no beevibe tools at all.
+      "--dir",
+      context.workspace.path,
     ];
     const model = context.model ?? this.config.model;
     if (model) args.push("--model", model);
@@ -49,14 +69,16 @@ export class OpenCodeRuntime implements AgentRuntime {
     const env: Record<string, string | undefined> = { ...process.env };
     if (context.env) Object.assign(env, context.env);
 
-    const events: JsonRecord[] = [];
+    const events: OpenCodeEvent[] = [];
     let pending = "";
     const handleLine = (line: string): void => {
-      const evt = parseJsonLine(line);
+      const evt = parseOpenCodeEventLine(line);
       if (!evt) return;
       events.push(evt);
-      const step = eventToStep(evt);
-      if (step) context.onStep?.(step);
+      if (!context.onStep) return;
+      for (const step of extractOpenCodeStepEvents(evt)) {
+        context.onStep(step);
+      }
     };
 
     const result = await runCliProcess({
@@ -95,11 +117,18 @@ export class OpenCodeRuntime implements AgentRuntime {
       };
     }
 
-    const parsed = parseOpenCodeEvents(events, result.stdout, result.exitCode);
+    const parsed = parseOpenCodeEvents(events, result.exitCode);
+    const STDERR_TAIL_BYTES = 4096;
+    const stderrTail =
+      parsed.status === "failed" && result.stderr
+        ? result.stderr.slice(-STDERR_TAIL_BYTES)
+        : undefined;
     return {
       ...parsed,
       process_pid: result.pid ?? undefined,
       process_group_id: result.process_group_id ?? undefined,
+      exit_code: result.exitCode,
+      ...(stderrTail ? { stderr: stderrTail } : {}),
     };
   }
 
@@ -171,145 +200,4 @@ export function buildOpenCodeConfig(apiKey: string, mcpServerUrl: string): strin
       2,
     ) + "\n"
   );
-}
-
-function parseJsonLine(line: string): JsonRecord | undefined {
-  const trimmed = line.trim();
-  if (!trimmed) return undefined;
-  try {
-    const value = JSON.parse(trimmed);
-    return isRecord(value) ? value : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function eventToStep(evt: JsonRecord): RuntimeStep | undefined {
-  const type = String(evt.type ?? evt.event ?? evt.kind ?? "").toLowerCase();
-  const tool = pickString(evt, ["tool", "tool_name", "name"]);
-  if (type.includes("tool") || tool) {
-    return {
-      kind: type.includes("result") ? "tool_result" : "tool_call",
-      tool,
-      description: summarizeTool(evt),
-      timestamp: new Date().toISOString(),
-    };
-  }
-  const text = pickText(evt);
-  if (text && (type.includes("message") || type.includes("assistant") || type.includes("text"))) {
-    return {
-      kind: "agent",
-      description: text,
-      timestamp: new Date().toISOString(),
-    };
-  }
-  return undefined;
-}
-
-function parseOpenCodeEvents(
-  events: JsonRecord[],
-  stdout: string,
-  exitCode: number | null,
-): Omit<RuntimeResult, "process_pid" | "process_group_id"> {
-  const assistantText = events.map(pickText).filter(Boolean).join("\n").trim();
-  const final = [...events].reverse().find((evt) => {
-    const type = String(evt.type ?? evt.event ?? evt.kind ?? "").toLowerCase();
-    return type.includes("result") || type.includes("done") || type.includes("complete");
-  });
-  const output = (final && pickText(final)) || assistantText || fallbackText(stdout);
-  return {
-    status: exitCode === 0 ? "completed" : "failed",
-    output: output || (exitCode === 0 ? "OpenCode completed." : "OpenCode failed."),
-    transcript: stdout || undefined,
-    usage: parseUsage(events),
-    cli_session_id: parseSessionId(events),
-  };
-}
-
-function parseUsage(events: JsonRecord[]): RuntimeResult["usage"] {
-  for (const evt of [...events].reverse()) {
-    const usage = evt.usage;
-    if (!isRecord(usage)) continue;
-    const input = pickNumber(usage, ["input_tokens", "inputTokens", "prompt_tokens", "promptTokens"]);
-    const output = pickNumber(usage, ["output_tokens", "outputTokens", "completion_tokens", "completionTokens"]);
-    const cost = pickNumber(usage, ["cost_usd", "costUSD", "cost"]);
-    const model = pickString(usage, ["model"]) ?? pickString(evt, ["model"]);
-    if (input === undefined && output === undefined && cost === undefined && model === undefined) {
-      continue;
-    }
-    return {
-      input_tokens: input ?? 0,
-      output_tokens: output ?? 0,
-      cache_creation_input_tokens: pickNumber(usage, ["cache_creation_input_tokens"]) ?? 0,
-      cache_read_input_tokens: pickNumber(usage, ["cache_read_input_tokens"]) ?? 0,
-      cost_usd: cost,
-      model,
-    };
-  }
-  const model = [...events].reverse().map((evt) => pickString(evt, ["model"])).find(Boolean);
-  return model ? { input_tokens: 0, output_tokens: 0, model } : undefined;
-}
-
-function parseSessionId(events: JsonRecord[]): string | undefined {
-  for (const evt of [...events].reverse()) {
-    const id =
-      pickString(evt, ["session_id", "sessionID", "sessionId"]) ??
-      (isRecord(evt.session) ? pickString(evt.session, ["id", "session_id"]) : undefined);
-    if (id) return id;
-  }
-  return undefined;
-}
-
-function pickText(evt: JsonRecord): string {
-  const direct = pickString(evt, ["output", "text", "content", "message"]);
-  if (direct) return direct;
-  if (isRecord(evt.message)) {
-    return pickString(evt.message, ["content", "text"]) ?? "";
-  }
-  return "";
-}
-
-function summarizeTool(evt: JsonRecord): string {
-  const input = evt.input ?? evt.arguments ?? evt.args ?? evt.params;
-  if (typeof input === "string") return input.slice(0, 300);
-  if (isRecord(input)) {
-    const path = pickString(input, ["file_path", "path", "file"]);
-    const command = pickString(input, ["command", "cmd"]);
-    if (path) return path;
-    if (command) return command;
-    return JSON.stringify(input).slice(0, 300);
-  }
-  return pickText(evt) || "tool call";
-}
-
-function fallbackText(stdout: string): string {
-  return stdout
-    .split("\n")
-    .map((line) => {
-      const parsed = parseJsonLine(line);
-      return parsed ? pickText(parsed) : line;
-    })
-    .filter(Boolean)
-    .join("\n")
-    .trim();
-}
-
-function pickString(obj: JsonRecord, keys: string[]): string | undefined {
-  for (const key of keys) {
-    const value = obj[key];
-    if (typeof value === "string" && value.length > 0) return value;
-  }
-  return undefined;
-}
-
-function pickNumber(obj: JsonRecord, keys: string[]): number | undefined {
-  for (const key of keys) {
-    const value = obj[key];
-    if (typeof value === "number" && Number.isFinite(value)) return value;
-  }
-  return undefined;
-}
-
-function isRecord(value: unknown): value is JsonRecord {
-  return !!value && typeof value === "object" && !Array.isArray(value);
 }

--- a/packages/core/src/adapters/opencode/runtime.ts
+++ b/packages/core/src/adapters/opencode/runtime.ts
@@ -1,0 +1,315 @@
+import { existsSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+  AgentRuntime,
+  RuntimeContext,
+  RuntimeHealth,
+  RuntimeResult,
+  RuntimeStep,
+  RuntimeWorkspaceContext,
+  Workspace,
+} from "../../ports/runtime.js";
+import { runCliProcess } from "../claude-code/spawn.js";
+
+export interface OpenCodeRuntimeConfig {
+  /** Override CLI command (defaults to "opencode" on PATH). */
+  command?: string;
+  /** OpenCode model id in provider/model form. Omit to use OpenCode's default. */
+  model?: string;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+/**
+ * OpenCode CLI subprocess runtime.
+ *
+ * OpenCode is the multi-provider runtime: it delegates provider/model
+ * plumbing to OpenCode itself, so Beevibe can support OpenRouter, Ollama,
+ * Groq, Cerebras, LM Studio, vLLM, and other OpenAI-compatible endpoints
+ * through one CLI adapter.
+ */
+export class OpenCodeRuntime implements AgentRuntime {
+  readonly type = "opencode";
+
+  constructor(private config: OpenCodeRuntimeConfig = {}) {}
+
+  async execute(context: RuntimeContext): Promise<RuntimeResult> {
+    const args = [
+      "run",
+      "--format",
+      "json",
+      "--dangerously-skip-permissions",
+    ];
+    const model = context.model ?? this.config.model;
+    if (model) args.push("--model", model);
+    if (context.resume_session_id) args.push("--session", context.resume_session_id);
+    args.push(composePrompt(context));
+
+    const env: Record<string, string | undefined> = { ...process.env };
+    if (context.env) Object.assign(env, context.env);
+
+    const events: JsonRecord[] = [];
+    let pending = "";
+    const handleLine = (line: string): void => {
+      const evt = parseJsonLine(line);
+      if (!evt) return;
+      events.push(evt);
+      const step = eventToStep(evt);
+      if (step) context.onStep?.(step);
+    };
+
+    const result = await runCliProcess({
+      command: this.config.command ?? "opencode",
+      args,
+      cwd: context.workspace.path,
+      env,
+      abortSignal: context.abort_signal,
+      onSpawn: ({ pid, process_group_id }) => {
+        context.onSpawn?.({ process_pid: pid, process_group_id });
+      },
+      onLog: (stream, chunk) => {
+        if (stream !== "stdout") return;
+        pending += chunk;
+        let nl: number;
+        while ((nl = pending.indexOf("\n")) !== -1) {
+          handleLine(pending.slice(0, nl));
+          pending = pending.slice(nl + 1);
+        }
+      },
+    });
+    if (pending) handleLine(pending);
+
+    if (result.truncated) {
+      console.warn(
+        "[OpenCodeRuntime] stdout truncated at 4MB — result parsing may be incomplete",
+      );
+    }
+
+    if (result.aborted) {
+      return {
+        status: "cancelled",
+        output: "Session cancelled.",
+        process_pid: result.pid ?? undefined,
+        process_group_id: result.process_group_id ?? undefined,
+      };
+    }
+
+    const parsed = parseOpenCodeEvents(events, result.stdout, result.exitCode);
+    return {
+      ...parsed,
+      process_pid: result.pid ?? undefined,
+      process_group_id: result.process_group_id ?? undefined,
+    };
+  }
+
+  async healthCheck(): Promise<RuntimeHealth> {
+    try {
+      const result = await runCliProcess({
+        command: this.config.command ?? "opencode",
+        args: ["--version"],
+        cwd: tmpdir(),
+        timeoutMs: 5_000,
+        graceMs: 0,
+      });
+      return { healthy: result.exitCode === 0 };
+    } catch {
+      return {
+        healthy: false,
+        error: `Command not found: ${this.config.command ?? "opencode"}`,
+      };
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    /* stateless — each session is a separate process */
+  }
+
+  skillsDir(workspace: Workspace): string {
+    return join(workspace.path, ".opencode", "skills");
+  }
+
+  prepareWorkspace(context: RuntimeWorkspaceContext): void {
+    const configPath = join(context.workspace.path, "opencode.json");
+    if (existsSync(configPath)) return;
+    writeFileSync(configPath, buildOpenCodeConfig(context.agentApiKey, context.mcpServerUrl), {
+      mode: 0o600,
+    });
+  }
+}
+
+function composePrompt(context: RuntimeContext): string {
+  if (context.system_prompt_append.length === 0) return context.intent;
+  return [
+    "<beevibe_system_context>",
+    context.system_prompt_append,
+    "</beevibe_system_context>",
+    "",
+    context.intent,
+  ].join("\n");
+}
+
+export function buildOpenCodeConfig(apiKey: string, mcpServerUrl: string): string {
+  return (
+    JSON.stringify(
+      {
+        "$schema": "https://opencode.ai/config.json",
+        mcp: {
+          beevibe: {
+            type: "remote",
+            url: mcpServerUrl,
+            enabled: true,
+            oauth: false,
+            headers: {
+              Authorization: `Bearer ${apiKey}`,
+              "X-Beevibe-Session": "{env:BEEVIBE_SESSION_ID}",
+            },
+          },
+        },
+      },
+      null,
+      2,
+    ) + "\n"
+  );
+}
+
+function parseJsonLine(line: string): JsonRecord | undefined {
+  const trimmed = line.trim();
+  if (!trimmed) return undefined;
+  try {
+    const value = JSON.parse(trimmed);
+    return isRecord(value) ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function eventToStep(evt: JsonRecord): RuntimeStep | undefined {
+  const type = String(evt.type ?? evt.event ?? evt.kind ?? "").toLowerCase();
+  const tool = pickString(evt, ["tool", "tool_name", "name"]);
+  if (type.includes("tool") || tool) {
+    return {
+      kind: type.includes("result") ? "tool_result" : "tool_call",
+      tool,
+      description: summarizeTool(evt),
+      timestamp: new Date().toISOString(),
+    };
+  }
+  const text = pickText(evt);
+  if (text && (type.includes("message") || type.includes("assistant") || type.includes("text"))) {
+    return {
+      kind: "agent",
+      description: text,
+      timestamp: new Date().toISOString(),
+    };
+  }
+  return undefined;
+}
+
+function parseOpenCodeEvents(
+  events: JsonRecord[],
+  stdout: string,
+  exitCode: number | null,
+): Omit<RuntimeResult, "process_pid" | "process_group_id"> {
+  const assistantText = events.map(pickText).filter(Boolean).join("\n").trim();
+  const final = [...events].reverse().find((evt) => {
+    const type = String(evt.type ?? evt.event ?? evt.kind ?? "").toLowerCase();
+    return type.includes("result") || type.includes("done") || type.includes("complete");
+  });
+  const output = (final && pickText(final)) || assistantText || fallbackText(stdout);
+  return {
+    status: exitCode === 0 ? "completed" : "failed",
+    output: output || (exitCode === 0 ? "OpenCode completed." : "OpenCode failed."),
+    transcript: stdout || undefined,
+    usage: parseUsage(events),
+    cli_session_id: parseSessionId(events),
+  };
+}
+
+function parseUsage(events: JsonRecord[]): RuntimeResult["usage"] {
+  for (const evt of [...events].reverse()) {
+    const usage = evt.usage;
+    if (!isRecord(usage)) continue;
+    const input = pickNumber(usage, ["input_tokens", "inputTokens", "prompt_tokens", "promptTokens"]);
+    const output = pickNumber(usage, ["output_tokens", "outputTokens", "completion_tokens", "completionTokens"]);
+    const cost = pickNumber(usage, ["cost_usd", "costUSD", "cost"]);
+    const model = pickString(usage, ["model"]) ?? pickString(evt, ["model"]);
+    if (input === undefined && output === undefined && cost === undefined && model === undefined) {
+      continue;
+    }
+    return {
+      input_tokens: input ?? 0,
+      output_tokens: output ?? 0,
+      cache_creation_input_tokens: pickNumber(usage, ["cache_creation_input_tokens"]) ?? 0,
+      cache_read_input_tokens: pickNumber(usage, ["cache_read_input_tokens"]) ?? 0,
+      cost_usd: cost,
+      model,
+    };
+  }
+  const model = [...events].reverse().map((evt) => pickString(evt, ["model"])).find(Boolean);
+  return model ? { input_tokens: 0, output_tokens: 0, model } : undefined;
+}
+
+function parseSessionId(events: JsonRecord[]): string | undefined {
+  for (const evt of [...events].reverse()) {
+    const id =
+      pickString(evt, ["session_id", "sessionID", "sessionId"]) ??
+      (isRecord(evt.session) ? pickString(evt.session, ["id", "session_id"]) : undefined);
+    if (id) return id;
+  }
+  return undefined;
+}
+
+function pickText(evt: JsonRecord): string {
+  const direct = pickString(evt, ["output", "text", "content", "message"]);
+  if (direct) return direct;
+  if (isRecord(evt.message)) {
+    return pickString(evt.message, ["content", "text"]) ?? "";
+  }
+  return "";
+}
+
+function summarizeTool(evt: JsonRecord): string {
+  const input = evt.input ?? evt.arguments ?? evt.args ?? evt.params;
+  if (typeof input === "string") return input.slice(0, 300);
+  if (isRecord(input)) {
+    const path = pickString(input, ["file_path", "path", "file"]);
+    const command = pickString(input, ["command", "cmd"]);
+    if (path) return path;
+    if (command) return command;
+    return JSON.stringify(input).slice(0, 300);
+  }
+  return pickText(evt) || "tool call";
+}
+
+function fallbackText(stdout: string): string {
+  return stdout
+    .split("\n")
+    .map((line) => {
+      const parsed = parseJsonLine(line);
+      return parsed ? pickText(parsed) : line;
+    })
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+}
+
+function pickString(obj: JsonRecord, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+function pickNumber(obj: JsonRecord, keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+  }
+  return undefined;
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/core/src/adapters/opencode/stream-json.test.ts
+++ b/packages/core/src/adapters/opencode/stream-json.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+import {
+  OPENCODE_EVENT_TYPE,
+  parseOpenCodeEventLine,
+  extractOpenCodeStepEvents,
+  parseOpenCodeEvents,
+  type OpenCodeEvent,
+} from "./stream-json.js";
+
+/**
+ * Fixtures match the wrapper shape emitted by opencode's run.ts `emit()`
+ * helper: `{ type, timestamp, sessionID, ...payload }`. If opencode
+ * changes the wire schema, these tests flip red first — that's the point.
+ */
+
+const SID = "ses_abc123";
+
+const TEXT_PART_COMPLETED: OpenCodeEvent = {
+  type: OPENCODE_EVENT_TYPE.Text,
+  timestamp: 1,
+  sessionID: SID,
+  part: {
+    id: "prt_t1",
+    sessionID: SID,
+    messageID: "msg_1",
+    type: "text",
+    text: "Here is the result.",
+    time: { start: 0, end: 1 },
+  },
+};
+
+const TOOL_USE_RUNNING: OpenCodeEvent = {
+  type: OPENCODE_EVENT_TYPE.ToolUse,
+  timestamp: 2,
+  sessionID: SID,
+  part: {
+    id: "prt_tool_1",
+    sessionID: SID,
+    messageID: "msg_1",
+    type: "tool",
+    tool: "read",
+    state: { status: "running", input: { file_path: "/src/x.ts" } },
+  },
+};
+
+const TOOL_USE_COMPLETED: OpenCodeEvent = {
+  type: OPENCODE_EVENT_TYPE.ToolUse,
+  timestamp: 3,
+  sessionID: SID,
+  part: {
+    id: "prt_tool_1",
+    sessionID: SID,
+    messageID: "msg_1",
+    type: "tool",
+    tool: "read",
+    state: {
+      status: "completed",
+      input: { file_path: "/src/x.ts" },
+      output: "file contents here",
+    },
+  },
+};
+
+const STEP_FINISH: OpenCodeEvent = {
+  type: OPENCODE_EVENT_TYPE.StepFinish,
+  timestamp: 4,
+  sessionID: SID,
+  part: {
+    id: "prt_step_1",
+    sessionID: SID,
+    messageID: "msg_1",
+    type: "step-finish",
+    cost: 0.0042,
+    tokens: {
+      total: 200,
+      input: 150,
+      output: 40,
+      reasoning: 10,
+      cache: { read: 100, write: 20 },
+    },
+  },
+};
+
+describe("parseOpenCodeEventLine", () => {
+  it("parses valid NDJSON wrapper events", () => {
+    const evt = parseOpenCodeEventLine(JSON.stringify(TEXT_PART_COMPLETED));
+    expect(evt).toEqual(TEXT_PART_COMPLETED);
+  });
+
+  it("returns null for empty / non-JSON lines", () => {
+    expect(parseOpenCodeEventLine("")).toBeNull();
+    expect(parseOpenCodeEventLine("   ")).toBeNull();
+    expect(parseOpenCodeEventLine("WARN provider rate limited")).toBeNull();
+  });
+});
+
+describe("extractOpenCodeStepEvents", () => {
+  it("emits an agent step on text events with part.text", () => {
+    const steps = extractOpenCodeStepEvents(TEXT_PART_COMPLETED);
+    expect(steps).toEqual([
+      expect.objectContaining({ kind: "agent", description: "Here is the result." }),
+    ]);
+  });
+
+  it("emits tool_call while running, tool_result on completed", () => {
+    expect(extractOpenCodeStepEvents(TOOL_USE_RUNNING)).toEqual([
+      expect.objectContaining({ kind: "tool_call", tool: "read", description: "/src/x.ts" }),
+    ]);
+    expect(extractOpenCodeStepEvents(TOOL_USE_COMPLETED)).toEqual([
+      expect.objectContaining({ kind: "tool_result", tool: "read" }),
+    ]);
+  });
+
+  it("emits tool_result on tool error too — terminal state regardless of success", () => {
+    const errorEvent: OpenCodeEvent = {
+      ...TOOL_USE_COMPLETED,
+      part: {
+        ...TOOL_USE_COMPLETED.part!,
+        state: { status: "error", input: { file_path: "/missing" }, error: "ENOENT" },
+      },
+    };
+    expect(extractOpenCodeStepEvents(errorEvent)).toEqual([
+      expect.objectContaining({ kind: "tool_result", tool: "read" }),
+    ]);
+  });
+
+  it("skips step_start / step_finish / reasoning — no transcript noise", () => {
+    expect(
+      extractOpenCodeStepEvents({
+        type: OPENCODE_EVENT_TYPE.StepStart,
+        sessionID: SID,
+        part: { id: "p", sessionID: SID, messageID: "m", type: "step-start" },
+      }),
+    ).toEqual([]);
+    expect(extractOpenCodeStepEvents(STEP_FINISH)).toEqual([]);
+    expect(
+      extractOpenCodeStepEvents({
+        type: OPENCODE_EVENT_TYPE.Reasoning,
+        sessionID: SID,
+        part: { id: "p", sessionID: SID, messageID: "m", type: "reasoning", text: "thinking" },
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("parseOpenCodeEvents", () => {
+  it("returns success with concatenated assistant text + summed per-step usage", () => {
+    const events: OpenCodeEvent[] = [
+      TOOL_USE_RUNNING,
+      TOOL_USE_COMPLETED,
+      TEXT_PART_COMPLETED,
+      STEP_FINISH,
+    ];
+    const result = parseOpenCodeEvents(events, 0);
+    expect(result.status).toBe("completed");
+    expect(result.output).toBe("Here is the result.");
+    expect(result.cli_session_id).toBe(SID);
+    expect(result.usage).toEqual({
+      input_tokens: 150,
+      // output is regular + reasoning summed so the cross-runtime total lines up
+      output_tokens: 50,
+      cache_creation_input_tokens: 20,
+      cache_read_input_tokens: 100,
+      cost_usd: 0.0042,
+    });
+  });
+
+  it("sums usage across multiple step_finish events (no terminal rollup exists)", () => {
+    // Integer cost so we don't trip floating-point summation noise — the
+    // sum-correctness assertion stands on its own.
+    const second: OpenCodeEvent = {
+      ...STEP_FINISH,
+      part: {
+        ...STEP_FINISH.part!,
+        cost: 1,
+        tokens: { input: 50, output: 10, reasoning: 0, cache: { read: 30, write: 5 } },
+      },
+    };
+    const first: OpenCodeEvent = {
+      ...STEP_FINISH,
+      part: { ...STEP_FINISH.part!, cost: 2 },
+    };
+    const result = parseOpenCodeEvents([first, second], 0);
+    expect(result.usage).toEqual({
+      input_tokens: 200,
+      // (40 + 10 reasoning) + (10 + 0 reasoning) = 60; we sum reasoning
+      // into output to keep cross-runtime totals comparable.
+      output_tokens: 60,
+      cache_creation_input_tokens: 25,
+      cache_read_input_tokens: 130,
+      cost_usd: 3,
+    });
+  });
+
+  it("returns no usage when no step_finish event was emitted", () => {
+    const result = parseOpenCodeEvents([TEXT_PART_COMPLETED], 0);
+    expect(result.usage).toBeUndefined();
+  });
+
+  it("maps non-zero exit code to failed and prefers error event message", () => {
+    const events: OpenCodeEvent[] = [
+      TEXT_PART_COMPLETED,
+      { type: OPENCODE_EVENT_TYPE.Error, sessionID: SID, error: { message: "provider auth missing" } },
+    ];
+    const result = parseOpenCodeEvents(events, 1);
+    expect(result.status).toBe("failed");
+    expect(result.output).toBe("provider auth missing");
+  });
+
+  it("falls back to bareCliExitMessage on failure with no error event — chat route can then swap", () => {
+    const result = parseOpenCodeEvents([], 1);
+    expect(result.output).toBe("CLI exited with code 1");
+  });
+
+  it("captures sessionID from any event (every event has it via emit()'s spread)", () => {
+    const result = parseOpenCodeEvents([STEP_FINISH], 0);
+    expect(result.cli_session_id).toBe(SID);
+  });
+
+  it("builds a transcript with [assistant] + [tool_call] + [tool_result from X] entries", () => {
+    const events: OpenCodeEvent[] = [TOOL_USE_RUNNING, TOOL_USE_COMPLETED, TEXT_PART_COMPLETED];
+    const result = parseOpenCodeEvents(events, 0);
+    expect(result.transcript).toContain("[tool_call] read");
+    expect(result.transcript).toContain("[tool_result from read] file contents here");
+    expect(result.transcript).toContain("[assistant] Here is the result.");
+  });
+});

--- a/packages/core/src/adapters/opencode/stream-json.ts
+++ b/packages/core/src/adapters/opencode/stream-json.ts
@@ -1,0 +1,261 @@
+import type { SessionUsage } from "../../domain/session.js";
+import type { RuntimeResult, RuntimeStep } from "../../ports/runtime.js";
+import { bareCliExitMessage } from "../claude-code/stream-json.js";
+
+/**
+ * Parser for `opencode run --format json` output.
+ *
+ * Source: https://github.com/sst/opencode/blob/dev/packages/opencode/src/cli/cmd/run.ts
+ * The `emit(type, data)` helper at the top of `run.ts` is the SOLE stdout
+ * writer in JSON mode. Every event has the wrapper shape:
+ *
+ *     { type, timestamp, sessionID, ...payload }
+ *
+ * — note camelCase `sessionID`, not `session_id`. `UI.println`/`UI.error` go
+ * to stderr; provider warnings (rate limits, model loading) also go to stderr.
+ * Stdout in JSON mode is strictly NDJSON.
+ *
+ * Unlike codex, opencode has NO terminal `turn.completed` rollup event.
+ * Usage + cost arrive PER STEP on `step_finish` events; this parser sums
+ * them across the run.
+ */
+
+export const OPENCODE_EVENT_TYPE = {
+  Text: "text",
+  Reasoning: "reasoning",
+  ToolUse: "tool_use",
+  StepStart: "step_start",
+  StepFinish: "step_finish",
+  Error: "error",
+} as const;
+
+/**
+ * `ToolState.status` from the opencode SDK. `error` carries `part.state.error`
+ * (string); `completed` carries `part.state.output` (string).
+ */
+const OPENCODE_TOOL_STATUS = {
+  Pending: "pending",
+  Running: "running",
+  Completed: "completed",
+  Error: "error",
+} as const;
+
+export interface OpenCodePart {
+  id?: string;
+  sessionID?: string;
+  messageID?: string;
+  type?: string;
+  /** text / reasoning */
+  text?: string;
+  /** tool_use */
+  tool?: string;
+  state?: {
+    status?: string;
+    input?: unknown;
+    output?: string;
+    error?: string;
+  };
+  /** step_finish */
+  cost?: number;
+  tokens?: {
+    total?: number;
+    input?: number;
+    output?: number;
+    reasoning?: number;
+    cache?: { read?: number; write?: number };
+  };
+  time?: { start?: number; end?: number };
+}
+
+export interface OpenCodeEvent {
+  type?: string;
+  timestamp?: number;
+  /** Top-level on every line via emit()'s spread. NOT `session_id`. */
+  sessionID?: string;
+  part?: OpenCodePart;
+  /** error event */
+  error?: { message?: string };
+  result?: { error?: { message?: string } };
+}
+
+export function parseOpenCodeEventLine(line: string): OpenCodeEvent | null {
+  const trimmed = line.trim();
+  if (!trimmed || !trimmed.startsWith("{")) return null;
+  try {
+    return JSON.parse(trimmed) as OpenCodeEvent;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Convert a parsed opencode event into 0+ RuntimeSteps for the live transcript.
+ *
+ * - `text` → one `agent` step with `part.text` (opencode emits text events
+ *   only on part completion — `part.time?.end` is set — so there's no
+ *   in-progress fragmentation to dedup).
+ * - `tool_use` → `tool_call` while `state.status` is pending/running;
+ *   `tool_result` once status flips to completed/error.
+ * - `step_start` / `step_finish` / `reasoning` / `error` → no step (lifecycle
+ *   or thinking; reasoning is already accounted for in tokens.reasoning).
+ */
+export function extractOpenCodeStepEvents(evt: OpenCodeEvent): RuntimeStep[] {
+  const now = new Date().toISOString();
+
+  if (evt.type === OPENCODE_EVENT_TYPE.Text) {
+    const text = evt.part?.text?.trim();
+    if (!text) return [];
+    return [{ kind: "agent", description: text, timestamp: now }];
+  }
+
+  if (evt.type === OPENCODE_EVENT_TYPE.ToolUse) {
+    const part = evt.part;
+    if (!part) return [];
+    const status = part.state?.status;
+    const isTerminal =
+      status === OPENCODE_TOOL_STATUS.Completed || status === OPENCODE_TOOL_STATUS.Error;
+    return [
+      {
+        kind: isTerminal ? "tool_result" : "tool_call",
+        tool: part.tool ?? "unknown",
+        description: describeOpenCodeInput(part.state?.input),
+        timestamp: now,
+      },
+    ];
+  }
+
+  return [];
+}
+
+const PREFERRED_OPENCODE_FIELDS = [
+  "file_path",
+  "path",
+  "command",
+  "cmd",
+  "query",
+  "pattern",
+  "url",
+  "intent",
+] as const;
+
+function describeOpenCodeInput(input: unknown): string {
+  if (typeof input === "string") return input.slice(0, 200);
+  if (!input || typeof input !== "object" || Array.isArray(input)) return "";
+  const obj = input as Record<string, unknown>;
+  for (const key of PREFERRED_OPENCODE_FIELDS) {
+    const v = obj[key];
+    if (typeof v === "string" && v.length > 0) return v.slice(0, 200);
+  }
+  return JSON.stringify(input).slice(0, 200);
+}
+
+/**
+ * Build a `RuntimeResult` from a parsed event stream.
+ *
+ * `step_finish` events are SUMMED — opencode has no terminal rollup event,
+ * so per-step tokens + cost are the only signal we get.
+ *
+ * `sessionID` is on every event; we just take the last one we see (they
+ * should all match within a run).
+ *
+ * On failure (`exitCode !== 0` or any `error` event), prefer the error
+ * event's message; final fallback is `bareCliExitMessage` so the chat
+ * route's failure-mapping helper can swap it for stderr or a daemon
+ * pointer.
+ */
+export function parseOpenCodeEvents(
+  events: OpenCodeEvent[],
+  exitCode: number | null,
+): Omit<RuntimeResult, "process_pid" | "process_group_id"> {
+  let sessionId: string | undefined;
+  let sawUsage = false;
+  let totalInput = 0;
+  let totalOutput = 0;
+  let totalReasoning = 0;
+  let totalCacheRead = 0;
+  let totalCacheWrite = 0;
+  let totalCost = 0;
+  const assistantTexts: string[] = [];
+  const transcriptParts: string[] = [];
+  let errorMessage: string | undefined;
+
+  for (const evt of events) {
+    if (evt.sessionID) sessionId = evt.sessionID;
+
+    switch (evt.type) {
+      case OPENCODE_EVENT_TYPE.StepFinish: {
+        const part = evt.part;
+        if (!part) break;
+        sawUsage = true;
+        totalCost += part.cost ?? 0;
+        totalInput += part.tokens?.input ?? 0;
+        totalOutput += part.tokens?.output ?? 0;
+        totalReasoning += part.tokens?.reasoning ?? 0;
+        totalCacheRead += part.tokens?.cache?.read ?? 0;
+        totalCacheWrite += part.tokens?.cache?.write ?? 0;
+        break;
+      }
+      case OPENCODE_EVENT_TYPE.Text: {
+        const text = evt.part?.text;
+        if (text) {
+          assistantTexts.push(text);
+          transcriptParts.push(`[assistant] ${text}\n`);
+        }
+        break;
+      }
+      case OPENCODE_EVENT_TYPE.ToolUse: {
+        const part = evt.part;
+        if (!part) break;
+        const tool = part.tool ?? "unknown";
+        const status = part.state?.status;
+        if (status === OPENCODE_TOOL_STATUS.Completed || status === OPENCODE_TOOL_STATUS.Error) {
+          const detail = (part.state?.error ?? part.state?.output ?? "")
+            .slice(0, 200)
+            .replace(/\n/g, " ");
+          transcriptParts.push(
+            detail ? `[tool_result from ${tool}] ${detail}\n` : `[tool_result from ${tool}]\n`,
+          );
+        } else {
+          transcriptParts.push(`[tool_call] ${tool}\n`);
+        }
+        break;
+      }
+      case OPENCODE_EVENT_TYPE.Error:
+        errorMessage = evt.error?.message ?? evt.result?.error?.message ?? errorMessage;
+        if (errorMessage) transcriptParts.push(`[error] ${errorMessage}\n`);
+        break;
+      default:
+        break;
+    }
+  }
+
+  const assistantText = assistantTexts.join("\n").trim();
+  const failed = exitCode !== 0 || !!errorMessage;
+  // `||` not `??` — empty assistantText must fall through to the next
+  // branch instead of short-circuiting at the empty string.
+  const output = failed
+    ? errorMessage || assistantText || bareCliExitMessage(exitCode)
+    : assistantText || "Session completed.";
+
+  const usage: SessionUsage | undefined = sawUsage
+    ? {
+        input_tokens: totalInput,
+        // Per opencode's StepFinishPart shape, `output` is post-reasoning
+        // assistant tokens; reasoning is its own bucket. Sum into a single
+        // `output_tokens` like Anthropic's shape so downstream consumers
+        // see one consistent number across runtimes.
+        output_tokens: totalOutput + totalReasoning,
+        cache_creation_input_tokens: totalCacheWrite,
+        cache_read_input_tokens: totalCacheRead,
+        cost_usd: totalCost,
+      }
+    : undefined;
+
+  return {
+    status: failed ? "failed" : "completed",
+    output,
+    transcript: transcriptParts.join("") || undefined,
+    cli_session_id: sessionId,
+    usage,
+  };
+}

--- a/packages/core/src/adapters/runtime-registry.test.ts
+++ b/packages/core/src/adapters/runtime-registry.test.ts
@@ -8,6 +8,18 @@ describe("createDefaultRuntimeRegistry", () => {
     expect(registry["claude"]!.type).toBe("claude");
   });
 
+  it("registers opencode", () => {
+    const registry = createDefaultRuntimeRegistry();
+    expect(registry["opencode"]).toBeDefined();
+    expect(registry["opencode"]!.type).toBe("opencode");
+  });
+
+  it("registers codex", () => {
+    const registry = createDefaultRuntimeRegistry();
+    expect(registry["codex"]).toBeDefined();
+    expect(registry["codex"]!.type).toBe("codex");
+  });
+
   it("every registry value's .type matches its registry key (sanity check against typos)", () => {
     const registry = createDefaultRuntimeRegistry();
     for (const [key, runtime] of Object.entries(registry)) {

--- a/packages/core/src/adapters/runtime-registry.ts
+++ b/packages/core/src/adapters/runtime-registry.ts
@@ -1,5 +1,7 @@
 import type { RuntimeRegistry } from "../ports/runtime.js";
 import { ClaudeCodeRuntime } from "./claude-code/runtime.js";
+import { CodexRuntime } from "./codex/runtime.js";
+import { OpenCodeRuntime } from "./opencode/runtime.js";
 
 /**
  * Default registry with all production runtimes wired.
@@ -18,5 +20,7 @@ import { ClaudeCodeRuntime } from "./claude-code/runtime.js";
 export function createDefaultRuntimeRegistry(): RuntimeRegistry {
   return {
     claude: new ClaudeCodeRuntime({}),
+    codex: new CodexRuntime({}),
+    opencode: new OpenCodeRuntime({}),
   };
 }

--- a/packages/core/src/ports/runtime.ts
+++ b/packages/core/src/ports/runtime.ts
@@ -32,6 +32,14 @@ export interface AgentRuntime {
    * sync the tier-filtered SKILL.md files.
    */
   skillsDir(workspace: Workspace): string;
+
+  /**
+   * Optional runtime-specific workspace provisioning hook. Called after the
+   * generic workspace + Claude-compatible mcp-config.json are present and
+   * before skills are synced. Runtimes use this for config files that must
+   * live in the workspace root, for example OpenCode's `opencode.json`.
+   */
+  prepareWorkspace?(context: RuntimeWorkspaceContext): Promise<void> | void;
 }
 
 /**
@@ -42,6 +50,12 @@ export interface AgentRuntime {
 export interface Workspace {
   /** Absolute path to the agent's home dir. E.g. "~/.beevibe/workspaces/agent_XXX/". */
   path: string;
+}
+
+export interface RuntimeWorkspaceContext {
+  workspace: Workspace;
+  agentApiKey: string;
+  mcpServerUrl: string;
 }
 
 /**

--- a/packages/daemon/src/claimer.ts
+++ b/packages/daemon/src/claimer.ts
@@ -12,7 +12,7 @@
  */
 
 import WebSocket from "ws";
-import { RUNTIME_HEARTBEAT_INTERVAL_MS } from "@beevibe/core";
+import { RUNTIME_HEARTBEAT_INTERVAL_MS, type RuntimeRegistry } from "@beevibe/core";
 import type { LocalWorkspaceManager } from "@beevibe/core/adapters/local-workspace";
 import type { ApiClient } from "./api-client.js";
 import type { Supervisor } from "./supervisor.js";
@@ -22,6 +22,7 @@ export interface ClaimerConfig {
   api: ApiClient;
   supervisor: Supervisor;
   workspaceManager: LocalWorkspaceManager;
+  runtimeRegistry: RuntimeRegistry;
   runtimeIds: string[];
   /** Default 30_000ms. */
   pollIntervalMs?: number;
@@ -185,7 +186,11 @@ export class Claimer {
       );
       const ctrl = this.cfg.supervisor.start(payload.session_id);
       void runDispatch(
-        { api: this.cfg.api, workspaceManager: this.cfg.workspaceManager },
+        {
+          api: this.cfg.api,
+          workspaceManager: this.cfg.workspaceManager,
+          runtimeRegistry: this.cfg.runtimeRegistry,
+        },
         payload,
         ctrl.signal,
       )

--- a/packages/daemon/src/spawner.test.ts
+++ b/packages/daemon/src/spawner.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AgentRuntime, RuntimeContext, RuntimeResult, RuntimeRegistry, Workspace } from "@beevibe/core";
+import { runDispatch, type DispatchPayload } from "./spawner.js";
+
+function payload(overrides: Partial<DispatchPayload> = {}): DispatchPayload {
+  return {
+    session_id: "sess_123",
+    agent_id: "agent_123",
+    agent_api_key: "bv_a_test",
+    agent_hierarchy_level: "team",
+    runtime_type: "opencode",
+    intent: "do work",
+    system_prompt_append: "<core />",
+    model: "openrouter/qwen/qwen3-coder",
+    max_turns: 3,
+    env: { BEEVIBE_SESSION_ID: "sess_123", BEEVIBE_AGENT_ID: "agent_123" },
+    type: "task",
+    mcp_server_url: "http://api.test/mcp",
+    ...overrides,
+  };
+}
+
+describe("runDispatch", () => {
+  it("uses payload.runtime_type for workspace provisioning and runtime execution", async () => {
+    let ensuredAgentRuntimeType: string | undefined;
+    let runtimeContext: RuntimeContext | undefined;
+    const runtime: AgentRuntime = {
+      type: "opencode",
+      execute: vi.fn(async (ctx: RuntimeContext): Promise<RuntimeResult> => {
+        runtimeContext = ctx;
+        ctx.onStep?.({
+          kind: "tool_call",
+          tool: "read",
+          description: "README.md",
+          timestamp: new Date().toISOString(),
+        });
+        return {
+          status: "completed",
+          output: "done",
+          cli_session_id: "opencode_sess_1",
+          usage: { input_tokens: 1, output_tokens: 2 },
+        };
+      }),
+      healthCheck: vi.fn(),
+      shutdown: vi.fn(),
+      skillsDir: (workspace: Workspace) => `${workspace.path}/.opencode/skills`,
+    };
+    const posts: Array<{ path: string; body: unknown }> = [];
+    const api = {
+      post: vi.fn(async (path: string, body: unknown) => {
+        posts.push({ path, body });
+      }),
+    };
+    const workspaceManager = {
+      ensureWorkspace: vi.fn(async ({ agent }) => {
+        ensuredAgentRuntimeType = agent.runtime_config.type;
+        return { path: "/tmp/ws-opencode" };
+      }),
+    };
+
+    await runDispatch(
+      {
+        api: api as never,
+        workspaceManager: workspaceManager as never,
+        runtimeRegistry: { opencode: runtime } as RuntimeRegistry,
+      },
+      payload(),
+    );
+
+    expect(ensuredAgentRuntimeType).toBe("opencode");
+    expect(runtime.execute).toHaveBeenCalledOnce();
+    expect(runtimeContext?.model).toBe("openrouter/qwen/qwen3-coder");
+    expect(posts.some((p) => p.path === "/runtime/events")).toBe(true);
+    const done = posts.find((p) => p.path === "/runtime/done")!.body as {
+      status: string;
+      cli_session_id: string;
+    };
+    expect(done.status).toBe("succeeded");
+    expect(done.cli_session_id).toBe("opencode_sess_1");
+  });
+});

--- a/packages/daemon/src/spawner.ts
+++ b/packages/daemon/src/spawner.ts
@@ -9,8 +9,15 @@
  * `<workspace>/.claude/skills/`).
  */
 
-import { ClaudeCodeRuntime } from "@beevibe/core/adapters/claude-code";
-import type { Agent, RuntimeStep, RuntimeResult, TerminalSessionStatus } from "@beevibe/core";
+import { createDefaultRuntimeRegistry } from "@beevibe/core/adapters/runtime-registry";
+import type {
+  Agent,
+  KnownCli,
+  RuntimeRegistry,
+  RuntimeStep,
+  RuntimeResult,
+  TerminalSessionStatus,
+} from "@beevibe/core";
 import type { LocalWorkspaceManager } from "@beevibe/core/adapters/local-workspace";
 import type { ApiClient } from "./api-client.js";
 
@@ -19,6 +26,7 @@ export interface DispatchPayload {
   agent_id: string;
   agent_api_key: string;
   agent_hierarchy_level: "ic" | "team" | "org";
+  runtime_type: KnownCli;
   intent: string;
   system_prompt_append: string;
   resume_session_id?: string;
@@ -32,8 +40,8 @@ export interface DispatchPayload {
 export interface SpawnDeps {
   api: ApiClient;
   workspaceManager: LocalWorkspaceManager;
-  /** Default ClaudeCodeRuntime; tests inject a fake. */
-  runtime?: ClaudeCodeRuntime;
+  /** Default registry; tests inject fakes. */
+  runtimeRegistry?: RuntimeRegistry;
 }
 
 /**
@@ -54,7 +62,7 @@ export async function runDispatch(
     id: payload.agent_id,
     api_key: payload.agent_api_key,
     hierarchy_level: payload.agent_hierarchy_level,
-    runtime_config: { type: "claude" as const },
+    runtime_config: { type: payload.runtime_type },
   } as unknown as Agent;
   const ws = await deps.workspaceManager.ensureWorkspace({ agent: syntheticAgent });
 
@@ -62,10 +70,14 @@ export async function runDispatch(
   // exit line below, so one session id grep'd from a daemon log shows
   // the full lifecycle.
   console.log(
-    `[daemon/spawn] sess=${payload.session_id} agent=${payload.agent_id} type=${payload.type} cwd=${ws.path}`,
+    `[daemon/spawn] sess=${payload.session_id} agent=${payload.agent_id} runtime=${payload.runtime_type} type=${payload.type} cwd=${ws.path}`,
   );
 
-  const runtime = deps.runtime ?? new ClaudeCodeRuntime();
+  const registry = deps.runtimeRegistry ?? createDefaultRuntimeRegistry();
+  const runtime = registry[payload.runtime_type];
+  if (!runtime) {
+    throw new Error(`No runtime registered for dispatch payload type '${payload.runtime_type}'`);
+  }
 
   // Buffer events so the daemon doesn't fire one POST per token. Flushed
   // every BATCH_INTERVAL_MS or when the buffer hits BATCH_MAX. Final

--- a/packages/daemon/src/start.ts
+++ b/packages/daemon/src/start.ts
@@ -49,6 +49,7 @@ export async function runStart(): Promise<void> {
     api,
     supervisor,
     workspaceManager,
+    runtimeRegistry,
     runtimeIds: cfg.runtimes.map((r) => r.id),
   });
   claimer.start();

--- a/packages/web/app/(authed)/agents/agents-client.tsx
+++ b/packages/web/app/(authed)/agents/agents-client.tsx
@@ -72,7 +72,7 @@ export function AgentsClient() {
             // scrolling the page or selecting card text mid-drag.
           >
             <div
-              className="absolute left-1/2 top-1/2 will-change-transform"
+              className="absolute left-1/2 top-1/2"
               style={panZoom.style}
             >
               {/* Self orbit anchored at world origin (0,0); the parent

--- a/packages/web/app/(authed)/chat/chat-client.tsx
+++ b/packages/web/app/(authed)/chat/chat-client.tsx
@@ -85,10 +85,21 @@ export function ChatClient() {
   const conversationParam = searchParams?.get("c") ?? undefined;
   const isFresh = searchParams?.get("new") === "1";
 
-  const { messages, send, isPending, isSubmitting, error, pendingSessionId } = useChat({
-    conversationId: conversationParam,
-    fresh: isFresh,
-  });
+  const { messages, send, isPending, isSubmitting, error, pendingSessionId, pinnedRuntimeCli } =
+    useChat({
+      conversationId: conversationParam,
+      fresh: isFresh,
+    });
+
+  // Once we load a conversation that's already claimed a runtime, mirror
+  // its CLI into the picker so the user sees the pinned value (instead
+  // of the "claude" default) and can't accidentally pick a different
+  // CLI — the server would 409 with `runtime_switch_requires_new_chat`.
+  useEffect(() => {
+    if (pinnedRuntimeCli && pinnedRuntimeCli !== runtimeType) {
+      setRuntimeType(pinnedRuntimeCli);
+    }
+  }, [pinnedRuntimeCli, runtimeType]);
   const liveSteps = useChatStream(pendingSessionId);
   const transcriptRef = useRef<HTMLDivElement | null>(null);
   const teamAgent = useTeamAgent();
@@ -214,6 +225,7 @@ export function ChatClient() {
                     value={runtimeType}
                     onChange={setRuntimeType}
                     disabled={isSubmitting}
+                    pinned={pinnedRuntimeCli}
                   />
                   <button
                     type="button"
@@ -365,10 +377,18 @@ function RuntimeSelector({
   value,
   onChange,
   disabled,
+  pinned,
 }: {
   value: KnownCli;
   onChange: (runtimeType: KnownCli) => void;
   disabled?: boolean;
+  /**
+   * Set when the current conversation has already claimed a runtime —
+   * the picker locks to that CLI because the server pins runtime per
+   * chain (switching mid-chat 409s). Empty conversations leave this
+   * unset and the user can pick freely.
+   */
+  pinned?: KnownCli;
 }) {
   const runtimesQuery = useQuery<RuntimesListResponse>({
     queryKey: queryKeys.runtimes.list(),
@@ -396,24 +416,31 @@ function RuntimeSelector({
   // default has none — that's a one-shot default-correction, not an
   // ongoing override. Switching silently on every poll would steal the
   // user's deliberate selection if their CLI flickered offline mid-session.
+  // Skip entirely when the conversation is pinned; the parent already
+  // mirrored that CLI into `value`.
   const didInitialPick = useRef(false);
   useEffect(() => {
-    if (didInitialPick.current || !runtimesQuery.data) return;
+    if (pinned || didInitialPick.current || !runtimesQuery.data) return;
     didInitialPick.current = true;
     if ((runtimeCounts.get(value)?.online ?? 0) > 0) return;
     const firstOnline = KNOWN_CLIS.find((cli) => (runtimeCounts.get(cli)?.online ?? 0) > 0);
     if (firstOnline) onChange(firstOnline);
-  }, [runtimesQuery.data, runtimeCounts, value, onChange]);
+  }, [pinned, runtimesQuery.data, runtimeCounts, value, onChange]);
 
+  const locked = pinned !== undefined;
   return (
     <label className="inline-flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
       <Terminal className="h-3.5 w-3.5 shrink-0" />
       <select
         value={value}
-        disabled={disabled || runtimesQuery.isLoading}
+        disabled={disabled || locked || runtimesQuery.isLoading}
         onChange={(e) => onChange(e.target.value as KnownCli)}
-        title="Choose the runtime for this chat turn"
-        className="max-w-[160px] rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground outline-none transition-colors hover:border-foreground/30 disabled:opacity-50"
+        title={
+          locked
+            ? "This conversation is pinned to this runtime. Start a new chat to switch."
+            : "Choose the runtime for this chat turn"
+        }
+        className="max-w-[160px] rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground outline-none transition-colors hover:border-foreground/30 disabled:opacity-50 disabled:cursor-not-allowed"
       >
         {KNOWN_CLIS.map((cli) => {
           const counts = runtimeCounts.get(cli) ?? { online: 0, total: 0 };

--- a/packages/web/app/(authed)/chat/chat-client.tsx
+++ b/packages/web/app/(authed)/chat/chat-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
@@ -9,10 +9,17 @@ import {
   ArrowRight,
   ArrowUp,
   MessageSquare,
+  Terminal,
 } from "lucide-react";
-import type { HierarchyLevel } from "@beevibe/core";
+import type { HierarchyLevel, KnownCli } from "@beevibe/core";
+import { isKnownCli, KNOWN_CLIS } from "@beevibe/core/domain";
 import { isApiConfigured } from "@/lib/api/config";
-import { api, type ChatConversationsResponse, type SuggestedAction } from "@/lib/api/client";
+import {
+  api,
+  type ChatConversationsResponse,
+  type RuntimesListResponse,
+  type SuggestedAction,
+} from "@/lib/api/client";
 import { useChat, type ChatMessage } from "@/lib/hooks/use-chat";
 import { useChatStream, type ChatStreamStep } from "@/lib/chat-stream";
 import { useMe } from "@/lib/hooks/use-me";
@@ -46,8 +53,22 @@ const ONBOARDING_PROMPT_SUGGESTIONS = [
   "What can you do for me?",
 ];
 
+const RUNTIME_LABELS: Record<KnownCli, string> = {
+  claude: "Claude",
+  codex: "Codex",
+  opencode: "OpenCode",
+};
+
+function runtimeStatusSuffix(counts: { online: number; total: number }): string {
+  if (counts.online > 1) return ` (${counts.online} online)`;
+  if (counts.online === 1) return "";
+  if (counts.total > 0) return " (offline)";
+  return " (not set up)";
+}
+
 export function ChatClient() {
   const [draft, setDraft] = useState("");
+  const [runtimeType, setRuntimeType] = useState<KnownCli>("claude");
   const router = useRouter();
   const searchParams = useSearchParams();
   const { data: me } = useMe();
@@ -115,7 +136,7 @@ export function ChatClient() {
   const submit = (text?: string) => {
     const value = text ?? draft;
     if (value.trim().length === 0) return;
-    send(value);
+    send(value, runtimeType);
     setDraft("");
   };
 
@@ -143,6 +164,8 @@ export function ChatClient() {
             draft={draft}
             setDraft={setDraft}
             onboarding={isOnboardingChat}
+            runtimeType={runtimeType}
+            setRuntimeType={setRuntimeType}
           />
         ) : (
           <>
@@ -186,7 +209,12 @@ export function ChatClient() {
                   disabled={isSubmitting}
                   className="w-full bg-transparent px-4 pt-3 pb-1 text-sm focus:outline-none resize-none placeholder:text-muted-foreground/60 disabled:opacity-60"
                 />
-                <div className="flex items-center justify-end px-3 pb-2">
+                <div className="flex items-center justify-between gap-3 px-3 pb-2">
+                  <RuntimeSelector
+                    value={runtimeType}
+                    onChange={setRuntimeType}
+                    disabled={isSubmitting}
+                  />
                   <button
                     type="button"
                     onClick={() => submit()}
@@ -211,11 +239,15 @@ function HeroEmptyChat({
   draft,
   setDraft,
   onboarding,
+  runtimeType,
+  setRuntimeType,
 }: {
   onSubmit: (text?: string) => void;
   draft: string;
   setDraft: (s: string) => void;
   onboarding: boolean;
+  runtimeType: KnownCli;
+  setRuntimeType: (runtimeType: KnownCli) => void;
 }) {
   const agents = useAgents();
   const teamAgent = agents.data?.find((a) => a.hierarchy !== "ic");
@@ -265,7 +297,8 @@ function HeroEmptyChat({
             autoFocus
             className="w-full bg-transparent px-4 pt-3 pb-2 text-sm focus:outline-none resize-none placeholder:text-muted-foreground/60"
           />
-          <div className="flex items-center justify-end px-3 pb-2">
+          <div className="flex items-center justify-between gap-3 px-3 pb-2">
+            <RuntimeSelector value={runtimeType} onChange={setRuntimeType} />
             <button
               type="button"
               onClick={() => onSubmit()}
@@ -325,6 +358,74 @@ function HeroEmptyChat({
         </div>
       </div>
     </div>
+  );
+}
+
+function RuntimeSelector({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: KnownCli;
+  onChange: (runtimeType: KnownCli) => void;
+  disabled?: boolean;
+}) {
+  const runtimesQuery = useQuery<RuntimesListResponse>({
+    queryKey: queryKeys.runtimes.list(),
+    queryFn: ({ signal }) => api.runtimes.list({ signal }),
+    enabled: isApiConfigured,
+    staleTime: 30_000,
+  });
+
+  const runtimeCounts = useMemo(() => {
+    const countsByCli = new Map<KnownCli, { online: number; total: number }>();
+    for (const cli of KNOWN_CLIS) countsByCli.set(cli, { online: 0, total: 0 });
+    for (const daemon of runtimesQuery.data?.daemons ?? []) {
+      for (const runtime of daemon.runtimes) {
+        if (!isKnownCli(runtime.cli)) continue;
+        const counts = countsByCli.get(runtime.cli)!;
+        counts.total += 1;
+        if (runtime.online) counts.online += 1;
+      }
+    }
+    return countsByCli;
+  }, [runtimesQuery.data]);
+
+  // The parent seeds `value` with a hardcoded default ("claude"). On the
+  // first arrival of runtime data, swap to the first online CLI if the
+  // default has none — that's a one-shot default-correction, not an
+  // ongoing override. Switching silently on every poll would steal the
+  // user's deliberate selection if their CLI flickered offline mid-session.
+  const didInitialPick = useRef(false);
+  useEffect(() => {
+    if (didInitialPick.current || !runtimesQuery.data) return;
+    didInitialPick.current = true;
+    if ((runtimeCounts.get(value)?.online ?? 0) > 0) return;
+    const firstOnline = KNOWN_CLIS.find((cli) => (runtimeCounts.get(cli)?.online ?? 0) > 0);
+    if (firstOnline) onChange(firstOnline);
+  }, [runtimesQuery.data, runtimeCounts, value, onChange]);
+
+  return (
+    <label className="inline-flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+      <Terminal className="h-3.5 w-3.5 shrink-0" />
+      <select
+        value={value}
+        disabled={disabled || runtimesQuery.isLoading}
+        onChange={(e) => onChange(e.target.value as KnownCli)}
+        title="Choose the runtime for this chat turn"
+        className="max-w-[160px] rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground outline-none transition-colors hover:border-foreground/30 disabled:opacity-50"
+      >
+        {KNOWN_CLIS.map((cli) => {
+          const counts = runtimeCounts.get(cli) ?? { online: 0, total: 0 };
+          return (
+            <option key={cli} value={cli} disabled={counts.online === 0}>
+              {RUNTIME_LABELS[cli]}
+              {runtimeStatusSuffix(counts)}
+            </option>
+          );
+        })}
+      </select>
+    </label>
   );
 }
 
@@ -482,4 +583,3 @@ function Thinking({
     </div>
   );
 }
-

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -88,6 +88,8 @@ export interface HealthResponse {
 
 export interface ChatSendInput {
   message: string;
+  /** Optional per-turn CLI preference. Server resolves this to an online runtime. */
+  runtime_type?: KnownCli;
   /** Previous turn's session id — enables `--resume` continuity. */
   prior_session_id?: string;
   /**

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -302,6 +302,13 @@ export interface ChatHistoryResponse {
    * transcript.
    */
   in_flight_session_id?: string;
+  /**
+   * CLI this conversation is pinned to (first turn's runtime cli).
+   * Absent for chains that never claimed a runtime (legacy sessions) or
+   * for empty conversations. The composer uses this to lock the runtime
+   * picker — switching CLIs mid-chat would 409 server-side.
+   */
+  pinned_runtime_cli?: KnownCli;
 }
 
 export interface ChatConversationSummary {

--- a/packages/web/lib/hooks/use-chat.ts
+++ b/packages/web/lib/hooks/use-chat.ts
@@ -9,6 +9,7 @@ import {
   type ChatTurnResponse,
   type SuggestedAction,
 } from "@/lib/api/client";
+import type { KnownCli } from "@beevibe/core";
 import { isApiConfigured } from "@/lib/api/config";
 import { ApiError } from "@/lib/api/http";
 import { queryKeys } from "./keys";
@@ -134,13 +135,14 @@ export function useChat(opts: UseChatOptions = {}) {
   const mutation = useMutation<
     ChatTurnResponse,
     Error,
-    { message: string; sessionId: string }
+    { message: string; sessionId: string; runtimeType?: KnownCli }
   >({
-    mutationFn: ({ message, sessionId }) =>
+    mutationFn: ({ message, sessionId, runtimeType }) =>
       api.chat.send({
         message,
         session_id: sessionId,
         prior_session_id: priorSessionId,
+        ...(runtimeType ? { runtime_type: runtimeType } : {}),
       }),
     onMutate: ({ message, sessionId }) => {
       // Optimistically append the user's turn AND stamp in_flight_session_id
@@ -222,10 +224,10 @@ export function useChat(opts: UseChatOptions = {}) {
   });
 
   const send = useCallback(
-    (rawMessage: string) => {
+    (rawMessage: string, runtimeType?: KnownCli) => {
       const trimmed = rawMessage.trim();
       if (!trimmed || mutation.isPending) return;
-      mutation.mutate({ message: trimmed, sessionId: mintSessionId() });
+      mutation.mutate({ message: trimmed, sessionId: mintSessionId(), runtimeType });
     },
     [mutation],
   );

--- a/packages/web/lib/hooks/use-chat.ts
+++ b/packages/web/lib/hooks/use-chat.ts
@@ -275,5 +275,11 @@ export function useChat(opts: UseChatOptions = {}) {
     pendingSessionId: inFlightSessionId,
     /** History query state, for showing a "loading prior conversation…" indicator. */
     isLoadingHistory: history.isLoading,
+    /**
+     * CLI this conversation is pinned to (set after the first claimed
+     * turn). The composer locks its runtime picker to this value so the
+     * user can't pick a different CLI and get a 409 on send.
+     */
+    pinnedRuntimeCli: history.data?.pinned_runtime_cli,
   };
 }

--- a/packages/web/lib/hooks/use-pan-zoom.ts
+++ b/packages/web/lib/hooks/use-pan-zoom.ts
@@ -23,8 +23,12 @@ interface PanZoomOptions {
 export interface PanZoomController {
   /** Attach to the outer (clipping) container. Wheel + pointer down land here. */
   containerRef: React.RefObject<HTMLDivElement>;
-  /** CSS transform string to apply to the inner content. */
-  style: { transform: string; transformOrigin: string };
+  /** CSS transform + will-change to apply to the inner content. */
+  style: {
+    transform: string;
+    transformOrigin: string;
+    willChange: "transform" | "auto";
+  };
   /** Reset to initial transform. */
   reset: () => void;
   /** Programmatically zoom in/out by a step (e.g. for +/- buttons). */
@@ -69,6 +73,34 @@ export function usePanZoom(opts: PanZoomOptions = {}): PanZoomController {
   const transformRef = useRef(transform);
   transformRef.current = transform;
 
+  // `will-change: transform` promotes the inner layer onto the GPU
+  // compositor so pan/zoom is cheap — but the layer is rasterized once
+  // and bitmap-scaled, so text and 1px borders blur at any non-1 scale.
+  // Pin it on only during active interaction; clear it ~200ms after the
+  // last gesture so the browser re-rasterizes at the displayed size and
+  // content snaps pixel-crisp at rest.
+  const [interacting, setInteracting] = useState(false);
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const markInteracting = useCallback(() => {
+    // Pointermove can fire at 120Hz — keep the per-event work minimal.
+    // Only flip state on the leading edge; otherwise just slide the
+    // idle timer forward.
+    if (idleTimerRef.current) {
+      clearTimeout(idleTimerRef.current);
+    } else {
+      setInteracting(true);
+    }
+    idleTimerRef.current = setTimeout(() => {
+      idleTimerRef.current = null;
+      setInteracting(false);
+    }, 200);
+  }, []);
+  useEffect(() => {
+    return () => {
+      if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+    };
+  }, []);
+
   // ── Wheel: zoom around cursor ──────────────────────────────────────
   useEffect(() => {
     const el = containerRef.current;
@@ -100,11 +132,12 @@ export function usePanZoom(opts: PanZoomOptions = {}): PanZoomController {
         y: cy - worldY * next,
         scale: next,
       });
+      markInteracting();
     };
 
     el.addEventListener("wheel", onWheel, { passive: false });
     return () => el.removeEventListener("wheel", onWheel);
-  }, [minScale, maxScale]);
+  }, [minScale, maxScale, markInteracting]);
 
   // ── Pointer drag: pan ──────────────────────────────────────────────
   useEffect(() => {
@@ -135,10 +168,12 @@ export function usePanZoom(opts: PanZoomOptions = {}): PanZoomController {
       if (!dragging) return;
       const dx = e.clientX - lastX;
       const dy = e.clientY - lastY;
+      if (dx === 0 && dy === 0) return;
       lastX = e.clientX;
       lastY = e.clientY;
       const cur = transformRef.current;
       setTransform({ x: cur.x + dx, y: cur.y + dy, scale: cur.scale });
+      markInteracting();
     };
 
     const stopDragging = () => {
@@ -164,9 +199,12 @@ export function usePanZoom(opts: PanZoomOptions = {}): PanZoomController {
       el.removeEventListener("pointercancel", stopDragging);
       el.removeEventListener("pointerleave", stopDragging);
     };
-  }, []);
+  }, [markInteracting]);
 
-  const reset = useCallback(() => setTransform(initial), [initial]);
+  const reset = useCallback(() => {
+    setTransform(initial);
+    markInteracting();
+  }, [initial, markInteracting]);
 
   const zoomBy = useCallback(
     (factor: number) => {
@@ -187,8 +225,9 @@ export function usePanZoom(opts: PanZoomOptions = {}): PanZoomController {
         y: cy - worldY * next,
         scale: next,
       });
+      markInteracting();
     },
-    [minScale, maxScale],
+    [minScale, maxScale, markInteracting],
   );
 
   return {
@@ -196,6 +235,7 @@ export function usePanZoom(opts: PanZoomOptions = {}): PanZoomController {
     style: {
       transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`,
       transformOrigin: "0 0",
+      willChange: interacting ? "transform" : "auto",
     },
     reset,
     zoomBy,


### PR DESCRIPTION
## Summary

- recovers the reverted pluggable runtime work from `49281a9` / PR #108 as a starting point
- restores runtime-registry based daemon dispatch and OpenCode adapter prior art
- adds a first `CodexRuntime` adapter using `codex exec --json`
- lets Codex pass the Beevibe session id via MCP URL query params when custom MCP headers are unavailable

### Per-turn runtime picker (5e7156e)

- Chat composer has a runtime dropdown; server resolves the choice to an online runtime, pins prior-session continuity, and rejects mid-conversation CLI switches (409).
- Dispatch payload now mirrors the claimed runtime's CLI (was always `agent.runtime_config.type`), so picking codex actually spawns codex.
- Codex adapter: fallback output drops non-JSON log noise — the `WARN codex_core_skills::loader` lines from the plugin loader no longer leak into chat replies. Added nested-delta extraction and a diagnostic `console.warn` when no assistant text was extractable, so the next failure surfaces the actual event shape in API logs.
- Pan/zoom: `will-change` is now scoped to active gestures so text stays pixel-crisp at non-1 scale when idle.

## Verification

- `pnpm --filter @beevibe/core typecheck`
- `pnpm --filter @beevibe/api typecheck`
- `pnpm --filter @beevibe/daemon typecheck`
- `pnpm --filter @beevibe/core test -- src/adapters/codex/runtime.test.ts src/adapters/opencode/runtime.test.ts src/adapters/runtime-registry.test.ts src/adapters/local-workspace/manager.test.ts`
- `pnpm --filter @beevibe/daemon test -- src/spawner.test.ts`

## Notes

API integration tests that require the local `beevibe_test` database were not run successfully in this shell because the database does not exist locally.

Related: #148