### PR TITLE
fix(runtime): use homedir as agent cwd

### DIFF
--- a/packages/core/src/adapters/claude-code/runtime.test.ts
+++ b/packages/core/src/adapters/claude-code/runtime.test.ts
@@ -57,12 +57,13 @@ afterEach(() => {
 });
 
 describe("ClaudeCodeRuntime.execute", () => {
-  it("sets cwd to workspace.path and derives mcpConfigPath inside it", async () => {
+  it("sets cwd to homedir and derives mcpConfigPath from workspace.path", async () => {
     mockRunCli();
     const runtime = new ClaudeCodeRuntime();
     await runtime.execute(ctx({ workspace: { path: "/sandbox/agent_xyz" } }));
 
-    expect(lastOptions?.cwd).toBe("/sandbox/agent_xyz");
+    const { homedir } = await import("node:os");
+    expect(lastOptions?.cwd).toBe(homedir());
     const mcpIdx = lastOptions!.args!.indexOf("--mcp-config");
     expect(mcpIdx).toBeGreaterThan(-1);
     expect(lastOptions!.args![mcpIdx + 1]).toBe("/sandbox/agent_xyz/mcp-config.json");

--- a/packages/core/src/adapters/claude-code/runtime.ts
+++ b/packages/core/src/adapters/claude-code/runtime.ts
@@ -1,4 +1,4 @@
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import type {
   AgentRuntime,
@@ -69,8 +69,8 @@ export class ClaudeCodeRuntime implements AgentRuntime {
   constructor(private config: ClaudeCodeRuntimeConfig = {}) {}
 
   async execute(context: RuntimeContext): Promise<RuntimeResult> {
-    const cwd = context.workspace.path;
-    const mcpConfigPath = join(cwd, "mcp-config.json");
+    const cwd = homedir();
+    const mcpConfigPath = join(context.workspace.path, "mcp-config.json");
 
     const args = [
       "--print",


### PR DESCRIPTION
## Summary
- Agent sessions now run from `~/` instead of the Beevibe workspace sandbox
- MCP config path still resolves from the workspace, so tools work as before
- Matches the behavior of a normal local `claude` or `codex` session

## Test plan
- [ ] Start an agent session and confirm it can access files in `~/Downloads`, `~/Projects`, etc.
- [ ] Confirm MCP tools (memory, tasks, rooms) still work — config path unchanged
- [ ] Confirm `--resume` sessions still work

🤖 Generated with [Claude Code](https://claude.ai/claude-code)