### PR TITLE
fix(routing): team agents cannot handle specialist work directly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,121 @@
+# Beevibe — Claude Code Guide
+
+## Monorepo structure
+
+```
+packages/
+  core/       shared domain, ports, services, adapters — compiled to dist/
+  api/        Express API + MCP server (tsx watch src/main.ts)
+  daemon/     Local agent runner (tsx watch src/main.ts start)
+  scheduler/  Cron + background jobs
+  web/        Next.js frontend
+scripts/
+  dev.sh      One-command local stack (postgres + core watch + api + scheduler)
+```
+
+## Running locally
+
+```bash
+pnpm dev          # everything: postgres, core watcher, api, scheduler, tunnel
+pnpm dev --no-tunnel
+```
+
+`pnpm dev` now:
+1. Kills any stale beevibe processes from previous runs
+2. Starts `tsc --watch` for `@beevibe/core` so source changes compile automatically
+3. Starts API and scheduler (tsx watch, reload on file change)
+
+The **daemon** is NOT started by `pnpm dev` — start it separately:
+```bash
+cd packages/daemon && npx tsx watch src/main.ts start
+```
+
+## Critical: @beevibe/core compiles to dist/
+
+`packages/core/package.json` exports point to `./dist/`, not `./src/`. Changes
+to `packages/core/src/**` are **invisible** to the API and daemon until compiled.
+
+`pnpm dev` now runs `tsc --watch` for core automatically. If you're not using
+`pnpm dev` (e.g. running the API standalone), rebuild manually first:
+
+```bash
+pnpm --filter @beevibe/core build
+```
+
+After a core rebuild, touch a file in the consuming package to force tsx reload:
+```bash
+touch packages/api/src/runtime/router.ts   # reload API
+touch packages/daemon/src/spawner.ts       # reload daemon
+```
+
+## Restarting cleanly
+
+`pnpm dev` uses `trap 'kill 0' EXIT` but only kills its own children. If you
+close the terminal without Ctrl+C, tsx/node processes linger and hold ports.
+
+To fully reset:
+```bash
+pkill -f "beevibe/(packages|scripts)"
+pkill -f "daemon/src/main"
+```
+
+Or just run `pnpm dev` — it does this cleanup at the start now.
+
+## Agent runtime (Claude Code CLI)
+
+- The CLI binary is `claude` on PATH
+- Sessions spawn with `--dangerously-skip-permissions --strict-mcp-config`
+- MCP config lives in `~/.beevibe/workspaces/<agent_id>/mcp-config.json`
+- Agent cwd is `homedir()` (not the workspace) — gives file system access like a normal local Claude session
+- Team agents in chat get `--disallowedTools Agent,Bash,Read,Write,Edit,Glob,...` to prevent self-handling of specialist work
+
+## Team agent routing
+
+Team agents (hierarchy_level = 'team') in chat sessions:
+- Are blocked from file/shell/subagent tools via `--disallowedTools`
+- Only have beevibe MCP tools available
+- Must route work to subordinate specialists or recommend spawning one
+- Routing directive fires post-onboarding, even with zero subordinates
+
+Routing is enforced structurally (tool restriction), not just by prompt.
+
+## Checking if a change is live
+
+```bash
+# API PID — if unchanged after touching a file, tsx didn't reload
+lsof -i :3000 -sTCP:LISTEN | grep LISTEN
+
+# Daemon log
+tail -f /tmp/beevibe-daemon.log
+
+# Verify core dist has your change
+grep "your_symbol" packages/core/dist/adapters/claude-code/runtime.js
+```
+
+## Claude Code CLI flags — check before using
+
+```bash
+claude --help | grep -A2 "allowed\|disallowed"
+```
+
+- `--allowedTools` / `--disallowedTools`: comma or space-separated tool names
+- Wildcards like `mcp__beevibe__*` are NOT supported — use explicit names or disallow the ones you don't want
+- `Agent` is a tool name (spawns subagents) — disallow it to prevent escape hatches
+
+## Database
+
+```bash
+# Local postgres via docker-compose
+docker exec beevibe-postgres psql -U beevibe -d beevibe -c "SELECT ..."
+
+# Connection string
+DATABASE_URL=postgresql://beevibe:beevibe@localhost:5433/beevibe
+```
+
+## Deploying
+
+```bash
+vercel --prod   # from beevibe-marketing for the marketing site
+```
+
+API deploys separately — see Vercel project settings.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Or just run `pnpm dev` — it does this cleanup at the start now.
 - The CLI binary is `claude` on PATH
 - Sessions spawn with `--dangerously-skip-permissions --strict-mcp-config`
 - MCP config lives in `~/.beevibe/workspaces/<agent_id>/mcp-config.json`
-- Agent cwd is `homedir()` (not the workspace) — gives file system access like a normal local Claude session
+- Agent cwd is the workspace path (`~/.beevibe/workspaces/<agent_id>`)
 - Team agents in chat get `--disallowedTools Agent,Bash,Read,Write,Edit,Glob,...` to prevent self-handling of specialist work
 
 ## Team agent routing

--- a/packages/api/src/runtime/router.ts
+++ b/packages/api/src/runtime/router.ts
@@ -427,12 +427,12 @@ async function composeDispatchPayload(
       ? deps.agentRepo.findSubordinates(agent.id)
       : Promise.resolve([]),
   ]);
-  // Team-agent routing only fires post-onboarding (the onboarding
-  // directives drive the build-your-team conversation themselves) and
-  // only when there's at least one specialist to route to.
+  // Team-agent routing fires post-onboarding for all team chat sessions —
+  // whether or not there are specialists yet. With no specialists the
+  // directive tells the agent to spawn one rather than do the work itself.
   const isOnboarding = isChat && !owner?.onboarding_completed_at;
   const teamRouting =
-    isTeamChat && !isOnboarding && subordinates.length > 0
+    isTeamChat && !isOnboarding
       ? teamAgentRoutingDirective(subordinates.map((s) => s.name))
       : "";
 
@@ -468,6 +468,7 @@ async function composeDispatchPayload(
     resume_session_id: priorSession?.cli_session_id,
     model: agent.runtime_config.model,
     max_turns: agent.runtime_config.max_turns,
+    disallowed_tools: isTeamChat ? ["Agent", "Bash", "Read", "Write", "Edit", "MultiEdit", "Glob", "NotebookRead", "NotebookEdit", "WebSearch", "WebFetch"] : undefined,
     env: { BEEVIBE_SESSION_ID: session.id, BEEVIBE_AGENT_ID: agent.id },
     type: session.type,
     mcp_server_url: deps.mcpServerUrl,

--- a/packages/api/src/runtime/router.ts
+++ b/packages/api/src/runtime/router.ts
@@ -25,6 +25,7 @@ import type { MemoryAgent } from "@beevibe/core/services/memory";
 import {
   composeIntent,
   composeSystemPromptAppend,
+  TEAM_COORDINATOR_DISALLOWED_TOOLS,
   teamAgentRoutingDirective,
 } from "@beevibe/core/services/agent-session";
 import { requireDaemon, requireHuman } from "../auth/middleware.js";
@@ -468,7 +469,7 @@ async function composeDispatchPayload(
     resume_session_id: priorSession?.cli_session_id,
     model: agent.runtime_config.model,
     max_turns: agent.runtime_config.max_turns,
-    disallowed_tools: isTeamChat ? ["Agent", "Bash", "Read", "Write", "Edit", "MultiEdit", "Glob", "NotebookRead", "NotebookEdit", "WebSearch", "WebFetch"] : undefined,
+    disallowed_tools: isTeamChat ? [...TEAM_COORDINATOR_DISALLOWED_TOOLS] : undefined,
     env: { BEEVIBE_SESSION_ID: session.id, BEEVIBE_AGENT_ID: agent.id },
     type: session.type,
     mcp_server_url: deps.mcpServerUrl,

--- a/packages/api/src/runtime/types.ts
+++ b/packages/api/src/runtime/types.ts
@@ -69,6 +69,8 @@ export interface DispatchPayload {
   max_turns?: number;
   /** Session-scoped env vars; daemon merges with its own when spawning. */
   env: Record<string, string>;
+  /** Tools blocked via --disallowedTools. Set for team-agent chat sessions. */
+  disallowed_tools?: string[];
   type: SessionType;
   /** /mcp endpoint daemon writes into mcp-config.json. */
   mcp_server_url: string;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -89,6 +89,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint src",
     "test": "vitest run",

--- a/packages/core/src/adapters/claude-code/runtime.test.ts
+++ b/packages/core/src/adapters/claude-code/runtime.test.ts
@@ -57,12 +57,13 @@ afterEach(() => {
 });
 
 describe("ClaudeCodeRuntime.execute", () => {
-  it("sets cwd to workspace.path and derives mcpConfigPath inside it", async () => {
+  it("sets cwd to homedir and derives mcpConfigPath from workspace.path", async () => {
     mockRunCli();
     const runtime = new ClaudeCodeRuntime();
     await runtime.execute(ctx({ workspace: { path: "/sandbox/agent_xyz" } }));
 
-    expect(lastOptions?.cwd).toBe("/sandbox/agent_xyz");
+    const { homedir } = await import("node:os");
+    expect(lastOptions?.cwd).toBe(homedir());
     const mcpIdx = lastOptions!.args!.indexOf("--mcp-config");
     expect(mcpIdx).toBeGreaterThan(-1);
     expect(lastOptions!.args![mcpIdx + 1]).toBe("/sandbox/agent_xyz/mcp-config.json");

--- a/packages/core/src/adapters/claude-code/runtime.test.ts
+++ b/packages/core/src/adapters/claude-code/runtime.test.ts
@@ -57,13 +57,12 @@ afterEach(() => {
 });
 
 describe("ClaudeCodeRuntime.execute", () => {
-  it("sets cwd to homedir and derives mcpConfigPath from workspace.path", async () => {
+  it("sets cwd to workspace.path and derives mcpConfigPath inside it", async () => {
     mockRunCli();
     const runtime = new ClaudeCodeRuntime();
     await runtime.execute(ctx({ workspace: { path: "/sandbox/agent_xyz" } }));
 
-    const { homedir } = await import("node:os");
-    expect(lastOptions?.cwd).toBe(homedir());
+    expect(lastOptions?.cwd).toBe("/sandbox/agent_xyz");
     const mcpIdx = lastOptions!.args!.indexOf("--mcp-config");
     expect(mcpIdx).toBeGreaterThan(-1);
     expect(lastOptions!.args![mcpIdx + 1]).toBe("/sandbox/agent_xyz/mcp-config.json");

--- a/packages/core/src/adapters/claude-code/runtime.ts
+++ b/packages/core/src/adapters/claude-code/runtime.ts
@@ -1,4 +1,4 @@
-import { homedir, tmpdir } from "node:os";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type {
   AgentRuntime,
@@ -69,8 +69,8 @@ export class ClaudeCodeRuntime implements AgentRuntime {
   constructor(private config: ClaudeCodeRuntimeConfig = {}) {}
 
   async execute(context: RuntimeContext): Promise<RuntimeResult> {
-    const cwd = homedir();
-    const mcpConfigPath = join(context.workspace.path, "mcp-config.json");
+    const cwd = context.workspace.path;
+    const mcpConfigPath = join(cwd, "mcp-config.json");
 
     const args = [
       "--print",

--- a/packages/core/src/adapters/claude-code/runtime.ts
+++ b/packages/core/src/adapters/claude-code/runtime.ts
@@ -1,4 +1,4 @@
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import type {
   AgentRuntime,
@@ -69,8 +69,8 @@ export class ClaudeCodeRuntime implements AgentRuntime {
   constructor(private config: ClaudeCodeRuntimeConfig = {}) {}
 
   async execute(context: RuntimeContext): Promise<RuntimeResult> {
-    const cwd = context.workspace.path;
-    const mcpConfigPath = join(cwd, "mcp-config.json");
+    const cwd = homedir();
+    const mcpConfigPath = join(context.workspace.path, "mcp-config.json");
 
     const args = [
       "--print",
@@ -88,6 +88,9 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     const maxTurns = context.max_turns ?? this.config.maxTurns;
     if (maxTurns) args.push("--max-turns", String(maxTurns));
     if (context.resume_session_id) args.push("--resume", context.resume_session_id);
+    if (context.disallowed_tools && context.disallowed_tools.length > 0) {
+      args.push("--disallowedTools", context.disallowed_tools.join(","));
+    }
     if (context.system_prompt_append.length > 0) {
       args.push("--append-system-prompt", context.system_prompt_append);
     }

--- a/packages/core/src/adapters/claude-code/runtime.ts
+++ b/packages/core/src/adapters/claude-code/runtime.ts
@@ -88,7 +88,7 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     const maxTurns = context.max_turns ?? this.config.maxTurns;
     if (maxTurns) args.push("--max-turns", String(maxTurns));
     if (context.resume_session_id) args.push("--resume", context.resume_session_id);
-    if (context.disallowed_tools && context.disallowed_tools.length > 0) {
+    if (context.disallowed_tools?.length) {
       args.push("--disallowedTools", context.disallowed_tools.join(","));
     }
     if (context.system_prompt_append.length > 0) {

--- a/packages/core/src/ports/runtime.ts
+++ b/packages/core/src/ports/runtime.ts
@@ -72,6 +72,13 @@ export interface RuntimeContext {
   max_turns?: number;
 
   /**
+   * Tools the CLI must not call. When set, passed as `--disallowedTools`
+   * to the Claude Code CLI. Used to prevent team agents from using
+   * file-system / shell tools directly.
+   */
+  disallowed_tools?: string[];
+
+  /**
    * Content appended to Claude Code's baseline system prompt via
    * `--append-system-prompt`. Required: AgentSession composes this from the
    * agent's `runtime_config.system_prompt_addition` baseline plus the memory

--- a/packages/core/src/services/agent-session.ts
+++ b/packages/core/src/services/agent-session.ts
@@ -19,6 +19,7 @@ export {
   BEEVIBE_MEMORY_REMINDER,
   CHAT_DIRECTIVES,
   ONBOARDING_DIRECTIVES,
+  TEAM_COORDINATOR_DISALLOWED_TOOLS,
   composeIntent,
   composeSystemPromptAppend,
   teamAgentRoutingDirective,

--- a/packages/core/src/services/spawn-prep.test.ts
+++ b/packages/core/src/services/spawn-prep.test.ts
@@ -7,8 +7,12 @@ import {
 } from "./spawn-prep.js";
 
 describe("teamAgentRoutingDirective", () => {
-  it("returns empty string when there are no specialists", () => {
-    expect(teamAgentRoutingDirective([])).toBe("");
+  it("still fires with no specialists — tells agent to spawn one, not handle work itself", () => {
+    const out = teamAgentRoutingDirective([]);
+    expect(out).toContain("team_agent_routing");
+    expect(out).toContain("TEAM AGENT");
+    expect(out.toLowerCase()).toContain("no specialists");
+    expect(out.toLowerCase()).toContain("do not handle");
   });
 
   it("includes each specialist name as a list item", () => {
@@ -22,7 +26,6 @@ describe("teamAgentRoutingDirective", () => {
     const out = teamAgentRoutingDirective(["frontend"]);
     expect(out).toContain("TEAM AGENT");
     expect(out).toContain("ROUTE");
-    // The "delegate-don't-absorb" anti-pattern is named explicitly.
     expect(out.toLowerCase()).toContain("absorb");
   });
 
@@ -49,12 +52,12 @@ describe("composeSystemPromptAppend with extra", () => {
     );
   });
 
-  it("omits the team-routing block entirely when specialists is empty", () => {
+  it("includes team-routing block even when specialists is empty", () => {
     const out = composeSystemPromptAppend(undefined, "<core_memory/>", {
       sessionKind: "chat",
       extra: teamAgentRoutingDirective([]),
     });
-    expect(out).not.toContain("team_agent_routing");
+    expect(out).toContain("team_agent_routing");
   });
 });
 
@@ -102,9 +105,13 @@ describe("composeSystemPromptAppend lifecycle branching", () => {
   });
 
   it("chat variant still allows create_task for team/org tier", () => {
-    // Discrete work surfaced mid-chat should still be promote-able to
-    // a tracked task — keep the affordance explicit.
     expect(BEEVIBE_LIFECYCLE_REMINDER_CHAT).toContain("create_task");
+  });
+
+  it("chat variant does not tell team agents to assign work to themselves", () => {
+    // The 'or to yourself when it is your specialty' clause was a loophole
+    // that caused team agents to handle specialist work directly.
+    expect(BEEVIBE_LIFECYCLE_REMINDER_CHAT).not.toContain("to yourself");
   });
 
   it("both variants share the outer <beevibe_lifecycle> tag so downstream parsing is stable", () => {

--- a/packages/core/src/services/spawn-prep.ts
+++ b/packages/core/src/services/spawn-prep.ts
@@ -315,24 +315,34 @@ directives the UI understands:
 </chat_directives>`;
 
 /**
- * Team-agent routing directive — appended only when the caller's primary
- * agent is hierarchy_level='team' AND has at least one subordinate. Tells
- * the agent its job is to *route* work, not do it itself.
+ * Tools team agents are blocked from using in chat sessions. Enforced
+ * structurally via --disallowedTools so the model cannot self-handle
+ * specialist work even if it ignores the routing prompt.
  *
- * Without this, a smart Claude tends to absorb requests into its own reply
- * (drafting the deliverable, asking great clarifying questions) instead of
- * recognizing whose domain the work belongs to or noting a domain gap.
- *
- * Returns the empty string for callers with no specialists yet — onboarding
- * directives already cover the "build your first specialists" conversation.
+ * Exported so router.ts can pass the same list to the CLI without
+ * maintaining a separate copy that could drift.
  */
+export const TEAM_COORDINATOR_DISALLOWED_TOOLS = [
+  "Agent",
+  "Bash",
+  "Read",
+  "Write",
+  "Edit",
+  "MultiEdit",
+  "Glob",
+  "NotebookRead",
+  "NotebookEdit",
+  "WebSearch",
+  "WebFetch",
+] as const;
+
 export function teamAgentRoutingDirective(
   specialistNames: readonly string[],
 ): string {
   const rosterSection =
     specialistNames.length > 0
-      ? `Your team currently has these specialists:\n\n${specialistNames.map((n) => `  - ${n}`).join("\n")}\n\nWhen the user brings work, your default move is to ROUTE it, not do it yourself:\n\n1. **Match the request's primary skill axis to an existing specialist.** Frontend? backend? data? comms? design? mobile? Look at the names above. If one fits, propose handing off — append a chip like:\n\n   \`<suggest_action label="Hand off to backend specialist" prompt="hand this off to the backend specialist" />\`\n\n2. **If no specialist owns it, name the gap.** Don't paper over it by absorbing the work yourself. Say plainly: "you have X, Y, Z — but nobody owns <domain>." Recommend spawning a new specialist with a concrete name + scope, and append:\n\n   \`<suggest_action label="Spawn <name> specialist" prompt="yes, draft the spec and spawn the specialist" />\``
-      : `You have no specialists yet. **Do not handle this request yourself.** Your only move is to identify what kind of specialist is needed, recommend spawning one with a concrete name and scope, and append:\n\n   \`<suggest_action label="Spawn <name> specialist" prompt="yes, draft the spec and spawn the specialist" />\``;
+      ? withSpecialists(specialistNames)
+      : withoutSpecialists();
   return `<team_agent_routing>
 You are a TEAM AGENT — a coordinator, not a specialist. ${rosterSection}
 
@@ -340,6 +350,29 @@ You are a TEAM AGENT — a coordinator, not a specialist. ${rosterSection}
 
 Clarifying questions are fine and encouraged — but ask them in service of *routing* the work, not in service of you doing it.
 </team_agent_routing>`;
+}
+
+function withSpecialists(names: readonly string[]): string {
+  const list = names.map((n) => `  - ${n}`).join("\n");
+  return `Your team currently has these specialists:
+
+${list}
+
+When the user brings work, your default move is to ROUTE it, not do it yourself:
+
+1. **Match the request's primary skill axis to an existing specialist.** Frontend? backend? data? comms? design? mobile? Look at the names above. If one fits, propose handing off — append a chip like:
+
+   \`<suggest_action label="Hand off to backend specialist" prompt="hand this off to the backend specialist" />\`
+
+2. **If no specialist owns it, name the gap.** Don't paper over it by absorbing the work yourself. Say plainly: "you have X, Y, Z — but nobody owns <domain>." Recommend spawning a new specialist with a concrete name + scope, and append:
+
+   \`<suggest_action label="Spawn <name> specialist" prompt="yes, draft the spec and spawn the specialist" />\``;
+}
+
+function withoutSpecialists(): string {
+  return `You have no specialists yet. **Do not handle this request yourself.** Your only move is to identify what kind of specialist is needed, recommend spawning one with a concrete name and scope, and append:
+
+   \`<suggest_action label="Spawn <name> specialist" prompt="yes, draft the spec and spawn the specialist" />\``;
 }
 
 /**

--- a/packages/core/src/services/spawn-prep.ts
+++ b/packages/core/src/services/spawn-prep.ts
@@ -95,10 +95,11 @@ work_product to record.
 
 2. If the user describes a discrete unit of work (a deliverable, a fix,
    a research goal) and you are team or org tier, you may call
-   mcp__beevibe__create_task to spawn it as a tracked task — to a
-   subordinate (call mcp__beevibe__find_subordinates first to pick a
-   matching specialty) when the domain fits them, or to yourself when
-   it is your specialty.
+   mcp__beevibe__create_task to spawn it as a tracked task — always to a
+   subordinate specialist (call mcp__beevibe__find_subordinates first to
+   pick a matching specialty). Team agents do not take on specialist work
+   themselves; if no subordinate fits, name the gap and recommend spawning
+   one.
 
 3. Memory management (see <beevibe_memory>) is especially valuable in
    chat. Preferences, decisions, and durable context surface here first;
@@ -328,21 +329,12 @@ directives the UI understands:
 export function teamAgentRoutingDirective(
   specialistNames: readonly string[],
 ): string {
-  if (specialistNames.length === 0) return "";
+  const rosterSection =
+    specialistNames.length > 0
+      ? `Your team currently has these specialists:\n\n${specialistNames.map((n) => `  - ${n}`).join("\n")}\n\nWhen the user brings work, your default move is to ROUTE it, not do it yourself:\n\n1. **Match the request's primary skill axis to an existing specialist.** Frontend? backend? data? comms? design? mobile? Look at the names above. If one fits, propose handing off — append a chip like:\n\n   \`<suggest_action label="Hand off to backend specialist" prompt="hand this off to the backend specialist" />\`\n\n2. **If no specialist owns it, name the gap.** Don't paper over it by absorbing the work yourself. Say plainly: "you have X, Y, Z — but nobody owns <domain>." Recommend spawning a new specialist with a concrete name + scope, and append:\n\n   \`<suggest_action label="Spawn <name> specialist" prompt="yes, draft the spec and spawn the specialist" />\``
+      : `You have no specialists yet. **Do not handle this request yourself.** Your only move is to identify what kind of specialist is needed, recommend spawning one with a concrete name and scope, and append:\n\n   \`<suggest_action label="Spawn <name> specialist" prompt="yes, draft the spec and spawn the specialist" />\``;
   return `<team_agent_routing>
-You are a TEAM AGENT — a coordinator, not a specialist. Your team currently has these specialists:
-
-${specialistNames.map((n) => `  - ${n}`).join("\n")}
-
-When the user brings work, your default move is to ROUTE it, not do it yourself:
-
-1. **Match the request's primary skill axis to an existing specialist.** Frontend? backend? data? comms? design? mobile? Look at the names above. If one fits, propose handing off — append a chip like:
-
-   \`<suggest_action label="Hand off to backend specialist" prompt="hand this off to the backend specialist" />\`
-
-2. **If no specialist owns it, name the gap.** Don't paper over it by absorbing the work yourself. Say plainly: "you have X, Y, Z — but nobody owns <domain>." Recommend spawning a new specialist with a concrete name + scope, and append:
-
-   \`<suggest_action label="Spawn <name> specialist" prompt="yes, draft the spec and spawn the specialist" />\`
+You are a TEAM AGENT — a coordinator, not a specialist. ${rosterSection}
 
 3. **You don't do specialist work yourself.** If you find yourself drafting the actual deliverable (writing the code, the copy, the analysis), stop — that's the signal that this request needs a specialist. Your job is recognizing whose domain this is, recommending the handoff or the gap, and getting the human to a fast next click.
 

--- a/packages/daemon/src/spawner.ts
+++ b/packages/daemon/src/spawner.ts
@@ -25,6 +25,7 @@ export interface DispatchPayload {
   model?: string;
   max_turns?: number;
   env: Record<string, string>;
+  disallowed_tools?: string[];
   type: "task" | "mesh_ask" | "mesh_negotiate" | "blocker" | "chat";
   mcp_server_url: string;
 }
@@ -120,6 +121,7 @@ export async function runDispatch(
       system_prompt_append: payload.system_prompt_append,
       model: payload.model,
       max_turns: payload.max_turns,
+      disallowed_tools: payload.disallowed_tools,
       env: payload.env,
       resume_session_id: payload.resume_session_id,
       abort_signal: abortSignal,

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -113,8 +113,27 @@ echo "  Scheduler:     health on http://localhost:${BEEVIBE_SCHEDULER_HEALTH_POR
 echo "  Workspace:     ${WORKSPACE_ROOT:-~/.beevibe/workspaces}"
 echo ""
 
+# ─────────────────── kill stale processes ───────────────────
+# Previous pnpm dev runs leave tsx/node children alive if the terminal
+# was closed rather than Ctrl+C'd. Kill them so the new run gets clean
+# ports and reloads the latest @beevibe/core dist.
+echo "==> Killing any stale beevibe processes..."
+pkill -f "beevibe/(packages|scripts)" 2>/dev/null || true
+pkill -f "daemon/src/main" 2>/dev/null || true
+sleep 1
+
 # Kill all children on exit (Ctrl+C, error, normal end).
 trap 'kill 0' EXIT
+
+# ─────────────────── core watch (compile-on-save) ───────────────────
+# @beevibe/core resolves to dist/ — changes to src/ are invisible to
+# the API and daemon until tsc recompiles. Run tsc --watch in the
+# background so edits land in dist/ automatically.
+pnpm --filter @beevibe/core dev 2>&1 \
+  | sed -u 's/^/[core] /' &
+
+# Give tsc one initial compile pass before starting consumers.
+sleep 3
 
 # Prefix each service's logs so a single terminal stays readable.
 pnpm --filter @beevibe/api dev 2>&1 \


### PR DESCRIPTION
## Summary

Team agents in chat were attempting to handle specialist tasks themselves (searching for files, running Bash, spawning subagents) instead of routing to specialists.

**Root causes fixed:**
- Routing directive only fired when subordinates existed — now fires always post-onboarding
- Lifecycle reminder said "or to yourself when it is your specialty" — removed that loophole
- Prompt-only enforcement wasn't enough — Claude ignored it and tried to help anyway

**Structural fix:** `--disallowedTools Agent,Bash,Read,Write,Edit,MultiEdit,Glob,...` is now passed to the CLI for all team agent chat sessions. The `Agent` tool is included to block the subagent escape hatch (agent spawning a subagent that then runs Bash).

**Dev pipeline fixes also included:**
- `CLAUDE.md` added documenting the monorepo, core build requirement, and agent routing behavior
- `@beevibe/core` gains a `dev` script (`tsc --watch`) so source changes compile automatically
- `scripts/dev.sh` kills stale processes at startup and runs the core watcher before API/scheduler

## Test plan
- [ ] Team agent chat responds "I have no specialists / here's who can do this" rather than attempting the task
- [ ] `pnpm dev` kills stale processes and auto-compiles core on change

🤖 Generated with [Claude Code](https://claude.com/claude-code)