### PR TITLE
fix(chat): wire client session_id so live steps appear while agent is running

### DIFF
--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -556,6 +556,7 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
         intent: messageRaw,
         reason,
         type: "chat",
+        sessionIdOverride: callerSessionId,
       });
     } catch (err) {
       rateOutcome.release();


### PR DESCRIPTION
## What was wrong

`mintSessionId()` pre-generates a session ID client-side so `useChatStream` can subscribe to SSE events immediately on send. But `dispatchTask` was ignoring it and generating its own — SSE step events fired for a session ID the client wasn't watching, so the `Thinking` component received nothing and the user saw a blank spinner for the full 1–2 minute session.

## Fix

Pass `callerSessionId` as `sessionIdOverride` to `dispatchTask`. The field already existed in `DispatchInput` — it just wasn't being used from the chat route.

## Result

Tool calls and agent text now stream into the `Thinking` component in real time as the session runs, instead of appearing all at once at the end.

## Test plan
- [ ] Send a chat message and confirm tool steps appear (e.g. "Glob", "Bash") before the final response
- [ ] Idempotent replay still works (sending the same `session_id` twice returns cached result)

🤖 Generated with [Claude Code](https://claude.com/claude-code)