### PR TITLE
feat: persist work product body + daemon fetch resilience

### DIFF
--- a/migrations/1780800000000_add-work-product-body.sql
+++ b/migrations/1780800000000_add-work-product-body.sql
@@ -1,0 +1,7 @@
+-- Adds work_product.body so specialists can persist the actual deliverable
+-- content (extracted tables, parsed analysis, full documents). Before this
+-- column, content was either stashed in metadata or stranded in
+-- session_event transcripts the dispatching agent could not see.
+
+ALTER TABLE work_product
+  ADD COLUMN body TEXT;

--- a/packages/api/src/routes/mcp.test.ts
+++ b/packages/api/src/routes/mcp.test.ts
@@ -133,8 +133,7 @@ describe.skipIf(!HAS_LIVE_API_KEYS)("/mcp router — integration", () => {
       });
 
       // Initialize was called inside connect. Inspect server info + tools.
-      // Team-tier caller gets 23 tools (Phase 9 added create_subordinate_agent):
-      //   2 memory + 15 hierarchy + 6 mesh.
+      // Team-tier caller gets 24 tools: 2 memory + 16 hierarchy + 6 mesh.
       const tools = await client.listTools();
       expect(tools.tools.map((t) => t.name).sort()).toEqual([
         "add_to_escalation",
@@ -149,6 +148,7 @@ describe.skipIf(!HAS_LIVE_API_KEYS)("/mcp router — integration", () => {
         "find_up",
         "get_agent_profile",
         "get_task",
+        "get_work_product",
         "list_work_products",
         "negotiate",
         "report_blocker",
@@ -192,7 +192,7 @@ describe.skipIf(!HAS_LIVE_API_KEYS)("/mcp router — integration", () => {
       const mcpSid = transport.sessionId;
       expect(mcpSid).toBeTruthy();
 
-      // tools/list — human caller, agent is team-tier → 22 tools.
+      // tools/list — human caller, agent is team-tier → 24 tools.
       const tools = await client.listTools();
       const names = tools.tools.map((t) => t.name);
       expect(names).toContain("save_memory");
@@ -204,8 +204,8 @@ describe.skipIf(!HAS_LIVE_API_KEYS)("/mcp router — integration", () => {
       expect(names).toContain("add_to_escalation");
       expect(names).toContain("revise_task");
       expect(names).toContain("create_subordinate_agent");
-      // Phase 9 added create_subordinate_agent → 23 (was 22).
-      expect(tools.tools.length).toBe(23);
+      expect(names).toContain("get_work_product");
+      expect(tools.tools.length).toBe(24);
 
       // tools/call save_memory — should write a fact stamped with the auto-
       // created beevibe chat session id. We don't know the sid client-side;

--- a/packages/api/src/tools/assemble.test.ts
+++ b/packages/api/src/tools/assemble.test.ts
@@ -79,20 +79,21 @@ function icCtx(spawnMode?: AssembleToolsContext["spawnMode"]): AssembleToolsCont
 }
 
 describe("assembleTools — daemon (full surface)", () => {
-  it("team caller gets the full team surface (23 tools)", () => {
+  it("team caller gets the full team surface (24 tools)", () => {
     const tools = assembleTools(teamCtx(), buildMinimalServices());
-    expect(tools.length).toBe(23);
+    expect(tools.length).toBe(24);
     const names = new Set(tools.map((t) => t.name));
     expect(names.has("create_task")).toBe(true);
     expect(names.has("update_work_product")).toBe(true);
+    expect(names.has("get_work_product")).toBe(true);
     expect(names.has("revise_task")).toBe(true);
     expect(names.has("add_to_escalation")).toBe(true);
     expect(names.has("create_subordinate_agent")).toBe(true);
   });
 
-  it("ic caller gets the IC surface (12 tools)", () => {
+  it("ic caller gets the IC surface (13 tools)", () => {
     const tools = assembleTools(icCtx(), buildMinimalServices());
-    expect(tools.length).toBe(12);
+    expect(tools.length).toBe(13);
     const names = new Set(tools.map((t) => t.name));
     expect(names.has("create_task")).toBe(false);
     expect(names.has("respond_ask")).toBe(true);

--- a/packages/api/src/tools/assemble.ts
+++ b/packages/api/src/tools/assemble.ts
@@ -69,6 +69,7 @@ const FALLBACK_ALLOWED_HIERARCHY = new Set([
   "get_agent_profile",
   "get_task",
   "list_work_products",
+  "get_work_product",
   "find_subordinates",
   "find_peers",
   "check_work_status",
@@ -81,16 +82,16 @@ const FALLBACK_ALLOWED_HIERARCHY = new Set([
  *
  * Tier breakdown (M9.1 final):
  *
- *   IC (12 tools):
+ *   IC (13 tools):
  *     2 memory: save_memory, update_core_memory
- *     8 hierarchy (shared): search_context, update_progress, find_up,
+ *     9 hierarchy (shared): search_context, update_progress, find_up,
  *       get_agent_profile, get_task, create_work_product,
- *       list_work_products, update_work_product
+ *       list_work_products, get_work_product, update_work_product
  *     2 mesh: respond_ask (when targeted by team-tier `ask`),
  *             report_blocker (escalate up to direct parent)
  *
- *   Team / org (23 tools):
- *     2 memory + 14 hierarchy (8 shared + 6 team-only) +
+ *   Team / org (24 tools):
+ *     2 memory + 15 hierarchy (9 shared + 6 team-only) +
  *     6 mesh (ask, respond_ask, negotiate, respond_negotiate,
  *             report_blocker, escalate_to_humans).
  *

--- a/packages/api/src/tools/hierarchy.test.ts
+++ b/packages/api/src/tools/hierarchy.test.ts
@@ -15,6 +15,7 @@ import type {
   Task,
   TaskRepository,
   WorkProduct,
+  WorkProductListItem,
   WorkProductRepository,
 } from "@beevibe/core";
 import type { MemoryAgent } from "@beevibe/core/services/memory";
@@ -67,6 +68,13 @@ function fakeWp(overrides: Partial<WorkProduct> = {}): WorkProduct {
   };
 }
 
+function fakeWpListItem(
+  overrides: Partial<WorkProductListItem> = {},
+): WorkProductListItem {
+  const { body: _body, ...rest } = fakeWp();
+  return { ...rest, body_bytes: 0, ...overrides };
+}
+
 function buildServices(overrides: {
   agentRepo?: Partial<AgentRepository>;
   taskRepo?: Partial<TaskRepository>;
@@ -102,6 +110,7 @@ function buildServices(overrides: {
     reviseTask: vi.fn(async () => fakeTask({ status: "needs_revision" })),
     createWorkProduct: vi.fn(async (input) => fakeWp(input as Partial<WorkProduct>)),
     listWorkProducts: vi.fn(async () => []),
+    getWorkProduct: vi.fn(async () => undefined),
     updateWorkProduct: vi.fn(async (id) => fakeWp({ id })),
     ...overrides.taskService,
   } as unknown as TaskService;
@@ -184,7 +193,7 @@ async function callTool(
 // ── Tier gating ──────────────────────────────────────────────────────────
 
 describe("buildHierarchyTools — IC vs team gating", () => {
-  it("IC tier exposes 8 shared tools (no find_subordinates / find_peers / create_task / check_work_status)", () => {
+  it("IC tier exposes 9 shared tools (no find_subordinates / find_peers / create_task / check_work_status)", () => {
     const tools = buildHierarchyTools(
       { agentId: "agent_ic", hierarchyLevel: "ic" },
       buildServices(),
@@ -195,6 +204,7 @@ describe("buildHierarchyTools — IC vs team gating", () => {
       "find_up",
       "get_agent_profile",
       "get_task",
+      "get_work_product",
       "list_work_products",
       "search_context",
       "update_progress",
@@ -202,13 +212,13 @@ describe("buildHierarchyTools — IC vs team gating", () => {
     ]);
   });
 
-  it("team tier exposes 15 tools (8 shared + 6 team-only + create_subordinate_agent)", () => {
+  it("team tier exposes 16 tools (9 shared + 6 team-only + create_subordinate_agent)", () => {
     const tools = buildHierarchyTools(
       { agentId: "agent_t", hierarchyLevel: "team" },
       buildServices(),
     );
     const names = tools.map((t) => t.name);
-    expect(names.length).toBe(15);
+    expect(names.length).toBe(16);
     expect(names).toContain("find_subordinates");
     expect(names).toContain("find_peers");
     expect(names).toContain("create_task");
@@ -218,12 +228,12 @@ describe("buildHierarchyTools — IC vs team gating", () => {
     expect(names).toContain("create_subordinate_agent");
   });
 
-  it("org tier also gets all 15 (parents have subordinates too)", () => {
+  it("org tier also gets all 16 (parents have subordinates too)", () => {
     const tools = buildHierarchyTools(
       { agentId: "agent_o", hierarchyLevel: "org" },
       buildServices(),
     );
-    expect(tools.length).toBe(15);
+    expect(tools.length).toBe(16);
   });
 });
 
@@ -364,8 +374,8 @@ describe("create_work_product / list_work_products / update_work_product", () =>
     const services = buildServices({
       taskService: {
         listWorkProducts: vi.fn(async () => [
-          fakeWp({ id: "wp_1", title: "first" }),
-          fakeWp({ id: "wp_2", title: "second", url: "https://example.com/x" }),
+          fakeWpListItem({ id: "wp_1", title: "first" }),
+          fakeWpListItem({ id: "wp_2", title: "second", url: "https://example.com/x" }),
         ]),
       } as Partial<TaskService>,
     });
@@ -386,11 +396,77 @@ describe("create_work_product / list_work_products / update_work_product", () =>
     expect(result.isError).toBeFalsy();
     expect(services.taskService.updateWorkProduct).toHaveBeenCalledWith("wp_1", {
       summary: "v2 summary",
+      body: undefined,
       url: "https://example.com/v2",
       provider: undefined,
       external_id: undefined,
       metadata: undefined,
     });
+  });
+
+  it("create_work_product forwards body to taskService", async () => {
+    const services = buildServices();
+    const tools = buildHierarchyTools({ agentId: "a", hierarchyLevel: "ic" }, services);
+    const result = await callTool(tools, "create_work_product", {
+      task_id: "t1",
+      type: "analysis",
+      title: "Extracted tables",
+      body: "| col | val |\n|-----|-----|\n| a   | 1   |\n",
+    });
+    expect(result.isError).toBeFalsy();
+    expect(services.taskService.createWorkProduct).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "analysis",
+        title: "Extracted tables",
+        body: "| col | val |\n|-----|-----|\n| a   | 1   |\n",
+      }),
+    );
+  });
+
+  it("list_work_products surfaces body_bytes from the repo's SQL-computed size", async () => {
+    const services = buildServices({
+      taskService: {
+        listWorkProducts: vi.fn(async () => [
+          fakeWpListItem({ id: "wp_1", body_bytes: 5 }),
+          fakeWpListItem({ id: "wp_2", body_bytes: 0 }),
+        ]),
+      } as Partial<TaskService>,
+    });
+    const tools = buildHierarchyTools({ agentId: "a", hierarchyLevel: "ic" }, services);
+    const result = await callTool(tools, "list_work_products", { task_id: "t1" });
+    const wps = (
+      result.content as { work_products: Array<{ id: string; body_bytes: number }> }
+    ).work_products;
+    expect(wps).toEqual([
+      expect.objectContaining({ id: "wp_1", body_bytes: 5 }),
+      expect.objectContaining({ id: "wp_2", body_bytes: 0 }),
+    ]);
+  });
+
+  it("get_work_product returns full body content", async () => {
+    const wp = fakeWp({ id: "wp_1", body: "## Table 1\n\nrow data" });
+    const services = buildServices({
+      taskService: {
+        getWorkProduct: vi.fn(async () => wp),
+      } as Partial<TaskService>,
+    });
+    const tools = buildHierarchyTools({ agentId: "a", hierarchyLevel: "ic" }, services);
+    const result = await callTool(tools, "get_work_product", { id: "wp_1" });
+    expect(result.isError).toBeFalsy();
+    const got = (result.content as { work_product: { id: string; body: string } }).work_product;
+    expect(got.id).toBe("wp_1");
+    expect(got.body).toContain("Table 1");
+  });
+
+  it("get_work_product 404s on missing id", async () => {
+    const services = buildServices({
+      taskService: {
+        getWorkProduct: vi.fn(async () => undefined),
+      } as Partial<TaskService>,
+    });
+    const tools = buildHierarchyTools({ agentId: "a", hierarchyLevel: "ic" }, services);
+    const result = await callTool(tools, "get_work_product", { id: "wp_nope" });
+    expect(result.isError).toBe(true);
   });
 });
 

--- a/packages/api/src/tools/hierarchy.ts
+++ b/packages/api/src/tools/hierarchy.ts
@@ -354,10 +354,14 @@ function createWorkProductTool(
     name: "create_work_product",
     description:
       "Record a deliverable produced for a task — a PR, branch, commit, " +
-      "document, design, analysis, report, artifact, or preview. Before " +
-      "creating, call list_work_products(task_id) to check whether the " +
-      "deliverable already exists (use update_work_product to amend an " +
-      "existing one with the same identity, e.g. same PR URL).",
+      "document, design, analysis, report, artifact, or preview. For " +
+      "deliverables whose content lives in this system (extracted tables, " +
+      "parsed analyses, full documents), pass the actual content as `body` " +
+      "so the dispatcher can read it. For external deliverables (PRs, " +
+      "commits), pass `url` instead and skip `body`. Before creating, call " +
+      "list_work_products(task_id) to check whether the deliverable already " +
+      "exists (use update_work_product to amend an existing one with the " +
+      "same identity, e.g. same PR URL).",
     schema: {
       type: "object",
       properties: {
@@ -369,7 +373,8 @@ function createWorkProductTool(
         },
         title: { type: "string", description: "Title of the work product." },
         url: { type: "string", description: "Link to the deliverable (e.g. GitHub PR URL)." },
-        summary: { type: "string", description: "What was produced; capture the why + what changed." },
+        summary: { type: "string", description: "Short description of what was produced — the why + what changed. Distinct from `body`, which holds the actual content." },
+        body: { type: "string", description: "The full deliverable content (markdown, JSON, plain text). Use this when the content itself IS the deliverable — extracted tables, parsed analysis, document text. Omit for external pointers (PRs, commits)." },
         provider: { type: "string", description: "Where it's hosted (github, notion, figma, etc)." },
         external_id: { type: "string", description: "External id (PR number, doc id, etc)." },
         metadata: { type: "object", description: "Additional structured fields." },
@@ -400,6 +405,7 @@ function createWorkProductTool(
           type: type as (typeof WORK_PRODUCT_TYPES)[number],
           title,
           summary: typeof input.summary === "string" ? input.summary : undefined,
+          body: typeof input.body === "string" ? input.body : undefined,
           url: typeof input.url === "string" ? input.url : undefined,
           provider: typeof input.provider === "string" ? input.provider : undefined,
           external_id: typeof input.external_id === "string" ? input.external_id : undefined,
@@ -430,7 +436,8 @@ function listWorkProductsTool(
       "List existing work products for a task in chronological order. Call " +
       "this BEFORE create_work_product to check if you should update an " +
       "existing deliverable (same identity / URL) instead of creating a " +
-      "duplicate row.",
+      "duplicate row. Returns metadata only; use get_work_product(id) to " +
+      "read the full `body` of a deliverable.",
     schema: {
       type: "object",
       properties: {
@@ -451,9 +458,62 @@ function listWorkProductsTool(
               title: w.title,
               url: w.url ?? null,
               summary: w.summary ?? null,
+              body_bytes: w.body_bytes,
               created_at: w.created_at.toISOString(),
               updated_at: w.updated_at.toISOString(),
             })),
+          },
+        };
+      } catch (err) {
+        return asError(err);
+      }
+    },
+  };
+}
+
+function getWorkProductTool(
+  _ctx: HierarchyToolContext,
+  services: HierarchyToolServices,
+): AgentTool {
+  return {
+    name: "get_work_product",
+    description:
+      "Fetch a single work product by id, including its full `body` " +
+      "content. Use after list_work_products(task_id) when you need to " +
+      "read what a subordinate actually produced — the extracted tables, " +
+      "parsed analysis, or document text.",
+    schema: {
+      type: "object",
+      properties: {
+        id: { type: "string", description: "The work_product id to fetch." },
+      },
+      required: ["id"],
+    },
+    handler: async (input) => {
+      try {
+        const id = String(input.id ?? "");
+        if (!id) return { content: { error: "id required" }, isError: true };
+        const wp = await services.taskService.getWorkProduct(id);
+        if (!wp) {
+          return { content: { error: `work_product ${id} not found` }, isError: true };
+        }
+        return {
+          content: {
+            work_product: {
+              id: wp.id,
+              task_id: wp.task_id,
+              agent_id: wp.agent_id,
+              type: wp.type,
+              title: wp.title,
+              summary: wp.summary ?? null,
+              body: wp.body ?? null,
+              url: wp.url ?? null,
+              provider: wp.provider ?? null,
+              external_id: wp.external_id ?? null,
+              metadata: wp.metadata ?? null,
+              created_at: wp.created_at.toISOString(),
+              updated_at: wp.updated_at.toISOString(),
+            },
           },
         };
       } catch (err) {
@@ -473,13 +533,14 @@ function updateWorkProductTool(
       "Amend an existing work product — useful when the same deliverable " +
       "evolved (PR got new commits, doc revised, summary needs updating). " +
       "Identity fields (type, title, task_id, agent_id) are immutable; " +
-      "only summary, url, provider, external_id, and metadata can change. " +
-      "Use list_work_products(task_id) to find the right id first.",
+      "only summary, body, url, provider, external_id, and metadata can " +
+      "change. Use list_work_products(task_id) to find the right id first.",
     schema: {
       type: "object",
       properties: {
         id: { type: "string", description: "The work_product id to amend." },
         summary: { type: "string", description: "Updated summary." },
+        body: { type: "string", description: "Updated full content (replaces existing body)." },
         url: { type: "string", description: "Updated URL." },
         provider: { type: "string", description: "Updated provider." },
         external_id: { type: "string", description: "Updated external id." },
@@ -493,6 +554,7 @@ function updateWorkProductTool(
         if (!id) return { content: { error: "id required" }, isError: true };
         const updated = await services.taskService.updateWorkProduct(id, {
           summary: typeof input.summary === "string" ? input.summary : undefined,
+          body: typeof input.body === "string" ? input.body : undefined,
           url: typeof input.url === "string" ? input.url : undefined,
           provider: typeof input.provider === "string" ? input.provider : undefined,
           external_id:
@@ -961,6 +1023,7 @@ function buildSharedTools(
     getTaskTool(ctx, services),
     createWorkProductTool(ctx, services),
     listWorkProductsTool(ctx, services),
+    getWorkProductTool(ctx, services),
     updateWorkProductTool(ctx, services),
   ];
 }

--- a/packages/api/src/views/tasks.ts
+++ b/packages/api/src/views/tasks.ts
@@ -308,6 +308,7 @@ function rowToWorkProduct(r: Record<string, unknown>): WorkProduct {
     type: r.type as WorkProduct["type"],
     title: String(r.title),
     summary: (r.summary as string | null) ?? undefined,
+    body: (r.body as string | null) ?? undefined,
     url: (r.url as string | null) ?? undefined,
     provider: (r.provider as string | null) ?? undefined,
     external_id: (r.external_id as string | null) ?? undefined,

--- a/packages/api/src/views/work-product.ts
+++ b/packages/api/src/views/work-product.ts
@@ -1,11 +1,10 @@
 /**
  * Single work product view — used by the dedicated detail page.
  *
- * For `file://` URLs (the most common case — agents write briefings to
- * their workspace), tries to read the file content from disk and inline
- * it. Fails open: a missing/unreadable file just means `body` is empty
- * and the page falls back to the summary blob. This is per-agent
- * sandboxed already, no extra auth.
+ * `body` is populated from the `work_product.body` column when the
+ * specialist persisted content directly. As a fallback, if the column is
+ * empty and `url` is a `file://` link (older work products written to an
+ * agent workspace), the file is read from disk inline.
  */
 
 import { readFile } from "node:fs/promises";
@@ -27,10 +26,9 @@ export interface WorkProductDetail {
   provider?: string;
   external_id?: string;
   /**
-   * Inlined contents of the file the work product points at, when the
-   * URL is `file://` and the file is readable. Lets the web render the
-   * full briefing/audit/document inline. Truncated to 256 KB (way more
-   * than any reasonable briefing).
+   * Full deliverable content. Sourced from `work_product.body` when set;
+   * otherwise falls back to reading a `file://` URL from disk. Truncated
+   * to 256 KB.
    */
   body?: string;
   /** True when `url` is file:// — UI uses this to suppress an unclickable link. */
@@ -41,8 +39,8 @@ export interface WorkProductDetail {
 
 const SQL = /* sql */ `
 SELECT
-  wp.id, wp.task_id, wp.agent_id, wp.type, wp.title, wp.summary, wp.url,
-  wp.provider, wp.external_id, wp.created_at, wp.updated_at,
+  wp.id, wp.task_id, wp.agent_id, wp.type, wp.title, wp.summary, wp.body,
+  wp.url, wp.provider, wp.external_id, wp.created_at, wp.updated_at,
   t.title AS task_title,
   a.name  AS agent_label
 FROM work_product wp
@@ -58,6 +56,7 @@ interface Row {
   type: WorkProductType;
   title: string;
   summary: string | null;
+  body: string | null;
   url: string | null;
   provider: string | null;
   external_id: string | null;
@@ -73,15 +72,19 @@ function deriveTaskShortId(id: string): string {
   return id.replace(/^[a-z]+_/, "").slice(0, 6);
 }
 
+function truncateToMax(body: string | null | undefined): string | undefined {
+  if (!body) return undefined;
+  if (Buffer.byteLength(body, "utf-8") <= MAX_BODY_BYTES) return body;
+  const buf = Buffer.from(body, "utf-8");
+  return buf.subarray(0, MAX_BODY_BYTES).toString("utf-8") + "\n\n[truncated]";
+}
+
 async function tryReadFileUrl(url: string): Promise<string | undefined> {
   if (!url.startsWith("file://")) return undefined;
   try {
     const path = fileURLToPath(url);
     const buf = await readFile(path);
-    if (buf.byteLength > MAX_BODY_BYTES) {
-      return buf.subarray(0, MAX_BODY_BYTES).toString("utf-8") + "\n\n[truncated]";
-    }
-    return buf.toString("utf-8");
+    return truncateToMax(buf.toString("utf-8"));
   } catch {
     return undefined;
   }
@@ -96,7 +99,8 @@ export async function getWorkProduct(
   if (!row) return undefined;
   const url = row.url ?? undefined;
   const url_is_local = !!url && url.startsWith("file://");
-  const body = url_is_local ? await tryReadFileUrl(url!) : undefined;
+  const body =
+    truncateToMax(row.body) ?? (url_is_local ? await tryReadFileUrl(url!) : undefined);
 
   return {
     id: row.id,

--- a/packages/core/src/adapters/claude-code/stream-json.test.ts
+++ b/packages/core/src/adapters/claude-code/stream-json.test.ts
@@ -91,6 +91,27 @@ describe("extractStepEvents", () => {
     });
     expect(step?.description).toBe("the value");
   });
+
+  it("emits a tool_result step with the result content", () => {
+    const step = firstStep({
+      type: "tool_result",
+      tool_use_id: "tu_1",
+      content: "file contents line 1\nline 2",
+    });
+    expect(step?.kind).toBe("tool_result");
+    expect(step?.description).toBe("file contents line 1 line 2");
+  });
+
+  it("tags tool_result with [error] prefix when is_error is true", () => {
+    const step = firstStep({
+      type: "tool_result",
+      tool_use_id: "tu_2",
+      is_error: true,
+      content: "task_id required",
+    });
+    expect(step?.kind).toBe("tool_result");
+    expect(step?.description).toBe("[error] task_id required");
+  });
 });
 
 describe("parseClaudeStreamJson", () => {

--- a/packages/core/src/adapters/claude-code/stream-json.ts
+++ b/packages/core/src/adapters/claude-code/stream-json.ts
@@ -39,6 +39,8 @@ export interface StreamJsonMessage {
   name?: string;
   input?: Record<string, unknown>;
   tool_use_id?: string;
+  /** Anthropic tool_result spec: `true` when the tool reported an error. */
+  is_error?: boolean;
   content?: unknown;
   session_id?: string;
   cost_usd?: number;
@@ -70,6 +72,9 @@ export function parseStreamJsonLine(line: string): StreamJsonMessage | null {
  * Convert a parsed stream-json message into 0+ RuntimeSteps.
  *
  * - tool_use messages → one tool_call step.
+ * - tool_result messages → one tool_result step. `[error] ` prefix on
+ *   `description` when the tool reported `is_error: true`, so the UI
+ *   can style failures distinctly.
  * - assistant messages with content blocks → one agent step per non-empty
  *   text block + one tool_call step per inline tool_use block.
  * - everything else → no step.
@@ -83,6 +88,16 @@ export function extractStepEvents(msg: StreamJsonMessage): RuntimeStep[] {
         kind: "tool_call",
         tool: msg.name ?? "unknown",
         description: describeToolInput(msg.input ?? {}),
+        timestamp: now,
+      },
+    ];
+  }
+
+  if (msg.type === STREAM_TYPE.ToolResult) {
+    return [
+      {
+        kind: "tool_result",
+        description: describeToolResult(msg.content, msg.is_error === true),
         timestamp: now,
       },
     ];
@@ -122,6 +137,14 @@ export function extractStepEvents(msg: StreamJsonMessage): RuntimeStep[] {
   }
 
   return [];
+}
+
+function describeToolResult(content: unknown, isError: boolean): string {
+  const text = typeof content === "string" ? content : JSON.stringify(content ?? "");
+  // Trigger truncates to 512 chars; keep the prefix tiny so the UI sees
+  // the actual payload, not just "[error]" overflow.
+  const collapsed = text.replace(/\s+/g, " ").trim();
+  return isError ? `[error] ${collapsed}` : collapsed;
 }
 
 /**

--- a/packages/core/src/adapters/postgres/row-types.ts
+++ b/packages/core/src/adapters/postgres/row-types.ts
@@ -95,6 +95,7 @@ export interface WorkProductRow {
   type: string;
   title: string;
   summary: string | null;
+  body: string | null;
   url: string | null;
   provider: string | null;
   external_id: string | null;
@@ -102,6 +103,16 @@ export interface WorkProductRow {
   created_at: Date;
   updated_at: Date;
 }
+
+/**
+ * List-query projection: `body` content is skipped; `body_bytes` carries
+ * the size from `octet_length(body)`. PG returns the latter as bigint, which
+ * the node-postgres driver may surface as either number or string depending
+ * on the parser config — the mapper coerces.
+ */
+export type WorkProductListRow = Omit<WorkProductRow, "body"> & {
+  body_bytes: number | string;
+};
 
 export interface MemoryFactRow {
   id: string;

--- a/packages/core/src/adapters/postgres/work-product-repo.test.ts
+++ b/packages/core/src/adapters/postgres/work-product-repo.test.ts
@@ -65,6 +65,7 @@ describe("PostgresWorkProductRepository", () => {
       newWp({
         id,
         summary: "Summary here",
+        body: "# Extracted tables\n\n| col | val |\n|-----|-----|\n| a   | 1   |\n",
         url: "https://github.com/foo/bar/pull/42",
         provider: "github",
         external_id: "42",
@@ -75,6 +76,7 @@ describe("PostgresWorkProductRepository", () => {
     expect(wp.type).toBe("pull_request");
     expect(wp.provider).toBe("github");
     expect(wp.external_id).toBe("42");
+    expect(wp.body).toContain("Extracted tables");
     expect(wp.metadata).toEqual({ files_changed: 3, lines_added: 120 });
 
     const found = await wps.findById(id);
@@ -84,6 +86,7 @@ describe("PostgresWorkProductRepository", () => {
   it("create without optional fields returns undefined (null→undefined mapping)", async () => {
     const wp = await wps.create(newWp());
     expect(wp.summary).toBeUndefined();
+    expect(wp.body).toBeUndefined();
     expect(wp.url).toBeUndefined();
     expect(wp.provider).toBeUndefined();
     expect(wp.external_id).toBeUndefined();
@@ -108,6 +111,18 @@ describe("PostgresWorkProductRepository", () => {
     const b = await wps.create(newWp({ title: "second" }));
     const list = await wps.listByAgent(agent);
     expect(list.map((w) => w.id)).toEqual([b.id, a.id]);
+  });
+
+  it("listByTask returns body_bytes from SQL and omits body content", async () => {
+    await wps.create(newWp({ title: "with body", body: "hello" }));
+    await wps.create(newWp({ title: "no body" }));
+    const list = await wps.listByTask(task);
+    const byTitle = new Map(list.map((w) => [w.title, w]));
+    expect(byTitle.get("with body")?.body_bytes).toBe(5);
+    expect(byTitle.get("no body")?.body_bytes).toBe(0);
+    // List projection is body-less; the body property is not present on the
+    // returned WorkProductListItem (TypeScript-enforced + runtime).
+    expect("body" in (byTitle.get("with body") as object)).toBe(false);
   });
 
   it("FK to task enforced — missing task rejects", async () => {
@@ -177,5 +192,18 @@ describe("PostgresWorkProductRepository", () => {
     await expect(wps.update("wp_nonexistent", { summary: "x" })).rejects.toThrow(
       /not found/,
     );
+  });
+
+  it("update body replaces previous body", async () => {
+    const wp = await wps.create(newWp({ body: "v1 content" }));
+    const updated = await wps.update(wp.id, { body: "v2 content" });
+    expect(updated.body).toBe("v2 content");
+  });
+
+  it("update with undefined body preserves existing body (COALESCE)", async () => {
+    const wp = await wps.create(newWp({ body: "keep me" }));
+    const updated = await wps.update(wp.id, { summary: "new summary" });
+    expect(updated.body).toBe("keep me");
+    expect(updated.summary).toBe("new summary");
   });
 });

--- a/packages/core/src/adapters/postgres/work-product-repo.ts
+++ b/packages/core/src/adapters/postgres/work-product-repo.ts
@@ -1,11 +1,22 @@
-import type { WorkProduct, WorkProductType } from "../../domain/work-product.js";
+import type {
+  WorkProduct,
+  WorkProductListItem,
+  WorkProductType,
+} from "../../domain/work-product.js";
 import type {
   WorkProductRepository,
   NewWorkProduct,
   WorkProductPatch,
 } from "../../ports/work-product-repo.js";
 import type { Pool } from "./client.js";
-import type { WorkProductRow } from "./row-types.js";
+import type { WorkProductListRow, WorkProductRow } from "./row-types.js";
+
+// List queries skip the (potentially huge) body and surface its byte size via
+// PG's octet_length instead. Single-row reads still pull body content.
+const LIST_COLUMNS = /* sql */ `
+  id, task_id, agent_id, type, title, summary, url, provider, external_id,
+  metadata, created_at, updated_at, COALESCE(octet_length(body), 0) AS body_bytes
+`;
 
 export class PostgresWorkProductRepository implements WorkProductRepository {
   constructor(private pool: Pool) {}
@@ -18,32 +29,32 @@ export class PostgresWorkProductRepository implements WorkProductRepository {
     return rows[0] ? rowToWorkProduct(rows[0]) : undefined;
   }
 
-  async listByTask(taskId: string): Promise<WorkProduct[]> {
-    const { rows } = await this.pool.query<WorkProductRow>(
-      `SELECT * FROM work_product
+  async listByTask(taskId: string): Promise<WorkProductListItem[]> {
+    const { rows } = await this.pool.query<WorkProductListRow>(
+      `SELECT ${LIST_COLUMNS} FROM work_product
         WHERE task_id = $1
         ORDER BY created_at DESC`,
       [taskId],
     );
-    return rows.map(rowToWorkProduct);
+    return rows.map(rowToWorkProductListItem);
   }
 
-  async listByAgent(agentId: string): Promise<WorkProduct[]> {
-    const { rows } = await this.pool.query<WorkProductRow>(
-      `SELECT * FROM work_product
+  async listByAgent(agentId: string): Promise<WorkProductListItem[]> {
+    const { rows } = await this.pool.query<WorkProductListRow>(
+      `SELECT ${LIST_COLUMNS} FROM work_product
         WHERE agent_id = $1
         ORDER BY created_at DESC`,
       [agentId],
     );
-    return rows.map(rowToWorkProduct);
+    return rows.map(rowToWorkProductListItem);
   }
 
   async create(input: NewWorkProduct): Promise<WorkProduct> {
     const { rows } = await this.pool.query<WorkProductRow>(
       `INSERT INTO work_product (
          id, task_id, agent_id, type, title,
-         summary, url, provider, external_id, metadata
-       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+         summary, body, url, provider, external_id, metadata
+       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
        RETURNING *`,
       [
         input.id,
@@ -52,6 +63,7 @@ export class PostgresWorkProductRepository implements WorkProductRepository {
         input.type,
         input.title,
         input.summary ?? null,
+        input.body ?? null,
         input.url ?? null,
         input.provider ?? null,
         input.external_id ?? null,
@@ -62,21 +74,22 @@ export class PostgresWorkProductRepository implements WorkProductRepository {
   }
 
   async update(id: string, patch: WorkProductPatch): Promise<WorkProduct> {
-    // Mutable: summary, url, provider, external_id, metadata.
-    // Each `??` lets the caller leave a field unchanged with `undefined`.
+    // COALESCE pattern: passing `undefined` for a field leaves it unchanged.
     const { rows } = await this.pool.query<WorkProductRow>(
       `UPDATE work_product
           SET summary     = COALESCE($2, summary),
-              url         = COALESCE($3, url),
-              provider    = COALESCE($4, provider),
-              external_id = COALESCE($5, external_id),
-              metadata    = COALESCE($6, metadata),
+              body        = COALESCE($3, body),
+              url         = COALESCE($4, url),
+              provider    = COALESCE($5, provider),
+              external_id = COALESCE($6, external_id),
+              metadata    = COALESCE($7, metadata),
               updated_at  = NOW()
         WHERE id = $1
         RETURNING *`,
       [
         id,
         patch.summary ?? null,
+        patch.body ?? null,
         patch.url ?? null,
         patch.provider ?? null,
         patch.external_id ?? null,
@@ -102,11 +115,30 @@ function rowToWorkProduct(row: WorkProductRow): WorkProduct {
     type: row.type as WorkProductType,
     title: row.title,
     summary: row.summary ?? undefined,
+    body: row.body ?? undefined,
     url: row.url ?? undefined,
     provider: row.provider ?? undefined,
     external_id: row.external_id ?? undefined,
     metadata: row.metadata ?? undefined,
     created_at: row.created_at,
     updated_at: row.updated_at,
+  };
+}
+
+function rowToWorkProductListItem(row: WorkProductListRow): WorkProductListItem {
+  return {
+    id: row.id,
+    task_id: row.task_id,
+    agent_id: row.agent_id,
+    type: row.type as WorkProductType,
+    title: row.title,
+    summary: row.summary ?? undefined,
+    url: row.url ?? undefined,
+    provider: row.provider ?? undefined,
+    external_id: row.external_id ?? undefined,
+    metadata: row.metadata ?? undefined,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    body_bytes: Number(row.body_bytes),
   };
 }

--- a/packages/core/src/domain/work-product.ts
+++ b/packages/core/src/domain/work-product.ts
@@ -28,6 +28,14 @@ export interface WorkProduct {
   type: WorkProductType;
   title: string;
   summary?: string;
+  /**
+   * Full deliverable content — the extracted tables, parsed analysis,
+   * complete document, etc. `summary` describes what was produced;
+   * `body` IS what was produced. Optional because some work products
+   * (a PR, a commit) are pointers to external systems and have nothing
+   * to inline; in those cases set `url` instead.
+   */
+  body?: string;
   url?: string;
   provider?: string;
   external_id?: string;
@@ -36,3 +44,13 @@ export interface WorkProduct {
   /** Bumped on every UPDATE via the update_work_product MCP tool. */
   updated_at: Date;
 }
+
+/**
+ * Body-less projection returned by list endpoints. Bodies can be huge
+ * (extracted tables, full documents), so listing pushes the size into
+ * SQL via `octet_length(body)` rather than shipping every byte. Callers
+ * who want the content read it via `findById`.
+ */
+export type WorkProductListItem = Omit<WorkProduct, "body"> & {
+  body_bytes: number;
+};

--- a/packages/core/src/ports/work-product-repo.ts
+++ b/packages/core/src/ports/work-product-repo.ts
@@ -1,4 +1,4 @@
-import type { WorkProduct } from "../domain/work-product.js";
+import type { WorkProduct, WorkProductListItem } from "../domain/work-product.js";
 
 export type NewWorkProduct = Omit<WorkProduct, "created_at" | "updated_at">;
 
@@ -9,15 +9,15 @@ export type NewWorkProduct = Omit<WorkProduct, "created_at" | "updated_at">;
  * `updated_at` are managed by the adapter.
  */
 export type WorkProductPatch = Partial<
-  Pick<WorkProduct, "summary" | "url" | "provider" | "external_id" | "metadata">
+  Pick<WorkProduct, "summary" | "body" | "url" | "provider" | "external_id" | "metadata">
 >;
 
 export interface WorkProductRepository {
   findById(id: string): Promise<WorkProduct | undefined>;
 
-  listByTask(taskId: string): Promise<WorkProduct[]>;
+  listByTask(taskId: string): Promise<WorkProductListItem[]>;
 
-  listByAgent(agentId: string): Promise<WorkProduct[]>;
+  listByAgent(agentId: string): Promise<WorkProductListItem[]>;
 
   create(input: NewWorkProduct): Promise<WorkProduct>;
 

--- a/packages/core/src/services/spawn-prep.ts
+++ b/packages/core/src/services/spawn-prep.ts
@@ -61,7 +61,11 @@ behavioral rules for every task session:
    PR you opened earlier), call mcp__beevibe__update_work_product on it;
    never create a duplicate row. The 'type' arg must be one of:
    pull_request, branch, commit, document, analysis, report, design,
-   artifact, preview.
+   artifact, preview. When the deliverable's content lives in-system
+   (extracted tables, parsed analysis, written document), pass the full
+   text as the 'body' arg so the dispatcher can read it — don't bury the
+   actual content in 'summary' or chat-only output. For external
+   pointers (PRs, commits), use 'url' instead and omit 'body'.
 
 5. For multi-step protocols (mesh negotiation, git workspace setup), the
    relevant beevibe-* skill in .claude/skills/ has the deep guidance —
@@ -164,11 +168,11 @@ blocks or the <archival_memory> block from your session-start briefing —
 never call search_context for facts already in your in-context memory.
 
 If search returns empty and the question is about a completed task,
-list_work_products(task_id) and re-read the relevant work product's
-summary BEFORE concluding you can't answer. Memory is a cache; the
-work product is the source of truth for what the task produced.
-Treating "no archival hit" as "no answer" makes you fail on questions
-the work product itself can answer.
+list_work_products(task_id), then get_work_product(id) on the relevant
+row to read its full body BEFORE concluding you can't answer. Memory
+is a cache; the work product is the source of truth for what the task
+produced. Treating "no archival hit" as "no answer" makes you fail on
+questions the work product itself can answer.
 
 Promotion ladder (archival is the default, core is reserved):
 - save_memory writes archival — cheap and forgiving; that's where new

--- a/packages/core/src/services/task-service.test.ts
+++ b/packages/core/src/services/task-service.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Agent, ReviewPolicy } from "../domain/agent.js";
 import type { Task } from "../domain/task.js";
-import type { WorkProduct } from "../domain/work-product.js";
+import type { WorkProduct, WorkProductListItem } from "../domain/work-product.js";
 import type { Session } from "../domain/session.js";
 import type { AgentRepository } from "../ports/agent-repo.js";
 import type { SessionRepository } from "../ports/session-repo.js";
@@ -38,6 +38,13 @@ function makeWorkProduct(overrides: Partial<WorkProduct> = {}): WorkProduct {
     updated_at: new Date(),
     ...overrides,
   };
+}
+
+function makeWorkProductListItem(
+  overrides: Partial<WorkProductListItem> = {},
+): WorkProductListItem {
+  const { body: _body, ...rest } = makeWorkProduct();
+  return { ...rest, body_bytes: 0, ...overrides };
 }
 
 function makeSession(overrides: Partial<Session> = {}): Session {
@@ -486,7 +493,9 @@ describe("TaskService.createWorkProduct + listWorkProducts", () => {
   });
 
   it("listWorkProducts delegates to the repo", async () => {
-    vi.mocked(workProductRepo.listByTask).mockResolvedValue([makeWorkProduct()]);
+    vi.mocked(workProductRepo.listByTask).mockResolvedValue([
+      makeWorkProductListItem(),
+    ]);
     const out = await service.listWorkProducts("task_1");
     expect(out).toHaveLength(1);
     expect(workProductRepo.listByTask).toHaveBeenCalledWith("task_1");

--- a/packages/core/src/services/task-service.ts
+++ b/packages/core/src/services/task-service.ts
@@ -1,5 +1,5 @@
 import type { NextDispatchContext, Task, TaskStatus } from "../domain/task.js";
-import type { WorkProduct } from "../domain/work-product.js";
+import type { WorkProduct, WorkProductListItem } from "../domain/work-product.js";
 import type { AgentRepository } from "../ports/agent-repo.js";
 import type { SessionRepository } from "../ports/session-repo.js";
 import type {
@@ -260,16 +260,20 @@ export class TaskService {
     return this.deps.workProductRepo.create(input);
   }
 
-  /** List work products for a task (chronological order is the repo's concern). */
-  async listWorkProducts(taskId: string): Promise<WorkProduct[]> {
+  /** List work products for a task (body content omitted; see WorkProductListItem). */
+  async listWorkProducts(taskId: string): Promise<WorkProductListItem[]> {
     return this.deps.workProductRepo.listByTask(taskId);
+  }
+
+  async getWorkProduct(id: string): Promise<WorkProduct | undefined> {
+    return this.deps.workProductRepo.findById(id);
   }
 
   /**
    * Amend a work product (used by the `update_work_product` MCP tool — see M9
    * for the agent skill that decides between create vs update). Mutable
-   * subset is `summary | url | provider | external_id | metadata`; identity
-   * (`type`, `title`, `task_id`, `agent_id`) is fixed at creation.
+   * subset is `summary | body | url | provider | external_id | metadata`;
+   * identity (`type`, `title`, `task_id`, `agent_id`) is fixed at creation.
    *
    * Bumps `updated_at = NOW()` via the repo. Throws if the row doesn't
    * exist (`work_product <id> not found`).

--- a/packages/daemon/src/claimer.test.ts
+++ b/packages/daemon/src/claimer.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import type { LocalWorkspaceManager } from "@beevibe/core/adapters/local-workspace";
+import type WebSocket from "ws";
+import type { ApiClient } from "./api-client.js";
+import { Claimer } from "./claimer.js";
+import { Supervisor } from "./supervisor.js";
+
+function makeApi(overrides: Partial<ApiClient> = {}): ApiClient {
+  // Minimal stub — Claimer only uses claim/post/openWebSocket.
+  return {
+    claim: vi.fn(async () => undefined),
+    post: vi.fn(async () => ({ status: 204, body: undefined })),
+    openWebSocket: vi.fn(() => fakeWs()),
+    ...overrides,
+  } as unknown as ApiClient;
+}
+
+function fakeWs(): WebSocket {
+  // Bare event-emitter shape — Claimer only attaches listeners + calls close.
+  const handlers = new Map<string, Array<(...args: unknown[]) => void>>();
+  const ws = {
+    on(event: string, cb: (...args: unknown[]) => void) {
+      const arr = handlers.get(event) ?? [];
+      arr.push(cb);
+      handlers.set(event, arr);
+      return ws;
+    },
+    removeAllListeners() {
+      handlers.clear();
+    },
+    close() {},
+  };
+  return ws as unknown as WebSocket;
+}
+
+describe("Claimer.pollRuntime resilience", () => {
+  it("swallows ECONNREFUSED from claim() without bubbling — daemon survives", async () => {
+    const claim = vi.fn(async () => {
+      // Mirror the actual shape of a Node 20+ fetch failure.
+      throw new TypeError("fetch failed");
+    });
+    const api = makeApi({ claim } as Partial<ApiClient>);
+    const claimer = new Claimer({
+      api,
+      supervisor: new Supervisor(2),
+      workspaceManager: {} as LocalWorkspaceManager,
+      runtimeIds: ["rt_1"],
+      pollIntervalMs: 60_000,
+      heartbeatIntervalMs: 60_000,
+    });
+
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+    try {
+      claimer.start();
+      // Yield twice — once for the initial pollAll, once for any deferred reject.
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+      expect(claim).toHaveBeenCalled();
+      expect(unhandled).not.toHaveBeenCalled();
+    } finally {
+      process.off("unhandledRejection", unhandled);
+      await claimer.stop();
+    }
+  });
+});

--- a/packages/daemon/src/claimer.ts
+++ b/packages/daemon/src/claimer.ts
@@ -172,10 +172,25 @@ export class Claimer {
    * Drain one runtime's pending queue: keep claiming until /runtime/claim
    * returns 204 or the supervisor is at capacity. Sessions are run
    * concurrently; this loop just hands off and keeps claiming.
+   *
+   * Transient API outages (e.g. an API restart during dev) surface as
+   * fetch rejections from `claim()`. We log and bail this tick — the
+   * interval + WS push will retry. Without this catch, a single
+   * ECONNREFUSED bubbles up as an unhandledRejection and kills the
+   * daemon under Node 20+'s `--unhandled-rejections=throw` default.
    */
   private async pollRuntime(runtimeId: string): Promise<void> {
     while (this.running && this.cfg.supervisor.hasCapacity()) {
-      const payload = await this.cfg.api.claim<DispatchPayload>(runtimeId);
+      let payload: DispatchPayload | undefined;
+      try {
+        payload = await this.cfg.api.claim<DispatchPayload>(runtimeId);
+      } catch (err) {
+        console.warn(
+          `[daemon] claim failed for runtime=${runtimeId}:`,
+          err instanceof Error ? err.message : String(err),
+        );
+        return;
+      }
       if (!payload) return;
       // Visibility: every claim shows up in the daemon's stdout. The
       // spawner logs the matching cwd + exit lines so one session id

--- a/packages/daemon/src/start.ts
+++ b/packages/daemon/src/start.ts
@@ -67,6 +67,18 @@ export async function runStart(): Promise<void> {
   process.on("SIGINT", () => void stop("SIGINT"));
   process.on("SIGTERM", () => void stop("SIGTERM"));
 
+  // Safety net for any fetch/promise that leaks past a call-site catch.
+  // Per-site try/catch is the correct fix; this exists so a single missed
+  // catch doesn't take the whole daemon down — the claimer loop is
+  // self-healing, so logging and continuing is the right behavior under
+  // Node 20+'s default `--unhandled-rejections=throw`.
+  process.on("unhandledRejection", (reason) => {
+    console.warn(
+      "[daemon] unhandledRejection (continuing):",
+      reason instanceof Error ? reason.message : String(reason),
+    );
+  });
+
   // Hold the process open. The `setInterval` in claimer keeps the event
   // loop alive on its own, but make this explicit so an empty
   // run-then-exit isn't possible.

--- a/packages/web/app/(authed)/chat/chat-client.tsx
+++ b/packages/web/app/(authed)/chat/chat-client.tsx
@@ -437,9 +437,13 @@ function Thinking({
   // Split agent text from tool steps. Agent text is the response being
   // written; tools are the substrate beneath, categorized so the
   // audience can SEE when the agent is asking another agent (mesh) vs
-  // saving memory vs reading a file. Final summary arrives via POST and
-  // replaces this whole block.
-  const toolSteps = steps.filter((s) => s.kind === "tool_call");
+  // saving memory vs reading a file. tool_result rows surface what each
+  // call returned — especially failures, which used to look like an
+  // empty success. Final summary arrives via POST and replaces this
+  // whole block.
+  const toolSteps = steps.filter(
+    (s) => s.kind === "tool_call" || s.kind === "tool_result",
+  );
   const agentSteps = steps.filter((s) => s.kind === "agent");
   // Each Claude turn between tool calls emits one assistant block — full
   // text, not deltas — so concatenating gives the response-so-far.

--- a/packages/web/app/(authed)/rooms/[id]/room-detail-client.tsx
+++ b/packages/web/app/(authed)/rooms/[id]/room-detail-client.tsx
@@ -512,7 +512,9 @@ function TypingBubble({ typing: t }: { typing: NonNullable<RoomDetail["typing"]>
     seen.add(s.event_id);
     merged.push(s);
   }
-  const toolSteps = merged.filter((s) => s.kind === "tool_call");
+  const toolSteps = merged.filter(
+    (s) => s.kind === "tool_call" || s.kind === "tool_result",
+  );
   const recentTools = toolSteps.slice(-6);
   const totalSteps = Math.max(toolSteps.length, t.total_steps ?? 0);
 

--- a/packages/web/components/chat/tool-step-list.tsx
+++ b/packages/web/components/chat/tool-step-list.tsx
@@ -1,17 +1,22 @@
 "use client";
 
+import { AlertCircle, CornerDownRight } from "lucide-react";
 import type { ChatStreamStep } from "@/lib/chat-stream";
 import { categoryAccent, formatTool } from "@/lib/tool-format";
 import { cn } from "@/lib/utils";
 
 /**
- * Compact list of streamed tool calls for a single agent session —
- * one row per call with a category-colored icon and a short detail
- * line ("Read foo.ts", "Asked another agent"). Used in:
+ * Compact list of streamed tool calls + results for a single agent
+ * session — one row per call with a category-colored icon and a short
+ * detail line ("Read foo.ts", "Asked another agent"). Used in:
  *
  *   - chat surface's Thinking bubble for the in-flight 1:1 turn
  *   - room view's typing indicators per running session, so audience
  *     sees what each typing agent is doing in real time
+ *
+ * tool_result rows render as indented follow-ups under their preceding
+ * tool_call — errors use a destructive accent so a failing tool no
+ * longer looks like a silent success.
  *
  * The latest step pulses to draw the eye to "now". Older steps are
  * rolled into a "+N earlier steps" line so the list stays scannable.
@@ -33,31 +38,11 @@ export function ToolStepList({
       )}
     >
       {steps.map((step, idx) => {
-        const display = formatTool(step.tool_name, step.content);
         const isLatest = idx === steps.length - 1;
-        return (
-          <li key={step.event_id} className="flex items-start gap-1.5">
-            <span
-              className={cn(
-                "shrink-0 inline-flex items-center justify-center h-4 w-4 rounded",
-                categoryAccent(display.category),
-                isLatest && "animate-pulse-breathe",
-              )}
-            >
-              <display.icon className="h-2.5 w-2.5" />
-            </span>
-            <div className="flex-1 min-w-0 leading-tight">
-              <div className="flex items-baseline gap-1.5">
-                <span className="font-medium text-foreground/85 shrink-0">{display.label}</span>
-                {display.detail ? (
-                  <span className="text-muted-foreground truncate min-w-0">
-                    {display.detail}
-                  </span>
-                ) : null}
-              </div>
-            </div>
-          </li>
-        );
+        if (step.kind === "tool_result") {
+          return <ResultRow key={step.event_id} step={step} isLatest={isLatest} />;
+        }
+        return <CallRow key={step.event_id} step={step} isLatest={isLatest} />;
       })}
       {totalSteps > steps.length ? (
         <li className="text-[10px] text-muted-foreground/70 pl-5">
@@ -65,5 +50,61 @@ export function ToolStepList({
         </li>
       ) : null}
     </ul>
+  );
+}
+
+function CallRow({ step, isLatest }: { step: ChatStreamStep; isLatest: boolean }) {
+  const display = formatTool(step.tool_name, step.content);
+  return (
+    <li className="flex items-start gap-1.5">
+      <span
+        className={cn(
+          "shrink-0 inline-flex items-center justify-center h-4 w-4 rounded",
+          categoryAccent(display.category),
+          isLatest && "animate-pulse-breathe",
+        )}
+      >
+        <display.icon className="h-2.5 w-2.5" />
+      </span>
+      <div className="flex-1 min-w-0 leading-tight">
+        <div className="flex items-baseline gap-1.5">
+          <span className="font-medium text-foreground/85 shrink-0">{display.label}</span>
+          {display.detail ? (
+            <span className="text-muted-foreground truncate min-w-0">{display.detail}</span>
+          ) : null}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function ResultRow({ step, isLatest }: { step: ChatStreamStep; isLatest: boolean }) {
+  // `[error] ` prefix comes from the runtime adapter when the tool
+  // reported `is_error: true`; strip it before display.
+  const isError = step.content.startsWith("[error] ");
+  const text = isError ? step.content.slice("[error] ".length) : step.content;
+  const Icon = isError ? AlertCircle : CornerDownRight;
+  return (
+    <li className="flex items-start gap-1.5 pl-3">
+      <span
+        className={cn(
+          "shrink-0 inline-flex items-center justify-center h-4 w-4",
+          isError ? "text-destructive" : "text-muted-foreground/60",
+          isLatest && "animate-pulse-breathe",
+        )}
+      >
+        <Icon className="h-2.5 w-2.5" />
+      </span>
+      <div className="flex-1 min-w-0 leading-tight">
+        <span
+          className={cn(
+            "truncate min-w-0 block",
+            isError ? "text-destructive/90" : "text-muted-foreground italic",
+          )}
+        >
+          {text || (isError ? "tool error" : "result")}
+        </span>
+      </div>
+    </li>
   );
 }


### PR DESCRIPTION
## Summary

Two related fixes from one debugging session, bundled as one PR per request.

### 1. `feat(work-product)`: persist deliverable body

**Problem:** When a team agent dispatched work to a specialist (e.g., \"extract tables from PDF\"), the specialist's actual output (the tables themselves) had no place to live where the dispatching chat could see it. `WorkProduct` stored `summary`/`url`/`metadata` but no `body` — content got stranded in `session_event` transcripts the dispatcher never reads. Symptom: user sees \"task done\" but can't see the deliverable.

**Fix:**
- New `work_product.body TEXT` column (migration `1780800000000_add-work-product-body.sql`).
- `create_work_product` and `update_work_product` MCP tools gain a `body` arg.
- New `get_work_product(id)` MCP tool returns the full body — list to discover, get to read.
- `list_work_products` returns `body_bytes` per row (size computed in SQL via `octet_length(body)`); list queries no longer ship body content over the wire.
- New `WorkProductListItem` type enforces body-less projection at the type level.
- Detail view prefers DB `body`, falls back to file:// URL for older work products written to agent workspaces.
- **Bug fix**: `views/tasks.ts` was silently dropping the new column in its rowToWorkProduct mapper.
- Spawn-prep guidance tells specialists to put content in `body=`, not `summary=` or chat-only output.

Tool counts: IC 12→13, team/org 23→24. `get_work_product` is read-only and allowed under `server_fallback_mesh`.

### 2. `fix(daemon)`: catch transient fetch failures in claim loop

**Problem:** The daemon's `pollRuntime` called `api.claim()` without try/catch, so a single ECONNREFUSED (e.g., during an API restart in dev) bubbled up via `void this.pollAll()` and crashed the daemon under Node 20+'s default `--unhandled-rejections=throw` behavior. Symptom: chat sessions stuck in `status='pending'` because no daemon was alive to claim them.

**Fix:**
- Wrap `claim()` in try/catch inside `pollRuntime` — mirrors the heartbeat pattern already in this file. Log and return; next poll retries.
- Add `process.on('unhandledRejection')` safety net in `start.ts` so any future leak doesn't take the daemon down.
- Regression test stubs `claim()` to throw `TypeError('fetch failed')` (the exact shape Node uses) and asserts no unhandledRejection fires.

## Test plan

- [x] `pnpm --filter @beevibe/core build` — clean
- [x] `tsc --noEmit` on core, api, daemon — clean
- [x] `vitest run hierarchy.test.ts assemble.test.ts task-service.test.ts spawn-prep.test.ts claimer.test.ts supervisor.test.ts` — 84/84 pass
- [ ] **Manual: run the migration locally** — `work_product.body` is a nullable TEXT add; safe.
- [ ] **Manual: postgres-backed repo tests** (`work-product-repo.test.ts`) — need live PG + new migration applied; the new \"listByTask returns body_bytes from SQL and omits body content\" test asserts the SQL-side projection.
- [ ] **Manual: end-to-end** — dispatch work via chat, specialist calls `create_work_product` with `body=`, team agent fetches via `get_work_product` and surfaces it in the chat reply.

## Notes for reviewer

- Two unrelated commits in one branch by user request — squash or keep separate at merge time, your call.
- Branch name is `feat/work-product-body-content` (not `feat/work-product-body`) because the latter is taken by a parallel session's docs commit (`09a1a0e`) that hasn't been PR'd yet. Worth coordinating on which branch landed first before resolving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)