### PR TITLE
fix(ui): strip task XML wrapper from session H1, wrap transcript content

### DIFF
--- a/packages/web/app/(authed)/tasks/[id]/sessions/[sid]/session-detail-client.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/sessions/[sid]/session-detail-client.tsx
@@ -14,7 +14,7 @@ import { BriefingComposer } from "@/components/sessions/briefing-composer";
 import { Transcript } from "@/components/sessions/transcript";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
-import { shortId } from "@/lib/format";
+import { formatIntent, shortId } from "@/lib/format";
 import type { SessionDisplay } from "@/lib/types/sessions";
 
 interface Props {
@@ -118,7 +118,7 @@ function SessionDetailBody({ session, taskId: _taskId }: { session: SessionDispl
           />
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-1">
-              <h1 className="text-base font-semibold leading-tight truncate">{session.intent}</h1>
+              <h1 className="text-base font-semibold leading-tight truncate">{formatIntent(session.intent)}</h1>
               <SessionStatusPill status={session.status} />
             </div>
             <div className="flex items-center gap-2 text-xs text-muted-foreground">

--- a/packages/web/components/sessions/transcript.tsx
+++ b/packages/web/components/sessions/transcript.tsx
@@ -66,7 +66,7 @@ export function Transcript({
                       </span>
                     ) : null}
                   </div>
-                  <p className="text-sm leading-relaxed">{entry.content}</p>
+                  <p className="text-sm leading-relaxed break-words [overflow-wrap:anywhere]">{entry.content}</p>
                 </div>
               </div>
               {trailingAsks.map((ath) => (

--- a/packages/web/lib/format.ts
+++ b/packages/web/lib/format.ts
@@ -41,6 +41,24 @@ export function shortId(id: string): string {
 }
 
 /**
+ * Session intents for task work are wrapped as `<task id="...">title\n\ndescription</task>`
+ * (or self-closing `<task id="..."/>` for lifecycle reminders). Strip the
+ * wrapper for display so the UI shows the human-readable title, not raw XML.
+ * Chat intents (no wrapper) pass through unchanged.
+ */
+export function formatIntent(intent: string): string {
+  const selfClosing = intent.match(/^\s*<task id="[^"]*"\/>\s*$/);
+  if (selfClosing) return "Lifecycle reminder";
+  const wrapped = intent.match(/^\s*<task id="[^"]*">\s*([\s\S]*?)\s*<\/task>\s*$/);
+  if (wrapped) {
+    const inner = wrapped[1];
+    const firstBlock = inner.split(/\n\n/)[0] ?? inner;
+    return firstBlock.trim();
+  }
+  return intent;
+}
+
+/**
  * Strip the typed-id prefix and return what's left — used as the
  * stable "@token" form for room mentions and as the short URL
  * fragment in the conversation sidebar. e.g. `agent_kBpTkqiCbsB3` →


### PR DESCRIPTION
## Summary

Two bugs in the session detail page (screenshots in the conversation):

- **Title leak.** The H1 was rendering `session.intent` raw, which for task sessions is wrapped as `<task id="task_xxx">title\n\ndescription</task>` by [agent-session.ts:380](https://github.com/beevibe-ai/beevibe/blob/main/packages/core/src/services/agent-session.ts#L380). Users saw the literal XML in the header. Added `formatIntent()` in [lib/format.ts](packages/web/lib/format.ts) that strips the wrapper and shows just the title. Chat intents (no wrapper) pass through unchanged. Self-closing lifecycle-reminder intents (`<task id="..."/>`) render as "Lifecycle reminder".
- **Transcript overflow.** Long tool-name lists like `select:mcp__beevibe__create_work_product,mcp__beevibe__list_work_products,...` ran past the column edge because the content `<p>` had no overflow handling. Added `break-words [overflow-wrap:anywhere]` so unbreakable strings wrap.

## Test plan

- [ ] Open a task session whose intent is wrapped — H1 shows clean title.
- [ ] Open a chat session — H1 shows the raw chat message unchanged.
- [ ] Confirm a transcript row with a long underscore/comma-separated string wraps inside the column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)