### PR TITLE
chore(routing): drop team-agent disallowed-tools plumbing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,17 +67,17 @@ Or just run `pnpm dev` — it does this cleanup at the start now.
 - Sessions spawn with `--dangerously-skip-permissions --strict-mcp-config`
 - MCP config lives in `~/.beevibe/workspaces/<agent_id>/mcp-config.json`
 - Agent cwd is the workspace path (`~/.beevibe/workspaces/<agent_id>`)
-- Team agents in chat get `--disallowedTools Agent,Bash,Read,Write,Edit,Glob,...` to prevent self-handling of specialist work
 
 ## Team agent routing
 
 Team agents (hierarchy_level = 'team') in chat sessions:
-- Are blocked from file/shell/subagent tools via `--disallowedTools`
-- Only have beevibe MCP tools available
+- Keep full tool access — they need to read code, search repos, and write
+  scratch files to ground handoffs in real context
 - Must route work to subordinate specialists or recommend spawning one
 - Routing directive fires post-onboarding, even with zero subordinates
 
-Routing is enforced structurally (tool restriction), not just by prompt.
+Routing is enforced by prompt (`teamAgentRoutingDirective` +
+`BEEVIBE_LIFECYCLE_REMINDER_CHAT`), not by tool restriction.
 
 ## Checking if a change is live
 
@@ -91,16 +91,6 @@ tail -f /tmp/beevibe-daemon.log
 # Verify core dist has your change
 grep "your_symbol" packages/core/dist/adapters/claude-code/runtime.js
 ```
-
-## Claude Code CLI flags — check before using
-
-```bash
-claude --help | grep -A2 "allowed\|disallowed"
-```
-
-- `--allowedTools` / `--disallowedTools`: comma or space-separated tool names
-- Wildcards like `mcp__beevibe__*` are NOT supported — use explicit names or disallow the ones you don't want
-- `Agent` is a tool name (spawns subagents) — disallow it to prevent escape hatches
 
 ## Database
 

--- a/packages/api/src/runtime/router.ts
+++ b/packages/api/src/runtime/router.ts
@@ -25,7 +25,6 @@ import type { MemoryAgent } from "@beevibe/core/services/memory";
 import {
   composeIntent,
   composeSystemPromptAppend,
-  TEAM_COORDINATOR_DISALLOWED_TOOLS,
   teamAgentRoutingDirective,
 } from "@beevibe/core/services/agent-session";
 import { requireDaemon, requireHuman } from "../auth/middleware.js";
@@ -469,7 +468,6 @@ async function composeDispatchPayload(
     resume_session_id: priorSession?.cli_session_id,
     model: agent.runtime_config.model,
     max_turns: agent.runtime_config.max_turns,
-    disallowed_tools: isTeamChat ? [...TEAM_COORDINATOR_DISALLOWED_TOOLS] : undefined,
     env: { BEEVIBE_SESSION_ID: session.id, BEEVIBE_AGENT_ID: agent.id },
     type: session.type,
     mcp_server_url: deps.mcpServerUrl,

--- a/packages/api/src/runtime/types.ts
+++ b/packages/api/src/runtime/types.ts
@@ -69,8 +69,6 @@ export interface DispatchPayload {
   max_turns?: number;
   /** Session-scoped env vars; daemon merges with its own when spawning. */
   env: Record<string, string>;
-  /** Tools blocked via --disallowedTools. Set for team-agent chat sessions. */
-  disallowed_tools?: string[];
   type: SessionType;
   /** /mcp endpoint daemon writes into mcp-config.json. */
   mcp_server_url: string;

--- a/packages/core/src/adapters/claude-code/runtime.ts
+++ b/packages/core/src/adapters/claude-code/runtime.ts
@@ -88,9 +88,6 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     const maxTurns = context.max_turns ?? this.config.maxTurns;
     if (maxTurns) args.push("--max-turns", String(maxTurns));
     if (context.resume_session_id) args.push("--resume", context.resume_session_id);
-    if (context.disallowed_tools?.length) {
-      args.push("--disallowedTools", context.disallowed_tools.join(","));
-    }
     if (context.system_prompt_append.length > 0) {
       args.push("--append-system-prompt", context.system_prompt_append);
     }

--- a/packages/core/src/ports/runtime.ts
+++ b/packages/core/src/ports/runtime.ts
@@ -72,13 +72,6 @@ export interface RuntimeContext {
   max_turns?: number;
 
   /**
-   * Tools the CLI must not call. When set, passed as `--disallowedTools`
-   * to the Claude Code CLI. Used to prevent team agents from using
-   * file-system / shell tools directly.
-   */
-  disallowed_tools?: string[];
-
-  /**
    * Content appended to Claude Code's baseline system prompt via
    * `--append-system-prompt`. Required: AgentSession composes this from the
    * agent's `runtime_config.system_prompt_addition` baseline plus the memory

--- a/packages/core/src/services/agent-session.ts
+++ b/packages/core/src/services/agent-session.ts
@@ -19,7 +19,6 @@ export {
   BEEVIBE_MEMORY_REMINDER,
   CHAT_DIRECTIVES,
   ONBOARDING_DIRECTIVES,
-  TEAM_COORDINATOR_DISALLOWED_TOOLS,
   composeIntent,
   composeSystemPromptAppend,
   teamAgentRoutingDirective,

--- a/packages/core/src/services/spawn-prep.ts
+++ b/packages/core/src/services/spawn-prep.ts
@@ -314,28 +314,6 @@ directives the UI understands:
    when there's nothing concrete to choose.
 </chat_directives>`;
 
-/**
- * Tools team agents are blocked from using in chat sessions. Enforced
- * structurally via --disallowedTools so the model cannot self-handle
- * specialist work even if it ignores the routing prompt.
- *
- * Exported so router.ts can pass the same list to the CLI without
- * maintaining a separate copy that could drift.
- */
-export const TEAM_COORDINATOR_DISALLOWED_TOOLS = [
-  "Agent",
-  "Bash",
-  "Read",
-  "Write",
-  "Edit",
-  "MultiEdit",
-  "Glob",
-  "NotebookRead",
-  "NotebookEdit",
-  "WebSearch",
-  "WebFetch",
-] as const;
-
 export function teamAgentRoutingDirective(
   specialistNames: readonly string[],
 ): string {

--- a/packages/daemon/src/spawner.ts
+++ b/packages/daemon/src/spawner.ts
@@ -25,7 +25,6 @@ export interface DispatchPayload {
   model?: string;
   max_turns?: number;
   env: Record<string, string>;
-  disallowed_tools?: string[];
   type: "task" | "mesh_ask" | "mesh_negotiate" | "blocker" | "chat";
   mcp_server_url: string;
 }
@@ -121,7 +120,6 @@ export async function runDispatch(
       system_prompt_append: payload.system_prompt_append,
       model: payload.model,
       max_turns: payload.max_turns,
-      disallowed_tools: payload.disallowed_tools,
       env: payload.env,
       resume_session_id: payload.resume_session_id,
       abort_signal: abortSignal,


### PR DESCRIPTION
## Summary

Follow-up to #154 — removes the `--disallowedTools` enforcement for team-agent chat sessions. Routing is now enforced purely by prompt.

**Why:** The block list from #154 cut off `Read`, `Glob`, `NotebookRead`, `WebSearch`, and `WebFetch` — all read-only tools the coordinator legitimately needs to investigate the problem (fetch repos, scan code, look up docs) before writing a clean spec for a subordinate. It also blocked `Write`/`Edit`, so the team agent couldn't keep scratch notes mid-session. Without those, handoffs were drafted in the dark.

**What's kept from #154 (still correct):**
- `teamAgentRoutingDirective` fires for every post-onboarding team chat, including the empty-roster branch
- `BEEVIBE_LIFECYCLE_REMINDER_CHAT` no longer says "or to yourself when it is your specialty"

These two prompt fixes were the load-bearing part. The tool block was overkill.

**What's removed:**
- `TEAM_COORDINATOR_DISALLOWED_TOOLS` constant
- `disallowed_tools` field from `DispatchPayload` (api + daemon) and `RuntimeContext`
- `--disallowedTools` arg in `ClaudeCodeRuntime.execute`
- `CLAUDE.md` notes about tool restriction (replaced with a note that routing is prompt-enforced)

8 files, 4 insertions / 53 deletions — pure deletion of dead plumbing.

## Test plan
- [x] All 5 packages typecheck clean
- [x] `spawn-prep.test.ts` (13/13 passes — the post-#154 expectations around the empty-roster directive still hold)
- [ ] Team agent in chat can `Read` repo files, `Glob` for patterns, and `WebFetch` library docs to ground a `create_task` spec
- [ ] Team agent still routes (doesn't draft the deliverable itself) — covered by the unchanged routing directive + lifecycle reminder

🤖 Generated with [Claude Code](https://claude.com/claude-code)