### PR TITLE
fix(daemon): claimer test passes runtimeRegistry to satisfy ClaimerConfig

### DIFF
--- a/packages/daemon/src/claimer.test.ts
+++ b/packages/daemon/src/claimer.test.ts
@@ -44,6 +44,7 @@ describe("Claimer.pollRuntime resilience", () => {
       api,
       supervisor: new Supervisor(2),
       workspaceManager: {} as LocalWorkspaceManager,
+      runtimeRegistry: {},
       runtimeIds: ["rt_1"],
       pollIntervalMs: 60_000,
       heartbeatIntervalMs: 60_000,


### PR DESCRIPTION
Post-merge fix: \`claimer.test.ts\` (added separately on main) doesn't pass \`runtimeRegistry\`, which became a required field on \`ClaimerConfig\` when PR #150 merged. Both landed independently, the test wasn't updated, CI tsc failed on main.

## Fix

One line — add \`runtimeRegistry: {}\` to the test's \`new Claimer({...})\` call. The test only asserts that a rejected \`claim()\` doesn't bubble (no \`runDispatch\` path), so an empty registry typechecks and is semantically a no-op.

## Verification

- \`pnpm --filter @beevibe/daemon build\` — green
- \`pnpm --filter @beevibe/daemon test\` — 7/7 (incl. the affected claimer test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)