### PR TITLE
feat(daemon): `sync` subcommand for registering newly-installed CLIs

### DIFF
--- a/packages/api/src/runtime/router.test.ts
+++ b/packages/api/src/runtime/router.test.ts
@@ -244,6 +244,102 @@ describe("/runtime — integration", () => {
     });
   });
 
+  /* ─── /runtime/sync ───────────────────────────────────────────────── */
+
+  describe("POST /runtime/sync", () => {
+    it("adds a newly-detected CLI to an existing daemon without rotating the token", async () => {
+      const alice = await makeAlice();
+      const { token, daemonId: dId, runtimeId: rId } = await makeRegisteredDaemon(
+        alice.person.id,
+      );
+
+      const res = await request(makeApp())
+        .post("/runtime/sync")
+        .set("Authorization", `Bearer ${token}`)
+        .send({
+          runtimes: [
+            { cli: "claude", cli_version: "1.2.3" },
+            { cli: "codex", cli_version: "0.47.0" },
+          ],
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.runtimes.map((r: { cli: string }) => r.cli).sort()).toEqual([
+        "claude",
+        "codex",
+      ]);
+      // Existing claude runtime keeps its id (upsert, not replace).
+      const claudeRow = res.body.runtimes.find(
+        (r: { cli: string }) => r.cli === "claude",
+      );
+      expect(claudeRow?.id).toBe(rId);
+      // The codex runtime was created fresh.
+      const codexRow = res.body.runtimes.find(
+        (r: { cli: string }) => r.cli === "codex",
+      );
+      expect(codexRow?.id).toMatch(/^rt_/);
+
+      // Token must NOT rotate — that's the whole point of /sync vs /register.
+      const daemon = await daemonRepo.findById(dId);
+      expect(daemon?.token_hash).toBe(hashDaemonToken(token));
+    });
+
+    it("updates cli_version when a re-detected CLI reports a new version", async () => {
+      const alice = await makeAlice();
+      const { token, runtimeId: rId } = await makeRegisteredDaemon(alice.person.id);
+
+      const res = await request(makeApp())
+        .post("/runtime/sync")
+        .set("Authorization", `Bearer ${token}`)
+        .send({ runtimes: [{ cli: "claude", cli_version: "2.0.0" }] });
+
+      expect(res.status).toBe(200);
+      const updated = await runtimeRepo.findById(rId);
+      expect(updated?.cli_version).toBe("2.0.0");
+    });
+
+    it("rejects human callers (only bv_d_ may sync)", async () => {
+      const alice = await makeAlice();
+      const res = await request(makeApp())
+        .post("/runtime/sync")
+        .set("Authorization", `Bearer ${alice.apiKey}`)
+        .send({ runtimes: [{ cli: "claude" }] });
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe("daemon_required");
+    });
+
+    it("returns 400 when body is malformed", async () => {
+      const alice = await makeAlice();
+      const { token } = await makeRegisteredDaemon(alice.person.id);
+      const res = await request(makeApp())
+        .post("/runtime/sync")
+        .set("Authorization", `Bearer ${token}`)
+        .send({ runtimes: [] });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("invalid_body");
+    });
+
+    it("scopes upsert to the caller's daemon — cannot mutate another daemon's runtimes", async () => {
+      const alice = await makeAlice();
+      const { person: bob } = await makePersonWithAgent("Bob", "bob-sync@example.com");
+      const aliceDaemon = await makeRegisteredDaemon(alice.person.id);
+      const bobDaemon = await makeRegisteredDaemon(bob.person.id);
+
+      // Alice's daemon syncs — should only touch Alice's runtimes.
+      await request(makeApp())
+        .post("/runtime/sync")
+        .set("Authorization", `Bearer ${aliceDaemon.token}`)
+        .send({ runtimes: [{ cli: "codex" }] });
+
+      // Bob's runtimes untouched: still exactly one runtime row (claude, from
+      // makeRegisteredDaemon), no codex row stamped under Bob's daemon.
+      const bobRuntime = await runtimeRepo.findById(bobDaemon.runtimeId);
+      expect(bobRuntime?.cli).toBe("claude");
+      const bobCodex = await runtimeRepo.findByDaemonAndCli(bobDaemon.daemonId, "codex");
+      expect(bobCodex).toBeUndefined();
+    });
+  });
+
   /* ─── /runtime/heartbeat ──────────────────────────────────────────── */
 
   describe("POST /runtime/heartbeat", () => {

--- a/packages/api/src/runtime/router.test.ts
+++ b/packages/api/src/runtime/router.test.ts
@@ -268,12 +268,10 @@ describe("/runtime — integration", () => {
         "claude",
         "codex",
       ]);
-      // Existing claude runtime keeps its id (upsert, not replace).
       const claudeRow = res.body.runtimes.find(
         (r: { cli: string }) => r.cli === "claude",
       );
       expect(claudeRow?.id).toBe(rId);
-      // The codex runtime was created fresh.
       const codexRow = res.body.runtimes.find(
         (r: { cli: string }) => r.cli === "codex",
       );
@@ -325,14 +323,11 @@ describe("/runtime — integration", () => {
       const aliceDaemon = await makeRegisteredDaemon(alice.person.id);
       const bobDaemon = await makeRegisteredDaemon(bob.person.id);
 
-      // Alice's daemon syncs — should only touch Alice's runtimes.
       await request(makeApp())
         .post("/runtime/sync")
         .set("Authorization", `Bearer ${aliceDaemon.token}`)
         .send({ runtimes: [{ cli: "codex" }] });
 
-      // Bob's runtimes untouched: still exactly one runtime row (claude, from
-      // makeRegisteredDaemon), no codex row stamped under Bob's daemon.
       const bobRuntime = await runtimeRepo.findById(bobDaemon.runtimeId);
       expect(bobRuntime?.cli).toBe("claude");
       const bobCodex = await runtimeRepo.findByDaemonAndCli(bobDaemon.daemonId, "codex");

--- a/packages/api/src/runtime/router.ts
+++ b/packages/api/src/runtime/router.ts
@@ -120,12 +120,8 @@ export function createRuntimeRouter(deps: RuntimeRouterDeps): Router {
     }
   });
 
-  // POST /runtime/sync — bv_d_ auth. Re-detect after the user installed
-  // a new CLI on the daemon's machine. Upserts runtimes against the
-  // caller's existing daemon row; does NOT rotate the daemon token (the
-  // bv_d_ in `req.caller.daemonId` is already proving identity). Returns
-  // the full post-upsert runtime list so the daemon can update its
-  // ~/.beevibe/config.json.
+  // Re-runs CLI detection; upserts runtimes scoped by the bv_d_ — no
+  // token rotation, unlike /register.
   router.post("/sync", async (req, res) => {
     if (!requireDaemon(req, res)) return;
     const body = parseSyncBody(req.body);
@@ -322,30 +318,40 @@ export function createRuntimeRouter(deps: RuntimeRouterDeps): Router {
 
 /* ─── helpers ────────────────────────────────────────────────────────── */
 
+/**
+ * Shape check for the `runtimes: [{cli, cli_version?}]` array shared by
+ * /register and /sync. Returns the typed array or null on any
+ * structural defect — caller decides whether the surrounding body is
+ * still valid.
+ */
+function parseRuntimesArray(
+  input: unknown,
+): RuntimeRegisterRequest["runtimes"] | null {
+  if (!Array.isArray(input) || input.length === 0) return null;
+  for (const r of input) {
+    if (!r || typeof r !== "object") return null;
+    const e = r as Partial<{ cli: unknown; cli_version: unknown }>;
+    if (typeof e.cli !== "string" || !e.cli) return null;
+    if (e.cli_version !== undefined && typeof e.cli_version !== "string") return null;
+  }
+  return input as RuntimeRegisterRequest["runtimes"];
+}
+
 function parseRegisterBody(body: unknown): RuntimeRegisterRequest | null {
   if (!body || typeof body !== "object") return null;
   const b = body as Partial<RuntimeRegisterRequest>;
   if (typeof b.external_id !== "string" || !b.external_id) return null;
   if (typeof b.device_name !== "string" || !b.device_name) return null;
-  if (!Array.isArray(b.runtimes) || b.runtimes.length === 0) return null;
-  for (const r of b.runtimes) {
-    if (!r || typeof r !== "object") return null;
-    if (typeof r.cli !== "string" || !r.cli) return null;
-    if (r.cli_version !== undefined && typeof r.cli_version !== "string") return null;
-  }
-  return b as RuntimeRegisterRequest;
+  const runtimes = parseRuntimesArray(b.runtimes);
+  if (!runtimes) return null;
+  return { external_id: b.external_id, device_name: b.device_name, runtimes };
 }
 
 function parseSyncBody(body: unknown): RuntimeSyncRequest | null {
   if (!body || typeof body !== "object") return null;
-  const b = body as Partial<RuntimeSyncRequest>;
-  if (!Array.isArray(b.runtimes) || b.runtimes.length === 0) return null;
-  for (const r of b.runtimes) {
-    if (!r || typeof r !== "object") return null;
-    if (typeof r.cli !== "string" || !r.cli) return null;
-    if (r.cli_version !== undefined && typeof r.cli_version !== "string") return null;
-  }
-  return b as RuntimeSyncRequest;
+  const runtimes = parseRuntimesArray((body as Partial<RuntimeSyncRequest>).runtimes);
+  if (!runtimes) return null;
+  return { runtimes };
 }
 
 function isValidEvent(e: unknown): e is RuntimeEventInput {

--- a/packages/api/src/runtime/router.ts
+++ b/packages/api/src/runtime/router.ts
@@ -39,6 +39,8 @@ import type {
   RuntimeRegisterResponse,
   RuntimeSkill,
   RuntimeSkillsResponse,
+  RuntimeSyncRequest,
+  RuntimeSyncResponse,
 } from "./types.js";
 
 export interface RuntimeRouterDeps {
@@ -115,6 +117,34 @@ export function createRuntimeRouter(deps: RuntimeRouterDeps): Router {
     } catch (err) {
       console.error("[runtime/register]", err);
       res.status(500).json({ error: "register_failed" });
+    }
+  });
+
+  // POST /runtime/sync — bv_d_ auth. Re-detect after the user installed
+  // a new CLI on the daemon's machine. Upserts runtimes against the
+  // caller's existing daemon row; does NOT rotate the daemon token (the
+  // bv_d_ in `req.caller.daemonId` is already proving identity). Returns
+  // the full post-upsert runtime list so the daemon can update its
+  // ~/.beevibe/config.json.
+  router.post("/sync", async (req, res) => {
+    if (!requireDaemon(req, res)) return;
+    const body = parseSyncBody(req.body);
+    if (!body) {
+      res.status(400).json({
+        error: "invalid_body",
+        message: "expected { runtimes: [{cli, cli_version?}] }",
+      });
+      return;
+    }
+    try {
+      const runtimes = await upsertRuntimes(deps, req.caller!.daemonId, body.runtimes);
+      const response: RuntimeSyncResponse = {
+        runtimes: runtimes.map((r) => ({ id: r.id, cli: r.cli })),
+      };
+      res.status(200).json(response);
+    } catch (err) {
+      console.error("[runtime/sync]", err);
+      res.status(500).json({ error: "sync_failed" });
     }
   });
 
@@ -304,6 +334,18 @@ function parseRegisterBody(body: unknown): RuntimeRegisterRequest | null {
     if (r.cli_version !== undefined && typeof r.cli_version !== "string") return null;
   }
   return b as RuntimeRegisterRequest;
+}
+
+function parseSyncBody(body: unknown): RuntimeSyncRequest | null {
+  if (!body || typeof body !== "object") return null;
+  const b = body as Partial<RuntimeSyncRequest>;
+  if (!Array.isArray(b.runtimes) || b.runtimes.length === 0) return null;
+  for (const r of b.runtimes) {
+    if (!r || typeof r !== "object") return null;
+    if (typeof r.cli !== "string" || !r.cli) return null;
+    if (r.cli_version !== undefined && typeof r.cli_version !== "string") return null;
+  }
+  return b as RuntimeSyncRequest;
 }
 
 function isValidEvent(e: unknown): e is RuntimeEventInput {

--- a/packages/api/src/runtime/types.ts
+++ b/packages/api/src/runtime/types.ts
@@ -35,6 +35,25 @@ export interface RuntimeRegisterResponse {
   runtimes: Array<{ id: string; cli: string }>;
 }
 
+/**
+ * `POST /runtime/sync` — bv_d_ auth. Re-runs CLI detection on a daemon
+ * that was already set up. Upserts runtimes against the caller's
+ * daemon row (no `external_id` lookup — the bv_d_ already identifies
+ * the daemon). Used by `beevibe-daemon sync` after the user installs
+ * a new CLI without rotating the daemon's token.
+ */
+export interface RuntimeSyncRequest {
+  runtimes: Array<{
+    cli: string;
+    cli_version?: string;
+  }>;
+}
+
+export interface RuntimeSyncResponse {
+  /** Full list of runtimes for this daemon after the upsert. */
+  runtimes: Array<{ id: string; cli: string }>;
+}
+
 /* ─── Heartbeat ──────────────────────────────────────────────────────── */
 
 export interface RuntimeHeartbeatRequest {

--- a/packages/daemon/src/claimer.test.ts
+++ b/packages/daemon/src/claimer.test.ts
@@ -44,6 +44,7 @@ describe("Claimer.pollRuntime resilience", () => {
       api,
       supervisor: new Supervisor(2),
       workspaceManager: {} as LocalWorkspaceManager,
+      runtimeRegistry: {},
       runtimeIds: ["rt_1"],
       pollIntervalMs: 60_000,
       heartbeatIntervalMs: 60_000,

--- a/packages/daemon/src/detect-clis.ts
+++ b/packages/daemon/src/detect-clis.ts
@@ -1,0 +1,28 @@
+/**
+ * Probe PATH for every CLI in `KNOWN_CLIS` and capture each one's
+ * `--version`. Shared by `beevibe-daemon setup` (initial registration)
+ * and `beevibe-daemon sync` (post-install re-registration).
+ */
+
+import { spawnSync } from "node:child_process";
+import { KNOWN_CLIS } from "@beevibe/core";
+
+export interface DetectedCli {
+  cli: string;
+  cli_version?: string;
+}
+
+export function detectClis(): DetectedCli[] {
+  const out: DetectedCli[] = [];
+  for (const cli of KNOWN_CLIS) {
+    const which = spawnSync("which", [cli], { encoding: "utf8" });
+    if (which.status !== 0 || !which.stdout.trim()) continue;
+    const version = spawnSync(cli, ["--version"], { encoding: "utf8" });
+    out.push({
+      cli,
+      cli_version:
+        version.status === 0 ? version.stdout.trim().split("\n")[0] : undefined,
+    });
+  }
+  return out;
+}

--- a/packages/daemon/src/detect-clis.ts
+++ b/packages/daemon/src/detect-clis.ts
@@ -2,9 +2,14 @@
  * Probe PATH for every CLI in `KNOWN_CLIS` and capture each one's
  * `--version`. Shared by `beevibe-daemon setup` (initial registration)
  * and `beevibe-daemon sync` (post-install re-registration).
+ *
+ * Probes run in parallel — `<cli> --version` on a cold machine can take
+ * hundreds of ms (subprocess startup + module loads), so sequential
+ * probing across 3+ known CLIs becomes noticeable wall time.
  */
 
-import { spawnSync } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { KNOWN_CLIS } from "@beevibe/core";
 
 export interface DetectedCli {
@@ -12,17 +17,26 @@ export interface DetectedCli {
   cli_version?: string;
 }
 
-export function detectClis(): DetectedCli[] {
-  const out: DetectedCli[] = [];
-  for (const cli of KNOWN_CLIS) {
-    const which = spawnSync("which", [cli], { encoding: "utf8" });
-    if (which.status !== 0 || !which.stdout.trim()) continue;
-    const version = spawnSync(cli, ["--version"], { encoding: "utf8" });
-    out.push({
-      cli,
-      cli_version:
-        version.status === 0 ? version.stdout.trim().split("\n")[0] : undefined,
-    });
+const execFileAsync = promisify(execFile);
+
+async function probeOne(cli: string): Promise<DetectedCli | null> {
+  try {
+    await execFileAsync("which", [cli]);
+  } catch {
+    return null;
   }
-  return out;
+  let cli_version: string | undefined;
+  try {
+    const { stdout } = await execFileAsync(cli, ["--version"]);
+    cli_version = stdout.trim().split("\n")[0];
+  } catch {
+    // CLI exists on PATH but --version errored. Still report the CLI;
+    // version stays undefined.
+  }
+  return { cli, cli_version };
+}
+
+export async function detectClis(): Promise<DetectedCli[]> {
+  const results = await Promise.all(KNOWN_CLIS.map((cli) => probeOne(cli)));
+  return results.filter((r): r is DetectedCli => r !== null);
 }

--- a/packages/daemon/src/main.ts
+++ b/packages/daemon/src/main.ts
@@ -104,20 +104,14 @@ async function main(): Promise<void> {
   if (command === "sync") {
     const result = await runSync();
     if (result.added.length === 0) {
-      console.log(
-        `No new CLIs detected. Registered runtimes: ${result.runtimes
-          .map((r) => r.cli)
-          .join(", ")}.`,
-      );
+      console.log("No new CLIs detected.");
     } else {
       console.log(
         `Added ${result.added.length} runtime(s): ${result.added
           .map((r) => `${r.cli} (${r.id})`)
           .join(", ")}.`,
       );
-      console.log(
-        "Restart 'beevibe-daemon start' to pick up the new runtime(s).",
-      );
+      console.log("Restart the daemon to pick up the new runtime(s).");
     }
     return;
   }

--- a/packages/daemon/src/main.ts
+++ b/packages/daemon/src/main.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 /**
- * `beevibe-daemon` CLI entry. Three subcommands:
+ * `beevibe-daemon` CLI entry. Four subcommands:
  *   - setup --api <url> --user-token <bv_u_…> [--device-name <name>]
  *   - start
+ *   - sync       Re-detect CLIs on PATH and register newly-installed ones.
  *   - update [--yes]
  *
  * The daemon owns its own config (~/.beevibe/config.json) and has no
@@ -14,6 +15,7 @@
 
 import { runSetup } from "./setup.js";
 import { runStart } from "./start.js";
+import { runSync } from "./sync.js";
 import { runUpdate } from "./update.js";
 
 interface Flags {
@@ -53,6 +55,7 @@ function printHelp(): void {
       "Commands:",
       "  setup    Register this machine with a beevibe api server.",
       "  start    Run the daemon: claim pending sessions and spawn the CLI.",
+      "  sync     Re-detect CLIs on PATH and register newly-installed ones.",
       "  update   Check for and install a newer daemon binary (brew/curl installs).",
       "",
       "setup flags:",
@@ -95,6 +98,27 @@ async function main(): Promise<void> {
 
   if (command === "start") {
     await runStart();
+    return;
+  }
+
+  if (command === "sync") {
+    const result = await runSync();
+    if (result.added.length === 0) {
+      console.log(
+        `No new CLIs detected. Registered runtimes: ${result.runtimes
+          .map((r) => r.cli)
+          .join(", ")}.`,
+      );
+    } else {
+      console.log(
+        `Added ${result.added.length} runtime(s): ${result.added
+          .map((r) => `${r.cli} (${r.id})`)
+          .join(", ")}.`,
+      );
+      console.log(
+        "Restart 'beevibe-daemon start' to pick up the new runtime(s).",
+      );
+    }
     return;
   }
 

--- a/packages/daemon/src/setup.ts
+++ b/packages/daemon/src/setup.ts
@@ -38,7 +38,7 @@ export async function runSetup(options: SetupOptions): Promise<DaemonConfig> {
   const externalId = options.externalId ?? hostname();
   const deviceName =
     options.deviceName ?? `${userInfo().username}@${hostname()}`;
-  const runtimes = options.detectedClis ?? detectClis();
+  const runtimes = options.detectedClis ?? (await detectClis());
   if (runtimes.length === 0) {
     throw new Error(
       `No supported CLIs detected on PATH. beevibe currently looks for: ${KNOWN_CLIS.join(", ")}`,

--- a/packages/daemon/src/setup.ts
+++ b/packages/daemon/src/setup.ts
@@ -9,9 +9,9 @@
  */
 
 import { hostname, userInfo } from "node:os";
-import { spawnSync } from "node:child_process";
 import { KNOWN_CLIS } from "@beevibe/core";
 import { saveConfig, type DaemonConfig } from "./config.js";
+import { detectClis } from "./detect-clis.js";
 
 export interface SetupOptions {
   apiUrl: string;
@@ -77,17 +77,3 @@ export async function runSetup(options: SetupOptions): Promise<DaemonConfig> {
   return config;
 }
 
-function detectClis(): Array<{ cli: string; cli_version?: string }> {
-  const out: Array<{ cli: string; cli_version?: string }> = [];
-  for (const cli of KNOWN_CLIS) {
-    const which = spawnSync("which", [cli], { encoding: "utf8" });
-    if (which.status !== 0 || !which.stdout.trim()) continue;
-    const version = spawnSync(cli, ["--version"], { encoding: "utf8" });
-    out.push({
-      cli,
-      cli_version:
-        version.status === 0 ? version.stdout.trim().split("\n")[0] : undefined,
-    });
-  }
-  return out;
-}

--- a/packages/daemon/src/sync.ts
+++ b/packages/daemon/src/sync.ts
@@ -1,0 +1,62 @@
+/**
+ * `beevibe-daemon sync` — pick up a newly-installed CLI on this machine
+ * without rotating the daemon's identity.
+ *
+ * Reads ~/.beevibe/config.json, re-runs detectClis(), POSTs the result
+ * to /runtime/sync (bv_d_ auth — no human token needed), and writes
+ * back the full runtime list returned by the api. Caller must restart
+ * `beevibe-daemon start` to make the new runtime ids show up in the
+ * poll loop.
+ */
+
+import { KNOWN_CLIS } from "@beevibe/core";
+import { loadConfig, saveConfig, CONFIG_PATH, type DaemonConfig } from "./config.js";
+import { detectClis } from "./detect-clis.js";
+
+interface SyncResponse {
+  runtimes: Array<{ id: string; cli: string }>;
+}
+
+export interface SyncResult {
+  /** Runtimes added since the previous config. */
+  added: Array<{ id: string; cli: string }>;
+  /** Full runtime list after the sync. */
+  runtimes: Array<{ id: string; cli: string }>;
+}
+
+export async function runSync(): Promise<SyncResult> {
+  const config = loadConfig();
+  if (!config) {
+    throw new Error(
+      `No daemon config at ${CONFIG_PATH}. Run 'beevibe-daemon setup' first.`,
+    );
+  }
+
+  const detected = detectClis();
+  if (detected.length === 0) {
+    throw new Error(
+      `No supported CLIs detected on PATH. beevibe currently looks for: ${KNOWN_CLIS.join(", ")}`,
+    );
+  }
+
+  const res = await fetch(`${config.api_url}/runtime/sync`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${config.daemon_token}`,
+    },
+    body: JSON.stringify({ runtimes: detected }),
+  });
+  if (res.status !== 200) {
+    throw new Error(`/runtime/sync failed: ${res.status} ${await res.text()}`);
+  }
+  const body = (await res.json()) as SyncResponse;
+
+  const before = new Set(config.runtimes.map((r) => r.cli));
+  const added = body.runtimes.filter((r) => !before.has(r.cli));
+
+  const next: DaemonConfig = { ...config, runtimes: body.runtimes };
+  saveConfig(next);
+
+  return { added, runtimes: body.runtimes };
+}

--- a/packages/daemon/src/sync.ts
+++ b/packages/daemon/src/sync.ts
@@ -10,6 +10,7 @@
  */
 
 import { KNOWN_CLIS } from "@beevibe/core";
+import { ApiClient } from "./api-client.js";
 import { loadConfig, saveConfig, CONFIG_PATH, type DaemonConfig } from "./config.js";
 import { detectClis } from "./detect-clis.js";
 
@@ -32,25 +33,23 @@ export async function runSync(): Promise<SyncResult> {
     );
   }
 
-  const detected = detectClis();
+  const detected = await detectClis();
   if (detected.length === 0) {
     throw new Error(
       `No supported CLIs detected on PATH. beevibe currently looks for: ${KNOWN_CLIS.join(", ")}`,
     );
   }
 
-  const res = await fetch(`${config.api_url}/runtime/sync`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      authorization: `Bearer ${config.daemon_token}`,
-    },
-    body: JSON.stringify({ runtimes: detected }),
+  const api = new ApiClient({
+    apiUrl: config.api_url,
+    daemonToken: config.daemon_token,
   });
-  if (res.status !== 200) {
-    throw new Error(`/runtime/sync failed: ${res.status} ${await res.text()}`);
+  const { status, body } = await api.post<SyncResponse>("/runtime/sync", {
+    runtimes: detected,
+  });
+  if (status !== 200 || !body) {
+    throw new Error(`/runtime/sync failed: ${status}`);
   }
-  const body = (await res.json()) as SyncResponse;
 
   const before = new Set(config.runtimes.map((r) => r.cli));
   const added = body.runtimes.filter((r) => !before.has(r.cli));


### PR DESCRIPTION
Adds `beevibe-daemon sync` — pick up a newly-installed CLI on the daemon's machine without re-running setup.

## Why

Today, the only way to register a CLI installed after `beevibe-daemon setup` is to re-run setup with the original `bv_u_` user token. That:

- Requires the user to keep their `bv_u_` handy long-term (most won't)
- Rotates the daemon's `bv_d_` token mid-flight, breaking any running daemon process
- Touches the whole daemon row when nothing about its identity changed

## What `sync` does

```
beevibe-daemon sync
→ Added 1 runtime(s): codex (rt_xyz).
  Restart 'beevibe-daemon start' to pick up the new runtime(s).
```

- Reads `~/.beevibe/config.json` for `daemon_token` + `api_url`
- Re-runs `detectClis()` against PATH
- POSTs to `/runtime/sync` with the daemon's existing `bv_d_` (no human token)
- Server upserts runtimes against `req.caller.daemonId` (no `external_id` lookup — daemon identity is already proven)
- Writes the updated runtime list back to `config.json`
- Returns the diff for clear user feedback

## API surface

New route: `POST /runtime/sync` — `bv_d_` auth only. Body: `{ runtimes: [{cli, cli_version?}] }`. Returns: `{ runtimes: [{id, cli}] }` (full post-upsert list).

Reuses the existing `upsertRuntimes()` helper so version updates and idempotent re-syncs Just Work. Cross-tenant safe — the upsert is scoped to `req.caller.daemonId`.

## Daemon-side

- Extracted `detectClis()` from `setup.ts` to a shared `detect-clis.ts` so setup + sync use one PATH-probe implementation
- New `sync.ts` module + `sync` subcommand wired into `main.ts`

## Out of scope (follow-up)

Hot-reload of the running daemon when a new runtime appears. Currently the user runs `sync` then restarts `start`. A 100-line follow-up could have the daemon watch `config.json` for changes and add the new runtime to its poll set without restart.

## Tests

Five new integration tests on `/runtime/sync` in `router.test.ts`:
- Adds a newly-detected CLI without rotating the token
- Updates `cli_version` when a re-detected CLI reports a new version
- Rejects human callers (403 `daemon_required`)
- Returns 400 on malformed body
- Cross-tenant isolation — Alice's daemon cannot mutate Bob's runtimes

## Verification

- `pnpm -w build` — 5/5 green
- `pnpm --filter @beevibe/api test` — 330/330 (incl. 5 new)
- `pnpm --filter @beevibe/daemon test` — 7/7

🤖 Generated with [Claude Code](https://claude.com/claude-code)