### PR TITLE
chore(chat): remove per-turn runtime picker from the chat composer

### DIFF
--- a/packages/api/src/bootstrap.ts
+++ b/packages/api/src/bootstrap.ts
@@ -399,7 +399,6 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
     authMiddleware: server.getAuthMiddleware(),
     agentRepo,
     personRepo,
-    runtimeRepo,
     sessionRepo,
     dispatchService,
     chatResolver,

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -25,12 +25,8 @@ import { randomUUID } from "node:crypto";
 import { Router, type RequestHandler, type Response } from "express";
 import {
   isInFlightSessionStatus,
-  isKnownCli,
-  KNOWN_CLIS,
   type AgentRepository,
-  type KnownCli,
   type PersonRepository,
-  type RuntimeRepository,
   type SessionRepository,
 } from "@beevibe/core";
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
@@ -46,7 +42,6 @@ export interface ChatRoutesDeps {
   authMiddleware: RequestHandler;
   agentRepo: AgentRepository;
   personRepo: PersonRepository;
-  runtimeRepo: RuntimeRepository;
   sessionRepo: SessionRepository;
   /**
    * Phase 4 daemon-first chat path: dispatchService inserts a pending
@@ -274,90 +269,6 @@ interface ChatTurnAgent {
   hierarchy_level: string;
 }
 
-async function resolvePinnedRuntimeCli(
-  deps: Pick<ChatRoutesDeps, "runtimeRepo">,
-  sessions: readonly ChatSession[],
-): Promise<KnownCli | undefined> {
-  // Walk newest → oldest so we surface the most recent claim. Legacy
-  // sessions with no runtime_id are skipped; if none in the chain ever
-  // ran on a runtime, the conversation isn't pinned.
-  for (let i = sessions.length - 1; i >= 0; i -= 1) {
-    const runtimeId = sessions[i]?.runtime_id;
-    if (!runtimeId) continue;
-    const runtime = await deps.runtimeRepo.findById(runtimeId);
-    if (runtime && isKnownCli(runtime.cli)) return runtime.cli;
-    return undefined;
-  }
-  return undefined;
-}
-
-async function resolveRuntimeOverride(
-  deps: Pick<ChatRoutesDeps, "runtimeRepo" | "sessionRepo" | "hub">,
-  ownerPersonId: string,
-  runtimeType: KnownCli | undefined,
-  priorSessionId: string | undefined,
-): Promise<
-  | { ok: true; runtimeIdOverride?: string }
-  | { ok: false; status: number; body: Record<string, unknown> }
-> {
-  if (!runtimeType) return { ok: true };
-
-  if (priorSessionId) {
-    const prior = await deps.sessionRepo.findById(priorSessionId);
-    if (prior?.runtime_id) {
-      const priorRuntime = await deps.runtimeRepo.findById(prior.runtime_id);
-      if (priorRuntime?.cli !== runtimeType) {
-        return {
-          ok: false,
-          status: 409,
-          body: {
-            error: "runtime_switch_requires_new_chat",
-            message:
-              "This conversation is already pinned to another runtime. Start a new chat to switch runtimes.",
-          },
-        };
-      }
-      if (!deps.hub.isOnline(prior.runtime_id)) {
-        return {
-          ok: false,
-          status: 503,
-          body: {
-            error: "runtime_offline",
-            message: `The ${runtimeType} runtime for this conversation is offline. Start the same daemon to resume it.`,
-          },
-        };
-      }
-      return { ok: true, runtimeIdOverride: prior.runtime_id };
-    }
-  }
-
-  const runtimes = await deps.runtimeRepo.listByOwnerAndCli(ownerPersonId, runtimeType);
-  if (runtimes.length === 0) {
-    return {
-      ok: false,
-      status: 400,
-      body: {
-        error: "runtime_not_registered",
-        message: `No ${runtimeType} runtime is registered for this account.`,
-      },
-    };
-  }
-
-  const online = runtimes.find((r) => deps.hub.isOnline(r.id));
-  if (!online) {
-    return {
-      ok: false,
-      status: 503,
-      body: {
-        error: "runtime_offline",
-        message: `No online ${runtimeType} runtime is available. Start beevibe-daemon on a machine with ${runtimeType}.`,
-      },
-    };
-  }
-
-  return { ok: true, runtimeIdOverride: online.id };
-}
-
 /**
  * Build the response body for a chat turn — used by both the live
  * POST success path and the idempotent-replay path. `replayed: true`
@@ -552,10 +463,6 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
     // present but the agent reply slot is empty until SSE auto-recovery
     // (PR #116) lands the response.
     const inFlightSessionId = isInFlightSessionStatus(latest.status) ? latest.id : undefined;
-    // Surface the CLI this conversation is pinned to so the composer can
-    // lock its runtime picker — otherwise the user can pick a different
-    // CLI mid-chat and the next send 409s.
-    const pinnedRuntimeCli = await resolvePinnedRuntimeCli(deps, chain.sessions);
 
     res.json({
       ok: true,
@@ -564,7 +471,6 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
       prior_session_id: latest.id,
       conversation_id: chain.head_id,
       in_flight_session_id: inFlightSessionId,
-      pinned_runtime_cli: pinnedRuntimeCli,
     });
   });
 
@@ -582,16 +488,6 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
     }
     const priorSessionId =
       typeof body.prior_session_id === "string" ? body.prior_session_id : undefined;
-    const runtimeTypeRaw = body.runtime_type;
-    const runtimeType =
-      runtimeTypeRaw === undefined ? undefined : isKnownCli(runtimeTypeRaw) ? runtimeTypeRaw : null;
-    if (runtimeType === null) {
-      res.status(400).json({
-        error: "invalid_runtime_type",
-        message: `runtime_type must be one of: ${KNOWN_CLIS.join(", ")}`,
-      });
-      return;
-    }
     const callerSessionId =
       typeof body.session_id === "string" && /^sess_[A-Za-z0-9]{12}$/.test(body.session_id)
         ? body.session_id
@@ -618,10 +514,6 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
     // another Claude Code subprocess. Each turn is real $$; this
     // collapses double-submits, browser-cache POST replays, and
     // network-blip retries to a single charge.
-    //
-    // Check this BEFORE resolving the runtime override — the original
-    // turn already validated and pinned a runtime, so a replay doesn't
-    // need to revalidate, and skipping it spares 1-2 DB hits on retries.
     if (callerSessionId) {
       const replay = await tryReplay(deps, agent, callerSessionId);
       if (replay) {
@@ -630,17 +522,6 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
           return;
         }
       }
-    }
-
-    const runtimeOverride = await resolveRuntimeOverride(
-      deps,
-      req.caller.personId,
-      runtimeType,
-      priorSessionId,
-    );
-    if (!runtimeOverride.ok) {
-      res.status(runtimeOverride.status).json(runtimeOverride.body);
-      return;
     }
 
     // Per-person rate limit (concurrent + sliding window). Compromised
@@ -676,7 +557,6 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
         intent: messageRaw,
         reason,
         type: "chat",
-        runtimeIdOverride: runtimeOverride.runtimeIdOverride,
         sessionIdOverride: callerSessionId,
       });
     } catch (err) {

--- a/packages/web/app/(authed)/chat/chat-client.tsx
+++ b/packages/web/app/(authed)/chat/chat-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
@@ -9,15 +9,12 @@ import {
   ArrowRight,
   ArrowUp,
   MessageSquare,
-  Terminal,
 } from "lucide-react";
-import type { HierarchyLevel, KnownCli } from "@beevibe/core";
-import { isKnownCli, KNOWN_CLIS } from "@beevibe/core/domain";
+import type { HierarchyLevel } from "@beevibe/core";
 import { isApiConfigured } from "@/lib/api/config";
 import {
   api,
   type ChatConversationsResponse,
-  type RuntimesListResponse,
   type SuggestedAction,
 } from "@/lib/api/client";
 import { useChat, type ChatMessage } from "@/lib/hooks/use-chat";
@@ -53,22 +50,8 @@ const ONBOARDING_PROMPT_SUGGESTIONS = [
   "What can you do for me?",
 ];
 
-const RUNTIME_LABELS: Record<KnownCli, string> = {
-  claude: "Claude",
-  codex: "Codex",
-  opencode: "OpenCode",
-};
-
-function runtimeStatusSuffix(counts: { online: number; total: number }): string {
-  if (counts.online > 1) return ` (${counts.online} online)`;
-  if (counts.online === 1) return "";
-  if (counts.total > 0) return " (offline)";
-  return " (not set up)";
-}
-
 export function ChatClient() {
   const [draft, setDraft] = useState("");
-  const [runtimeType, setRuntimeType] = useState<KnownCli>("claude");
   const router = useRouter();
   const searchParams = useSearchParams();
   const { data: me } = useMe();
@@ -85,21 +68,11 @@ export function ChatClient() {
   const conversationParam = searchParams?.get("c") ?? undefined;
   const isFresh = searchParams?.get("new") === "1";
 
-  const { messages, send, isPending, isSubmitting, error, pendingSessionId, pinnedRuntimeCli } =
-    useChat({
-      conversationId: conversationParam,
-      fresh: isFresh,
-    });
+  const { messages, send, isPending, isSubmitting, error, pendingSessionId } = useChat({
+    conversationId: conversationParam,
+    fresh: isFresh,
+  });
 
-  // Once we load a conversation that's already claimed a runtime, mirror
-  // its CLI into the picker so the user sees the pinned value (instead
-  // of the "claude" default) and can't accidentally pick a different
-  // CLI — the server would 409 with `runtime_switch_requires_new_chat`.
-  useEffect(() => {
-    if (pinnedRuntimeCli && pinnedRuntimeCli !== runtimeType) {
-      setRuntimeType(pinnedRuntimeCli);
-    }
-  }, [pinnedRuntimeCli, runtimeType]);
   const liveSteps = useChatStream(pendingSessionId);
   const transcriptRef = useRef<HTMLDivElement | null>(null);
   const teamAgent = useTeamAgent();
@@ -147,7 +120,7 @@ export function ChatClient() {
   const submit = (text?: string) => {
     const value = text ?? draft;
     if (value.trim().length === 0) return;
-    send(value, runtimeType);
+    send(value);
     setDraft("");
   };
 
@@ -175,8 +148,6 @@ export function ChatClient() {
             draft={draft}
             setDraft={setDraft}
             onboarding={isOnboardingChat}
-            runtimeType={runtimeType}
-            setRuntimeType={setRuntimeType}
           />
         ) : (
           <>
@@ -220,13 +191,7 @@ export function ChatClient() {
                   disabled={isSubmitting}
                   className="w-full bg-transparent px-4 pt-3 pb-1 text-sm focus:outline-none resize-none placeholder:text-muted-foreground/60 disabled:opacity-60"
                 />
-                <div className="flex items-center justify-between gap-3 px-3 pb-2">
-                  <RuntimeSelector
-                    value={runtimeType}
-                    onChange={setRuntimeType}
-                    disabled={isSubmitting}
-                    pinned={pinnedRuntimeCli}
-                  />
+                <div className="flex items-center justify-end gap-3 px-3 pb-2">
                   <button
                     type="button"
                     onClick={() => submit()}
@@ -251,15 +216,11 @@ function HeroEmptyChat({
   draft,
   setDraft,
   onboarding,
-  runtimeType,
-  setRuntimeType,
 }: {
   onSubmit: (text?: string) => void;
   draft: string;
   setDraft: (s: string) => void;
   onboarding: boolean;
-  runtimeType: KnownCli;
-  setRuntimeType: (runtimeType: KnownCli) => void;
 }) {
   const agents = useAgents();
   const teamAgent = agents.data?.find((a) => a.hierarchy !== "ic");
@@ -309,8 +270,7 @@ function HeroEmptyChat({
             autoFocus
             className="w-full bg-transparent px-4 pt-3 pb-2 text-sm focus:outline-none resize-none placeholder:text-muted-foreground/60"
           />
-          <div className="flex items-center justify-between gap-3 px-3 pb-2">
-            <RuntimeSelector value={runtimeType} onChange={setRuntimeType} />
+          <div className="flex items-center justify-end gap-3 px-3 pb-2">
             <button
               type="button"
               onClick={() => onSubmit()}
@@ -370,89 +330,6 @@ function HeroEmptyChat({
         </div>
       </div>
     </div>
-  );
-}
-
-function RuntimeSelector({
-  value,
-  onChange,
-  disabled,
-  pinned,
-}: {
-  value: KnownCli;
-  onChange: (runtimeType: KnownCli) => void;
-  disabled?: boolean;
-  /**
-   * Set when the current conversation has already claimed a runtime —
-   * the picker locks to that CLI because the server pins runtime per
-   * chain (switching mid-chat 409s). Empty conversations leave this
-   * unset and the user can pick freely.
-   */
-  pinned?: KnownCli;
-}) {
-  const runtimesQuery = useQuery<RuntimesListResponse>({
-    queryKey: queryKeys.runtimes.list(),
-    queryFn: ({ signal }) => api.runtimes.list({ signal }),
-    enabled: isApiConfigured,
-    staleTime: 30_000,
-  });
-
-  const runtimeCounts = useMemo(() => {
-    const countsByCli = new Map<KnownCli, { online: number; total: number }>();
-    for (const cli of KNOWN_CLIS) countsByCli.set(cli, { online: 0, total: 0 });
-    for (const daemon of runtimesQuery.data?.daemons ?? []) {
-      for (const runtime of daemon.runtimes) {
-        if (!isKnownCli(runtime.cli)) continue;
-        const counts = countsByCli.get(runtime.cli)!;
-        counts.total += 1;
-        if (runtime.online) counts.online += 1;
-      }
-    }
-    return countsByCli;
-  }, [runtimesQuery.data]);
-
-  // The parent seeds `value` with a hardcoded default ("claude"). On the
-  // first arrival of runtime data, swap to the first online CLI if the
-  // default has none — that's a one-shot default-correction, not an
-  // ongoing override. Switching silently on every poll would steal the
-  // user's deliberate selection if their CLI flickered offline mid-session.
-  // Skip entirely when the conversation is pinned; the parent already
-  // mirrored that CLI into `value`.
-  const didInitialPick = useRef(false);
-  useEffect(() => {
-    if (pinned || didInitialPick.current || !runtimesQuery.data) return;
-    didInitialPick.current = true;
-    if ((runtimeCounts.get(value)?.online ?? 0) > 0) return;
-    const firstOnline = KNOWN_CLIS.find((cli) => (runtimeCounts.get(cli)?.online ?? 0) > 0);
-    if (firstOnline) onChange(firstOnline);
-  }, [pinned, runtimesQuery.data, runtimeCounts, value, onChange]);
-
-  const locked = pinned !== undefined;
-  return (
-    <label className="inline-flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
-      <Terminal className="h-3.5 w-3.5 shrink-0" />
-      <select
-        value={value}
-        disabled={disabled || locked || runtimesQuery.isLoading}
-        onChange={(e) => onChange(e.target.value as KnownCli)}
-        title={
-          locked
-            ? "This conversation is pinned to this runtime. Start a new chat to switch."
-            : "Choose the runtime for this chat turn"
-        }
-        className="max-w-[160px] rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground outline-none transition-colors hover:border-foreground/30 disabled:opacity-50 disabled:cursor-not-allowed"
-      >
-        {KNOWN_CLIS.map((cli) => {
-          const counts = runtimeCounts.get(cli) ?? { online: 0, total: 0 };
-          return (
-            <option key={cli} value={cli} disabled={counts.online === 0}>
-              {RUNTIME_LABELS[cli]}
-              {runtimeStatusSuffix(counts)}
-            </option>
-          );
-        })}
-      </select>
-    </label>
   );
 }
 

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -88,8 +88,6 @@ export interface HealthResponse {
 
 export interface ChatSendInput {
   message: string;
-  /** Optional per-turn CLI preference. Server resolves this to an online runtime. */
-  runtime_type?: KnownCli;
   /** Previous turn's session id — enables `--resume` continuity. */
   prior_session_id?: string;
   /**
@@ -302,13 +300,6 @@ export interface ChatHistoryResponse {
    * transcript.
    */
   in_flight_session_id?: string;
-  /**
-   * CLI this conversation is pinned to (first turn's runtime cli).
-   * Absent for chains that never claimed a runtime (legacy sessions) or
-   * for empty conversations. The composer uses this to lock the runtime
-   * picker — switching CLIs mid-chat would 409 server-side.
-   */
-  pinned_runtime_cli?: KnownCli;
 }
 
 export interface ChatConversationSummary {

--- a/packages/web/lib/hooks/use-chat.ts
+++ b/packages/web/lib/hooks/use-chat.ts
@@ -9,7 +9,6 @@ import {
   type ChatTurnResponse,
   type SuggestedAction,
 } from "@/lib/api/client";
-import type { KnownCli } from "@beevibe/core";
 import { isApiConfigured } from "@/lib/api/config";
 import { ApiError } from "@/lib/api/http";
 import { queryKeys } from "./keys";
@@ -135,14 +134,13 @@ export function useChat(opts: UseChatOptions = {}) {
   const mutation = useMutation<
     ChatTurnResponse,
     Error,
-    { message: string; sessionId: string; runtimeType?: KnownCli }
+    { message: string; sessionId: string }
   >({
-    mutationFn: ({ message, sessionId, runtimeType }) =>
+    mutationFn: ({ message, sessionId }) =>
       api.chat.send({
         message,
         session_id: sessionId,
         prior_session_id: priorSessionId,
-        ...(runtimeType ? { runtime_type: runtimeType } : {}),
       }),
     onMutate: ({ message, sessionId }) => {
       // Optimistically append the user's turn AND stamp in_flight_session_id
@@ -224,10 +222,10 @@ export function useChat(opts: UseChatOptions = {}) {
   });
 
   const send = useCallback(
-    (rawMessage: string, runtimeType?: KnownCli) => {
+    (rawMessage: string) => {
       const trimmed = rawMessage.trim();
       if (!trimmed || mutation.isPending) return;
-      mutation.mutate({ message: trimmed, sessionId: mintSessionId(), runtimeType });
+      mutation.mutate({ message: trimmed, sessionId: mintSessionId() });
     },
     [mutation],
   );
@@ -275,11 +273,5 @@ export function useChat(opts: UseChatOptions = {}) {
     pendingSessionId: inFlightSessionId,
     /** History query state, for showing a "loading prior conversation…" indicator. */
     isLoadingHistory: history.isLoading,
-    /**
-     * CLI this conversation is pinned to (set after the first claimed
-     * turn). The composer locks its runtime picker to this value so the
-     * user can't pick a different CLI and get a 409 on send.
-     */
-    pinnedRuntimeCli: history.data?.pinned_runtime_cli,
   };
 }


### PR DESCRIPTION
The chat composer's CLI dropdown was added in #150. After review, the per-turn switching isn't needed:

- Runtime is an **agent-level** decision, not a per-message one. The agent detail page already has `<RuntimePicker>` writing to `agent.preferred_runtime_id` + `agent.runtime_config.type`.
- Having both surfaces created a parallel system that was confusing — *"my agent's type is 'claude' but I can pick 'codex' from the chat composer — what wins?"*
- The server-side enforcement for mid-conversation swaps (409 `runtime_switch_requires_new_chat`, hub.isOnline gates) was load-bearing only because the picker invited the switch attempt in the first place. Remove the affordance, remove the policing.

## Removed

**Frontend** (`packages/web/`)
- `<RuntimeSelector>` component, `useEffect` initial-pick logic, `runtimeType` state, `pinnedRuntimeCli` consumption, label map, `Terminal` icon + `RuntimesListResponse` query
- `use-chat.ts`: `runtimeType` param on `send()`, `runtime_type` on mutation payload, `pinnedRuntimeCli` return
- `client.ts`: `ChatSendInput.runtime_type`, `ChatHistoryResponse.pinned_runtime_cli`

**Backend** (`packages/api/`)
- `chat.ts`: `resolveRuntimeOverride` + `resolvePinnedRuntimeCli` helpers, `runtime_type` body parsing + validation, `pinned_runtime_cli` in GET /chat response, `runtimeIdOverride` on the dispatchTask call, unused `runtimeRepo` from `ChatRoutesDeps`
- `bootstrap.ts`: `runtimeRepo` from `createChatRouter` wiring

## Kept (not picker-related)

- `DispatchPayload.runtime_type` and daemon's adapter lookup via `runtimeRegistry[runtime_type]` — wire protocol; daemon needs to know which CLI to spawn
- `composeDispatchPayload` deriving `runtime_type` from claimed-runtime CLI or `agent.runtime_config.type` fallback
- `agent.preferred_runtime_id` + agent detail page `<RuntimePicker>` — the actual source of truth for runtime selection

## Verification

- `pnpm -w build` — 5/5 packages green
- `pnpm --filter @beevibe/api test` — 330/330
- `pnpm --filter @beevibe/web test` — 141/141
- Chat tests (`chat-rate-limit` + `chat-internals`) — 17/17, no usages of removed fields

Net diff: **-274 / +13** lines across 5 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)