### PR TITLE
feat(chat): surface runtime-pinning to the user

### DIFF
--- a/packages/api/src/bootstrap.ts
+++ b/packages/api/src/bootstrap.ts
@@ -399,6 +399,7 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
     authMiddleware: server.getAuthMiddleware(),
     agentRepo,
     personRepo,
+    runtimeRepo,
     sessionRepo,
     dispatchService,
     chatResolver,

--- a/packages/api/src/routes/chat-internals.test.ts
+++ b/packages/api/src/routes/chat-internals.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { groupIntoConversations, type ChatSession } from "./chat.js";
+import { failureMessageFor, groupIntoConversations, type ChatSession } from "./chat.js";
 
 function makeSession(overrides: Partial<ChatSession> & Pick<ChatSession, "id">): ChatSession {
   return {
@@ -98,5 +98,53 @@ describe("groupIntoConversations", () => {
     const chains = groupIntoConversations([a1, a2, b1]);
     expect(chains).toHaveLength(2);
     expect(chains.map((c) => c.head_id).sort()).toEqual(["sess_a1", "sess_b1"]);
+  });
+});
+
+describe("failureMessageFor", () => {
+  it("returns the error string verbatim for normal failures", () => {
+    const out = failureMessageFor({ error: "ENOMEM: out of memory" });
+    expect(out).toBe("ENOMEM: out of memory");
+  });
+
+  it("falls back to result_summary when error is a bareCliExitMessage", () => {
+    const out = failureMessageFor({
+      error: "CLI exited with code 137",
+      result_summary: "Killed by OOM.",
+    });
+    expect(out).toBe("Killed by OOM.");
+  });
+
+  it("rewrites the daemon's runtime-missing throw to a user-actionable message", () => {
+    const out = failureMessageFor({
+      error: "No runtime registered for dispatch payload type 'claude'",
+    });
+    expect(out).toContain("This conversation is pinned to the claude runtime");
+    expect(out).toContain("beevibe-daemon sync");
+    expect(out).toContain("new chat");
+    // The friendly message should NOT include the raw "No runtime registered…"
+    // wording — that's an internal detail the user doesn't need to see.
+    expect(out).not.toContain("No runtime registered");
+  });
+
+  it("preserves the runtime-missing rewrite even when result_summary is non-empty", () => {
+    const out = failureMessageFor({
+      error: "No runtime registered for dispatch payload type 'codex'",
+      result_summary: "Codex completed.",
+    });
+    expect(out).toContain("pinned to the codex runtime");
+  });
+
+  it("returns the daemon-log pointer when neither field is informative", () => {
+    const out = failureMessageFor({
+      error: "CLI exited with code 1",
+      result_summary: "CLI exited with code 1",
+    });
+    expect(out).toContain("beevibe-daemon start");
+  });
+
+  it("returns the daemon-log pointer when both fields are empty", () => {
+    const out = failureMessageFor({});
+    expect(out).toContain("beevibe-daemon start");
   });
 });

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -25,8 +25,11 @@ import { randomUUID } from "node:crypto";
 import { Router, type RequestHandler, type Response } from "express";
 import {
   isInFlightSessionStatus,
+  isKnownCli,
   type AgentRepository,
+  type KnownCli,
   type PersonRepository,
+  type RuntimeRepository,
   type SessionRepository,
 } from "@beevibe/core";
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
@@ -42,6 +45,8 @@ export interface ChatRoutesDeps {
   authMiddleware: RequestHandler;
   agentRepo: AgentRepository;
   personRepo: PersonRepository;
+  /** Needed by GET /chat to flag conversations pinned to an old CLI. */
+  runtimeRepo: RuntimeRepository;
   sessionRepo: SessionRepository;
   /**
    * Phase 4 daemon-first chat path: dispatchService inserts a pending
@@ -200,12 +205,36 @@ const DAEMON_LOG_POINTER =
   "Couldn't reach your team agent. Check the terminal where you ran " +
   "`beevibe-daemon start` for the failure detail.";
 
+/**
+ * Matches the daemon's spawner throw when it receives a dispatch payload
+ * for a CLI that isn't in its `runtimeRegistry` — for example, the user
+ * uninstalled claude but the conversation is still pinned to a claude
+ * runtime row. The api persists this exact string as `session.error`
+ * via /runtime/done, and we swap it for a user-actionable message.
+ */
+const RUNTIME_MISSING_PATTERN = /No runtime registered for dispatch payload type '([^']+)'/;
+
+function rewriteRuntimeMissingError(raw: string): string | undefined {
+  const match = raw.match(RUNTIME_MISSING_PATTERN);
+  if (!match) return undefined;
+  const cli = match[1];
+  return (
+    `This conversation is pinned to the ${cli} runtime, which isn't installed ` +
+    `on the daemon claiming it. Install ${cli} on the daemon's machine and ` +
+    "run `beevibe-daemon sync`, or start a new chat to use your agent's current runtime."
+  );
+}
+
 export function failureMessageFor(s: {
   result_summary?: string | null;
   error?: string | null;
 }): string {
   const error = s.error?.trim();
-  if (error && !isBareCliExitMessage(error)) return error;
+  if (error) {
+    const rewritten = rewriteRuntimeMissingError(error);
+    if (rewritten) return rewritten;
+    if (!isBareCliExitMessage(error)) return error;
+  }
   const summary = s.result_summary?.trim();
   if (summary && !isBareCliExitMessage(summary)) return summary;
   return DAEMON_LOG_POINTER;
@@ -267,6 +296,25 @@ interface ChatTurnAgent {
   id: string;
   name: string;
   hierarchy_level: string;
+}
+
+export interface RuntimeMismatch {
+  /** CLI this chain is pinned to (the runtime the head session claimed). */
+  pinned_cli: KnownCli;
+  /** Agent's current CLI per `runtime_config.type`. */
+  current_cli: KnownCli;
+}
+
+async function detectRuntimeMismatch(
+  deps: Pick<ChatRoutesDeps, "runtimeRepo">,
+  tailRuntimeId: string | undefined,
+  currentCli: KnownCli,
+): Promise<RuntimeMismatch | undefined> {
+  if (!tailRuntimeId) return undefined;
+  const runtime = await deps.runtimeRepo.findById(tailRuntimeId);
+  if (!runtime || !isKnownCli(runtime.cli)) return undefined;
+  if (runtime.cli === currentCli) return undefined;
+  return { pinned_cli: runtime.cli, current_cli: currentCli };
 }
 
 /**
@@ -464,6 +512,20 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
     // (PR #116) lands the response.
     const inFlightSessionId = isInFlightSessionStatus(latest.status) ? latest.id : undefined;
 
+    // Chains are runtime-pinned: every session in a chain inherits the
+    // head's `runtime_id`, and the dispatchService re-pins each
+    // continuation via `prior.runtime_id`. So any session in the chain
+    // is equivalent for the "what CLI does this chain run on" question.
+    // We surface a mismatch to the UI when the agent's currently-
+    // configured CLI is different — the next turn WILL still run on the
+    // pinned CLI (correct, because resume needs the original .jsonl),
+    // but the user should know why their new runtime isn't being used.
+    const runtimeMismatch = await detectRuntimeMismatch(
+      deps,
+      latest.runtime_id,
+      agent.runtime_config.type,
+    );
+
     res.json({
       ok: true,
       agent: { id: agent.id, name: agent.name, hierarchy: agent.hierarchy_level },
@@ -471,6 +533,7 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
       prior_session_id: latest.id,
       conversation_id: chain.head_id,
       in_flight_session_id: inFlightSessionId,
+      ...(runtimeMismatch ? { runtime_mismatch: runtimeMismatch } : {}),
     });
   });
 

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -35,6 +35,7 @@ import {
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
 import type { ResumeReason } from "@beevibe/core/services/agent-session";
 import { isBareCliExitMessage } from "@beevibe/core/adapters/claude-code";
+import { parseRuntimeMissingError } from "@beevibe/core/adapters/runtime-registry";
 import { requireHuman } from "../auth/middleware.js";
 import type { ChatResolver } from "../runtime/chat-resolver.js";
 import type { DaemonHub } from "../runtime/hub.js";
@@ -206,18 +207,16 @@ const DAEMON_LOG_POINTER =
   "`beevibe-daemon start` for the failure detail.";
 
 /**
- * Matches the daemon's spawner throw when it receives a dispatch payload
- * for a CLI that isn't in its `runtimeRegistry` — for example, the user
- * uninstalled claude but the conversation is still pinned to a claude
- * runtime row. The api persists this exact string as `session.error`
- * via /runtime/done, and we swap it for a user-actionable message.
+ * Rewrites the daemon's runtime-missing throw (e.g. user uninstalled
+ * claude but the conversation is still pinned to a claude runtime row)
+ * into a user-actionable message. The raw string is persisted as
+ * `session.error` by /runtime/done; we recognize it via the shared
+ * `parseRuntimeMissingError` matcher so the producer (`spawner.ts`'s
+ * `runtimeMissingError(cli)`) and this consumer stay in sync.
  */
-const RUNTIME_MISSING_PATTERN = /No runtime registered for dispatch payload type '([^']+)'/;
-
 function rewriteRuntimeMissingError(raw: string): string | undefined {
-  const match = raw.match(RUNTIME_MISSING_PATTERN);
-  if (!match) return undefined;
-  const cli = match[1];
+  const cli = parseRuntimeMissingError(raw);
+  if (!cli) return undefined;
   return (
     `This conversation is pinned to the ${cli} runtime, which isn't installed ` +
     `on the daemon claiming it. Install ${cli} on the daemon's machine and ` +
@@ -230,11 +229,9 @@ export function failureMessageFor(s: {
   error?: string | null;
 }): string {
   const error = s.error?.trim();
-  if (error) {
-    const rewritten = rewriteRuntimeMissingError(error);
-    if (rewritten) return rewritten;
-    if (!isBareCliExitMessage(error)) return error;
-  }
+  const rewritten = error ? rewriteRuntimeMissingError(error) : undefined;
+  if (rewritten) return rewritten;
+  if (error && !isBareCliExitMessage(error)) return error;
   const summary = s.result_summary?.trim();
   if (summary && !isBareCliExitMessage(summary)) return summary;
   return DAEMON_LOG_POINTER;

--- a/packages/core/src/adapters/runtime-registry.test.ts
+++ b/packages/core/src/adapters/runtime-registry.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { createDefaultRuntimeRegistry } from "./runtime-registry.js";
+import {
+  createDefaultRuntimeRegistry,
+  parseRuntimeMissingError,
+  runtimeMissingError,
+} from "./runtime-registry.js";
 
 describe("createDefaultRuntimeRegistry", () => {
   it("registers claude-code", () => {
@@ -32,5 +36,30 @@ describe("createDefaultRuntimeRegistry", () => {
     const b = createDefaultRuntimeRegistry();
     // Different object identity — consumers can mutate one without affecting the other.
     expect(a).not.toBe(b);
+  });
+});
+
+describe("runtimeMissingError / parseRuntimeMissingError", () => {
+  it("round-trips a CLI name through the producer/consumer pair", () => {
+    // The daemon's spawner produces this string when it gets a dispatch
+    // payload for a CLI it doesn't have registered; the api's chat route
+    // parses it to swap for a user-actionable message. The two must stay
+    // byte-for-byte in sync — this test is the enforcement.
+    for (const cli of ["claude", "codex", "opencode", "future-cli"]) {
+      const produced = runtimeMissingError(cli);
+      expect(parseRuntimeMissingError(produced)).toBe(cli);
+    }
+  });
+
+  it("returns undefined for strings that don't match the pattern", () => {
+    expect(parseRuntimeMissingError("ENOMEM")).toBeUndefined();
+    expect(parseRuntimeMissingError("CLI exited with code 1")).toBeUndefined();
+    expect(parseRuntimeMissingError("")).toBeUndefined();
+    // Substring-only matches don't count — the pattern is anchored.
+    expect(
+      parseRuntimeMissingError(
+        "PREFIX No runtime registered for dispatch payload type 'claude' SUFFIX",
+      ),
+    ).toBeUndefined();
   });
 });

--- a/packages/core/src/adapters/runtime-registry.ts
+++ b/packages/core/src/adapters/runtime-registry.ts
@@ -24,3 +24,22 @@ export function createDefaultRuntimeRegistry(): RuntimeRegistry {
     opencode: new OpenCodeRuntime({}),
   };
 }
+
+/**
+ * Producer-consumer pair for the "daemon got a dispatch for a CLI it
+ * doesn't have registered" error string — daemon throws via
+ * `runtimeMissingError(cli)`; api side parses via `parseRuntimeMissingError`
+ * to swap for a user-actionable message in the chat surface. Co-located
+ * here so the two stay byte-for-byte in sync; mirrors the
+ * `bareCliExitMessage` / `isBareCliExitMessage` pair in claude-code's
+ * stream-json module.
+ */
+export function runtimeMissingError(cli: string): string {
+  return `No runtime registered for dispatch payload type '${cli}'`;
+}
+
+const RUNTIME_MISSING_PATTERN = /^No runtime registered for dispatch payload type '([^']+)'$/;
+
+export function parseRuntimeMissingError(s: string): string | undefined {
+  return s.match(RUNTIME_MISSING_PATTERN)?.[1];
+}

--- a/packages/daemon/src/spawner.ts
+++ b/packages/daemon/src/spawner.ts
@@ -9,7 +9,10 @@
  * `<workspace>/.claude/skills/`).
  */
 
-import { createDefaultRuntimeRegistry } from "@beevibe/core/adapters/runtime-registry";
+import {
+  createDefaultRuntimeRegistry,
+  runtimeMissingError,
+} from "@beevibe/core/adapters/runtime-registry";
 import type {
   Agent,
   KnownCli,
@@ -76,7 +79,7 @@ export async function runDispatch(
   const registry = deps.runtimeRegistry ?? createDefaultRuntimeRegistry();
   const runtime = registry[payload.runtime_type];
   if (!runtime) {
-    throw new Error(`No runtime registered for dispatch payload type '${payload.runtime_type}'`);
+    throw new Error(runtimeMissingError(payload.runtime_type));
   }
 
   // Buffer events so the daemon doesn't fire one POST per token. Flushed

--- a/packages/web/app/(authed)/chat/chat-client.tsx
+++ b/packages/web/app/(authed)/chat/chat-client.tsx
@@ -10,7 +10,7 @@ import {
   ArrowUp,
   MessageSquare,
 } from "lucide-react";
-import type { HierarchyLevel } from "@beevibe/core";
+import type { HierarchyLevel, KnownCli } from "@beevibe/core";
 import { isApiConfigured } from "@/lib/api/config";
 import {
   api,
@@ -68,10 +68,11 @@ export function ChatClient() {
   const conversationParam = searchParams?.get("c") ?? undefined;
   const isFresh = searchParams?.get("new") === "1";
 
-  const { messages, send, isPending, isSubmitting, error, pendingSessionId } = useChat({
-    conversationId: conversationParam,
-    fresh: isFresh,
-  });
+  const { messages, send, isPending, isSubmitting, error, pendingSessionId, runtimeMismatch } =
+    useChat({
+      conversationId: conversationParam,
+      fresh: isFresh,
+    });
 
   const liveSteps = useChatStream(pendingSessionId);
   const transcriptRef = useRef<HTMLDivElement | null>(null);
@@ -151,6 +152,9 @@ export function ChatClient() {
           />
         ) : (
           <>
+            {runtimeMismatch ? (
+              <RuntimeMismatchBanner mismatch={runtimeMismatch} />
+            ) : null}
             <div ref={transcriptRef} className="flex-1 overflow-y-auto px-6 py-8">
               <div className="max-w-3xl mx-auto">
                 {messages.map((m, i) => {
@@ -207,6 +211,35 @@ export function ChatClient() {
           </>
         )}
       </div>
+    </div>
+  );
+}
+
+const RUNTIME_DISPLAY_NAME: Record<KnownCli, string> = {
+  claude: "Claude",
+  codex: "Codex",
+  opencode: "OpenCode",
+};
+
+function RuntimeMismatchBanner({
+  mismatch,
+}: {
+  mismatch: { pinned_cli: KnownCli; current_cli: KnownCli };
+}) {
+  const pinned = RUNTIME_DISPLAY_NAME[mismatch.pinned_cli];
+  const current = RUNTIME_DISPLAY_NAME[mismatch.current_cli];
+  return (
+    <div className="mx-6 mt-3 rounded-lg border border-status-review/40 bg-status-review/5 px-3 py-2 text-xs text-foreground/80">
+      <span className="font-medium">{pinned}</span> is running this conversation
+      because that&apos;s the runtime it started on. Your agent is now set to{" "}
+      <span className="font-medium">{current}</span> — to use it, start a{" "}
+      <Link
+        href="/chat?new=1"
+        className="font-medium text-foreground underline underline-offset-2 hover:text-foreground/80"
+      >
+        new chat
+      </Link>
+      .
     </div>
   );
 }

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -300,6 +300,17 @@ export interface ChatHistoryResponse {
    * transcript.
    */
   in_flight_session_id?: string;
+  /**
+   * Set when the agent's currently-configured CLI differs from the CLI
+   * the conversation chain is pinned to. The chain still runs on its
+   * pinned CLI (resume needs the original CLI's on-disk state); this
+   * field lets the UI tell the user why their new runtime isn't being
+   * used. Undefined when there's no mismatch.
+   */
+  runtime_mismatch?: {
+    pinned_cli: KnownCli;
+    current_cli: KnownCli;
+  };
 }
 
 export interface ChatConversationSummary {

--- a/packages/web/lib/hooks/use-chat.ts
+++ b/packages/web/lib/hooks/use-chat.ts
@@ -273,5 +273,11 @@ export function useChat(opts: UseChatOptions = {}) {
     pendingSessionId: inFlightSessionId,
     /** History query state, for showing a "loading prior conversation…" indicator. */
     isLoadingHistory: history.isLoading,
+    /**
+     * Set when the agent's currently-configured CLI differs from the CLI
+     * this conversation is pinned to. UI surfaces a banner so the user
+     * knows why their new runtime isn't being used here.
+     */
+    runtimeMismatch: history.data?.runtime_mismatch,
   };
 }


### PR DESCRIPTION
Two related signals so users understand why an old conversation isn't using their newly-configured agent runtime. Follow-up to #162 (which removed the per-turn picker).

## Gap 1: Mismatch banner

When a chain's pinned runtime CLI differs from the agent's current \`runtime_config.type\`, GET /chat returns:

\`\`\`ts
runtime_mismatch?: { pinned_cli: KnownCli; current_cli: KnownCli }
\`\`\`

The chat UI renders an amber banner above the transcript:

> **Claude** is running this conversation because that's the runtime it started on. Your agent is now set to **Codex** — to use it, start a [**new chat**](?new=1).

Resume on the same chain still works correctly — it continues on the pinned CLI because that's the only place its \`--resume\` state lives on disk. The banner just explains the behavior.

Backend computes the mismatch in GET /chat: one \`runtimeRepo.findById\` lookup on the tail session's \`runtime_id\`, skipped entirely when the chain has no \`runtime_id\` (legacy sessions, server-fallback) or when CLIs match.

## Gap 2: Friendlier failure when the pinned CLI was uninstalled

When the daemon throws \`No runtime registered for dispatch payload type 'X'\` (e.g. user uninstalled claude but conversation is still pinned to a claude runtime row), \`failureMessageFor\` now rewrites it:

> This conversation is pinned to the **claude** runtime, which isn't installed on the daemon claiming it. Install claude on the daemon's machine and run \`beevibe-daemon sync\`, or start a new chat to use your agent's current runtime.

Internal error string never reaches the UI.

## Tests

+6 new unit tests in \`chat-internals.test.ts\` covering the failure-message rewrites:
- normal error string returned verbatim
- bareCliExitMessage falls back to result_summary
- runtime-missing pattern → rewritten message contains pinned CLI, install instructions, "new chat" CTA, and excludes the raw internal phrase
- runtime-missing rewrite wins over a generic result_summary
- daemon-log pointer for fully-empty failures

## Out of scope (filed separately)

Gap 3 — "Continue on new runtime" affordance that migrates an old chain's context into a fresh dispatch on the new CLI — is its own design problem (summary length, what context carries, whether to mark the old chain as migrated). Tracked at #TBD.

## Verification

- \`pnpm -w build\` — 5/5 green
- \`pnpm --filter @beevibe/api test\` — 336/336 (+6)
- \`pnpm --filter @beevibe/web test\` — 141/141

🤖 Generated with [Claude Code](https://claude.com/claude-code)