### PR TITLE
feat(web): surface `beevibe-daemon sync` in the runtimes panel + agent detail

### DIFF
--- a/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
+++ b/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
@@ -511,6 +511,13 @@ function RuntimePicker({ agent }: { agent: AgentDetail }) {
             sessions sit pending until rebound; mesh asks fall back to the
             server.
           </p>
+          <p className="text-[11px] text-muted-foreground mt-1 leading-snug">
+            Don&apos;t see a CLI you just installed?{" "}
+            <Link href="/runtimes" className="underline hover:text-foreground">
+              Sync your daemon
+            </Link>
+            .
+          </p>
         </>
       )}
     </section>

--- a/packages/web/app/(authed)/runtimes/runtimes-client.tsx
+++ b/packages/web/app/(authed)/runtimes/runtimes-client.tsx
@@ -10,6 +10,7 @@ import {
   RefreshCw,
   Terminal,
   Trash2,
+  type LucideIcon,
 } from "lucide-react";
 import {
   api,
@@ -298,36 +299,57 @@ function NoDaemonsState() {
 
 function AddAnotherMachine() {
   return (
-    <details className="group rounded-lg border border-dashed border-border bg-card/40">
-      <summary className="cursor-pointer px-4 py-3 list-none flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors">
-        <Plus className="h-3.5 w-3.5" />
-        Set up another machine
-      </summary>
-      <div className="border-t border-border/60 px-4 py-3">
-        <InstallSnippet />
-      </div>
-    </details>
+    <ExpandableHint icon={Plus} label="Set up another machine">
+      <InstallSnippet />
+    </ExpandableHint>
   );
 }
 
 function SyncNewCli() {
   return (
+    <ExpandableHint
+      icon={RefreshCw}
+      label="Installed a new CLI on a machine that's already registered?"
+      bodyClassName="space-y-2.5 text-xs text-muted-foreground"
+    >
+      <p>
+        Run this on the machine where the daemon is set up. It re-detects
+        every supported CLI on <span className="font-mono">PATH</span> and
+        registers any new ones here — no reinstall, no token rotation.
+      </p>
+      <CommandBlock label="On the daemon machine" command="beevibe-daemon sync" />
+      <p>
+        Restart <span className="font-mono">beevibe-daemon start</span>{" "}
+        afterwards so the active poll loop picks up the new runtime.
+      </p>
+    </ExpandableHint>
+  );
+}
+
+/**
+ * Dashed-border `<details>` block for opt-in setup affordances at the
+ * bottom of the runtimes panel. Used by both "Set up another machine"
+ * and "Installed a new CLI…" — same visual treatment, different bodies.
+ */
+function ExpandableHint({
+  icon: Icon,
+  label,
+  bodyClassName,
+  children,
+}: {
+  icon: LucideIcon;
+  label: string;
+  bodyClassName?: string;
+  children: React.ReactNode;
+}) {
+  return (
     <details className="group rounded-lg border border-dashed border-border bg-card/40">
       <summary className="cursor-pointer px-4 py-3 list-none flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors">
-        <RefreshCw className="h-3.5 w-3.5" />
-        Installed a new CLI on a machine that&apos;s already registered?
+        <Icon className="h-3.5 w-3.5" />
+        {label}
       </summary>
-      <div className="border-t border-border/60 px-4 py-3 space-y-2.5 text-xs text-muted-foreground">
-        <p>
-          Run this on the machine where the daemon is set up. It re-detects
-          every supported CLI on <span className="font-mono">PATH</span> and
-          registers any new ones here — no reinstall, no token rotation.
-        </p>
-        <CommandBlock label="On the daemon machine" command="beevibe-daemon sync" />
-        <p>
-          Restart <span className="font-mono">beevibe-daemon start</span>{" "}
-          afterwards so the active poll loop picks up the new runtime.
-        </p>
+      <div className={cn("border-t border-border/60 px-4 py-3", bodyClassName)}>
+        {children}
       </div>
     </details>
   );

--- a/packages/web/app/(authed)/runtimes/runtimes-client.tsx
+++ b/packages/web/app/(authed)/runtimes/runtimes-client.tsx
@@ -7,6 +7,7 @@ import {
   Cpu,
   HardDrive,
   Plus,
+  RefreshCw,
   Terminal,
   Trash2,
 } from "lucide-react";
@@ -20,6 +21,7 @@ import { isApiConfigured } from "@/lib/api/config";
 import { describeError } from "@/lib/api/http";
 import { queryKeys } from "@/lib/hooks/keys";
 import { formatRelativeTime } from "@/lib/format";
+import { CommandBlock } from "@/components/command-block";
 import { DaemonInstallInstructions } from "@/components/daemon-install";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
@@ -113,6 +115,7 @@ function Body({
       {daemons.map((d) => (
         <DaemonCard key={d.id} daemon={d} />
       ))}
+      <SyncNewCli />
       <AddAnotherMachine />
     </div>
   );
@@ -302,6 +305,29 @@ function AddAnotherMachine() {
       </summary>
       <div className="border-t border-border/60 px-4 py-3">
         <InstallSnippet />
+      </div>
+    </details>
+  );
+}
+
+function SyncNewCli() {
+  return (
+    <details className="group rounded-lg border border-dashed border-border bg-card/40">
+      <summary className="cursor-pointer px-4 py-3 list-none flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors">
+        <RefreshCw className="h-3.5 w-3.5" />
+        Installed a new CLI on a machine that&apos;s already registered?
+      </summary>
+      <div className="border-t border-border/60 px-4 py-3 space-y-2.5 text-xs text-muted-foreground">
+        <p>
+          Run this on the machine where the daemon is set up. It re-detects
+          every supported CLI on <span className="font-mono">PATH</span> and
+          registers any new ones here — no reinstall, no token rotation.
+        </p>
+        <CommandBlock label="On the daemon machine" command="beevibe-daemon sync" />
+        <p>
+          Restart <span className="font-mono">beevibe-daemon start</span>{" "}
+          afterwards so the active poll loop picks up the new runtime.
+        </p>
       </div>
     </details>
   );


### PR DESCRIPTION
PR #161 shipped \`beevibe-daemon sync\` (re-detect newly-installed CLIs without re-running setup, no token rotation). Nothing in the UI surfaced this, so the natural flow — *\"I just installed codex, why isn't it on the agent runtime picker?\"* — had no answer.

## Surfaces touched

### 1. Runtimes panel (\`/runtimes\`)

New collapsible alongside the existing \"Set up another machine\" one, using the same dashed-border \`<details>\` pattern:

> ⟳ Installed a new CLI on a machine that's already registered?

Expands to:

> Run this on the machine where the daemon is set up. It re-detects every supported CLI on PATH and registers any new ones here — no reinstall, no token rotation.
>
> \`\`\`
> beevibe-daemon sync
> \`\`\`  *(with copy button via existing \`<CommandBlock>\`)*
>
> Restart \`beevibe-daemon start\` afterwards so the active poll loop picks up the new runtime.

The \"restart afterwards\" line matches the stdout the sync subcommand already prints.

### 2. Agent detail page → RuntimePicker section

One new line below the existing helper text:

> Don't see a CLI you just installed? **Sync your daemon**.

Links to \`/runtimes\` (where the new collapsible lives) rather than duplicating the explanation. Targets the user who's specifically looking for a CLI to pick and not finding it.

## What I considered but skipped

- **Per-daemon-card hint on the Runtimes panel** — would clutter cards for users who already know. The single collapsible matches the existing \"add another\" pattern and stays opt-in.
- **Surfacing in chat composer / mismatch banner** — the mismatch banner (#163) already names \`beevibe-daemon sync\` in the failure-message rewrite for the \"daemon has no runtime for this CLI\" case. No additional surface needed there.

## Verification

- \`pnpm --filter @beevibe/web build\` green
- \`pnpm --filter @beevibe/web test\` — 141/141 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)