### PR TITLE
feat(agents): list view as default, with inline runtime/model/review pickers

### DIFF
--- a/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
+++ b/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
@@ -1,21 +1,24 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, AlertTriangle, Bot, Archive } from "lucide-react";
 import { useAgent } from "@/lib/hooks/use-agents";
 import { useIsOwner, useMe } from "@/lib/hooks/use-me";
 import { isApiConfigured } from "@/lib/api/config";
 import { formatReviewPolicy } from "@/lib/format";
-import { api, type RuntimesListResponse } from "@/lib/api/client";
+import { api } from "@/lib/api/client";
 import { queryKeys } from "@/lib/hooks/keys";
 import { Avatar } from "@/components/avatar";
 import { CliMcpInstructions } from "@/components/cli-mcp-instructions";
 import { HierChip } from "@/components/hier-chip";
 import { CoreBlockCard } from "@/components/agents/core-block-card";
 import { RecentSessionRow } from "@/components/agents/recent-session-row";
+import { RuntimePicker } from "@/components/agents/pickers/runtime-picker";
+import { ModelPicker } from "@/components/agents/pickers/model-picker";
+import { ReviewPolicyPicker } from "@/components/agents/pickers/review-policy-picker";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
@@ -24,7 +27,6 @@ import { FooterField } from "@/components/detail/footer-field";
 import { Metric } from "@/components/detail/metric";
 import { cn } from "@/lib/utils";
 import type { AgentDetail } from "@/lib/api/types";
-import type { ReviewPolicy } from "@beevibe/core";
 
 const AgentsBackLink = () => (
   <Link
@@ -283,243 +285,5 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
         ) : null}
       </footer>
     </DetailShell>
-  );
-}
-
-// Common Claude model aliases the CLI accepts. Users can also pick "Other"
-// to type a pinned model ID (e.g. claude-opus-4-7). The empty-string sentinel
-// represents "CLI default" — clears `runtime_config.model` server-side.
-const MODEL_PRESETS: ReadonlyArray<{ value: string; label: string }> = [
-  { value: "", label: "CLI default (recommended)" },
-  { value: "opus", label: "opus" },
-  { value: "sonnet", label: "sonnet" },
-  { value: "haiku", label: "haiku" },
-];
-
-function ModelPicker({ agent }: { agent: AgentDetail }) {
-  const queryClient = useQueryClient();
-  const current = agent.model ?? "";
-  const isPreset = MODEL_PRESETS.some((p) => p.value === current);
-  // Lazy initializers so we don't recompute MODEL_PRESETS.some on every
-  // render — useState only consumes the seed on mount.
-  const [customMode, setCustomMode] = useState(() => !isPreset && current !== "");
-  const [customValue, setCustomValue] = useState(() => (isPreset ? "" : current));
-
-  // Resync local state when agent.model changes underneath us (SSE refresh,
-  // user navigates to a different agent without unmounting, etc.). Without
-  // this, the custom-input field would show stale text after an external
-  // update.
-  useEffect(() => {
-    const nextIsPreset = MODEL_PRESETS.some((p) => p.value === current);
-    setCustomMode(!nextIsPreset && current !== "");
-    setCustomValue(nextIsPreset ? "" : current);
-  }, [current]);
-
-  const mutation = useMutation({
-    mutationFn: (model: string | null) => api.agents.setModel(agent.id, model),
-    onSuccess: () => {
-      // Targeted invalidation — only this agent's detail. Was previously
-      // queryKeys.agents.all which refetches every agent list across the
-      // app, which is unnecessary for a per-agent model change.
-      void queryClient.invalidateQueries({
-        queryKey: queryKeys.agents.detail(agent.id),
-      });
-    },
-  });
-
-  return (
-    <section className="rounded-lg border border-border bg-card p-4">
-      <h3 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-2 font-medium">
-        Model
-      </h3>
-      <select
-        value={customMode ? "__custom" : current}
-        disabled={mutation.isPending}
-        onChange={(e) => {
-          const v = e.target.value;
-          if (v === "__custom") {
-            setCustomMode(true);
-            return;
-          }
-          setCustomMode(false);
-          // "" means CLI default → null clears the field server-side.
-          mutation.mutate(v === "" ? null : v);
-        }}
-        className="w-full text-sm rounded border border-border bg-background px-2 py-1.5 cursor-pointer disabled:opacity-50"
-      >
-        {MODEL_PRESETS.map((p) => (
-          <option key={p.value || "__default"} value={p.value}>
-            {p.label}
-          </option>
-        ))}
-        <option value="__custom">Other (pinned model ID)…</option>
-      </select>
-      {customMode ? (
-        <form
-          className="mt-2 flex gap-1"
-          onSubmit={(e) => {
-            e.preventDefault();
-            const v = customValue.trim();
-            if (v) mutation.mutate(v);
-          }}
-        >
-          <input
-            type="text"
-            value={customValue}
-            onChange={(e) => setCustomValue(e.target.value)}
-            placeholder="e.g. claude-opus-4-7"
-            className="flex-1 text-sm rounded border border-border bg-background px-2 py-1.5"
-          />
-          <button
-            type="submit"
-            disabled={mutation.isPending || !customValue.trim()}
-            className="h-7 px-3 rounded text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50"
-          >
-            Set
-          </button>
-        </form>
-      ) : null}
-      {mutation.isError ? (
-        <p className="text-xs text-destructive mt-1.5">
-          Couldn&apos;t update model.
-        </p>
-      ) : null}
-      <p className="text-[11px] text-muted-foreground mt-2 leading-snug">
-        Model alias passed to the CLI via <span className="font-mono">--model</span>.
-        Leave on &quot;CLI default&quot; to inherit whatever you&apos;ve
-        configured in <span className="font-mono">~/.claude</span>.
-      </p>
-    </section>
-  );
-}
-
-function ReviewPolicyPicker({ agent }: { agent: AgentDetail }) {
-  const queryClient = useQueryClient();
-  // Legacy agents (provisioned before this column had a default) carry
-  // review_policy=null; behaviorally that's identical to 'auto_done' in
-  // TaskService, so render it that way too.
-  const current: ReviewPolicy =
-    agent.review_policy === "require_human" ? "require_human" : "auto_done";
-  const mutation = useMutation({
-    mutationFn: (policy: ReviewPolicy) => api.agents.setReviewPolicy(agent.id, policy),
-    // Invalidate all agent queries: the list view's AgentDisplay also
-    // carries review_policy, so a single agent's flip can affect
-    // /agents cards + the peek panel, not just this detail page.
-    // Mirrors RuntimePicker's invalidation scope.
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
-    },
-  });
-
-  return (
-    <section className="rounded-lg border border-border bg-card p-4">
-      <h3 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-2 font-medium">
-        Review policy
-      </h3>
-      <select
-        value={current}
-        disabled={mutation.isPending}
-        onChange={(e) => mutation.mutate(e.target.value as ReviewPolicy)}
-        className="w-full text-sm rounded border border-border bg-background px-2 py-1.5 cursor-pointer disabled:opacity-50"
-      >
-        <option value="auto_done">Auto-done (default)</option>
-        <option value="require_human">Require human review</option>
-      </select>
-      {mutation.isError ? (
-        <p className="text-xs text-destructive mt-1.5">
-          Couldn&apos;t update review policy.
-        </p>
-      ) : null}
-      <p className="text-[11px] text-muted-foreground mt-2 leading-snug">
-        When the agent declares a task <span className="font-mono">done</span>,
-        auto-done closes it. Require-human routes it through{" "}
-        <span className="font-mono">review</span> so you sign off first.
-      </p>
-    </section>
-  );
-}
-
-function RuntimePicker({ agent }: { agent: AgentDetail }) {
-  const queryClient = useQueryClient();
-  const runtimesQuery = useQuery<RuntimesListResponse>({
-    queryKey: queryKeys.runtimes.list(),
-    queryFn: ({ signal }) => api.runtimes.list({ signal }),
-    staleTime: 30_000,
-  });
-  const mutation = useMutation({
-    mutationFn: (runtimeId: string | null) => api.agents.setRuntime(agent.id, runtimeId),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
-    },
-  });
-
-  const allRuntimes =
-    runtimesQuery.data?.daemons.flatMap((d) =>
-      d.runtimes.map((r) => ({
-        id: r.id,
-        cli: r.cli,
-        cli_version: r.cli_version,
-        online: r.online,
-        device: d.device_name ?? d.external_id,
-      })),
-    ) ?? [];
-
-  const value = agent.preferred_runtime_id ?? "";
-
-  return (
-    <section className="rounded-lg border border-border bg-card p-4">
-      <h3 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-2 font-medium">
-        Runtime
-      </h3>
-      {runtimesQuery.isLoading ? (
-        <p className="text-xs text-muted-foreground italic">Loading runtimes…</p>
-      ) : allRuntimes.length === 0 ? (
-        <p className="text-xs text-muted-foreground">
-          No daemons registered yet.{" "}
-          <Link href="/runtimes" className="underline hover:text-foreground">
-            Set up a daemon
-          </Link>
-          .
-        </p>
-      ) : (
-        <>
-          <select
-            value={value}
-            disabled={mutation.isPending}
-            onChange={(e) => {
-              const next = e.target.value === "" ? null : e.target.value;
-              mutation.mutate(next);
-            }}
-            className="w-full text-sm rounded border border-border bg-background px-2 py-1.5 cursor-pointer disabled:opacity-50"
-          >
-            <option value="">— unbound —</option>
-            {allRuntimes.map((r) => (
-              <option key={r.id} value={r.id}>
-                {r.device} · {r.cli}
-                {r.cli_version ? ` ${r.cli_version}` : ""}
-                {r.online ? " (online)" : " (offline)"}
-              </option>
-            ))}
-          </select>
-          {mutation.isError ? (
-            <p className="text-xs text-destructive mt-1.5">
-              Couldn&apos;t update runtime.
-            </p>
-          ) : null}
-          <p className="text-[11px] text-muted-foreground mt-2 leading-snug">
-            The agent runs on this daemon&apos;s CLI. Unbinding makes task / chat
-            sessions sit pending until rebound; mesh asks fall back to the
-            server.
-          </p>
-          <p className="text-[11px] text-muted-foreground mt-1 leading-snug">
-            Don&apos;t see a CLI you just installed?{" "}
-            <Link href="/runtimes" className="underline hover:text-foreground">
-              Sync your daemon
-            </Link>
-            .
-          </p>
-        </>
-      )}
-    </section>
   );
 }

--- a/packages/web/app/(authed)/agents/agents-client.test.tsx
+++ b/packages/web/app/(authed)/agents/agents-client.test.tsx
@@ -6,6 +6,9 @@ import type { AgentDisplay } from "@/lib/types/agents";
 import type { AgentNetwork } from "@/lib/types/agent-network";
 
 const apiState = { isApiConfigured: true };
+// Dynamic search params so individual tests can flip ?view=orbit to
+// mount the orbit branch directly. Default is empty (list view).
+const searchState = { params: new URLSearchParams() };
 
 vi.mock("@/lib/api/config", () => ({
   get isApiConfigured() {
@@ -21,7 +24,7 @@ vi.mock("@/lib/api/client", () => ({
 // These mocks just keep the hooks happy under happy-dom.
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => searchState.params,
   usePathname: () => "/agents",
 }));
 
@@ -61,6 +64,7 @@ const baseIc: AgentDisplay = {
 
 beforeEach(() => {
   apiState.isApiConfigured = true;
+  searchState.params = new URLSearchParams();
   networkMock.mockReset();
 });
 
@@ -93,6 +97,10 @@ describe("AgentsClient", () => {
   });
 
   it("renders peer orbits when the network includes other owners", async () => {
+    // List is the default landing now, but list view only shows the
+    // caller's own agents. The peer-satellite rendering lives in the
+    // orbit branch, so this test mounts that branch directly.
+    searchState.params = new URLSearchParams("view=orbit");
     networkMock.mockResolvedValue({
       self: [baseAgent],
       peers: [
@@ -113,7 +121,5 @@ describe("AgentsClient", () => {
     renderAgents();
     // Peer satellite orbit renders the peer's agent card.
     expect(await screen.findByText("Roadmap pod")).toBeInTheDocument();
-    // The page caption mentions collaborators when peers are present.
-    expect(screen.getByText(/Other teams sit further out/)).toBeInTheDocument();
   });
 });

--- a/packages/web/app/(authed)/agents/agents-client.tsx
+++ b/packages/web/app/(authed)/agents/agents-client.tsx
@@ -2,14 +2,21 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { AlertTriangle, Bot, Maximize2, Minus, Plus } from "lucide-react";
+import { AlertTriangle, Bot, LayoutGrid, List, Maximize2, Minus, Plus } from "lucide-react";
 import type { PanZoomTransform } from "@/lib/hooks/use-pan-zoom";
 import { useAgentNetwork } from "@/lib/hooks/use-agent-network";
 import { isApiConfigured } from "@/lib/api/config";
 import { EmptyState } from "@/components/empty-state";
 import { TeamOrbit } from "@/components/team-orbit";
 import { AgentDetailPanel } from "@/components/agents/agent-detail-panel";
+import { AgentsListView } from "@/components/agents/agents-list-view";
 import { usePanZoom } from "@/lib/hooks/use-pan-zoom";
+
+type ViewMode = "orbit" | "list";
+
+function parseView(raw: string | null | undefined): ViewMode {
+  return raw === "list" ? "list" : "orbit";
+}
 
 /**
  * /agents — pan/zoom canvas of the agent network.
@@ -28,23 +35,52 @@ export function AgentsClient() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const selectedAgentId = searchParams?.get("p") ?? undefined;
+  const view = parseView(searchParams?.get("view"));
+
+  // Build a URL that preserves the *other* params while overriding one
+  // we care about. Used by both the peek panel toggle (`?p=`) and the
+  // orbit/list view switcher (`?view=`). Without this, swapping views
+  // would clobber the currently-open peek panel and vice versa.
+  const buildHref = useCallback(
+    (patch: Partial<Record<"p" | "view", string | null>>) => {
+      const sp = new URLSearchParams(searchParams?.toString() ?? "");
+      for (const [key, value] of Object.entries(patch)) {
+        if (value === null) sp.delete(key);
+        else if (value !== undefined) sp.set(key, value);
+      }
+      const qs = sp.toString();
+      return qs ? `/agents?${qs}` : "/agents";
+    },
+    [searchParams],
+  );
 
   const openAgent = useCallback(
     (agentId: string) => {
       // Replace, not push — opening the panel shouldn't make the back
       // button bounce through every agent the user clicked. Closing
       // (cleared param) DOES push so back button restores the panel.
-      router.replace(`/agents?p=${encodeURIComponent(agentId)}`, { scroll: false });
+      router.replace(buildHref({ p: agentId }), { scroll: false });
     },
-    [router],
+    [router, buildHref],
   );
 
   const closeAgent = useCallback(() => {
-    router.push("/agents", { scroll: false });
-  }, [router]);
+    router.push(buildHref({ p: null }), { scroll: false });
+  }, [router, buildHref]);
+
+  const setView = useCallback(
+    (next: ViewMode) => {
+      // Default view is orbit, so encode it by *removing* the param.
+      router.replace(buildHref({ view: next === "orbit" ? null : "list" }), {
+        scroll: false,
+      });
+    },
+    [router, buildHref],
+  );
 
   const { data, isLoading, isError } = useAgentNetwork();
   const peers = data?.peers ?? [];
+  const selfAgents = data?.self ?? [];
 
   const panZoom = usePanZoom({ minScale: 0.4, maxScale: 2.5 });
 
@@ -60,67 +96,79 @@ export function AgentsClient() {
         <CenteredShell icon={AlertTriangle} title="Couldn't load the network" />
       ) : (
         <>
-          <Caption hasPeers={peers.length > 0} />
-          <GestureHint transform={panZoom.transform} />
+          <ViewToggle view={view} onChange={setView} />
 
-          {/* Pan/zoom container — captures wheel + pointer, transforms
-              the inner world. Cursor hint reads as "draggable canvas". */}
-          <div
-            ref={panZoom.containerRef}
-            className="absolute inset-0 cursor-grab touch-none select-none"
-            // Touch-action none + select-none keep mobile pan from
-            // scrolling the page or selecting card text mid-drag.
-          >
-            <div
-              className="absolute left-1/2 top-1/2"
-              style={panZoom.style}
-            >
-              {/* Self orbit anchored at world origin (0,0); the parent
-                  div is already centered via left-50%/top-50%, so a
-                  translate(-50%,-50%) on the orbit's wrapper keeps it
-                  visually centered when the canvas is at scale 1 with
-                  zero pan. */}
+          {view === "list" ? (
+            <AgentsListView
+              agents={selfAgents}
+              onSelect={openAgent}
+              selectedAgentId={selectedAgentId}
+            />
+          ) : (
+            <>
+              <Caption hasPeers={peers.length > 0} />
+              <GestureHint transform={panZoom.transform} />
+
+              {/* Pan/zoom container — captures wheel + pointer, transforms
+                  the inner world. Cursor hint reads as "draggable canvas". */}
               <div
-                className="absolute"
-                style={{ left: 0, top: 0, transform: "translate(-50%, -50%)" }}
+                ref={panZoom.containerRef}
+                className="absolute inset-0 cursor-grab touch-none select-none"
+                // Touch-action none + select-none keep mobile pan from
+                // scrolling the page or selecting card text mid-drag.
               >
-                <TeamOrbit
-                  agents={data?.self}
-                  size="large"
-                  loading={isLoading}
-                  onSelect={openAgent}
-                />
-              </div>
-
-              {peers.map((peer, i) => {
-                const pos = satellitePosition(i, peers.length);
-                return (
+                <div
+                  className="absolute left-1/2 top-1/2"
+                  style={panZoom.style}
+                >
+                  {/* Self orbit anchored at world origin (0,0); the parent
+                      div is already centered via left-50%/top-50%, so a
+                      translate(-50%,-50%) on the orbit's wrapper keeps it
+                      visually centered when the canvas is at scale 1 with
+                      zero pan. */}
                   <div
-                    key={peer.owner_id}
-                    className="absolute flex flex-col items-center"
-                    style={{
-                      left: `${pos.x}px`,
-                      top: `${pos.y}px`,
-                      transform: "translate(-50%, -50%)",
-                    }}
+                    className="absolute"
+                    style={{ left: 0, top: 0, transform: "translate(-50%, -50%)" }}
                   >
                     <TeamOrbit
-                      agents={peer.agents}
-                      size="satellite"
+                      agents={data?.self}
+                      size="large"
+                      loading={isLoading}
                       onSelect={openAgent}
                     />
                   </div>
-                );
-              })}
-            </div>
-          </div>
 
-          <CanvasControls
-            scale={panZoom.transform.scale}
-            onZoomIn={() => panZoom.zoomBy(1.25)}
-            onZoomOut={() => panZoom.zoomBy(0.8)}
-            onReset={panZoom.reset}
-          />
+                  {peers.map((peer, i) => {
+                    const pos = satellitePosition(i, peers.length);
+                    return (
+                      <div
+                        key={peer.owner_id}
+                        className="absolute flex flex-col items-center"
+                        style={{
+                          left: `${pos.x}px`,
+                          top: `${pos.y}px`,
+                          transform: "translate(-50%, -50%)",
+                        }}
+                      >
+                        <TeamOrbit
+                          agents={peer.agents}
+                          size="satellite"
+                          onSelect={openAgent}
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <CanvasControls
+                scale={panZoom.transform.scale}
+                onZoomIn={() => panZoom.zoomBy(1.25)}
+                onZoomOut={() => panZoom.zoomBy(0.8)}
+                onReset={panZoom.reset}
+              />
+            </>
+          )}
         </>
       )}
 
@@ -217,6 +265,70 @@ function satellitePosition(i: number, n: number): { x: number; y: number } {
     x: Math.cos(angle) * distance,
     y: Math.sin(angle) * distance,
   };
+}
+
+function ViewToggle({
+  view,
+  onChange,
+}: {
+  view: ViewMode;
+  onChange: (next: ViewMode) => void;
+}) {
+  return (
+    <div
+      className="absolute top-6 right-6 z-10 inline-flex items-center gap-0.5 rounded-full border border-border bg-card/90 backdrop-blur-sm shadow-sm p-0.5"
+      data-pan="ignore"
+    >
+      <ToggleButton
+        active={view === "orbit"}
+        onClick={() => onChange("orbit")}
+        label="Orbit"
+        title="Orbit view — pan and zoom the network"
+      >
+        <LayoutGrid className="h-3.5 w-3.5" />
+      </ToggleButton>
+      <ToggleButton
+        active={view === "list"}
+        onClick={() => onChange("list")}
+        label="List"
+        title="List view — manage runtime, model, review policy"
+      >
+        <List className="h-3.5 w-3.5" />
+      </ToggleButton>
+    </div>
+  );
+}
+
+function ToggleButton({
+  active,
+  onClick,
+  label,
+  title,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      aria-pressed={active}
+      className={
+        "h-7 px-2.5 inline-flex items-center gap-1.5 rounded-full text-xs font-medium transition-colors cursor-pointer " +
+        (active
+          ? "bg-secondary text-foreground"
+          : "text-muted-foreground hover:text-foreground hover:bg-secondary/60")
+      }
+    >
+      {children}
+      <span className="leading-none">{label}</span>
+    </button>
+  );
 }
 
 function CanvasControls({

--- a/packages/web/app/(authed)/agents/agents-client.tsx
+++ b/packages/web/app/(authed)/agents/agents-client.tsx
@@ -10,6 +10,7 @@ import { EmptyState } from "@/components/empty-state";
 import { TeamOrbit } from "@/components/team-orbit";
 import { AgentDetailPanel } from "@/components/agents/agent-detail-panel";
 import { AgentsListView } from "@/components/agents/agents-list-view";
+import { PageHeader } from "@/components/page-header";
 import { usePanZoom } from "@/lib/hooks/use-pan-zoom";
 
 type ViewMode = "orbit" | "list";
@@ -86,12 +87,12 @@ export function AgentsClient() {
 
   return (
     <div className="relative flex-1 flex flex-col overflow-hidden bg-gradient-to-b from-background to-secondary/20">
-      {/* Persistent header — only the view toggle. Orbit mode shows its
-          own top-left Caption overlay, list mode lets the table column
-          headers identify the surface, so no duplicate page title here. */}
-      <header className="shrink-0 flex items-center justify-end px-6 h-12 border-b border-border/60">
+      <PageHeader
+        title="Agents"
+        subtitle="Your team and how each one is configured."
+      >
         <ViewToggle view={view} onChange={setView} />
-      </header>
+      </PageHeader>
 
       <div className="relative flex-1 overflow-hidden">
       {!isApiConfigured ? (
@@ -112,7 +113,6 @@ export function AgentsClient() {
             />
           ) : (
             <>
-              <Caption hasPeers={peers.length > 0} />
               <GestureHint transform={panZoom.transform} />
 
               {/* Pan/zoom container — captures wheel + pointer, transforms
@@ -182,34 +182,6 @@ export function AgentsClient() {
         <AgentDetailPanel agentId={selectedAgentId} onClose={closeAgent} />
       ) : null}
       </div>
-    </div>
-  );
-}
-
-function Caption({ hasPeers }: { hasPeers: boolean }) {
-  // Top-left overlay framing what the user is looking at the first
-  // time they land. `pointer-events-none` so it never absorbs a pan
-  // start. The pan handler also skips children with data-pan="ignore"
-  // but pointer-events-none is the cheaper guarantee.
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  return (
-    <div
-      className={`absolute top-6 left-6 max-w-[260px] pointer-events-none z-10 transition-all duration-500 ease-out motion-reduce:transition-none ${
-        mounted ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-1"
-      }`}
-      data-pan="ignore"
-    >
-      <h1 className="text-sm font-semibold tracking-tight">Your team</h1>
-      <div className="mt-1.5 h-px w-6 bg-border/80" aria-hidden />
-      <p className="mt-2 text-[13px] text-muted-foreground leading-relaxed">
-        {hasPeers
-          ? "Lead in the middle, specialists around them. Other teams sit further out."
-          : "Lead in the middle, specialists around them."}
-      </p>
     </div>
   );
 }

--- a/packages/web/app/(authed)/agents/agents-client.tsx
+++ b/packages/web/app/(authed)/agents/agents-client.tsx
@@ -86,20 +86,10 @@ export function AgentsClient() {
 
   return (
     <div className="relative flex-1 flex flex-col overflow-hidden bg-gradient-to-b from-background to-secondary/20">
-      {/* Persistent header — view toggle lives here so it never overlaps
-          content. Title appears in list mode only; orbit mode keeps its
-          own top-left Caption overlay so the canvas can stay edge-to-edge. */}
-      <header className="shrink-0 flex items-center justify-between gap-3 px-6 h-12 border-b border-border/60">
-        {view === "list" ? (
-          <h1 className="text-sm font-semibold tracking-tight">
-            Agents{" "}
-            <span className="text-muted-foreground/70 tabular-nums font-normal">
-              {selfAgents.length}
-            </span>
-          </h1>
-        ) : (
-          <span aria-hidden />
-        )}
+      {/* Persistent header — only the view toggle. Orbit mode shows its
+          own top-left Caption overlay, list mode lets the table column
+          headers identify the surface, so no duplicate page title here. */}
+      <header className="shrink-0 flex items-center justify-end px-6 h-12 border-b border-border/60">
         <ViewToggle view={view} onChange={setView} />
       </header>
 

--- a/packages/web/app/(authed)/agents/agents-client.tsx
+++ b/packages/web/app/(authed)/agents/agents-client.tsx
@@ -15,8 +15,13 @@ import { usePanZoom } from "@/lib/hooks/use-pan-zoom";
 
 type ViewMode = "orbit" | "list";
 
+// List is the default — most visits to /agents are about checking or
+// changing per-agent config (runtime, model, review policy), which the
+// list view exposes directly. The orbit view is the spatial alternative
+// for "look at the shape of my team," kept one click away behind
+// ?view=orbit.
 function parseView(raw: string | null | undefined): ViewMode {
-  return raw === "list" ? "list" : "orbit";
+  return raw === "orbit" ? "orbit" : "list";
 }
 
 /**
@@ -71,8 +76,9 @@ export function AgentsClient() {
 
   const setView = useCallback(
     (next: ViewMode) => {
-      // Default view is orbit, so encode it by *removing* the param.
-      router.replace(buildHref({ view: next === "orbit" ? null : "list" }), {
+      // List is the default; encode it by *removing* the param so the
+      // common case has a clean URL.
+      router.replace(buildHref({ view: next === "list" ? null : "orbit" }), {
         scroll: false,
       });
     },
@@ -259,20 +265,20 @@ function ViewToggle({
       data-pan="ignore"
     >
       <ToggleButton
-        active={view === "orbit"}
-        onClick={() => onChange("orbit")}
-        label="Orbit"
-        title="Orbit view — pan and zoom the network"
-      >
-        <LayoutGrid className="h-3.5 w-3.5" />
-      </ToggleButton>
-      <ToggleButton
         active={view === "list"}
         onClick={() => onChange("list")}
         label="List"
         title="List view — manage runtime, model, review policy"
       >
         <List className="h-3.5 w-3.5" />
+      </ToggleButton>
+      <ToggleButton
+        active={view === "orbit"}
+        onClick={() => onChange("orbit")}
+        label="Orbit"
+        title="Orbit view — pan and zoom the network"
+      >
+        <LayoutGrid className="h-3.5 w-3.5" />
       </ToggleButton>
     </div>
   );

--- a/packages/web/app/(authed)/agents/agents-client.tsx
+++ b/packages/web/app/(authed)/agents/agents-client.tsx
@@ -85,7 +85,25 @@ export function AgentsClient() {
   const panZoom = usePanZoom({ minScale: 0.4, maxScale: 2.5 });
 
   return (
-    <div className="relative flex-1 overflow-hidden bg-gradient-to-b from-background to-secondary/20">
+    <div className="relative flex-1 flex flex-col overflow-hidden bg-gradient-to-b from-background to-secondary/20">
+      {/* Persistent header — view toggle lives here so it never overlaps
+          content. Title appears in list mode only; orbit mode keeps its
+          own top-left Caption overlay so the canvas can stay edge-to-edge. */}
+      <header className="shrink-0 flex items-center justify-between gap-3 px-6 h-12 border-b border-border/60">
+        {view === "list" ? (
+          <h1 className="text-sm font-semibold tracking-tight">
+            Agents{" "}
+            <span className="text-muted-foreground/70 tabular-nums font-normal">
+              {selfAgents.length}
+            </span>
+          </h1>
+        ) : (
+          <span aria-hidden />
+        )}
+        <ViewToggle view={view} onChange={setView} />
+      </header>
+
+      <div className="relative flex-1 overflow-hidden">
       {!isApiConfigured ? (
         <CenteredShell
           icon={Bot}
@@ -96,8 +114,6 @@ export function AgentsClient() {
         <CenteredShell icon={AlertTriangle} title="Couldn't load the network" />
       ) : (
         <>
-          <ViewToggle view={view} onChange={setView} />
-
           {view === "list" ? (
             <AgentsListView
               agents={selfAgents}
@@ -175,6 +191,7 @@ export function AgentsClient() {
       {selectedAgentId ? (
         <AgentDetailPanel agentId={selectedAgentId} onClose={closeAgent} />
       ) : null}
+      </div>
     </div>
   );
 }
@@ -276,7 +293,7 @@ function ViewToggle({
 }) {
   return (
     <div
-      className="absolute top-6 right-6 z-10 inline-flex items-center gap-0.5 rounded-full border border-border bg-card/90 backdrop-blur-sm shadow-sm p-0.5"
+      className="inline-flex items-center gap-0.5 rounded-full border border-border bg-card/90 backdrop-blur-sm shadow-sm p-0.5"
       data-pan="ignore"
     >
       <ToggleButton

--- a/packages/web/components/agents/agents-list-view.tsx
+++ b/packages/web/components/agents/agents-list-view.tsx
@@ -31,7 +31,7 @@ export function AgentsListView({
   if (agents.length === 0) {
     return (
       <div className="px-6 py-12 text-center text-sm text-muted-foreground">
-        No agents yet.
+        No agents yet
       </div>
     );
   }

--- a/packages/web/components/agents/agents-list-view.tsx
+++ b/packages/web/components/agents/agents-list-view.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import Link from "next/link";
+import { ExternalLink } from "lucide-react";
+import { Avatar } from "@/components/avatar";
+import { HierChip } from "@/components/hier-chip";
+import { RuntimeSelect } from "@/components/agents/pickers/runtime-picker";
+import { ModelSelect } from "@/components/agents/pickers/model-picker";
+import { ReviewPolicySelect } from "@/components/agents/pickers/review-policy-picker";
+import type { AgentDisplay } from "@/lib/api/types";
+
+/**
+ * Flat table of the caller's agents with inline Runtime / Model /
+ * Review policy editors. Each select mutates through the same hooks
+ * the detail aside uses, so changing a value here updates everywhere
+ * the agent appears (orbit dot, peek panel, detail aside).
+ *
+ * Clicking a row opens the same peek panel as the orbit canvas — the
+ * parent route owns the `?p=<id>` state and renders `AgentDetailPanel`
+ * over both views.
+ */
+export function AgentsListView({
+  agents,
+  onSelect,
+  selectedAgentId,
+}: {
+  agents: AgentDisplay[];
+  onSelect: (agentId: string) => void;
+  selectedAgentId: string | undefined;
+}) {
+  if (agents.length === 0) {
+    return (
+      <div className="px-6 py-12 text-center text-sm text-muted-foreground">
+        No agents yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-6 py-6 overflow-auto h-full">
+      <table className="w-full text-sm border-collapse">
+        <thead>
+          <tr className="text-left text-[11px] uppercase tracking-wider text-muted-foreground border-b border-border/60">
+            <th className="font-medium pb-2 pr-3">Agent</th>
+            <th className="font-medium pb-2 pr-3">Hierarchy</th>
+            <th className="font-medium pb-2 pr-3 tabular-nums">Sessions</th>
+            <th className="font-medium pb-2 pr-3 min-w-[180px]">Runtime</th>
+            <th className="font-medium pb-2 pr-3 min-w-[140px]">Model</th>
+            <th className="font-medium pb-2 pr-3 min-w-[160px]">Review policy</th>
+            <th className="font-medium pb-2 w-8" aria-label="Open detail" />
+          </tr>
+        </thead>
+        <tbody>
+          {agents.map((agent) => (
+            <AgentRow
+              key={agent.id}
+              agent={agent}
+              selected={agent.id === selectedAgentId}
+              onSelect={() => onSelect(agent.id)}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function AgentRow({
+  agent,
+  selected,
+  onSelect,
+}: {
+  agent: AgentDisplay;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const initial = agent.display_name.charAt(0).toUpperCase();
+  const archived = Boolean(agent.archived_at);
+
+  return (
+    <tr
+      className={
+        "border-b border-border/40 align-middle " +
+        (selected ? "bg-secondary/40" : "hover:bg-secondary/20")
+      }
+    >
+      <td className="py-2.5 pr-3">
+        <button
+          type="button"
+          onClick={onSelect}
+          className="flex items-center gap-2.5 text-left cursor-pointer"
+          title="Open peek panel"
+        >
+          <Avatar initial={initial} kind={agent.hierarchy} size={28} />
+          <div className="min-w-0">
+            <div className="flex items-center gap-1.5">
+              <span className="font-medium truncate">{agent.display_name}</span>
+              {archived ? (
+                <span className="rounded bg-muted px-1 py-0.5 text-[9px] uppercase tracking-wider text-muted-foreground">
+                  archived
+                </span>
+              ) : null}
+            </div>
+            {agent.specialization ? (
+              <p className="text-xs text-muted-foreground truncate max-w-[260px]">
+                {agent.specialization}
+              </p>
+            ) : null}
+          </div>
+        </button>
+      </td>
+      <td className="py-2.5 pr-3">
+        <HierChip hier={agent.hierarchy} />
+      </td>
+      <td className="py-2.5 pr-3 text-muted-foreground tabular-nums">
+        {agent.sessions_count ?? 0}
+      </td>
+      <td className="py-2.5 pr-3">
+        <RuntimeSelect agent={agent} />
+      </td>
+      <td className="py-2.5 pr-3">
+        <ModelSelect agent={agent} allowCustom={false} />
+      </td>
+      <td className="py-2.5 pr-3">
+        <ReviewPolicySelect agent={agent} />
+      </td>
+      <td className="py-2.5">
+        <Link
+          href={`/agents/${agent.id}`}
+          className="inline-flex items-center justify-center h-7 w-7 rounded text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+          title="Open full detail page"
+          aria-label="Open full detail page"
+        >
+          <ExternalLink className="h-3.5 w-3.5" />
+        </Link>
+      </td>
+    </tr>
+  );
+}

--- a/packages/web/components/agents/pickers/model-picker.tsx
+++ b/packages/web/components/agents/pickers/model-picker.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api/client";
+import { queryKeys } from "@/lib/hooks/keys";
+import { cn } from "@/lib/utils";
+import type { AgentDisplay } from "@/lib/api/types";
+
+// Common Claude model aliases the CLI accepts. The empty-string sentinel
+// represents "CLI default" — clears `runtime_config.model` server-side.
+export const MODEL_PRESETS: ReadonlyArray<{ value: string; label: string }> = [
+  { value: "", label: "CLI default (recommended)" },
+  { value: "opus", label: "opus" },
+  { value: "sonnet", label: "sonnet" },
+  { value: "haiku", label: "haiku" },
+];
+
+/**
+ * Bare model `<select>` for table cells. With `allowCustom: true` (the
+ * card variant) an "Other (pinned model ID)…" option appears, which
+ * reveals a tiny inline form for typing a model ID like
+ * `claude-opus-4-7`. Compact callers (list rows) leave it off so
+ * picking a value never expands the row height.
+ */
+export function ModelSelect({
+  agent,
+  className,
+  allowCustom = true,
+}: {
+  agent: AgentDisplay;
+  className?: string;
+  allowCustom?: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const current = agent.model ?? "";
+  const isPreset = MODEL_PRESETS.some((p) => p.value === current);
+
+  const [customMode, setCustomMode] = useState(
+    () => allowCustom && !isPreset && current !== "",
+  );
+  const [customValue, setCustomValue] = useState(() =>
+    isPreset ? "" : current,
+  );
+
+  useEffect(() => {
+    const nextIsPreset = MODEL_PRESETS.some((p) => p.value === current);
+    setCustomMode(allowCustom && !nextIsPreset && current !== "");
+    setCustomValue(nextIsPreset ? "" : current);
+  }, [current, allowCustom]);
+
+  const mutation = useMutation({
+    mutationFn: (model: string | null) => api.agents.setModel(agent.id, model),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.agents.detail(agent.id),
+      });
+      // List view consumes AgentDisplay.model from the agents list query,
+      // not the per-agent detail. Invalidate the list scope too so a row
+      // re-renders after mutation.
+      void queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
+    },
+  });
+
+  // When a non-preset value comes back from the server but allowCustom
+  // is off, the select can't represent it — surface as a flat label so
+  // the user still sees what's set instead of a blank dropdown.
+  if (!allowCustom && !isPreset && current !== "") {
+    return (
+      <span className="text-xs font-mono text-muted-foreground" title={current}>
+        {current}
+      </span>
+    );
+  }
+
+  return (
+    <>
+      <select
+        value={customMode ? "__custom" : current}
+        disabled={mutation.isPending}
+        onChange={(e) => {
+          const v = e.target.value;
+          if (v === "__custom") {
+            setCustomMode(true);
+            return;
+          }
+          setCustomMode(false);
+          mutation.mutate(v === "" ? null : v);
+        }}
+        className={cn(
+          "w-full text-sm rounded border border-border bg-background px-2 py-1.5 cursor-pointer disabled:opacity-50",
+          className,
+        )}
+      >
+        {MODEL_PRESETS.map((p) => (
+          <option key={p.value || "__default"} value={p.value}>
+            {p.label}
+          </option>
+        ))}
+        {allowCustom ? (
+          <option value="__custom">Other (pinned model ID)…</option>
+        ) : null}
+      </select>
+      {customMode ? (
+        <form
+          className="mt-2 flex gap-1"
+          onSubmit={(e) => {
+            e.preventDefault();
+            const v = customValue.trim();
+            if (v) mutation.mutate(v);
+          }}
+        >
+          <input
+            type="text"
+            value={customValue}
+            onChange={(e) => setCustomValue(e.target.value)}
+            placeholder="e.g. claude-opus-4-7"
+            className="flex-1 text-sm rounded border border-border bg-background px-2 py-1.5"
+          />
+          <button
+            type="submit"
+            disabled={mutation.isPending || !customValue.trim()}
+            className="h-7 px-3 rounded text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50"
+          >
+            Set
+          </button>
+        </form>
+      ) : null}
+      {mutation.isError ? (
+        <p className="text-xs text-destructive mt-1.5">
+          Couldn&apos;t update model.
+        </p>
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * Card-wrapped model picker for the agent detail aside.
+ */
+export function ModelPicker({ agent }: { agent: AgentDisplay }) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-4">
+      <h3 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-2 font-medium">
+        Model
+      </h3>
+      <ModelSelect agent={agent} />
+      <p className="text-[11px] text-muted-foreground mt-2 leading-snug">
+        Model alias passed to the CLI via <span className="font-mono">--model</span>.
+        Leave on &quot;CLI default&quot; to inherit whatever you&apos;ve
+        configured in <span className="font-mono">~/.claude</span>.
+      </p>
+    </section>
+  );
+}

--- a/packages/web/components/agents/pickers/review-policy-picker.tsx
+++ b/packages/web/components/agents/pickers/review-policy-picker.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api/client";
+import { queryKeys } from "@/lib/hooks/keys";
+import { cn } from "@/lib/utils";
+import type { AgentDisplay } from "@/lib/api/types";
+import type { ReviewPolicy } from "@beevibe/core";
+
+/**
+ * Bare review-policy `<select>`. Legacy agents (provisioned before this
+ * column had a default) carry `review_policy=null`; behaviorally that's
+ * identical to `auto_done` in TaskService, so render it that way too.
+ */
+export function ReviewPolicySelect({
+  agent,
+  className,
+}: {
+  agent: AgentDisplay;
+  className?: string;
+}) {
+  const queryClient = useQueryClient();
+  const current: ReviewPolicy =
+    agent.review_policy === "require_human" ? "require_human" : "auto_done";
+  const mutation = useMutation({
+    mutationFn: (policy: ReviewPolicy) =>
+      api.agents.setReviewPolicy(agent.id, policy),
+    onSuccess: () => {
+      // Invalidate all agent queries: list rows + peek panel + detail
+      // all carry review_policy.
+      void queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
+    },
+  });
+
+  return (
+    <>
+      <select
+        value={current}
+        disabled={mutation.isPending}
+        onChange={(e) => mutation.mutate(e.target.value as ReviewPolicy)}
+        className={cn(
+          "w-full text-sm rounded border border-border bg-background px-2 py-1.5 cursor-pointer disabled:opacity-50",
+          className,
+        )}
+      >
+        <option value="auto_done">Auto-done (default)</option>
+        <option value="require_human">Require human review</option>
+      </select>
+      {mutation.isError ? (
+        <p className="text-xs text-destructive mt-1.5">
+          Couldn&apos;t update review policy.
+        </p>
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * Card-wrapped review-policy picker for the agent detail aside.
+ */
+export function ReviewPolicyPicker({ agent }: { agent: AgentDisplay }) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-4">
+      <h3 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-2 font-medium">
+        Review policy
+      </h3>
+      <ReviewPolicySelect agent={agent} />
+      <p className="text-[11px] text-muted-foreground mt-2 leading-snug">
+        When the agent declares a task <span className="font-mono">done</span>,
+        auto-done closes it. Require-human routes it through{" "}
+        <span className="font-mono">review</span> so you sign off first.
+      </p>
+    </section>
+  );
+}

--- a/packages/web/components/agents/pickers/runtime-picker.tsx
+++ b/packages/web/components/agents/pickers/runtime-picker.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import Link from "next/link";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api, type RuntimesListResponse } from "@/lib/api/client";
+import { queryKeys } from "@/lib/hooks/keys";
+import { cn } from "@/lib/utils";
+import type { AgentDisplay } from "@/lib/api/types";
+
+type RuntimeOption = {
+  id: string;
+  cli: string;
+  cli_version?: string;
+  online: boolean;
+  device: string;
+};
+
+function flattenRuntimes(data: RuntimesListResponse | undefined): RuntimeOption[] {
+  return (
+    data?.daemons.flatMap((d) =>
+      d.runtimes.map((r) => ({
+        id: r.id,
+        cli: r.cli,
+        cli_version: r.cli_version,
+        online: r.online,
+        device: d.device_name ?? d.external_id,
+      })),
+    ) ?? []
+  );
+}
+
+/**
+ * Bare `<select>` for an agent's preferred runtime. Used in table rows
+ * where the surrounding chrome supplies its own heading + help text.
+ * The card-wrapped form is `RuntimePicker`.
+ */
+export function RuntimeSelect({
+  agent,
+  className,
+  autoFocus,
+}: {
+  agent: AgentDisplay;
+  className?: string;
+  autoFocus?: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const runtimesQuery = useQuery<RuntimesListResponse>({
+    queryKey: queryKeys.runtimes.list(),
+    queryFn: ({ signal }) => api.runtimes.list({ signal }),
+    staleTime: 30_000,
+  });
+  const mutation = useMutation({
+    mutationFn: (runtimeId: string | null) => api.agents.setRuntime(agent.id, runtimeId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
+    },
+  });
+
+  const runtimes = flattenRuntimes(runtimesQuery.data);
+  const value = agent.preferred_runtime_id ?? "";
+
+  if (runtimesQuery.isLoading) {
+    return <p className="text-xs text-muted-foreground italic">Loading…</p>;
+  }
+
+  if (runtimes.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        No daemons.{" "}
+        <Link href="/runtimes" className="underline hover:text-foreground">
+          Set up
+        </Link>
+      </p>
+    );
+  }
+
+  return (
+    <>
+      <select
+        value={value}
+        autoFocus={autoFocus}
+        disabled={mutation.isPending}
+        onChange={(e) => {
+          const next = e.target.value === "" ? null : e.target.value;
+          mutation.mutate(next);
+        }}
+        className={cn(
+          "w-full text-sm rounded border border-border bg-background px-2 py-1.5 cursor-pointer disabled:opacity-50",
+          className,
+        )}
+      >
+        <option value="">— unbound —</option>
+        {runtimes.map((r) => (
+          <option key={r.id} value={r.id}>
+            {r.device} · {r.cli}
+            {r.cli_version ? ` ${r.cli_version}` : ""}
+            {r.online ? " (online)" : " (offline)"}
+          </option>
+        ))}
+      </select>
+      {mutation.isError ? (
+        <p className="text-xs text-destructive mt-1.5">
+          Couldn&apos;t update runtime.
+        </p>
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * Card-wrapped runtime picker for the agent detail aside. Composes
+ * `RuntimeSelect` with the section heading + help copy users saw in
+ * the original sidebar.
+ */
+export function RuntimePicker({ agent }: { agent: AgentDisplay }) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-4">
+      <h3 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-2 font-medium">
+        Runtime
+      </h3>
+      <RuntimeSelect agent={agent} />
+      <p className="text-[11px] text-muted-foreground mt-2 leading-snug">
+        The agent runs on this daemon&apos;s CLI. Unbinding makes task / chat
+        sessions sit pending until rebound; mesh asks fall back to the
+        server.
+      </p>
+      <p className="text-[11px] text-muted-foreground mt-1 leading-snug">
+        Don&apos;t see a CLI you just installed?{" "}
+        <Link href="/runtimes" className="underline hover:text-foreground">
+          Sync your daemon
+        </Link>
+        .
+      </p>
+    </section>
+  );
+}

--- a/packages/web/components/page-header.tsx
+++ b/packages/web/components/page-header.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from "react";
+
+/**
+ * Shared horizontal page header for top-level routes like /agents,
+ * /tasks, /rooms — title on the left, optional subtitle, actions slot
+ * on the right. Matches the strip /tasks shipped first; any new page
+ * with a header band should use this so spacing and typography stay
+ * consistent without each route re-deriving them.
+ *
+ * Actions go in `children` so callers can compose freely (toggles,
+ * search boxes, archive chips, etc.).
+ */
+export function PageHeader({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children?: ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-3 px-6 pt-5 pb-4 border-b border-border/60 shrink-0">
+      <h1 className="text-base font-semibold tracking-tight leading-none">
+        {title}
+      </h1>
+      {subtitle ? (
+        <p className="text-xs text-muted-foreground leading-none flex-1 min-w-0 truncate">
+          {subtitle}
+        </p>
+      ) : (
+        <div className="flex-1" />
+      )}
+      {children ? (
+        <div className="shrink-0 flex items-center gap-2">{children}</div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/web/components/tasks/view-tabs.tsx
+++ b/packages/web/components/tasks/view-tabs.tsx
@@ -4,6 +4,7 @@ import { useRef } from "react";
 import { Archive, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useSlashFocus } from "@/lib/hooks/use-slash-focus";
+import { PageHeader } from "@/components/page-header";
 
 // Header for /tasks. The earlier strip had "All tasks / My tasks"
 // tabs but "My tasks" was a placebo — the backend treated mine = all,
@@ -32,25 +33,21 @@ export function ViewTabs({
   onToggleArchived,
 }: Props) {
   return (
-    <div className="flex items-center gap-3 px-6 pt-5 pb-4 border-b border-border/60">
-      <h1 className="text-base font-semibold tracking-tight leading-none">Tasks</h1>
-      <p className="text-xs text-muted-foreground leading-none flex-1 min-w-0 truncate">
-        Work the team is moving through, grouped by status.
-      </p>
-
-      <div className="shrink-0 flex items-center gap-2">
-        {/* Archive toggle — always rendered so the affordance is
-            discoverable even when there's nothing archived yet. Failed
-            and cancelled tasks would otherwise dominate Done, so they're
-            hidden by default behind this toggle. */}
-        <ArchiveToggle
-          count={archivedCount}
-          showing={showArchived}
-          onToggle={onToggleArchived}
-        />
-        <SearchBox query={query} onChange={onQueryChange} onFocus={onSearch} />
-      </div>
-    </div>
+    <PageHeader
+      title="Tasks"
+      subtitle="Work the team is moving through, grouped by status."
+    >
+      {/* Archive toggle — always rendered so the affordance is
+          discoverable even when there's nothing archived yet. Failed
+          and cancelled tasks would otherwise dominate Done, so they're
+          hidden by default behind this toggle. */}
+      <ArchiveToggle
+        count={archivedCount}
+        showing={showArchived}
+        onToggle={onToggleArchived}
+      />
+      <SearchBox query={query} onChange={onQueryChange} onFocus={onSearch} />
+    </PageHeader>
   );
 }
 

--- a/packages/web/lib/api/types.ts
+++ b/packages/web/lib/api/types.ts
@@ -9,6 +9,7 @@ export type {
   TaskDetail,
   TaskDetailSessionRow,
   AgentDetail,
+  AgentDisplay,
   DashboardSummary,
   MeshOverview,
 } from "@beevibe/api/views/types";


### PR DESCRIPTION
## Summary

The /agents page was a beautiful orbit canvas but a bad management surface. Per-agent settings (runtime, model, review policy) lived behind 3 clicks: Teams → click agent → scroll aside. Many users never found them.

This adds a **list view** that's now the **default** on /agents, with all three pickers inline per row. Orbit is still one click away via the toggle.

## What's in the PR

- **`/agents` list view** ([agents-list-view.tsx](packages/web/components/agents/agents-list-view.tsx)) — flat table of your own agents with Runtime / Model / Review policy as inline `<select>`s. Clicking a row opens the same peek panel as the orbit; chevron on the right goes to the full detail page.
- **Orbit ⇄ List toggle** in a persistent header bar. `?view=orbit` switches; clean `/agents` URL = list. Peek panel `?p=` is preserved across view switches.
- **Shared `PageHeader` component** ([page-header.tsx](packages/web/components/page-header.tsx)) — `/tasks` migrates to it, so the next page that needs a top strip picks up consistent typography + spacing for free.
- **Extracted pickers** ([components/agents/pickers/](packages/web/components/agents/pickers/)) — each picker now exports a bare `XxxSelect` (for table cells) and a card-wrapped `XxxPicker` (for the detail aside). No behavior change on `/agents/[id]`.

## What's not in this PR (follow-ups)

- Promote `AgentOnlineDot` to a labeled clickable chip ("● claude 2.1.143" / "○ Set runtime") that routes to list+focus
- Sort unbound agents to the top of the list with a one-line callout
- Bulk action bar (multi-select rows → "Set review policy → … for N selected")

## Test plan

- [ ] Land on `/agents` — see list view by default, no `?view=` param in URL
- [ ] Click "Orbit" toggle — URL becomes `?view=orbit`, canvas renders, reload preserves view
- [ ] Click an agent row — peek panel opens, URL adds `?p=<id>`, view param preserved
- [ ] Change Runtime / Model / Review policy from a row — value persists, refreshes everywhere the agent shows
- [ ] `/agents/[id]` aside still renders three picker cards unchanged
- [ ] `/tasks` header looks identical to before the PageHeader migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)