### PR TITLE
feat(agents): chip-style pickers for Runtime / Model / Review policy

### DIFF
--- a/packages/api/src/views/agent-network.ts
+++ b/packages/api/src/views/agent-network.ts
@@ -32,7 +32,8 @@ const PEERS_LIMIT = 500;
 const SELF_SQL = /* sql */ `
 SELECT
   a.id, a.name, a.owner_id, a.parent_agent_id, a.hierarchy_level,
-  a.review_policy, a.runtime_config, a.created_at, a.updated_at,
+  a.review_policy, a.runtime_config, a.preferred_runtime_id,
+  a.created_at, a.updated_at,
   COALESCE(sc.n, 0)::int  AS sessions_count,
   COALESCE(fc.n, 0)::int  AS facts_learned,
   tl.content              AS tag_line
@@ -57,7 +58,8 @@ ORDER BY
 const PEERS_SQL = /* sql */ `
 SELECT
   a.id, a.name, a.owner_id, a.parent_agent_id, a.hierarchy_level,
-  a.review_policy, a.runtime_config, a.created_at, a.updated_at,
+  a.review_policy, a.runtime_config, a.preferred_runtime_id,
+  a.created_at, a.updated_at,
   p.name AS owner_label,
   COALESCE(sc.n, 0)::int  AS sessions_count,
   COALESCE(fc.n, 0)::int  AS facts_learned,
@@ -85,6 +87,7 @@ interface AgentRow {
   hierarchy_level: "ic" | "team" | "org";
   review_policy: string | null;
   runtime_config: RuntimeConfig;
+  preferred_runtime_id: string | null;
   created_at: Date;
   updated_at: Date;
   sessions_count: string | number;
@@ -119,6 +122,7 @@ function rowToAgentDisplay(row: AgentRow): AgentDisplay {
     model,
     specialization,
     review_policy: (row.review_policy ?? undefined) as AgentDisplay["review_policy"],
+    preferred_runtime_id: row.preferred_runtime_id ?? undefined,
   };
 }
 

--- a/packages/web/components/agents/agents-list-view.tsx
+++ b/packages/web/components/agents/agents-list-view.tsx
@@ -4,9 +4,9 @@ import Link from "next/link";
 import { ExternalLink } from "lucide-react";
 import { Avatar } from "@/components/avatar";
 import { HierChip } from "@/components/hier-chip";
-import { RuntimeSelect } from "@/components/agents/pickers/runtime-picker";
-import { ModelSelect } from "@/components/agents/pickers/model-picker";
-import { ReviewPolicySelect } from "@/components/agents/pickers/review-policy-picker";
+import { RuntimeChip } from "@/components/agents/pickers/runtime-picker";
+import { ModelChip } from "@/components/agents/pickers/model-picker";
+import { ReviewPolicyChip } from "@/components/agents/pickers/review-policy-picker";
 import type { AgentDisplay } from "@/lib/api/types";
 
 /**
@@ -44,9 +44,9 @@ export function AgentsListView({
             <th className="font-medium pb-2 pr-3">Agent</th>
             <th className="font-medium pb-2 pr-3">Hierarchy</th>
             <th className="font-medium pb-2 pr-3 tabular-nums">Sessions</th>
-            <th className="font-medium pb-2 pr-3 min-w-[180px]">Runtime</th>
-            <th className="font-medium pb-2 pr-3 min-w-[140px]">Model</th>
-            <th className="font-medium pb-2 pr-3 min-w-[160px]">Review policy</th>
+            <th className="font-medium pb-2 pr-3 min-w-[160px]">Runtime</th>
+            <th className="font-medium pb-2 pr-3 min-w-[110px]">Model</th>
+            <th className="font-medium pb-2 pr-3 min-w-[140px]">Review policy</th>
             <th className="font-medium pb-2 w-8" aria-label="Open detail" />
           </tr>
         </thead>
@@ -116,13 +116,13 @@ function AgentRow({
         {agent.sessions_count ?? 0}
       </td>
       <td className="py-2.5 pr-3">
-        <RuntimeSelect agent={agent} />
+        <RuntimeChip agent={agent} />
       </td>
       <td className="py-2.5 pr-3">
-        <ModelSelect agent={agent} allowCustom={false} />
+        <ModelChip agent={agent} />
       </td>
       <td className="py-2.5 pr-3">
-        <ReviewPolicySelect agent={agent} />
+        <ReviewPolicyChip agent={agent} />
       </td>
       <td className="py-2.5">
         <Link

--- a/packages/web/components/agents/pickers/chip-popover.tsx
+++ b/packages/web/components/agents/pickers/chip-popover.tsx
@@ -89,7 +89,13 @@ export function ChipPopover({
           id={menuId}
           role="menu"
           className={cn(
-            "absolute top-full mt-1.5 z-50 min-w-[220px] max-w-[320px] rounded-md border border-border bg-popover shadow-lg py-1 text-sm",
+            "absolute top-full mt-1.5 z-50 min-w-[220px] max-w-[320px] rounded-md border border-border py-1 text-sm",
+            // bg-card resolves via Tailwind config; bg-popover is not
+            // wired (see tailwind.config.ts colors map) and renders
+            // transparent, which causes the rows below the chip to
+            // bleed through. Pair with shadow-xl so the popover reads
+            // as floating above the table, not inline with it.
+            "bg-card shadow-xl",
             align === "right" ? "right-0" : "left-0",
           )}
         >

--- a/packages/web/components/agents/pickers/chip-popover.tsx
+++ b/packages/web/components/agents/pickers/chip-popover.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Shared chip-button + click-outside popover used by the Runtime,
+ * Model, and Review-policy chip pickers in the agent list view.
+ *
+ * Trigger is a `<button>` styled as a status chip; popover content is
+ * authored by the caller. Manages open state, click-outside, and
+ * Escape. The same click-outside pattern lives in `user-widget.tsx`;
+ * this just packages it for reuse so three pickers don't each
+ * re-derive it.
+ */
+export function ChipPopover({
+  ariaLabel,
+  chipClassName,
+  chip,
+  children,
+  disabled,
+  align = "left",
+}: {
+  ariaLabel: string;
+  chipClassName?: string;
+  /** Inline content of the chip button (dot + label + caret). */
+  chip: ReactNode;
+  /** Rendered when the popover is open. Receives a close callback. */
+  children: (close: () => void) => ReactNode;
+  disabled?: boolean;
+  /** Which edge the popover aligns to. */
+  align?: "left" | "right";
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const menuId = useId();
+  const close = useCallback(() => setOpen(false), []);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <div ref={rootRef} className="relative inline-flex">
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label={ariaLabel}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
+        disabled={disabled}
+        onClick={() => setOpen((v) => !v)}
+        className={cn(
+          "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs leading-none cursor-pointer transition-colors",
+          "disabled:opacity-50 disabled:cursor-not-allowed",
+          chipClassName,
+        )}
+      >
+        {chip}
+      </button>
+      {open ? (
+        <div
+          id={menuId}
+          role="menu"
+          className={cn(
+            "absolute top-full mt-1.5 z-50 min-w-[220px] max-w-[320px] rounded-md border border-border bg-popover shadow-lg py-1 text-sm",
+            align === "right" ? "right-0" : "left-0",
+          )}
+        >
+          {children(close)}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Single row inside a ChipPopover. Composes a menu-item button with a
+ * leading slot (dot / icon), a label, an optional sublabel, and an
+ * optional trailing checkmark when selected. Keeps the three pickers
+ * visually aligned without each re-deriving the row layout.
+ */
+export function ChipMenuItem({
+  selected,
+  disabled,
+  onClick,
+  leading,
+  label,
+  sublabel,
+  trailing,
+}: {
+  selected?: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+  leading?: ReactNode;
+  label: ReactNode;
+  sublabel?: ReactNode;
+  trailing?: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      disabled={disabled}
+      onClick={onClick}
+      className={cn(
+        "w-full flex items-center gap-2 px-2.5 py-1.5 text-left text-sm cursor-pointer",
+        "hover:bg-secondary disabled:opacity-50 disabled:cursor-not-allowed",
+        selected ? "text-foreground" : "text-foreground/85",
+      )}
+    >
+      {leading ? <span className="shrink-0 flex items-center">{leading}</span> : null}
+      <span className="flex-1 min-w-0 truncate">{label}</span>
+      {sublabel ? (
+        <span className="shrink-0 text-[11px] text-muted-foreground/80">
+          {sublabel}
+        </span>
+      ) : null}
+      {trailing ?? (selected ? <Check /> : null)}
+    </button>
+  );
+}
+
+function Check() {
+  return (
+    <svg
+      className="h-3 w-3 text-muted-foreground"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+/** Tiny status dot for chip leading slot. Reusable across pickers. */
+export function StatusDot({
+  tone,
+  glow = true,
+}: {
+  tone: "green" | "amber" | "gray";
+  glow?: boolean;
+}) {
+  const bg =
+    tone === "green"
+      ? "bg-emerald-500"
+      : tone === "amber"
+        ? "bg-amber-500"
+        : "bg-muted-foreground/50";
+  const ring =
+    tone === "green"
+      ? "shadow-[0_0_0_3px_rgba(16,185,129,0.18)]"
+      : tone === "amber"
+        ? "shadow-[0_0_0_3px_rgba(245,158,11,0.20)]"
+        : "";
+  return (
+    <span
+      aria-hidden
+      className={cn("inline-block h-1.5 w-1.5 rounded-full", bg, glow ? ring : "")}
+    />
+  );
+}
+
+/** Down caret used at the trailing edge of a chip to signal "click to change". */
+export function ChipCaret() {
+  return (
+    <svg
+      className="h-3 w-3 text-current opacity-50"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  );
+}

--- a/packages/web/components/agents/pickers/model-picker.tsx
+++ b/packages/web/components/agents/pickers/model-picker.tsx
@@ -4,40 +4,128 @@ import { useEffect, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
 import { queryKeys } from "@/lib/hooks/keys";
+import {
+  ChipCaret,
+  ChipMenuItem,
+  ChipPopover,
+} from "@/components/agents/pickers/chip-popover";
 import { cn } from "@/lib/utils";
 import type { AgentDisplay } from "@/lib/api/types";
 
 // Common Claude model aliases the CLI accepts. The empty-string sentinel
 // represents "CLI default" — clears `runtime_config.model` server-side.
-export const MODEL_PRESETS: ReadonlyArray<{ value: string; label: string }> = [
-  { value: "", label: "CLI default (recommended)" },
+export const MODEL_PRESETS: ReadonlyArray<{
+  value: string;
+  label: string;
+  sublabel?: string;
+}> = [
+  { value: "", label: "CLI default", sublabel: "from ~/.claude" },
   { value: "opus", label: "opus" },
   { value: "sonnet", label: "sonnet" },
   { value: "haiku", label: "haiku" },
 ];
 
+function useModelMutation(agentId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (model: string | null) => api.agents.setModel(agentId, model),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.agents.detail(agentId),
+      });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
+    },
+  });
+}
+
+function presetLabel(value: string): string | undefined {
+  return MODEL_PRESETS.find((p) => p.value === value)?.label;
+}
+
 /**
- * Bare model `<select>` for table cells. With `allowCustom: true` (the
- * card variant) an "Other (pinned model ID)…" option appears, which
- * reveals a tiny inline form for typing a model ID like
- * `claude-opus-4-7`. Compact callers (list rows) leave it off so
- * picking a value never expands the row height.
+ * Chip-style model picker for the agent list view. Muted gray pill in
+ * the resting state — model choice is rarely the load-bearing setting
+ * compared to runtime, so it gets visual second billing. Click opens a
+ * popover with the four common presets; custom pinned model IDs are
+ * available via the detail page's full picker (not duplicated here so
+ * row height stays stable).
  */
-export function ModelSelect({
-  agent,
-  className,
-  allowCustom = true,
-}: {
-  agent: AgentDisplay;
-  className?: string;
-  allowCustom?: boolean;
-}) {
+export function ModelChip({ agent }: { agent: AgentDisplay }) {
+  const mutation = useModelMutation(agent.id);
+  const current = agent.model ?? "";
+  const label = presetLabel(current) ?? current ?? "CLI default";
+  const isDefault = current === "";
+
+  return (
+    <ChipPopover
+      ariaLabel={`Model: ${label}. Click to change.`}
+      chipClassName={cn(
+        "border border-border bg-transparent hover:bg-secondary/60",
+        isDefault ? "text-muted-foreground italic" : "text-foreground/90",
+      )}
+      disabled={mutation.isPending}
+      chip={
+        <>
+          <span className="font-mono text-[11.5px] tabular-nums">{label}</span>
+          <ChipCaret />
+        </>
+      }
+    >
+      {(close) => (
+        <>
+          {MODEL_PRESETS.map((p) => (
+            <ChipMenuItem
+              key={p.value || "__default"}
+              selected={p.value === current}
+              label={
+                <span className={cn("text-[13px]", p.value === "" ? "italic" : "font-mono")}>
+                  {p.label}
+                </span>
+              }
+              sublabel={p.sublabel}
+              onClick={() => {
+                mutation.mutate(p.value === "" ? null : p.value);
+                close();
+              }}
+            />
+          ))}
+          {current && !MODEL_PRESETS.some((p) => p.value === current) ? (
+            <>
+              <div className="my-1 border-t border-border" />
+              <ChipMenuItem
+                selected
+                label={
+                  <span className="text-[13px] font-mono">{current}</span>
+                }
+                sublabel="pinned"
+                onClick={() => close()}
+              />
+            </>
+          ) : null}
+          <div className="my-1 border-t border-border" />
+          <div className="px-2.5 py-1.5 text-[11px] text-muted-foreground/80">
+            Pin a custom model ID from the agent&apos;s detail page.
+          </div>
+        </>
+      )}
+    </ChipPopover>
+  );
+}
+
+/**
+ * Card-wrapped model picker for the agent detail aside. Keeps the
+ * full-width native `<select>` plus the "Other (pinned model ID)…"
+ * custom-text path that the chip variant intentionally drops. The
+ * detail page is where users do substantive config; the list view is
+ * for quick toggles.
+ */
+export function ModelPicker({ agent }: { agent: AgentDisplay }) {
   const queryClient = useQueryClient();
   const current = agent.model ?? "";
   const isPreset = MODEL_PRESETS.some((p) => p.value === current);
 
   const [customMode, setCustomMode] = useState(
-    () => allowCustom && !isPreset && current !== "",
+    () => !isPreset && current !== "",
   );
   const [customValue, setCustomValue] = useState(() =>
     isPreset ? "" : current,
@@ -45,9 +133,9 @@ export function ModelSelect({
 
   useEffect(() => {
     const nextIsPreset = MODEL_PRESETS.some((p) => p.value === current);
-    setCustomMode(allowCustom && !nextIsPreset && current !== "");
+    setCustomMode(!nextIsPreset && current !== "");
     setCustomValue(nextIsPreset ? "" : current);
-  }, [current, allowCustom]);
+  }, [current]);
 
   const mutation = useMutation({
     mutationFn: (model: string | null) => api.agents.setModel(agent.id, model),
@@ -55,26 +143,15 @@ export function ModelSelect({
       void queryClient.invalidateQueries({
         queryKey: queryKeys.agents.detail(agent.id),
       });
-      // List view consumes AgentDisplay.model from the agents list query,
-      // not the per-agent detail. Invalidate the list scope too so a row
-      // re-renders after mutation.
       void queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
     },
   });
 
-  // When a non-preset value comes back from the server but allowCustom
-  // is off, the select can't represent it — surface as a flat label so
-  // the user still sees what's set instead of a blank dropdown.
-  if (!allowCustom && !isPreset && current !== "") {
-    return (
-      <span className="text-xs font-mono text-muted-foreground" title={current}>
-        {current}
-      </span>
-    );
-  }
-
   return (
-    <>
+    <section className="rounded-lg border border-border bg-card p-4">
+      <h3 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-2 font-medium">
+        Model
+      </h3>
       <select
         value={customMode ? "__custom" : current}
         disabled={mutation.isPending}
@@ -87,19 +164,15 @@ export function ModelSelect({
           setCustomMode(false);
           mutation.mutate(v === "" ? null : v);
         }}
-        className={cn(
-          "w-full text-sm rounded border border-border bg-background px-2 py-1.5 cursor-pointer disabled:opacity-50",
-          className,
-        )}
+        className="w-full text-sm rounded border border-border bg-background px-2 py-1.5 cursor-pointer disabled:opacity-50"
       >
         {MODEL_PRESETS.map((p) => (
           <option key={p.value || "__default"} value={p.value}>
             {p.label}
+            {p.value === "" ? " (recommended)" : ""}
           </option>
         ))}
-        {allowCustom ? (
-          <option value="__custom">Other (pinned model ID)…</option>
-        ) : null}
+        <option value="__custom">Other (pinned model ID)…</option>
       </select>
       {customMode ? (
         <form
@@ -131,20 +204,6 @@ export function ModelSelect({
           Couldn&apos;t update model.
         </p>
       ) : null}
-    </>
-  );
-}
-
-/**
- * Card-wrapped model picker for the agent detail aside.
- */
-export function ModelPicker({ agent }: { agent: AgentDisplay }) {
-  return (
-    <section className="rounded-lg border border-border bg-card p-4">
-      <h3 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-2 font-medium">
-        Model
-      </h3>
-      <ModelSelect agent={agent} />
       <p className="text-[11px] text-muted-foreground mt-2 leading-snug">
         Model alias passed to the CLI via <span className="font-mono">--model</span>.
         Leave on &quot;CLI default&quot; to inherit whatever you&apos;ve

--- a/packages/web/components/agents/pickers/model-picker.tsx
+++ b/packages/web/components/agents/pickers/model-picker.tsx
@@ -34,6 +34,7 @@ function useModelMutation(agentId: string) {
         queryKey: queryKeys.agents.detail(agentId),
       });
       void queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.agentNetwork.all });
     },
   });
 }
@@ -144,6 +145,7 @@ export function ModelPicker({ agent }: { agent: AgentDisplay }) {
         queryKey: queryKeys.agents.detail(agent.id),
       });
       void queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.agentNetwork.all });
     },
   });
 

--- a/packages/web/components/agents/pickers/review-policy-picker.tsx
+++ b/packages/web/components/agents/pickers/review-policy-picker.tsx
@@ -3,44 +3,128 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
 import { queryKeys } from "@/lib/hooks/keys";
+import {
+  ChipCaret,
+  ChipMenuItem,
+  ChipPopover,
+} from "@/components/agents/pickers/chip-popover";
 import { cn } from "@/lib/utils";
 import type { AgentDisplay } from "@/lib/api/types";
 import type { ReviewPolicy } from "@beevibe/core";
 
-/**
- * Bare review-policy `<select>`. Legacy agents (provisioned before this
- * column had a default) carry `review_policy=null`; behaviorally that's
- * identical to `auto_done` in TaskService, so render it that way too.
- */
-export function ReviewPolicySelect({
-  agent,
-  className,
-}: {
-  agent: AgentDisplay;
-  className?: string;
-}) {
+function useReviewPolicyMutation(agentId: string) {
   const queryClient = useQueryClient();
-  const current: ReviewPolicy =
-    agent.review_policy === "require_human" ? "require_human" : "auto_done";
-  const mutation = useMutation({
+  return useMutation({
     mutationFn: (policy: ReviewPolicy) =>
-      api.agents.setReviewPolicy(agent.id, policy),
+      api.agents.setReviewPolicy(agentId, policy),
     onSuccess: () => {
-      // Invalidate all agent queries: list rows + peek panel + detail
-      // all carry review_policy.
+      // List rows + peek panel + detail aside all carry review_policy.
       void queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
     },
   });
+}
+
+/** Eye icon used on the "Require human" chip. Tracks the chip's text color. */
+function EyeIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  );
+}
+
+/**
+ * Chip-style review-policy picker. Shape-encoded state so you can read
+ * the value at a glance even before the text registers:
+ *   - Auto-done renders as a filled teal chip
+ *   - Require-human renders as a ringed amber chip with an eye icon
+ *
+ * Legacy agents (provisioned before this column had a default) carry
+ * review_policy=null; behaviorally that's identical to 'auto_done' in
+ * TaskService, so render it that way too.
+ */
+export function ReviewPolicyChip({ agent }: { agent: AgentDisplay }) {
+  const mutation = useReviewPolicyMutation(agent.id);
+  const current: ReviewPolicy =
+    agent.review_policy === "require_human" ? "require_human" : "auto_done";
+
+  const isHuman = current === "require_human";
+  const chipClass = isHuman
+    ? "border border-amber-500/45 bg-transparent text-amber-300 hover:bg-amber-500/10"
+    : "border border-emerald-500/35 bg-emerald-500/12 text-emerald-300 hover:bg-emerald-500/18";
 
   return (
-    <>
+    <ChipPopover
+      ariaLabel={`Review policy: ${isHuman ? "Require human" : "Auto-done"}. Click to change.`}
+      chipClassName={chipClass}
+      disabled={mutation.isPending}
+      chip={
+        <>
+          {isHuman ? <EyeIcon className="h-3 w-3" /> : null}
+          <span>{isHuman ? "Require human" : "Auto-done"}</span>
+          <ChipCaret />
+        </>
+      }
+    >
+      {(close) => (
+        <>
+          <ChipMenuItem
+            selected={current === "auto_done"}
+            label={<span className="text-[13px]">Auto-done</span>}
+            sublabel="closes on done"
+            onClick={() => {
+              mutation.mutate("auto_done");
+              close();
+            }}
+          />
+          <ChipMenuItem
+            selected={current === "require_human"}
+            leading={<EyeIcon className="h-3 w-3 text-amber-400" />}
+            label={<span className="text-[13px]">Require human</span>}
+            sublabel="you sign off"
+            onClick={() => {
+              mutation.mutate("require_human");
+              close();
+            }}
+          />
+        </>
+      )}
+    </ChipPopover>
+  );
+}
+
+/**
+ * Card-wrapped review-policy picker for the agent detail aside. Same
+ * native-select chrome the original card shipped with; the chip
+ * variant above is the one the list view uses.
+ */
+export function ReviewPolicyPicker({ agent }: { agent: AgentDisplay }) {
+  const mutation = useReviewPolicyMutation(agent.id);
+  const current: ReviewPolicy =
+    agent.review_policy === "require_human" ? "require_human" : "auto_done";
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-4">
+      <h3 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-2 font-medium">
+        Review policy
+      </h3>
       <select
         value={current}
         disabled={mutation.isPending}
         onChange={(e) => mutation.mutate(e.target.value as ReviewPolicy)}
         className={cn(
-          "w-full text-sm rounded border border-border bg-background px-2 py-1.5 cursor-pointer disabled:opacity-50",
-          className,
+          "w-full text-sm rounded border border-border bg-background px-2 py-1.5",
+          "cursor-pointer disabled:opacity-50",
         )}
       >
         <option value="auto_done">Auto-done (default)</option>
@@ -51,20 +135,6 @@ export function ReviewPolicySelect({
           Couldn&apos;t update review policy.
         </p>
       ) : null}
-    </>
-  );
-}
-
-/**
- * Card-wrapped review-policy picker for the agent detail aside.
- */
-export function ReviewPolicyPicker({ agent }: { agent: AgentDisplay }) {
-  return (
-    <section className="rounded-lg border border-border bg-card p-4">
-      <h3 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-2 font-medium">
-        Review policy
-      </h3>
-      <ReviewPolicySelect agent={agent} />
       <p className="text-[11px] text-muted-foreground mt-2 leading-snug">
         When the agent declares a task <span className="font-mono">done</span>,
         auto-done closes it. Require-human routes it through{" "}

--- a/packages/web/components/agents/pickers/review-policy-picker.tsx
+++ b/packages/web/components/agents/pickers/review-policy-picker.tsx
@@ -18,8 +18,11 @@ function useReviewPolicyMutation(agentId: string) {
     mutationFn: (policy: ReviewPolicy) =>
       api.agents.setReviewPolicy(agentId, policy),
     onSuccess: () => {
-      // List rows + peek panel + detail aside all carry review_policy.
+      // List rows source from useAgentNetwork() — different cache
+      // slot from the per-agent detail. Both need to be bumped or
+      // the view that wasn't invalidated stays stale.
       void queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.agentNetwork.all });
     },
   });
 }

--- a/packages/web/components/agents/pickers/runtime-picker.tsx
+++ b/packages/web/components/agents/pickers/runtime-picker.tsx
@@ -64,7 +64,13 @@ function useRuntimeMutation(agentId: string) {
     mutationFn: (runtimeId: string | null) =>
       api.agents.setRuntime(agentId, runtimeId),
     onSuccess: () => {
+      // The list view consumes data via useAgentNetwork() — that's
+      // a separate cache slot (["agent-network", ...]) from the
+      // per-agent detail (["agents", ...]). Invalidating only one
+      // leaves the other stale, so a mutation appears to silently
+      // do nothing in whichever view didn't get its key bumped.
       void queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.agentNetwork.all });
     },
   });
 }

--- a/packages/web/components/agents/pickers/runtime-picker.tsx
+++ b/packages/web/components/agents/pickers/runtime-picker.tsx
@@ -5,6 +5,12 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api, type RuntimesListResponse } from "@/lib/api/client";
 import { queryKeys } from "@/lib/hooks/keys";
 import { cn } from "@/lib/utils";
+import {
+  ChipCaret,
+  ChipMenuItem,
+  ChipPopover,
+  StatusDot,
+} from "@/components/agents/pickers/chip-popover";
 import type { AgentDisplay } from "@/lib/api/types";
 
 type RuntimeOption = {
@@ -15,122 +21,219 @@ type RuntimeOption = {
   device: string;
 };
 
-function flattenRuntimes(data: RuntimesListResponse | undefined): RuntimeOption[] {
-  return (
-    data?.daemons.flatMap((d) =>
-      d.runtimes.map((r) => ({
-        id: r.id,
-        cli: r.cli,
-        cli_version: r.cli_version,
-        online: r.online,
-        device: d.device_name ?? d.external_id,
-      })),
-    ) ?? []
-  );
+type DaemonGroup = {
+  device: string;
+  runtimes: RuntimeOption[];
+};
+
+function groupRuntimesByDaemon(
+  data: RuntimesListResponse | undefined,
+): DaemonGroup[] {
+  if (!data) return [];
+  return data.daemons.map((d) => ({
+    device: d.device_name ?? d.external_id,
+    runtimes: d.runtimes.map((r) => ({
+      id: r.id,
+      cli: r.cli,
+      cli_version: r.cli_version,
+      online: r.online,
+      device: d.device_name ?? d.external_id,
+    })),
+  }));
 }
 
-/**
- * Bare `<select>` for an agent's preferred runtime. Used in table rows
- * where the surrounding chrome supplies its own heading + help text.
- * The card-wrapped form is `RuntimePicker`.
- */
-export function RuntimeSelect({
-  agent,
-  className,
-  autoFocus,
-}: {
-  agent: AgentDisplay;
-  className?: string;
-  autoFocus?: boolean;
-}) {
-  const queryClient = useQueryClient();
-  const runtimesQuery = useQuery<RuntimesListResponse>({
+function flattenRuntimes(groups: DaemonGroup[]): RuntimeOption[] {
+  return groups.flatMap((g) => g.runtimes);
+}
+
+function shortRuntimeLabel(r: RuntimeOption): string {
+  return r.cli_version ? `${r.cli} ${r.cli_version}` : r.cli;
+}
+
+function useRuntimesQuery() {
+  return useQuery<RuntimesListResponse>({
     queryKey: queryKeys.runtimes.list(),
     queryFn: ({ signal }) => api.runtimes.list({ signal }),
     staleTime: 30_000,
   });
-  const mutation = useMutation({
-    mutationFn: (runtimeId: string | null) => api.agents.setRuntime(agent.id, runtimeId),
+}
+
+function useRuntimeMutation(agentId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (runtimeId: string | null) =>
+      api.agents.setRuntime(agentId, runtimeId),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: queryKeys.agents.all });
     },
   });
+}
 
-  const runtimes = flattenRuntimes(runtimesQuery.data);
-  const value = agent.preferred_runtime_id ?? "";
+/**
+ * Chip-style runtime picker for the agent list view. Green dot when
+ * bound to an online runtime, amber-outlined "Set runtime" CTA when
+ * unbound so the call-to-action is impossible to miss. Click opens a
+ * popover with runtimes grouped by daemon.
+ */
+export function RuntimeChip({ agent }: { agent: AgentDisplay }) {
+  const runtimesQuery = useRuntimesQuery();
+  const mutation = useRuntimeMutation(agent.id);
 
-  if (runtimesQuery.isLoading) {
-    return <p className="text-xs text-muted-foreground italic">Loading…</p>;
-  }
+  const groups = groupRuntimesByDaemon(runtimesQuery.data);
+  const all = flattenRuntimes(groups);
+  const current = all.find((r) => r.id === agent.preferred_runtime_id);
+  const isUnbound = !current;
+  const isOnline = current?.online ?? false;
 
-  if (runtimes.length === 0) {
+  // No daemons registered: render a static muted chip linking to /runtimes
+  // so the empty-state still tells users where to go.
+  if (!runtimesQuery.isLoading && all.length === 0) {
     return (
-      <p className="text-xs text-muted-foreground">
-        No daemons.{" "}
-        <Link href="/runtimes" className="underline hover:text-foreground">
-          Set up
-        </Link>
-      </p>
+      <Link
+        href="/runtimes"
+        className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs leading-none border border-amber-500/30 bg-amber-500/5 text-amber-300 hover:bg-amber-500/10 transition-colors"
+      >
+        <StatusDot tone="amber" />
+        <span>Set up a daemon</span>
+      </Link>
     );
   }
 
+  const chipClass = isUnbound
+    ? "border border-amber-500/35 bg-amber-500/[0.06] text-amber-300 hover:bg-amber-500/[0.10]"
+    : isOnline
+      ? "border border-border bg-secondary/40 text-foreground hover:bg-secondary"
+      : "border border-border bg-secondary/40 text-muted-foreground hover:bg-secondary";
+
   return (
-    <>
-      <select
-        value={value}
-        autoFocus={autoFocus}
-        disabled={mutation.isPending}
-        onChange={(e) => {
-          const next = e.target.value === "" ? null : e.target.value;
-          mutation.mutate(next);
-        }}
-        className={cn(
-          "w-full text-sm rounded border border-border bg-background px-2 py-1.5 cursor-pointer disabled:opacity-50",
-          className,
-        )}
-      >
-        <option value="">— unbound —</option>
-        {runtimes.map((r) => (
-          <option key={r.id} value={r.id}>
-            {r.device} · {r.cli}
-            {r.cli_version ? ` ${r.cli_version}` : ""}
-            {r.online ? " (online)" : " (offline)"}
-          </option>
-        ))}
-      </select>
-      {mutation.isError ? (
-        <p className="text-xs text-destructive mt-1.5">
-          Couldn&apos;t update runtime.
-        </p>
-      ) : null}
-    </>
+    <ChipPopover
+      ariaLabel={`Runtime: ${current ? shortRuntimeLabel(current) : "unbound"}. Click to change.`}
+      chipClassName={chipClass}
+      disabled={mutation.isPending}
+      chip={
+        <>
+          <StatusDot
+            tone={isUnbound ? "amber" : isOnline ? "green" : "gray"}
+            glow={!isUnbound && isOnline}
+          />
+          <span className="font-mono tabular-nums">
+            {current ? shortRuntimeLabel(current) : "Set runtime"}
+          </span>
+          <ChipCaret />
+        </>
+      }
+    >
+      {(close) => (
+        <>
+          {groups.map((g, gi) => (
+            <div key={gi}>
+              <div className="px-2.5 pt-1.5 pb-0.5 text-[10px] uppercase tracking-wider text-muted-foreground/80">
+                {g.device}
+              </div>
+              {g.runtimes.map((r) => (
+                <ChipMenuItem
+                  key={r.id}
+                  selected={r.id === agent.preferred_runtime_id}
+                  leading={<StatusDot tone={r.online ? "green" : "gray"} glow={false} />}
+                  label={
+                    <span className="font-mono tabular-nums text-[13px]">
+                      {shortRuntimeLabel(r)}
+                    </span>
+                  }
+                  sublabel={r.online ? undefined : "offline"}
+                  onClick={() => {
+                    mutation.mutate(r.id);
+                    close();
+                  }}
+                />
+              ))}
+            </div>
+          ))}
+          <div className="my-1 border-t border-border" />
+          <ChipMenuItem
+            selected={isUnbound}
+            leading={<StatusDot tone="amber" glow={false} />}
+            label={<span className="text-[13px]">Unbind</span>}
+            sublabel="sessions pause"
+            onClick={() => {
+              mutation.mutate(null);
+              close();
+            }}
+          />
+        </>
+      )}
+    </ChipPopover>
   );
 }
 
 /**
- * Card-wrapped runtime picker for the agent detail aside. Composes
- * `RuntimeSelect` with the section heading + help copy users saw in
- * the original sidebar.
+ * Card-wrapped runtime picker for the agent detail aside. Keeps the
+ * full-width native `<select>` because the side-panel context wants
+ * substantial chrome + help copy, not a chip. Reuses the same mutation
+ * hook so behavior stays in sync with the chip variant.
  */
 export function RuntimePicker({ agent }: { agent: AgentDisplay }) {
+  const runtimesQuery = useRuntimesQuery();
+  const mutation = useRuntimeMutation(agent.id);
+  const all = flattenRuntimes(groupRuntimesByDaemon(runtimesQuery.data));
+  const value = agent.preferred_runtime_id ?? "";
+
   return (
     <section className="rounded-lg border border-border bg-card p-4">
       <h3 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-2 font-medium">
         Runtime
       </h3>
-      <RuntimeSelect agent={agent} />
-      <p className="text-[11px] text-muted-foreground mt-2 leading-snug">
-        The agent runs on this daemon&apos;s CLI. Unbinding makes task / chat
-        sessions sit pending until rebound; mesh asks fall back to the
-        server.
-      </p>
-      <p className="text-[11px] text-muted-foreground mt-1 leading-snug">
-        Don&apos;t see a CLI you just installed?{" "}
-        <Link href="/runtimes" className="underline hover:text-foreground">
-          Sync your daemon
-        </Link>
-        .
-      </p>
+      {runtimesQuery.isLoading ? (
+        <p className="text-xs text-muted-foreground italic">Loading runtimes…</p>
+      ) : all.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          No daemons registered yet.{" "}
+          <Link href="/runtimes" className="underline hover:text-foreground">
+            Set up a daemon
+          </Link>
+          .
+        </p>
+      ) : (
+        <>
+          <select
+            value={value}
+            disabled={mutation.isPending}
+            onChange={(e) => {
+              const next = e.target.value === "" ? null : e.target.value;
+              mutation.mutate(next);
+            }}
+            className={cn(
+              "w-full text-sm rounded border border-border bg-background px-2 py-1.5",
+              "cursor-pointer disabled:opacity-50",
+            )}
+          >
+            <option value="">— unbound —</option>
+            {all.map((r) => (
+              <option key={r.id} value={r.id}>
+                {r.device} · {shortRuntimeLabel(r)}
+                {r.online ? " (online)" : " (offline)"}
+              </option>
+            ))}
+          </select>
+          {mutation.isError ? (
+            <p className="text-xs text-destructive mt-1.5">
+              Couldn&apos;t update runtime.
+            </p>
+          ) : null}
+          <p className="text-[11px] text-muted-foreground mt-2 leading-snug">
+            The agent runs on this daemon&apos;s CLI. Unbinding makes task / chat
+            sessions sit pending until rebound; mesh asks fall back to the
+            server.
+          </p>
+          <p className="text-[11px] text-muted-foreground mt-1 leading-snug">
+            Don&apos;t see a CLI you just installed?{" "}
+            <Link href="/runtimes" className="underline hover:text-foreground">
+              Sync your daemon
+            </Link>
+            .
+          </p>
+        </>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary

The agent list view's three native `<select>`s read as a form — every cell looks like "please configure me," none of them communicates *state*. This replaces them with **status chips** that encode state in shape + color so a row can be read at a glance.

Picked via `/design-shotgun` from three directions: chip-style (A, this), premium-settings-buttons (B), Notion inline edit (C). Comparison board lives at `~/.gstack/projects/beevibe-ai-beevibe/designs/agent-list-dropdowns-20260518/design-board.html`.

## What changes

**Runtime chip** — leading colored dot encodes daemon state.
- `● claude 2.1.143` (green dot + glow) = bound and online
- `● claude 2.1.143` (gray dot) = bound but daemon offline
- `○ Set runtime` (amber outline, no fill) = unbound. Previously a quiet "— unbound —" option in a dropdown; now an impossible-to-miss CTA.
- Popover groups runtimes by daemon device, with a trailing Unbind row.

**Model chip** — muted gray pill, mono text. `CLI default` renders italic + muted so it reads as "inherits from elsewhere," not a chosen value. Popover shows the four presets with a sublabel hint that CLI default comes from `~/.claude`. Custom pinned model IDs stay on the agent detail page — not duplicated in the list to keep row height stable.

**Review policy chip** — shape-encoded so you can read the value by silhouette:
- Filled teal chip = Auto-done
- Ringed amber chip + eye icon = Require human

## Implementation

- New [chip-popover.tsx](packages/web/components/agents/pickers/chip-popover.tsx) primitive — reuses the click-outside + Escape pattern from [user-widget.tsx](packages/web/components/user-widget.tsx), no popover dependency added. Exports `ChipPopover`, `ChipMenuItem`, `StatusDot`, `ChipCaret`.
- Each picker file now exports `*Chip` (list view) and the existing `*Picker` card (detail aside — kept verbatim since the side panel still wants substantial chrome + help copy).
- [agents-list-view.tsx](packages/web/components/agents/agents-list-view.tsx) swaps to the `*Chip` imports and tightens column min-widths since chips are narrower than full selects.

## Defaults

The "make defaults better" ask is addressed visually rather than functionally:
- Unbound is now LOUD (amber outline + CTA copy), not a quiet dropdown option
- CLI default is italic muted text with a sublabel hinting where it resolves from
- Auto-done is the resting filled-chip state; the conspicuous policy is the *non-default* one, which matches its severity

Real server-side auto-bind on agent creation is intentionally out of scope — too many edge cases (all runtimes offline, user explicitly unbound, etc.) for a UI-only PR. Easy to add later as a separate change in the agent factory.

## Test plan

- [ ] List view: every row renders three chips, all clickable, popover opens on click, closes on outside-click and Esc
- [ ] Runtime chip: green dot for online runtime, amber "Set runtime" CTA when unbound, popover groups by daemon device
- [ ] Model chip: "CLI default" italic + muted, presets switch correctly, pinned IDs from detail page still render readable
- [ ] Review policy chip: auto-done filled teal, require-human ringed amber + eye icon, toggle works
- [ ] Detail aside (/agents/[id]): the three card-wrapped pickers still render with native selects + help copy, no regression
- [ ] Tests: `pnpm test` from packages/web still passes (141 tests, run locally before push)
- [ ] Mobile / narrow viewport: chips wrap / truncate gracefully (untested in PR — flag if it bites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)