### PR TITLE
fix(chat): first click on "New chat" was a no-op when FRESH slot was stale

### DIFF
--- a/packages/web/lib/hooks/use-chat.ts
+++ b/packages/web/lib/hooks/use-chat.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   api,
@@ -111,19 +111,36 @@ export function useChat(opts: UseChatOptions = {}) {
   // draft from a prior /chat?new=1 visit doesn't reappear. Depends on
   // primitives only — `queryKey` is a fresh array every render, which
   // would re-fire this effect and clobber optimistic updates.
+  //
+  // `freshSeeded` flips to true once the seed has run for the current
+  // fresh entry. The `messages` memo below uses it to suppress stale
+  // cache reads on the FIRST render of a fresh surface (see comment
+  // there for the cleanup-effect-strips-`new=1` symptom this prevents).
+  const [freshSeeded, setFreshSeeded] = useState(false);
   useEffect(() => {
-    if (!fresh) return;
+    if (!fresh) {
+      setFreshSeeded(false);
+      return;
+    }
     queryClient.setQueryData<ChatHistoryResponse>(
       queryKeys.chat.history(FRESH_CACHE_ID),
       FRESH_HISTORY,
     );
+    setFreshSeeded(true);
     // Run on entry only — onMutate/onSuccess own the slot from then on.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fresh]);
 
+  // First render of a fresh surface reads the cache *before* the seed
+  // effect above has cleared it, so a draft left behind by a prior
+  // /chat?new=1 visit would appear here as `messages.length > 0`.
+  // ChatClient's cleanup useEffect interprets that as "user has sent
+  // something on this fresh surface" and immediately strips `?new=1`
+  // from the URL — first click looks like a no-op, second click works.
+  // Suppress the stale read until the seed has fired this entry.
   const messages = useMemo<ChatMessage[]>(
-    () => (history.data?.messages ?? []).map(fromHistory),
-    [history.data],
+    () => (fresh && !freshSeeded ? [] : (history.data?.messages ?? []).map(fromHistory)),
+    [fresh, freshSeeded, history.data],
   );
 
   // Derived from the cache, not duplicated in component state. Whoever


### PR DESCRIPTION
## Repro

1. Open `/chat?c=<id>` (any prior conversation)
2. Click "New chat" in the sidebar
3. First click looks like nothing happens
4. Click again → fresh surface opens

## Why

When entering `?new=1`, `useChat` returns `messages` derived from the `FRESH_CACHE_ID` React Query slot. If a previous `/chat?new=1` visit left draft state in that slot, the first render of the freshly-entered surface reads it back as `messages.length > 0`. [chat-client.tsx:87](packages/web/app/(authed)/chat/chat-client.tsx#L87)'s cleanup `useEffect` sees `isFresh && messages.length > 0` and immediately strips `?new=1` from the URL — interpreting the stale cache as "user already sent on this fresh surface."

The seed `useEffect` in [use-chat.ts](packages/web/lib/hooks/use-chat.ts) that clears the slot fires *after* the cleanup, too late.

Second click works because the seed from the first click already cleared the slot.

## Fix

In [use-chat.ts](packages/web/lib/hooks/use-chat.ts): gate `messages` on a `freshSeeded` state flag. Until the seed effect has run for the current fresh entry, the hook returns `[]`. ChatClient's cleanup sees `length === 0` and leaves `?new=1` alone.

When the user actually sends, optimistic update populates the slot through `setQueryData`, `messages.length > 0`, cleanup fires as intended — URL gets cleaned after the real send.

`freshSeeded` resets when `fresh` transitions back to false, so the next entry starts clean.

## Test plan

- [ ] From `/chat?c=<id>`, click "New chat" once — fresh empty surface appears immediately (not after second click)
- [ ] Send a message on the fresh surface — `?new=1` drops from the URL after send, reload restores the new conversation
- [ ] Repeat steps above multiple times in one session — first click always works
- [ ] `pnpm test` passes (141 tests, ran locally before push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)