### PR TITLE
style(web): refresh agent cards with DiceBear avatars

### DIFF
--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -349,25 +349,24 @@
   .animate-toast-in { animation: none; }
 }
 
-/* Agent avatar glass — tiny frosted badges for the custom role marks.
-   Uses a shared treatment with per-hierarchy tint variables so team
-   agents pick up the primary theme color instead of the old purple. */
+/* Agent avatar glass — tiny frosted badges for the generated DiceBear
+   robot marks. Uses per-hierarchy tint variables so team agents pick
+   up the primary theme color. */
 .agent-avatar-glass {
   --agent-avatar-tint: var(--muted-foreground);
-  --agent-avatar-fg: var(--foreground);
   position: relative;
   isolation: isolate;
   overflow: hidden;
-  color: hsl(var(--agent-avatar-fg));
+  border-radius: 0.55rem;
   background:
     linear-gradient(
       145deg,
-      hsl(0 0% 100% / 0.7) 0%,
-      hsl(var(--agent-avatar-tint) / 0.18) 48%,
-      hsl(var(--card) / 0.32) 100%
+      hsl(0 0% 100% / 0.76) 0%,
+      hsl(var(--agent-avatar-tint) / 0.18) 52%,
+      hsl(var(--card) / 0.42) 100%
     ),
     hsl(var(--agent-avatar-tint) / 0.12);
-  border: 1px solid hsl(0 0% 100% / 0.68);
+  border: 1px solid hsl(0 0% 100% / 0.7);
   backdrop-filter: blur(12px) saturate(165%);
   -webkit-backdrop-filter: blur(12px) saturate(165%);
   box-shadow:
@@ -387,37 +386,41 @@
     hsl(0 0% 100% / 0)
   );
   pointer-events: none;
-  z-index: 0;
+  z-index: 2;
 }
-.agent-avatar-glass svg {
+.agent-avatar-glass-avatar {
   position: relative;
   z-index: 1;
-  filter: drop-shadow(0 1px 0 hsl(0 0% 100% / 0.46));
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: calc(0.55rem - 1px);
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+  filter: saturate(0.96) contrast(1.02) drop-shadow(0 1px 0 hsl(0 0% 100% / 0.34));
 }
 .agent-avatar-glass-ic {
-  --agent-avatar-tint: var(--hier-ic);
-  --agent-avatar-fg: var(--hier-ic);
+  --agent-avatar-tint: 211 70% 55%;
 }
 .agent-avatar-glass-team {
   --agent-avatar-tint: var(--primary);
-  --agent-avatar-fg: 36 72% 28%;
   background:
     linear-gradient(
       145deg,
-      hsl(0 0% 100% / 0.52) 0%,
-      hsl(var(--primary) / 0.34) 56%,
-      hsl(var(--card) / 0.18) 100%
+      hsl(50 100% 88% / 0.9) 0%,
+      hsl(var(--primary) / 0.42) 58%,
+      hsl(38 92% 46% / 0.18) 100%
     ),
-    hsl(var(--primary) / 0.3);
-  border-color: hsl(var(--primary) / 0.34);
+    hsl(var(--primary) / 0.26);
+  border-color: hsl(42 90% 42% / 0.38);
   box-shadow:
-    inset 0 0.16rem 0.32rem hsl(0 0% 100% / 0.5),
-    inset 0 -0.08rem 0.22rem hsl(var(--primary) / 0.14),
-    0 0.26rem 0.62rem hsl(var(--primary) / 0.14);
+    inset 0 0.16rem 0.32rem hsl(0 0% 100% / 0.56),
+    inset 0 -0.08rem 0.22rem hsl(35 90% 30% / 0.18),
+    0 0.26rem 0.62rem hsl(var(--primary) / 0.18);
 }
 .agent-avatar-glass-org {
-  --agent-avatar-tint: var(--hier-org);
-  --agent-avatar-fg: var(--hier-org);
+  --agent-avatar-tint: 32 92% 52%;
 }
 .dark .agent-avatar-glass {
   background:
@@ -435,16 +438,15 @@
     0 0.35rem 0.8rem hsl(0 0% 0% / 0.28);
 }
 .dark .agent-avatar-glass-team {
-  color: hsl(var(--agent-avatar-fg));
   background:
     linear-gradient(
       145deg,
-      hsl(0 0% 100% / 0.22) 0%,
-      hsl(var(--primary) / 0.48) 58%,
-      hsl(var(--card) / 0.26) 100%
+      hsl(50 100% 84% / 0.28) 0%,
+      hsl(var(--primary) / 0.46) 58%,
+      hsl(var(--card) / 0.28) 100%
     ),
-    hsl(var(--primary) / 0.38);
-  border-color: hsl(var(--primary) / 0.32);
+    hsl(var(--primary) / 0.28);
+  border-color: hsl(var(--primary) / 0.36);
 }
 @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
   .agent-avatar-glass { background-color: hsl(var(--agent-avatar-tint) / 0.16); }
@@ -540,44 +542,64 @@
   cursor: not-allowed;
 }
 
-/* Cyber agent card — sci-fi treatment for orbit-canvas nodes.
-   Adapted from Uiverse by hpaccol. 3D tilt is driven by a React
-   mousemove handler (cleaner than the 25-tracker grid in the
-   original — fewer DOM nodes when the orbit has many cards).
-   Light mode: cool blue-gray body, purple corner brackets,
-   teal-to-cobalt title gradient. Dark mode: near-black body with
-   the original neon cyan/blue accents. */
+/* Cyber agent card — compact system card for orbit-canvas nodes.
+   The palette follows Beevibe's honey primary with blue/slate support
+   colors. */
 .cyber-card {
+  --cyber-edge: hsl(var(--primary) / 0.5);
+  --cyber-edge-strong: hsl(var(--primary) / 0.86);
+  --cyber-blue: 96 165 250;
+  --cyber-text: hsl(224 24% 17%);
+  --cyber-muted: hsl(218 16% 42%);
+  --cyber-title-start: hsl(38 92% 32%);
+  --cyber-title-end: hsl(211 78% 42%);
   position: relative;
   border-radius: 14px;
-  background: linear-gradient(135deg, #f4f6fa, #e3e9f1);
-  border: 1.5px solid rgba(92, 103, 255, 0.18);
+  background:
+    radial-gradient(circle at 14% 12%, hsl(var(--primary) / 0.22), transparent 34%),
+    radial-gradient(circle at 85% 78%, hsl(var(--cyber-blue) / 0.18), transparent 42%),
+    linear-gradient(135deg, hsl(40 25% 97% / 0.98), hsl(213 22% 91% / 0.94));
+  border: 1.5px solid hsl(var(--primary) / 0.22);
   overflow: hidden;
-  color: hsl(240, 10%, 18%);
+  color: var(--cyber-text);
   box-shadow:
-    0 4px 16px rgba(92, 103, 255, 0.10),
-    inset 0 1px 0 rgba(255, 255, 255, 0.7);
+    0 10px 24px hsl(220 28% 30% / 0.12),
+    inset 0 1px 0 hsl(0 0% 100% / 0.72),
+    inset 0 -1px 0 hsl(var(--primary) / 0.1);
   transition: transform 150ms ease-out, box-shadow 300ms, filter 300ms;
   transform-style: preserve-3d;
 }
 .cyber-card:hover {
   box-shadow:
-    0 6px 22px rgba(92, 103, 255, 0.18),
-    inset 0 1px 0 rgba(255, 255, 255, 0.8);
+    0 14px 30px hsl(220 28% 30% / 0.16),
+    0 0 18px hsl(var(--primary) / 0.16),
+    inset 0 1px 0 hsl(0 0% 100% / 0.82);
 }
 .dark .cyber-card {
-  background: linear-gradient(45deg, #1a1a1a, #262626);
-  border: 1.5px solid rgba(255, 255, 255, 0.08);
-  color: rgba(255, 255, 255, 0.85);
+  --cyber-edge: hsl(var(--primary) / 0.42);
+  --cyber-edge-strong: hsl(var(--primary) / 0.9);
+  --cyber-blue: 59 130 246;
+  --cyber-text: hsl(0 0% 98% / 0.88);
+  --cyber-muted: hsl(220 14% 72% / 0.68);
+  --cyber-title-start: hsl(var(--primary));
+  --cyber-title-end: hsl(205 90% 72%);
+  background:
+    radial-gradient(circle at 14% 12%, hsl(var(--primary) / 0.14), transparent 34%),
+    radial-gradient(circle at 85% 80%, hsl(var(--cyber-blue) / 0.14), transparent 42%),
+    linear-gradient(145deg, hsl(220 18% 15% / 0.96), hsl(220 16% 9% / 0.96));
+  border: 1.5px solid hsl(var(--primary) / 0.18);
+  color: var(--cyber-text);
   box-shadow:
-    0 0 20px rgba(0, 0, 0, 0.35),
-    inset 0 0 20px rgba(0, 0, 0, 0.2);
+    0 16px 30px hsl(0 0% 0% / 0.36),
+    inset 0 1px 0 hsl(0 0% 100% / 0.08),
+    inset 0 0 20px hsl(0 0% 0% / 0.16);
 }
 .dark .cyber-card:hover {
-  filter: brightness(1.12);
+  filter: brightness(1.08);
   box-shadow:
-    0 0 20px rgba(0, 0, 0, 0.35),
-    inset 0 0 20px rgba(0, 0, 0, 0.2);
+    0 16px 30px hsl(0 0% 0% / 0.38),
+    0 0 20px hsl(var(--primary) / 0.12),
+    inset 0 1px 0 hsl(0 0% 100% / 0.1);
 }
 .cyber-card::before {
   content: "";
@@ -585,8 +607,8 @@
   inset: -25%;
   background: radial-gradient(
     circle at center,
-    rgba(92, 103, 255, 0.18) 0%,
-    rgba(0, 162, 255, 0.08) 50%,
+    hsl(var(--primary) / 0.22) 0%,
+    hsl(var(--cyber-blue) / 0.1) 50%,
     transparent 100%
   );
   filter: blur(20px);
@@ -600,8 +622,8 @@
 .dark .cyber-card::before {
   background: radial-gradient(
     circle at center,
-    rgba(0, 255, 170, 0.15) 0%,
-    rgba(0, 162, 255, 0.08) 50%,
+    hsl(var(--primary) / 0.15) 0%,
+    hsl(var(--cyber-blue) / 0.1) 50%,
     transparent 100%
   );
 }
@@ -627,9 +649,9 @@
   background: linear-gradient(
     125deg,
     rgba(255, 255, 255, 0) 0%,
-    rgba(255, 255, 255, 0.05) 45%,
-    rgba(255, 255, 255, 0.12) 50%,
-    rgba(255, 255, 255, 0.05) 55%,
+    rgba(255, 255, 255, 0.04) 45%,
+    rgba(255, 255, 255, 0.1) 50%,
+    rgba(255, 255, 255, 0.04) 55%,
     rgba(255, 255, 255, 0) 100%
   );
 }
@@ -640,20 +662,20 @@
   position: absolute;
   width: 10px;
   height: 10px;
-  border: 1.5px solid rgba(92, 103, 255, 0.55);
+  border: 1.5px solid var(--cyber-edge);
   transition: border-color 0.3s ease, box-shadow 0.3s ease;
   pointer-events: none;
 }
 .cyber-card:hover .cyber-corners span {
-  border-color: rgba(92, 103, 255, 1);
-  box-shadow: 0 0 8px rgba(92, 103, 255, 0.5);
+  border-color: var(--cyber-edge-strong);
+  box-shadow: 0 0 8px hsl(var(--primary) / 0.36);
 }
 .dark .cyber-card .cyber-corners span {
-  border-color: rgba(92, 103, 255, 0.45);
+  border-color: var(--cyber-edge);
 }
 .dark .cyber-card:hover .cyber-corners span {
-  border-color: rgba(92, 103, 255, 0.95);
-  box-shadow: 0 0 8px rgba(92, 103, 255, 0.5);
+  border-color: var(--cyber-edge-strong);
+  box-shadow: 0 0 8px hsl(var(--primary) / 0.36);
 }
 .cyber-card .cyber-corners span:nth-child(1) {
   top: 6px;
@@ -685,7 +707,7 @@
   background: linear-gradient(
     to bottom,
     transparent,
-    rgba(92, 103, 255, 0.14),
+    hsl(var(--primary) / 0.12),
     transparent
   );
   transform: translateY(-100%);
@@ -699,7 +721,7 @@
   background: linear-gradient(
     90deg,
     transparent,
-    rgba(92, 103, 255, 0.5),
+    hsl(var(--cyber-blue) / 0.34),
     transparent
   );
 }
@@ -707,7 +729,7 @@
   background: linear-gradient(
     90deg,
     transparent,
-    rgba(92, 103, 255, 0.35),
+    hsl(var(--cyber-blue) / 0.32),
     transparent
   );
 }
@@ -728,13 +750,13 @@
   animation: cyber-line 4s linear infinite 2s;
 }
 .cyber-card .cyber-title {
-  background: linear-gradient(45deg, #00997a, #0066cc);
+  background: linear-gradient(45deg, var(--cyber-title-start), var(--cyber-title-end));
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
 }
 .dark .cyber-card .cyber-title {
-  background: linear-gradient(45deg, #00ffaa, #00a2ff);
+  background: linear-gradient(45deg, var(--cyber-title-start), var(--cyber-title-end));
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -743,20 +765,20 @@
    cyber backgrounds. The accent variant is used for the right-side
    stats so they pop slightly against the muted body text. */
 .cyber-card .cyber-badge {
-  color: rgba(0, 90, 180, 0.85);
+  color: hsl(38 92% 34%);
 }
 .cyber-card .cyber-footer {
-  color: hsl(220, 12%, 38%);
+  color: var(--cyber-muted);
 }
 .cyber-card .cyber-footer-accent {
-  color: rgba(0, 90, 180, 0.9);
+  color: hsl(211 78% 38%);
 }
 .dark .cyber-card .cyber-badge,
 .dark .cyber-card .cyber-footer-accent {
-  color: rgba(103, 232, 249, 0.7);
+  color: hsl(var(--primary) / 0.76);
 }
 .dark .cyber-card .cyber-footer {
-  color: rgba(255, 255, 255, 0.55);
+  color: var(--cyber-muted);
 }
 @keyframes cyber-scan {
   0% { transform: translateY(-100%); }

--- a/packages/web/components/avatar.tsx
+++ b/packages/web/components/avatar.tsx
@@ -1,19 +1,7 @@
+import { createAvatar } from "@dicebear/core";
+import { botttsNeutral } from "@dicebear/collection";
 import { cn } from "@/lib/utils";
 import type { HierarchyLevel } from "@beevibe/core";
-
-type AgentIconVariant =
-  | "team"
-  | "org"
-  | "conversation"
-  | "document"
-  | "pitch"
-  | "code"
-  | "data"
-  | "research"
-  | "design"
-  | "memory"
-  | "ops"
-  | "generic";
 
 const HIER_BG = {
   ic: "agent-avatar-glass agent-avatar-glass-ic",
@@ -26,6 +14,28 @@ const PRESENCE_BG = {
   idle: "bg-muted-foreground",
   off: "bg-secondary",
 } as const;
+
+const AVATAR_BACKGROUND: Record<HierarchyLevel, string[]> = {
+  ic: ["60a5fa", "64748b", "94a3b8"],
+  team: ["facc15", "fbbf24", "f59e0b"],
+  org: ["fb923c", "f59e0b", "94a3b8"],
+};
+
+const AVATAR_EYES: Array<"eva" | "happy" | "round" | "sensor" | "shade01"> = [
+  "eva",
+  "happy",
+  "round",
+  "sensor",
+  "shade01",
+];
+const AVATAR_MOUTH: Array<"diagram" | "smile01" | "smile02" | "square01" | "square02"> = [
+  "diagram",
+  "smile01",
+  "smile02",
+  "square01",
+  "square02",
+];
+const avatarSrcCache = new Map<string, string>();
 
 interface Props {
   initial: string;
@@ -48,22 +58,28 @@ export function Avatar({
 }: Props) {
   const baseStyle = { width: size, height: size, fontSize: Math.max(9, Math.round(size * 0.39)) };
   const dotSize = Math.max(6, Math.round(size * 0.32));
-  const iconSize = Math.max(13, Math.round(size * 0.58));
   const isPerson = kind === "person";
-  const icon = isPerson ? undefined : pickAgentIcon(kind, label, specialization);
+  const agentAvatarSrc = isPerson
+    ? undefined
+    : createAgentAvatarSrc({ initial, kind, label, specialization });
+
   return (
     <span className={cn("relative inline-block", className)}>
       <span
         style={baseStyle}
         className={cn(
-          "rounded-full inline-flex items-center justify-center font-semibold shrink-0",
+          "inline-flex items-center justify-center font-semibold shrink-0",
           isPerson
-            ? "bg-secondary text-foreground border border-border"
+            ? "rounded-full bg-secondary text-foreground border border-border"
             : HIER_BG[kind],
         )}
       >
         {isPerson ? initial : (
-          <AgentIconMark variant={icon ?? "generic"} size={iconSize} />
+          <span
+            aria-hidden
+            className="agent-avatar-glass-avatar"
+            style={{ backgroundImage: `url("${agentAvatarSrc}")` }}
+          />
         )}
       </span>
       {presence ? (
@@ -80,143 +96,31 @@ export function Avatar({
   );
 }
 
-function pickAgentIcon(
-  kind: HierarchyLevel,
-  label?: string,
-  specialization?: string,
-): AgentIconVariant {
-  const text = `${label ?? ""} ${specialization ?? ""}`.toLowerCase();
-  if (kind === "org") return "org";
-  if (kind === "team") return "team";
-  if (/\b(chat|conversation|conversational|dialog|message|ui|ux|interface)\b/.test(text)) {
-    return "conversation";
-  }
-  if (/\b(pdf|document|doc|extract|extraction|ocr|table|tables|parse|parser)\b/.test(text)) {
-    return "document";
-  }
-  if (/\b(pitch|narrative|story|deck|slide|fundraising|founder)\b/.test(text)) {
-    return "pitch";
-  }
-  if (/\b(code|coding|engineer|developer|frontend|backend|fullstack|repo|test)\b/.test(text)) {
-    return "code";
-  }
-  if (/\b(data|analytics|metric|dashboard|sql|warehouse|pipeline)\b/.test(text)) {
-    return "data";
-  }
-  if (/\b(research|search|synthesis|market|competitive|analysis)\b/.test(text)) {
-    return "research";
-  }
-  if (/\b(design|brand|visual|prototype|product)\b/.test(text)) {
-    return "design";
-  }
-  if (/\b(memory|knowledge|archive|facts|taxonomy)\b/.test(text)) {
-    return "memory";
-  }
-  if (/\b(ops|operations|workflow|process|automation|support)\b/.test(text)) {
-    return "ops";
-  }
-  return "generic";
-}
-
-function AgentIconMark({
-  variant,
-  size,
+function createAgentAvatarSrc({
+  initial,
+  kind,
+  label,
+  specialization,
 }: {
-  variant: AgentIconVariant;
-  size: number;
+  initial: string;
+  kind: HierarchyLevel;
+  label?: string;
+  specialization?: string;
 }) {
-  return (
-    <svg
-      aria-hidden
-      viewBox="0 0 24 24"
-      width={size}
-      height={size}
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.9"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className="shrink-0"
-    >
-      {variant === "team" ? (
-        <>
-          <path
-            d="M8.8 10.8c-2.1-1.2-4.1-.3-4.4 1.5-.3 1.9 1.6 3.1 3.6 2.1"
-            fill="currentColor"
-            opacity="0.14"
-          />
-          <path
-            d="M15.2 10.8c2.1-1.2 4.1-.3 4.4 1.5.3 1.9-1.6 3.1-3.6 2.1"
-            fill="currentColor"
-            opacity="0.14"
-          />
-          <path d="M8.7 12.7c0-2.6 1.3-4.6 3.3-4.6s3.3 2 3.3 4.6-1.3 4.8-3.3 4.8-3.3-2.2-3.3-4.8Z" />
-          <path d="M9.4 11h5.2M9.3 13.3h5.4M10.2 15.4h3.6" />
-          <circle cx="12" cy="6.3" r="1.45" fill="currentColor" stroke="none" />
-          <path d="M11 5.2 9.8 3.8M13 5.2l1.2-1.4M10.8 8l-1 1.1M13.2 8l1 1.1" />
-        </>
-      ) : variant === "org" ? (
-        <>
-          <path d="M7 19V9.2L12 6l5 3.2V19" />
-          <path d="M9.2 19v-3.5h5.6V19M9.5 11h.1M14.4 11h.1M9.5 14h.1M14.4 14h.1" />
-          <path d="M5.5 19h13" />
-        </>
-      ) : variant === "conversation" ? (
-        <>
-          <path d="M6.2 8.2h8.1a3 3 0 0 1 3 3v1.3a3 3 0 0 1-3 3H11l-3.4 2.4v-2.4H6.2a3 3 0 0 1-3-3v-1.3a3 3 0 0 1 3-3Z" />
-          <path d="M8.2 11.1h5.8M8.2 13.1h3.8" />
-          <path d="M16.5 7.2c2.1.3 3.3 1.7 3.3 3.6v1" opacity="0.55" />
-        </>
-      ) : variant === "document" ? (
-        <>
-          <path d="M7 4.8h6.4L17 8.4v10.8H7z" />
-          <path d="M13.2 4.9v3.7h3.6M9.4 11h5.2M9.4 13.6h5.2M9.4 16.2h2.4" />
-          <path d="M15 15.2 18 18.2M15.8 14a2 2 0 1 1-4 0 2 2 0 0 1 4 0Z" />
-        </>
-      ) : variant === "pitch" ? (
-        <>
-          <path d="M5.5 6.4h13v9.2h-13zM8 18.8h8M12 15.6v3.2" />
-          <path d="M8.3 12.8 10.7 10l2 1.8 3-3.4" />
-          <path d="M15.7 8.4v3h-3" />
-        </>
-      ) : variant === "code" ? (
-        <>
-          <path d="M9.5 7.5 5.5 12l4 4.5M14.5 7.5l4 4.5-4 4.5" />
-          <path d="m13 6.5-2 11" />
-        </>
-      ) : variant === "data" ? (
-        <>
-          <path d="M5.5 8.2c0-1.7 3-3 6.5-3s6.5 1.3 6.5 3-3 3-6.5 3-6.5-1.3-6.5-3Z" />
-          <path d="M5.5 8.2v4c0 1.7 3 3 6.5 3s6.5-1.3 6.5-3v-4" />
-          <path d="M5.5 12.2v3.6c0 1.7 3 3 6.5 3s6.5-1.3 6.5-3v-3.6" />
-        </>
-      ) : variant === "research" ? (
-        <>
-          <circle cx="10.8" cy="10.8" r="4.6" />
-          <path d="m14.2 14.2 4.3 4.3M9.2 10.6l1.2 1.2 2.4-2.9" />
-        </>
-      ) : variant === "design" ? (
-        <>
-          <path d="M6.2 15.8 15.8 6.2a2.1 2.1 0 0 1 3 3l-9.6 9.6-4 1Z" />
-          <path d="m14.5 7.5 2 2M6.8 15.2l2 2" />
-        </>
-      ) : variant === "memory" ? (
-        <>
-          <path d="M7 6.8a3 3 0 0 1 5-2.2 3 3 0 0 1 5 2.2v9.1a3.1 3.1 0 0 1-3.1 3.1H10A3.1 3.1 0 0 1 7 15.9Z" />
-          <path d="M12 4.6V19M9.5 9h5M9.5 12h5M9.5 15h3" />
-        </>
-      ) : variant === "ops" ? (
-        <>
-          <path d="M12 5v3M12 16v3M5 12h3M16 12h3" />
-          <path d="M8 8.1 10.1 10M15.9 8.1 14 10M8 15.9l2.1-1.9M15.9 15.9 14 14" />
-          <circle cx="12" cy="12" r="3.2" />
-        </>
-      ) : (
-        <>
-          <path d="M12 4.8 17.8 8v6.6L12 19.2l-5.8-4.6V8z" />
-          <path d="M12 8.3v7.4M8.8 10.1l6.4 3.8M15.2 10.1l-6.4 3.8" />
-        </>
-      )}
-    </svg>
-  );
+  const seed = [kind, label || initial, specialization].filter(Boolean).join(":");
+  const cacheKey = `${kind}:${seed}`;
+  const cachedSrc = avatarSrcCache.get(cacheKey);
+  if (cachedSrc) return cachedSrc;
+
+  const avatarSrc = createAvatar(botttsNeutral, {
+    seed,
+    backgroundColor: AVATAR_BACKGROUND[kind],
+    eyes: AVATAR_EYES,
+    mouth: AVATAR_MOUTH,
+    radius: 18,
+    scale: 84,
+  }).toDataUri();
+  avatarSrcCache.set(cacheKey, avatarSrc);
+
+  return avatarSrc;
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -22,6 +22,8 @@
   "dependencies": {
     "@beevibe/api": "workspace:*",
     "@beevibe/core": "workspace:*",
+    "@dicebear/collection": "^9.4.2",
+    "@dicebear/core": "^9.4.2",
     "@tanstack/react-query": "^5.59.0",
     "@tanstack/react-query-devtools": "^5.59.0",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
       eslint-plugin-import:
         specifier: ^2.30.0
-        version: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
+        version: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       express:
         specifier: ^5.2.1
         version: 5.2.1
@@ -162,6 +162,12 @@ importers:
       '@beevibe/core':
         specifier: workspace:*
         version: link:../core
+      '@dicebear/collection':
+        specifier: ^9.4.2
+        version: 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/core':
+        specifier: ^9.4.2
+        version: 9.4.2
       '@tanstack/react-query':
         specifier: ^5.59.0
         version: 5.100.5(react@18.3.1)
@@ -337,6 +343,202 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@dicebear/adventurer-neutral@9.4.2':
+    resolution: {integrity: sha512-5xgkG/mNL4j3Q4SJGQLBU/KnU90tng8Ze5ofThD+55wi0oeY/nSAUowg6UFCmHrktjifj/MEx3CQqbpcPWtfIA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/adventurer@9.4.2':
+    resolution: {integrity: sha512-jqYp834ZmGDA9HBBDQAdgF1O2UTCwHF4vVrktXWa2Dppp1JczPL5HnVOWsjtrLmXNn61Wd6OLmBb2e6rhzp3ig==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/avataaars-neutral@9.4.2':
+    resolution: {integrity: sha512-/eNrp0YCNJRwQXqOloLm1+3Ss2C+pMpUQIGkbEnGsP1UK+13Ge80ggDDof1HpdqvG9HAZcKa7hnbG/0HSwyDSw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/avataaars@9.4.2':
+    resolution: {integrity: sha512-3x9jKFkOkFSPmpTbt9xvhiU2E1GX7beCSsX0tXRUShj8x6+5Ks9yBRT1VlkySbnXrZ/GglADGg7vJ/D2uIx1Yw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/big-ears-neutral@9.4.2':
+    resolution: {integrity: sha512-M8Ozmzza4eY4hpLOYULgJxMYmBA0CsBnrE15/xw6LZkEREXnrX5z0NJsf8hUfdyF6BWZ+RBgzoiav32DAC5zcg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/big-ears@9.4.2':
+    resolution: {integrity: sha512-mNfz3ppNA7UBq0IO3nXCiV5pFPG7c1DfzRB0foNU2Wo1XXT8FIcSY2BvDlYqorZTOUOz7dHb0vx06hqvG0HP5w==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/big-smile@9.4.2':
+    resolution: {integrity: sha512-hmT5i7rcPPhStjZyg28pbIhdTnnMBzK3RObI0vKCpY30EFrzaPkkdDL6Ck5fAFBdvDIW1EpOJkenyR0XPmhgbQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/bottts-neutral@9.4.2':
+    resolution: {integrity: sha512-kFNwWt6j+gzZ5n5Pz7WVwePubREAQOF8ZwWA9ztwVYDVMLnOChWbAofy5FED4j5md2MXFH2EgLCFCMr5K2BmIA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/bottts@9.4.2':
+    resolution: {integrity: sha512-tsx+dII7EFUCVA8URj66G1GqORCCVduCAx4dY2prEY2IeFianVpkntXuFsWZ9BBGx1NZFndvDith5oTwKMQPbQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/collection@9.4.2':
+    resolution: {integrity: sha512-KArubv7if8H7j9sIfpDK2hJJqrdNVR5zMPAMOSpIU2JPyXx8TC9o5wsmXb8il5wOHgaS9Q/cla7jUNIiDD7Gsg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/core@9.4.2':
+    resolution: {integrity: sha512-MF0042+Z3s8PGZKZLySfhft28bUa3B1iq0e5NSjCvY8gfMi5aIH/iRJGRJa1N9Jz1BNkxYb4yvJ/N9KO8Z6Y+w==}
+    engines: {node: '>=18.0.0'}
+
+  '@dicebear/croodles-neutral@9.4.2':
+    resolution: {integrity: sha512-oG5IeUdtiYshQ89gkAVcl5w3xAEi5UZX2fTzIyelpBPCG176l7VuuFzlxi2umnB3E6LVHYy06DXvUo/p+rXB2Q==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/croodles@9.4.2':
+    resolution: {integrity: sha512-6VoO0JviIf7dKKMBTL/SMXxWhnXHaZuzufX90G0nXxS77ELG1YkGNMaZzawizN4C09Gbya2gJkozqrWiJN/aGw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/dylan@9.4.2':
+    resolution: {integrity: sha512-1vQvRu9x9DrwFxhFaIU2rf0EUL04yDTbAt7fHyAjM0mEsKzTD4mRNf95tCRuavCoW6W48u7A/OY6jyIub6kxLQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/fun-emoji@9.4.2':
+    resolution: {integrity: sha512-kqB6LPkdYCdEU/mwbyz34xLzoNUKL6ARcoo3fr5ASq9D6ZE07qIKybC3xv5+CPz7VmspJ1Q3c/VVWVMDRP7Twg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/glass@9.4.2':
+    resolution: {integrity: sha512-z5qUogHQ1b6UJ2zCqT848mU2U9DKbVDhiX6GPDjD7tYLisCCJVisH9p6WyNdHvflUd4SHkA6gRqVJIh2v2HnTA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/icons@9.4.2':
+    resolution: {integrity: sha512-QSMMz0NA03ypSGhXC8HQX8FSj8lYT+/5yqH+/N03OH2IjL0q7wwGZ7nqsrtlRp76O5WqMTwGfSbTUUYPjFr+Xw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/identicon@9.4.2':
+    resolution: {integrity: sha512-JVDSmZsv11mSWqwAktK5x9Bslht2xY3TFUn8xzu6slAYe1Z7hEXZ76eb+UJ6F4qEzdwZ7xPWzAS6Nb0Y3A0pww==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/initials@9.4.2':
+    resolution: {integrity: sha512-yePuIUasmwtl9IrtB6rEzE/zb5fImKP/neW0CdcTC2MwLgMuP1GLHEGRgg1zI8exIh+PMv1YdLGyyUuRTE2Qpw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/lorelei-neutral@9.4.2':
+    resolution: {integrity: sha512-yspanTthA5vh6iCdeLzn6xZ4yYMYRcfcxblcgSvHTF1ut0bjAXtw5SXzZ6aJTrJWiHkzYOQuTOR6GVYiW80Q7w==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/lorelei@9.4.2':
+    resolution: {integrity: sha512-YMv6vnriW6VLFDsreKuOnUFFno6SRe7+7X7R7zPY0rZ+MaHX9V3jcioIG+1PSjIHEDfOLUHpr5vd1JBWv8y7UA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/micah@9.4.2':
+    resolution: {integrity: sha512-e4D3W/OlChSsLo7Llwsy0J18vk0azJqF/uFoY+EKACCNHBc1HGNsqVvu2CTf+OWOA8wTyAK6UkjBN5p01r7D+g==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/miniavs@9.4.2':
+    resolution: {integrity: sha512-wLwyFNNUnDRd3BbhSBhXR0XEpX8sG0/xDA5M/OkDoapLqZnnI48YLUSDd2N5QTAVMmcSEuZOYxkcnj7WW79vlg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/notionists-neutral@9.4.2':
+    resolution: {integrity: sha512-AyD9kEfVxQUwDGf4Op059gVmYIOAkTKg3dtE9h9mEKP7zl/kMy5B67BFFOo7sB0mXCjzAegZ6ekGU02E8+hIHw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/notionists@9.4.2':
+    resolution: {integrity: sha512-ZCySq+nxcD/x4xyYgytcj2N9uY3gxrL+qpnmOdp2BdA221KacVrxlsUPpIgEMqxS2rMmBQXfxg129Pzn4ycIpA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/open-peeps@9.4.2':
+    resolution: {integrity: sha512-i01tLgtp2g937T81sVeAOVlqsCtiTck/Kw20g7hN80+7xrXjOUepz2HPLy3HeiMjwjMGRy5o54kSd0/8Ht4Dqg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/personas@9.4.2':
+    resolution: {integrity: sha512-NJlkvI5F5gugt6t2+7QrYNTwQC7+4IQZS3vG0dYk2BncxOHax0BuLovdSdiAesTL4ZkytFYIydWmKmV2/xcUwg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/pixel-art-neutral@9.4.2':
+    resolution: {integrity: sha512-9e9Lz554uQvWaXV2P17ss+hPa6rTyuAKBtB8zk8ECjHiZzIl61N/KcTVLZ4dILVZwj7gYriaLo16QEqvL2GJCg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/pixel-art@9.4.2':
+    resolution: {integrity: sha512-peHf7oKICDgBZ8dUyj+txPnS7VZEWgvKE+xW4mNQqBt6dYZIjmva2shOVHn0b1JU+FDxMx3uIkWVixKdUq4WGg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/rings@9.4.2':
+    resolution: {integrity: sha512-Pc3ymWrRDQPJFNrbbLt7RJrzGvUuuxUiDkrfLhoVE+B6mZWEL1PC78DPbS1yUWYLErJOpJuM2GSwXmTbVjWf+g==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/shapes@9.4.2':
+    resolution: {integrity: sha512-AFL6jAaiLztvcqyq+ds+lWZu6Vbp3PlGWhJeJRm842jxtiluJpl6r4f6nUXP2fdMz7MNpDzXfLooQK9E04NbUQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/thumbs@9.4.2':
+    resolution: {integrity: sha512-ccWvDBqbkWS5uzHbsg5L6uML6vBfX7jT3J3jHCQksvz8haHItxTK02w+6e1UavZUsvza4lG5X/XY3eji3siJ4Q==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
+
+  '@dicebear/toon-head@9.4.2':
+    resolution: {integrity: sha512-lwFeSXyAnaKnCfMt9TiJwnD1cXQUGkey/0h6i/+4TVHVMCz5/Ri5u1ynovPNHy1SnBf858QwoXHkxilGLwQX/g==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@dicebear/core': ^9.0.0
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -1065,6 +1267,9 @@ packages:
 
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
@@ -3816,6 +4021,169 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@dicebear/adventurer-neutral@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/adventurer@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/avataaars-neutral@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/avataaars@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/big-ears-neutral@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/big-ears@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/big-smile@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/bottts-neutral@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/bottts@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/collection@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/adventurer': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/adventurer-neutral': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/avataaars': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/avataaars-neutral': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/big-ears': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/big-ears-neutral': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/big-smile': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/bottts': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/bottts-neutral': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/core': 9.4.2
+      '@dicebear/croodles': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/croodles-neutral': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/dylan': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/fun-emoji': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/glass': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/icons': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/identicon': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/initials': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/lorelei': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/lorelei-neutral': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/micah': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/miniavs': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/notionists': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/notionists-neutral': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/open-peeps': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/personas': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/pixel-art': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/pixel-art-neutral': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/rings': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/shapes': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/thumbs': 9.4.2(@dicebear/core@9.4.2)
+      '@dicebear/toon-head': 9.4.2(@dicebear/core@9.4.2)
+
+  '@dicebear/core@9.4.2':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@dicebear/croodles-neutral@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/croodles@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/dylan@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/fun-emoji@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/glass@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/icons@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/identicon@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/initials@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/lorelei-neutral@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/lorelei@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/micah@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/miniavs@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/notionists-neutral@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/notionists@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/open-peeps@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/personas@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/pixel-art-neutral@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/pixel-art@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/rings@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/shapes@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/thumbs@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
+  '@dicebear/toon-head@9.4.2(@dicebear/core@9.4.2)':
+    dependencies:
+      '@dicebear/core': 9.4.2
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -4355,6 +4723,8 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/http-errors@2.0.5': {}
+
+  '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
 
@@ -5235,7 +5605,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -5265,11 +5635,11 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -5280,7 +5650,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -5291,7 +5661,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary
- replace custom agent marks with seeded DiceBear bottts-neutral avatars
- retheme orbit cards around honey, slate, and blue accents instead of purple/neon green
- add DiceBear web dependencies and lockfile entries

## Verification
- pnpm --filter @beevibe/web typecheck
- pnpm --filter @beevibe/web lint
- pnpm --filter @beevibe/web build