### PR TITLE
fix(prompts): three-lane team-agent routing + universal injection across chat/task/MCP

### DIFF
--- a/packages/api/src/routes/mcp.ts
+++ b/packages/api/src/routes/mcp.ts
@@ -221,7 +221,7 @@ async function handleMcpRequest(
   // MemoryAgent (closed over caller.agentId) so search_context queries hit
   // the right agent's archival memory.
   const memoryAgent = deps.makeMemoryAgent(caller.agentId);
-  const instructions = await buildInstructions(caller, memoryAgent);
+  const instructions = await buildInstructions(caller, memoryAgent, deps.agentRepo);
   // Look up the bound beevibe session so we can branch the tool surface for
   // server-fallback-mesh spawns (restricted set; see assembleTools). Failure
   // to load is non-fatal — we default to the full surface and the caller

--- a/packages/api/src/routes/room.ts
+++ b/packages/api/src/routes/room.ts
@@ -577,18 +577,17 @@ async function runMentionedAgents(
         agent.id,
         roomId,
       );
-      // Team agents in rooms ALSO get the routing directive (delegate-don't-
-      // absorb) on top of room directives — same reasoning as in the chat
-      // path: a team agent's job is to route work, even when collaborating
-      // with peers from other teams in a shared room.
-      const subordinates =
-        agent.hierarchy_level === "team"
-          ? await deps.agentRepo.findSubordinates(agent.id)
-          : [];
-      const teamRouting =
-        subordinates.length > 0
-          ? teamAgentRoutingDirective(subordinates.map((s) => s.name))
-          : "";
+      // Team agents in rooms ALSO get the routing directive on top of
+      // room directives — same three-lane rubric (handle / delegate /
+      // spawn) applies whether the team agent is in a 1:1 chat, a task
+      // session, or collaborating in a room.
+      const isTeamAgent = agent.hierarchy_level === "team";
+      const subordinates = isTeamAgent
+        ? await deps.agentRepo.findSubordinates(agent.id)
+        : [];
+      const teamRouting = isTeamAgent
+        ? teamAgentRoutingDirective(subordinates.map((s) => s.name))
+        : "";
       const session = await agentSession.run({
         agentId: agent.id,
         intent,

--- a/packages/api/src/runtime/router.ts
+++ b/packages/api/src/runtime/router.ts
@@ -480,10 +480,8 @@ async function composeDispatchPayload(
       ? deps.agentRepo.findSubordinates(agent.id)
       : Promise.resolve([]),
   ]);
-  // Team-agent routing is universal across chat AND task sessions for
-  // team-tier agents — the three-lane rubric (handle / delegate / spawn)
-  // doesn't depend on surface. Suppressed during onboarding so the
-  // wizard directives drive the build-your-team conversation themselves.
+  // Routing is suppressed during onboarding so the wizard directives
+  // drive the build-your-team conversation themselves.
   const isOnboarding = isChat && !owner?.onboarding_completed_at;
   const teamRouting =
     isTeamAgent && !isOnboarding

--- a/packages/api/src/runtime/router.ts
+++ b/packages/api/src/runtime/router.ts
@@ -466,26 +466,27 @@ async function composeDispatchPayload(
 
   const memoryAgent = deps.makeMemoryAgent(agent.id);
   const isChat = session.type === "chat";
-  const isTeamChat = isChat && agent.hierarchy_level === "team";
+  const isTeamAgent = agent.hierarchy_level === "team";
   // Briefing, prior-session, (for chat) onboarding-state, and (for team
-  // chat) subordinate roster lookups are independent — overlap them so
-  // the resume-chain hot path doesn't pay all round-trips serially.
+  // agents) subordinate roster lookups are independent — overlap them
+  // so the resume-chain hot path doesn't pay all round-trips serially.
   const [briefing, priorSession, owner, subordinates] = await Promise.all([
     memoryAgent.prepareBriefing(session.intent),
     session.prior_session_id
       ? deps.sessionRepo.findById(session.prior_session_id)
       : Promise.resolve(undefined),
     isChat ? deps.personRepo.findById(agent.owner_id) : Promise.resolve(undefined),
-    isTeamChat
+    isTeamAgent
       ? deps.agentRepo.findSubordinates(agent.id)
       : Promise.resolve([]),
   ]);
-  // Team-agent routing fires post-onboarding for all team chat sessions —
-  // whether or not there are specialists yet. With no specialists the
-  // directive tells the agent to spawn one rather than do the work itself.
+  // Team-agent routing is universal across chat AND task sessions for
+  // team-tier agents — the three-lane rubric (handle / delegate / spawn)
+  // doesn't depend on surface. Suppressed during onboarding so the
+  // wizard directives drive the build-your-team conversation themselves.
   const isOnboarding = isChat && !owner?.onboarding_completed_at;
   const teamRouting =
-    isTeamChat && !isOnboarding
+    isTeamAgent && !isOnboarding
       ? teamAgentRoutingDirective(subordinates.map((s) => s.name))
       : "";
 

--- a/packages/api/src/tools/instructions.test.ts
+++ b/packages/api/src/tools/instructions.test.ts
@@ -1,70 +1,157 @@
 import { describe, expect, it, vi } from "vitest";
+import type { Agent, AgentRepository } from "@beevibe/core";
 import type { MemoryAgent } from "@beevibe/core/services/memory";
 import { buildInstructions } from "./instructions.js";
 
 function fakeMemoryAgent(opts: {
-  systemPromptAppend?: string;
-  userMessagePrefix?: string;
-}): MemoryAgent {
+  coreOnlySystemPrompt?: string;
+} = {}): MemoryAgent {
   return {
     prepareBriefing: vi.fn(async () => ({
-      systemPromptAppend: opts.systemPromptAppend ?? "",
-      userMessagePrefix: opts.userMessagePrefix ?? "",
+      systemPromptAppend: "<core_memory>full briefing</core_memory>",
+      userMessagePrefix: "<archival_memory><leak_canary_token/></archival_memory>",
       snapshot: { block_count: 0, fact_count: 0, token_count: 0, blocks: [], facts: [] },
+    })),
+    prepareCoreOnly: vi.fn(async () => ({
+      systemPromptAppend:
+        opts.coreOnlySystemPrompt ??
+        '<core_memory>\n  <block name="persona">You are Alice\'s team agent.</block>\n</core_memory>',
+      userMessagePrefix: "",
+      snapshot: { block_count: 1, fact_count: 0, token_count: 10, blocks: [], facts: [] },
     })),
     searchArchival: vi.fn(async () => "<archival_memory></archival_memory>"),
     onTaskComplete: vi.fn(async () => {}),
   };
 }
 
+function fakeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: "agent_b",
+    owner_id: "p1",
+    parent_id: null,
+    hierarchy_level: "team",
+    name: "team-agent",
+    display_name: "Alice's team",
+    api_key: "bv_a_xxx",
+    api_key_revoked_at: null,
+    onboarding_completed_at: new Date(),
+    runtime_config: {
+      type: "claude",
+      system_prompt_addition: "<agent_baseline>persona stuff</agent_baseline>",
+    },
+    created_at: new Date(),
+    updated_at: new Date(),
+    archived_at: null,
+    ...overrides,
+  } as unknown as Agent;
+}
+
+function fakeAgentRepo(opts: {
+  agent?: Agent | undefined;
+  subordinates?: readonly Agent[];
+} = {}): AgentRepository {
+  return {
+    findById: vi.fn(async () => opts.agent ?? null),
+    findSubordinates: vi.fn(async () => opts.subordinates ?? []),
+  } as unknown as AgentRepository;
+}
+
 describe("buildInstructions", () => {
-  it("returns empty string for agent callers (briefing already injected via --append-system-prompt + intent prefix)", async () => {
-    const memoryAgent = fakeMemoryAgent({
-      systemPromptAppend: "<core_memory>...</core_memory>",
-      userMessagePrefix: "<archival_memory>...</archival_memory>",
-    });
+  it("returns empty string for agent callers (briefing already injected via --append-system-prompt)", async () => {
+    const memoryAgent = fakeMemoryAgent();
+    const agentRepo = fakeAgentRepo();
 
     const result = await buildInstructions(
       { source: "agent", agentId: "agent_a", hierarchyLevel: "team" },
       memoryAgent,
+      agentRepo,
     );
 
     expect(result).toBe("");
-    // Agent-source path shouldn't query memory.
+    // Agent-source path shouldn't query any memory or agent metadata.
     expect(memoryAgent.prepareBriefing).not.toHaveBeenCalled();
+    expect(memoryAgent.prepareCoreOnly).not.toHaveBeenCalled();
+    expect(agentRepo.findById).not.toHaveBeenCalled();
+    expect(agentRepo.findSubordinates).not.toHaveBeenCalled();
   });
 
-  it("returns BOTH halves joined for human callers (M9.4 — humans can't host the per-message prefix)", async () => {
-    const memoryAgent = fakeMemoryAgent({
-      systemPromptAppend:
-        '<core_memory>\n  <block name="persona">You are Alice\'s team agent.</block>\n</core_memory>',
-      userMessagePrefix: "<archival_memory>\n  <fact>top-k vector hit</fact>\n</archival_memory>",
+  it("composes the full team-chat stack for human team-tier callers", async () => {
+    const memoryAgent = fakeMemoryAgent();
+    const agentRepo = fakeAgentRepo({
+      agent: fakeAgent(),
+      subordinates: [
+        fakeAgent({ id: "ic_1", name: "frontend", hierarchy_level: "ic" }),
+        fakeAgent({ id: "ic_2", name: "backend", hierarchy_level: "ic" }),
+      ],
     });
 
     const result = await buildInstructions(
       { source: "human", agentId: "agent_b", hierarchyLevel: "team", personId: "p1" },
       memoryAgent,
+      agentRepo,
     );
 
-    // Both halves present, joined by blank line so the human's claude
-    // session sees core_memory and archival_memory contextually adjacent.
+    // Universal blocks present.
+    expect(result).toContain("beevibe_lifecycle");
+    expect(result).toContain("beevibe_memory");
+    // Team routing with the roster.
+    expect(result).toContain("team_agent_routing");
+    expect(result).toContain("- frontend");
+    expect(result).toContain("- backend");
+    // Per-agent baseline threaded through.
+    expect(result).toContain("<agent_baseline>");
+    // Core memory present.
     expect(result).toContain("<core_memory>");
-    expect(result).toContain("<archival_memory>");
-    expect(result).toContain("\n\n");
-    expect(memoryAgent.prepareBriefing).toHaveBeenCalledWith("(interactive)");
+    // Things the human-MCP variant must NOT carry.
+    expect(result).not.toContain("chat_directives");
+    expect(result).not.toContain("onboarding_directives");
+    // The memory reminder's prose mentions <archival_memory> / "top-k"
+    // describing Layer 2, so neither is a clean negative signal. Use a
+    // distinctive canary that only appears in prepareBriefing's mock
+    // userMessagePrefix — its absence proves prepareCoreOnly was used.
+    expect(result).not.toContain("leak_canary_token");
+    // Used prepareCoreOnly, not prepareBriefing — no embed/query wasted on
+    // a placeholder retrieval query at MCP init time.
+    expect(memoryAgent.prepareCoreOnly).toHaveBeenCalled();
+    expect(memoryAgent.prepareBriefing).not.toHaveBeenCalled();
   });
 
-  it("filters out empty halves when only one is present", async () => {
-    const memoryAgent = fakeMemoryAgent({
-      systemPromptAppend: "<core_memory>only this</core_memory>",
-      userMessagePrefix: "",
+  it("omits team_agent_routing for org-tier humans (routing rubric is team-only today)", async () => {
+    const memoryAgent = fakeMemoryAgent();
+    const agentRepo = fakeAgentRepo({
+      agent: fakeAgent({ hierarchy_level: "org" }),
     });
 
     const result = await buildInstructions(
-      { source: "human", agentId: "agent_c", hierarchyLevel: "ic", personId: "p1" },
+      { source: "human", agentId: "agent_org", hierarchyLevel: "org", personId: "p1" },
       memoryAgent,
+      agentRepo,
     );
 
-    expect(result).toBe("<core_memory>only this</core_memory>");
+    expect(result).not.toContain("team_agent_routing");
+    // But still gets lifecycle + memory + baseline + core_memory.
+    expect(result).toContain("beevibe_lifecycle");
+    expect(result).toContain("beevibe_memory");
+    expect(result).toContain("<agent_baseline>");
+    expect(result).toContain("<core_memory>");
+    // Subordinate fetch is skipped — org-tier doesn't need the roster
+    // (no routing block to populate).
+    expect(agentRepo.findSubordinates).not.toHaveBeenCalled();
+  });
+
+  it("survives missing agent record without throwing (returns stack minus baseline)", async () => {
+    const memoryAgent = fakeMemoryAgent();
+    const agentRepo = fakeAgentRepo({ agent: undefined });
+
+    const result = await buildInstructions(
+      { source: "human", agentId: "ghost", hierarchyLevel: "team", personId: "p1" },
+      memoryAgent,
+      agentRepo,
+    );
+
+    expect(result).toContain("beevibe_lifecycle");
+    expect(result).toContain("<core_memory>");
+    // No per-agent baseline content when the agent record is missing.
+    expect(result).not.toContain("<agent_baseline>");
   });
 });

--- a/packages/api/src/tools/instructions.ts
+++ b/packages/api/src/tools/instructions.ts
@@ -1,3 +1,8 @@
+import type { AgentRepository } from "@beevibe/core";
+import {
+  composeSystemPromptAppend,
+  teamAgentRoutingDirective,
+} from "@beevibe/core/services/agent-session";
 import type { MemoryAgent } from "@beevibe/core/services/memory";
 import type { McpCaller } from "./assemble.js";
 
@@ -6,32 +11,40 @@ import type { McpCaller } from "./assemble.js";
  *
  * Branch on `caller.source`:
  *   - "agent" → empty string. The agent's CLI was spawned by the executor
- *     (or a mesh tool handler), which already injected the briefing via
- *     `--append-system-prompt` (system) + intent prefix (user) — duplicating
- *     either as `instructions` would waste tokens.
- *   - "human" → full briefing (BOTH halves joined). The user ran `claude`
- *     themselves; no system-prompt arg was passed and no way to prepend to
- *     their first user message, so we deliver everything through the MCP
- *     `instructions` field. M9.4's split-by-stability optimization is
- *     agent-only — humans get the consolidated briefing because their path
- *     can't host the per-message prefix.
- *
- * Takes the already-built `MemoryAgent` (constructed once per session at
- * the call site) rather than the factory — avoids rebuilding it just to
- * call `prepareBriefing`.
+ *     (or a mesh tool handler), which already injected the full prompt
+ *     stack via `--append-system-prompt` (system) + intent prefix (user).
+ *     Duplicating either as `instructions` would waste tokens.
+ *   - "human" → the team agent's full chat-flavored prompt stack
+ *     (lifecycle reminder, memory reminder, team_agent_routing,
+ *     per-agent baseline, core_memory). The human's local CLI consumes
+ *     the team agent's identity over MCP, so we ship the same prompt
+ *     content a team chat session would get — minus the beevibe chat UI
+ *     grammar (the local CLI can't render our suggest_action chips) and
+ *     minus archival memory (no intent yet — the CLI uses
+ *     `search_context` on demand instead).
  */
 export async function buildInstructions(
   caller: McpCaller,
   memoryAgent: MemoryAgent,
+  agentRepo: AgentRepository,
 ): Promise<string> {
   if (caller.source === "agent") {
     return "";
   }
-  const briefing = await memoryAgent.prepareBriefing("(interactive)");
-  // Join system + user halves with a blank line so the human's session sees
-  // both core_memory and archival_memory contextually adjacent in the
-  // initial system prompt.
-  return [briefing.systemPromptAppend, briefing.userMessagePrefix]
-    .filter((s) => s.length > 0)
-    .join("\n\n");
+  const [briefing, agent, subordinates] = await Promise.all([
+    memoryAgent.prepareCoreOnly(),
+    agentRepo.findById(caller.agentId),
+    caller.hierarchyLevel === "team"
+      ? agentRepo.findSubordinates(caller.agentId)
+      : Promise.resolve([]),
+  ]);
+  const teamRouting =
+    caller.hierarchyLevel === "team"
+      ? teamAgentRoutingDirective(subordinates.map((s) => s.name))
+      : "";
+  return composeSystemPromptAppend(
+    agent?.runtime_config.system_prompt_addition,
+    briefing.systemPromptAppend,
+    { sessionKind: "human_mcp", extra: teamRouting },
+  );
 }

--- a/packages/core/src/services/memory/memory-agent.test.ts
+++ b/packages/core/src/services/memory/memory-agent.test.ts
@@ -206,6 +206,41 @@ describe("MemoryAgent.prepareBriefing", () => {
   });
 });
 
+describe("MemoryAgent.prepareCoreOnly", () => {
+  it("returns core memory with an empty archival half (no embed / no fact search)", async () => {
+    vi.mocked(coreMemory.read).mockResolvedValue([
+      makeBlock("persona", "You are the team agent."),
+    ]);
+
+    const briefing = await agent.prepareCoreOnly();
+
+    expect(briefing.systemPromptAppend).toContain("<core_memory>");
+    expect(briefing.systemPromptAppend).toContain(
+      "You are the team agent.",
+    );
+    // No archival half — human MCP path uses search_context on demand
+    // instead of pre-loading hits against a placeholder intent.
+    expect(briefing.userMessagePrefix).toBe("");
+    expect(briefing.snapshot.fact_count).toBe(0);
+    expect(briefing.snapshot.facts).toEqual([]);
+    // Embed + fact search are the wasted-work pieces this method exists
+    // to avoid — keep this assertion to lock that property in.
+    expect(embed.embed).not.toHaveBeenCalled();
+    expect(factStore.search).not.toHaveBeenCalled();
+  });
+
+  it("renders an empty <core_memory> envelope when the agent has no blocks", async () => {
+    vi.mocked(coreMemory.read).mockResolvedValue([]);
+
+    const briefing = await agent.prepareCoreOnly();
+
+    expect(briefing.systemPromptAppend).toBe(
+      "<core_memory>\n</core_memory>",
+    );
+    expect(briefing.snapshot.block_count).toBe(0);
+  });
+});
+
 describe("MemoryAgent.searchArchival", () => {
   it("vector-searches with the query and returns archival envelope only", async () => {
     vi.mocked(embed.embed).mockResolvedValue([0.7, 0.8]);

--- a/packages/core/src/services/memory/memory-agent.ts
+++ b/packages/core/src/services/memory/memory-agent.ts
@@ -51,6 +51,18 @@ export interface MemoryAgent {
    */
   prepareBriefing(intent: string): Promise<BriefingResult>;
   /**
+   * Session-start briefing for surfaces that have no intent at init time
+   * (human MCP — the user hasn't said anything yet). Returns the same
+   * `BriefingResult` shape as `prepareBriefing` but with an empty
+   * `userMessagePrefix` and zero facts in the snapshot.
+   *
+   * Skips the OpenAI embed + pgvector query entirely — there's no signal
+   * to query against, so any retrieval would be noise. The caller's CLI
+   * uses the `search_context` MCP tool to pull archival facts on demand
+   * when it realizes it needs them.
+   */
+  prepareCoreOnly(): Promise<BriefingResult>;
+  /**
    * Mid-session: vector-search the agent's archival facts by `query` and
    * return ONLY the `<archival_memory>...</archival_memory>` XML envelope.
    * Used by the `search_context` MCP tool — the agent already has its
@@ -114,6 +126,11 @@ export function createMemoryAgent(deps: MemoryAgentDeps): MemoryAgent {
         searchFacts(intent),
       ]);
       return composeBriefing(blocks, facts);
+    },
+
+    async prepareCoreOnly(): Promise<BriefingResult> {
+      const blocks = await deps.coreMemory.read(deps.agentId);
+      return composeBriefing(blocks, []);
     },
 
     async searchArchival(query: string): Promise<string> {

--- a/packages/core/src/services/spawn-prep.test.ts
+++ b/packages/core/src/services/spawn-prep.test.ts
@@ -7,12 +7,18 @@ import {
 } from "./spawn-prep.js";
 
 describe("teamAgentRoutingDirective", () => {
-  it("still fires with no specialists — tells agent to spawn one, not handle work itself", () => {
+  it("emits the three-lane rubric with no specialists (lane A still applies)", () => {
     const out = teamAgentRoutingDirective([]);
     expect(out).toContain("team_agent_routing");
     expect(out).toContain("TEAM AGENT");
-    expect(out.toLowerCase()).toContain("no specialists");
-    expect(out.toLowerCase()).toContain("do not handle");
+    // All three lanes must be addressable in the empty-roster case too —
+    // lane A (small/exploratory/coordination) doesn't require a roster.
+    expect(out).toContain("A) **Handle it yourself**");
+    expect(out).toContain("B) **Delegate to one specialist**");
+    expect(out).toContain("C) **Propose spawning a specialist**");
+    // Empty-roster framing should still mention portability of spawns,
+    // so the agent recommends cross-project specialists, not project-bound.
+    expect(out.toLowerCase()).toContain("portable");
   });
 
   it("includes each specialist name as a list item", () => {
@@ -22,33 +28,70 @@ describe("teamAgentRoutingDirective", () => {
     expect(out).toContain("- data");
   });
 
-  it("frames the agent as a coordinator and warns against absorbing work", () => {
+  it("frames specialists as portable across projects, not project-bound", () => {
+    // Cross-project specialty is load-bearing: spawned specialists serve
+    // every repo this user touches, not just the current project.
     const out = teamAgentRoutingDirective(["frontend"]);
-    expect(out).toContain("TEAM AGENT");
-    expect(out).toContain("ROUTE");
-    expect(out.toLowerCase()).toContain("absorb");
+    expect(out).toContain("PORTABLE");
+    expect(out.toLowerCase()).toContain("every project and repo");
   });
 
-  it("provides suggest_action examples the chat UI knows how to render", () => {
+  it("carries a stop signal against absorbing substantial single-domain work", () => {
     const out = teamAgentRoutingDirective(["frontend"]);
-    expect(out).toContain("<suggest_action");
+    expect(out).toContain("Stop signal");
+    expect(out.toLowerCase()).toContain("substantial single-domain deliverable");
+  });
+
+  it("warns against create_task on self (avoids parallel session for the same agent)", () => {
+    const out = teamAgentRoutingDirective(["frontend"]);
+    expect(out).toContain("Do NOT");
+    expect(out).toMatch(/create_task on yourself/);
+  });
+
+  it("contains no chat-only UI grammar (suggest_action chips live in CHAT_DIRECTIVES)", () => {
+    // team_agent_routing is universal across chat AND task sessions —
+    // suggest_action is a chat-only display token and belongs in
+    // CHAT_DIRECTIVES, not here.
+    const out = teamAgentRoutingDirective(["frontend"]);
+    expect(out).not.toContain("<suggest_action");
   });
 });
 
 describe("composeSystemPromptAppend with extra", () => {
-  it("threads the team-routing directive at the tail (most-volatile slot)", () => {
+  it("orders blocks by stability: static cross-agent → static surface → roster-stable → per-agent → per-session", () => {
     const teamRouting = teamAgentRoutingDirective(["frontend", "backend"]);
-    const out = composeSystemPromptAppend(undefined, "<core_memory/>", {
-      sessionKind: "chat",
-      extra: teamRouting,
-    });
-    // Cache-friendly order: most-stable first. Lifecycle reminder leads.
-    expect(out.indexOf("beevibe_lifecycle")).toBeLessThan(
-      out.indexOf("core_memory"),
+    // Use distinctive markers so indexOf can't collide with the memory
+    // reminder's prose mentions of "core_memory" / "persona".
+    const out = composeSystemPromptAppend(
+      "<agent_baseline_marker/>",
+      "<briefing_marker/>",
+      {
+        sessionKind: "chat",
+        extra: teamRouting,
+      },
     );
-    // CHAT_DIRECTIVES come before extra (extra is the most-volatile tail).
+    // Tier 1: static cross-agent constants lead.
+    expect(out.indexOf("beevibe_lifecycle")).toBeLessThan(
+      out.indexOf("beevibe_memory"),
+    );
+    // Tier 2 → Tier 3: memory reminder before surface-specific static.
+    expect(out.indexOf("beevibe_memory")).toBeLessThan(
+      out.indexOf("chat_directives"),
+    );
+    // Tier 3 → Tier 4: chat directives before the roster-stable team
+    // routing block — adding a new specialist invalidates everything
+    // after this point, so it sits below the fully-static blocks.
     expect(out.indexOf("chat_directives")).toBeLessThan(
       out.indexOf("team_agent_routing"),
+    );
+    // Tier 4 → Tier 5: team routing before per-agent baseline (operator
+    // edits invalidate baseline + briefing; roster changes are rarer).
+    expect(out.indexOf("team_agent_routing")).toBeLessThan(
+      out.indexOf("agent_baseline_marker"),
+    );
+    // Tier 5 → Tier 6: per-agent baseline before per-session briefing.
+    expect(out.indexOf("agent_baseline_marker")).toBeLessThan(
+      out.indexOf("briefing_marker"),
     );
   });
 
@@ -104,14 +147,13 @@ describe("composeSystemPromptAppend lifecycle branching", () => {
     expect(BEEVIBE_LIFECYCLE_REMINDER_CHAT).toMatch(/NO\s+work_product/);
   });
 
-  it("chat variant still allows create_task for team/org tier", () => {
-    expect(BEEVIBE_LIFECYCLE_REMINDER_CHAT).toContain("create_task");
-  });
-
-  it("chat variant does not tell team agents to assign work to themselves", () => {
-    // The 'or to yourself when it is your specialty' clause was a loophole
-    // that caused team agents to handle specialist work directly.
-    expect(BEEVIBE_LIFECYCLE_REMINDER_CHAT).not.toContain("to yourself");
+  it("chat variant does not duplicate routing guidance from team_agent_routing", () => {
+    // The chat reminder used to carry a create_task / routing bullet
+    // that overlapped with <team_agent_routing>. Routing is now the
+    // sole responsibility of that block (universal across chat + task),
+    // so the chat reminder shouldn't mention create_task at all.
+    expect(BEEVIBE_LIFECYCLE_REMINDER_CHAT).not.toContain("create_task");
+    expect(BEEVIBE_LIFECYCLE_REMINDER_CHAT).not.toContain("find_subordinates");
   });
 
   it("both variants share the outer <beevibe_lifecycle> tag so downstream parsing is stable", () => {

--- a/packages/core/src/services/spawn-prep.test.ts
+++ b/packages/core/src/services/spawn-prep.test.ts
@@ -104,6 +104,62 @@ describe("composeSystemPromptAppend with extra", () => {
   });
 });
 
+describe("composeSystemPromptAppend with sessionKind: 'human_mcp'", () => {
+  // Human MCP sessions: human's local CLI consumes the team agent's
+  // identity over MCP. Same prompt content as a team chat session —
+  // minus the beevibe chat UI grammar (the local CLI can't render
+  // suggest_action chips) and minus onboarding directives (not a
+  // first-touch surface).
+
+  it("uses the chat-variant lifecycle reminder (interactive, not task-tracked)", () => {
+    const out = composeSystemPromptAppend(undefined, "<core_memory/>", {
+      sessionKind: "human_mcp",
+    });
+    expect(out).toContain(BEEVIBE_LIFECYCLE_REMINDER_CHAT);
+    expect(out).not.toContain(BEEVIBE_LIFECYCLE_REMINDER_TASK);
+  });
+
+  it("skips CHAT_DIRECTIVES (chat UI grammar is beevibe-surface-only)", () => {
+    const out = composeSystemPromptAppend(undefined, "<core_memory/>", {
+      sessionKind: "human_mcp",
+      extra: teamAgentRoutingDirective(["frontend"]),
+    });
+    expect(out).not.toContain("chat_directives");
+    expect(out).not.toContain("<suggest_action");
+    expect(out).not.toContain("<open_view");
+  });
+
+  it("still threads team_agent_routing extra (universal directive)", () => {
+    const out = composeSystemPromptAppend(undefined, "<core_memory/>", {
+      sessionKind: "human_mcp",
+      extra: teamAgentRoutingDirective(["frontend"]),
+    });
+    expect(out).toContain("team_agent_routing");
+    expect(out).toContain("- frontend");
+  });
+
+  it("preserves stability ordering minus the chat_directives slot", () => {
+    const teamRouting = teamAgentRoutingDirective(["frontend"]);
+    const out = composeSystemPromptAppend(
+      "<agent_baseline_marker/>",
+      "<briefing_marker/>",
+      { sessionKind: "human_mcp", extra: teamRouting },
+    );
+    expect(out.indexOf("beevibe_lifecycle")).toBeLessThan(
+      out.indexOf("beevibe_memory"),
+    );
+    expect(out.indexOf("beevibe_memory")).toBeLessThan(
+      out.indexOf("team_agent_routing"),
+    );
+    expect(out.indexOf("team_agent_routing")).toBeLessThan(
+      out.indexOf("agent_baseline_marker"),
+    );
+    expect(out.indexOf("agent_baseline_marker")).toBeLessThan(
+      out.indexOf("briefing_marker"),
+    );
+  });
+});
+
 describe("composeSystemPromptAppend lifecycle branching", () => {
   // Production bug pre-fix: chat sessions got the task-only lifecycle
   // reminder telling them to "call update_progress with task_id from

--- a/packages/core/src/services/spawn-prep.ts
+++ b/packages/core/src/services/spawn-prep.ts
@@ -324,15 +324,11 @@ directives the UI understands:
 export function teamAgentRoutingDirective(
   specialistNames: readonly string[],
 ): string {
-  const rosterSection =
-    specialistNames.length > 0
-      ? withSpecialists(specialistNames)
-      : withoutSpecialists();
   return `<team_agent_routing>
 You are a TEAM AGENT — a coordinator who can roll up sleeves for small or
 unscoped work, but delegates substantial single-domain work to specialists.
 
-${rosterSection}
+${rosterSection(specialistNames)}
 
 Three lanes for any work that lands on you:
 
@@ -351,17 +347,20 @@ C) **Propose spawning a specialist** — when the work is substantive single-dom
 </team_agent_routing>`;
 }
 
-function withSpecialists(names: readonly string[]): string {
-  const list = names.map((n) => `  - ${n}`).join("\n");
-  return `Your team currently has these specialists:
+// Trailing reminder used in both roster-present and roster-empty
+// branches. Specialists must be framed as cross-project from day one,
+// otherwise spawn recommendations drift into project-scoped ("hire a
+// backend specialist for this repo") rather than skill-scoped ("add
+// backend to the team").
+const PORTABLE_SPECIALIST_FRAMING =
+  `Specialists are PORTABLE — their expertise spans every project and repo this user touches, not just this one. Frame each spawn as "adding this skill to the team," not "hiring for this project."`;
 
-${list}
-
-These are PORTABLE specialists — each one's expertise spans every project and repo this user touches, not just this one. When you spawn a new specialist, frame it as "adding this skill to the team," not "hiring for this project."`;
-}
-
-function withoutSpecialists(): string {
-  return `Your team has no specialists yet. Every specialist you spawn is PORTABLE — their expertise spans every project and repo this user touches, not just this one. Frame each spawn as "adding this skill to the team," not "hiring for this project."`;
+function rosterSection(names: readonly string[]): string {
+  const intro =
+    names.length > 0
+      ? `Your team currently has these specialists:\n\n${names.map((n) => `  - ${n}`).join("\n")}`
+      : `Your team has no specialists yet.`;
+  return `${intro}\n\n${PORTABLE_SPECIALIST_FRAMING}`;
 }
 
 /**

--- a/packages/core/src/services/spawn-prep.ts
+++ b/packages/core/src/services/spawn-prep.ts
@@ -97,19 +97,11 @@ work_product to record.
    don't summarize what they just said back at them, don't open with a
    meta-acknowledgement of the question.
 
-2. If the user describes a discrete unit of work (a deliverable, a fix,
-   a research goal) and you are team or org tier, you may call
-   mcp__beevibe__create_task to spawn it as a tracked task — always to a
-   subordinate specialist (call mcp__beevibe__find_subordinates first to
-   pick a matching specialty). Team agents do not take on specialist work
-   themselves; if no subordinate fits, name the gap and recommend spawning
-   one.
-
-3. Memory management (see <beevibe_memory>) is especially valuable in
+2. Memory management (see <beevibe_memory>) is especially valuable in
    chat. Preferences, decisions, and durable context surface here first;
    save them so the next chat and the next task inherit them.
 
-4. For multi-step protocols whose triggers match your situation (mesh
+3. For multi-step protocols whose triggers match your situation (mesh
    negotiation, etc.) the relevant beevibe-* skill in .claude/skills/
    has the deep guidance — invoke via the Skill tool. Note that
    beevibe-pre-task-setup is git-workspace setup for tasks; it does NOT
@@ -318,6 +310,17 @@ directives the UI understands:
    when there's nothing concrete to choose.
 </chat_directives>`;
 
+/**
+ * Universal routing directive for team-tier agents. Injected for every
+ * team-agent session (chat AND task) — the three-lane rubric is the
+ * same regardless of surface. Chat-specific affordances (suggest_action
+ * chips, clarifying-question framing) live in CHAT_DIRECTIVES and the
+ * chat lifecycle reminder, not here.
+ *
+ * Empty roster is a normal state, not a failure mode: the agent can
+ * still lane-A small work and lane-C propose spawns. The roster section
+ * varies; the lane rubric is identical for both shapes.
+ */
 export function teamAgentRoutingDirective(
   specialistNames: readonly string[],
 ): string {
@@ -326,11 +329,25 @@ export function teamAgentRoutingDirective(
       ? withSpecialists(specialistNames)
       : withoutSpecialists();
   return `<team_agent_routing>
-You are a TEAM AGENT — a coordinator, not a specialist. ${rosterSection}
+You are a TEAM AGENT — a coordinator who can roll up sleeves for small or
+unscoped work, but delegates substantial single-domain work to specialists.
 
-3. **You don't do specialist work yourself.** If you find yourself drafting the actual deliverable (writing the code, the copy, the analysis), stop — that's the signal that this request needs a specialist. Your job is recognizing whose domain this is, recommending the handoff or the gap, and getting the human to a fast next click.
+${rosterSection}
 
-Clarifying questions are fine and encouraged — but ask them in service of *routing* the work, not in service of you doing it.
+Three lanes for any work that lands on you:
+
+A) **Handle it yourself** — when:
+   - The work is ambiguous and needs exploration (read code, look up docs, sketch the shape of the problem) before anyone can do it well.
+   - It's small enough that handing off costs more than doing — a quick lookup, a one-line fix.
+   - It's cross-cutting coordination work that doesn't decompose into a single domain (you produce a plan, a summary, or a decision — not single-domain code).
+
+   You have full tool access (Read, Glob, Grep, Bash, Write, WebFetch, …). Use it freely to scope, investigate, and land the work. Do NOT call mcp__beevibe__create_task on yourself — that spawns a separate session for the same agent, wasteful when you can just do the work here.
+
+B) **Delegate to one specialist** — when the work is a substantive single-domain deliverable AND a subordinate's specialty clearly fits. Route via mcp__beevibe__create_task to that subordinate; call mcp__beevibe__find_subordinates first to pick by specialty.
+
+C) **Propose spawning a specialist** — when the work is substantive single-domain work AND no subordinate fits. Name the gap plainly ("you have X, Y, Z — but nobody owns <domain>"), and recommend a concrete name + cross-project scope for the new specialist.
+
+**Stop signal:** if you find yourself producing a substantial single-domain deliverable yourself (writing real production code, a full design doc, a finished analysis for one domain), you slipped into lane B without realizing — pull back and route.
 </team_agent_routing>`;
 }
 
@@ -340,35 +357,29 @@ function withSpecialists(names: readonly string[]): string {
 
 ${list}
 
-When the user brings work, your default move is to ROUTE it, not do it yourself:
-
-1. **Match the request's primary skill axis to an existing specialist.** Frontend? backend? data? comms? design? mobile? Look at the names above. If one fits, propose handing off — append a chip like:
-
-   \`<suggest_action label="Hand off to backend specialist" prompt="hand this off to the backend specialist" />\`
-
-2. **If no specialist owns it, name the gap.** Don't paper over it by absorbing the work yourself. Say plainly: "you have X, Y, Z — but nobody owns <domain>." Recommend spawning a new specialist with a concrete name + scope, and append:
-
-   \`<suggest_action label="Spawn <name> specialist" prompt="yes, draft the spec and spawn the specialist" />\``;
+These are PORTABLE specialists — each one's expertise spans every project and repo this user touches, not just this one. When you spawn a new specialist, frame it as "adding this skill to the team," not "hiring for this project."`;
 }
 
 function withoutSpecialists(): string {
-  return `You have no specialists yet. **Do not handle this request yourself.** Your only move is to identify what kind of specialist is needed, recommend spawning one with a concrete name and scope, and append:
-
-   \`<suggest_action label="Spawn <name> specialist" prompt="yes, draft the spec and spawn the specialist" />\``;
+  return `Your team has no specialists yet. Every specialist you spawn is PORTABLE — their expertise spans every project and repo this user touches, not just this one. Frame each spawn as "adding this skill to the team," not "hiring for this project."`;
 }
 
 /**
  * Compose the `--append-system-prompt` value. Cache-friendly order:
- * most-stable first (cross-agent constants → agent baseline → per-agent
- * core-memory briefing). archival_memory rides on the user message via
- * `composeIntent`, not here, because it's the per-session bit that breaks
- * cache.
+ * most-stable first (cross-agent constants → surface-specific static
+ * directives → roster-stable team routing → per-agent baseline →
+ * per-session briefing → one-shot onboarding). archival_memory rides
+ * on the user message via `composeIntent`, not here, because it's the
+ * per-session bit that breaks cache.
  *
- * For chat sessions, pass `appendChatDirectives: true` so the static
- * UI-format directives land at the tail (most-volatile slot — they
- * don't affect cache for non-chat sessions). When also onboarding,
- * `appendOnboardingDirectives: true` adds the one-time wizard directives
- * after CHAT_DIRECTIVES.
+ * Stability tiers (highest to lowest):
+ *   1. lifecycle reminder  — fully static per surface
+ *   2. memory reminder     — fully static
+ *   3. chat directives     — fully static, chat-only
+ *   4. team routing extra  — changes only when team roster changes
+ *   5. per-agent baseline  — changes only when operator edits the agent
+ *   6. briefing            — changes per-session (memory blocks update)
+ *   7. onboarding          — one-shot, never re-fires (tail slot is fine)
  */
 export type SessionSurfaceKind = "task" | "chat";
 
@@ -401,11 +412,11 @@ export function composeSystemPromptAppend(
   return [
     lifecycleReminder,
     BEEVIBE_MEMORY_REMINDER,
+    isChat ? CHAT_DIRECTIVES : "",
+    options.extra ?? "",
     agentSystemPromptAddition ?? "",
     briefingSystemPromptAppend,
-    isChat ? CHAT_DIRECTIVES : "",
     options.appendOnboardingDirectives ? ONBOARDING_DIRECTIVES : "",
-    options.extra ?? "",
   ]
     .filter((s) => s.length > 0)
     .join("\n\n");

--- a/packages/core/src/services/spawn-prep.ts
+++ b/packages/core/src/services/spawn-prep.ts
@@ -380,7 +380,7 @@ function rosterSection(names: readonly string[]): string {
  *   6. briefing            — changes per-session (memory blocks update)
  *   7. onboarding          — one-shot, never re-fires (tail slot is fine)
  */
-export type SessionSurfaceKind = "task" | "chat";
+export type SessionSurfaceKind = "task" | "chat" | "human_mcp";
 
 export function composeSystemPromptAppend(
   agentSystemPromptAddition: string | undefined,
@@ -389,14 +389,19 @@ export function composeSystemPromptAppend(
     /**
      * Which session surface is being spawned. Drives both the
      * lifecycle reminder variant AND whether CHAT_DIRECTIVES is
-     * appended — the two are coupled by definition (chat surface
-     * implies chat lifecycle and display tokens; task surface implies
-     * task lifecycle and no display tokens). Defaults to "task" so
-     * existing task-side callers don't need to pass the flag.
+     * appended.
      *
-     * When mesh-ask / blocker-response sessions eventually need their
-     * own surface treatment, extend this union — don't reintroduce
-     * orthogonal flags.
+     *   "task"      — task lifecycle, no display tokens.
+     *   "chat"      — chat lifecycle + display tokens (the beevibe
+     *                 chat surface renders id-hydration, open_view,
+     *                 suggest_action chips).
+     *   "human_mcp" — chat lifecycle (interactive conversation, no
+     *                 task tracking) but NO display tokens — the
+     *                 human's local CLI runs in their terminal and
+     *                 can't render our chips.
+     *
+     * Defaults to "task" so existing task-side callers don't need
+     * to pass the flag.
      */
     sessionKind?: SessionSurfaceKind;
     appendOnboardingDirectives?: boolean;
@@ -404,14 +409,19 @@ export function composeSystemPromptAppend(
     extra?: string;
   } = {},
 ): string {
-  const isChat = options.sessionKind === "chat";
-  const lifecycleReminder = isChat
+  const usesChatLifecycle =
+    options.sessionKind === "chat" || options.sessionKind === "human_mcp";
+  const lifecycleReminder = usesChatLifecycle
     ? BEEVIBE_LIFECYCLE_REMINDER_CHAT
     : BEEVIBE_LIFECYCLE_REMINDER_TASK;
+  // CHAT_DIRECTIVES is the beevibe chat UI grammar — only fires for
+  // sessions actually rendered in our chat surface. human_mcp uses
+  // chat lifecycle but skips this block.
+  const isChatSurface = options.sessionKind === "chat";
   return [
     lifecycleReminder,
     BEEVIBE_MEMORY_REMINDER,
-    isChat ? CHAT_DIRECTIVES : "",
+    isChatSurface ? CHAT_DIRECTIVES : "",
     options.extra ?? "",
     agentSystemPromptAddition ?? "",
     briefingSystemPromptAppend,


### PR DESCRIPTION
## Summary

Rewrites the team-agent routing prompt around three lanes and unifies the prompt-injection path across every surface a team agent can appear on (chat, task, human MCP). Stacks three commits:

1. **`fix(routing): rewrite team-agent prompt with three lanes + cache reorder`** — new directive content + composition reorder
2. **`chore(routing): collapse roster helpers + trim comment`** — simplify pass cleanup
3. **`feat(mcp): give human MCP sessions the full team-chat prompt stack`** — extends the universal directive to the human MCP path

---

### The original failure mode

The previous directive (post #154/#159) was binary — every ask was either *route to a specialist* or *recommend spawning one*. Even ambiguous, exploratory, or one-line asks got pushed into the "stop, hand off" funnel. Team agents either over-routed or silently absorbed substantial work anyway.

### The three lanes

Each turn the team agent picks one:

| Lane | When | Action |
|---|---|---|
| **A) Handle it yourself** | ambiguous / exploratory / small / cross-cutting coordination | Full tool access (Read, Glob, Grep, Bash, Write, WebFetch) to scope and land directly |
| **B) Delegate to one specialist** | substantive single-domain deliverable + fit subordinate | `create_task` to the subordinate |
| **C) Propose spawning a specialist** | substantive single-domain work + no fit | name the gap; recommend a **portable** (cross-project, cross-repo) specialist |

A **stop signal** catches the failure mode: *"if you find yourself producing a substantial single-domain deliverable yourself, you slipped into lane B without realizing — pull back and route."*

### Universality — same directive across surfaces

The routing directive now injects for team agents on **every** surface they appear on:

| Surface | Injects routing? | Notes |
|---|---|---|
| Chat session | ✓ (post-onboarding) | unchanged from before |
| Task session | ✓ | **new** — was chat-only before |
| Room session | ✓ | gate widened from `subordinates.length > 0` to `isTeamAgent` |
| Human MCP session | ✓ | **new** — see commit 3 |

The three-lane rubric doesn't depend on surface. Chat-specific affordances (`<chat_directives>` UI grammar, onboarding wizard) stay in their own blocks — routing is its own concern.

### Chat lifecycle reminder simplified

Dropped the `create_task` / routing bullet entirely from `BEEVIBE_LIFECYCLE_REMINDER_CHAT` — that guidance now lives in `<team_agent_routing>` only. Single source of truth, no overlap.

### Cache-stability reorder

`composeSystemPromptAppend` blocks reordered most-stable → least-stable:

```
1. lifecycle reminder      (static per surface)
2. memory reminder         (static)
3. chat directives         (static, chat-only)
4. team routing            (changes only when team roster changes)
5. per-agent baseline      (changes only when operator edits)
6. core memory briefing    (changes per-session — least stable)
7. onboarding              (one-shot, tail-safe)
```

Static blocks now lead. Adding a specialist or editing per-agent baseline no longer invalidates the lifecycle / memory / chat-directives prefix.

### Lane A explicit anti-pattern

> Do NOT call `mcp__beevibe__create_task` on yourself — that spawns a separate session for the same agent.

Catches the temptation to self-track inline work, which would spawn a parallel task session for the same agent.

### Human MCP path — full team-chat stack (commit 3)

**Before this PR:** the MCP `instructions` field for human callers carried only `briefing.systemPromptAppend` (core_memory) plus `briefing.userMessagePrefix` — and that prefix was the result of `prepareBriefing("(interactive)")`, vector-searching archival memory against the literal placeholder string. The retrieval crossed the similarity floor approximately never, so the human's CLI got core_memory plus an empty `<archival_memory></archival_memory>` envelope. No lifecycle directive, no memory rules, no routing rubric.

**After:** human MCP sessions get the same prompt content a team chat session would get:

- `<beevibe_lifecycle>` (chat variant — interactive, not task-tracked)
- `<beevibe_memory>` (layer 1 / layer 2 memory rules)
- `<team_agent_routing>` (three lanes)
- per-agent baseline (operator-configured persona)
- `<core_memory>` (per-session briefing)

Skipped vs. team chat:

- `<chat_directives>` — the beevibe UI grammar (suggest_action chips, open_view) that the human's local CLI can't render
- `<onboarding_directives>` — not a first-touch surface
- `<archival_memory>` — no intent at init, so retrieval would be noise. Archival access is on-demand via the already-exposed `search_context` MCP tool

Net: human MCP sessions now make the human's local CLI genuinely *act as* the team agent (with identity, memory rules, and routing discipline) instead of just having access to its memory data.

### Mechanics

- `MemoryAgent.prepareCoreOnly()` — new method, returns the same `BriefingResult` shape with empty archival half. Skips the OpenAI embed + pgvector query when there's no intent to query against.
- `SessionSurfaceKind` extends with `"human_mcp"` — chat-variant lifecycle reminder, skips `CHAT_DIRECTIVES`.
- `buildInstructions` (in `packages/api/src/tools/instructions.ts`) for human callers composes the full stack via `composeSystemPromptAppend({sessionKind: \"human_mcp\", extra: teamRouting})`.
- `mcp.ts` route handler plumbs `deps.agentRepo` to `buildInstructions`.

### Files changed

```
packages/api/src/routes/mcp.ts                          (+1 -1)
packages/api/src/routes/room.ts                         (+11 -12)
packages/api/src/runtime/router.ts                      (+9 -9)
packages/api/src/tools/instructions.ts                  (+39 -19)
packages/api/src/tools/instructions.test.ts             (+120 -27)
packages/core/src/services/memory/memory-agent.ts       (+17)
packages/core/src/services/memory/memory-agent.test.ts  (+35)
packages/core/src/services/spawn-prep.ts                (+50 -53)
packages/core/src/services/spawn-prep.test.ts           (+93 -16)
```

## Test plan

- [x] All five packages typecheck clean (core + api + scheduler + daemon; web has a pre-existing DiceBear module issue from #173 unrelated to this PR)
- [x] `spawn-prep.test.ts` — 18 tests cover three-lane shape, portable framing, stop signal, no chat-grammar leakage, the new \`human_mcp\` session kind, cache-stability ordering
- [x] `memory-agent.test.ts` — 2 new tests cover `prepareCoreOnly` populated and empty-blocks cases; assert no embed/pgvector calls
- [x] `instructions.test.ts` — 4 tests cover agent caller → empty string, human team-tier → full stack, human org-tier → stack without team_routing, missing-agent record fallback
- [x] Existing test suites still pass (agent-session 24/24, scheduler dispatch 3/3, api hierarchy 25/25)
- [ ] Team agent in a chat with zero specialists: lane A works for small asks; lane C proposes a portable specialist for substantive work
- [ ] Team agent in a **task** session: receives the same routing directive
- [ ] Team agent in a room: same three-lane behavior
- [ ] **Human MCP session**: local CLI configured against the team agent receives the full team-chat-flavored prompt; \`search_context\` works for archival retrieval

🤖 Generated with [Claude Code](https://claude.com/claude-code)