### PR TITLE
docs: add Star History chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,3 +181,13 @@ The Beevibe name and logo are project trademarks. Apache 2.0 grants rights
 to the source code; it does not grant rights to use the project's name or
 marks. Forks and derivative works are welcome under names that are not
 "Beevibe."
+
+## Star History
+
+<a href="https://www.star-history.com/?repos=beevibe-ai%2Fbeevibe&type=date&legend=bottom-right">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=beevibe-ai/beevibe&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=beevibe-ai/beevibe&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=beevibe-ai/beevibe&type=date&legend=top-left" />
+ </picture>
+</a>


### PR DESCRIPTION
## Summary

Adds a Star History chart at the bottom of the README so visitors can see growth over time. Standard star-history.com embed with prefers-color-scheme dark/light variants.

## Test plan
- [ ] Chart renders on GitHub README (light + dark modes)
- [ ] Clicking the chart opens the full interactive view on star-history.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)