### PR TITLE
fix(routing): tell team agents to check task state before reporting on it

### DIFF
--- a/packages/core/src/services/spawn-prep.test.ts
+++ b/packages/core/src/services/spawn-prep.test.ts
@@ -55,6 +55,19 @@ describe("teamAgentRoutingDirective", () => {
     const out = teamAgentRoutingDirective(["frontend"]);
     expect(out).not.toContain("<suggest_action");
   });
+
+  it("instructs the agent to check task state via MCP tools before stating progress", () => {
+    // Failure mode this guards against: user (or the agent itself)
+    // refers to a previously-delegated task, agent answers from chat
+    // history or memory without re-checking, gets stale state
+    // ("both still running" when one finished an hour ago). The rule
+    // is firm: call check_work_status or get_task first, never infer.
+    const out = teamAgentRoutingDirective(["frontend"]);
+    expect(out).toContain("Tracking delegated work");
+    expect(out).toContain("mcp__beevibe__check_work_status");
+    expect(out).toContain("mcp__beevibe__get_task");
+    expect(out.toLowerCase()).toContain("never infer");
+  });
 });
 
 describe("composeSystemPromptAppend with extra", () => {

--- a/packages/core/src/services/spawn-prep.ts
+++ b/packages/core/src/services/spawn-prep.ts
@@ -344,6 +344,8 @@ B) **Delegate to one specialist** — when the work is a substantive single-doma
 C) **Propose spawning a specialist** — when the work is substantive single-domain work AND no subordinate fits. Name the gap plainly ("you have X, Y, Z — but nobody owns <domain>"), and recommend a concrete name + cross-project scope for the new specialist.
 
 **Stop signal:** if you find yourself producing a substantial single-domain deliverable yourself (writing real production code, a full design doc, a finished analysis for one domain), you slipped into lane B without realizing — pull back and route.
+
+**Tracking delegated work:** Before stating the status, progress, or completion of any task you previously delegated, call mcp__beevibe__check_work_status or mcp__beevibe__get_task to confirm current state. Never infer from chat history or memory — task state changes asynchronously while you're not looking, and stale assumptions ("both still running" when one finished) are the most common tracking failure.
 </team_agent_routing>`;
 }
 


### PR DESCRIPTION
## Summary

Failure mode this guards against: user assigns two tasks an hour apart in chat. By the time the second one is assigned, the first has often already completed. The team agent — answering from chat history rather than re-checking — reports "both still running." Stale state, wrong answer.

Adds a firm tracking rule to the universal \`<team_agent_routing>\` block:

> **Tracking delegated work:** Before stating the status, progress, or completion of any task you previously delegated, call \`mcp__beevibe__check_work_status\` or \`mcp__beevibe__get_task\` to confirm current state. Never infer from chat history or memory — task state changes asynchronously while you're not looking, and stale assumptions ("both still running" when one finished) are the most common tracking failure.

## Design choice — pure prompt discipline (Proposal 4)

Considered three approaches:

| Approach | Pros | Cons |
|---|---|---|
| Inject \`<delegated_work>\` snapshot in user message prefix every turn (Proposal 1/2) | proactive; agent never has to remember to check | per-chat-turn DB query; new render helper; 50–200 tokens per active task |
| Write task lifecycle events to archival memory (Proposal 3) | uses existing infra | abuses archival (built for durable patterns, not transient state); accumulates indefinitely |
| **Prompt discipline only (Proposal 4)** ✓ | zero infrastructure; zero token cost when nothing's happening; clean upgrade path | depends on agent discipline |

Picked Proposal 4 because the failure mode is bounded — it's a *check before claiming* discipline rule, not a *surface unknown state* problem. The two MCP tools already exist (\`check_work_status\`, \`get_task\`) and are exposed to team agents. The agent just needs to be told *when* to call them.

If behavior drifts in practice, the upgrade path is clean: add the per-turn injection block to the **user message prefix** (alongside \`<archival_memory>\`, since per-turn-volatile content belongs there per M9.4, not in the system prompt). The prompt rule stays useful even with injection added.

## Why team_agent_routing (not chat lifecycle)

Three reasons:

1. **Universal across surfaces** — the directive injects for team agents in chat, task, AND human MCP sessions. All three are places this failure can happen.
2. **Tier-scoped** — only team-tier agents see \`<team_agent_routing>\`. IC agents don't delegate, so the rule doesn't apply to them and shouldn't pollute their prompt.
3. **Adjacent to the delegation rubric** — the block already covers "you delegate work; here's how (lanes A/B/C)." The new rule is just "and once delegated, check before reporting." Cohesive concern in one place.

## Test plan

- [x] All 19 \`spawn-prep.test.ts\` tests pass (18 prior + 1 new asserting the rule wording + named tools)
- [x] Core build + typecheck clean
- [ ] Team agent assigned two tasks an hour apart: when asked status, calls \`check_work_status\` for each rather than inferring
- [ ] Team agent answering "is X done?" cold (no recent context): also calls a status tool first

## Phrasing intent

Soft suggestions ("you may want to check") drift fast. The rule uses imperative form + named tool + "never infer" — model follows this shape more reliably than soft hints. Validated by similar discipline patterns elsewhere in beevibe prompts (the M9.4 lifecycle reminder's "MUST call update_progress" works the same way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)