### PR TITLE
style(web): polish chat working state

### DIFF
--- a/packages/web/app/(authed)/chat/chat-client.tsx
+++ b/packages/web/app/(authed)/chat/chat-client.tsx
@@ -425,21 +425,27 @@ function Bubble({
           ) : null}
         </div>
       ) : null}
-      <div className={cn("flex flex-col max-w-[78%]", isUser ? "items-end" : "items-start")}>
-        <div
-          className={cn(
-            "rounded-2xl px-3.5 py-2",
-            isUser ? "glass-bubble-user" : "glass-bubble-agent",
-          )}
-        >
-          {isUser ? (
+      <div
+        className={cn(
+          "flex flex-col min-w-0",
+          isUser ? "items-end max-w-[68%]" : "items-start max-w-[78%]",
+        )}
+      >
+        {isUser ? (
+          <div className="rounded-2xl px-3.5 py-2 glass-bubble-user">
             <div className="text-sm whitespace-pre-wrap">{message.content}</div>
-          ) : (
+          </div>
+        ) : (
+          <div className="py-1 text-sm leading-6 text-foreground/90">
             <ChatMarkdown content={message.content} inverted={false} />
-          )}
-          {refIds.length > 0 ? <ReferenceCards ids={refIds} /> : null}
-          {message.open_view ? <OpenViewCta open_view={message.open_view} /> : null}
-        </div>
+          </div>
+        )}
+        {!isUser ? (
+          <>
+            {refIds.length > 0 ? <ReferenceCards ids={refIds} /> : null}
+            {message.open_view ? <OpenViewCta open_view={message.open_view} /> : null}
+          </>
+        ) : null}
         {suggestions.length > 0 && onSuggest ? (
           <SuggestedActions actions={suggestions} onPick={onSuggest} />
         ) : null}
@@ -456,14 +462,14 @@ function SuggestedActions({
   onPick: (text: string) => void;
 }) {
   return (
-    <div className="mt-2 flex flex-wrap gap-1.5">
+    <div className="mt-3 flex flex-wrap gap-1.5">
       {actions.map((a) => (
         <button
           key={a.label}
           type="button"
           onClick={() => onPick(a.prompt ?? a.label)}
           title={a.prompt && a.prompt !== a.label ? a.prompt : undefined}
-          className="text-left rounded-md border border-border bg-card hover:bg-secondary hover:border-foreground/30 px-2.5 py-1.5 text-xs text-foreground transition-colors cursor-pointer"
+          className="text-left rounded-full border border-border/50 bg-transparent hover:bg-secondary/45 hover:border-border px-2.5 py-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
         >
           {a.label}
         </button>
@@ -476,7 +482,7 @@ function OpenViewCta({ open_view }: { open_view: { path: string; label?: string 
   return (
     <Link
       href={open_view.path}
-      className="mt-2 inline-flex items-center gap-1.5 rounded-md bg-foreground text-background hover:opacity-90 transition-opacity px-3 py-1.5 text-xs font-medium cursor-pointer"
+      className="mt-2 inline-flex items-center gap-1.5 rounded-full border border-border/50 bg-transparent px-2.5 py-1 text-[11px] font-medium text-muted-foreground hover:text-foreground hover:bg-secondary/45 transition-colors cursor-pointer"
     >
       {open_view.label ?? "Open this"}
       <ArrowRight className="h-3 w-3" />
@@ -514,22 +520,10 @@ function Thinking({
   // breaks. (Pre-streaming, each step was a whole message and we joined
   // with "\n\n"; that's wrong now since deltas are mid-sentence.)
   const streamingText = agentSteps.map((s) => s.content).join("");
-  // Show the latest 8 tool steps. With strong categorization the list
-  // stays scannable; the running pulse on the most recent makes it
-  // clear where the agent is "now."
-  const recentTools = toolSteps.slice(-8);
-
-  // Before any text or tool step lands, hand the reply column over to
-  // the brand orb — single deliberate "agent is starting" moment in
-  // place of three-dot flicker. Once anything arrives we fall back to
-  // the normal avatar + bubble layout.
-  if (!streamingText && recentTools.length === 0) {
-    return (
-      <div className="flex w-full justify-start mt-4 pl-9">
-        <ChatLoader />
-      </div>
-    );
-  }
+  // Keep the working trace to the latest six moves. Anything older
+  // collapses into the "+N earlier moves" row in ToolStepList.
+  const recentTools = toolSteps.slice(-6);
+  const hasWorkingText = streamingText.trim().length > 0;
 
   return (
     <div className="flex w-full justify-start mt-4">
@@ -542,21 +536,28 @@ function Thinking({
           size={28}
         />
       </div>
-      <div className="max-w-[78%] rounded-2xl px-3.5 py-2 glass-bubble-agent">
-        {streamingText ? (
-          <ChatMarkdown content={streamingText} />
+      <div className="max-w-[78%] min-w-0 py-1">
+        {hasWorkingText ? (
+          <div className="text-sm leading-6 text-foreground/90">
+            <ChatMarkdown content={streamingText} />
+          </div>
         ) : (
-          <div className="flex items-center gap-2 text-muted-foreground italic text-sm">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground/80">
             <ChatLoader compact />
-            <span>thinking…</span>
+            <span className="italic">Thinking…</span>
           </div>
         )}
         {recentTools.length > 0 ? (
-          <ToolStepList
-            steps={recentTools}
-            totalSteps={toolSteps.length}
-            withTopBorder={!!streamingText}
-          />
+          <div className={cn(hasWorkingText ? "mt-3" : "mt-2")}>
+            <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground/45">
+              Working
+            </div>
+            <ToolStepList
+              steps={recentTools}
+              totalSteps={toolSteps.length}
+              withTopBorder={hasWorkingText}
+            />
+          </div>
         ) : null}
       </div>
     </div>

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -867,7 +867,7 @@
 .bv-chat-loader {
   /* --bv-loader-s drives every internal dimension via calc(); set it
      once and the whole solid scales. Default 40px works at the empty
-     reply-column entry; compact variant below shrinks to 18px for the
+     reply-column entry; compact variant below shrinks to 16px for the
      inline "thinking…" indicator. */
   --bv-loader-s: 40px;
   display: inline-flex;
@@ -878,7 +878,7 @@
   perspective: calc(var(--bv-loader-s) * 6);
   pointer-events: none;
 }
-.bv-chat-loader.compact { --bv-loader-s: 18px; }
+.bv-chat-loader.compact { --bv-loader-s: 16px; }
 .bv-chat-loader .solid {
   position: relative;
   width: var(--bv-loader-s);
@@ -896,28 +896,28 @@
   transform-origin: 50% 0%;
 }
 /* Top cap — 5 faces meeting at the apex. */
-.bv-chat-loader .side:nth-child(1)  { transform: translateY(calc(var(--bv-loader-s) * -0.0925)) rotateY(72deg)  rotateX(52.62deg); border-bottom-color: rgba(134,   7, 147, 0.4); }
-.bv-chat-loader .side:nth-child(2)  { transform: translateY(calc(var(--bv-loader-s) * -0.0925)) rotateY(144deg) rotateX(52.62deg); border-bottom-color: rgba( 42, 160,  39, 0.4); }
-.bv-chat-loader .side:nth-child(3)  { transform: translateY(calc(var(--bv-loader-s) * -0.0925)) rotateY(216deg) rotateX(52.62deg); border-bottom-color: rgba(209,  83,  84, 0.4); }
-.bv-chat-loader .side:nth-child(4)  { transform: translateY(calc(var(--bv-loader-s) * -0.0925)) rotateY(288deg) rotateX(52.62deg); border-bottom-color: rgba(244, 202, 236, 0.4); }
-.bv-chat-loader .side:nth-child(5)  { transform: translateY(calc(var(--bv-loader-s) * -0.0925)) rotateY(360deg) rotateX(52.62deg); border-bottom-color: rgba( 73, 232, 200, 0.4); }
+.bv-chat-loader .side:nth-child(1)  { transform: translateY(calc(var(--bv-loader-s) * -0.0925)) rotateY(72deg)  rotateX(52.62deg); border-bottom-color: hsl(var(--primary) / 0.52); }
+.bv-chat-loader .side:nth-child(2)  { transform: translateY(calc(var(--bv-loader-s) * -0.0925)) rotateY(144deg) rotateX(52.62deg); border-bottom-color: hsl(211 78% 62% / 0.36); }
+.bv-chat-loader .side:nth-child(3)  { transform: translateY(calc(var(--bv-loader-s) * -0.0925)) rotateY(216deg) rotateX(52.62deg); border-bottom-color: hsl(220 14% 72% / 0.32); }
+.bv-chat-loader .side:nth-child(4)  { transform: translateY(calc(var(--bv-loader-s) * -0.0925)) rotateY(288deg) rotateX(52.62deg); border-bottom-color: hsl(var(--primary) / 0.4); }
+.bv-chat-loader .side:nth-child(5)  { transform: translateY(calc(var(--bv-loader-s) * -0.0925)) rotateY(360deg) rotateX(52.62deg); border-bottom-color: hsl(205 90% 72% / 0.3); }
 /* Bottom cap — mirrored 5 faces. */
-.bv-chat-loader .side:nth-child(6)  { transform: translateY(calc(var(--bv-loader-s) * 1.809)) rotateY(468deg) rotateX(127.38deg); border-bottom-color: rgba(105,  77,   3, 0.4); }
-.bv-chat-loader .side:nth-child(7)  { transform: translateY(calc(var(--bv-loader-s) * 1.809)) rotateY(540deg) rotateX(127.38deg); border-bottom-color: rgba(255,  45,  71, 0.4); }
-.bv-chat-loader .side:nth-child(8)  { transform: translateY(calc(var(--bv-loader-s) * 1.809)) rotateY(612deg) rotateX(127.38deg); border-bottom-color: rgba(177, 172,   3, 0.4); }
-.bv-chat-loader .side:nth-child(9)  { transform: translateY(calc(var(--bv-loader-s) * 1.809)) rotateY(684deg) rotateX(127.38deg); border-bottom-color: rgba(175, 200, 228, 0.4); }
-.bv-chat-loader .side:nth-child(10) { transform: translateY(calc(var(--bv-loader-s) * 1.809)) rotateY(756deg) rotateX(127.38deg); border-bottom-color: rgba(187, 195, 141, 0.4); }
+.bv-chat-loader .side:nth-child(6)  { transform: translateY(calc(var(--bv-loader-s) * 1.809)) rotateY(468deg) rotateX(127.38deg); border-bottom-color: hsl(38 92% 42% / 0.34); }
+.bv-chat-loader .side:nth-child(7)  { transform: translateY(calc(var(--bv-loader-s) * 1.809)) rotateY(540deg) rotateX(127.38deg); border-bottom-color: hsl(211 78% 62% / 0.28); }
+.bv-chat-loader .side:nth-child(8)  { transform: translateY(calc(var(--bv-loader-s) * 1.809)) rotateY(612deg) rotateX(127.38deg); border-bottom-color: hsl(var(--primary) / 0.42); }
+.bv-chat-loader .side:nth-child(9)  { transform: translateY(calc(var(--bv-loader-s) * 1.809)) rotateY(684deg) rotateX(127.38deg); border-bottom-color: hsl(220 14% 72% / 0.28); }
+.bv-chat-loader .side:nth-child(10) { transform: translateY(calc(var(--bv-loader-s) * 1.809)) rotateY(756deg) rotateX(127.38deg); border-bottom-color: hsl(205 90% 72% / 0.26); }
 /* Equator band — 5 upward + 5 downward triangles. */
-.bv-chat-loader .side:nth-child(11) { transform: translateY(calc(var(--bv-loader-s) * 0.433))  rotateY(828deg)  translateZ(calc(var(--bv-loader-s) * 0.8505)) rotateX(-10.81deg); border-bottom-color: rgba(212, 249,   1, 0.4); }
-.bv-chat-loader .side:nth-child(12) { transform: translateY(calc(var(--bv-loader-s) * 0.433))  rotateY(900deg)  translateZ(calc(var(--bv-loader-s) * 0.8505)) rotateX(-10.81deg); border-bottom-color: rgba( 85, 161,  43, 0.4); }
-.bv-chat-loader .side:nth-child(13) { transform: translateY(calc(var(--bv-loader-s) * 0.433))  rotateY(972deg)  translateZ(calc(var(--bv-loader-s) * 0.8505)) rotateX(-10.81deg); border-bottom-color: rgba( 15, 209,  47, 0.4); }
-.bv-chat-loader .side:nth-child(14) { transform: translateY(calc(var(--bv-loader-s) * 0.433))  rotateY(1044deg) translateZ(calc(var(--bv-loader-s) * 0.8505)) rotateX(-10.81deg); border-bottom-color: rgba(131,  69,  22, 0.4); }
-.bv-chat-loader .side:nth-child(15) { transform: translateY(calc(var(--bv-loader-s) * 0.433))  rotateY(1116deg) translateZ(calc(var(--bv-loader-s) * 0.8505)) rotateX(-10.81deg); border-bottom-color: rgba( 43,  13, 170, 0.4); }
-.bv-chat-loader .side:nth-child(16) { transform: translateY(calc(var(--bv-loader-s) * 1.2835)) rotateY(1152deg) rotateZ(180deg) translateZ(calc(var(--bv-loader-s) * 0.8505)) rotateX(-10.81deg); border-bottom-color: rgba( 68,  85,  95, 0.4); }
-.bv-chat-loader .side:nth-child(17) { transform: translateY(calc(var(--bv-loader-s) * 1.2835)) rotateY(1224deg) rotateZ(180deg) translateZ(calc(var(--bv-loader-s) * 0.8505)) rotateX(-10.81deg); border-bottom-color: rgba(159,  76, 176, 0.4); }
-.bv-chat-loader .side:nth-child(18) { transform: translateY(calc(var(--bv-loader-s) * 1.2835)) rotateY(1296deg) rotateZ(180deg) translateZ(calc(var(--bv-loader-s) * 0.8505)) rotateX(-10.81deg); border-bottom-color: rgba( 54,  95, 172, 0.4); }
-.bv-chat-loader .side:nth-child(19) { transform: translateY(calc(var(--bv-loader-s) * 1.2835)) rotateY(1368deg) rotateZ(180deg) translateZ(calc(var(--bv-loader-s) * 0.8505)) rotateX(-10.81deg); border-bottom-color: rgba(162,  92, 204, 0.4); }
-.bv-chat-loader .side:nth-child(20) { transform: translateY(calc(var(--bv-loader-s) * 1.2835)) rotateY(1440deg) rotateZ(180deg) translateZ(calc(var(--bv-loader-s) * 0.8505)) rotateX(-10.81deg); border-bottom-color: rgba(218,   1, 139, 0.4); }
+.bv-chat-loader .side:nth-child(11) { transform: translateY(calc(var(--bv-loader-s) * 0.433))  rotateY(828deg)  translateZ(calc(var(--bv-loader-s) * 0.8505)) rotateX(-10.81deg); border-bottom-color: hsl(var(--primary) / 0.5); }
+.bv-chat-loader .side:nth-child(12) { transform: translateY(calc(var(--bv-loader-s) * 0.433))  rotateY(900deg)  translateZ(calc(var(--bv-loader-s) * 0.8505)) rotateX(-10.81deg); border-bottom-color: hsl(211 78% 62% / 0.3); }
+.bv-chat-loader .side:nth-child(13) { transform: translateY(calc(var(--bv-loader-s) * 0.433))  rotateY(972deg)  translateZ(calc(var(--bv-loader-s) * 0.8505)) rotateX(-10.81deg); border-bottom-color: hsl(220 14% 72% / 0.3); }
+.bv-chat-loader .side:nth-child(14) { transform: translateY(calc(var(--bv-loader-s) * 0.433))  rotateY(1044deg) translateZ(calc(var(--bv-loader-s) * 0.8505)) rotateX(-10.81deg); border-bottom-color: hsl(38 92% 42% / 0.34); }
+.bv-chat-loader .side:nth-child(15) { transform: translateY(calc(var(--bv-loader-s) * 0.433))  rotateY(1116deg) translateZ(calc(var(--bv-loader-s) * 0.8505)) rotateX(-10.81deg); border-bottom-color: hsl(205 90% 72% / 0.26); }
+.bv-chat-loader .side:nth-child(16) { transform: translateY(calc(var(--bv-loader-s) * 1.2835)) rotateY(1152deg) rotateZ(180deg) translateZ(calc(var(--bv-loader-s) * 0.8505)) rotateX(-10.81deg); border-bottom-color: hsl(220 14% 72% / 0.28); }
+.bv-chat-loader .side:nth-child(17) { transform: translateY(calc(var(--bv-loader-s) * 1.2835)) rotateY(1224deg) rotateZ(180deg) translateZ(calc(var(--bv-loader-s) * 0.8505)) rotateX(-10.81deg); border-bottom-color: hsl(var(--primary) / 0.42); }
+.bv-chat-loader .side:nth-child(18) { transform: translateY(calc(var(--bv-loader-s) * 1.2835)) rotateY(1296deg) rotateZ(180deg) translateZ(calc(var(--bv-loader-s) * 0.8505)) rotateX(-10.81deg); border-bottom-color: hsl(211 78% 62% / 0.28); }
+.bv-chat-loader .side:nth-child(19) { transform: translateY(calc(var(--bv-loader-s) * 1.2835)) rotateY(1368deg) rotateZ(180deg) translateZ(calc(var(--bv-loader-s) * 0.8505)) rotateX(-10.81deg); border-bottom-color: hsl(38 92% 42% / 0.3); }
+.bv-chat-loader .side:nth-child(20) { transform: translateY(calc(var(--bv-loader-s) * 1.2835)) rotateY(1440deg) rotateZ(180deg) translateZ(calc(var(--bv-loader-s) * 0.8505)) rotateX(-10.81deg); border-bottom-color: hsl(205 90% 72% / 0.24); }
 @keyframes bv-solid-spin {
   0%   { transform: rotateX(0deg)   rotateY(0deg)   rotateZ(0deg); }
   100% { transform: rotateX(360deg) rotateY(720deg) rotateZ(1080deg); }

--- a/packages/web/components/chat/tool-step-list.tsx
+++ b/packages/web/components/chat/tool-step-list.tsx
@@ -18,8 +18,8 @@ import { cn } from "@/lib/utils";
  * tool_call — errors use a destructive accent so a failing tool no
  * longer looks like a silent success.
  *
- * The latest step pulses to draw the eye to "now". Older steps are
- * rolled into a "+N earlier steps" line so the list stays scannable.
+ * Older steps are rolled into a "+N earlier moves" line so the list
+ * stays scannable.
  */
 export function ToolStepList({
   steps,
@@ -33,8 +33,8 @@ export function ToolStepList({
   return (
     <ul
       className={cn(
-        "space-y-1 text-[11px]",
-        withTopBorder ? "mt-2 pt-2 border-t border-border/60" : "mt-1",
+        "space-y-0.5 text-[11px]",
+        withTopBorder ? "mt-3 pt-2 border-t border-border/45" : "mt-1.5",
       )}
     >
       {steps.map((step, idx) => {
@@ -45,8 +45,8 @@ export function ToolStepList({
         return <CallRow key={step.event_id} step={step} isLatest={isLatest} />;
       })}
       {totalSteps > steps.length ? (
-        <li className="text-[10px] text-muted-foreground/70 pl-5">
-          + {totalSteps - steps.length} earlier step{totalSteps - steps.length === 1 ? "" : "s"}
+        <li className="text-[10px] text-muted-foreground/50 pl-5 pt-0.5">
+          + {totalSteps - steps.length} earlier move{totalSteps - steps.length === 1 ? "" : "s"}
         </li>
       ) : null}
     </ul>
@@ -56,21 +56,21 @@ export function ToolStepList({
 function CallRow({ step, isLatest }: { step: ChatStreamStep; isLatest: boolean }) {
   const display = formatTool(step.tool_name, step.content);
   return (
-    <li className="flex items-start gap-1.5">
+    <li className="flex items-center gap-1.5 text-muted-foreground/80">
       <span
         className={cn(
-          "shrink-0 inline-flex items-center justify-center h-4 w-4 rounded",
+          "shrink-0 inline-flex items-center justify-center h-4 w-4 rounded opacity-70",
           categoryAccent(display.category),
-          isLatest && "animate-pulse-breathe",
+          isLatest && "opacity-100",
         )}
       >
         <display.icon className="h-2.5 w-2.5" />
       </span>
-      <div className="flex-1 min-w-0 leading-tight">
+      <div className="flex-1 min-w-0 leading-4">
         <div className="flex items-baseline gap-1.5">
-          <span className="font-medium text-foreground/85 shrink-0">{display.label}</span>
+          <span className="text-foreground/70 shrink-0">{display.label}</span>
           {display.detail ? (
-            <span className="text-muted-foreground truncate min-w-0">{display.detail}</span>
+            <span className="text-muted-foreground/60 truncate min-w-0">{display.detail}</span>
           ) : null}
         </div>
       </div>
@@ -85,21 +85,21 @@ function ResultRow({ step, isLatest }: { step: ChatStreamStep; isLatest: boolean
   const text = isError ? step.content.slice("[error] ".length) : step.content;
   const Icon = isError ? AlertCircle : CornerDownRight;
   return (
-    <li className="flex items-start gap-1.5 pl-3">
+    <li className="flex items-center gap-1.5 pl-3">
       <span
         className={cn(
           "shrink-0 inline-flex items-center justify-center h-4 w-4",
-          isError ? "text-destructive" : "text-muted-foreground/60",
-          isLatest && "animate-pulse-breathe",
+          isError ? "text-destructive" : "text-muted-foreground/40",
+          isLatest && "text-muted-foreground/70",
         )}
       >
         <Icon className="h-2.5 w-2.5" />
       </span>
-      <div className="flex-1 min-w-0 leading-tight">
+      <div className="flex-1 min-w-0 leading-4">
         <span
           className={cn(
             "truncate min-w-0 block",
-            isError ? "text-destructive/90" : "text-muted-foreground italic",
+            isError ? "text-destructive/90" : "text-muted-foreground/50",
           )}
         >
           {text || (isError ? "tool error" : "result")}

--- a/packages/web/lib/tool-format.ts
+++ b/packages/web/lib/tool-format.ts
@@ -36,6 +36,34 @@ export interface ToolDisplay {
   icon: LucideIcon;
 }
 
+const MCP_PREFIX_RE = /^mcp__[^_]+__/;
+const TASK_ID_RE = /\btask_[A-Za-z0-9_-]+\b/g;
+
+function normalizeToolName(toolName: string | undefined): string {
+  return (toolName ?? "").trim().replace(MCP_PREFIX_RE, "");
+}
+
+function cleanToolDetail(content: string): string {
+  const detail = content
+    .trim()
+    .replace(/mcp__[^_]+__/g, "")
+    .replace(/select:/gi, "selected ")
+    .replace(TASK_ID_RE, "task")
+    .replace(/,/g, ", ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (detail.toLowerCase().startsWith("selected ")) return detail.replace(/_/g, " ");
+  return detail;
+}
+
+function fallbackLabel(toolName: string): string {
+  return toolName
+    .replace(MCP_PREFIX_RE, "")
+    .replace(/_/g, " ")
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .trim() || "step";
+}
+
 /**
  * Map a streamed tool-call event to a chat-friendly display: an
  * imperative verb ("asked", "saved a memory", "Read"), the most
@@ -47,8 +75,13 @@ export interface ToolDisplay {
  * by stream-json's describeToolInput); we just polish the surface.
  */
 export function formatTool(toolName: string | undefined, content: string): ToolDisplay {
-  const name = (toolName ?? "").trim();
-  const detail = content.trim();
+  const rawName = (toolName ?? "").trim();
+  const name = normalizeToolName(toolName);
+  const detail = cleanToolDetail(content);
+
+  if (rawName === "ToolSearch") {
+    return { label: "Selected tools", detail, category: "other", icon: Wrench };
+  }
 
   // ── Mesh: agent-to-agent collaboration (the "team" pitch moments) ──
   if (name === "ask") {
@@ -121,7 +154,7 @@ export function formatTool(toolName: string | undefined, content: string): ToolD
 
   // Unknown / future tool — fall back to verbatim name.
   return {
-    label: name || "step",
+    label: fallbackLabel(name || rawName),
     detail,
     category: "other",
     icon: Wrench,


### PR DESCRIPTION
## Summary
- drop the agent-side message bubble so final replies read like transcript text
- quiet open-view/suggested-action directives into subtle chips
- unify the in-flight thinking state with a small loader and latest six moves
- normalize MCP tool names/details so the trace says things like "Checked work status" instead of raw mcp names
- retheme the icosahedron loader to honey/blue/slate instead of random purple/green faces

Fixes #172

## Verification
- pnpm --filter @beevibe/web typecheck
- pnpm --filter @beevibe/web lint
- pnpm --filter @beevibe/web build