### PR TITLE
fix(skills): pre-task-setup defaults to one clone + per-task branch

### DIFF
--- a/skills/beevibe-pre-task-setup/SKILL.md
+++ b/skills/beevibe-pre-task-setup/SKILL.md
@@ -4,21 +4,23 @@ description: >
   Cold-start git workspace setup for a fresh beevibe task. Use at the start
   of a session whose intent has a `<task>` block but NO `<context
   type="revision">` or `<context type="post_escalation">` block — i.e. the
-  first dispatch of this task. Checks for an existing repo clone, pulls
-  the base branch if present (clone if missing), and creates a fresh
-  worktree per task on a dedicated branch. Do NOT use on a resumed session
-  — the executor passes `--resume` to Claude Code on revisions, so your
-  prior turn's `cd` and worktree state are already in your conversation
-  history; just continue. Do NOT work directly in the base clone — that
-  stays on the default branch for easy pulls and is shared across tasks.
-  Use only when running as a beevibe agent.
+  first dispatch of this task. Clones the repo on first use, then for every
+  subsequent task pulls the default branch and starts a per-task branch
+  IN PLACE in the same clone. One directory per repo, never per task — old
+  per-task branches stay as branches (cheap), not as full working-tree
+  copies (expensive, clutter the workspace). Falls back to a per-task
+  worktree only when a sibling session is already using the clone. Do NOT
+  use on a resumed session — the executor passes `--resume`, so your prior
+  turn's `cd` and branch state are already in your conversation history;
+  just continue (see "Resumed sessions" below for the one branch-restore
+  edge case).
 ---
 
 # Pre-Task Setup
 
 ## When this fires
 
-Every session that starts with a `<task id="..."/>` intent block. The session lifecycle (per the `beevibe` umbrella) requires you to set up your worktree before doing any work.
+Every session that starts with a `<task id="..."/>` intent block. The session lifecycle (per the `beevibe` umbrella) requires you to be on a fresh task branch in the repo before doing any work.
 
 ## The protocol
 
@@ -33,43 +35,62 @@ If `task.repo_url` is null:
 
 ### 2. Check for existing clone
 
-Your cwd is the workspace root (`~/.beevibe/workspaces/<your_agent_id>/`). The base clone lives at `<repo_name>/`:
+Your cwd is the workspace root (`~/.beevibe/workspaces/<your_agent_id>/`). The clone lives at `<repo_name>/`:
 
 ```bash
 ls <repo_name>/.git/HEAD 2>/dev/null && echo "EXISTS" || echo "MISSING"
 ```
 
-### 3. Clone or pull
+### 3. Clone or refresh, then branch in place
 
-- **If missing**: `git clone <task.repo_url>`
-- **If present**: `cd <repo_name> && git fetch && git pull origin <default_branch>` to refresh the base
-
-### 4. Create a fresh worktree
-
-Always create a NEW worktree per task — never work in the base clone:
+`<task_id_short>` = first ~8 chars of `task.id`. Branch name `agent/<task_id_short>` is what shows in `git branch -a` and on any PR.
 
 ```bash
+# Clone if missing.
+[ -d <repo_name>/.git ] || git clone <task.repo_url>
 cd <repo_name>
-git worktree add ./../<repo_name>-<task_id_short> -b agent/<task_id_short>
-cd ./../<repo_name>-<task_id_short>
+
+# Refresh the default branch and start the task branch in place.
+git fetch origin
+if git checkout <default_branch> 2>/dev/null && git pull --ff-only; then
+  # Clone is idle — branch off in place, no extra dir.
+  git checkout -b agent/<task_id_short> 2>/dev/null || git checkout agent/<task_id_short>
+else
+  # Couldn't claim the clone (a sibling task session has uncommitted
+  # work or is on a non-default branch). Fall back to an isolated
+  # worktree for this task only.
+  git worktree add ./../<repo_name>-<task_id_short> -b agent/<task_id_short>
+  cd ./../<repo_name>-<task_id_short>
+fi
 ```
 
-`<task_id_short>` is the first ~8 chars of `task.id`. The branch name `agent/<task_id_short>` makes it obvious in `git branch -a` who created the branch.
+### 4. Now do the work
 
-### 5. Now do the work
+You're on `agent/<task_id_short>` either in the shared clone or (in the rare concurrency case) in your own worktree. Make changes, commit, push the branch, open a PR — all from your current directory.
 
-You're now in a clean per-task worktree. Make changes, commit them, push the branch, open a PR — all inside this directory.
+When you're done, leave the branch alone. The next task will branch off the default again. Old `agent/<...>` branches stay locally and on origin for history; they don't fork the working tree.
 
-## Why a separate worktree
+## Why one clone, not one worktree per task
 
-- **Concurrent tasks**: each task gets its own worktree, so `max_task_sessions > 1` works without contention
-- **Clean base**: the base clone stays on the default branch for easy pulls
-- **Easy reset**: if something goes wrong, just delete the worktree and re-create
+The earlier design — `git worktree add ./../<repo>-<task_id_short>` on every task — accumulated `<repo>`, `<repo>-AAAA1234`, `<repo>-BBBB5678`, … one full working-tree copy per task, never reclaimed. On a busy agent that's dozens of duplicated project folders.
+
+Branches are the right primitive for "isolate this task's commits." Worktrees are the right primitive for "two task sessions need a separate working tree at the same time." Default `max_task_sessions = 1` means almost no agent ever has the second problem; serving the first with branches alone is enough.
+
+The worktree fallback in step 3 covers the rare concurrent case without polluting the steady state.
 
 ## Resumed sessions are NOT this skill
 
-If your spawn intent contains `<context type="revision">` or `<context type="post_escalation">`, the executor used `--resume` to spawn you, so your prior turn's `cd <worktree>` and tool calls are already in your conversation history. Don't re-clone, don't re-worktree, don't re-invoke this skill — just continue from where you left off.
+If your spawn intent contains `<context type="revision">` or `<context type="post_escalation">`, the executor used `--resume` to spawn you. Your prior turn's `cd <repo>` and commits are in your conversation history — don't re-clone, don't re-branch, don't re-invoke this skill.
+
+**One edge case to handle:** if you originally branched in place (no worktree fallback) and a different task ran between your turns, the shared clone may now be on a different branch. Before continuing your work, restore yours:
+
+```bash
+cd <repo_name>
+git checkout agent/<your_task_id_short>
+```
+
+If your prior turn fell back to a worktree (`<repo>-<your_task_id_short>/`), it's still there; cd into it as before.
 
 ## Non-code tasks
 
-If the task is research/drafting/etc. with no `repo_url`, this skill mostly doesn't apply. You can work directly in your workspace dir without a worktree. When you produce a deliverable, follow the deliverable-handling rule in your `<beevibe_lifecycle>` reminder (call `list_work_products(task_id)` first to dedupe, then `create_work_product` or `update_work_product`).
+If the task is research/drafting/etc. with no `repo_url`, this skill mostly doesn't apply. You can work directly in your workspace dir without cloning. When you produce a deliverable, follow the deliverable-handling rule in your `<beevibe_lifecycle>` reminder (call `list_work_products(task_id)` first to dedupe, then `create_work_product` or `update_work_product`).

--- a/skills/beevibe-pre-task-setup/SKILL.md
+++ b/skills/beevibe-pre-task-setup/SKILL.md
@@ -3,17 +3,11 @@ name: beevibe-pre-task-setup
 description: >
   Cold-start git workspace setup for a fresh beevibe task. Use at the start
   of a session whose intent has a `<task>` block but NO `<context
-  type="revision">` or `<context type="post_escalation">` block — i.e. the
-  first dispatch of this task. Clones the repo on first use, then for every
-  subsequent task pulls the default branch and starts a per-task branch
-  IN PLACE in the same clone. One directory per repo, never per task — old
-  per-task branches stay as branches (cheap), not as full working-tree
-  copies (expensive, clutter the workspace). Falls back to a per-task
+  type="revision">` or `<context type="post_escalation">` block. Clones the
+  repo on first use; on every subsequent task refreshes the default branch
+  and starts a per-task branch in place in the same clone. Falls back to a
   worktree only when a sibling session is already using the clone. Do NOT
-  use on a resumed session — the executor passes `--resume`, so your prior
-  turn's `cd` and branch state are already in your conversation history;
-  just continue (see "Resumed sessions" below for the one branch-restore
-  edge case).
+  use on a resumed session.
 ---
 
 # Pre-Task Setup
@@ -70,26 +64,18 @@ You're on `agent/<task_id_short>` either in the shared clone or (in the rare con
 
 When you're done, leave the branch alone. The next task will branch off the default again. Old `agent/<...>` branches stay locally and on origin for history; they don't fork the working tree.
 
-## Why one clone, not one worktree per task
+## Resumed sessions
 
-The earlier design — `git worktree add ./../<repo>-<task_id_short>` on every task — accumulated `<repo>`, `<repo>-AAAA1234`, `<repo>-BBBB5678`, … one full working-tree copy per task, never reclaimed. On a busy agent that's dozens of duplicated project folders.
+`<context type="revision">` / `<context type="post_escalation">` spawns use `--resume` — your prior turn's `cd` and commits are in your conversation history, so don't re-clone or re-branch.
 
-Branches are the right primitive for "isolate this task's commits." Worktrees are the right primitive for "two task sessions need a separate working tree at the same time." Default `max_task_sessions = 1` means almost no agent ever has the second problem; serving the first with branches alone is enough.
-
-The worktree fallback in step 3 covers the rare concurrent case without polluting the steady state.
-
-## Resumed sessions are NOT this skill
-
-If your spawn intent contains `<context type="revision">` or `<context type="post_escalation">`, the executor used `--resume` to spawn you. Your prior turn's `cd <repo>` and commits are in your conversation history — don't re-clone, don't re-branch, don't re-invoke this skill.
-
-**One edge case to handle:** if you originally branched in place (no worktree fallback) and a different task ran between your turns, the shared clone may now be on a different branch. Before continuing your work, restore yours:
+Edge case: if you branched in place (no worktree fallback) and a different task ran between turns, the shared clone may now be on a different branch. Restore yours first:
 
 ```bash
 cd <repo_name>
 git checkout agent/<your_task_id_short>
 ```
 
-If your prior turn fell back to a worktree (`<repo>-<your_task_id_short>/`), it's still there; cd into it as before.
+If your prior turn fell back to a worktree (`<repo>-<your_task_id_short>/`), it's still there — cd into it as before.
 
 ## Non-code tasks
 


### PR DESCRIPTION
## Summary

- The `beevibe-pre-task-setup` skill used to instruct agents to `git worktree add` a fresh sibling dir per task. On an agent with many sequential tasks this accumulates `<repo>`, `<repo>-AAAA1234`, `<repo>-BBBB5678`, … — one full working-tree copy per task, never reclaimed. User-reported clutter in the agent workspace.
- Default `max_task_sessions = 1` means agents almost never need a second working tree at the same time; a per-task branch in the shared clone isolates commits just as well.
- Skill now branches in place by default and only falls back to a per-task worktree when the clone is genuinely busy (sibling session has uncommitted state on a non-default branch). Resume guidance adds a one-line branch-restore for the edge case where another task ran between turns.

## Behavior change

Before:
```bash
cd <repo>
git worktree add ./../<repo>-<task_id_short> -b agent/<task_id_short>
cd ./../<repo>-<task_id_short>
```
Result: one new sibling dir per task, forever.

After:
```bash
cd <repo>
git fetch origin
if git checkout <default_branch> && git pull --ff-only; then
  git checkout -b agent/<task_id_short>
else
  # Sibling session is busy in the clone — isolate with a worktree.
  git worktree add ./../<repo>-<task_id_short> -b agent/<task_id_short>
  cd ./../<repo>-<task_id_short>
fi
```
Result: one clone, branches accumulate locally (cheap), worktree only when needed.

## Propagation

Daemons re-sync the skill bundle on the next workspace ensure (`readSkills` is content-hashed in `packages/api/src/runtime/router.ts:562-573`). No daemon restart needed.

## Cleanup (optional, manual)

Existing `<repo>-<task_id_short>/` worktree dirs in users' workspaces are inert under the new skill — nothing references them. They can be reclaimed at the user's discretion:
```bash
cd ~/.beevibe/workspaces/<agent_id>/<repo>
for wt in $(git worktree list --porcelain | awk '/^worktree/ && $2 ~ /-[a-z0-9]{6,}$/ {print $2}'); do
  git worktree remove --force "$wt"
done
```

## Test plan

- [x] `pnpm --filter @beevibe/core build` green
- [x] `pnpm --filter @beevibe/core test -- --run manager.test.ts` — 24/24 pass (universal-tier skill still listed)
- [ ] Manual: trigger a fresh task on an agent with `repo_url` set; confirm work happens in `<repo>/` on `agent/<task_id>` with no new sibling dir
- [ ] Manual: trigger two tasks in parallel on a `max_task_sessions = 2` agent; confirm second falls back to a worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)