### PR TITLE
fix(skills): pre-task-setup prunes landed worktrees before adding a new one

### DIFF
--- a/skills/beevibe-pre-task-setup/SKILL.md
+++ b/skills/beevibe-pre-task-setup/SKILL.md
@@ -5,13 +5,15 @@ description: >
   of a session whose intent has a `<task>` block but NO `<context
   type="revision">` or `<context type="post_escalation">` block — i.e. the
   first dispatch of this task. Checks for an existing repo clone, pulls
-  the base branch if present (clone if missing), and creates a fresh
-  worktree per task on a dedicated branch. Do NOT use on a resumed session
-  — the executor passes `--resume` to Claude Code on revisions, so your
-  prior turn's `cd` and worktree state are already in your conversation
-  history; just continue. Do NOT work directly in the base clone — that
-  stays on the default branch for easy pulls and is shared across tasks.
-  Use only when running as a beevibe agent.
+  the base branch if present (clone if missing), prunes any per-task
+  worktrees from earlier tasks whose work has already landed on the
+  default branch, and creates a fresh worktree for this task on a
+  dedicated branch. Do NOT use on a resumed session — the executor passes
+  `--resume` to Claude Code on revisions, so your prior turn's `cd` and
+  worktree state are already in your conversation history; just continue.
+  Do NOT work directly in the base clone — that stays on the default
+  branch for easy pulls and is shared across tasks. Use only when running
+  as a beevibe agent.
 ---
 
 # Pre-Task Setup
@@ -42,11 +44,38 @@ ls <repo_name>/.git/HEAD 2>/dev/null && echo "EXISTS" || echo "MISSING"
 ### 3. Clone or pull
 
 - **If missing**: `git clone <task.repo_url>`
-- **If present**: `cd <repo_name> && git fetch && git pull origin <default_branch>` to refresh the base
+- **If present**: refresh the base:
+  ```bash
+  cd <repo_name>
+  git fetch --prune origin
+  git checkout <default_branch>
+  git pull --ff-only
+  ```
 
-### 4. Create a fresh worktree
+### 4. Prune landed worktrees from earlier tasks
 
-Always create a NEW worktree per task — never work in the base clone:
+Before adding a new worktree, reclaim sibling `<repo_name>-<task_id_short>` dirs from earlier tasks whose work has already landed on `origin/<default_branch>`. `git cherry` compares by patch-id, so this catches both merge-commit and squash-merge cases:
+
+```bash
+# Run from inside <repo_name>/ (the base clone).
+for wt in $(git worktree list --porcelain | awk '/^worktree/ {print $2}'); do
+  branch=$(git -C "$wt" symbolic-ref --short HEAD 2>/dev/null || echo "")
+  case "$branch" in
+    agent/*)
+      # 0 unmerged commits → all work already on the default branch → safe to remove.
+      if [ "$(git cherry origin/<default_branch> "$branch" 2>/dev/null | grep -c '^+')" = "0" ]; then
+        git worktree remove "$wt" 2>/dev/null && git branch -D "$branch" 2>/dev/null
+      fi
+      ;;
+  esac
+done
+```
+
+Worktrees with uncommitted state or unmerged commits stay — those may be pending revision or post-escalation. No `--force` here on purpose: if `git worktree remove` refuses, the worktree was still doing something useful.
+
+### 5. Create a fresh worktree
+
+Always create a NEW worktree for this task — never work in the base clone:
 
 ```bash
 cd <repo_name>
@@ -56,15 +85,15 @@ cd ./../<repo_name>-<task_id_short>
 
 `<task_id_short>` is the first ~8 chars of `task.id`. The branch name `agent/<task_id_short>` makes it obvious in `git branch -a` who created the branch.
 
-### 5. Now do the work
+### 6. Now do the work
 
 You're now in a clean per-task worktree. Make changes, commit them, push the branch, open a PR — all inside this directory.
 
-## Why a separate worktree
+## Why a separate worktree (with pruning)
 
 - **Concurrent tasks**: each task gets its own worktree, so `max_task_sessions > 1` works without contention
 - **Clean base**: the base clone stays on the default branch for easy pulls
-- **Easy reset**: if something goes wrong, just delete the worktree and re-create
+- **No accumulation**: step 4 reclaims dirs from tasks whose PRs are merged, so the workspace doesn't pile up `<repo>-AAAA1234`, `<repo>-BBBB5678`, … over time
 
 ## Resumed sessions are NOT this skill
 


### PR DESCRIPTION
## Summary

- The `beevibe-pre-task-setup` skill creates one worktree per task — `<repo>-<task_id_short>` — and never reclaims them. A busy agent's workspace accumulates dozens of near-identical project folders (`multica`, `multica-AAAA1234`, `multica-BBBB5678`, …).
- Keep the worktree-per-task model — it's what makes `max_task_sessions > 1` work without contention, and avoids the branch-switching headaches of [#181](https://github.com/beevibe-ai/beevibe/pull/181) (closed in favor of this).
- Add a prune step before creating the new worktree: walk `git worktree list`, and for any worktree on an `agent/<...>` branch where `git cherry origin/<default> <branch>` reports zero unmerged commits, `git worktree remove` it. `git cherry` compares by patch-id, so this catches both merge-commits and squash-merges.

## Behavior

Inserted as step 4, between "Clone or pull" and "Create a fresh worktree":

```bash
for wt in $(git worktree list --porcelain | awk '/^worktree/ {print $2}'); do
  branch=$(git -C "$wt" symbolic-ref --short HEAD 2>/dev/null || echo "")
  case "$branch" in
    agent/*)
      if [ "$(git cherry origin/<default_branch> "$branch" 2>/dev/null | grep -c '^+')" = "0" ]; then
        git worktree remove "$wt" 2>/dev/null && git branch -D "$branch" 2>/dev/null
      fi
      ;;
  esac
done
```

**Safety:** no `--force` on `git worktree remove`. If the worktree has uncommitted state OR `git cherry` shows any `+` lines (unmerged commits), the worktree stays — it may be pending revision or post-escalation.

**Origin:** mirrors Claude Code's Agent tool `isolation: "worktree"` semantics, which auto-clean a subagent's worktree when the agent didn't change anything. Beevibe's persistent-workspace model means cleanup has to happen explicitly on next session entry rather than at subagent exit.

## Propagation

Daemons re-sync the skill bundle on the next workspace ensure — `readSkills` content-hashes the bundle (`packages/api/src/runtime/router.ts:562`). No daemon restart needed.

## Cleanup of legacy stale worktrees (one-shot, optional)

Existing dirs that pre-date this skill version will be reclaimed by step 4 the next time the affected agent fires a task, as long as their branches' commits are on `origin/<default>`. If the user wants to reclaim them immediately without waiting for the next dispatch, the same loop works as a one-off:

```bash
cd ~/.beevibe/workspaces/<agent_id>/<repo>
git fetch --prune origin
# run the step-4 loop here
```

## Test plan

- [x] `pnpm --filter @beevibe/core build` green
- [x] `pnpm --filter @beevibe/core test -- --run manager.test.ts` — 24/24 pass (universal-tier skill still listed)
- [ ] Manual: agent with merged worktree from a prior task fires a new task; confirm the old `<repo>-<old_id>/` is reclaimed before `<repo>-<new_id>/` is created
- [ ] Manual: agent with unmerged worktree (in-flight task) fires a new task; confirm the old worktree is NOT touched

Closes #181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)