### PR TITLE
chore: type SessionRow.deleted_at + drop runtime/register success log

### DIFF
--- a/packages/api/src/runtime/router.ts
+++ b/packages/api/src/runtime/router.ts
@@ -386,9 +386,6 @@ async function maybeAutoBindPrimaryAgent(
     const primary = await deps.agentRepo.findTopLevelForOwner(ownerPersonId);
     if (!primary || primary.preferred_runtime_id) return;
     await deps.agentRepo.update(primary.id, { preferred_runtime_id: runtimeId });
-    console.log(
-      `[runtime/register] auto-bound agent ${primary.id} → runtime ${runtimeId}`,
-    );
   } catch (err) {
     console.warn(
       "[runtime/register] auto-bind failed (non-fatal):",

--- a/packages/core/src/adapters/postgres/row-types.ts
+++ b/packages/core/src/adapters/postgres/row-types.ts
@@ -74,6 +74,7 @@ export interface SessionRow {
   started_at: Date | null;
   completed_at: Date | null;
   created_at: Date;
+  deleted_at: Date | null;
 }
 
 export interface CoreMemoryBlockRow {


### PR DESCRIPTION
## Summary
Two hygiene P1s from audit `wp_wscE24lMukal`.

- **F-PG-1**: `SessionRow` (packages/core/src/adapters/postgres/row-types.ts) was missing `deleted_at` even though migration `1780700000000_add-session-deleted-at.sql` added the column and `session-repo.ts` already filtered on it at the SQL layer. Added `deleted_at: Date | null` — type-surface only, no behavior change. Domain `Session` left untouched (soft-delete is an infra concern; `rowToSession` doesn't surface it).
- **F-TD-1**: Dropped the `console.log` happy-path in `maybeAutoBindPrimaryAgent` (packages/api/src/runtime/router.ts:389). It was the only `console.log` in production code; failure branch keeps `console.warn`.

## Test plan
- [x] `pnpm --filter @beevibe/core build`
- [x] `pnpm --filter @beevibe/core typecheck`
- [x] `pnpm --filter @beevibe/api typecheck`
- [x] `pnpm --filter @beevibe/core test -- session-repo` → 24/24 pass (against migrated local test DB)
- [ ] Smoke: `/runtime/register` for a fresh owner — confirm no log line on auto-bind success; failure still warns

🤖 Generated with [Claude Code](https://claude.com/claude-code)