### PR TITLE
fix(runtimes): surface opencode env-leak + document codex/opencode skill gap

### DIFF
--- a/packages/core/src/adapters/codex/runtime.ts
+++ b/packages/core/src/adapters/codex/runtime.ts
@@ -196,6 +196,20 @@ export class CodexRuntime implements AgentRuntime {
     /* stateless — each session is a separate process */
   }
 
+  /**
+   * Where the workspace manager writes tier-filtered SKILL.md files for
+   * codex-runtime agents.
+   *
+   * Convention only — codex does NOT auto-discover files under
+   * `.codex/skills/`. Codex's customization surface today is
+   * `AGENTS.md` (project-level instructions) and `~/.codex/`
+   * profiles; skill files written here are present for forward-compat
+   * / parity with the claude-code adapter but the spawned CLI will
+   * not load them. Until upstream adds discovery (or we wire the
+   * prose into `system_prompt_append` ourselves), skill guidance
+   * reaches codex agents only via the briefing the router already
+   * injects.
+   */
   skillsDir(workspace: Workspace): string {
     return join(workspace.path, ".codex", "skills");
   }

--- a/packages/core/src/adapters/opencode/runtime.test.ts
+++ b/packages/core/src/adapters/opencode/runtime.test.ts
@@ -228,15 +228,10 @@ describe("OpenCodeRuntime.execute", () => {
     // keys. Asserting the wording locks the message format that the
     // daemon README documents.
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const prior = process.env.OPENROUTER_API_KEY;
-    process.env.OPENROUTER_API_KEY = "leaked-key";
-    try {
+    await withEnv({ OPENROUTER_API_KEY: "leaked-key" }, async () => {
       mockRunCli();
       await new OpenCodeRuntime().execute(ctx());
-    } finally {
-      if (prior === undefined) delete process.env.OPENROUTER_API_KEY;
-      else process.env.OPENROUTER_API_KEY = prior;
-    }
+    });
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining("[opencode] provider env keys present"),
     );
@@ -248,32 +243,52 @@ describe("OpenCodeRuntime.execute", () => {
 
   it("does not warn when no provider keys are in the env", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const PROVIDER_VARS = [
-      "OPENAI_API_KEY",
-      "OPENROUTER_API_KEY",
-      "ANTHROPIC_API_KEY",
-      "GROQ_API_KEY",
-      "MISTRAL_API_KEY",
-    ];
-    const prior: Record<string, string | undefined> = {};
-    for (const k of PROVIDER_VARS) {
-      prior[k] = process.env[k];
-      delete process.env[k];
-    }
-    try {
-      mockRunCli();
-      await new OpenCodeRuntime().execute(ctx());
-    } finally {
-      for (const k of PROVIDER_VARS) {
-        if (prior[k] === undefined) delete process.env[k];
-        else process.env[k] = prior[k];
-      }
-    }
+    await withEnv(
+      {
+        OPENAI_API_KEY: undefined,
+        OPENROUTER_API_KEY: undefined,
+        ANTHROPIC_API_KEY: undefined,
+        GROQ_API_KEY: undefined,
+        MISTRAL_API_KEY: undefined,
+      },
+      async () => {
+        mockRunCli();
+        await new OpenCodeRuntime().execute(ctx());
+      },
+    );
     const calls = warnSpy.mock.calls.flat().join(" ");
     expect(calls).not.toContain("provider env keys present");
     warnSpy.mockRestore();
   });
 });
+
+/**
+ * Run `fn` with `process.env` patched per `overrides`, then restore. Set
+ * a key to `undefined` to delete it for the duration of the call;
+ * otherwise the string replaces (or creates) the var. The save-restore
+ * dance is per-key so tests that touch >1 var don't have to hand-roll
+ * the loop.
+ */
+async function withEnv(
+  overrides: Record<string, string | undefined>,
+  fn: () => Promise<void>,
+): Promise<void> {
+  const prior: Record<string, string | undefined> = {};
+  for (const k of Object.keys(overrides)) {
+    prior[k] = process.env[k];
+    const v = overrides[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  try {
+    await fn();
+  } finally {
+    for (const k of Object.keys(overrides)) {
+      if (prior[k] === undefined) delete process.env[k];
+      else process.env[k] = prior[k];
+    }
+  }
+}
 
 describe("OpenCodeRuntime.healthCheck", () => {
   it("runs opencode --version", async () => {

--- a/packages/core/src/adapters/opencode/runtime.test.ts
+++ b/packages/core/src/adapters/opencode/runtime.test.ts
@@ -220,6 +220,59 @@ describe("OpenCodeRuntime.execute", () => {
     expect(result.status).toBe("completed");
     expect(result.stderr).toBeUndefined();
   });
+
+  it("warns when daemon-env provider keys are present so API-key billing isn't silent", async () => {
+    // Provider keys aren't stripped (opencode routes by env presence), so
+    // the only safety net is a per-spawn log so operators can spot a
+    // subscription-auth user accidentally getting billed via env-leaked
+    // keys. Asserting the wording locks the message format that the
+    // daemon README documents.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const prior = process.env.OPENROUTER_API_KEY;
+    process.env.OPENROUTER_API_KEY = "leaked-key";
+    try {
+      mockRunCli();
+      await new OpenCodeRuntime().execute(ctx());
+    } finally {
+      if (prior === undefined) delete process.env.OPENROUTER_API_KEY;
+      else process.env.OPENROUTER_API_KEY = prior;
+    }
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[opencode] provider env keys present"),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("OPENROUTER_API_KEY"),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("does not warn when no provider keys are in the env", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const PROVIDER_VARS = [
+      "OPENAI_API_KEY",
+      "OPENROUTER_API_KEY",
+      "ANTHROPIC_API_KEY",
+      "GROQ_API_KEY",
+      "MISTRAL_API_KEY",
+    ];
+    const prior: Record<string, string | undefined> = {};
+    for (const k of PROVIDER_VARS) {
+      prior[k] = process.env[k];
+      delete process.env[k];
+    }
+    try {
+      mockRunCli();
+      await new OpenCodeRuntime().execute(ctx());
+    } finally {
+      for (const k of PROVIDER_VARS) {
+        if (prior[k] === undefined) delete process.env[k];
+        else process.env[k] = prior[k];
+      }
+    }
+    const calls = warnSpy.mock.calls.flat().join(" ");
+    expect(calls).not.toContain("provider env keys present");
+    warnSpy.mockRestore();
+  });
 });
 
 describe("OpenCodeRuntime.healthCheck", () => {

--- a/packages/core/src/adapters/opencode/runtime.ts
+++ b/packages/core/src/adapters/opencode/runtime.ts
@@ -39,8 +39,19 @@ export interface OpenCodeRuntimeConfig {
  *
  * Provider auth env vars (OPENROUTER_API_KEY, OPENAI_API_KEY, etc.) are
  * intentionally NOT stripped — opencode depends on them to know which
- * provider to route to.
+ * provider to route to. Their presence forces opencode onto API-key
+ * billing rather than the subscription auth a user may have configured
+ * via `opencode auth login`; the runtime logs a one-line warning per
+ * spawn so this isn't a silent UX footgun.
  */
+const PROVIDER_AUTH_VARS = [
+  "OPENAI_API_KEY",
+  "OPENROUTER_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "GROQ_API_KEY",
+  "MISTRAL_API_KEY",
+] as const;
+
 export class OpenCodeRuntime implements AgentRuntime {
   readonly type = "opencode";
 
@@ -68,6 +79,19 @@ export class OpenCodeRuntime implements AgentRuntime {
 
     const env: Record<string, string | undefined> = { ...process.env };
     if (context.env) Object.assign(env, context.env);
+
+    // Surface the auth-routing footgun: any provider key in the daemon
+    // env forces opencode onto API-key billing for that provider, even
+    // if the user expected `opencode auth login` subscription auth to
+    // win. Logged per spawn so operators can spot it in daemon logs;
+    // scrub the env (see packages/daemon/README.md) to opt back into
+    // subscription auth.
+    const leakedProviderKeys = PROVIDER_AUTH_VARS.filter((k) => env[k]);
+    if (leakedProviderKeys.length > 0) {
+      console.warn(
+        `[opencode] provider env keys present — agent will use API-key billing for: ${leakedProviderKeys.join(", ")}`,
+      );
+    }
 
     const events: OpenCodeEvent[] = [];
     let pending = "";
@@ -154,6 +178,20 @@ export class OpenCodeRuntime implements AgentRuntime {
     /* stateless — each session is a separate process */
   }
 
+  /**
+   * Where the workspace manager writes tier-filtered SKILL.md files for
+   * opencode-runtime agents.
+   *
+   * Convention only — opencode does NOT auto-discover files under
+   * `.opencode/skills/`. opencode's customization surface today is
+   * custom agents (`.opencode/agent/*.md`) and project-level
+   * instructions (`AGENTS.md`); skill files written here are present
+   * for forward-compat / parity with the claude-code adapter but the
+   * spawned CLI will not load them. Until upstream adds discovery (or
+   * we wire the prose into `system_prompt_append` ourselves), skill
+   * guidance reaches opencode agents only via the briefing the router
+   * already injects.
+   */
   skillsDir(workspace: Workspace): string {
     return join(workspace.path, ".opencode", "skills");
   }

--- a/packages/daemon/README.md
+++ b/packages/daemon/README.md
@@ -93,6 +93,46 @@ Each workspace contains `mcp-config.json` (mode `0600`) with `Bearer <bv_a_…>`
 
 Skills cache: `~/.beevibe/skills/`, version-gated via `.version`. Refreshed on every `start`.
 
+## Multi-runtime caveats
+
+The daemon supports three CLI runtimes (`claude`, `codex`, `opencode`). They are NOT at full parity — these are the live gaps the daemon papers over.
+
+### OpenCode authentication
+
+OpenCode picks its provider by looking for that provider's API key in the spawned process env (`OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GROQ_API_KEY`, `MISTRAL_API_KEY`, etc.). The daemon **intentionally does not strip these** — opencode needs at least one of them to route at all. The trade-off:
+
+- If a provider key is present in the daemon's env, opencode bills that key, **even if the user has run `opencode auth login` to set up subscription auth.** Subscription auth gets silently overridden.
+- The opencode runtime adapter (`packages/core/src/adapters/opencode/runtime.ts`) prints a one-line warning per spawn when any common provider key is present, e.g.:
+
+  ```
+  [opencode] provider env keys present — agent will use API-key billing for: OPENROUTER_API_KEY
+  ```
+
+- To force subscription auth instead, scrub the offending keys from the daemon's shell before starting it. For a launchctl/systemd-managed daemon, edit the unit's `Environment=` lines; for an ad-hoc terminal:
+
+  ```bash
+  unset OPENROUTER_API_KEY OPENAI_API_KEY ANTHROPIC_API_KEY GROQ_API_KEY MISTRAL_API_KEY
+  beevibe-daemon start
+  ```
+
+- Per-agent env scrubbing (e.g. `runtime_config.scrub_env`) is not yet implemented — the gating decision is still open with the team lead. If you need it, file an issue.
+
+This contrasts with the claude and codex runtimes, which both strip their provider keys (`ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` for claude, `OPENAI_API_KEY` / `OPENAI_AUTH_TOKEN` for codex) so subscription auth always wins.
+
+### Skill discovery on codex / opencode
+
+`/runtime/skills` ships tier-filtered SKILL.md files; the workspace manager writes them into the per-runtime discovery dir returned by `runtime.skillsDir(workspace)`:
+
+| Runtime | Path | Auto-discovered by CLI? |
+|---|---|---|
+| claude | `<ws>/.claude/skills/` | **Yes** — Claude Code loads `SKILL.md` files from this dir. |
+| codex | `<ws>/.codex/skills/` | **No** — codex reads `AGENTS.md` and `~/.codex/` profiles only; files here are dead weight. |
+| opencode | `<ws>/.opencode/skills/` | **No** — opencode's customization surface is custom agents (`.opencode/agent/*.md`) and `AGENTS.md`; files here are dead weight. |
+
+Skill prose still reaches codex / opencode agents indirectly: the dispatch briefing the api router injects (`packages/api/src/runtime/router.ts`) carries the relevant instructions via `system_prompt_append`. The on-disk files are present for parity and forward-compat only.
+
+If upstream adds skill discovery (or we wire the prose into `system_prompt_append` ourselves), the JSDoc on `CodexRuntime.skillsDir` / `OpenCodeRuntime.skillsDir` and this table should be updated together.
+
 ## What it doesn't do
 
 - **No MCP proxy.** The CLI calls `/mcp` directly using the `bv_a_` token in `mcp-config.json`. The daemon's job stops at writing the file and supervising the subprocess.


### PR DESCRIPTION
## Summary

Two related polish items from the runtime audit (`wp_gF18qrZi0T3T`).

**Finding A — OpenCode silently lets shell-env provider keys override subscription auth.**
- `OpenCodeRuntime.execute` now prints a one-line warning per spawn when any of `OPENAI_API_KEY` / `OPENROUTER_API_KEY` / `ANTHROPIC_API_KEY` / `GROQ_API_KEY` / `MISTRAL_API_KEY` is in the daemon's env.
- Format matches the task spec: `[opencode] provider env keys present — agent will use API-key billing for: OPENROUTER_API_KEY`.
- No env scrubbing yet (open question #3 with the team lead). Operators wanting subscription auth must scrub the env themselves; the README documents how.

**Finding B — codex/opencode `skillsDir` paths are convention, not auto-discovered.**
- **Verification:** Neither CLI auto-discovers `SKILL.md` files under `.codex/skills/` or `.opencode/skills/`. Codex's customization surface is `AGENTS.md` + `~/.codex/` profiles; opencode's is custom agents (`.opencode/agent/*.md`) + `AGENTS.md`. Skill discovery is currently a Claude-specific feature. The skill files we write into those subdirs are inert on codex/opencode today — skill prose reaches those agents only via the briefing the api router prepends to `system_prompt_append`.
- Picked option **(a)** per the team lead's lean: JSDoc on `CodexRuntime.skillsDir` / `OpenCodeRuntime.skillsDir` + a new "Multi-runtime caveats" section in `packages/daemon/README.md` (covering both findings) spell out the gap. Option (b) — wiring skill content into `system_prompt_append` — is the obvious follow-up if we want parity.

## Files

- `packages/core/src/adapters/opencode/runtime.ts` — `PROVIDER_AUTH_VARS` constant, per-spawn warn log, skillsDir JSDoc.
- `packages/core/src/adapters/opencode/runtime.test.ts` — two new tests pinning the warn-on-leak and silent-when-clean behavior.
- `packages/core/src/adapters/codex/runtime.ts` — skillsDir JSDoc only.
- `packages/daemon/README.md` — new "Multi-runtime caveats" section: OpenCode auth + skill discovery gap table.

## Test plan

- [x] `pnpm --filter @beevibe/core build` — clean.
- [x] `pnpm --filter @beevibe/core test -- adapters/opencode adapters/codex` — 58/58 passing including the two new warn-log tests.
- [ ] Manual smoke: start the daemon with `OPENROUTER_API_KEY=foo` set, spawn an opencode session, confirm the warn line lands in the daemon log.

(Pre-existing `adapters/openai` test failures on main are env-driven — `OPENAI_API_KEY` missing — and unrelated to this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)