### PR TITLE
refactor(core): lift CLI-error matchers into @beevibe/core/domain (F-LV-1)

### DIFF
--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -34,8 +34,10 @@ import {
 } from "@beevibe/core";
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
 import type { ResumeReason } from "@beevibe/core/services/agent-session";
-import { isBareCliExitMessage } from "@beevibe/core/adapters/claude-code";
-import { parseRuntimeMissingError } from "@beevibe/core/adapters/runtime-registry";
+import {
+  isBareCliExitMessage,
+  parseRuntimeMissingError,
+} from "@beevibe/core/domain";
 import { requireHuman } from "../auth/middleware.js";
 import type { ChatResolver } from "../runtime/chat-resolver.js";
 import type { DaemonHub } from "../runtime/hub.js";

--- a/packages/core/src/adapters/claude-code/index.ts
+++ b/packages/core/src/adapters/claude-code/index.ts
@@ -7,6 +7,5 @@ export {
   extractStepEvents,
   parseClaudeStreamJson,
   bareCliExitMessage,
-  isBareCliExitMessage,
 } from "./stream-json.js";
 export type { StreamJsonMessage } from "./stream-json.js";

--- a/packages/core/src/adapters/claude-code/stream-json.ts
+++ b/packages/core/src/adapters/claude-code/stream-json.ts
@@ -292,23 +292,15 @@ export function parseClaudeMessages(
 
 /**
  * The placeholder message `parseClaudeMessages` returns when the CLI
- * exited non-zero with no final-result message to surface. Exported so
- * downstream consumers (e.g. the chat route's user-facing failure
- * mapping) can detect this exact string and replace it with something
- * more actionable instead of pattern-matching across package boundaries.
+ * exited non-zero with no final-result message to surface. The codex
+ * and opencode adapters reuse this same producer so the format stays
+ * in lock-step across runtimes. Consumers that want to swap this
+ * stand-in for a friendlier diagnostic use `isBareCliExitMessage`
+ * from `@beevibe/core/domain`, which is anchored to the exact format
+ * this function emits.
  */
 export function bareCliExitMessage(exitCode: number | null): string {
   return `CLI exited with code ${exitCode}`;
-}
-
-/**
- * Matches strings produced by `bareCliExitMessage` — the only "useless"
- * stand-in this layer emits on failure. Consumers that want to swap a
- * bare exit for a friendlier diagnostic gate on this predicate so the
- * coupling stays in one place.
- */
-export function isBareCliExitMessage(s: string): boolean {
-  return /^CLI exited with code (-?\d+|null)$/.test(s);
 }
 
 /**

--- a/packages/core/src/adapters/runtime-registry.test.ts
+++ b/packages/core/src/adapters/runtime-registry.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { parseRuntimeMissingError } from "../domain/cli-errors.js";
 import {
   createDefaultRuntimeRegistry,
-  parseRuntimeMissingError,
   runtimeMissingError,
 } from "./runtime-registry.js";
 

--- a/packages/core/src/adapters/runtime-registry.ts
+++ b/packages/core/src/adapters/runtime-registry.ts
@@ -26,20 +26,16 @@ export function createDefaultRuntimeRegistry(): RuntimeRegistry {
 }
 
 /**
- * Producer-consumer pair for the "daemon got a dispatch for a CLI it
- * doesn't have registered" error string — daemon throws via
- * `runtimeMissingError(cli)`; api side parses via `parseRuntimeMissingError`
- * to swap for a user-actionable message in the chat surface. Co-located
- * here so the two stay byte-for-byte in sync; mirrors the
- * `bareCliExitMessage` / `isBareCliExitMessage` pair in claude-code's
- * stream-json module.
+ * Producer for the "daemon got a dispatch for a CLI it doesn't have
+ * registered" error string — thrown from the daemon's spawner so the
+ * api's chat route can swap it for a user-actionable message. The
+ * matching consumer is `parseRuntimeMissingError` in
+ * `@beevibe/core/domain`; the two are round-tripped against this
+ * producer in `runtime-registry.test.ts` to keep the format from
+ * drifting. Mirrors the `bareCliExitMessage` / `isBareCliExitMessage`
+ * pair (producer in claude-code's stream-json module, matcher in
+ * domain).
  */
 export function runtimeMissingError(cli: string): string {
   return `No runtime registered for dispatch payload type '${cli}'`;
-}
-
-const RUNTIME_MISSING_PATTERN = /^No runtime registered for dispatch payload type '([^']+)'$/;
-
-export function parseRuntimeMissingError(s: string): string | undefined {
-  return s.match(RUNTIME_MISSING_PATTERN)?.[1];
 }

--- a/packages/core/src/domain/cli-errors.ts
+++ b/packages/core/src/domain/cli-errors.ts
@@ -1,0 +1,40 @@
+/**
+ * Classifiers for the well-known error strings adapters and the daemon emit
+ * when a CLI subprocess fails in a structured-but-stringly way. Consumers
+ * (chiefly the api chat route) gate on these predicates to swap an opaque
+ * stand-in for a user-actionable diagnostic.
+ *
+ * Lives in `domain/` rather than under any single adapter because the
+ * importing surface — request-handling code that has no business depending
+ * on a specific runtime — must not reach into adapter packages to do
+ * error classification. Producers stay in their respective adapter / daemon
+ * modules and reference these matchers' patterns via the round-trip tests
+ * that pair them.
+ */
+
+const BARE_CLI_EXIT_PATTERN = /^CLI exited with code (-?\d+|null)$/;
+
+/**
+ * Matches the placeholder string emitted when a CLI exited non-zero with
+ * no final-result message — see `bareCliExitMessage` in
+ * `adapters/claude-code/stream-json.ts` for the producer. Both the
+ * codex and opencode adapters reuse the same producer so the format
+ * stays in lock-step across runtimes.
+ */
+export function isBareCliExitMessage(s: string): boolean {
+  return BARE_CLI_EXIT_PATTERN.test(s);
+}
+
+const RUNTIME_MISSING_PATTERN =
+  /^No runtime registered for dispatch payload type '([^']+)'$/;
+
+/**
+ * Matches the error string the daemon throws when it receives a dispatch
+ * payload for a CLI it doesn't have registered — see `runtimeMissingError`
+ * in `adapters/runtime-registry.ts` for the producer. Returns the offending
+ * CLI name on a match, `undefined` otherwise. The producer/consumer pair
+ * is round-tripped in `adapters/runtime-registry.test.ts`.
+ */
+export function parseRuntimeMissingError(s: string): string | undefined {
+  return s.match(RUNTIME_MISSING_PATTERN)?.[1];
+}

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -11,3 +11,4 @@ export * from "./escalation.js";
 export * from "./daemon.js";
 export * from "./runtime.js";
 export * from "./room.js";
+export * from "./cli-errors.js";


### PR DESCRIPTION
## Summary
- Move `isBareCliExitMessage` and `parseRuntimeMissingError` from the claude-code adapter and `adapters/runtime-registry.ts` into a new `packages/core/src/domain/cli-errors.ts`, re-exported via `@beevibe/core/domain`.
- Update `packages/api/src/routes/chat.ts` and `packages/core/src/adapters/runtime-registry.test.ts` to import from the new domain location.
- Adapter producers (`bareCliExitMessage`, `runtimeMissingError`) stay where they are — only the matchers move; doc comments now point at the new matcher location.

Satisfies **F-LV-1** from the Backend Platform layering audit (`wp_wscE24lMukal`) and resolves open question #2 from the agent-runtime audit (`wp_gF18qrZi0T3T`). Routes used to reach into adapter packages for error classification, which is the layering smell the audit flagged.

No behavior change. The `runtimeMissingError` / `parseRuntimeMissingError` round-trip test in `runtime-registry.test.ts` still pairs producer and matcher across files, so format drift is still caught.

## Test plan
- [x] `pnpm --filter @beevibe/core build`
- [x] `pnpm --filter @beevibe/core test` — `runtime-registry.test.ts`, `stream-json.test.ts` (claude-code / codex / opencode) all pass; pre-existing failures in this package are env-only (Anthropic / OpenAI / Postgres / auth integration).
- [x] `pnpm --filter @beevibe/api typecheck`
- [x] `pnpm --filter @beevibe/api test -- --run chat` — `chat-internals`, `chat-rate-limit`, `chat-resolver` all green.
- [x] `pnpm --filter @beevibe/daemon typecheck`
- [x] `pnpm --filter @beevibe/scheduler typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)