### PR TITLE
fix(deploy): rename stale pgmigrations row before migrate up

### DIFF
--- a/infra/railway/api.railway.json
+++ b/infra/railway/api.railway.json
@@ -6,7 +6,7 @@
   },
   "deploy": {
     "startCommand": "node packages/api/dist/main.js",
-    "preDeployCommand": "pnpm migrate:deploy up",
+    "preDeployCommand": "node scripts/pre-deploy-fix-migration-names.cjs && pnpm migrate:deploy up",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10,
     "healthcheckPath": "/health",

--- a/scripts/pre-deploy-fix-migration-names.cjs
+++ b/scripts/pre-deploy-fix-migration-names.cjs
@@ -1,0 +1,58 @@
+/**
+ * Idempotent migration-name fix that runs BEFORE node-pg-migrate on
+ * Railway. The capability-network rebase shipped two migrations at
+ * the same `1780800000000_…` timestamp prefix; the work-product-body
+ * file was renamed locally to `1780900000000_…` to break the tie, but
+ * production DBs already have the OLD name recorded in `pgmigrations`.
+ *
+ * node-pg-migrate compares file list vs DB rows by name; sorting puts
+ * `1780800000000_add-capability-network` before
+ * `1780800000000_add-work-product-body`, and refuses to run the
+ * "preceding" one with code 1.
+ *
+ * Fix: rename the recorded row to match the new filename so the file
+ * and DB agree. Safe in all states:
+ *   - Old name recorded → UPDATE flips it to the new name (this deploy).
+ *   - Already renamed   → 0 rows updated (subsequent deploys).
+ *   - Fresh DB          → no matching row, 0 updates.
+ *
+ * Plain CommonJS so we don't need tsx/ts-node in the api image — `pg`
+ * is already a runtime dep of @beevibe/core which the api bundles.
+ */
+const { Client } = require("pg");
+
+async function main() {
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    console.error("[pre-deploy] DATABASE_URL not set; skipping fix.");
+    process.exit(0);
+  }
+  const client = new Client({ connectionString: url });
+  await client.connect();
+  try {
+    // Guard against the table not existing on first-ever deploys —
+    // node-pg-migrate creates it on its own first run.
+    const exists = await client.query(
+      `SELECT to_regclass('public.pgmigrations') IS NOT NULL AS present`,
+    );
+    if (!exists.rows[0]?.present) {
+      console.log("[pre-deploy] pgmigrations table not present; nothing to rename.");
+      return;
+    }
+    const result = await client.query(
+      `UPDATE pgmigrations
+         SET name = '1780900000000_add-work-product-body'
+       WHERE name = '1780800000000_add-work-product-body'`,
+    );
+    console.log(
+      `[pre-deploy] migration-name fix: renamed ${result.rowCount} row(s).`,
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error("[pre-deploy] migration-name fix failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds \`scripts/pre-deploy-fix-migration-names.cjs\` — an idempotent renamer for the \`pgmigrations\` row left in production by the capability-network rebase.
- Updates \`infra/railway/api.railway.json\` preDeployCommand to run the script before \`pnpm migrate:deploy up\`.

## Why

The capability-network PR (#153) shipped two migrations at the same \`1780800000000_…\` timestamp prefix. We renamed the work-product-body file locally to \`1780900000000_…\` to break the tie, but production DBs already have the OLD name recorded in \`pgmigrations\`. \`node-pg-migrate\` sorts by name and refuses to run \`1780800000000_add-capability-network\` because the alphabetically-later \`1780800000000_add-work-product-body\` is already applied — exit code 1, deploy fails.

The script renames that row to match the new filename so file list and DB agree.

Idempotent in all three states:
- Prod DB in the broken state → renames the row, migrate proceeds, the two new migrations apply cleanly.
- Already renamed (next deploy) → 0 rows updated, migrate runs the normal path.
- Fresh DB (no \`pgmigrations\` table yet) → script detects via \`to_regclass\` and skips with a log line; \`node-pg-migrate\` creates the table on its own first run.

Plain CommonJS so the api image (which doesn't bundle tsx) can run it via \`node\`; \`pg\` is already a transitive runtime dep through @beevibe/core.

## Test plan
- [x] Smoke-ran against local dev DB — \`renamed 0 rows\`, exits 0.
- [ ] Next Railway deploy of the api service should succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)