### PR TITLE
fix(deploy): run migrations from api startCommand, ship node-pg-migrate in image

### DIFF
--- a/infra/railway/api.railway.json
+++ b/infra/railway/api.railway.json
@@ -5,8 +5,7 @@
     "dockerfilePath": "infra/railway/Dockerfile.api"
   },
   "deploy": {
-    "startCommand": "node packages/api/dist/main.js",
-    "preDeployCommand": "node scripts/pre-deploy-fix-migration-names.cjs && pnpm migrate:deploy up",
+    "startCommand": "sh scripts/start-api.sh",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10,
     "healthcheckPath": "/health",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -39,6 +39,8 @@
     "@beevibe/core": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "express": "^5.2.1",
+    "node-pg-migrate": "^7.7.1",
+    "pg": "^8.13.0",
     "ws": "^8.18.0",
     "zod": "^4.3.6"
   },
@@ -48,7 +50,6 @@
     "@types/pg": "^8.11.10",
     "@types/supertest": "^6.0.2",
     "@types/ws": "^8.18.1",
-    "pg": "^8.13.0",
     "supertest": "^7.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
       eslint-plugin-import:
         specifier: ^2.30.0
-        version: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+        version: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
       express:
         specifier: ^5.2.1
         version: 5.2.1
@@ -68,6 +68,12 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      node-pg-migrate:
+        specifier: ^7.7.1
+        version: 7.9.1(@types/pg@8.20.0)(pg@8.20.0)
+      pg:
+        specifier: ^8.13.0
+        version: 8.20.0
       ws:
         specifier: ^8.18.0
         version: 8.20.0
@@ -90,9 +96,6 @@ importers:
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
-      pg:
-        specifier: ^8.13.0
-        version: 8.20.0
       supertest:
         specifier: ^7.0.0
         version: 7.2.2
@@ -5616,7 +5619,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -5646,11 +5649,11 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -5661,7 +5664,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -5672,7 +5675,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/scripts/start-api.sh
+++ b/scripts/start-api.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Beevibe API startup wrapper.
+#
+# Runs the pre-deploy migration-name fix + applies pending migrations BEFORE
+# exec'ing the api process. We do this in startCommand (not Railway's
+# preDeployCommand) because the preDeploy step has been failing silently in
+# our setup — likely because node-pg-migrate was a root devDep that the
+# api image's filtered install skipped. Running here guarantees migrations
+# apply on every container start; in steady state it's a fast no-op.
+#
+# node-pg-migrate is now a direct dep of @beevibe/api, so its binary lives
+# at packages/api/node_modules/.bin/node-pg-migrate inside the image.
+set -e
+
+cd /app
+
+echo "[start-api] migration-name fix"
+node scripts/pre-deploy-fix-migration-names.cjs
+
+echo "[start-api] applying pending migrations"
+packages/api/node_modules/.bin/node-pg-migrate up
+
+echo "[start-api] launching api"
+exec node packages/api/dist/main.js


### PR DESCRIPTION
## Why prod is broken

Production is currently running PR #153's code but none of its DB objects exist (`learned_skill`, `repo_run`, `person.capability_network_enabled`). Live API logs:

\`\`\`
error: column "capability_network_enabled" of relation "person" does not exist
[learned-skills/list] error: relation "learned_skill" does not exist
[repo-runs/list] error: relation "repo_run" does not exist
\`\`\`

PR #187 added a pre-deploy command:
\`\`\`
node scripts/pre-deploy-fix-migration-names.cjs && pnpm migrate:deploy up
\`\`\`

But \`node-pg-migrate\` was a **root devDep**, and the api Dockerfile does:
\`\`\`
RUN pnpm install --frozen-lockfile --filter @beevibe/api...
\`\`\`

The filter skips root-level devDeps. So \`pnpm migrate:deploy up\` failed in-container with "command not found", Railway treated preDeploy as failed/skipped, and the api booted against a stale DB.

## What this PR does

1. **Moves `node-pg-migrate` + `pg` into `@beevibe/api`'s dependencies** so the binary ships in the image at `packages/api/node_modules/.bin/node-pg-migrate`.

2. **Adds `scripts/start-api.sh`** — runs the migration-name fix + `node-pg-migrate up` before `exec`'ing the api. Migrations now apply on every container start; steady-state it's a fast no-op.

3. **Removes `preDeployCommand` from `api.railway.json`** — the work moves to `startCommand`, which we know Railway honors (the current image already boots from json's startCommand).

If a migration fails, the container crashes and Railway restarts up to 10x — same failure surface as a bad release. After this lands, the live API should self-heal: it'll apply the four pending migrations (`add-capability-network`, `add-session-type-run-repo`, `add-work-product-body`, `add-person-capability-network-enabled`) and start serving with all tables present.

## Test plan

- [x] Verified `packages/api/node_modules/.bin/node-pg-migrate` resolves after `pnpm install --filter @beevibe/api...`
- [x] Ran `./packages/api/node_modules/.bin/node-pg-migrate up` against local DB — clean "No migrations to run!"
- [ ] Merge → Railway deploy → check api logs for `[start-api]` lines + verify `GET /me` returns `preferences.capability_network_enabled: true`
- [ ] Verify `/settings` toggle saves without 500
- [ ] Verify `/capabilities` page loads (no missing-relation errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)