### PR TITLE
fix(deploy): pass --no-check-order so out-of-order capability migration applies

### DIFF
--- a/scripts/start-api.sh
+++ b/scripts/start-api.sh
@@ -18,7 +18,12 @@ echo "[start-api] migration-name fix"
 node scripts/pre-deploy-fix-migration-names.cjs
 
 echo "[start-api] applying pending migrations"
-packages/api/node_modules/.bin/node-pg-migrate up
+# --no-check-order: prod has 1780900000000_add-work-product-body recorded
+# (via PR #187's rename) but the older 1780800000000_add-capability-network
+# never applied. Default ordering check refuses to run a "preceding" file
+# after a later one was recorded. We need exactly this out-of-order apply
+# to unstick prod; once all four are in, subsequent boots are no-ops.
+packages/api/node_modules/.bin/node-pg-migrate --no-check-order up
 
 echo "[start-api] launching api"
 exec node packages/api/dist/main.js


### PR DESCRIPTION
## Why prod is crashlooping

After PR #188 merged, `scripts/start-api.sh` now runs migrations on every container boot. But node-pg-migrate refuses to start:

\`\`\`
Migration 1780800000000_add-capability-network is preceding already run migration 1780900000000_add-work-product-body
\`\`\`

Production's `pgmigrations` table currently looks like:

| name |
|---|
| ... |
| 1780900000000_add-work-product-body | ← PR #187's rename script put it here |
| (nothing else from PR #153) |

PR #153's deploy never applied `1780800000000_add-capability-network`, `1780850000000_add-session-type-run-repo`, or `1781000000000_add-person-capability-network-enabled` (that's how we got into this mess in the first place). Now we need to apply them out of order relative to the already-recorded body row — which the default ordering check forbids. Result: api container crashes on every boot, healthcheck at `/health` times out, prod stays broken.

## What this PR does

Adds `--no-check-order` to the migrate command in `scripts/start-api.sh`. That bypasses the ordering guard for the one-shot apply that unsticks prod. Once the three pending migrations are recorded, every subsequent boot is a no-op (\`No migrations to run!\`) regardless of the flag.

## Test plan

- [x] Smoke-tested `node-pg-migrate --no-check-order up` locally — accepts the flag, no-op when nothing pending
- [ ] Merge → Railway deploy → check api logs for `[start-api] applying pending migrations` followed by 3 applied migrations
- [ ] `GET /me` returns `preferences.capability_network_enabled: true`
- [ ] `/settings` toggle saves without 500
- [ ] `/capabilities` page loads without missing-relation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)