### PR TITLE
feat(task): retry from cancelled + Cancel/Retry in side panel

### DIFF
--- a/packages/api/src/routes/task.test.ts
+++ b/packages/api/src/routes/task.test.ts
@@ -313,12 +313,12 @@ describe("task routes — integration", () => {
     expect(newSession?.prior_session_id).toBe(priorSession.id);
   });
 
-  it("retry from a non-failed status → 409", async () => {
+  it("retry from done → 409 (success isn't a retry candidate)", async () => {
     const { owner, agent } = await setupHuman();
     const task = await taskRepo.create({
       id: taskId(),
-      title: "cancelled task",
-      status: "cancelled",
+      title: "completed task",
+      status: "done",
       priority: "medium",
       assignee_id: agent.agent.id,
       creator_id: agent.agent.id,

--- a/packages/core/src/services/task-service.test.ts
+++ b/packages/core/src/services/task-service.test.ts
@@ -502,10 +502,24 @@ describe("TaskService.prepareRetry", () => {
     expect(out.priorSessionId).toBeUndefined();
   });
 
-  it("rejects retry from a non-failed status (use Revise / new task instead)", async () => {
+  it("allows retry from cancelled (operators use cancel as cleanup for stuck tasks)", async () => {
     vi.mocked(taskRepo.findById).mockResolvedValue(
-      makeTask({ status: "cancelled" }),
+      makeTask({ status: "cancelled", assignee_id: "agent_x" }),
     );
+    vi.mocked(sessionRepo.findLatestForTask).mockResolvedValue({
+      id: "sess_prior",
+      cli_session_id: "cli_xyz",
+    } as never);
+    vi.mocked(taskRepo.update).mockImplementation(async (id, patch) =>
+      makeTask({ id, status: patch.status ?? "cancelled", assignee_id: "agent_x" }),
+    );
+    const out = await service.prepareRetry("task_1");
+    expect(out.task.status).toBe("assigned");
+    expect(out.priorSessionId).toBe("sess_prior");
+  });
+
+  it("rejects retry from done (success isn't a retry candidate)", async () => {
+    vi.mocked(taskRepo.findById).mockResolvedValue(makeTask({ status: "done" }));
     await expect(service.prepareRetry("task_1")).rejects.toBeInstanceOf(
       InvalidTaskTransitionError,
     );

--- a/packages/core/src/services/task-service.ts
+++ b/packages/core/src/services/task-service.ts
@@ -255,19 +255,22 @@ export class TaskService {
   }
 
   /**
-   * Retry a `failed` task. Resets the task to `assigned` and clears the
-   * prior failure summary; the caller is expected to follow up with a
-   * `dispatchService.dispatchTask` using `crash_recovery` resume so the
-   * new session resumes the prior CLI conversation via `--resume`.
+   * Retry a `failed` or `cancelled` task. Resets to `assigned`; caller
+   * follows up with `dispatchService.dispatchTask` using `crash_recovery`
+   * resume so the new session continues the prior CLI conversation via
+   * `--resume`.
    *
-   * Only `failed` is retryable — `cancelled` means the user explicitly
-   * stopped the work and shouldn't be undone by Retry (use Revise / new
-   * task instead). `done` is success; no retry makes sense.
+   * `done` is excluded — success isn't a retry candidate. `cancelled`
+   * was initially excluded (with the reasoning "user explicitly stopped
+   * the work") but operators do use cancel as a cleanup mechanism for
+   * stuck pre-#190 tasks; rejecting Retry on cancelled forces them
+   * through a workaround. User has agency — they only click Retry on
+   * the ones they actually want re-engaged.
    *
    * Returns the prior session id (when one exists) so the caller can
    * build the right ResumeReason. Returns undefined when there was
-   * never a session (an edge case for tasks that failed at dispatch
-   * time before claiming).
+   * never a session (edge case for tasks that failed at dispatch
+   * before claiming).
    */
   async prepareRetry(taskId: string): Promise<{
     task: Task;
@@ -275,9 +278,9 @@ export class TaskService {
     priorSessionId: string | undefined;
   }> {
     const task = await this.requireTask(taskId);
-    if (task.status !== "failed") {
+    if (task.status !== "failed" && task.status !== "cancelled") {
       throw new InvalidTaskTransitionError(
-        `Task ${taskId} is in status '${task.status}'; retry is only allowed from 'failed'`,
+        `Task ${taskId} is in status '${task.status}'; retry is only allowed from 'failed' or 'cancelled'`,
       );
     }
     if (!task.assignee_id) {

--- a/packages/web/app/(authed)/tasks/[id]/task-detail-client.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/task-detail-client.tsx
@@ -135,7 +135,10 @@ function TaskDetailLoaded({ task }: { task: TaskDetail }) {
   const revise = useReviseTask(task.id);
   const cancel = useCancelTask(task.id);
   const retry = useRetryTask(task.id);
-  const canRetry = task.status === "failed";
+  // Retry is allowed from failed or cancelled. Operators used cancel as
+  // a cleanup hatch for pre-#190 stuck tasks; rejecting Retry there would
+  // force them through a workaround.
+  const canRetry = task.status === "failed" || task.status === "cancelled";
   const [reviseOpen, setReviseOpen] = useState(false);
   const [reviseFeedback, setReviseFeedback] = useState("");
 

--- a/packages/web/app/(authed)/tasks/[id]/task-detail-client.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/task-detail-client.tsx
@@ -16,11 +16,11 @@ import { api } from "@/lib/api/client";
 import { useTask } from "@/lib/hooks/use-tasks";
 import {
   useApproveTask,
-  useCancelTask,
   useRejectTask,
-  useRetryTask,
   useReviseTask,
 } from "@/lib/hooks/use-task-mutations";
+import { TaskLifecycleActions } from "@/components/tasks/task-lifecycle-actions";
+import { isTerminalTaskStatus } from "@/lib/task-status";
 import { isApiConfigured } from "@/lib/api/config";
 import { TaskStatusPill, SessionStatusPill } from "@/components/detail/status-pill";
 import { ChatMarkdown } from "@/components/chat/markdown";
@@ -106,47 +106,21 @@ function reviewStatus(
   };
 }
 
-// Mirrors CANCELLABLE_FROM in packages/api/src/routes/task.ts — the
-// statuses where the api will accept a cancel. Terminal statuses
-// (done/failed/cancelled) reject with 409, so don't show the button.
-const TASK_TERMINAL_STATUSES = ["done", "failed", "cancelled"] as const;
-
-function MutationError({
-  mutation,
-  verb,
-}: {
-  mutation: { isError: boolean; error: Error | null };
-  verb: string;
-}) {
-  if (!mutation.isError) return null;
-  return (
-    <div className="text-xs text-status-failed text-right mb-2">
-      Couldn&apos;t {verb}: {mutation.error?.message}
-    </div>
-  );
-}
-
 function TaskDetailLoaded({ task }: { task: TaskDetail }) {
   const isInReview = task.status === "review";
-  const isTerminal = (TASK_TERMINAL_STATUSES as readonly string[]).includes(task.status);
+  const isTerminal = isTerminalTaskStatus(task.status);
   const activeSession = task.latest_session?.status === "running" ? task.latest_session : null;
   const approve = useApproveTask(task.id);
   const reject = useRejectTask(task.id);
   const revise = useReviseTask(task.id);
-  const cancel = useCancelTask(task.id);
-  const retry = useRetryTask(task.id);
-  // Retry is allowed from failed or cancelled. Operators used cancel as
-  // a cleanup hatch for pre-#190 stuck tasks; rejecting Retry there would
-  // force them through a workaround.
-  const canRetry = task.status === "failed" || task.status === "cancelled";
   const [reviseOpen, setReviseOpen] = useState(false);
   const [reviseFeedback, setReviseFeedback] = useState("");
 
+  // Review actions in flight gate each other AND the lifecycle Cancel
+  // button (passed via `extraDisabled` to TaskLifecycleActions) — if
+  // cancel raced with an in-flight approve/reject, the task could end
+  // up in a weird mid-transition state.
   const { anyPending: reviewPending, lastError, lastErrorAction } = reviewStatus({ approve, reject, revise });
-  // Cancel disables the review actions too — if cancel is in flight,
-  // the task is about to become terminal and approve/reject/revise
-  // would race against it.
-  const anyPending = reviewPending || cancel.isPending;
 
   const submitRevise = () => {
     const feedback = reviseFeedback.trim();
@@ -170,39 +144,16 @@ function TaskDetailLoaded({ task }: { task: TaskDetail }) {
           <div className="flex items-center gap-1.5 mt-1.5 shrink-0">
             <TaskStatusPill status={task.status} />
             {task.assignee_hierarchy ? <HierChip hier={task.assignee_hierarchy} /> : null}
-            {!isTerminal ? (
-              <button
-                type="button"
-                disabled={anyPending}
-                onClick={() => cancel.mutate({})}
-                className="h-7 px-2.5 rounded text-xs font-medium border border-border text-muted-foreground hover:bg-secondary hover:text-foreground transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-                title="Cancel this task — stops any running session"
-              >
-                {cancel.isPending ? "Cancelling…" : "Cancel"}
-              </button>
-            ) : null}
-            {canRetry ? (
-              <button
-                type="button"
-                disabled={retry.isPending}
-                onClick={() => retry.mutate()}
-                className="h-7 px-2.5 rounded text-xs font-medium border border-border text-muted-foreground hover:bg-secondary hover:text-foreground transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-                title="Retry — re-dispatches the task; the agent resumes the prior CLI conversation"
-              >
-                {retry.isPending ? "Retrying…" : "Retry"}
-              </button>
-            ) : null}
           </div>
         </div>
-        <MutationError mutation={cancel} verb="cancel" />
-        <MutationError mutation={retry} verb="retry" />
+        <TaskLifecycleActions task={task} extraDisabled={reviewPending} />
 
         {isInReview ? (
           <>
             <div className="flex justify-end gap-2 mb-2">
               <button
                 type="button"
-                disabled={anyPending}
+                disabled={reviewPending}
                 onClick={() => reject.mutate({})}
                 className="h-9 px-3 rounded text-sm font-medium border border-border hover:bg-secondary transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               >
@@ -210,7 +161,7 @@ function TaskDetailLoaded({ task }: { task: TaskDetail }) {
               </button>
               <button
                 type="button"
-                disabled={anyPending}
+                disabled={reviewPending}
                 onClick={() => setReviseOpen((v) => !v)}
                 className="h-9 px-3 rounded text-sm font-medium border border-border hover:bg-secondary transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               >
@@ -218,7 +169,7 @@ function TaskDetailLoaded({ task }: { task: TaskDetail }) {
               </button>
               <button
                 type="button"
-                disabled={anyPending}
+                disabled={reviewPending}
                 onClick={() => approve.mutate({})}
                 className="h-9 px-3 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               >
@@ -250,7 +201,7 @@ function TaskDetailLoaded({ task }: { task: TaskDetail }) {
                   </button>
                   <button
                     type="button"
-                    disabled={anyPending || reviseFeedback.trim().length === 0}
+                    disabled={reviewPending || reviseFeedback.trim().length === 0}
                     onClick={submitRevise}
                     className="h-8 px-3 rounded text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                   >

--- a/packages/web/components/mutation-error.tsx
+++ b/packages/web/components/mutation-error.tsx
@@ -1,0 +1,19 @@
+/**
+ * Renders a "Couldn't <verb>: <error message>" line when a mutation
+ * failed. Returns null when the mutation isn't in an error state, so
+ * callers can drop it inline without a surrounding conditional.
+ */
+export function MutationError({
+  mutation,
+  verb,
+}: {
+  mutation: { isError: boolean; error: Error | null };
+  verb: string;
+}) {
+  if (!mutation.isError) return null;
+  return (
+    <div className="text-xs text-status-failed text-right mb-2">
+      Couldn&apos;t {verb}: {mutation.error?.message}
+    </div>
+  );
+}

--- a/packages/web/components/tasks/task-detail-panel.tsx
+++ b/packages/web/components/tasks/task-detail-panel.tsx
@@ -20,11 +20,10 @@ import { isApiConfigured } from "@/lib/api/config";
 import { useTask } from "@/lib/hooks/use-tasks";
 import {
   useApproveTask,
-  useCancelTask,
   useRejectTask,
-  useRetryTask,
   useReviseTask,
 } from "@/lib/hooks/use-task-mutations";
+import { TaskLifecycleActions } from "./task-lifecycle-actions";
 import { formatRelativeTime, shortId } from "@/lib/format";
 import { richTextToMarkdown, type RichText } from "@/components/rich-text";
 import { cn } from "@/lib/utils";
@@ -159,17 +158,8 @@ function PanelBody({ taskId }: { taskId: string }) {
   return <PanelLoaded task={data} />;
 }
 
-// Statuses where Retry / Cancel apply. Matches the gates used in the
-// route handlers (TASK_TERMINAL_STATUSES for Cancel; failed|cancelled
-// for Retry) — keep these in lockstep with task.ts CANCELLABLE_FROM
-// and task-service.ts prepareRetry.
-const TASK_TERMINAL_STATUSES = ["done", "failed", "cancelled"] as const;
-const RETRYABLE_STATUSES = ["failed", "cancelled"] as const;
-
 function PanelLoaded({ task }: { task: TaskDetail }) {
   const isInReview = task.status === "review";
-  const isTerminal = (TASK_TERMINAL_STATUSES as readonly string[]).includes(task.status);
-  const canRetry = (RETRYABLE_STATUSES as readonly string[]).includes(task.status);
   const activeSession =
     task.latest_session?.status === "running" ? task.latest_session : null;
 
@@ -204,9 +194,7 @@ function PanelLoaded({ task }: { task: TaskDetail }) {
         </div>
       </header>
 
-      {!isTerminal || canRetry ? (
-        <LifecycleActions task={task} isTerminal={isTerminal} canRetry={canRetry} />
-      ) : null}
+      <TaskLifecycleActions task={task} />
 
       {isInReview ? <ReviewActions task={task} /> : null}
 
@@ -554,59 +542,3 @@ function ReviewActions({ task }: { task: TaskDetail }) {
   );
 }
 
-// ── Lifecycle actions (Cancel / Retry) ──────────────────────────────
-
-/**
- * Lifecycle-stage actions inline in the side panel so users don't have
- * to open the detail page to cancel or retry. Cancel shows when the
- * task isn't terminal; Retry shows when it's failed or cancelled.
- * Renders nothing when neither applies.
- */
-function LifecycleActions({
-  task,
-  isTerminal,
-  canRetry,
-}: {
-  task: TaskDetail;
-  isTerminal: boolean;
-  canRetry: boolean;
-}) {
-  const cancel = useCancelTask(task.id);
-  const retry = useRetryTask(task.id);
-  return (
-    <div className="mt-3 flex items-center gap-2">
-      {!isTerminal ? (
-        <button
-          type="button"
-          disabled={cancel.isPending}
-          onClick={() => cancel.mutate({})}
-          className="h-7 px-2.5 rounded text-[11px] font-medium border border-border text-muted-foreground hover:bg-secondary hover:text-foreground transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-          title="Cancel this task — stops any running session"
-        >
-          {cancel.isPending ? "Cancelling…" : "Cancel"}
-        </button>
-      ) : null}
-      {canRetry ? (
-        <button
-          type="button"
-          disabled={retry.isPending}
-          onClick={() => retry.mutate()}
-          className="h-7 px-2.5 rounded text-[11px] font-medium border border-border text-muted-foreground hover:bg-secondary hover:text-foreground transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-          title="Retry — re-dispatches the task; the agent resumes the prior CLI conversation"
-        >
-          {retry.isPending ? "Retrying…" : "Retry"}
-        </button>
-      ) : null}
-      {cancel.isError ? (
-        <span className="text-[11px] text-status-failed ml-auto">
-          Couldn&apos;t cancel: {cancel.error.message}
-        </span>
-      ) : null}
-      {retry.isError ? (
-        <span className="text-[11px] text-status-failed ml-auto">
-          Couldn&apos;t retry: {retry.error.message}
-        </span>
-      ) : null}
-    </div>
-  );
-}

--- a/packages/web/components/tasks/task-detail-panel.tsx
+++ b/packages/web/components/tasks/task-detail-panel.tsx
@@ -20,7 +20,9 @@ import { isApiConfigured } from "@/lib/api/config";
 import { useTask } from "@/lib/hooks/use-tasks";
 import {
   useApproveTask,
+  useCancelTask,
   useRejectTask,
+  useRetryTask,
   useReviseTask,
 } from "@/lib/hooks/use-task-mutations";
 import { formatRelativeTime, shortId } from "@/lib/format";
@@ -157,8 +159,17 @@ function PanelBody({ taskId }: { taskId: string }) {
   return <PanelLoaded task={data} />;
 }
 
+// Statuses where Retry / Cancel apply. Matches the gates used in the
+// route handlers (TASK_TERMINAL_STATUSES for Cancel; failed|cancelled
+// for Retry) — keep these in lockstep with task.ts CANCELLABLE_FROM
+// and task-service.ts prepareRetry.
+const TASK_TERMINAL_STATUSES = ["done", "failed", "cancelled"] as const;
+const RETRYABLE_STATUSES = ["failed", "cancelled"] as const;
+
 function PanelLoaded({ task }: { task: TaskDetail }) {
   const isInReview = task.status === "review";
+  const isTerminal = (TASK_TERMINAL_STATUSES as readonly string[]).includes(task.status);
+  const canRetry = (RETRYABLE_STATUSES as readonly string[]).includes(task.status);
   const activeSession =
     task.latest_session?.status === "running" ? task.latest_session : null;
 
@@ -192,6 +203,10 @@ function PanelLoaded({ task }: { task: TaskDetail }) {
           <span className="capitalize">{task.priority}</span>
         </div>
       </header>
+
+      {!isTerminal || canRetry ? (
+        <LifecycleActions task={task} isTerminal={isTerminal} canRetry={canRetry} />
+      ) : null}
 
       {isInReview ? <ReviewActions task={task} /> : null}
 
@@ -534,6 +549,63 @@ function ReviewActions({ task }: { task: TaskDetail }) {
         <p className="text-[11px] text-status-failed">
           Action failed: {lastError.message}
         </p>
+      ) : null}
+    </div>
+  );
+}
+
+// ── Lifecycle actions (Cancel / Retry) ──────────────────────────────
+
+/**
+ * Lifecycle-stage actions inline in the side panel so users don't have
+ * to open the detail page to cancel or retry. Cancel shows when the
+ * task isn't terminal; Retry shows when it's failed or cancelled.
+ * Renders nothing when neither applies.
+ */
+function LifecycleActions({
+  task,
+  isTerminal,
+  canRetry,
+}: {
+  task: TaskDetail;
+  isTerminal: boolean;
+  canRetry: boolean;
+}) {
+  const cancel = useCancelTask(task.id);
+  const retry = useRetryTask(task.id);
+  return (
+    <div className="mt-3 flex items-center gap-2">
+      {!isTerminal ? (
+        <button
+          type="button"
+          disabled={cancel.isPending}
+          onClick={() => cancel.mutate({})}
+          className="h-7 px-2.5 rounded text-[11px] font-medium border border-border text-muted-foreground hover:bg-secondary hover:text-foreground transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          title="Cancel this task — stops any running session"
+        >
+          {cancel.isPending ? "Cancelling…" : "Cancel"}
+        </button>
+      ) : null}
+      {canRetry ? (
+        <button
+          type="button"
+          disabled={retry.isPending}
+          onClick={() => retry.mutate()}
+          className="h-7 px-2.5 rounded text-[11px] font-medium border border-border text-muted-foreground hover:bg-secondary hover:text-foreground transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          title="Retry — re-dispatches the task; the agent resumes the prior CLI conversation"
+        >
+          {retry.isPending ? "Retrying…" : "Retry"}
+        </button>
+      ) : null}
+      {cancel.isError ? (
+        <span className="text-[11px] text-status-failed ml-auto">
+          Couldn&apos;t cancel: {cancel.error.message}
+        </span>
+      ) : null}
+      {retry.isError ? (
+        <span className="text-[11px] text-status-failed ml-auto">
+          Couldn&apos;t retry: {retry.error.message}
+        </span>
       ) : null}
     </div>
   );

--- a/packages/web/components/tasks/task-lifecycle-actions.tsx
+++ b/packages/web/components/tasks/task-lifecycle-actions.tsx
@@ -1,0 +1,70 @@
+import { useCancelTask, useRetryTask } from "@/lib/hooks/use-task-mutations";
+import {
+  isRetryableTaskStatus,
+  isTerminalTaskStatus,
+} from "@/lib/task-status";
+import { MutationError } from "@/components/mutation-error";
+import type { TaskStatus } from "@beevibe/core";
+
+/**
+ * Self-contained Cancel + Retry block. Shared between the detail page
+ * (`/tasks/[id]`) and the side peek panel (`/tasks?p=<id>`) so both
+ * surfaces stay in sync on which statuses show which buttons.
+ *
+ * - Cancel renders when the task isn't terminal.
+ * - Retry renders when the task is `failed` or `cancelled`.
+ * - When neither applies (status is `done`), the component returns
+ *   null and contributes nothing to layout.
+ *
+ * Renders a wrapper div so callers drop it as a sibling block — not
+ * inside another flex row. The buttons are right-aligned to mirror
+ * the previous detail-page placement (next to the status pill).
+ *
+ * `extraDisabled` lets the detail page also gate buttons during in-flight
+ * review actions (approve/reject/revise) — without it, clicking Cancel
+ * mid-approval would race. Defaults to false for callers (like the
+ * panel) that have no concurrent review actions at the same scope.
+ */
+export function TaskLifecycleActions({
+  task,
+  extraDisabled = false,
+}: {
+  task: { id: string; status: TaskStatus };
+  extraDisabled?: boolean;
+}) {
+  const cancel = useCancelTask(task.id);
+  const retry = useRetryTask(task.id);
+  const showCancel = !isTerminalTaskStatus(task.status);
+  const showRetry = isRetryableTaskStatus(task.status);
+  if (!showCancel && !showRetry) return null;
+  return (
+    <div className="mb-2">
+      <div className="flex items-center justify-end gap-1.5">
+        {showCancel ? (
+          <button
+            type="button"
+            disabled={extraDisabled || cancel.isPending}
+            onClick={() => cancel.mutate({})}
+            className="h-7 px-2.5 rounded text-xs font-medium border border-border text-muted-foreground hover:bg-secondary hover:text-foreground transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            title="Cancel this task — stops any running session"
+          >
+            {cancel.isPending ? "Cancelling…" : "Cancel"}
+          </button>
+        ) : null}
+        {showRetry ? (
+          <button
+            type="button"
+            disabled={extraDisabled || retry.isPending}
+            onClick={() => retry.mutate()}
+            className="h-7 px-2.5 rounded text-xs font-medium border border-border text-muted-foreground hover:bg-secondary hover:text-foreground transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            title="Retry — re-dispatches the task; the agent resumes the prior CLI conversation"
+          >
+            {retry.isPending ? "Retrying…" : "Retry"}
+          </button>
+        ) : null}
+      </div>
+      <MutationError mutation={cancel} verb="cancel" />
+      <MutationError mutation={retry} verb="retry" />
+    </div>
+  );
+}

--- a/packages/web/lib/task-status.ts
+++ b/packages/web/lib/task-status.ts
@@ -1,0 +1,30 @@
+import type { TaskStatus } from "@beevibe/core";
+
+/**
+ * Status sets the lifecycle-action UI gates on. Single source of truth
+ * for "should we show Cancel?" / "should we show Retry?" — keep these
+ * in lockstep with:
+ *   - api/src/routes/task.ts `CANCELLABLE_FROM` (terminal complement)
+ *   - core/src/services/task-service.ts `prepareRetry` (failed | cancelled)
+ *
+ * Typed as `readonly TaskStatus[]` so `.includes(task.status)` typechecks
+ * without a cast.
+ */
+export const TERMINAL_TASK_STATUSES: readonly TaskStatus[] = [
+  "done",
+  "failed",
+  "cancelled",
+];
+
+export const RETRYABLE_TASK_STATUSES: readonly TaskStatus[] = [
+  "failed",
+  "cancelled",
+];
+
+export function isTerminalTaskStatus(status: TaskStatus): boolean {
+  return TERMINAL_TASK_STATUSES.includes(status);
+}
+
+export function isRetryableTaskStatus(status: TaskStatus): boolean {
+  return RETRYABLE_TASK_STATUSES.includes(status);
+}


### PR DESCRIPTION
Two operational ergonomics fixes that surfaced after merging #190 (Retry button) and using bulk-cancel to clean up pre-fix stuck tasks.

## Fix 1 — Retry from cancelled

When I shipped Retry in #190, I deliberately rejected \`cancelled\` with the reasoning:

> Only \`failed\` is retryable — \`cancelled\` means the user explicitly stopped the work and shouldn't be undone by Retry.

That logic doesn't hold when operators use bulk-cancel as a cleanup hatch — exactly what happened with pre-#190 tasks that were stuck at \`in_progress\` after their session terminated. Bulk-cancel was the cleanup mechanism (since there was no path to "mass-fail"); now those tasks need to be selectively re-engaged.

User agency is the safety net here: Retry doesn't auto-fire. The user only clicks it on tasks they actually want re-engaged. So expanding the allowed-from set to \`failed | cancelled\` doesn't risk undoing intentional cancellations.

Changes:
- \`prepareRetry\` accepts \`failed\` OR \`cancelled\`, still rejects \`done\` (success isn't a retry candidate)
- \`canRetry\` on the task detail page expanded to match
- Tests updated: the existing \"rejects cancelled\" unit test rewritten as \"allows cancelled\"; new test for rejecting \`done\`; route integration test's 409 case switched from cancelled → done

## Fix 2 — Cancel + Retry buttons in the task side panel

Today the side panel (the right-side peek that opens via \`/tasks?p=<id>\`) only carries Approve / Reject / Revise — and only for review-status tasks. For any other action (cancel a stuck task, retry a failed one), the user has to navigate to the full detail page (\`/tasks/<id>\`). The user noticed: \"in_progress task side panel view, we need to have the cancel button there as well so user doesn't have to go to the detail page.\"

Added a \`LifecycleActions\` component that renders below the panel header:

| Status | Button shown |
|---|---|
| \`pending\` / \`assigned\` / \`in_progress\` / \`revision\` / \`needs_revision\` / \`review\` / \`blocked\` | Cancel |
| \`failed\` / \`cancelled\` | Retry |
| \`done\` | (nothing) |

Uses the same hooks (\`useCancelTask\`, \`useRetryTask\`) and same status gates as the detail page. Errors render inline, right-aligned, so they don't push other content. ReviewActions (approve/reject/revise for review status) stays in its existing slot and renders separately when both apply.

## Test plan

- [x] 41 task-service tests pass (1 new for retry-from-cancelled, 1 modified for retry-from-done rejection)
- [x] 17 task route tests pass (1 modified to use \`done\` instead of \`cancelled\` as the 409 case)
- [x] 141 web tests pass (no new tests; UI components don't currently have unit coverage on this surface)
- [x] All 6 packages typecheck clean
- [ ] Live: open a task panel (\`?p=<id>\`) on a failed/cancelled task → Retry button works; on a non-terminal task → Cancel button works

## Files

\`\`\`
packages/core/src/services/task-service.ts         +25 / -25   prepareRetry accepts cancelled
packages/core/src/services/task-service.test.ts    +18 / -8    new test + modified test
packages/api/src/routes/task.test.ts               +3 / -3     409 case uses done
packages/web/app/(authed)/tasks/[id]/task-detail-client.tsx +5 / -2  canRetry expanded
packages/web/components/tasks/task-detail-panel.tsx +72       LifecycleActions component
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)