### PR TITLE
fix(release): pre-build @beevibe/sandbox before bun-bundle daemon

### DIFF
--- a/packages/daemon/scripts/build-binaries.sh
+++ b/packages/daemon/scripts/build-binaries.sh
@@ -17,14 +17,23 @@ set -euo pipefail
 DAEMON_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 REPO_ROOT="$(cd "$DAEMON_DIR/../.." && pwd)"
 
-# Build core first — bun --compile resolves @beevibe/core via its package
-# manifest's main field, which points at dist/.
-cd "$REPO_ROOT"
-# Idempotent core build — skip if dist is fresh enough. Ad-hoc local
+# Build workspace deps first — bun --compile resolves their imports via
+# package.json `main` / `exports` which point at `dist/`. Without these
+# pre-builds, bun-bundle errors with "Could not resolve" on cold checkouts
+# (e.g., CI's fresh clone after pnpm install --frozen-lockfile).
+#
+# Idempotent — skip per package if dist is already fresh. Ad-hoc local
 # runs hit the cold case; the release workflow pre-builds once and the
 # sibling prepare-publish.sh reuses the result.
+cd "$REPO_ROOT"
 if [ ! -f packages/core/dist/index.js ]; then
   pnpm --filter @beevibe/core build >/dev/null
+fi
+# Capability Network (#153): daemon's repo-runs.ts imports
+# @beevibe/sandbox/orchestrator whose package exports point at
+# packages/sandbox/dist/. Needs the same treatment as core.
+if [ ! -f packages/sandbox/dist/orchestrator.js ]; then
+  pnpm --filter @beevibe/sandbox build >/dev/null
 fi
 
 cd "$DAEMON_DIR"

--- a/packages/daemon/scripts/prepare-publish.sh
+++ b/packages/daemon/scripts/prepare-publish.sh
@@ -19,10 +19,15 @@ DAEMON_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 REPO_ROOT="$(cd "$DAEMON_DIR/../.." && pwd)"
 
 cd "$REPO_ROOT"
-# Idempotent core build — skip if dist exists. The release workflow
-# pre-builds via build-binaries.sh, and ad-hoc runs handle the cold case.
+# Idempotent workspace-dep builds — skip per package if dist exists.
+# The release workflow pre-builds via build-binaries.sh; ad-hoc runs
+# handle the cold case. Both core and sandbox need dist/ for bun-bundle
+# to resolve `@beevibe/core` and `@beevibe/sandbox/orchestrator`.
 if [ ! -f packages/core/dist/index.js ]; then
   pnpm --filter @beevibe/core build >/dev/null
+fi
+if [ ! -f packages/sandbox/dist/orchestrator.js ]; then
+  pnpm --filter @beevibe/sandbox build >/dev/null
 fi
 
 cd "$DAEMON_DIR"


### PR DESCRIPTION
The v0.1.4 release workflow failed at the \`build-binaries\` step:

\`\`\`
error: Could not resolve: \"@beevibe/sandbox/orchestrator\". Maybe you
need to \"bun install\"?
  at packages/daemon/src/repo-runs.ts:17:52
\`\`\`

Failed run: https://github.com/beevibe-ai/beevibe/actions/runs/26250836930/job/77261205812

## Why

The capability network PR (#153) made \`packages/daemon/src/repo-runs.ts\` import from \`@beevibe/sandbox/orchestrator\`. That package's \`exports\` field points at \`packages/sandbox/dist/\` — so \`bun --compile\` can't resolve the import unless dist/ has been built.

\`build-binaries.sh\` already pre-builds \`@beevibe/core\` for this exact reason (the existing block at lines 20-28). Sandbox needs the same treatment.

## Fix

Add the same idempotent pre-build for \`@beevibe/sandbox\` to both scripts:

- \`build-binaries.sh\` — runs before \`bun build --compile\` for the 4 native binaries
- \`prepare-publish.sh\` — runs before \`bun build --target=node\` for the npm bundle

Idempotent: each block skips when \`dist/\` is already fresh, so ad-hoc local runs and the release workflow's single-pass behavior both work.

## Validated locally

\`\`\`bash
rm -rf packages/sandbox/dist/orchestrator.js
bash packages/daemon/scripts/build-binaries.sh
# → all 4 binaries build successfully
\`\`\`

## Next steps after merge

The failed \`v0.1.4\` tag points at \`b4b7f91\` (PR #192's merge commit) which doesn't include this fix. Two options:

1. **Delete + re-cut**: \`git tag -d v0.1.4 && git push origin :v0.1.4\` after merging this, then \`git tag v0.1.4 && git push origin v0.1.4\`. Reuses the version number; cleaner from a downstream consumer perspective.
2. **Bump to v0.1.5**: leave v0.1.4 as the failed tag and cut v0.1.5 with this fix included. Avoids overwriting history, but leaves a dead v0.1.4 tag.

I'd lean #1 — the tag never produced any release artifacts (GitHub release / npm publish / homebrew formula are all unchanged), so re-using v0.1.4 doesn't break any downstream consumer. But your call.

## Test plan

- [x] Local build via \`build-binaries.sh\` produces all 4 binaries
- [ ] Release workflow re-runs cleanly after this lands and the v0.1.4 tag is re-cut

🤖 Generated with [Claude Code](https://claude.com/claude-code)