### PR TITLE
fix(skills): register beevibe-verify-pr in tier filter

### DIFF
--- a/packages/core/src/services/skills/tier-filter.ts
+++ b/packages/core/src/services/skills/tier-filter.ts
@@ -11,7 +11,10 @@
 
 import type { HierarchyLevel } from "../../domain/agent.js";
 
-export const UNIVERSAL_SKILLS = ["beevibe-pre-task-setup"] as const;
+export const UNIVERSAL_SKILLS = [
+  "beevibe-pre-task-setup",
+  "beevibe-verify-pr",
+] as const;
 
 export const TEAM_ONLY_SKILLS = ["beevibe-team-mesh-negotiation"] as const;
 


### PR DESCRIPTION
## Summary

Add `beevibe-verify-pr` to `UNIVERSAL_SKILLS` in `packages/core/src/services/skills/tier-filter.ts`. The skill shipped in #191 with its SKILL.md on disk and cache delivery via `/runtime/skills`, but the name was never registered in the tier filter — so `syncSkills` silently excluded it from every agent's `<workspace>/.claude/skills/`. The skill existed everywhere except where agents could find it.

`beevibe-discover-repo` and `beevibe-use-repo` stay out of the filter — they're scoped to the sandbox-agent path (use-repo's content is hardcoded into `packages/sandbox/src/orchestrator.ts`'s `DEFAULT_PROMPT_HEADER`; discover-repo is invoked from sandbox-related flows, not standard agent workspaces).

## Why the bug was invisible

- `~/.beevibe/skills/` has the skill (cache sync works).
- `LocalWorkspaceManager.ensureWorkspace` runs `syncSkills(... filter: tierFilterFor(agent.hierarchy_level), ...)` on every spawn including retry.
- The filter is the gate. `beevibe-verify-pr` not being listed there meant the skill was dropped before reaching the workspace.
- Verified live: every workspace under `~/.beevibe/workspaces/*/.claude/skills/` had only `beevibe-pre-task-setup` (+ `beevibe-team-mesh-negotiation` for team-tier).

## User-visible symptom

Repro: retried a PR-bearing task; agent called `update_progress(done)` immediately after `gh pr create` without running the `beevibe-verify-pr` CI gate. Diagnosis ruled out `--resume` cache replay — the skill was simply never on disk for the agent to invoke.

## Test plan

- [x] `pnpm --filter @beevibe/core test src/services/skills src/adapters/local-workspace` — 34/34 pass
- [x] `pnpm vitest run scripts/install-skills.test.ts` — 11/11 pass (install-skills derives `ALL_SKILLS` from the filter)
- [x] `pnpm --filter @beevibe/core build` — clean
- [ ] After v0.1.5 ships, retry a PR-bearing task and confirm `beevibe-verify-pr` fires before `update_progress(done)`
- [ ] Fresh agent spawn lists `beevibe-verify-pr` in `~/.beevibe/workspaces/<agent_id>/.claude/skills/`

## Notes

- `tier-filter.ts` is bundled into the daemon binary; a running release-binary daemon needs a restart against a new build (v0.1.5) to pick this up. Dev-mode (`tsx watch`) daemons pick it up on next spawn.
- Follow-up worth tracking: a test that asserts every `skills/beevibe-*/SKILL.md` is either registered in `UNIVERSAL_SKILLS ∪ TEAM_ONLY_SKILLS` or explicitly excluded with rationale. Would have caught this at PR-time instead of in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)