### PR TITLE
fix(dashboard): active_sessions KPI counts running sessions, not active agents

### DIFF
--- a/packages/api/src/views/dashboard.test.ts
+++ b/packages/api/src/views/dashboard.test.ts
@@ -9,6 +9,8 @@
  *   3) TREND_SQL                 → 14 days of completed sessions
  *   4) ATTENTION_SQL             → blocked/failed/review tasks
  *   5) KPI_TREND_SQL             → 7 days of per-KPI counts
+ *   6) USAGE_WINDOW_SQL          → per-agent cost/token rollup
+ *   7) RUNNING_SESSIONS_SQL      → current running session count
  */
 import { describe, it, expect, vi } from "vitest";
 import type { Pool } from "@beevibe/core/adapters/postgres";
@@ -127,6 +129,8 @@ describe("getDashboardSummary", () => {
       makeTrendRows(),
       [],
       makeKpiTrendRows(),
+      [], // usage
+      [{ n: 10 }], // running sessions
     ]);
     const { kpis } = await getDashboardSummary(pool);
     expect(kpis.map((k) => k.kind)).toEqual([
@@ -135,10 +139,27 @@ describe("getDashboardSummary", () => {
       "completed_today",
       "blocked",
     ]);
-    expect(kpis.find((k) => k.kind === "active_sessions")?.value).toBe(2); // fleet_active
+    expect(kpis.find((k) => k.kind === "active_sessions")?.value).toBe(10);
     expect(kpis.find((k) => k.kind === "in_review")?.value).toBe(4);
     expect(kpis.find((k) => k.kind === "completed_today")?.value).toBe(5); // last day of trend
     expect(kpis.find((k) => k.kind === "blocked")?.value).toBe(2);
+  });
+
+  it("active_sessions KPI counts running sessions, not active agents", async () => {
+    // 1 agent with 10 running sessions: fleet_active=1, running_sessions=10.
+    // The KPI must report 10, not 1.
+    const pool = makeMockPool([
+      [],
+      [{ hier: "team", count: 1, active: 1 }],
+      makeTrendRows(),
+      [],
+      makeKpiTrendRows(),
+      [],
+      [{ n: 10 }],
+    ]);
+    const summary = await getDashboardSummary(pool);
+    expect(summary.fleet_active).toBe(1);
+    expect(summary.kpis.find((k) => k.kind === "active_sessions")?.value).toBe(10);
   });
 
   it("handles 0 totals without dividing by zero", async () => {
@@ -189,7 +210,7 @@ describe("getDashboardSummary", () => {
     });
   });
 
-  it("fires all 6 queries in parallel (single Promise.all)", async () => {
+  it("fires all 7 queries in parallel (single Promise.all)", async () => {
     const calls: number[] = [];
     let next = 0;
     const query = vi.fn(async (sql: unknown) => {
@@ -208,8 +229,8 @@ describe("getDashboardSummary", () => {
     });
     const pool = { query } as unknown as Pool;
     await getDashboardSummary(pool);
-    expect(calls).toEqual([0, 1, 2, 3, 4, 5]);
-    expect(query).toHaveBeenCalledTimes(6);
+    expect(calls).toEqual([0, 1, 2, 3, 4, 5, 6]);
+    expect(query).toHaveBeenCalledTimes(7);
   });
 });
 

--- a/packages/api/src/views/dashboard.ts
+++ b/packages/api/src/views/dashboard.ts
@@ -89,6 +89,10 @@ LEFT JOIN active_agents aa ON aa.agent_id = a.id
 GROUP BY a.hierarchy_level
 `;
 
+const RUNNING_SESSIONS_SQL = /* sql */ `
+SELECT COUNT(*)::int AS n FROM session WHERE status = 'running'
+`;
+
 const TREND_SQL = /* sql */ `
 WITH days AS (
   SELECT (CURRENT_DATE - i)::date AS d
@@ -246,6 +250,7 @@ export async function getDashboardSummary(pool: Pool): Promise<DashboardSummary>
     attentionResult,
     kpiTrendResult,
     usageResult,
+    runningSessionsResult,
   ] = await Promise.all([
     pool.query<StatusCountRow>(STATUS_COUNT_SQL),
     pool.query<FleetCountRow>(FLEET_SQL),
@@ -253,6 +258,7 @@ export async function getDashboardSummary(pool: Pool): Promise<DashboardSummary>
     pool.query<AttentionRow>(ATTENTION_SQL, [ATTENTION_LIMIT]),
     pool.query<KpiTrendRow>(KPI_TREND_SQL, [TREND_WINDOW_DAYS]),
     pool.query<UsageWindowRow>(USAGE_WINDOW_SQL, [TREND_WINDOW_DAYS]),
+    pool.query<{ n: number }>(RUNNING_SESSIONS_SQL),
   ]);
 
   const status_total = statusResult.rows.reduce((s, r) => s + Number(r.count), 0);
@@ -308,7 +314,8 @@ export async function getDashboardSummary(pool: Pool): Promise<DashboardSummary>
     created_at: r.created_at,
   }));
 
-  const kpis: KpiData[] = buildKpis(kpiTrendResult.rows, statusResult.rows, fleet_active);
+  const running_sessions = Number(runningSessionsResult.rows[0]?.n ?? 0);
+  const kpis: KpiData[] = buildKpis(kpiTrendResult.rows, statusResult.rows, running_sessions);
 
   const usage_summary: UsageSummaryData = buildUsageSummary(
     usageResult.rows,
@@ -335,7 +342,7 @@ export async function getDashboardSummary(pool: Pool): Promise<DashboardSummary>
 function buildKpis(
   kpiRows: KpiTrendRow[],
   statusRows: StatusCountRow[],
-  activeAgents: number,
+  runningSessions: number,
 ): KpiData[] {
   const statusMap = new Map<TaskStatus, number>();
   for (const r of statusRows) statusMap.set(r.status, Number(r.count));
@@ -348,7 +355,7 @@ function buildKpis(
   return [
     {
       kind: "active_sessions",
-      value: activeAgents,
+      value: runningSessions,
       unit: "running",
       trend: trend("active_sessions"),
     },

--- a/packages/api/src/views/dashboard.ts
+++ b/packages/api/src/views/dashboard.ts
@@ -33,6 +33,10 @@ interface FleetCountRow {
   active: string;
 }
 
+interface RunningSessionsCountRow {
+  n: string;
+}
+
 interface TrendRow {
   day: string;
   count: string;
@@ -258,7 +262,7 @@ export async function getDashboardSummary(pool: Pool): Promise<DashboardSummary>
     pool.query<AttentionRow>(ATTENTION_SQL, [ATTENTION_LIMIT]),
     pool.query<KpiTrendRow>(KPI_TREND_SQL, [TREND_WINDOW_DAYS]),
     pool.query<UsageWindowRow>(USAGE_WINDOW_SQL, [TREND_WINDOW_DAYS]),
-    pool.query<{ n: number }>(RUNNING_SESSIONS_SQL),
+    pool.query<RunningSessionsCountRow>(RUNNING_SESSIONS_SQL),
   ]);
 
   const status_total = statusResult.rows.reduce((s, r) => s + Number(r.count), 0);


### PR DESCRIPTION
## Summary

The "Active sessions" KPI on `/dashboard` was wired to `fleet_active` — a count of **distinct agents** with at least one running session, not the count of running sessions. With 10 running sessions concentrated on 2 agents, the widget reported `2`.

`packages/api/src/views/dashboard.ts:81` is `SELECT DISTINCT agent_id FROM session WHERE status = 'running'`, so `fleet_active` (line 277) is "agents with work in flight." That's correct for the fleet widget's idle/active split, but wrong for the KPI labeled "Active sessions" (`packages/web/lib/dashboard-display.ts:57-58`).

## The fix

Add a tiny `RUNNING_SESSIONS_SQL` (`SELECT COUNT(*) FROM session WHERE status = 'running'`), fire it in parallel with the existing six dashboard queries, and pass that count to `buildKpis` instead of `fleet_active`. The fleet widget keeps using `fleet_active` (agent count is what it actually wants).

Renamed the `buildKpis` parameter `activeAgents → runningSessions` so the receiver matches the new wire semantics. Refreshed the test header comment that was already missing the existing 6th query (USAGE_WINDOW_SQL) — now lists all 7.

## Test plan

- [x] Updated existing "emits 4 KPIs" test to feed `[{ n: 10 }]` for the new query and assert the KPI value matches it
- [x] Added a regression test "active_sessions KPI counts running sessions, not active agents" — 1 agent + 10 running sessions → fleet_active=1, KPI=10
- [x] Updated "fires all 7 queries in parallel" (was 6)
- [x] `pnpm vitest run src/views/dashboard.test.ts` — 20/20 pass
- [x] `pnpm tsc --noEmit` on api — clean
- [x] `pnpm vitest run` on web dashboard tests — 11/11 still pass (web shape unchanged)
- [ ] After this lands, dashboard "Active sessions" KPI should match `SELECT COUNT(*) FROM session WHERE status = 'running'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)