### PR TITLE
fix(claim): honor task priority when claiming pending sessions

### DIFF
--- a/packages/core/src/adapters/postgres/pg-helpers.ts
+++ b/packages/core/src/adapters/postgres/pg-helpers.ts
@@ -38,3 +38,27 @@ export function buildPatchClause<T extends object>(
   }
   return { fields, values, nextIndex: i };
 }
+
+/**
+ * SQL fragment ranking task.priority numerically (critical=4, high=3,
+ * medium=2, low=1, unknown/NULL=0). TEXT alphabetical DESC orders
+ * 'low' > 'high' > 'critical' (backwards), so ORDER BY clauses on
+ * priority need this numeric expression instead.
+ *
+ * Pass `priority` for bare-column refs (task-repo `listAssignable`),
+ * or `t.priority` when joined with a task alias (session-repo claim).
+ *
+ * Mirror of `migrations/1777500000000_fix-task-dispatch-index.sql`'s
+ * partial-index CASE — the index uses the same numeric ranks, so the
+ * planner can match queries that ORDER BY this expression. If you
+ * change the numbers here, change them in that migration too.
+ */
+export function taskPriorityRankSql(column: string): string {
+  return `(CASE ${column}
+            WHEN 'critical' THEN 4
+            WHEN 'high'     THEN 3
+            WHEN 'medium'   THEN 2
+            WHEN 'low'      THEN 1
+            ELSE 0
+          END)`;
+}

--- a/packages/core/src/adapters/postgres/session-repo.test.ts
+++ b/packages/core/src/adapters/postgres/session-repo.test.ts
@@ -443,6 +443,92 @@ describe("PostgresSessionRepository", () => {
       expect(claimed?.id).toBe(chatId);
       expect(claimed?.type).toBe("chat");
     });
+
+    it("orders task sessions by task priority (critical > high > medium > low), then FIFO", async () => {
+      // Four pending task sessions, created OLDEST-FIRST as low, then
+      // medium, then high, then critical — i.e. inverse priority order.
+      // FIFO alone would claim them in [low, medium, high, critical].
+      // Priority-aware claim must claim [critical, high, medium, low].
+      await agents.update(agent, { max_task_sessions: 4 });
+      const priorities = ["low", "medium", "high", "critical"] as const;
+      const idsByPriority = new Map<string, string>();
+      for (const p of priorities) {
+        const t = await tasks.create({
+          id: taskId(),
+          title: `T-${p}`,
+          priority: p,
+          creator_id: person,
+          creator_type: "person",
+        });
+        const sid = sessionId();
+        idsByPriority.set(p, sid);
+        await sessions.create(
+          newSession({
+            id: sid,
+            task_id: t.id,
+            runtime_id: runtime,
+            status: "pending",
+          }),
+        );
+        await new Promise((r) => setTimeout(r, 5));
+      }
+      const claimedOrder: string[] = [];
+      for (let i = 0; i < 4; i++) {
+        const c = await sessions.claimNextForRuntime(runtime);
+        if (c) claimedOrder.push(c.id);
+      }
+      expect(claimedOrder).toEqual([
+        idsByPriority.get("critical"),
+        idsByPriority.get("high"),
+        idsByPriority.get("medium"),
+        idsByPriority.get("low"),
+      ]);
+    });
+
+    it("ties on priority break by created_at ASC (FIFO within a priority bucket)", async () => {
+      await agents.update(agent, { max_task_sessions: 2 });
+      const t1 = await tasks.create({
+        id: taskId(), title: "h1", priority: "high",
+        creator_id: person, creator_type: "person",
+      });
+      const t2 = await tasks.create({
+        id: taskId(), title: "h2", priority: "high",
+        creator_id: person, creator_type: "person",
+      });
+      const first = sessionId();
+      const second = sessionId();
+      await sessions.create(newSession({ id: first, task_id: t1.id, runtime_id: runtime, status: "pending" }));
+      await new Promise((r) => setTimeout(r, 10));
+      await sessions.create(newSession({ id: second, task_id: t2.id, runtime_id: runtime, status: "pending" }));
+      expect((await sessions.claimNextForRuntime(runtime))?.id).toBe(first);
+      expect((await sessions.claimNextForRuntime(runtime))?.id).toBe(second);
+    });
+
+    it("ranks non-task sessions (chat/mesh/etc.) at the medium tier", async () => {
+      // critical task should claim before chat; chat should claim before low task.
+      await agents.update(agent, { max_task_sessions: 3 });
+      const critTask = await tasks.create({
+        id: taskId(), title: "crit", priority: "critical",
+        creator_id: person, creator_type: "person",
+      });
+      const lowTask = await tasks.create({
+        id: taskId(), title: "low", priority: "low",
+        creator_id: person, creator_type: "person",
+      });
+      // Insert in inverse-of-expected order so created_at can't carry the test.
+      const lowId = sessionId();
+      const chatId = sessionId();
+      const critId = sessionId();
+      await sessions.create(newSession({ id: lowId, task_id: lowTask.id, runtime_id: runtime, status: "pending" }));
+      await new Promise((r) => setTimeout(r, 5));
+      await sessions.create(newSession({ id: chatId, runtime_id: runtime, type: "chat", status: "pending" }));
+      await new Promise((r) => setTimeout(r, 5));
+      await sessions.create(newSession({ id: critId, task_id: critTask.id, runtime_id: runtime, status: "pending" }));
+
+      expect((await sessions.claimNextForRuntime(runtime))?.id).toBe(critId);
+      expect((await sessions.claimNextForRuntime(runtime))?.id).toBe(chatId);
+      expect((await sessions.claimNextForRuntime(runtime))?.id).toBe(lowId);
+    });
   });
 
   describe("claimNextForServerFallback — per-agent task cap", () => {

--- a/packages/core/src/adapters/postgres/session-repo.ts
+++ b/packages/core/src/adapters/postgres/session-repo.ts
@@ -12,7 +12,7 @@ import type {
   SessionPatch,
 } from "../../ports/session-repo.js";
 import type { Pool } from "./client.js";
-import { buildPatchClause } from "./pg-helpers.js";
+import { buildPatchClause, taskPriorityRankSql } from "./pg-helpers.js";
 import type { SessionRow } from "./row-types.js";
 
 export class PostgresSessionRepository implements SessionRepository {
@@ -177,12 +177,11 @@ export class PostgresSessionRepository implements SessionRepository {
     runtimePredicate: string,
     params: unknown[],
   ): Promise<Session | undefined> {
-    // Same priority CASE as task-repo.ts `listAssignable` — TEXT
-    // alphabetical DESC orders low > high > critical, so the rank has to
-    // be expressed numerically. Non-task sessions (chat/mesh/blocker/
-    // run_repo) slot at the medium tier (= 2) so high+critical tasks
-    // preempt them while they still beat low-priority tasks; preserves
-    // the prior FIFO ordering within the non-task group.
+    // Non-task sessions (chat/mesh/blocker/run_repo) have task_id NULL,
+    // so they fall into the LEFT JOIN's NULL branch and the outer CASE
+    // slots them at the medium tier (= 2): high+critical tasks preempt
+    // them, they preempt medium and low tasks. Preserves the prior FIFO
+    // ordering within the non-task group.
     const defaultCapParam = `$${params.length + 1}`;
     const { rows } = await this.pool.query<SessionRow>(
       `WITH candidate AS (
@@ -201,16 +200,9 @@ export class PostgresSessionRepository implements SessionRepository {
               ) < COALESCE(a.max_task_sessions, ${defaultCapParam})
             )
           ORDER BY
-            (CASE
-               WHEN s.type = 'task' THEN
-                 (CASE t.priority
-                    WHEN 'critical' THEN 4
-                    WHEN 'high'     THEN 3
-                    WHEN 'medium'   THEN 2
-                    WHEN 'low'      THEN 1
-                    ELSE 0
-                  END)
-               ELSE 2
+            (CASE WHEN s.type = 'task'
+                  THEN ${taskPriorityRankSql("t.priority")}
+                  ELSE 2
              END) DESC,
             s.created_at ASC
           FOR UPDATE OF s, a SKIP LOCKED

--- a/packages/core/src/adapters/postgres/session-repo.ts
+++ b/packages/core/src/adapters/postgres/session-repo.ts
@@ -177,11 +177,18 @@ export class PostgresSessionRepository implements SessionRepository {
     runtimePredicate: string,
     params: unknown[],
   ): Promise<Session | undefined> {
+    // Same priority CASE as task-repo.ts `listAssignable` — TEXT
+    // alphabetical DESC orders low > high > critical, so the rank has to
+    // be expressed numerically. Non-task sessions (chat/mesh/blocker/
+    // run_repo) slot at the medium tier (= 2) so high+critical tasks
+    // preempt them while they still beat low-priority tasks; preserves
+    // the prior FIFO ordering within the non-task group.
     const defaultCapParam = `$${params.length + 1}`;
     const { rows } = await this.pool.query<SessionRow>(
       `WITH candidate AS (
          SELECT s.id FROM session s
            JOIN agent a ON a.id = s.agent_id
+           LEFT JOIN task t ON t.id = s.task_id
           WHERE ${runtimePredicate}
             AND s.status = 'pending'
             AND (
@@ -193,7 +200,19 @@ export class PostgresSessionRepository implements SessionRepository {
                    AND s2.type = 'task'
               ) < COALESCE(a.max_task_sessions, ${defaultCapParam})
             )
-          ORDER BY s.created_at ASC
+          ORDER BY
+            (CASE
+               WHEN s.type = 'task' THEN
+                 (CASE t.priority
+                    WHEN 'critical' THEN 4
+                    WHEN 'high'     THEN 3
+                    WHEN 'medium'   THEN 2
+                    WHEN 'low'      THEN 1
+                    ELSE 0
+                  END)
+               ELSE 2
+             END) DESC,
+            s.created_at ASC
           FOR UPDATE OF s, a SKIP LOCKED
           LIMIT 1
        )

--- a/packages/core/src/adapters/postgres/task-repo.ts
+++ b/packages/core/src/adapters/postgres/task-repo.ts
@@ -11,7 +11,7 @@ import type {
   TaskListFilter,
 } from "../../ports/task-repo.js";
 import type { Pool } from "./client.js";
-import { buildPatchClause } from "./pg-helpers.js";
+import { buildPatchClause, taskPriorityRankSql } from "./pg-helpers.js";
 import type { TaskRow } from "./row-types.js";
 
 export class PostgresTaskRepository implements TaskRepository {
@@ -81,15 +81,8 @@ export class PostgresTaskRepository implements TaskRepository {
       `SELECT * FROM task
         WHERE status IN ('assigned', 'needs_revision')
           AND assignee_id IS NOT NULL
-        ORDER BY
-          (CASE priority
-             WHEN 'critical' THEN 4
-             WHEN 'high'     THEN 3
-             WHEN 'medium'   THEN 2
-             WHEN 'low'      THEN 1
-             ELSE 0
-           END) DESC,
-          created_at ASC`,
+        ORDER BY ${taskPriorityRankSql("priority")} DESC,
+                 created_at ASC`,
     );
     return rows.map(rowToTask);
   }

--- a/packages/core/src/ports/session-repo.ts
+++ b/packages/core/src/ports/session-repo.ts
@@ -73,19 +73,24 @@ export interface SessionRepository {
   }): Promise<Session[]>;
 
   /**
-   * Atomically claim the oldest pending session bound to `runtimeId` and
+   * Atomically claim the next pending session bound to `runtimeId` and
    * promote it to `running`. Returns undefined when nothing is pending.
    * Implemented with `SELECT … FOR UPDATE SKIP LOCKED` so concurrent claims
    * by parallel daemons each get a distinct session (or undefined).
+   *
+   * Ordering: task sessions ranked by `task.priority` desc (critical >
+   * high > medium > low), non-task sessions (chat/mesh/blocker/run_repo)
+   * slot at the medium tier; ties break on `session.created_at` asc
+   * (FIFO within a priority bucket).
    */
   claimNextForRuntime(runtimeId: string): Promise<Session | undefined>;
 
   /**
-   * Atomically claim the oldest pending session that has NO runtime_id
+   * Atomically claim the next pending session that has NO runtime_id
    * bound. Used by the legacy in-process executor as the fallback
    * claimant for agents without a `preferred_runtime_id`. Daemon-bound
    * sessions are never returned — those go to the matching daemon via
-   * `claimNextForRuntime`.
+   * `claimNextForRuntime`. Same priority+FIFO ordering as that method.
    */
   claimNextForServerFallback(): Promise<Session | undefined>;
 


### PR DESCRIPTION
## Summary

`claimNextWhere` — the shared CTE behind both `claimNextForRuntime` (the daemon's hot path) and `claimNextForServerFallback` — was ordering pending sessions by `session.created_at ASC` only. The session row doesn't carry priority and there was no join on `task`, so a **critical** task dispatched seconds after a **low** task got claimed later anyway.

`task-repo.ts` `listAssignable` already does priority-first ordering (`CASE priority WHEN 'critical' THEN 4 ... END DESC, created_at ASC`), so the bug was localized: tasks were correctly **queued** by priority at the assignment layer, then **re-FIFOed** at the claim layer. The dispatch-aware priority ladder was effectively cosmetic.

## Fix

`packages/core/src/adapters/postgres/session-repo.ts:176-225`: join `task` (LEFT — chat/mesh/run_repo sessions have `task_id IS NULL`) and apply the same priority CASE listAssignable uses. Non-task sessions slot at the **medium** tier (= 2): critical and high tasks preempt them, they preempt medium and low tasks. This preserves the prior FIFO ordering within the non-task group and matches the implicit semantic that chat/mesh work is "regular priority" by default.

## Why not fold into FLEET_SQL or skip the JOIN?

- `task` has a primary key on `id`, so the LEFT JOIN is an index lookup per row. Negligible at typical pending-session counts (single-digit-thousands worst case).
- No new index needed — `idx_task_dispatch` is on the task table for `listAssignable`, but claim sorts on a small filtered set (`status = 'pending'`).

## Test plan

- [x] Added `orders task sessions by task priority (critical > high > medium > low), then FIFO` — inserts pending sessions in *inverse* priority order so `created_at` alone can't explain the claim order; asserts the four claims come back critical → high → medium → low
- [x] Added `ties on priority break by created_at ASC` — two `high` task sessions, claim order matches creation order
- [x] Added `ranks non-task sessions (chat/mesh/etc.) at the medium tier` — critical → chat → low (insertion order is reverse, again proving priority drives it)
- [x] All 13 existing claim tests still pass (`pnpm vitest -t "claim"`)
- [x] `pnpm --filter @beevibe/core build` — clean
- [x] Updated `packages/core/src/ports/session-repo.ts` doc comments — were stale (still said "oldest pending session")

The 4 pre-existing `softDeleteChatChain` test failures on the local test DB are due to a missing `deleted_at` column in my local instance, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)