### PR TITLE
refactor(api): route pg_notify cancel/escalation through repo+service layer

### DIFF
--- a/packages/api/src/bootstrap.ts
+++ b/packages/api/src/bootstrap.ts
@@ -307,14 +307,12 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
     runtimeRepo,
     dispatchService,
     hub: daemonHub,
-    pool,
   });
   server.getApp().use("/task", taskRouter);
 
   const escalationRouter = createEscalationRouter({
     authMiddleware: server.getAuthMiddleware(),
     escalationService,
-    pool,
   });
   server.getApp().use("/escalation", escalationRouter);
 

--- a/packages/api/src/routes/escalation.test.ts
+++ b/packages/api/src/routes/escalation.test.ts
@@ -87,7 +87,6 @@ describe("escalation routes — integration", () => {
       createEscalationRouter({
         authMiddleware: createAuthMiddleware({ agentRepo, personRepo }),
         escalationService,
-        pool,
       }),
     );
     return app;

--- a/packages/api/src/routes/escalation.ts
+++ b/packages/api/src/routes/escalation.ts
@@ -18,7 +18,6 @@
  */
 
 import { Router, type RequestHandler } from "express";
-import type { Pool } from "@beevibe/core/adapters/postgres";
 import {
   type EscalationService,
   type ResolveSelector,
@@ -31,7 +30,6 @@ import { requireHuman } from "../auth/middleware.js";
 export interface EscalationRoutesDeps {
   authMiddleware: RequestHandler;
   escalationService: EscalationService;
-  pool: Pool;
 }
 
 function buildSelector(body: unknown):
@@ -117,7 +115,7 @@ export function createEscalationRouter(deps: EscalationRoutesDeps): Router {
       });
 
       // Notify any future M8 web-UI listeners. Zero cost in M6.
-      await deps.pool.query(`SELECT pg_notify('escalation_resolved', $1)`, [id]);
+      await deps.escalationService.notifyResolved(id);
 
       res.json({
         ok: true,

--- a/packages/api/src/routes/task.test.ts
+++ b/packages/api/src/routes/task.test.ts
@@ -73,7 +73,6 @@ describe("task routes — integration", () => {
         runtimeRepo,
         dispatchService,
         hub,
-        pool,
       }),
     );
     return app;

--- a/packages/api/src/routes/task.ts
+++ b/packages/api/src/routes/task.ts
@@ -17,7 +17,6 @@
  */
 
 import { Router, type RequestHandler, type Response } from "express";
-import type { Pool } from "@beevibe/core/adapters/postgres";
 import {
   TASK_PRIORITIES,
   isInFlightSessionStatus,
@@ -63,8 +62,6 @@ export interface TaskRoutesDeps {
   dispatchService: DispatchService;
   /** Push cancel frames over WS to daemon-bound running sessions. */
   hub: DaemonHub;
-  /** For pg_notify('cancel_task', task_id) — server-fallback path only. */
-  pool: Pool;
 }
 
 function handleServiceError(err: unknown, res: Response): void {
@@ -290,7 +287,7 @@ export function createTaskRouter(deps: TaskRoutesDeps): Router {
         );
       }
       await Promise.all(cancelPushes);
-      await deps.pool.query(`SELECT pg_notify('cancel_task', $1)`, [id]);
+      await deps.taskService.notifyCancelled(id);
 
       res.json({
         ok: true,

--- a/packages/api/src/routes/task.ts
+++ b/packages/api/src/routes/task.ts
@@ -286,8 +286,7 @@ export function createTaskRouter(deps: TaskRoutesDeps): Router {
           }),
         );
       }
-      await Promise.all(cancelPushes);
-      await deps.taskService.notifyCancelled(id);
+      await Promise.all([...cancelPushes, deps.taskService.notifyCancelled(id)]);
 
       res.json({
         ok: true,

--- a/packages/core/src/adapters/postgres/escalation-repo.ts
+++ b/packages/core/src/adapters/postgres/escalation-repo.ts
@@ -121,6 +121,13 @@ export class PostgresEscalationRepository implements EscalationRepository {
     if (!rows[0]) throw new Error(`Escalation not found: ${id}`);
     return rowToEscalation(rows[0]);
   }
+
+  async notifyResolved(escalationId: string): Promise<void> {
+    await this.pool.query(
+      `SELECT pg_notify('escalation_resolved', $1)`,
+      [escalationId],
+    );
+  }
 }
 
 function rowToEscalation(row: EscalationRow): Escalation {

--- a/packages/core/src/adapters/postgres/task-repo.ts
+++ b/packages/core/src/adapters/postgres/task-repo.ts
@@ -263,6 +263,10 @@ export class PostgresTaskRepository implements TaskRepository {
   async delete(id: string): Promise<void> {
     await this.pool.query(`DELETE FROM task WHERE id = $1`, [id]);
   }
+
+  async notifyCancelled(taskId: string): Promise<void> {
+    await this.pool.query(`SELECT pg_notify('cancel_task', $1)`, [taskId]);
+  }
 }
 
 function rowToTask(row: TaskRow): Task {

--- a/packages/core/src/ports/escalation-repo.ts
+++ b/packages/core/src/ports/escalation-repo.ts
@@ -45,4 +45,12 @@ export interface EscalationRepository {
   listPending(): Promise<Escalation[]>;
   create(input: NewEscalation): Promise<Escalation>;
   update(id: string, patch: EscalationPatch): Promise<Escalation>;
+
+  /**
+   * Fire `pg_notify('escalation_resolved', escalation_id)` on the repo's pool.
+   * Notification side-channel for future web-UI listeners; routed through the
+   * repo so route handlers don't reach around the data layer to issue raw pool
+   * queries.
+   */
+  notifyResolved(escalationId: string): Promise<void>;
 }

--- a/packages/core/src/ports/task-repo.ts
+++ b/packages/core/src/ports/task-repo.ts
@@ -75,6 +75,14 @@ export interface TaskRepository {
   clearBlocker(id: string): Promise<Task>;
 
   delete(id: string): Promise<void>;
+
+  /**
+   * Fire `pg_notify('cancel_task', task_id)` on the repo's pool. The scheduler's
+   * CancelListener subscribes to this channel and aborts server-fallback
+   * (in-process) sessions running the task. Routed through the repo so route
+   * handlers don't reach around the data layer to issue raw pool queries.
+   */
+  notifyCancelled(taskId: string): Promise<void>;
 }
 
 export type TaskCreatorInput = {

--- a/packages/core/src/services/escalation-service.test.ts
+++ b/packages/core/src/services/escalation-service.test.ts
@@ -62,6 +62,7 @@ beforeEach(() => {
     listPending: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
+    notifyResolved: vi.fn(),
   };
   negotiationRepo = {
     findById: vi.fn(),
@@ -92,6 +93,7 @@ beforeEach(() => {
     markBlocked: vi.fn(),
     clearBlocker: vi.fn(),
     delete: vi.fn(),
+    notifyCancelled: vi.fn(),
   };
   agentRepo = {
     findById: vi.fn(),

--- a/packages/core/src/services/escalation-service.ts
+++ b/packages/core/src/services/escalation-service.ts
@@ -372,11 +372,7 @@ export class EscalationService {
     };
   }
 
-  /**
-   * Fire `pg_notify('escalation_resolved', escalation_id)`. Wraps the repo's
-   * notify so `POST /escalation/:id/resolve` can issue the wakeup signal
-   * without reaching around the data layer for a raw pool query.
-   */
+  /** See `EscalationRepository.notifyResolved`. Service hop keeps routes one call from a service like every other side-effect. */
   async notifyResolved(escalationId: string): Promise<void> {
     await this.deps.escalationRepo.notifyResolved(escalationId);
   }

--- a/packages/core/src/services/escalation-service.ts
+++ b/packages/core/src/services/escalation-service.ts
@@ -372,6 +372,15 @@ export class EscalationService {
     };
   }
 
+  /**
+   * Fire `pg_notify('escalation_resolved', escalation_id)`. Wraps the repo's
+   * notify so `POST /escalation/:id/resolve` can issue the wakeup signal
+   * without reaching around the data layer for a raw pool query.
+   */
+  async notifyResolved(escalationId: string): Promise<void> {
+    await this.deps.escalationRepo.notifyResolved(escalationId);
+  }
+
   // ── helpers ────────────────────────────────────────────────────────────
 
   private callerRole(

--- a/packages/core/src/services/task-service.test.ts
+++ b/packages/core/src/services/task-service.test.ts
@@ -96,6 +96,7 @@ beforeEach(() => {
     markBlocked: vi.fn(),
     clearBlocker: vi.fn(),
     delete: vi.fn(),
+    notifyCancelled: vi.fn(),
   };
   workProductRepo = {
     findById: vi.fn(),

--- a/packages/core/src/services/task-service.ts
+++ b/packages/core/src/services/task-service.ts
@@ -254,6 +254,17 @@ export class TaskService {
     });
   }
 
+  /**
+   * Fire `pg_notify('cancel_task', task_id)`. Wraps the repo's notify so
+   * `POST /task/:id/cancel` can issue the scheduler signal without reaching
+   * around the data layer for a raw pool query. The route already updated the
+   * task's status; this is the cross-process wakeup for server-fallback
+   * sessions still running the work.
+   */
+  async notifyCancelled(taskId: string): Promise<void> {
+    await this.deps.taskRepo.notifyCancelled(taskId);
+  }
+
   /** Record a work product (PR, doc, artifact, etc.) produced by a task. */
   async createWorkProduct(input: NewWorkProduct): Promise<WorkProduct> {
     await this.requireTask(input.task_id);

--- a/packages/core/src/services/task-service.ts
+++ b/packages/core/src/services/task-service.ts
@@ -254,13 +254,7 @@ export class TaskService {
     });
   }
 
-  /**
-   * Fire `pg_notify('cancel_task', task_id)`. Wraps the repo's notify so
-   * `POST /task/:id/cancel` can issue the scheduler signal without reaching
-   * around the data layer for a raw pool query. The route already updated the
-   * task's status; this is the cross-process wakeup for server-fallback
-   * sessions still running the work.
-   */
+  /** See `TaskRepository.notifyCancelled`. Service hop keeps routes one call from a service like every other side-effect. */
   async notifyCancelled(taskId: string): Promise<void> {
     await this.deps.taskRepo.notifyCancelled(taskId);
   }

--- a/packages/scheduler/src/post-dispatch.test.ts
+++ b/packages/scheduler/src/post-dispatch.test.ts
@@ -61,6 +61,7 @@ beforeEach(() => {
     markBlocked: vi.fn(),
     clearBlocker: vi.fn(),
     delete: vi.fn(),
+    notifyCancelled: vi.fn(),
   };
   taskService = {
     checkAndCompleteParent: vi.fn(),


### PR DESCRIPTION
## Summary

P1 finding **F-LV-2** from the M6 layering audit (wp_wscE24lMukal). Two
route handlers were issuing raw `deps.pool.query(\"SELECT pg_notify(...)\")`
calls, reaching past the repo/service layer that owns DB writes
everywhere else:

- \`packages/api/src/routes/task.ts\` → \`pg_notify('cancel_task', task_id)\`
- \`packages/api/src/routes/escalation.ts\` → \`pg_notify('escalation_resolved', escalation_id)\`

Functionally it's a notification side-channel rather than a row write,
but the layering rule is the same: routes call services, services call
ports, ports talk to Postgres.

## Approach

Picked option 3 from the audit's open question: keep the notify
execution in the existing Postgres repo (it already holds the \`Pool\`).
Service exposes a thin pass-through; routes call the service.

- **No new abstraction** — no \`NotificationPort\`, no Pool injected into
  service constructors. The repo is already the chokepoint for SQL
  writes on the same domain object.
- **End-to-end behavior identical** — same SQL fires on the same pool;
  the integration tests that \`LISTEN\` on those channels continue to
  pass.

## Changes

- \`TaskRepository.notifyCancelled(taskId)\` /
  \`EscalationRepository.notifyResolved(escalationId)\` added to the
  ports + Postgres adapters.
- \`TaskService.notifyCancelled\` / \`EscalationService.notifyResolved\`
  wrap the repo calls.
- Routes call the service methods; \`pool: Pool\` dep is dropped from
  \`TaskRoutesDeps\` / \`EscalationRoutesDeps\` (and from the bootstrap
  wiring + route tests).
- Mock repos in \`task-service.test.ts\`, \`escalation-service.test.ts\`,
  \`post-dispatch.test.ts\` updated with the new methods.

## Test plan

- [x] \`pnpm -r build\` — all packages compile.
- [x] \`pnpm -r typecheck\` — all packages typecheck.
- [x] \`@beevibe/core\` unit tests (task-service, escalation-service,
      orphan-reaper) — pass.
- [x] \`@beevibe/core\` Postgres adapter tests (task-repo, escalation-repo)
      — pass against local DB.
- [x] \`@beevibe/api\` route integration tests
      (\`routes/task.test.ts\`, \`routes/escalation.test.ts\`) — pass; the
      existing \`LISTEN cancel_task\` / \`LISTEN escalation_resolved\`
      assertions still see the notifications.
- [x] \`@beevibe/scheduler\` \`post-dispatch.test.ts\` — pass.

Reference: audit \`wp_wscE24lMukal\` (F-LV-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)