### PR TITLE
fix(session-cache): drop eviction status-write, sweep restart orphans, harden prepareBriefing

### DIFF
--- a/packages/api/src/bootstrap.ts
+++ b/packages/api/src/bootstrap.ts
@@ -283,7 +283,6 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
    * on the hot path.
    */
   const sessionCache = new SessionCache({
-    sessionRepo,
     maxEntries: cfg.sessionCacheMaxEntries,
     idleTimeoutMs: cfg.sessionCacheIdleTimeoutMs,
     onEvict: async (beevibeSid) => {
@@ -293,6 +292,31 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
       await memoryAgent.onTaskComplete(beevibeSid);
     },
   });
+
+  // F-SL-2: SessionCache state is lost on api restart. Any human MCP chat
+  // session that was `running` when the api went down becomes orphaned —
+  // no eviction will ever fire, and (post F-SL-1) cache eviction no longer
+  // writes status anyway. One-shot sweep at boot reaps `running` chat
+  // sessions whose newest activity timestamp is older than 2× the cache's
+  // idle TTL (default 60 min). Has to run BEFORE startIdleSweep so a
+  // fresh idle sweep that fires immediately doesn't race against the
+  // orphan-write.
+  const chatOrphanThresholdMs = (cfg.sessionCacheIdleTimeoutMs ?? 30 * 60 * 1000) * 2;
+  try {
+    const reaped = await sessionRepo.markAbandonedChatSessions(chatOrphanThresholdMs);
+    if (reaped > 0) {
+      console.warn(
+        `[bootstrap] reaped ${reaped} abandoned chat session(s) older than ${Math.round(
+          chatOrphanThresholdMs / 60_000,
+        )}m at startup`,
+      );
+    }
+  } catch (err) {
+    console.error(
+      "[bootstrap] markAbandonedChatSessions failed (non-fatal):",
+      err instanceof Error ? err.message : err,
+    );
+  }
   sessionCache.startIdleSweep();
 
   const server = new BeevibeApiServer({

--- a/packages/api/src/bootstrap.ts
+++ b/packages/api/src/bootstrap.ts
@@ -293,14 +293,10 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
     },
   });
 
-  // F-SL-2: SessionCache state is lost on api restart. Any human MCP chat
-  // session that was `running` when the api went down becomes orphaned —
-  // no eviction will ever fire, and (post F-SL-1) cache eviction no longer
-  // writes status anyway. One-shot sweep at boot reaps `running` chat
-  // sessions whose newest activity timestamp is older than 2× the cache's
-  // idle TTL (default 60 min). Has to run BEFORE startIdleSweep so a
-  // fresh idle sweep that fires immediately doesn't race against the
-  // orphan-write.
+  // SessionCache is in-memory: on api restart a `running` chat session
+  // has no daemon to report it terminal and would sit `running` forever.
+  // One-shot sweep at boot reaps stale chat rows (2× the cache's idle TTL)
+  // before startIdleSweep so the sweep can't race the orphan write.
   const chatOrphanThresholdMs = (cfg.sessionCacheIdleTimeoutMs ?? 30 * 60 * 1000) * 2;
   try {
     const reaped = await sessionRepo.markAbandonedChatSessions(chatOrphanThresholdMs);

--- a/packages/api/src/session-cache.test.ts
+++ b/packages/api/src/session-cache.test.ts
@@ -1,17 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { SessionRepository } from "@beevibe/core";
 import { SessionCache } from "./session-cache.js";
-
-function fakeSessionRepo(): { repo: SessionRepository; updates: Array<{ id: string; patch: unknown }> } {
-  const updates: Array<{ id: string; patch: unknown }> = [];
-  const repo = {
-    update: vi.fn(async (id: string, patch: unknown) => {
-      updates.push({ id, patch });
-      return {} as unknown as ReturnType<SessionRepository["update"]>;
-    }),
-  } as unknown as SessionRepository;
-  return { repo, updates };
-}
 
 describe("SessionCache", () => {
   beforeEach(() => {
@@ -23,8 +11,7 @@ describe("SessionCache", () => {
   });
 
   it("set + get round-trips an mcpSid → beevibeSid mapping", () => {
-    const { repo } = fakeSessionRepo();
-    const cache = new SessionCache({ sessionRepo: repo });
+    const cache = new SessionCache();
 
     cache.set("mcp-1", "beevibe-1");
     expect(cache.get("mcp-1")).toBe("beevibe-1");
@@ -32,15 +19,13 @@ describe("SessionCache", () => {
   });
 
   it("get on unknown sid returns undefined", () => {
-    const { repo } = fakeSessionRepo();
-    const cache = new SessionCache({ sessionRepo: repo });
+    const cache = new SessionCache();
     expect(cache.get("unknown")).toBeUndefined();
   });
 
-  it("LRU evicts oldest when maxEntries reached on set()", async () => {
-    const { repo, updates } = fakeSessionRepo();
+  it("LRU evicts oldest when maxEntries reached on set() and fires onEvict (no status write)", async () => {
     const onEvict = vi.fn(async () => {});
-    const cache = new SessionCache({ sessionRepo: repo, maxEntries: 2, onEvict });
+    const cache = new SessionCache({ maxEntries: 2, onEvict });
 
     cache.set("A", "beevibe-A");
     await vi.advanceTimersByTimeAsync(10);
@@ -53,20 +38,19 @@ describe("SessionCache", () => {
     expect(cache.get("B")).toBe("beevibe-B");
     expect(cache.get("C")).toBe("beevibe-C");
 
-    // The evicted A should have been promoted via repo.update + onEvict.
-    // Eviction is fire-and-forget (void promise) so we drain the microtask queue.
+    // Eviction is fire-and-forget (void promise) so drain the microtask queue.
     await vi.runAllTimersAsync();
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(updates.length).toBe(1);
-    expect(updates[0]?.id).toBe("beevibe-A");
+    // F-SL-1: LRU eviction must NOT write status — that happens only via
+    // /runtime/done. onEvict still fires so the memory pipeline can
+    // promote facts.
     expect(onEvict).toHaveBeenCalledWith("beevibe-A", "lru");
   });
 
   it("get() refreshes the access time so the recently-used isn't evicted", async () => {
-    const { repo } = fakeSessionRepo();
-    const cache = new SessionCache({ sessionRepo: repo, maxEntries: 2 });
+    const cache = new SessionCache({ maxEntries: 2 });
 
     cache.set("A", "beevibe-A");
     await vi.advanceTimersByTimeAsync(10);
@@ -85,14 +69,9 @@ describe("SessionCache", () => {
     expect(cache.get("C")).toBe("beevibe-C");
   });
 
-  it("idle sweep evicts entries past idleTimeoutMs and triggers update + onEvict", async () => {
-    const { repo, updates } = fakeSessionRepo();
+  it("idle sweep evicts entries past idleTimeoutMs and fires onEvict (no status write)", async () => {
     const onEvict = vi.fn(async () => {});
-    const cache = new SessionCache({
-      sessionRepo: repo,
-      idleTimeoutMs: 1000,
-      onEvict,
-    });
+    const cache = new SessionCache({ idleTimeoutMs: 1000, onEvict });
 
     cache.set("idle-sid", "beevibe-idle");
     expect(cache.size()).toBe(1);
@@ -102,15 +81,13 @@ describe("SessionCache", () => {
     await cache.sweepIdle();
 
     expect(cache.size()).toBe(0);
-    expect(updates).toHaveLength(1);
-    expect(updates[0]?.id).toBe("beevibe-idle");
-    expect((updates[0]?.patch as { status: string }).status).toBe("succeeded");
+    // F-SL-1: idle eviction is UI/promotion-only — only onEvict fires.
     expect(onEvict).toHaveBeenCalledWith("beevibe-idle", "idle");
   });
 
   it("idle sweep skips entries that were recently accessed", async () => {
-    const { repo, updates } = fakeSessionRepo();
-    const cache = new SessionCache({ sessionRepo: repo, idleTimeoutMs: 1000 });
+    const onEvict = vi.fn(async () => {});
+    const cache = new SessionCache({ idleTimeoutMs: 1000, onEvict });
 
     cache.set("fresh-sid", "beevibe-fresh");
     await vi.advanceTimersByTimeAsync(800);
@@ -121,39 +98,71 @@ describe("SessionCache", () => {
     await cache.sweepIdle();
 
     expect(cache.size()).toBe(1);
-    expect(updates).toHaveLength(0);
+    expect(onEvict).not.toHaveBeenCalled();
   });
 
-  it("explicit delete fires onEvict with reason='explicit' and updates the session row", async () => {
-    const { repo, updates } = fakeSessionRepo();
+  it("explicit delete fires onEvict with reason='explicit' (no status write)", async () => {
     const onEvict = vi.fn(async () => {});
-    const cache = new SessionCache({ sessionRepo: repo, onEvict });
+    const cache = new SessionCache({ onEvict });
 
     cache.set("X", "beevibe-X");
     const removed = await cache.delete("X");
 
     expect(removed).toBe(true);
     expect(cache.size()).toBe(0);
-    expect(updates).toHaveLength(1);
-    expect(updates[0]?.id).toBe("beevibe-X");
     expect(onEvict).toHaveBeenCalledWith("beevibe-X", "explicit");
   });
 
   it("explicit delete on unknown sid returns false and triggers nothing", async () => {
-    const { repo, updates } = fakeSessionRepo();
     const onEvict = vi.fn(async () => {});
-    const cache = new SessionCache({ sessionRepo: repo, onEvict });
+    const cache = new SessionCache({ onEvict });
 
     const removed = await cache.delete("never-set");
 
     expect(removed).toBe(false);
-    expect(updates).toHaveLength(0);
     expect(onEvict).not.toHaveBeenCalled();
   });
 
+  it("eviction without an onEvict callback wired is a clean no-op", async () => {
+    // Construct with no onEvict so we can verify nothing throws when the
+    // hook isn't wired (e.g., tests / minimal setups). All three eviction
+    // paths must remain safe.
+    const cache = new SessionCache({ maxEntries: 1, idleTimeoutMs: 100 });
+
+    cache.set("A", "beevibe-A");
+    cache.set("B", "beevibe-B"); // LRU evict A
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+    expect(cache.get("A")).toBeUndefined();
+
+    cache.set("C", "beevibe-C");
+    await vi.advanceTimersByTimeAsync(500);
+    await cache.sweepIdle(); // idle evict B and C
+    expect(cache.size()).toBe(0);
+
+    cache.set("D", "beevibe-D");
+    await expect(cache.delete("D")).resolves.toBe(true);
+  });
+
+  it("logs and swallows an onEvict error so eviction always removes the entry", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const onEvict = vi.fn(async () => {
+      throw new Error("promotion blew up");
+    });
+    const cache = new SessionCache({ onEvict });
+
+    cache.set("X", "beevibe-X");
+    const removed = await cache.delete("X");
+
+    expect(removed).toBe(true);
+    expect(cache.size()).toBe(0);
+    expect(onEvict).toHaveBeenCalledOnce();
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
   it("startIdleSweep is idempotent and stopIdleSweep clears the timer", () => {
-    const { repo } = fakeSessionRepo();
-    const cache = new SessionCache({ sessionRepo: repo });
+    const cache = new SessionCache();
 
     cache.startIdleSweep(1000);
     cache.startIdleSweep(1000); // no-op

--- a/packages/api/src/session-cache.ts
+++ b/packages/api/src/session-cache.ts
@@ -1,15 +1,12 @@
-import type { SessionRepository } from "@beevibe/core";
-
 export interface SessionCacheConfig {
-  sessionRepo: SessionRepository;
   /** Maximum entries before LRU eviction kicks in. Default 1000. */
   maxEntries?: number;
   /** Idle timeout in ms. After this much time without access, eviction fires. Default 30 min. */
   idleTimeoutMs?: number;
   /**
-   * Called after a session is evicted (idle or LRU). Typically wired to
-   * `memoryAgent.onTaskComplete(beevibeSid)` for fact promotion. Errors are
-   * caught and logged.
+   * Called after a session is evicted (idle / LRU / explicit). Typically
+   * wired to `memoryAgent.onTaskComplete(beevibeSid)` for fact promotion.
+   * Errors are caught and logged.
    */
   onEvict?: (beevibeSid: string, reason: "idle" | "lru" | "explicit") => Promise<void>;
 }
@@ -28,10 +25,18 @@ interface CacheEntry {
  * Eviction:
  *   - LRU when `maxEntries` reached on `set()`.
  *   - Idle timeout via the periodic sweep (`startIdleSweep`).
- * Both eviction paths call `sessionRepo.update(sid, {status:'succeeded'})`
- * and fire `onEvict` to allow downstream cleanup (memory promotion).
+ *   - Explicit via `delete()` (e.g., on `DELETE /mcp`).
  *
- * Lost on api-server restart — matches the resolver-map limitation. M6 doc'd.
+ * Eviction is UI/promotion-only — it fires `onEvict` so the memory pipeline
+ * can promote facts for the ended turn, but it does NOT write the session
+ * row's status. All session-status writes flow through the daemon's
+ * `/runtime/done`; treating cache eviction as a status signal would
+ * silently mark legitimately-running sessions `succeeded` when the cache
+ * hits its `maxEntries` cap or the idle TTL fires mid-turn.
+ *
+ * Lost on api-server restart. Rows that were `running` when the cache
+ * vanished are reaped by the bootstrap `markAbandonedChatSessions` sweep,
+ * not by this cache.
  */
 export class SessionCache {
   private map = new Map<string, CacheEntry>();
@@ -39,7 +44,7 @@ export class SessionCache {
   private readonly idleTimeoutMs: number;
   private sweepTimer?: ReturnType<typeof setInterval>;
 
-  constructor(private readonly config: SessionCacheConfig) {
+  constructor(private readonly config: SessionCacheConfig = {}) {
     this.maxEntries = config.maxEntries ?? 1000;
     this.idleTimeoutMs = config.idleTimeoutMs ?? 30 * 60 * 1000;
   }
@@ -122,17 +127,12 @@ export class SessionCache {
     beevibeSid: string,
     reason: "idle" | "lru" | "explicit",
   ): Promise<void> {
+    if (!this.config.onEvict) return;
     try {
-      await this.config.sessionRepo.update(beevibeSid, {
-        status: "succeeded",
-        completed_at: new Date(),
-      });
-      if (this.config.onEvict) {
-        await this.config.onEvict(beevibeSid, reason);
-      }
+      await this.config.onEvict(beevibeSid, reason);
     } catch (err) {
       console.error(
-        `[session-cache] eviction (${reason}) failed for ${beevibeSid}:`,
+        `[session-cache] onEvict (${reason}) failed for ${beevibeSid}:`,
         err,
       );
     }

--- a/packages/core/src/adapters/postgres/session-repo.test.ts
+++ b/packages/core/src/adapters/postgres/session-repo.test.ts
@@ -666,4 +666,87 @@ describe("PostgresSessionRepository", () => {
       expect(await sessions.countOwnedByDaemon(dId, [s])).toBe(0);
     });
   });
+
+  describe("markAbandonedChatSessions", () => {
+    // Direct UPDATE so we can backdate fields the public API doesn't normally
+    // let us rewrite (created_at, last_event_at). Mirrors the orphan-reaper
+    // tests' pattern.
+    const backdate = async (id: string, intervalSql: string): Promise<void> => {
+      await pool.query(
+        `UPDATE session
+            SET last_event_at = now() - $2::interval,
+                started_at = now() - $2::interval,
+                created_at = now() - $2::interval
+          WHERE id = $1`,
+        [id, intervalSql],
+      );
+    };
+
+    it("marks a stale running chat session as failed with error='abandoned_at_restart'", async () => {
+      const chat = await sessions.create(
+        newSession({ type: "chat", intent: "hi", status: "running" }),
+      );
+      await backdate(chat.id, "2 hours");
+
+      // Threshold = 1 hour. The 2-hour-old chat must be reaped.
+      const count = await sessions.markAbandonedChatSessions(60 * 60 * 1000);
+      expect(count).toBe(1);
+
+      const after = await sessions.findById(chat.id);
+      expect(after?.status).toBe("failed");
+      expect(after?.error).toBe("abandoned_at_restart");
+      expect(after?.completed_at).toBeInstanceOf(Date);
+    });
+
+    it("leaves recent chat sessions alone", async () => {
+      const fresh = await sessions.create(
+        newSession({ type: "chat", intent: "hi", status: "running" }),
+      );
+      // No backdate — created seconds ago, well inside the 1-hour window.
+
+      const count = await sessions.markAbandonedChatSessions(60 * 60 * 1000);
+      expect(count).toBe(0);
+
+      const after = await sessions.findById(fresh.id);
+      expect(after?.status).toBe("running");
+      expect(after?.error).toBeUndefined();
+    });
+
+    it("does not touch non-chat sessions even when stale", async () => {
+      // A task session that's been running for hours has its own
+      // DaemonOrphanReaper path (heartbeat join) — markAbandonedChatSessions
+      // must stay out of its way.
+      const taskRun = await sessions.create(
+        newSession({ type: "task", task_id: task, status: "running" }),
+      );
+      await backdate(taskRun.id, "5 hours");
+
+      const count = await sessions.markAbandonedChatSessions(60 * 60 * 1000);
+      expect(count).toBe(0);
+
+      const after = await sessions.findById(taskRun.id);
+      expect(after?.status).toBe("running");
+    });
+
+    it("does not touch already-terminal chat sessions", async () => {
+      // A row that's already `succeeded`/`failed`/`cancelled` must not be
+      // re-stamped — the sweep is for sessions still claiming to be live.
+      const chat = await sessions.create(
+        newSession({ type: "chat", intent: "hi", status: "running" }),
+      );
+      await sessions.update(chat.id, {
+        status: "succeeded",
+        result_summary: "done",
+        completed_at: new Date(),
+      });
+      await backdate(chat.id, "2 hours");
+
+      const count = await sessions.markAbandonedChatSessions(60 * 60 * 1000);
+      expect(count).toBe(0);
+
+      const after = await sessions.findById(chat.id);
+      expect(after?.status).toBe("succeeded");
+      expect(after?.error).toBeUndefined();
+    });
+  });
 });

--- a/packages/core/src/adapters/postgres/session-repo.ts
+++ b/packages/core/src/adapters/postgres/session-repo.ts
@@ -249,6 +249,27 @@ export class PostgresSessionRepository implements SessionRepository {
     return rows[0] ? rowToSession(rows[0]) : undefined;
   }
 
+  async markAbandonedChatSessions(olderThanMs: number): Promise<number> {
+    const seconds = Math.max(0, Math.floor(olderThanMs / 1000));
+    // COALESCE(last_event_at, started_at, created_at) gives the freshest
+    // signal of activity we have for a chat row. SessionEventRepository
+    // touches last_event_at for daemon-bound sessions; human MCP chat
+    // sessions don't emit those events, so they fall through to
+    // started_at/created_at.
+    const { rowCount } = await this.pool.query(
+      `UPDATE session
+          SET status = 'failed',
+              error = 'abandoned_at_restart',
+              completed_at = now()
+        WHERE status = 'running'
+          AND type = 'chat'
+          AND COALESCE(last_event_at, started_at, created_at)
+              < now() - ($1 * INTERVAL '1 second')`,
+      [seconds],
+    );
+    return rowCount ?? 0;
+  }
+
   async listRunningInRoom(roomId: string): Promise<Session[]> {
     const { rows } = await this.pool.query<SessionRow>(
       `SELECT * FROM session

--- a/packages/core/src/ports/session-repo.ts
+++ b/packages/core/src/ports/session-repo.ts
@@ -131,6 +131,26 @@ export interface SessionRepository {
    */
   listRunningInRoom(roomId: string): Promise<Session[]>;
 
+  /**
+   * One-shot startup sweep for orphaned human MCP chat sessions. The
+   * SessionCache is in-memory only, so on api restart any chat session
+   * that was `running` when the process went down has no daemon to
+   * report it terminal — the row sits `running` forever. This call
+   * marks every chat session that's been idle longer than
+   * `olderThanMs` (measured against `COALESCE(last_event_at,
+   * started_at, created_at)`) as `failed` with
+   * `error='abandoned_at_restart'`.
+   *
+   * Returns the number of rows reaped. Run from bootstrap BEFORE
+   * `sessionCache.startIdleSweep()`.
+   *
+   * Only touches `type='chat'` rows so daemon-bound task/mesh sessions
+   * aren't accidentally reaped — those have their own
+   * `DaemonOrphanReaper` path that joins against the daemon's
+   * heartbeat.
+   */
+  markAbandonedChatSessions(olderThanMs: number): Promise<number>;
+
   create(input: NewSession): Promise<Session>;
 
   update(id: string, patch: SessionPatch): Promise<Session>;

--- a/packages/core/src/services/memory/memory-agent.test.ts
+++ b/packages/core/src/services/memory/memory-agent.test.ts
@@ -186,6 +186,65 @@ describe("MemoryAgent.prepareBriefing", () => {
     expect(briefing.snapshot.fact_count).toBe(0);
   });
 
+  it("returns a degraded briefing (empty archival half) when the embedder throws", async () => {
+    // F-SL-3: a transient OpenAI hiccup inside prepareBriefing used to
+    // propagate up through /runtime/claim's composeDispatchPayload and
+    // mark a legitimately-claimed session 'failed'. Now prepareBriefing
+    // logs and degrades to zero archival facts — core_memory still
+    // ships in the system prompt unchanged.
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.mocked(coreMemory.read).mockResolvedValue([
+      makeBlock("persona", "Senior infra engineer."),
+    ]);
+    vi.mocked(embed.embed).mockRejectedValue(new Error("OpenAI 503"));
+
+    const briefing = await agent.prepareBriefing("anything");
+
+    expect(briefing.systemPromptAppend).toContain(
+      '<block name="persona">Senior infra engineer.</block>',
+    );
+    expect(briefing.userMessagePrefix).toBe("");
+    expect(briefing.snapshot.block_count).toBe(1);
+    expect(briefing.snapshot.fact_count).toBe(0);
+    // factStore.search must NOT have been called — the embed step failed
+    // before we'd have a query vector to hand it.
+    expect(factStore.search).not.toHaveBeenCalled();
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it("returns a degraded briefing when factStore.search throws (pgvector hiccup)", async () => {
+    // The pgvector query is the other half of the transient-failure path —
+    // same degradation contract applies. Keeps the audit's "structural vs
+    // transient" line clean: searchFacts as a unit degrades, coreMemory.read
+    // still propagates.
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.mocked(coreMemory.read).mockResolvedValue([]);
+    vi.mocked(embed.embed).mockResolvedValue([0.1, 0.2]);
+    vi.mocked(factStore.search).mockRejectedValue(new Error("pgvector OOM"));
+
+    const briefing = await agent.prepareBriefing("anything");
+
+    expect(briefing.userMessagePrefix).toBe("");
+    expect(briefing.snapshot.fact_count).toBe(0);
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it("still propagates coreMemory.read errors (DB failure is structural, not transient)", async () => {
+    // coreMemory.read hits Postgres directly — a failure there means the
+    // claim path should bail rather than dispatch the agent with a hollow
+    // briefing. Locks the audit's contract: structural failures fail
+    // hard; transient provider hiccups degrade.
+    vi.mocked(coreMemory.read).mockRejectedValue(new Error("connection terminated"));
+    vi.mocked(embed.embed).mockResolvedValue([]);
+    vi.mocked(factStore.search).mockResolvedValue([]);
+
+    await expect(agent.prepareBriefing("anything")).rejects.toThrow(
+      "connection terminated",
+    );
+  });
+
   it("accepts a custom factsPerBriefing limit", async () => {
     const custom = createMemoryAgent({
       agentId: "agent_1",

--- a/packages/core/src/services/memory/memory-agent.ts
+++ b/packages/core/src/services/memory/memory-agent.ts
@@ -121,10 +121,26 @@ export function createMemoryAgent(deps: MemoryAgentDeps): MemoryAgent {
 
   return {
     async prepareBriefing(intent: string): Promise<BriefingResult> {
-      const [blocks, facts] = await Promise.all([
-        deps.coreMemory.read(deps.agentId),
-        searchFacts(intent),
-      ]);
+      // searchFacts() drives the OpenAI embed call + the pgvector query.
+      // A transient OpenAI hiccup must not fail the whole briefing —
+      // /runtime/claim already won the atomic UPDATE for this session,
+      // so throwing here would mark a legitimately-claimed session
+      // `failed`. Degrade to an empty archival half (the agent's core
+      // memory still ships in the system prompt) and log loudly so the
+      // operator sees the underlying provider error.
+      //
+      // coreMemory.read is a plain Postgres read; structural DB failures
+      // should propagate so the caller can decide whether to retry the
+      // whole claim.
+      const blocksPromise = deps.coreMemory.read(deps.agentId);
+      const factsPromise = searchFacts(intent).catch((err: unknown) => {
+        console.error(
+          `[MemoryAgent] prepareBriefing search degraded for ${deps.agentId} — returning 0 archival facts:`,
+          err instanceof Error ? err.message : err,
+        );
+        return [] as readonly MemoryFact[];
+      });
+      const [blocks, facts] = await Promise.all([blocksPromise, factsPromise]);
       return composeBriefing(blocks, facts);
     },
 


### PR DESCRIPTION
## Summary
Three lifecycle correctness fixes for api-side human MCP chat sessions. All three findings come from the Backend Platform audit ([wp_wscE24lMukal](#)).

**F-SL-1 (P0)** — `SessionCache` eviction force-wrote `status='succeeded'` on every LRU / idle / explicit path. A running human MCP session that hit the cache cap (default `maxEntries=1000`) or sat idle for 30 minutes got silently marked succeeded, masking real state and triggering `onTaskComplete` fact promotion for an unfinished session. Cache is now UI/promotion-only: it fires `onEvict` so memory promotion still runs, but does NOT write status. All session-status writes flow through the daemon's `/runtime/done`.

**F-SL-2 (P1)** — `SessionCache` is in-memory; on api restart any chat session that was `running` became orphaned forever. New `sessionRepo.markAbandonedChatSessions(olderThanMs)` runs at bootstrap (BEFORE `startIdleSweep`) and reaps chat rows older than 2× the cache's idle TTL (default 60 min), marking them `failed` with `error='abandoned_at_restart'`. Threshold uses `COALESCE(last_event_at, started_at, created_at)`, the freshest activity signal available for chat rows. Only touches `type='chat'` — task/mesh sessions have their own `DaemonOrphanReaper` path.

**F-SL-3 (P1)** — A transient OpenAI/pgvector hiccup inside `memoryAgent.prepareBriefing` propagated up through `/runtime/claim`'s `composeDispatchPayload` and marked a legitimately-claimed session `failed`, wasting the atomic claim. `prepareBriefing` now wraps the embed + vector-search path; on throw it logs loudly and degrades to zero archival facts (`core_memory` still ships in the system prompt unchanged). `coreMemory.read` errors still propagate — DB failures are structural, not transient.

## Test plan
- [x] `pnpm --filter @beevibe/core build` — clean
- [x] `pnpm --filter @beevibe/api build` — clean
- [x] `pnpm --filter @beevibe/api test -- --run session-cache` — 11 / 11 pass (rewritten to drop the `sessionRepo` dep and assert "no status write on eviction" across LRU / idle / explicit)
- [x] `pnpm --filter @beevibe/core test -- --run memory-agent agent-session` — 46 / 46 pass (3 new cases for the degraded-briefing contract: embed throws → degrade, factStore.search throws → degrade, coreMemory.read throws → propagate)
- [ ] `pnpm --filter @beevibe/core test -- --run session-repo` — requires postgres (4 new cases for `markAbandonedChatSessions`: stale chat reaped, fresh chat skipped, non-chat sessions skipped, already-terminal rows untouched). Build is type-correct; the cases follow the same pattern as the existing reaper tests.

## Notes
- Threshold for the restart sweep is `2 × cfg.sessionCacheIdleTimeoutMs` (default 60 min). Plumbing a separate knob seemed like overkill — same axis as the cache's own idleness.
- Sweep status = `'failed'` + `error='abandoned_at_restart'` to match the existing `DaemonOrphanReaper` / agent-missing-at-claim convention.
- `prepareBriefing`'s try/catch is scoped to `searchFacts(intent)` only — that's the structural-vs-transient line the audit recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)