### PR TITLE
feat(secrets): sandbox env injection for use_repo via encrypted person store

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,14 @@ DATABASE_URL_TEST=postgresql://beevibe:beevibe@localhost:5433/beevibe_test
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
 
+# ─── Secret store encryption (required when person_secret is in use) ──
+# AES-256-GCM master key for the per-person encrypted secret store
+# (used to inject env vars into sandboxed use_repo runs). 64 hex chars
+# = 32 bytes. Generate fresh per deployment:
+#   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# Rotating today requires re-encrypting all rows (no key-ring support).
+BEEVIBE_SECRETS_KEY=
+
 # ─── API server ────────────────────────────────────────────────────────
 # URL agent CLIs use for tool calls. For local dev this is localhost.
 # In cloud deploys: set to https://<api-public-url>/mcp.

--- a/migrations/1781200000000_add-person-secret.sql
+++ b/migrations/1781200000000_add-person-secret.sql
@@ -1,0 +1,46 @@
+-- Per-person encrypted secret store, used to inject env vars (API keys,
+-- tokens) into sandboxed `use_repo` runs.
+--
+-- Motivation: today's sandbox spawns docker with NO --env flags, so a
+-- repo like @beevibe/architecture-deep-research (needs OPENAI_API_KEY +
+-- a search-provider key to call cloud APIs) fundamentally cannot run
+-- via use_repo. The capability network was built for offline tools
+-- (yt-dlp / ffmpeg / pdf parsing). Adding a secret store + injection
+-- path unblocks cloud-API-using repos.
+--
+-- Encryption: AES-256-GCM, master key from BEEVIBE_SECRETS_KEY env
+-- (32-byte hex). Each row stores its own IV + auth tag — the key never
+-- lives in the DB. value_encrypted is the ciphertext only; never the
+-- plaintext. Decryption happens server-side in the api process; the
+-- decrypted value is threaded to the daemon in the dispatch payload and
+-- to the docker container via `docker run --env`, but is never returned
+-- to any client and never logged in session_event content.
+--
+-- Auth model v1: person-scoped, implicit. Any of a person's agents can
+-- request any of their secrets in a use_repo call. Per-agent / per-repo
+-- grants are a follow-up. Org-scoped shared secrets are also a follow-up.
+
+CREATE TABLE person_secret (
+  id              TEXT PRIMARY KEY,
+  person_id       TEXT NOT NULL REFERENCES person(id) ON DELETE CASCADE,
+  -- Env-var-style name. Convention: SCREAMING_SNAKE_CASE. We don't
+  -- enforce a regex at the DB level — the API route validates shape
+  -- so an existing row's name can still be read even if we tighten
+  -- the rules later.
+  name            TEXT NOT NULL,
+  -- AES-256-GCM ciphertext (hex). value_iv + value_tag are the per-row
+  -- nonce + auth tag, both hex-encoded. value_iv is 12 bytes (24 hex
+  -- chars), value_tag is 16 bytes (32 hex chars).
+  value_encrypted TEXT NOT NULL,
+  value_iv        TEXT NOT NULL,
+  value_tag       TEXT NOT NULL,
+  -- Optional one-line description shown in the settings UI ("Used by
+  -- ADR specialist for deep research runs"). Never sent to the
+  -- sandbox; this is metadata for the human.
+  description     TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (person_id, name)
+);
+
+CREATE INDEX person_secret_person_id_idx ON person_secret (person_id);

--- a/migrations/1781200000001_add-repo-run-requested-secret-names.sql
+++ b/migrations/1781200000001_add-repo-run-requested-secret-names.sql
@@ -1,0 +1,20 @@
+-- Per-run list of secret NAMES (not values) the caller asked use_repo to
+-- inject into the sandbox container as env vars.
+--
+-- We persist names only because the dispatch path is:
+--   use_repo MCP handler (api)           [validates secret names exist]
+--     → INSERT session + repo_run rows
+--     → daemon polls /runtime/claim
+--     → composeDispatchPayload reads repo_run
+--     → looks up + decrypts named person_secret rows
+--     → puts decrypted values into DispatchPayload.run_repo.sandbox_env
+--     → daemon spawns docker run --env NAME=VALUE
+--
+-- The decryption happens at /runtime/claim time, so decrypted values
+-- never land in the DB. If a user deletes a secret between the
+-- use_repo call and the daemon's claim, that secret is silently
+-- omitted from the env (graceful degradation: the run can still try
+-- with whatever IS configured).
+
+ALTER TABLE repo_run
+  ADD COLUMN requested_secret_names TEXT[];

--- a/packages/api/src/bootstrap.ts
+++ b/packages/api/src/bootstrap.ts
@@ -10,6 +10,7 @@ import {
   PostgresNegotiationRoundRepository,
   PostgresAgentProvisionEventRepository,
   PostgresPersonRepository,
+  PostgresPersonSecretRepository,
   PostgresRepoRunRepository,
   PostgresRoomRepository,
   PostgresRuntimeRepository,
@@ -47,6 +48,7 @@ import { createRepoRunsRouter } from "./routes/repo-runs.js";
 import { createLearnedSkillsRouter } from "./routes/learned-skills.js";
 import { createFindRepoRouter } from "./routes/find-repo.js";
 import { createCapabilitiesRouter } from "./routes/capabilities.js";
+import { createSecretsRouter } from "./routes/secrets.js";
 import { createEscalationRouter } from "./routes/escalation.js";
 import { createViewRouter } from "./routes/view.js";
 import { createStreamRouter } from "./routes/stream.js";
@@ -141,6 +143,7 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
   const repoRunRepo = new PostgresRepoRunRepository(pool);
   const learnedSkillRepo = new PostgresLearnedSkillRepository(pool);
   const skillOutcomeRepo = new PostgresSkillOutcomeRepository(pool);
+  const personSecretRepo = new PostgresPersonSecretRepository(pool);
 
   const skillsDir =
     cfg.skillsSourceDir ?? path.resolve(process.cwd(), "skills");
@@ -326,6 +329,7 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
     learnedSkillRepo,
     embeddings: embed,
     personRepo,
+    personSecretRepo,
   });
   server.getApp().use("/mcp", mcpRouter);
 
@@ -407,6 +411,7 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
     taskRepo,
     repoRunRepo,
     workProductRepo,
+    personSecretRepo,
     hub: daemonHub,
     makeMemoryAgent,
     mcpServerUrl: cfg.mcpServerUrl,
@@ -512,9 +517,21 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
     workProductRepo,
     repoRunRepo,
     learnedSkillRepo,
+    personSecretRepo,
     dispatchService,
   });
   server.getApp().use("/capabilities", capabilitiesRouter);
+
+  // Per-person encrypted secret store — drives sandbox env injection
+  // for use_repo runs (so cloud-API-using repos like
+  // architecture-deep-research can call OPENAI / search providers).
+  // See migration 1781200000000_add-person-secret.sql for the threat
+  // model. Requires BEEVIBE_SECRETS_KEY in the api server's env.
+  const secretsRouter = createSecretsRouter({
+    authMiddleware: server.getAuthMiddleware(),
+    personSecretRepo,
+  });
+  server.getApp().use("/secrets", secretsRouter);
 
   // Phase 8 — onboarding/identity surface (bv_u_).
   // GET /me, POST /me/onboarding/complete, GET /health/runtime.

--- a/packages/api/src/routes/capabilities.ts
+++ b/packages/api/src/routes/capabilities.ts
@@ -19,6 +19,7 @@ import { Router, type RequestHandler } from "express";
 import type {
   AgentRepository,
   LearnedSkillRepository,
+  PersonSecretRepository,
   RepoRunRepository,
   SessionEventRepository,
   SessionRepository,
@@ -39,6 +40,7 @@ export interface CapabilitiesRouterDeps {
   workProductRepo: WorkProductRepository;
   repoRunRepo: RepoRunRepository;
   learnedSkillRepo: LearnedSkillRepository;
+  personSecretRepo: PersonSecretRepository;
   dispatchService: DispatchService;
 }
 
@@ -126,6 +128,7 @@ export function createCapabilitiesRouter(deps: CapabilitiesRouterDeps): Router {
           taskRepo: deps.taskRepo,
           repoRunRepo: deps.repoRunRepo,
           dispatchService: deps.dispatchService,
+          personSecretRepo: deps.personSecretRepo,
         },
       );
       const result = await tool.handler({ goal, repo_url: repoUrl });

--- a/packages/api/src/routes/capabilities.ts
+++ b/packages/api/src/routes/capabilities.ts
@@ -97,9 +97,16 @@ export function createCapabilitiesRouter(deps: CapabilitiesRouterDeps): Router {
   router.post("/use", async (req, res) => {
     if (!requireHuman(req, res)) return;
 
-    const body = req.body as Partial<{ repo_url: string; goal: string }>;
+    const body = req.body as Partial<{
+      repo_url: string;
+      goal: string;
+      secrets: string[];
+    }>;
     const repoUrl = typeof body.repo_url === "string" ? body.repo_url.trim() : "";
     const goal = typeof body.goal === "string" ? body.goal.trim() : "";
+    const secrets = Array.isArray(body.secrets)
+      ? body.secrets.filter((s): s is string => typeof s === "string" && s.length > 0)
+      : undefined;
     if (!repoUrl) {
       res.status(400).json({ error: "missing_repo_url" });
       return;
@@ -131,7 +138,11 @@ export function createCapabilitiesRouter(deps: CapabilitiesRouterDeps): Router {
           personSecretRepo: deps.personSecretRepo,
         },
       );
-      const result = await tool.handler({ goal, repo_url: repoUrl });
+      const result = await tool.handler({
+        goal,
+        repo_url: repoUrl,
+        ...(secrets ? { secrets } : {}),
+      });
       if (result.isError) {
         res.status(400).json(result.content);
         return;

--- a/packages/api/src/routes/mcp.ts
+++ b/packages/api/src/routes/mcp.ts
@@ -18,6 +18,7 @@ import type {
   EmbeddingService,
   LearnedSkillRepository,
   PersonRepository,
+  PersonSecretRepository,
   RepoRunRepository,
   SessionRepository,
   TaskRepository,
@@ -61,6 +62,8 @@ export interface McpRouterDeps {
   embeddings: EmbeddingService;
   /** Used to read the caller's owner's capability_network_enabled flag. */
   personRepo: PersonRepository;
+  /** Capability Network: backs use_repo's `secrets: string[]` param. */
+  personSecretRepo: PersonSecretRepository;
 }
 
 /** Tracked per-MCP-session state. mcpSid ↔ transport + server. */
@@ -282,6 +285,7 @@ async function handleMcpRequest(
       repoRunRepo: deps.repoRunRepo,
       learnedSkillRepo: deps.learnedSkillRepo,
       embeddings: deps.embeddings,
+      personSecretRepo: deps.personSecretRepo,
     },
   );
 

--- a/packages/api/src/routes/secrets.ts
+++ b/packages/api/src/routes/secrets.ts
@@ -1,0 +1,165 @@
+/**
+ * /secrets REST surface — the human-facing CRUD for the per-person
+ * encrypted secret store. Used by the Settings page to manage API keys
+ * + tokens that get injected as env vars into sandboxed `use_repo`
+ * runs (the architecture-deep-research specialist needs this for
+ * OPENAI_API_KEY + a search-provider key).
+ *
+ *   GET    /secrets                 List the caller's secrets.
+ *                                   Returns metadata only — never
+ *                                   ciphertext or decrypted values.
+ *
+ *   POST   /secrets       { name, value, description? }
+ *                                   Upsert. Re-adding the same name
+ *                                   rotates the stored value in place
+ *                                   (single row per (person, name)).
+ *
+ *   DELETE /secrets/:id             Owner-scoped delete. 404 if the row
+ *                                   doesn't exist OR belongs to another
+ *                                   person (the repo's delete returns
+ *                                   false either way).
+ *
+ * Auth: bv_u_ (human) only. The MCP / agent path consumes secrets via
+ * the use_repo tool, not via this REST surface.
+ *
+ * Names follow SCREAMING_SNAKE_CASE env-var convention: the value will
+ * be passed verbatim to `docker run --env NAME=VALUE`, so the name has
+ * to be a valid env-var identifier. Validated at the route level.
+ */
+import { Router, type RequestHandler } from "express";
+import type { PersonSecretRepository } from "@beevibe/core";
+import { personSecretId } from "@beevibe/core";
+import { encryptSecret } from "@beevibe/core/auth";
+import { requireHuman } from "../auth/middleware.js";
+
+const ENV_VAR_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
+const MAX_NAME_LENGTH = 128;
+const MAX_VALUE_LENGTH = 16_384;
+const MAX_DESCRIPTION_LENGTH = 512;
+
+export interface SecretsRouterDeps {
+  authMiddleware: RequestHandler;
+  personSecretRepo: PersonSecretRepository;
+}
+
+export function createSecretsRouter(deps: SecretsRouterDeps): Router {
+  const router = Router();
+  router.use(deps.authMiddleware);
+
+  // GET /secrets — list metadata only.
+  router.get("/", async (req, res) => {
+    if (!requireHuman(req, res)) return;
+    try {
+      const secrets = await deps.personSecretRepo.listByPerson(
+        req.caller!.personId,
+      );
+      res.json({ secrets });
+    } catch (err) {
+      console.error("[secrets/list]", err);
+      res.status(500).json({ error: "list_failed" });
+    }
+  });
+
+  // POST /secrets — upsert (insert OR rotate).
+  router.post("/", async (req, res) => {
+    if (!requireHuman(req, res)) return;
+    const body = req.body as Partial<{
+      name: string;
+      value: string;
+      description: string;
+    }>;
+    const name = typeof body.name === "string" ? body.name.trim() : "";
+    const value = typeof body.value === "string" ? body.value : "";
+    const description =
+      typeof body.description === "string" && body.description.trim()
+        ? body.description.trim()
+        : undefined;
+
+    if (!name) {
+      res.status(400).json({ error: "missing_name" });
+      return;
+    }
+    if (name.length > MAX_NAME_LENGTH || !ENV_VAR_NAME_RE.test(name)) {
+      res.status(400).json({
+        error: "invalid_name",
+        message: `name must be a SCREAMING_SNAKE_CASE env-var (max ${MAX_NAME_LENGTH} chars)`,
+      });
+      return;
+    }
+    if (!value) {
+      res.status(400).json({ error: "missing_value" });
+      return;
+    }
+    if (value.length > MAX_VALUE_LENGTH) {
+      res.status(400).json({
+        error: "value_too_large",
+        message: `value must be at most ${MAX_VALUE_LENGTH} chars`,
+      });
+      return;
+    }
+    if (description && description.length > MAX_DESCRIPTION_LENGTH) {
+      res.status(400).json({
+        error: "description_too_large",
+        message: `description must be at most ${MAX_DESCRIPTION_LENGTH} chars`,
+      });
+      return;
+    }
+
+    try {
+      // encryptSecret throws if BEEVIBE_SECRETS_KEY isn't configured;
+      // surface that as 500 with a clear error so misconfigured envs
+      // don't silently corrupt rows.
+      const encrypted = encryptSecret(value);
+      const saved = await deps.personSecretRepo.upsert({
+        id: personSecretId(),
+        person_id: req.caller!.personId,
+        name,
+        description,
+        value_encrypted: encrypted.value_encrypted,
+        value_iv: encrypted.value_iv,
+        value_tag: encrypted.value_tag,
+      });
+      // Return metadata only — value never leaves the server.
+      res.status(201).json({ secret: saved });
+    } catch (err) {
+      // Don't include the original error message in the body; it could
+      // contain fragments of the value on validation failures.
+      console.error(
+        "[secrets/upsert]",
+        err instanceof Error ? err.message : String(err),
+      );
+      if (err instanceof Error && /BEEVIBE_SECRETS_KEY/.test(err.message)) {
+        res.status(500).json({
+          error: "secrets_key_unconfigured",
+          message:
+            "Server cannot encrypt secrets — BEEVIBE_SECRETS_KEY is not set. Contact the operator.",
+        });
+        return;
+      }
+      res.status(500).json({ error: "upsert_failed" });
+    }
+  });
+
+  // DELETE /secrets/:id — owner-scoped.
+  router.delete("/:id", async (req, res) => {
+    if (!requireHuman(req, res)) return;
+    const id = req.params.id;
+    if (!id) {
+      res.status(400).json({ error: "missing_id" });
+      return;
+    }
+    try {
+      const ok = await deps.personSecretRepo.delete(id, req.caller!.personId);
+      if (!ok) {
+        res.status(404).json({ error: "not_found" });
+        return;
+      }
+      res.status(204).send();
+    } catch (err) {
+      console.error("[secrets/delete]", err);
+      res.status(500).json({ error: "delete_failed" });
+    }
+  });
+
+  return router;
+}

--- a/packages/api/src/runtime/router.test.ts
+++ b/packages/api/src/runtime/router.test.ts
@@ -110,6 +110,13 @@ describe("/runtime — integration", () => {
       workProductRepo: {
         create: vi.fn(async () => ({})),
       } as unknown as import("@beevibe/core").WorkProductRepository,
+      personSecretRepo: {
+        listByPerson: vi.fn(async () => []),
+        findRecord: vi.fn(async () => undefined),
+        findRecordsByNames: vi.fn(async () => new Map()),
+        upsert: vi.fn(),
+        delete: vi.fn(async () => false),
+      } as unknown as import("@beevibe/core").PersonSecretRepository,
       hub,
       makeMemoryAgent: () => makeMemoryAgentStub(),
       mcpServerUrl: "http://api.test/mcp",

--- a/packages/api/src/runtime/router.ts
+++ b/packages/api/src/runtime/router.ts
@@ -12,6 +12,7 @@ import {
   type AgentRepository,
   type DaemonRepository,
   type PersonRepository,
+  type PersonSecretRepository,
   type RepoRunRepository,
   type RepoRunStatus,
   type Session,
@@ -22,6 +23,7 @@ import {
   type WorkProductRepository,
 } from "@beevibe/core";
 import {
+  decryptSecret,
   generateDaemonApiKey,
   hashDaemonToken,
 } from "@beevibe/core/auth";
@@ -62,6 +64,14 @@ export interface RuntimeRouterDeps {
   repoRunRepo: RepoRunRepository;
   /** Capability Network: artifacts from a run_repo come back here as work_products. */
   workProductRepo: WorkProductRepository;
+  /**
+   * Per-person encrypted secret store. composeDispatchPayload reads
+   * repo_run.requested_secret_names at /runtime/claim time and uses
+   * this repo to resolve + decrypt the values so they can ride along
+   * in DispatchPayload.run_repo.sandbox_env to the daemon's
+   * docker run --env path.
+   */
+  personSecretRepo: PersonSecretRepository;
   hub: DaemonHub;
   /** Per-agent factory for prepareBriefing at claim time. */
   makeMemoryAgent: (agentId: string) => MemoryAgent;
@@ -587,10 +597,47 @@ async function composeDispatchPayload(
       );
       return null;
     }
+    // Resolve + decrypt the requested secrets here, at claim time, so
+    // decrypted values never persist in the DB. If a name was deleted
+    // between the use_repo call and this claim, it's silently omitted
+    // (graceful degradation — the run still gets whatever IS available).
+    let sandboxEnv: Record<string, string> | undefined;
+    const requested = repoRun.requested_secret_names ?? [];
+    if (requested.length > 0) {
+      try {
+        const records = await deps.personSecretRepo.findRecordsByNames(
+          agent.owner_id,
+          requested,
+        );
+        const env: Record<string, string> = {};
+        for (const name of requested) {
+          const record = records.get(name);
+          if (!record) continue;
+          try {
+            env[name] = decryptSecret(record);
+          } catch (err) {
+            // A decrypt failure here means an admin rotated
+            // BEEVIBE_SECRETS_KEY without re-encrypting rows. Don't
+            // leak the original error (could carry key/IV fragments);
+            // just drop the secret from the env so the rest still
+            // flow through.
+            console.warn(
+              `[runtime/claim] secret decrypt failed for ${name}: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        }
+        if (Object.keys(env).length > 0) sandboxEnv = env;
+      } catch (err) {
+        console.warn(
+          `[runtime/claim] secret resolution failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
     runRepoSidecar = {
       repo_run_id: repoRun.id,
       repo_url: repoRun.repo_url,
       goal: repoRun.goal,
+      sandbox_env: sandboxEnv,
     };
     // Flip the row's status to running so the UI shows the right pill
     // the moment the daemon claims; daemon will overwrite at /done.

--- a/packages/api/src/runtime/types.ts
+++ b/packages/api/src/runtime/types.ts
@@ -118,6 +118,14 @@ export interface RunRepoDispatch {
     max_install_attempts?: number;
     disk_mb?: number;
   };
+  /**
+   * Decrypted env vars to inject into the sandbox container via
+   * `docker run --env NAME=VALUE`. Resolved server-side at
+   * /runtime/claim from the caller's person_secret store (only
+   * names the user authorized via use_repo({ secrets: [...] })).
+   * The daemon must NEVER log values from this map.
+   */
+  sandbox_env?: Record<string, string>;
 }
 
 /* ─── Skills sync ────────────────────────────────────────────────────── */

--- a/packages/api/src/tools/assemble.test.ts
+++ b/packages/api/src/tools/assemble.test.ts
@@ -67,6 +67,13 @@ function buildMinimalServices(): AssembleToolsServices {
       embed: vi.fn(async () => [1, 0]),
       embedBatch: vi.fn(async (texts: string[]) => texts.map(() => [1, 0])),
     },
+    personSecretRepo: {
+      listByPerson: vi.fn(async () => []),
+      findRecord: vi.fn(async () => undefined),
+      findRecordsByNames: vi.fn(async () => new Map()),
+      upsert: vi.fn(),
+      delete: vi.fn(async () => false),
+    } as unknown as import("@beevibe/core").PersonSecretRepository,
   };
 }
 

--- a/packages/api/src/tools/assemble.ts
+++ b/packages/api/src/tools/assemble.ts
@@ -5,6 +5,7 @@ import type {
   CoreMemoryBlockRepository,
   EmbeddingService,
   LearnedSkillRepository,
+  PersonSecretRepository,
   RepoRunRepository,
   SessionSpawnMode,
   TaskRepository,
@@ -46,6 +47,12 @@ export interface AssembleToolsServices {
   learnedSkillRepo: LearnedSkillRepository;
   /** Capability Network: powers find_repo's semantic relevance gate. */
   embeddings: EmbeddingService;
+  /**
+   * Per-person encrypted secret store. use_repo validates requested
+   * secret names against this; composeDispatchPayload at claim time
+   * does the actual decryption.
+   */
+  personSecretRepo: PersonSecretRepository;
 }
 
 /**
@@ -196,6 +203,7 @@ export function assembleTools(
             taskRepo: services.taskRepo,
             repoRunRepo: services.repoRunRepo,
             dispatchService: services.dispatchService,
+            personSecretRepo: services.personSecretRepo,
           },
         ),
       ]

--- a/packages/api/src/tools/use-repo.ts
+++ b/packages/api/src/tools/use-repo.ts
@@ -23,6 +23,7 @@ import {
   sessionId as newSessionId,
   taskId as newTaskId,
   type AgentRepository,
+  type PersonSecretRepository,
   type RepoRunRepository,
   type TaskRepository,
 } from "@beevibe/core";
@@ -77,6 +78,20 @@ const USE_REPO_SCHEMA = {
       },
       additionalProperties: false,
     },
+    secrets: {
+      type: "array",
+      items: { type: "string" },
+      description:
+        "Optional list of env-var names from the caller's secret store to " +
+        "inject into the sandbox (set via `docker run --env <NAME>=<VALUE>`). " +
+        "Use for repos that need cloud-API credentials: e.g. " +
+        "['OPENAI_API_KEY', 'TAVILY_API_KEY'] for the " +
+        "architecture-deep-research repo. The named secrets must already " +
+        "exist for the caller (the user adds them via /settings → Secrets). " +
+        "Unknown names are silently skipped — the run can still proceed " +
+        "if the repo can fall back. Values are never logged or surfaced " +
+        "in the transcript.",
+    },
   },
   required: ["goal", "repo_url"],
   additionalProperties: false,
@@ -92,6 +107,7 @@ export interface UseRepoServices {
   taskRepo: TaskRepository;
   repoRunRepo: RepoRunRepository;
   dispatchService: DispatchService;
+  personSecretRepo: PersonSecretRepository;
 }
 
 export function createUseRepoTool(
@@ -159,6 +175,51 @@ export function createUseRepoTool(
         };
       }
 
+      // Per-run secret resolution. The handler ONLY validates that the
+      // requested names exist in the caller's secret store (existence
+      // check, NO decryption). The names get persisted on repo_run.
+      // requested_secret_names; composeDispatchPayload at /runtime/claim
+      // time does the actual decryption and puts the values into
+      // DispatchPayload.run_repo.sandbox_env. That keeps decrypted
+      // values out of any DB row.
+      //
+      // Unknown names are reported in missing_secret_names but don't
+      // block dispatch — the run can still try if the repo has a
+      // fallback. Whether to fail is the calling agent's call (it can
+      // re-prompt the user to add the missing key).
+      const requestedSecrets = Array.isArray(input.secrets)
+        ? Array.from(
+            new Set(
+              (input.secrets as unknown[]).filter(
+                (s): s is string => typeof s === "string" && s.length > 0,
+              ),
+            ),
+          )
+        : [];
+      const resolvedSecretNames: string[] = [];
+      const missingSecrets: string[] = [];
+      if (requestedSecrets.length > 0) {
+        let existingNames: Set<string>;
+        try {
+          const listed = await services.personSecretRepo.listByPerson(
+            agent.owner_id,
+          );
+          existingNames = new Set(listed.map((s) => s.name));
+        } catch (err) {
+          return {
+            content: {
+              error: "secret_lookup_failed",
+              message: err instanceof Error ? err.message : String(err),
+            },
+            isError: true,
+          };
+        }
+        for (const name of requestedSecrets) {
+          if (existingNames.has(name)) resolvedSecretNames.push(name);
+          else missingSecrets.push(name);
+        }
+      }
+
       // Container task — the artifact has to live somewhere, and
       // work_product requires a task_id. Title is a short cut of the
       // goal so the inbox row is scannable.
@@ -213,6 +274,11 @@ export function createUseRepoTool(
           goal,
           repo_url: repoUrl,
           status: "pending",
+          // Only persist the names that actually resolved. Missing names
+          // would just be dead weight at claim time; the agent already
+          // got told about them in the return payload.
+          requested_secret_names:
+            resolvedSecretNames.length > 0 ? resolvedSecretNames : undefined,
         });
       } catch (err) {
         // Session row landed but repo_run insert failed — orphan
@@ -245,6 +311,12 @@ export function createUseRepoTool(
           limits,
           input_url: inputUrl,
           input_filename: inputFilename,
+          // Echo back the secret names that were resolved / missed so the
+          // agent can tell the user which keys they still need to add
+          // (e.g. "I need OPENAI_API_KEY in /settings → Secrets to run
+          // ADR end-to-end"). Values are NEVER returned — names only.
+          resolved_secret_names: resolvedSecretNames,
+          missing_secret_names: missingSecrets,
         },
       };
     },

--- a/packages/core/src/adapters/postgres/index.ts
+++ b/packages/core/src/adapters/postgres/index.ts
@@ -36,3 +36,4 @@ export {
   PostgresSkillOutcomeRepository,
   newSkillOutcomeId,
 } from "./repo-run-repo.js";
+export { PostgresPersonSecretRepository } from "./person-secret-repo.js";

--- a/packages/core/src/adapters/postgres/person-secret-repo.test.ts
+++ b/packages/core/src/adapters/postgres/person-secret-repo.test.ts
@@ -1,0 +1,121 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { personId, personSecretId } from "../../domain/ids.js";
+import type { Pool } from "./client.js";
+import { createTestPool, truncateAll } from "../../test-helpers.js";
+import { PostgresPersonSecretRepository } from "./person-secret-repo.js";
+import { PostgresPersonRepository } from "./person-repo.js";
+
+const SAMPLE_RECORD = (overrides: Partial<{
+  id: string;
+  person_id: string;
+  name: string;
+  description: string;
+}> = {}) => ({
+  id: overrides.id ?? personSecretId(),
+  person_id: overrides.person_id!,
+  name: overrides.name ?? "OPENAI_API_KEY",
+  description: overrides.description,
+  // Realistic-shape ciphertext stand-ins. We're testing the SQL layer
+  // here, not the crypto layer — secrets.test.ts covers AES-GCM
+  // correctness end-to-end.
+  value_encrypted: "deadbeefcafef00d",
+  value_iv: "000102030405060708090a0b",
+  value_tag: "00112233445566778899aabbccddeeff",
+});
+
+describe("PostgresPersonSecretRepository", () => {
+  let pool: Pool;
+  let secrets: PostgresPersonSecretRepository;
+  let persons: PostgresPersonRepository;
+  let ownerId: string;
+  let otherOwnerId: string;
+
+  beforeAll(() => {
+    pool = createTestPool();
+    secrets = new PostgresPersonSecretRepository(pool);
+    persons = new PostgresPersonRepository(pool);
+  });
+
+  beforeEach(async () => {
+    await truncateAll(pool);
+    ownerId = (await persons.create({ id: personId(), name: "Owner" })).id;
+    otherOwnerId = (await persons.create({ id: personId(), name: "Other" })).id;
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("upsert inserts a new row + listByPerson returns metadata only (no ciphertext)", async () => {
+    const sample = SAMPLE_RECORD({ person_id: ownerId, description: "for ADR" });
+    await secrets.upsert(sample);
+    const listed = await secrets.listByPerson(ownerId);
+    expect(listed).toHaveLength(1);
+    expect(listed[0]!.name).toBe("OPENAI_API_KEY");
+    expect(listed[0]!.description).toBe("for ADR");
+    // PersonSecret intentionally lacks the ciphertext fields — TypeScript
+    // hides them at compile-time, this guards against any future widening.
+    expect((listed[0] as Record<string, unknown>).value_encrypted).toBeUndefined();
+  });
+
+  it("upsert overwrites ciphertext + updates updated_at when re-adding the same name", async () => {
+    const first = SAMPLE_RECORD({ person_id: ownerId });
+    await secrets.upsert(first);
+    const before = await secrets.findRecord(ownerId, "OPENAI_API_KEY");
+    expect(before).toBeDefined();
+    expect(before!.value_encrypted).toBe("deadbeefcafef00d");
+    expect(before!.value_iv).toBe("000102030405060708090a0b");
+
+    // Wait a tick so the updated_at delta is observable.
+    await new Promise((r) => setTimeout(r, 25));
+
+    const rotated = {
+      ...first,
+      value_encrypted: "1111111111111111",
+      value_iv: "111213141516171819202122",
+      value_tag: "33445566778899aabbccddeeff001122",
+    };
+    await secrets.upsert(rotated);
+    const after = await secrets.findRecord(ownerId, "OPENAI_API_KEY");
+    expect(after!.value_encrypted).toBe("1111111111111111");
+    expect(after!.value_iv).toBe("111213141516171819202122");
+    expect(after!.updated_at.getTime()).toBeGreaterThan(before!.updated_at.getTime());
+
+    // Still only one row — the unique constraint kept it merged.
+    const listed = await secrets.listByPerson(ownerId);
+    expect(listed).toHaveLength(1);
+  });
+
+  it("findRecord returns undefined when the secret belongs to a different person", async () => {
+    await secrets.upsert(SAMPLE_RECORD({ person_id: ownerId }));
+    const found = await secrets.findRecordsByNames(otherOwnerId, ["OPENAI_API_KEY"]);
+    expect(found.size).toBe(0);
+  });
+
+  it("findRecordsByNames batches and returns only matching names", async () => {
+    await secrets.upsert(SAMPLE_RECORD({ person_id: ownerId, name: "OPENAI_API_KEY" }));
+    await secrets.upsert(SAMPLE_RECORD({ person_id: ownerId, name: "TAVILY_API_KEY" }));
+    const found = await secrets.findRecordsByNames(ownerId, [
+      "OPENAI_API_KEY",
+      "TAVILY_API_KEY",
+      "BRAVE_SEARCH_API_KEY",
+    ]);
+    expect(found.size).toBe(2);
+    expect(found.get("OPENAI_API_KEY")).toBeDefined();
+    expect(found.get("TAVILY_API_KEY")).toBeDefined();
+    expect(found.get("BRAVE_SEARCH_API_KEY")).toBeUndefined();
+  });
+
+  it("delete is owner-scoped and returns false on cross-tenant attempts", async () => {
+    const secret = SAMPLE_RECORD({ person_id: ownerId });
+    await secrets.upsert(secret);
+
+    const crossTenant = await secrets.delete(secret.id, otherOwnerId);
+    expect(crossTenant).toBe(false);
+    expect(await secrets.listByPerson(ownerId)).toHaveLength(1);
+
+    const own = await secrets.delete(secret.id, ownerId);
+    expect(own).toBe(true);
+    expect(await secrets.listByPerson(ownerId)).toHaveLength(0);
+  });
+});

--- a/packages/core/src/adapters/postgres/person-secret-repo.ts
+++ b/packages/core/src/adapters/postgres/person-secret-repo.ts
@@ -1,0 +1,144 @@
+/**
+ * Postgres adapter for {@link PersonSecretRepository}.
+ *
+ * The two read paths are intentionally distinct:
+ *   - listByPerson + similar metadata reads NEVER select value_encrypted
+ *     / value_iv / value_tag. Keeps the ciphertext off any code path
+ *     that might log a row or surface it to a client.
+ *   - findRecord + findRecordsByNames are the explicit "I need to
+ *     decrypt" paths and pull the ciphertext columns.
+ *
+ * Upsert collapses re-add into rotate-in-place: the unique
+ * (person_id, name) constraint guarantees at most one row per env-var
+ * name per person, so the settings UI's "add" button works for both
+ * first-time and rotation flows.
+ */
+import type { Pool } from "./client.js";
+import type {
+  PersonSecret,
+  PersonSecretRecord,
+} from "../../domain/person-secret.js";
+import type {
+  NewPersonSecretInput,
+  PersonSecretRepository,
+} from "../../ports/person-secret-repo.js";
+
+interface PersonSecretListRow {
+  id: string;
+  person_id: string;
+  name: string;
+  description: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+interface PersonSecretFullRow extends PersonSecretListRow {
+  value_encrypted: string;
+  value_iv: string;
+  value_tag: string;
+}
+
+export class PostgresPersonSecretRepository implements PersonSecretRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async listByPerson(personId: string): Promise<PersonSecret[]> {
+    const { rows } = await this.pool.query<PersonSecretListRow>(
+      `SELECT id, person_id, name, description, created_at, updated_at
+         FROM person_secret
+        WHERE person_id = $1
+        ORDER BY name ASC`,
+      [personId],
+    );
+    return rows.map(rowToSecret);
+  }
+
+  async findRecord(
+    personId: string,
+    name: string,
+  ): Promise<PersonSecretRecord | undefined> {
+    const { rows } = await this.pool.query<PersonSecretFullRow>(
+      `SELECT id, person_id, name, description,
+              value_encrypted, value_iv, value_tag,
+              created_at, updated_at
+         FROM person_secret
+        WHERE person_id = $1 AND name = $2`,
+      [personId, name],
+    );
+    const row = rows[0];
+    return row ? rowToRecord(row) : undefined;
+  }
+
+  async findRecordsByNames(
+    personId: string,
+    names: string[],
+  ): Promise<Map<string, PersonSecretRecord>> {
+    if (names.length === 0) return new Map();
+    const { rows } = await this.pool.query<PersonSecretFullRow>(
+      `SELECT id, person_id, name, description,
+              value_encrypted, value_iv, value_tag,
+              created_at, updated_at
+         FROM person_secret
+        WHERE person_id = $1 AND name = ANY($2::text[])`,
+      [personId, names],
+    );
+    const map = new Map<string, PersonSecretRecord>();
+    for (const row of rows) {
+      map.set(row.name, rowToRecord(row));
+    }
+    return map;
+  }
+
+  async upsert(input: NewPersonSecretInput): Promise<PersonSecret> {
+    const { rows } = await this.pool.query<PersonSecretListRow>(
+      `INSERT INTO person_secret (
+         id, person_id, name, description,
+         value_encrypted, value_iv, value_tag
+       ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+       ON CONFLICT (person_id, name) DO UPDATE SET
+         value_encrypted = EXCLUDED.value_encrypted,
+         value_iv = EXCLUDED.value_iv,
+         value_tag = EXCLUDED.value_tag,
+         description = COALESCE(EXCLUDED.description, person_secret.description),
+         updated_at = NOW()
+       RETURNING id, person_id, name, description, created_at, updated_at`,
+      [
+        input.id,
+        input.person_id,
+        input.name,
+        input.description ?? null,
+        input.value_encrypted,
+        input.value_iv,
+        input.value_tag,
+      ],
+    );
+    return rowToSecret(rows[0]!);
+  }
+
+  async delete(id: string, personId: string): Promise<boolean> {
+    const result = await this.pool.query(
+      `DELETE FROM person_secret WHERE id = $1 AND person_id = $2`,
+      [id, personId],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+}
+
+function rowToSecret(row: PersonSecretListRow): PersonSecret {
+  return {
+    id: row.id,
+    person_id: row.person_id,
+    name: row.name,
+    description: row.description ?? undefined,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+function rowToRecord(row: PersonSecretFullRow): PersonSecretRecord {
+  return {
+    ...rowToSecret(row),
+    value_encrypted: row.value_encrypted,
+    value_iv: row.value_iv,
+    value_tag: row.value_tag,
+  };
+}

--- a/packages/core/src/adapters/postgres/repo-run-repo.ts
+++ b/packages/core/src/adapters/postgres/repo-run-repo.ts
@@ -36,6 +36,7 @@ interface RepoRunRow {
   error: string | null;
   learned_skill_id: string | null;
   ranker_candidates: unknown;
+  requested_secret_names: string[] | null;
   started_at: Date;
   ended_at: Date | null;
 }
@@ -78,8 +79,8 @@ export class PostgresRepoRunRepository implements RepoRunRepository {
     const { rows } = await this.pool.query<RepoRunRow>(
       `INSERT INTO repo_run
          (id, session_id, task_id, agent_id, goal, repo_url, repo_ref,
-          status, transcript)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+          status, transcript, requested_secret_names)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
        RETURNING *`,
       [
         input.id,
@@ -91,6 +92,9 @@ export class PostgresRepoRunRepository implements RepoRunRepository {
         input.repo_ref ?? null,
         status,
         JSON.stringify(transcript),
+        input.requested_secret_names && input.requested_secret_names.length > 0
+          ? input.requested_secret_names
+          : null,
       ],
     );
     return rowToRepoRun(rows[0]!);
@@ -400,6 +404,7 @@ function rowToRepoRun(row: RepoRunRow): RepoRun {
     error: row.error ?? undefined,
     learned_skill_id: row.learned_skill_id ?? undefined,
     ranker_candidates: row.ranker_candidates ?? undefined,
+    requested_secret_names: row.requested_secret_names ?? undefined,
     started_at: row.started_at,
     ended_at: row.ended_at ?? undefined,
   };

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -4,3 +4,4 @@ export * from "./constants.js";
 export * from "./find-user-agent.js";
 export * from "./password.js";
 export * from "./provision.js";
+export * from "./secrets.js";

--- a/packages/core/src/auth/secrets.test.ts
+++ b/packages/core/src/auth/secrets.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { randomBytes } from "node:crypto";
+import {
+  encryptSecret,
+  decryptSecret,
+  getSecretsKey,
+  __resetSecretsKeyForTests,
+} from "./secrets.js";
+
+const KEY_A = randomBytes(32).toString("hex");
+const KEY_B = randomBytes(32).toString("hex");
+
+let savedKey: string | undefined;
+
+beforeEach(() => {
+  savedKey = process.env.BEEVIBE_SECRETS_KEY;
+  __resetSecretsKeyForTests();
+});
+
+afterEach(() => {
+  if (savedKey === undefined) delete process.env.BEEVIBE_SECRETS_KEY;
+  else process.env.BEEVIBE_SECRETS_KEY = savedKey;
+  __resetSecretsKeyForTests();
+});
+
+describe("getSecretsKey", () => {
+  it("throws when env var is missing", () => {
+    delete process.env.BEEVIBE_SECRETS_KEY;
+    expect(() => getSecretsKey()).toThrow(/BEEVIBE_SECRETS_KEY is not set/);
+  });
+
+  it("throws on wrong length", () => {
+    process.env.BEEVIBE_SECRETS_KEY = "abcd";
+    expect(() => getSecretsKey()).toThrow(/must decode to 32 bytes/);
+  });
+
+  it("accepts a valid 64-hex key", () => {
+    process.env.BEEVIBE_SECRETS_KEY = KEY_A;
+    expect(getSecretsKey()).toHaveLength(32);
+  });
+});
+
+describe("encrypt / decrypt roundtrip", () => {
+  it("recovers the plaintext", () => {
+    process.env.BEEVIBE_SECRETS_KEY = KEY_A;
+    const enc = encryptSecret("sk-test-OPENAI_API_KEY-abc123");
+    expect(decryptSecret(enc)).toBe("sk-test-OPENAI_API_KEY-abc123");
+  });
+
+  it("produces a fresh IV per encryption (no reuse)", () => {
+    process.env.BEEVIBE_SECRETS_KEY = KEY_A;
+    const a = encryptSecret("same-plaintext");
+    const b = encryptSecret("same-plaintext");
+    expect(a.value_iv).not.toBe(b.value_iv);
+    expect(a.value_encrypted).not.toBe(b.value_encrypted);
+  });
+
+  it("handles UTF-8 with multibyte characters", () => {
+    process.env.BEEVIBE_SECRETS_KEY = KEY_A;
+    const plaintext = "token-with-日本語-and-emoji-🔐";
+    const enc = encryptSecret(plaintext);
+    expect(decryptSecret(enc)).toBe(plaintext);
+  });
+
+  it("handles empty string", () => {
+    process.env.BEEVIBE_SECRETS_KEY = KEY_A;
+    const enc = encryptSecret("");
+    expect(decryptSecret(enc)).toBe("");
+  });
+});
+
+describe("decryptSecret tamper detection", () => {
+  it("throws when ciphertext is modified", () => {
+    process.env.BEEVIBE_SECRETS_KEY = KEY_A;
+    const enc = encryptSecret("original-secret");
+    const tampered = {
+      ...enc,
+      value_encrypted: enc.value_encrypted.replace(/.$/, (c) =>
+        c === "0" ? "1" : "0",
+      ),
+    };
+    expect(() => decryptSecret(tampered)).toThrow();
+  });
+
+  it("throws when auth tag is modified", () => {
+    process.env.BEEVIBE_SECRETS_KEY = KEY_A;
+    const enc = encryptSecret("original-secret");
+    const tampered = {
+      ...enc,
+      value_tag: enc.value_tag.replace(/.$/, (c) => (c === "0" ? "1" : "0")),
+    };
+    expect(() => decryptSecret(tampered)).toThrow();
+  });
+
+  it("throws when wrong key is used", () => {
+    process.env.BEEVIBE_SECRETS_KEY = KEY_A;
+    const enc = encryptSecret("original-secret");
+    process.env.BEEVIBE_SECRETS_KEY = KEY_B;
+    __resetSecretsKeyForTests();
+    expect(() => decryptSecret(enc)).toThrow();
+  });
+
+  it("throws on malformed IV length", () => {
+    process.env.BEEVIBE_SECRETS_KEY = KEY_A;
+    const enc = encryptSecret("x");
+    expect(() => decryptSecret({ ...enc, value_iv: "deadbeef" })).toThrow(
+      /iv must be 12 bytes/,
+    );
+  });
+
+  it("throws on malformed tag length", () => {
+    process.env.BEEVIBE_SECRETS_KEY = KEY_A;
+    const enc = encryptSecret("x");
+    expect(() => decryptSecret({ ...enc, value_tag: "deadbeef" })).toThrow(
+      /tag must be 16 bytes/,
+    );
+  });
+});

--- a/packages/core/src/auth/secrets.ts
+++ b/packages/core/src/auth/secrets.ts
@@ -1,0 +1,128 @@
+/**
+ * Symmetric encryption for the per-person secret store (api keys,
+ * tokens) that gets injected into sandboxed `use_repo` runs as env
+ * vars.
+ *
+ * Algorithm: AES-256-GCM via node's stdlib `createCipheriv`. GCM gives
+ * authenticated encryption — tampering with the ciphertext makes
+ * `decryptSecret` throw, so a compromised DB row can't silently inject
+ * the wrong value. The 96-bit IV is per-row random; the 128-bit auth
+ * tag is per-row from the cipher.
+ *
+ * Key material: 32 bytes (256 bits) read from the BEEVIBE_SECRETS_KEY
+ * env var as 64 hex chars. Generated once per deployment with
+ * `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"`.
+ * Rotating the key today requires re-encrypting all rows (no key-ring
+ * support yet); flagged for follow-up when first rotation is needed.
+ *
+ * What this module is NOT:
+ *   - not for hashing user passwords (use ./password.ts)
+ *   - not for hashing API tokens stored on `person.api_key` (those are
+ *     compared as plaintext — different threat model)
+ *
+ * Returned shape `{ value_encrypted, value_iv, value_tag }` maps 1:1
+ * to the `person_secret` table columns of the same names.
+ */
+
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+const ALGORITHM = "aes-256-gcm";
+const KEY_BYTES = 32; // 256-bit key
+const IV_BYTES = 12; // 96-bit nonce (GCM standard)
+const TAG_BYTES = 16; // 128-bit auth tag
+
+export interface EncryptedSecret {
+  /** Hex-encoded ciphertext. */
+  value_encrypted: string;
+  /** Hex-encoded 12-byte IV. Unique per encryption. */
+  value_iv: string;
+  /** Hex-encoded 16-byte GCM auth tag. */
+  value_tag: string;
+}
+
+let cachedKey: Buffer | undefined;
+
+/**
+ * Read + validate the master key from BEEVIBE_SECRETS_KEY env. Cached
+ * for the process lifetime — the env var doesn't change at runtime.
+ *
+ * Throws a clear error if the key is missing or the wrong length so
+ * mis-configuration surfaces at first encrypt/decrypt instead of
+ * producing silent data corruption.
+ */
+export function getSecretsKey(): Buffer {
+  if (cachedKey) return cachedKey;
+  const raw = process.env.BEEVIBE_SECRETS_KEY;
+  if (!raw) {
+    throw new Error(
+      "BEEVIBE_SECRETS_KEY is not set. Generate with: node -e \"console.log(require('crypto').randomBytes(32).toString('hex'))\"",
+    );
+  }
+  let key: Buffer;
+  try {
+    key = Buffer.from(raw.trim(), "hex");
+  } catch {
+    throw new Error("BEEVIBE_SECRETS_KEY must be hex-encoded");
+  }
+  if (key.length !== KEY_BYTES) {
+    throw new Error(
+      `BEEVIBE_SECRETS_KEY must decode to ${KEY_BYTES} bytes (got ${key.length}). Use 64 hex chars.`,
+    );
+  }
+  cachedKey = key;
+  return key;
+}
+
+/** Test seam — clears the cached key so tests can rotate it. */
+export function __resetSecretsKeyForTests(): void {
+  cachedKey = undefined;
+}
+
+/**
+ * Encrypt a secret value (UTF-8 string) under the master key. The
+ * returned shape maps directly onto person_secret's three storage
+ * columns.
+ */
+export function encryptSecret(plaintext: string): EncryptedSecret {
+  if (typeof plaintext !== "string") {
+    throw new TypeError("encryptSecret: plaintext must be a string");
+  }
+  const key = getSecretsKey();
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+  return {
+    value_encrypted: ciphertext.toString("hex"),
+    value_iv: iv.toString("hex"),
+    value_tag: tag.toString("hex"),
+  };
+}
+
+/**
+ * Inverse of {@link encryptSecret}. Throws if the ciphertext or tag
+ * has been tampered with (GCM auth failure) — the API surface treats
+ * this as a 500 and logs without the value (no `console.error(e)` with
+ * `e` containing fragments of plaintext).
+ */
+export function decryptSecret(record: EncryptedSecret): string {
+  const key = getSecretsKey();
+  const iv = Buffer.from(record.value_iv, "hex");
+  const tag = Buffer.from(record.value_tag, "hex");
+  if (iv.length !== IV_BYTES) {
+    throw new Error(`decryptSecret: iv must be ${IV_BYTES} bytes`);
+  }
+  if (tag.length !== TAG_BYTES) {
+    throw new Error(`decryptSecret: tag must be ${TAG_BYTES} bytes`);
+  }
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(tag);
+  const plaintext = Buffer.concat([
+    decipher.update(Buffer.from(record.value_encrypted, "hex")),
+    decipher.final(),
+  ]);
+  return plaintext.toString("utf8");
+}

--- a/packages/core/src/domain/ids.ts
+++ b/packages/core/src/domain/ids.ts
@@ -27,3 +27,4 @@ export const agentProvisionEventId = (): string => generateId("ape");
 export const repoRunId = (): string => generateId("repo");
 export const learnedSkillId = (): string => generateId("skill");
 export const skillOutcomeId = (): string => generateId("sout");
+export const personSecretId = (): string => generateId("psec");

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -12,3 +12,4 @@ export * from "./daemon.js";
 export * from "./runtime.js";
 export * from "./room.js";
 export * from "./repo-run.js";
+export * from "./person-secret.js";

--- a/packages/core/src/domain/person-secret.ts
+++ b/packages/core/src/domain/person-secret.ts
@@ -1,0 +1,34 @@
+/**
+ * Per-person encrypted secret — typically an API key or token a
+ * person's agents need to inject into sandboxed `use_repo` runs as
+ * env vars (e.g. OPENAI_API_KEY for the architecture-deep-research
+ * specialist).
+ *
+ * See migration 1781200000000_add-person-secret.sql for schema and
+ * threat model. See packages/core/src/auth/secrets.ts for the AES-GCM
+ * helpers that produce the stored shape.
+ *
+ * `value_encrypted` / `value_iv` / `value_tag` are intentionally NOT
+ * exposed via this type — domain readers shouldn't need ciphertext.
+ * Use {@link PersonSecretRecord} when working directly against the row.
+ */
+
+export interface PersonSecret {
+  id: string;
+  person_id: string;
+  /** Env-var-style name. Convention: SCREAMING_SNAKE_CASE. */
+  name: string;
+  description?: string;
+  created_at: Date;
+  updated_at: Date;
+}
+
+/**
+ * Internal full row shape including the ciphertext fields. Use only
+ * inside the api/core auth layer that decrypts; never expose to clients.
+ */
+export interface PersonSecretRecord extends PersonSecret {
+  value_encrypted: string;
+  value_iv: string;
+  value_tag: string;
+}

--- a/packages/core/src/domain/repo-run.ts
+++ b/packages/core/src/domain/repo-run.ts
@@ -53,6 +53,13 @@ export interface RepoRun {
   learned_skill_id?: string;
   /** Discovery candidates considered for this run (debug only). */
   ranker_candidates?: unknown;
+  /**
+   * Names (not values) of person_secret rows the caller asked to be
+   * injected into the sandbox container as env vars. Resolved + decrypted
+   * at /runtime/claim time so decrypted values never persist in the DB.
+   * Empty / undefined when use_repo was called without secrets.
+   */
+  requested_secret_names?: string[];
 
   started_at: Date;
   ended_at?: Date;

--- a/packages/core/src/ports/index.ts
+++ b/packages/core/src/ports/index.ts
@@ -18,3 +18,4 @@ export * from "./escalation-repo.js";
 export * from "./room-repo.js";
 export * from "./agent-provision-event-repo.js";
 export * from "./repo-run-repo.js";
+export * from "./person-secret-repo.js";

--- a/packages/core/src/ports/person-secret-repo.ts
+++ b/packages/core/src/ports/person-secret-repo.ts
@@ -1,0 +1,53 @@
+import type {
+  PersonSecret,
+  PersonSecretRecord,
+} from "../domain/person-secret.js";
+
+export type NewPersonSecretInput = {
+  id: string;
+  person_id: string;
+  name: string;
+  description?: string;
+  value_encrypted: string;
+  value_iv: string;
+  value_tag: string;
+};
+
+export type PersonSecretPatch = {
+  value_encrypted?: string;
+  value_iv?: string;
+  value_tag?: string;
+  description?: string;
+};
+
+export interface PersonSecretRepository {
+  /**
+   * List a person's secrets WITHOUT ciphertext — for the settings UI.
+   * The api route layer should never return PersonSecretRecord shapes
+   * to clients.
+   */
+  listByPerson(personId: string): Promise<PersonSecret[]>;
+
+  /**
+   * Read a single secret WITH ciphertext, for server-side decryption
+   * in the sandbox-injection path. Returns undefined if the secret
+   * doesn't exist OR doesn't belong to `personId` (so the caller
+   * doesn't need a separate ownership check).
+   */
+  findRecord(personId: string, name: string): Promise<PersonSecretRecord | undefined>;
+
+  /**
+   * Batch-fetch records for a set of names, all scoped to one person.
+   * Returns a map keyed by name; missing names are simply absent.
+   * Used by use_repo to load the requested secrets in one round-trip.
+   */
+  findRecordsByNames(
+    personId: string,
+    names: string[],
+  ): Promise<Map<string, PersonSecretRecord>>;
+
+  /** Upsert is intentional — `name` is unique per person, so a re-add overwrites. */
+  upsert(input: NewPersonSecretInput): Promise<PersonSecret>;
+
+  delete(id: string, personId: string): Promise<boolean>;
+}

--- a/packages/daemon/src/repo-runs.ts
+++ b/packages/daemon/src/repo-runs.ts
@@ -121,6 +121,11 @@ export async function runRepoDispatch(
     input_filename: rr.input_filename,
     claude_bin: CLAUDE_BIN,
     max_runtime_seconds: (rr.limits?.wall_clock_minutes ?? 20) * 60,
+    // Decrypted secrets the api resolved at /runtime/claim and shipped
+    // in the DispatchPayload. createSandbox feeds them to
+    // `docker run --env` so the sandboxed child can read them as
+    // process.env.<NAME>. Never logged or echoed into the transcript.
+    sandbox_env: rr.sandbox_env,
     on_state: (s) => {
       pushNew(s.transcript);
       // Walk new tool-call events to capture install/invocation hints.

--- a/packages/daemon/src/spawner.ts
+++ b/packages/daemon/src/spawner.ts
@@ -62,6 +62,15 @@ export interface RunRepoDispatch {
     max_install_attempts?: number;
     disk_mb?: number;
   };
+  /**
+   * Decrypted env vars to inject into the sandbox container via
+   * `docker run --env NAME=VALUE`. Resolved server-side at
+   * /runtime/claim from the caller's person_secret store (only
+   * names the user authorized via use_repo({ secrets: [...] })).
+   * The daemon must NEVER log values from this map — orchestrator
+   * code already avoids echoing env into transcripts.
+   */
+  sandbox_env?: Record<string, string>;
 }
 
 export interface RunRepoArtifact {

--- a/packages/sandbox/src/docker.ts
+++ b/packages/sandbox/src/docker.ts
@@ -44,6 +44,14 @@ export interface SandboxOptions {
    * suffix to make the actual container name.
    */
   label?: string;
+  /**
+   * Env vars to set on the container via `docker run --env NAME=VALUE`.
+   * Used to inject decrypted person_secret values for use_repo runs.
+   * Values are visible to any process inside the container — that's
+   * the point — but never logged or stamped on the Sandbox return
+   * shape, so callers can't accidentally serialize them.
+   */
+  env?: Record<string, string>;
 }
 
 export interface Sandbox {
@@ -143,6 +151,14 @@ export async function createSandbox(opts: SandboxOptions = {}): Promise<Sandbox>
 
   if (!limits.network) {
     args.push("--network=none");
+  }
+
+  // Per-call env injection. Values are passed to docker via individual
+  // --env flags; docker forwards them as the container's process env.
+  // Skipped silently when no env was provided so the existing behavior
+  // (no env at all) stays identical for callers that don't opt in.
+  for (const [k, v] of Object.entries(opts.env ?? {})) {
+    args.push("--env", `${k}=${v}`);
   }
 
   args.push(image, "-f", "/dev/null");

--- a/packages/sandbox/src/orchestrator.ts
+++ b/packages/sandbox/src/orchestrator.ts
@@ -87,6 +87,16 @@ export interface OrchestratorOptions {
   mcp_server_command?: { command: string; args: string[] };
   /** Callback fired every time RunState changes. */
   on_state?: (state: RunState) => void;
+  /**
+   * Env vars to set inside the sandbox container at create time
+   * (via `docker run --env NAME=VALUE`). Used by use_repo to inject
+   * decrypted person_secret values (API keys, tokens) so the child
+   * agent can call cloud APIs from inside the sandbox.
+   *
+   * Never logged into the transcript — only the variable names are
+   * surfaced in any debug output, never the values.
+   */
+  sandbox_env?: Record<string, string>;
 }
 
 const DEFAULT_PROMPT_HEADER = `\
@@ -194,12 +204,22 @@ export async function runRepoAgent(opts: OrchestratorOptions): Promise<RunState>
     state.status = "preparing";
     emit();
     try {
-      sandbox = await createSandbox({ label: `bv-run-${opts.run_id}` });
+      sandbox = await createSandbox({
+        label: `bv-run-${opts.run_id}`,
+        env: opts.sandbox_env,
+      });
     } catch (err) {
       throw new Error(classifyStartupError(err));
     }
     state.sandbox_id = sandbox.id;
     log("log", `Sandbox ${sandbox.id} created (image ${sandbox.image}).`);
+    if (opts.sandbox_env && Object.keys(opts.sandbox_env).length > 0) {
+      // Log NAMES only, never values.
+      log(
+        "log",
+        `Injected env vars: ${Object.keys(opts.sandbox_env).join(", ")}.`,
+      );
+    }
 
     log("log", "Installing git + curl in the sandbox base image…");
     await prepareBaseEnvironment(sandbox);

--- a/packages/web/app/(authed)/settings/settings-client.tsx
+++ b/packages/web/app/(authed)/settings/settings-client.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import Link from "next/link";
+import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowRight, Cpu, Sparkles } from "lucide-react";
+import { ArrowRight, Cpu, KeyRound, Sparkles, Trash2 } from "lucide-react";
 import {
   api,
   type MeResponse,
+  type PersonSecretDisplay,
   type UserPreferences,
 } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
@@ -73,6 +75,24 @@ export function SettingsClient() {
               errored={toggle.isError}
             />
           )}
+        </section>
+
+        <section className="space-y-3">
+          <div className="flex items-center gap-2">
+            <KeyRound className="h-3.5 w-3.5 text-muted-foreground" />
+            <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground font-medium">
+              Secrets
+            </h2>
+          </div>
+          <p className="text-xs text-muted-foreground leading-relaxed">
+            API keys + tokens your agents can inject into sandboxed{" "}
+            <span className="font-mono">use_repo</span> runs (e.g.{" "}
+            <span className="font-mono">OPENAI_API_KEY</span> for the
+            architecture-deep-research repo). Values are encrypted at rest
+            (AES-256-GCM) and only decrypted in-memory at sandbox spawn
+            time — never returned to the browser.
+          </p>
+          <SecretsSection />
         </section>
 
         <section className="space-y-3">
@@ -152,5 +172,164 @@ function CapabilityNetworkToggle({
         </button>
       </div>
     </div>
+  );
+}
+
+function SecretsSection() {
+  const qc = useQueryClient();
+  const list = useQuery({
+    queryKey: queryKeys.secrets.list(),
+    queryFn: ({ signal }) => api.secrets.list({ signal }),
+    enabled: isApiConfigured,
+    staleTime: 30_000,
+  });
+
+  const secrets = list.data?.secrets ?? [];
+  // Touched by both upsert + delete so the list refetches after either.
+  const invalidate = () =>
+    qc.invalidateQueries({ queryKey: queryKeys.secrets.all });
+
+  if (list.isLoading) return <Skeleton className="h-24 w-full rounded-lg" />;
+  if (list.isError) {
+    return (
+      <EmptyState
+        title="Couldn't load secrets"
+        description="Try refreshing the page."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {secrets.map((s) => (
+        <SecretRow key={s.id} secret={s} onDeleted={invalidate} />
+      ))}
+      <AddSecretForm onAdded={invalidate} />
+    </div>
+  );
+}
+
+function SecretRow({
+  secret,
+  onDeleted,
+}: {
+  secret: PersonSecretDisplay;
+  onDeleted: () => void;
+}) {
+  const del = useMutation({
+    mutationFn: () => api.secrets.delete(secret.id),
+    onSuccess: onDeleted,
+  });
+  return (
+    <div className="rounded-lg border border-border/40 bg-card px-4 py-3">
+      <div className="flex items-start gap-3">
+        <div className="flex-1 min-w-0">
+          <p className="font-mono text-sm">{secret.name}</p>
+          {secret.description ? (
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {secret.description}
+            </p>
+          ) : null}
+          {del.isError ? (
+            <p className="text-[11px] text-red-500 mt-1">
+              Delete failed — try again.
+            </p>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          onClick={() => del.mutate()}
+          disabled={del.isPending}
+          aria-label={`Delete ${secret.name}`}
+          className="shrink-0 inline-flex items-center justify-center h-7 w-7 rounded text-muted-foreground hover:text-red-500 hover:bg-red-500/10 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function AddSecretForm({ onAdded }: { onAdded: () => void }) {
+  const [name, setName] = useState("");
+  const [value, setValue] = useState("");
+  const [description, setDescription] = useState("");
+  const upsert = useMutation({
+    mutationFn: () =>
+      api.secrets.upsert({
+        name: name.trim(),
+        value,
+        ...(description.trim() ? { description: description.trim() } : {}),
+      }),
+    onSuccess: () => {
+      setName("");
+      setValue("");
+      setDescription("");
+      onAdded();
+    },
+  });
+
+  // Mirror the api route's validation so the user sees the same rule
+  // before round-tripping. The server is still the source of truth.
+  const nameValid = /^[A-Z_][A-Z0-9_]*$/.test(name.trim());
+  const canSubmit = nameValid && value.length > 0 && !upsert.isPending;
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (canSubmit) upsert.mutate();
+      }}
+      className="rounded-lg border border-dashed border-border/50 bg-card/40 px-4 py-3 space-y-2"
+    >
+      <p className="text-[11px] uppercase tracking-wider text-muted-foreground font-medium">
+        Add or rotate
+      </p>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="OPENAI_API_KEY"
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck={false}
+          className="rounded border border-border/40 bg-background px-2.5 py-1.5 text-xs font-mono focus:outline-none focus:ring-1 focus:ring-ring"
+        />
+        <input
+          type="password"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="value (never shown again)"
+          autoComplete="off"
+          spellCheck={false}
+          className="rounded border border-border/40 bg-background px-2.5 py-1.5 text-xs font-mono focus:outline-none focus:ring-1 focus:ring-ring"
+        />
+      </div>
+      <input
+        type="text"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        placeholder="What's this for? (optional)"
+        maxLength={512}
+        className="w-full rounded border border-border/40 bg-background px-2.5 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+      />
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-[11px] text-muted-foreground">
+          {name.length > 0 && !nameValid
+            ? "Name must be SCREAMING_SNAKE_CASE."
+            : upsert.isError
+              ? "Save failed — check the name + value."
+              : "Re-adding an existing name rotates it."}
+        </p>
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          className="inline-flex items-center gap-1.5 rounded bg-foreground text-background text-xs font-medium px-2.5 py-1 disabled:opacity-50 disabled:cursor-not-allowed hover:opacity-90 transition-opacity"
+        >
+          {upsert.isPending ? "Saving…" : "Save"}
+        </button>
+      </div>
+    </form>
   );
 }

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -716,17 +716,55 @@ export const api = {
         `/capabilities/referenced-repos?task_id=${encodeURIComponent(taskId)}`,
         { signal: opts.signal },
       ),
-    /** Trigger a use_repo sandbox run from a human caller. Returns 202. */
-    use: (input: { repo_url: string; goal: string }) =>
+    /**
+     * Trigger a use_repo sandbox run from a human caller. Returns 202.
+     * Pass `secrets` to inject env vars into the sandbox container from
+     * the caller's secret store; values never leave the server.
+     */
+    use: (input: { repo_url: string; goal: string; secrets?: string[] }) =>
       fetchJson<{
         repo_run_id: string;
         session_id: string;
         task_id: string;
         status: string;
         watch_url: string;
+        resolved_secret_names?: string[];
+        missing_secret_names?: string[];
       }>("/capabilities/use", { method: "POST", body: input }),
   },
+  /**
+   * Per-person encrypted secret store — backs sandbox env injection for
+   * use_repo runs. Settings page reads listByPerson; the agent-driven
+   * MCP path injects them server-side via use_repo's `secrets` param.
+   * Values are NEVER returned by any of these endpoints — the API
+   * surface is metadata-only for clients.
+   */
+  secrets: {
+    list: (opts: ReadOptions = {}) =>
+      fetchJson<{ secrets: PersonSecretDisplay[] }>("/secrets/", {
+        signal: opts.signal,
+      }),
+    upsert: (input: { name: string; value: string; description?: string }) =>
+      fetchJson<{ secret: PersonSecretDisplay }>("/secrets/", {
+        method: "POST",
+        body: input,
+      }),
+    delete: (id: string) =>
+      fetchJson<void>(`/secrets/${encodeURIComponent(id)}`, {
+        method: "DELETE",
+      }),
+  },
 } as const;
+
+/** Metadata-only secret shape — never carries `value_*` cipher fields. */
+export interface PersonSecretDisplay {
+  id: string;
+  person_id: string;
+  name: string;
+  description?: string;
+  created_at: string;
+  updated_at: string;
+}
 
 export interface ReferencedRepo {
   owner: string;

--- a/packages/web/lib/hooks/keys.ts
+++ b/packages/web/lib/hooks/keys.ts
@@ -72,4 +72,8 @@ export const queryKeys = {
     historyAll: ["chat", "history"] as const,
     conversations: () => ["chat", "conversations"] as const,
   },
+  secrets: {
+    all: ["secrets"] as const,
+    list: () => ["secrets", "list"] as const,
+  },
 } as const;


### PR DESCRIPTION
## Summary

Adds a per-person encrypted secret store and threads decrypted values through to sandboxed \`use_repo\` runs as \`docker run --env\` vars. Unblocks repos that need cloud-API credentials (architecture-deep-research, anything needing OPENAI / search-provider keys) — the sandbox previously spawned with NO \`--env\` flags so cloud-using repos were structurally impossible.

## Flow

\`\`\`
user adds OPENAI_API_KEY in /settings → Secrets (encrypted with AES-256-GCM)
              ↓
agent calls use_repo({ secrets: [\"OPENAI_API_KEY\"] })
              ↓
api handler validates names exist (no decrypt) → persists requested
names on repo_run.requested_secret_names
              ↓
api dispatchService writes the session row → daemon polls /runtime/claim
              ↓
composeDispatchPayload reads repo_run.requested_secret_names → looks
up + decrypts records via personSecretRepo → puts plaintext into
DispatchPayload.run_repo.sandbox_env
              ↓
daemon's runRepoDispatch passes sandbox_env to runRepoAgent
              ↓
orchestrator passes opts.sandbox_env to createSandbox
              ↓
createSandbox emits \`docker run --env NAME=VALUE\` for each entry
\`\`\`

Decrypted values exist only in the api process at claim time → daemon runtime payload → container env. Never persisted in any DB row, never logged in any session_event content, never returned by any REST endpoint.

## Schema (2 migrations)

- \`1781200000000_add-person-secret\` — \`person_secret\` table: id, person_id (FK CASCADE), name (UNIQUE per person), value_encrypted + value_iv + value_tag (hex AES-256-GCM), description?, timestamps
- \`1781200000001_add-repo-run-requested-secret-names\` — adds \`requested_secret_names TEXT[]\` to \`repo_run\` so the dispatch flow can look up + decrypt secrets at claim time without ever persisting decrypted values

## Crypto

- \`packages/core/src/auth/secrets.ts\` — AES-256-GCM via node stdlib. Master key from \`BEEVIBE_SECRETS_KEY\` env (32-byte hex, validated at first use). Per-row random 96-bit IV. 128-bit auth tag detects tampering (decrypt throws on ciphertext / tag / key mismatch).
- 12 unit tests covering roundtrip, key absence/length, UTF-8 multibyte, empty string, IV uniqueness, ciphertext tamper, tag tamper, wrong-key, malformed IV/tag.

## API surface

- \`GET /secrets\` / \`POST /secrets\` / \`DELETE /secrets/:id\` — bv_u_ only, metadata-only responses, validation (SCREAMING_SNAKE_CASE name ≤128, value ≤16KB, description ≤512)
- \`use_repo\` MCP tool gained \`secrets?: string[]\` param. Returns \`resolved_secret_names\` + \`missing_secret_names\` so the agent can re-prompt for missing keys
- \`POST /capabilities/use\` accepts \`secrets\` from the human-driven Capabilities Try-button path too

## Auth model v1 (intentional simplifications)

- person-scoped (your keys, your runs); org-shared is follow-up
- implicit auth (any of your agents can request any of your secrets); per-repo / per-agent grants are follow-up
- no key rotation tooling (rotating \`BEEVIBE_SECRETS_KEY\` today requires re-encrypting all rows out-of-band)

## UI

New Secrets section on \`/settings\` with list, add/rotate (\`type=\"password\"\` value field, \`autoComplete=\"off\"\`), and delete. Inline validation mirrors the server. Copy on the section header explains the threat model in one line.

## Test plan

- [x] 17 unit tests pass (12 crypto + 5 adapter integration)
- [x] All existing suites green: 574 core / 372 api / 141 web / 7 daemon / sandbox e2e skipped
- [x] **End-to-end backend smoke** via curl + standalone Node script:
  - POST /secrets stores; direct DB check confirms \`is_plaintext = false\`
  - GET /secrets returns metadata only (no \`value_*\` fields)
  - Validation: invalid name → 400, missing value → 400
  - Rotation: re-POST same name → 1 row, \`updated_at\` advances
  - DELETE: owner-scoped (404 cross-tenant)
  - POST /capabilities/use with \`secrets: [...]\` → \`resolved_secret_names\` + \`missing_secret_names\` correct; \`repo_run.requested_secret_names\` persisted as \`{TEST_API_KEY, TAVILY_API_KEY}\`
  - Standalone replay of \`composeDispatchPayload\` decrypt path recovered exact plaintexts (\`sk-test-12345\`, \`tvly-test-67890\`)
- [ ] Set \`BEEVIBE_SECRETS_KEY\` in staging env (generate fresh: \`node -e \"console.log(require('crypto').randomBytes(32).toString('hex'))\"\`)
- [ ] Apply both migrations to staging DB
- [ ] Open /settings → Secrets, add an OPENAI_API_KEY
- [ ] Hit Try on architecture-deep-research from the Capabilities page with \`secrets: [\"OPENAI_API_KEY\"]\` and confirm the sandbox container actually has the env

🤖 Generated with [Claude Code](https://claude.com/claude-code)