### PR TITLE
docs(tools): sharpen update_core_memory description (append-vs-replace + dated-update ban)

### DIFF
--- a/packages/api/src/tools/update-core-memory.ts
+++ b/packages/api/src/tools/update-core-memory.ts
@@ -65,19 +65,28 @@ export function createUpdateCoreMemoryTool(
         type: "string",
         enum: OPERATIONS,
         description:
-          "append: add new content at the end of the existing block. " +
-          "replace: substitute old_content with content (old_content required).",
+          "append: concatenate content as a new line at the end of the " +
+          "block. ONLY for accumulating-list blocks (e.g. team_members); " +
+          "never for narrative blocks — see the tool description's " +
+          "decision criterion. replace: substitute old_content with " +
+          "content (old_content required). Use replace for surgical " +
+          "fixes AND for consolidating rewrites of narrative blocks " +
+          "(pass the whole current block as old_content).",
       },
       content: {
         type: "string",
         description:
-          "The new content. For append: appended verbatim. For replace: replaces old_content.",
+          "The new content. For append: appended verbatim with a leading " +
+          "newline. For replace: the substring (or whole-block contents) " +
+          "that takes the place of old_content.",
       },
       old_content: {
         type: "string",
         description:
-          "Required for replace. The exact substring to substitute. Must match " +
-          "exactly (verbatim) somewhere in the existing block.",
+          "Required for replace. The exact substring to substitute — " +
+          "must match verbatim somewhere in the existing block. For a " +
+          "consolidating rewrite of a narrative block, pass the FULL " +
+          "current block contents (verbatim from <core_memory>).",
       },
     },
     required: ["block_name", "operation", "content"],
@@ -86,14 +95,79 @@ export function createUpdateCoreMemoryTool(
   return {
     name: "update_core_memory",
     description:
-      "Edit one of your core-memory blocks. These appear in every future " +
-      "session's briefing — treat as expensive real estate. Use ONLY for " +
-      "stable, durable shifts that should appear in every future briefing: " +
-      "persona changes, long-term constraint changes, patterns confirmed " +
-      "across multiple sessions. NOT for one-shot facts (use save_memory " +
-      "instead). If unsure between core and archival, use save_memory; " +
-      "promote to core later if the fact recurs across sessions. Use " +
-      "append to add a paragraph, replace to substitute a specific passage.",
+      "Edit one of your core-memory blocks. These blocks ride in every " +
+      "future session's system prompt — treat as expensive real estate. " +
+      "The block's current contents are already visible in your " +
+      "<core_memory> render; read them there before composing the edit. " +
+      "This tool does not return current contents.\n\n" +
+      "## Choosing between `append` and `replace`\n\n" +
+      "Use `append` ONLY when the block is an accumulating list — every " +
+      "line is a discrete, self-contained item that gets added over time " +
+      "(e.g. `team_members` where each line is one teammate, `teams` for " +
+      "an org agent's roster). Append concatenates with a newline; it " +
+      "does not merge, deduplicate, or consolidate.\n\n" +
+      "Use `replace` for everything else:\n" +
+      "  - Surgical fix: substitute one substring with another.\n" +
+      "  - Folding new information into a narrative block (persona, " +
+      "domain, active_context, active_work, patterns, constraints, " +
+      "strategy, tag_line). Read the current contents from " +
+      "<core_memory>, mentally merge the new info into a consolidated " +
+      "version, then call replace with the FULL OLD contents as " +
+      "`old_content` and the FULL NEW contents as `content`. Without a " +
+      "separate consolidation tool, this whole-block replace is how you " +
+      "rewrite a narrative block.\n" +
+      "  - Removing content: replace with empty string.\n\n" +
+      "## Hard rule: never append to narrative blocks\n\n" +
+      "Narrative blocks summarize CURRENT STATE — they are not " +
+      "changelogs. Appending to them causes bloat that lands in every " +
+      "future session's system prompt. If you have new info for a " +
+      "narrative block, do a consolidating replace, not an append.\n\n" +
+      "NEVER prepend or append `UPDATE YYYY-MM-DD:` entries to any " +
+      "block. The block is current state, not a log. Dated facts belong " +
+      "in archival memory via `save_memory`, which auto-stamps the date.\n\n" +
+      "If unsure between core and archival, prefer `save_memory` " +
+      "(archival is cheap and forgiving). Promote to core only when a " +
+      "fact has already surfaced across multiple sessions AND belongs " +
+      "in every future briefing.\n\n" +
+      "## Examples\n\n" +
+      "GOOD — surgical fix (one substring → another):\n" +
+      "  update_core_memory(\n" +
+      "    block_name=\"domain\",\n" +
+      "    operation=\"replace\",\n" +
+      "    old_content=\"Postgres\",\n" +
+      "    content=\"Postgres + pgvector\"\n" +
+      "  )\n\n" +
+      "GOOD — new item on an accumulating-list block:\n" +
+      "  update_core_memory(\n" +
+      "    block_name=\"team_members\",\n" +
+      "    operation=\"append\",\n" +
+      "    content=\"- Frontend Platform (agent_Y) — Next.js + Tailwind\"\n" +
+      "  )\n\n" +
+      "GOOD — consolidating rewrite of a narrative block (use replace, not append):\n" +
+      "  update_core_memory(\n" +
+      "    block_name=\"active_context\",\n" +
+      "    operation=\"replace\",\n" +
+      "    old_content=\"<entire current contents of active_context, verbatim>\",\n" +
+      "    content=\"<new consolidated contents reflecting prior state + new info>\"\n" +
+      "  )\n\n" +
+      "BAD — appending a dated update to a narrative block:\n" +
+      "  update_core_memory(\n" +
+      "    block_name=\"active_work\",\n" +
+      "    operation=\"append\",\n" +
+      "    content=\"UPDATE 2026-05-25: Audit complete. Dispatching 11 fix tasks...\"\n" +
+      "  )\n" +
+      "  # Wrong: bloats the block and turns it into a changelog that\n" +
+      "  # every future session inherits. Use replace with a consolidated\n" +
+      "  # rewrite, or save the dated note via save_memory.\n\n" +
+      "BAD — using append to revise an existing fact:\n" +
+      "  update_core_memory(\n" +
+      "    block_name=\"team_members\",\n" +
+      "    operation=\"append\",\n" +
+      "    content=\"- Backend Platform now also handles Redis\"\n" +
+      "  )\n" +
+      "  # Wrong: now the block has two contradictory lines about\n" +
+      "  # Backend Platform. Use replace to update the existing bullet\n" +
+      "  # in place.",
     schema: schema as Record<string, unknown>,
     handler: async (input) => {
       const blockName = input.block_name;

--- a/packages/core/src/services/spawn-prep.ts
+++ b/packages/core/src/services/spawn-prep.ts
@@ -125,11 +125,13 @@ history is gone.
 Layer 1 — core memory (small, in-context per session, rendered into your
 system prompt at session start as <core_memory>...</core_memory>):
 - Edit via mcp__beevibe__update_core_memory(block_name, operation, content,
-  old_content?). operation ∈ {append, replace}.
-- Common blocks: persona / domain / constraints / learnings.
-- Use for STABLE shifts: persona updates ("I now also handle X"),
-  long-term constraint changes, durable patterns that should appear in
-  every future session's briefing.
+  old_content?). operation ∈ {append, replace} — see the tool's
+  description for the append-vs-replace decision criterion (append is
+  for accumulating-list blocks only; narrative blocks must be rewritten
+  via a consolidating replace).
+- Use for STABLE shifts: persona consolidations, long-term constraint
+  changes, durable patterns that should appear in every future
+  session's briefing.
 - Treat as expensive real estate — every byte is in every future system
   prompt.
 


### PR DESCRIPTION
## Summary

Rewrites the `update_core_memory` MCP tool description so agents stop appending dated `UPDATE YYYY-MM-DD:` entries to narrative blocks (persona / active_work / patterns), which turned current-state blocks into changelogs that bloated every future session's system prompt. Modeled on Letta v2's `memory_replace` / `memory_insert` docstring pedagogy.

The rewrite carries four behavioral goals:

1. **Sharp decision criterion** — `append` ONLY for accumulating-list blocks (e.g. `team_members`, `teams`); `replace` for everything else.
2. **Consolidating-replace pattern made explicit** — beevibe has no separate rethink tool, so the way to fold new info into a narrative block is `replace` with the FULL current contents as `old_content` and the consolidated new contents as `content`. Spelled out so agents don't have to infer it from a generic "replace text" sentence.
3. **Hard rule against dated entries** — `UPDATE YYYY-MM-DD:` is explicitly forbidden in any block; dated facts go to archival memory via `save_memory`, which auto-stamps the date.
4. **GOOD and BAD examples** — including BAD cases for (a) appending a dated update to a narrative block and (b) using `append` to revise an existing fact (which leaves two contradictory lines in the block instead of updating in place).

The `operation` / `content` / `old_content` field descriptions are tightened to stay consistent with the top-level decision criterion.

`BEEVIBE_MEMORY_REMINDER` in `packages/core/src/services/spawn-prep.ts` is aligned: the stale `learnings` block reference (no tier has a `learnings` block) is dropped, and the bullet now points back to the tool description for append-vs-replace mechanics — no new policy added to the system prompt per the task scope.

No schema changes, no new tools, no server-side validation. Pure description / docstring change.

Task: `task_8qYPeOB91WrJ`

## Test plan

- [x] `pnpm --filter @beevibe/core build && pnpm --filter @beevibe/api build` — clean
- [x] `pnpm --filter @beevibe/api vitest run src/tools/update-core-memory.test.ts src/tools/assemble.test.ts src/tools/instructions.test.ts` — 17/17 pass
- [x] `pnpm --filter @beevibe/core vitest run src/services/spawn-prep.test.ts src/services/agent-session.test.ts` — 46/46 pass
- [x] `pnpm lint` — no new errors / warnings (5 pre-existing warnings unrelated to this change)
- [ ] CI green (DCO sign-off + GitHub Actions)