### PR TITLE
fix(dashboard): give 'cancelled' tasks their own legend bucket

### DIFF
--- a/packages/api/src/views/dashboard.test.ts
+++ b/packages/api/src/views/dashboard.test.ts
@@ -63,12 +63,14 @@ describe("getDashboardSummary", () => {
       [
         { status: "pending", count: 1 },
         { status: "assigned", count: 2 },
+        { status: "needs_revision", count: 9 },
         { status: "in_progress", count: 3 },
         { status: "revision", count: 4 },
         { status: "review", count: 5 },
         { status: "blocked", count: 6 },
         { status: "done", count: 7 },
         { status: "failed", count: 8 },
+        { status: "cancelled", count: 11 },
       ],
       [],
       makeTrendRows(),
@@ -77,12 +79,13 @@ describe("getDashboardSummary", () => {
     ]);
     const { status_legend } = await getDashboardSummary(pool);
     const map = new Map(status_legend.map((l) => [l.bucket, l.count]));
-    expect(map.get("pending")).toBe(3); // pending + assigned
+    expect(map.get("pending")).toBe(12); // pending + assigned + needs_revision
     expect(map.get("running")).toBe(7); // in_progress + revision
     expect(map.get("review")).toBe(5);
     expect(map.get("blocked")).toBe(6);
     expect(map.get("done")).toBe(7);
     expect(map.get("failed")).toBe(8);
+    expect(map.get("cancelled")).toBe(11);
   });
 
   it("aggregates fleet counts across hierarchies and computes active total", async () => {

--- a/packages/api/src/views/dashboard.ts
+++ b/packages/api/src/views/dashboard.ts
@@ -238,10 +238,11 @@ function legendBucket(status: TaskStatus): LegendBucket {
       return "done";
     case "failed":
       return "failed";
+    case "cancelled":
+      return "cancelled";
     case "pending":
     case "assigned":
     case "needs_revision":
-    case "cancelled":
       return "pending";
   }
 }

--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -361,7 +361,7 @@ export interface StatusBreakdownData {
 
 /**
  * Legend entries are coarser than the breakdown: lifecycle groupings
- * mapped onto the UI's 6 status dots. The mapper (web) joins these with
+ * mapped onto the UI's status dots. The mapper (web) joins these with
  * label + color.
  */
 export type LegendBucket =
@@ -369,6 +369,7 @@ export type LegendBucket =
   | "done"
   | "blocked"
   | "failed"
+  | "cancelled"
   | "running"
   | "pending";
 

--- a/packages/web/components/home/status-breakdown.tsx
+++ b/packages/web/components/home/status-breakdown.tsx
@@ -8,6 +8,7 @@ const COLOR_CLASS = {
   blocked: "bg-status-blocked",
   done: "bg-status-done",
   failed: "bg-status-failed",
+  cancelled: "bg-status-cancelled",
 } as const;
 
 const DOT_CLASS = {
@@ -17,6 +18,7 @@ const DOT_CLASS = {
   blocked: "bg-status-blocked",
   done: "bg-status-done",
   failed: "bg-status-failed",
+  cancelled: "bg-status-cancelled",
 } as const;
 
 export function StatusBreakdownBar({

--- a/packages/web/components/home/status-breakdown.tsx
+++ b/packages/web/components/home/status-breakdown.tsx
@@ -1,7 +1,11 @@
 import { cn } from "@/lib/utils";
-import type { StatusBreakdownEntry, StatusLegendEntry } from "@/lib/types/dashboard";
+import type {
+  LegendBucket,
+  StatusBreakdownEntry,
+  StatusLegendEntry,
+} from "@/lib/types/dashboard";
 
-const COLOR_CLASS = {
+const BG_CLASS: Record<LegendBucket, string> = {
   pending: "bg-status-pending",
   running: "bg-status-running",
   review: "bg-status-review",
@@ -9,17 +13,7 @@ const COLOR_CLASS = {
   done: "bg-status-done",
   failed: "bg-status-failed",
   cancelled: "bg-status-cancelled",
-} as const;
-
-const DOT_CLASS = {
-  pending: "bg-status-pending",
-  running: "bg-status-running",
-  review: "bg-status-review",
-  blocked: "bg-status-blocked",
-  done: "bg-status-done",
-  failed: "bg-status-failed",
-  cancelled: "bg-status-cancelled",
-} as const;
+};
 
 export function StatusBreakdownBar({
   entries,
@@ -44,7 +38,7 @@ export function StatusBreakdownBar({
         {entries.map((e, i) => (
           <div
             key={`${e.status}-${i}`}
-            className={COLOR_CLASS[e.color]}
+            className={BG_CLASS[e.color]}
             style={{ width: `${e.percent}%`, opacity: e.opacity ?? 1 }}
             title={`${e.label} ${e.count}`}
           />
@@ -53,7 +47,7 @@ export function StatusBreakdownBar({
       <div className="grid grid-cols-2 gap-x-6 gap-y-1.5 text-xs">
         {legend.map((l) => (
           <div key={l.label} className="flex items-center gap-2">
-            <span className={cn("h-1.5 w-1.5 rounded-full", DOT_CLASS[l.color])} />
+            <span className={cn("h-1.5 w-1.5 rounded-full", BG_CLASS[l.color])} />
             <span className="text-muted-foreground flex-1">{l.label}</span>
             <span className="font-mono tabular-nums">{l.count}</span>
           </div>

--- a/packages/web/lib/dashboard-display.test.ts
+++ b/packages/web/lib/dashboard-display.test.ts
@@ -94,12 +94,12 @@ describe("summaryToDisplay — status breakdown + legend", () => {
     expect(status_breakdown[2]?.color).toBe("blocked");
   });
 
-  it("maps cancelled to the pending color (de-emphasized terminal state)", () => {
+  it("maps cancelled to its own color (terminal state, distinct from pending)", () => {
     const data: DashboardSummary = {
       ...emptyData(),
       status_breakdown: [{ status: "cancelled", count: 1, percent: 100 }],
     };
-    expect(summaryToDisplay(data).status_breakdown[0]?.color).toBe("pending");
+    expect(summaryToDisplay(data).status_breakdown[0]?.color).toBe("cancelled");
   });
 
   it("legend uses the bucket as the color and humanizes the label", () => {

--- a/packages/web/lib/dashboard-display.ts
+++ b/packages/web/lib/dashboard-display.ts
@@ -119,7 +119,7 @@ const STATUS_COLOR: Record<TaskStatus, StatusBreakdownEntry["color"]> = {
   blocked: "blocked",
   done: "done",
   failed: "failed",
-  cancelled: "pending",
+  cancelled: "cancelled",
 };
 
 function breakdownToDisplay(data: StatusBreakdownData): StatusBreakdownEntry {

--- a/packages/web/lib/dashboard-display.ts
+++ b/packages/web/lib/dashboard-display.ts
@@ -141,6 +141,7 @@ const LEGEND_LABEL: Record<LegendBucket, string> = {
   blocked: "Blocked",
   done: "Done",
   failed: "Failed",
+  cancelled: "Cancelled",
 };
 
 function legendToDisplay(data: StatusLegendData): StatusLegendEntry {

--- a/packages/web/lib/types/dashboard.ts
+++ b/packages/web/lib/types/dashboard.ts
@@ -35,7 +35,7 @@ export interface StatusBreakdownEntry {
 }
 
 export interface StatusLegendEntry {
-  color: "review" | "done" | "blocked" | "failed" | "running" | "pending";
+  color: "review" | "done" | "blocked" | "failed" | "cancelled" | "running" | "pending";
   label: string;
   count: number;
 }

--- a/packages/web/lib/types/dashboard.ts
+++ b/packages/web/lib/types/dashboard.ts
@@ -1,4 +1,5 @@
 import type { TaskStatus } from "@beevibe/core";
+import type { LegendBucket } from "@beevibe/api/views/types";
 
 // ── Display shapes the home page binds against ─────────────────────────────
 //
@@ -28,14 +29,14 @@ export interface KpiStat {
 export interface StatusBreakdownEntry {
   status: TaskStatus | "running_group" | "pending_group";
   label: string;
-  color: "pending" | "running" | "review" | "blocked" | "done" | "failed";
+  color: LegendBucket;
   count: number;
   percent: number;
   opacity?: number;
 }
 
 export interface StatusLegendEntry {
-  color: "review" | "done" | "blocked" | "failed" | "cancelled" | "running" | "pending";
+  color: LegendBucket;
   label: string;
   count: number;
 }


### PR DESCRIPTION
## Summary

`legendBucket` in `packages/api/src/views/dashboard.ts:228-247` mapped `cancelled` into the `pending` bucket along with the genuinely-pending statuses (`pending`, `assigned`, `needs_revision`). Result: the dashboard's "Pending" legend pill silently inflated by every cancelled task, hiding the real backlog.

`cancelled` is a terminal state (user stopped the work) — semantically distinct from `pending` (waiting to claim) and `failed` (agent tried and couldn't). Gave it its own bucket.

The color infrastructure was already in place — `tailwind.config.ts:53` and `app/globals.css` already define `status-cancelled` / `--status-cancelled`. The only thing missing was wiring it through the legend type.

## Changes

- `packages/api/src/views/types.ts:367-374` — `LegendBucket` gains `"cancelled"`
- `packages/api/src/views/dashboard.ts:228-249` — `legendBucket` routes `cancelled` to `"cancelled"` instead of `"pending"`
- `packages/web/lib/types/dashboard.ts:38` — `StatusLegendEntry.color` union gains `"cancelled"`
- `packages/web/lib/dashboard-display.ts:137-145` — `LEGEND_LABEL` adds `cancelled: "Cancelled"`
- `packages/web/components/home/status-breakdown.tsx` — `COLOR_CLASS` + `DOT_CLASS` add `bg-status-cancelled`

The `failed` bucket the user originally suspected was also misbucketed actually already has its own branch (`case "failed": return "failed"` at line 239-240). Only `cancelled` was wrong.

## Test plan

- [x] Extended `dashboard.test.ts` "buckets statuses" fixture to include `cancelled` and `needs_revision` rows (previously omitted by the test, which is how this regression slipped past). Asserts both the new `cancelled` bucket count and the corrected `pending` total (`pending + assigned + needs_revision`, no longer including `cancelled`).
- [x] `pnpm vitest run src/views/dashboard.test.ts` — 20/20 pass
- [x] `pnpm vitest run lib/dashboard-display.test.ts` on web — 8/8 pass
- [x] `pnpm tsc --noEmit` on api + web — clean

## Notes

- `--status-cancelled` CSS variable is currently the same gray as `--status-pending`. The bucket is now structurally distinct but visually identical to pending — worth picking a distinct color (muted slate, struck-through, etc.) in a follow-up so cancelled and pending are visually separable too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)