### PR TITLE
Add ADR visual reports and community layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,22 @@ beevibe-daemon start
 The `bv_u_` token is created by `pnpm provision-user` (see
 [CONTRIBUTING.md](./CONTRIBUTING.md#minting-a-bv_u_-token-for-the-daemon)).
 
+### ADR visual reports
+
+ADR run directories under `.adr-runs/` can be distilled into visual report
+artifacts for community briefs, newsletters, or product-review pages:
+
+```bash
+pnpm adr:visual .adr-runs/<run-name>
+pnpm adr:slides .adr-runs/<run-name>
+```
+
+This writes `visual-report.json` and `visual-report.md` next to the ADR output.
+The JSON is the stable contract for visual surfaces; the Markdown includes
+Mermaid diagrams for the decision funnel and evidence mix. `adr:slides`
+renders the same visual report into a fixed-stage HTML deck that follows the
+frontend-slides 1920x1080 presentation model.
+
 ## Contributing
 
 Issues and PRs are welcome. For larger changes, open an issue first so the

--- a/migrations/1780900000000_add-newsletter-subscriber.sql
+++ b/migrations/1780900000000_add-newsletter-subscriber.sql
@@ -1,0 +1,14 @@
+-- Stores public newsletter interest for the Beevibe community layer.
+-- Delivery tooling can sync from this table without making the core API
+-- depend on a newsletter vendor.
+
+CREATE TABLE newsletter_subscriber (
+  id         TEXT PRIMARY KEY,
+  email      TEXT NOT NULL UNIQUE,
+  source     TEXT NOT NULL DEFAULT 'community',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_newsletter_subscriber_created_at
+  ON newsletter_subscriber(created_at DESC);

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "migrate:test": "node-pg-migrate --envPath .env -d DATABASE_URL_TEST",
     "db:reset": "docker compose down -v && docker compose up -d --wait postgres && pnpm migrate up",
     "install-skills": "tsx scripts/install-skills.ts",
+    "adr:visual": "tsx scripts/adr-visual-report.ts",
+    "adr:slides": "tsx scripts/adr-slide-deck.ts",
     "bootstrap": "tsx scripts/init.ts",
     "provision-user": "tsx scripts/provision-user.ts",
     "sync-core-memory": "tsx scripts/sync-core-memory-descriptions.ts",

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -147,6 +147,7 @@ When a mesh `ask` / `negotiate` target's daemon is offline at dispatch, the api 
 | `GET` | `/health/runtime` | Caller's daemon liveness summary, for the welcome wizard's "verify daemon" step. |
 | `POST` | `/signup` | Email + password. (Public; gated by `BEEVIBE_SIGNUP_ENABLED`.) |
 | `POST` | `/signin` | Email + password. (Public.) |
+| `POST` | `/newsletter/subscribe` | Email capture for the public community newsletter. (Public.) |
 
 ### Read-only views
 

--- a/packages/api/src/bootstrap.ts
+++ b/packages/api/src/bootstrap.ts
@@ -54,6 +54,7 @@ import { createChatRouter } from "./routes/chat.js";
 import { createRuntimesRouter } from "./routes/runtimes.js";
 import { createSignupRouter } from "./routes/signup.js";
 import { createSigninRouter } from "./routes/signin.js";
+import { createNewsletterRouter } from "./routes/newsletter.js";
 import { createMeRouter } from "./routes/me.js";
 import { createRoomRouter } from "./routes/room.js";
 import { createStreamAuthMiddleware, streamTokenAdapter } from "./auth/middleware.js";
@@ -371,6 +372,11 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
     enabled: process.env.BEEVIBE_SIGNUP_ENABLED !== "0",
   });
   server.getApp().use(signinRouter);
+
+  // Public newsletter capture for the community layer. Mounted before
+  // the root view router so it remains unauthenticated.
+  const newsletterRouter = createNewsletterRouter({ pool });
+  server.getApp().use(newsletterRouter);
 
   // SSE auth adapter — must run ahead of viewRouter's root-mounted
   // header-only auth, which would otherwise 401 EventSource requests

--- a/packages/api/src/routes/newsletter.test.ts
+++ b/packages/api/src/routes/newsletter.test.ts
@@ -1,0 +1,58 @@
+import express, { json } from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createNewsletterRouter } from "./newsletter.js";
+
+describe("newsletter routes", () => {
+  const query = vi.fn();
+
+  beforeEach(() => {
+    query.mockReset();
+    query.mockResolvedValue({ rows: [] });
+  });
+
+  function makeApp() {
+    const app = express();
+    app.use(json());
+    app.use(createNewsletterRouter({ pool: { query } }));
+    return app;
+  }
+
+  it("upserts a normalized email", async () => {
+    const res = await request(makeApp())
+      .post("/newsletter/subscribe")
+      .send({ email: " Alice@Example.COM ", source: "community" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      subscriber: { email: "alice@example.com", source: "community" },
+    });
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls[0]?.[1]).toEqual([
+      expect.stringMatching(/^nl_[a-f0-9]{32}$/),
+      "alice@example.com",
+      "community",
+    ]);
+  });
+
+  it("rejects invalid email input", async () => {
+    const res = await request(makeApp())
+      .post("/newsletter/subscribe")
+      .send({ email: "not-an-email" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_email");
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it("accepts honeypot submissions without persisting", async () => {
+    const res = await request(makeApp())
+      .post("/newsletter/subscribe")
+      .send({ email: "bot@example.com", website: "https://spam.test" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+    expect(query).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/routes/newsletter.ts
+++ b/packages/api/src/routes/newsletter.ts
@@ -1,0 +1,76 @@
+/**
+ * Public newsletter capture for the community layer.
+ *
+ * This intentionally stays small: validate + upsert an email into Postgres.
+ * Delivery tooling (beehiiv/Buttondown/Customer.io/etc.) can sync from this
+ * table later without coupling the API server to a vendor on day one.
+ */
+
+import { randomUUID } from "node:crypto";
+import { Router, type Response } from "express";
+import type { Pool } from "@beevibe/core/adapters/postgres";
+
+export interface NewsletterRoutesDeps {
+  pool: Pick<Pool, "query">;
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const SOURCE_RE = /^[a-z0-9][a-z0-9_-]{0,59}$/;
+
+function makeSubscriberId(): string {
+  return `nl_${randomUUID().replace(/-/g, "")}`;
+}
+
+function handleError(err: unknown, res: Response): void {
+  console.error("[newsletter route]", err);
+  res.status(500).json({
+    error: "internal_error",
+    message: err instanceof Error ? err.message : String(err),
+  });
+}
+
+export function createNewsletterRouter(deps: NewsletterRoutesDeps): Router {
+  const router = Router();
+
+  router.post("/newsletter/subscribe", async (req, res) => {
+    try {
+      const body = (req.body ?? {}) as Record<string, unknown>;
+
+      // Bot trap: real clients leave this empty. Pretend success so bots
+      // don't learn which field gave them away.
+      if (typeof body.website === "string" && body.website.trim().length > 0) {
+        res.json({ ok: true });
+        return;
+      }
+
+      const email =
+        typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
+      const source =
+        typeof body.source === "string" && SOURCE_RE.test(body.source.trim())
+          ? body.source.trim()
+          : "community";
+
+      if (!email || !EMAIL_RE.test(email)) {
+        res
+          .status(400)
+          .json({ error: "invalid_email", message: "valid email required" });
+        return;
+      }
+
+      await deps.pool.query(
+        `INSERT INTO newsletter_subscriber (id, email, source)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (email) DO UPDATE
+           SET source = EXCLUDED.source,
+               updated_at = now()`,
+        [makeSubscriberId(), email, source],
+      );
+
+      res.json({ ok: true, subscriber: { email, source } });
+    } catch (err) {
+      handleError(err, res);
+    }
+  });
+
+  return router;
+}

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -32,6 +32,7 @@ Public pages (no auth):
 - `/sign-in` — email + password
 - `/sign-up` — email + password (gated server-side by `BEEVIBE_SIGNUP_ENABLED`)
 - `/welcome` — post-signup wizard: install daemon, verify runtimes, meet your team agent
+- `/community` — public pattern index and newsletter signup
 
 The `bv_u_` token is sourced from `NEXT_PUBLIC_BV_USER_KEY` for now (single-tenant local dev) — sign-in / sign-up live API endpoints exist on the api side and the wizard reads from them, but the production token-storage flow is still in progress.
 
@@ -55,6 +56,11 @@ The `bv_u_` token is sourced from `NEXT_PUBLIC_BV_USER_KEY` for now (single-tena
 | `/rooms` | Shared rooms list. |
 | `/rooms/:id` | Room detail — team-orbit visualization (`components/team-orbit.tsx`), message stream, mention picker. |
 | `/runtimes` | Worker daemon panel — list of registered daemons + their CLIs, online/offline badges (live via `runtime.updated` SSE), revoke action, install instructions for fresh machines. |
+| `/community` | Public community surface for pattern curation and newsletter capture. |
+
+`/community` is shaped around the ADR visual-report contract
+(`lib/community/adr-visual-report.ts`). Fresh ADR runs can be converted into
+the same visual primitives with `pnpm adr:visual <.adr-runs/run-name>`.
 
 ## Data flow
 

--- a/packages/web/app/community/community-client.tsx
+++ b/packages/web/app/community/community-client.tsx
@@ -1,0 +1,751 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  ArrowRight,
+  BookOpenText,
+  CheckCircle2,
+  GitCompareArrows,
+  Layers3,
+  Loader2,
+  Mail,
+  Network,
+  RadioTower,
+  Search,
+  Sparkles,
+} from "lucide-react";
+import { api } from "@/lib/api/client";
+import { isApiConfigured } from "@/lib/api/config";
+import { describeError } from "@/lib/api/http";
+import { COMMUNITY_ADR_VISUAL_REPORT } from "@/lib/community/adr-visual-report";
+import { cn } from "@/lib/utils";
+
+type PatternCategory =
+  | "All"
+  | "Interface"
+  | "Workflow"
+  | "Review"
+  | "Platform"
+  | "Memory";
+
+type Pattern = {
+  team: string;
+  category: Exclude<PatternCategory, "All">;
+  pattern: string;
+  signal: string;
+  ctoAngle: string;
+  scores: {
+    clarity: number;
+    leverage: number;
+    transfer: number;
+  };
+  tags: string[];
+};
+
+const CATEGORIES: PatternCategory[] = [
+  "All",
+  "Interface",
+  "Workflow",
+  "Review",
+  "Platform",
+  "Memory",
+];
+
+const PATTERNS: Pattern[] = [
+  {
+    team: "Linear",
+    category: "Workflow",
+    pattern: "Opinionated work grammar",
+    signal:
+      "Issues, cycles, status, ownership, and keyboard flow keep work crisp.",
+    ctoAngle:
+      "Agent tasks need a tight shape too: owner, review gate, state, and next move.",
+    scores: { clarity: 94, leverage: 88, transfer: 92 },
+    tags: ["triage", "status", "ownership"],
+  },
+  {
+    team: "Figma",
+    category: "Interface",
+    pattern: "Multiplayer as the default surface",
+    signal:
+      "Presence, comments, branches, and live context turn critique into the artifact.",
+    ctoAngle:
+      "AI teams need shared rooms where agents and humans can inspect the same context.",
+    scores: { clarity: 86, leverage: 95, transfer: 89 },
+    tags: ["presence", "critique", "artifact"],
+  },
+  {
+    team: "Stripe",
+    category: "Memory",
+    pattern: "Docs as product infrastructure",
+    signal:
+      "Canonical examples, constraints, and edge cases reduce support load and drift.",
+    ctoAngle:
+      "Long-lived agent memory should carry decisions, gotchas, and operating constraints.",
+    scores: { clarity: 96, leverage: 91, transfer: 87 },
+    tags: ["docs", "constraints", "examples"],
+  },
+  {
+    team: "GitHub",
+    category: "Review",
+    pattern: "Review embedded in the unit of change",
+    signal:
+      "Diffs, checks, comments, owners, and merge gates compress review into one loop.",
+    ctoAngle:
+      "AI deliverables should land with transcript, work product, reviewer action, and audit.",
+    scores: { clarity: 90, leverage: 93, transfer: 94 },
+    tags: ["review", "checks", "audit"],
+  },
+  {
+    team: "Vercel",
+    category: "Platform",
+    pattern: "Preview as decision artifact",
+    signal:
+      "Every change becomes a URL that product, design, and engineering can inspect.",
+    ctoAngle:
+      "Agent work becomes legible faster when outputs are concrete surfaces, not summaries.",
+    scores: { clarity: 91, leverage: 90, transfer: 86 },
+    tags: ["preview", "handoff", "artifact"],
+  },
+  {
+    team: "OpenAI",
+    category: "Review",
+    pattern: "Evals before shipping judgment",
+    signal:
+      "Behavioral tests make qualitative progress visible before a release depends on it.",
+    ctoAngle:
+      "AI CTO workflows need repeatable checks for agents, prompts, memory, and tools.",
+    scores: { clarity: 83, leverage: 96, transfer: 90 },
+    tags: ["evals", "quality", "release"],
+  },
+];
+
+const ISSUES = [
+  {
+    title: "Preview environments as leadership surface",
+    note: "How teams turn an implementation detail into faster product judgment.",
+    focus: "Vercel, GitHub, Beevibe tasks",
+  },
+  {
+    title: "Shared memory without knowledge sludge",
+    note: "The difference between useful context and permanent organizational noise.",
+    focus: "Stripe docs, Figma comments, agent memory",
+  },
+  {
+    title: "Review loops for AI-made work",
+    note: "Patterns that keep speed high while preserving ownership and taste.",
+    focus: "GitHub reviews, Linear states, eval gates",
+  },
+];
+
+const RADAR = [
+  { label: "Context permanence", value: 92 },
+  { label: "Handoff clarity", value: 88 },
+  { label: "Review loop", value: 94 },
+  { label: "Artifact quality", value: 86 },
+  { label: "Signal density", value: 91 },
+];
+
+export function CommunityClient() {
+  const [activeCategory, setActiveCategory] = useState<PatternCategory>("All");
+
+  const visiblePatterns = useMemo(
+    () =>
+      activeCategory === "All"
+        ? PATTERNS
+        : PATTERNS.filter((pattern) => pattern.category === activeCategory),
+    [activeCategory],
+  );
+
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <TopBar />
+      <section className="px-5 sm:px-6 lg:px-8 pt-12 pb-10 border-b border-border/60">
+        <div className="max-w-7xl mx-auto grid lg:grid-cols-[minmax(0,0.9fr)_minmax(520px,1.1fr)] gap-8 lg:gap-12 items-center">
+          <div className="min-w-0">
+            <div className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              <RadioTower className="h-3.5 w-3.5 text-status-running" />
+              Beevibe Community
+            </div>
+            <h1 className="mt-4 text-4xl sm:text-5xl lg:text-6xl font-semibold tracking-normal leading-[1.02] max-w-3xl">
+              Building Patterns Index
+            </h1>
+            <p className="mt-5 max-w-2xl text-base sm:text-lg leading-8 text-muted-foreground">
+              A curated map of how excellent teams turn taste into operating
+              systems: product rituals, design surfaces, review gates, memory
+              loops, and platform primitives worth stealing for AI-native work.
+            </p>
+            <div className="mt-7 flex flex-col sm:flex-row gap-3">
+              <a
+                href="#patterns"
+                className="inline-flex h-10 items-center justify-center gap-2 rounded bg-primary px-4 text-sm font-semibold text-primary-foreground hover:opacity-90 transition-opacity"
+              >
+                <GitCompareArrows className="h-4 w-4" />
+                Browse patterns
+              </a>
+              <a
+                href="#newsletter"
+                className="inline-flex h-10 items-center justify-center gap-2 rounded border border-border bg-card/70 px-4 text-sm font-semibold hover:bg-secondary/70 transition-colors"
+              >
+                <Mail className="h-4 w-4" />
+                Get the brief
+              </a>
+            </div>
+          </div>
+
+          <PatternAtlas patterns={PATTERNS} />
+        </div>
+      </section>
+
+      <section id="patterns" className="px-5 sm:px-6 lg:px-8 py-10">
+        <div className="max-w-7xl mx-auto">
+          <div className="flex flex-col gap-5 md:flex-row md:items-end md:justify-between">
+            <div>
+              <div className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                <Search className="h-3.5 w-3.5 text-status-done" />
+                Pattern library
+              </div>
+              <h2 className="mt-2 text-2xl font-semibold tracking-normal">
+                Compare what is actually being built
+              </h2>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {CATEGORIES.map((category) => (
+                <button
+                  key={category}
+                  type="button"
+                  onClick={() => setActiveCategory(category)}
+                  className={cn(
+                    "h-8 rounded-full px-3 text-xs font-semibold transition-colors",
+                    activeCategory === category
+                      ? "bg-foreground text-background"
+                      : "border border-border bg-card/70 text-muted-foreground hover:text-foreground hover:bg-secondary",
+                  )}
+                >
+                  {category}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="mt-6 grid md:grid-cols-2 xl:grid-cols-3 gap-4">
+            {visiblePatterns.map((pattern) => (
+              <PatternCard key={`${pattern.team}-${pattern.pattern}`} pattern={pattern} />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <ReportVisuals />
+
+      <section className="px-5 sm:px-6 lg:px-8 py-10 border-y border-border/60 bg-secondary/25">
+        <div className="max-w-7xl mx-auto grid lg:grid-cols-[0.85fr_1.15fr] gap-8">
+          <div>
+            <div className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              <Network className="h-3.5 w-3.5 text-status-review" />
+              Community loop
+            </div>
+            <h2 className="mt-2 text-2xl font-semibold tracking-normal">
+              From curation to compounding context
+            </h2>
+            <p className="mt-3 text-sm leading-7 text-muted-foreground max-w-xl">
+              The community layer should not be another feed. It should become a
+              shared pattern memory: what changed, why it mattered, what failed
+              to transfer, and how Beevibe agents can apply the lesson inside
+              real work.
+            </p>
+          </div>
+          <div className="grid sm:grid-cols-3 gap-3">
+            {[
+              {
+                icon: BookOpenText,
+                label: "Curate",
+                text: "Collect primary artifacts, teardown notes, and durable product moves.",
+              },
+              {
+                icon: GitCompareArrows,
+                label: "Compare",
+                text: "Score patterns by clarity, leverage, transferability, and risk.",
+              },
+              {
+                icon: Layers3,
+                label: "Operationalize",
+                text: "Convert strong patterns into agent memory, tasks, and review playbooks.",
+              },
+            ].map((item) => (
+              <div key={item.label} className="rounded-lg glass-surface p-4">
+                <item.icon className="h-5 w-5 text-foreground/80" />
+                <div className="mt-3 text-sm font-semibold">{item.label}</div>
+                <p className="mt-2 text-xs leading-6 text-muted-foreground">
+                  {item.text}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section id="newsletter" className="px-5 sm:px-6 lg:px-8 py-12">
+        <div className="max-w-7xl mx-auto grid lg:grid-cols-[0.9fr_1.1fr] gap-8 items-start">
+          <NewsletterPanel />
+          <div className="space-y-3">
+            <div className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              <Sparkles className="h-3.5 w-3.5 text-primary" />
+              Upcoming briefs
+            </div>
+            {ISSUES.map((issue) => (
+              <article key={issue.title} className="rounded-lg border border-border bg-card/70 p-4">
+                <div className="flex items-start gap-3">
+                  <div className="mt-0.5 h-7 w-7 rounded bg-primary/20 text-primary-foreground border border-primary/30 flex items-center justify-center shrink-0">
+                    <ArrowRight className="h-3.5 w-3.5 text-foreground" />
+                  </div>
+                  <div className="min-w-0">
+                    <h3 className="text-sm font-semibold">{issue.title}</h3>
+                    <p className="mt-1 text-xs leading-6 text-muted-foreground">
+                      {issue.note}
+                    </p>
+                    <p className="mt-2 text-[11px] uppercase tracking-wider text-muted-foreground/70">
+                      {issue.focus}
+                    </p>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function ReportVisuals() {
+  const report = COMMUNITY_ADR_VISUAL_REPORT;
+  const maxEvidenceCount = Math.max(
+    1,
+    ...report.evidenceMix.map((entry) => entry.count),
+  );
+
+  return (
+    <section className="px-5 sm:px-6 lg:px-8 pb-10">
+      <div className="max-w-7xl mx-auto rounded-lg border border-border bg-card/65 overflow-hidden">
+        <div className="grid lg:grid-cols-[0.9fr_1.1fr]">
+          <div className="p-5 sm:p-6 border-b lg:border-b-0 lg:border-r border-border">
+            <div className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              <GitCompareArrows className="h-3.5 w-3.5 text-status-running" />
+              ADR visual report
+            </div>
+            <h2 className="mt-3 text-2xl font-semibold tracking-normal">
+              {report.decision.title}
+            </h2>
+            <p className="mt-3 text-sm leading-7 text-muted-foreground">
+              {report.decision.summary}
+            </p>
+            <div className="mt-5 grid grid-cols-2 gap-2">
+              {report.kpis.map((kpi) => (
+                <div
+                  key={kpi.id}
+                  className="rounded border border-border bg-background/60 p-3"
+                >
+                  <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                    {kpi.label}
+                  </div>
+                  <div
+                    className={cn(
+                      "mt-1 text-lg font-semibold tabular-nums",
+                      kpi.tone === "good"
+                        ? "text-status-done"
+                        : kpi.tone === "warning"
+                          ? "text-status-review"
+                          : kpi.tone === "critical"
+                            ? "text-status-failed"
+                            : "text-foreground",
+                    )}
+                  >
+                    {kpi.value}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-5 rounded border border-border bg-background/60 p-3">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <div className="text-xs font-semibold">Matrix coverage</div>
+                  <div className="mt-1 text-[11px] text-muted-foreground">
+                    {report.matrixCoverage.filledCells} of{" "}
+                    {report.matrixCoverage.totalCells} scored cells
+                  </div>
+                </div>
+                <div className="text-xl font-semibold tabular-nums">
+                  {report.matrixCoverage.coveragePercent}%
+                </div>
+              </div>
+              <div className="mt-3 grid grid-cols-10 gap-1">
+                {Array.from({ length: report.matrixCoverage.totalCells }).map((_, i) => (
+                  <div
+                    key={i}
+                    className={cn(
+                      "aspect-square rounded-sm",
+                      i < report.matrixCoverage.filledCells
+                        ? "bg-status-done"
+                        : "bg-secondary",
+                    )}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div className="p-5 sm:p-6 space-y-5">
+            <div>
+              <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Decision funnel
+              </div>
+              <div className="mt-3 grid grid-cols-5 gap-2">
+                {report.decisionFunnel.map((step, index) => (
+                  <div key={step.label} className="min-w-0">
+                    <div
+                      className={cn(
+                        "h-2 rounded-full",
+                        index === report.decisionFunnel.length - 1
+                          ? "bg-primary"
+                          : "bg-foreground/80",
+                      )}
+                    />
+                    <div className="mt-2 text-sm font-semibold tabular-nums">
+                      {step.count}
+                    </div>
+                    <div className="mt-0.5 text-[10px] uppercase tracking-wider text-muted-foreground truncate">
+                      {step.label}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Evidence mix
+              </div>
+              <div className="mt-3 space-y-2">
+                {report.evidenceMix.map((entry) => (
+                  <div
+                    key={entry.sourceType}
+                    className="grid grid-cols-[132px_1fr_34px] items-center gap-3"
+                  >
+                    <div className="text-xs text-muted-foreground truncate">
+                      {entry.sourceType.replace(/_/g, " ")}
+                    </div>
+                    <div className="h-2 rounded-full bg-secondary overflow-hidden">
+                      <div
+                        className="h-full rounded-full bg-status-running"
+                        style={{
+                          width: `${Math.max(8, (entry.count / maxEvidenceCount) * 100)}%`,
+                        }}
+                      />
+                    </div>
+                    <div className="text-right text-xs tabular-nums">
+                      {entry.count}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Risk signals
+              </div>
+              <div className="mt-3 grid md:grid-cols-3 gap-2">
+                {report.riskSignals.map((signal) => (
+                  <div key={signal.topic} className="rounded border border-border bg-background/60 p-3">
+                    <div className="text-xs font-semibold">{signal.topic}</div>
+                    <p className="mt-2 text-[11px] leading-5 text-muted-foreground">
+                      {signal.risk}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function TopBar() {
+  return (
+    <header className="sticky top-0 z-20 border-b border-border/60 bg-background/80 backdrop-blur-xl">
+      <div className="max-w-7xl mx-auto h-14 px-5 sm:px-6 lg:px-8 flex items-center gap-4">
+        <Link href="/" className="flex items-center gap-2 min-w-0">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src="/logo.png"
+            alt="Beevibe"
+            className="h-7 w-7 rounded-md object-cover object-center shrink-0"
+          />
+          <span className="text-sm font-semibold tracking-normal">Beevibe</span>
+        </Link>
+        <nav className="ml-auto flex items-center gap-2 text-xs font-semibold text-muted-foreground">
+          <a href="#patterns" className="hidden sm:inline-flex h-8 items-center px-2 hover:text-foreground">
+            Patterns
+          </a>
+          <a href="#newsletter" className="hidden sm:inline-flex h-8 items-center px-2 hover:text-foreground">
+            Newsletter
+          </a>
+          <Link
+            href="/sign-up"
+            className="inline-flex h-8 items-center justify-center rounded bg-foreground px-3 text-background hover:opacity-90 transition-opacity"
+          >
+            Join
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+}
+
+function PatternAtlas({ patterns }: { patterns: Pattern[] }) {
+  const topPatterns = patterns.slice(0, 5);
+
+  return (
+    <div className="rounded-lg glass-surface p-4 sm:p-5">
+      <div className="grid sm:grid-cols-[1fr_180px] gap-5">
+        <div className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Signal map
+              </div>
+              <div className="mt-1 text-sm font-semibold">
+                Patterns by transfer value
+              </div>
+            </div>
+            <div className="text-[11px] tabular-nums text-muted-foreground">
+              {patterns.length} references
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            {topPatterns.map((pattern, index) => {
+              const value = Math.round(
+                (pattern.scores.clarity +
+                  pattern.scores.leverage +
+                  pattern.scores.transfer) /
+                  3,
+              );
+              return (
+                <div key={pattern.team} className="grid grid-cols-[84px_1fr_34px] items-center gap-3">
+                  <div className="text-xs font-medium truncate">{pattern.team}</div>
+                  <div className="h-2 rounded-full bg-secondary overflow-hidden">
+                    <div
+                      className={cn(
+                        "h-full rounded-full",
+                        index % 3 === 0
+                          ? "bg-status-running"
+                          : index % 3 === 1
+                            ? "bg-status-done"
+                            : "bg-primary",
+                      )}
+                      style={{ width: `${value}%` }}
+                    />
+                  </div>
+                  <div className="text-right text-xs tabular-nums text-muted-foreground">
+                    {value}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-border bg-background/55 p-3">
+          <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            AI CTO fit
+          </div>
+          <div className="mt-3 space-y-2.5">
+            {RADAR.map((item) => (
+              <div key={item.label}>
+                <div className="flex items-center justify-between gap-3 text-[11px]">
+                  <span className="text-muted-foreground">{item.label}</span>
+                  <span className="tabular-nums">{item.value}</span>
+                </div>
+                <div className="mt-1 h-1.5 rounded-full bg-secondary overflow-hidden">
+                  <div
+                    className="h-full rounded-full bg-foreground"
+                    style={{ width: `${item.value}%` }}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PatternCard({ pattern }: { pattern: Pattern }) {
+  const avg = Math.round(
+    (pattern.scores.clarity + pattern.scores.leverage + pattern.scores.transfer) /
+      3,
+  );
+
+  return (
+    <article className="rounded-lg border border-border bg-card/75 p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-xs font-semibold text-muted-foreground">
+            {pattern.team}
+          </div>
+          <h3 className="mt-1 text-base font-semibold tracking-normal">
+            {pattern.pattern}
+          </h3>
+        </div>
+        <div className="h-9 w-9 rounded bg-secondary flex items-center justify-center text-sm font-semibold tabular-nums shrink-0">
+          {avg}
+        </div>
+      </div>
+      <p className="mt-3 text-sm leading-7 text-foreground/85">{pattern.signal}</p>
+      <p className="mt-3 text-xs leading-6 text-muted-foreground">
+        {pattern.ctoAngle}
+      </p>
+      <div className="mt-4 grid grid-cols-3 gap-2">
+        {[
+          ["Clarity", pattern.scores.clarity],
+          ["Leverage", pattern.scores.leverage],
+          ["Transfer", pattern.scores.transfer],
+        ].map(([label, value]) => (
+          <div key={label} className="rounded border border-border bg-background/55 p-2">
+            <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+              {label}
+            </div>
+            <div className="mt-1 text-sm font-semibold tabular-nums">{value}</div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-4 flex flex-wrap gap-1.5">
+        {pattern.tags.map((tag) => (
+          <span
+            key={tag}
+            className="rounded-full bg-secondary px-2 py-1 text-[11px] text-muted-foreground"
+          >
+            {tag}
+          </span>
+        ))}
+      </div>
+    </article>
+  );
+}
+
+function NewsletterPanel() {
+  const [email, setEmail] = useState("");
+  const [website, setWebsite] = useState("");
+  const [status, setStatus] = useState<"idle" | "submitting" | "success">("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!isApiConfigured) {
+      setError("Newsletter capture is not configured for this deployment.");
+      return;
+    }
+    setStatus("submitting");
+    setError(null);
+    try {
+      await api.newsletter.subscribe({
+        email: email.trim(),
+        source: "community",
+        website,
+      });
+      setStatus("success");
+    } catch (err) {
+      setStatus("idle");
+      setError(describeError(err));
+    }
+  };
+
+  return (
+    <div className="rounded-lg glass-surface p-5 sm:p-6">
+      <div className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        <Mail className="h-3.5 w-3.5 text-status-running" />
+        Weekly newsletter
+      </div>
+      <h2 className="mt-3 text-2xl font-semibold tracking-normal">
+        The brief for builders who care about the work beneath the launch.
+      </h2>
+      <p className="mt-3 text-sm leading-7 text-muted-foreground">
+        One issue each week: a teardown, a comparison matrix, implementation
+        notes, and the Beevibe angle for AI-native teams.
+      </p>
+
+      <form onSubmit={submit} className="mt-5 space-y-3">
+        <label htmlFor="community-email" className="sr-only">
+          Email
+        </label>
+        <div className="flex flex-col sm:flex-row gap-2">
+          <input
+            id="community-email"
+            type="email"
+            required
+            autoComplete="email"
+            inputMode="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            placeholder="you@company.com"
+            disabled={status === "submitting" || status === "success"}
+            className="min-w-0 flex-1 h-10 rounded border border-border bg-background px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-60"
+          />
+          <button
+            type="submit"
+            disabled={status === "submitting" || status === "success"}
+            className="inline-flex h-10 items-center justify-center gap-2 rounded bg-primary px-4 text-sm font-semibold text-primary-foreground hover:opacity-90 transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {status === "submitting" ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Joining
+              </>
+            ) : status === "success" ? (
+              <>
+                <CheckCircle2 className="h-4 w-4" />
+                Joined
+              </>
+            ) : (
+              <>
+                <Mail className="h-4 w-4" />
+                Subscribe
+              </>
+            )}
+          </button>
+        </div>
+        <label className="sr-only" htmlFor="community-website">
+          Website
+        </label>
+        <input
+          id="community-website"
+          type="text"
+          tabIndex={-1}
+          autoComplete="off"
+          value={website}
+          onChange={(event) => setWebsite(event.target.value)}
+          className="sr-only"
+          aria-hidden="true"
+        />
+        {error ? (
+          <p className="text-xs text-status-failed">{error}</p>
+        ) : status === "success" ? (
+          <p className="text-xs text-status-done">
+            You are on the list. First issue will focus on preview environments.
+          </p>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            No generic launch recap. Just patterns, artifacts, and judgment.
+          </p>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/packages/web/app/community/page.tsx
+++ b/packages/web/app/community/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { CommunityClient } from "./community-client";
+
+export const metadata: Metadata = {
+  title: "Community",
+  description:
+    "Curated design and operating patterns from teams building durable products.",
+};
+
+export default function CommunityPage() {
+  return <CommunityClient />;
+}

--- a/packages/web/lib/api/client-mutations.test.ts
+++ b/packages/web/lib/api/client-mutations.test.ts
@@ -138,4 +138,22 @@ describe("api mutations", () => {
       });
     });
   });
+
+  describe("newsletter", () => {
+    it("subscribe(input) POSTs to /newsletter/subscribe", async () => {
+      await api.newsletter.subscribe({
+        email: "alice@example.com",
+        source: "community",
+        website: "",
+      });
+      expect(fetchJsonMock).toHaveBeenCalledWith("/newsletter/subscribe", {
+        method: "POST",
+        body: {
+          email: "alice@example.com",
+          source: "community",
+          website: "",
+        },
+      });
+    });
+  });
 });

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -303,6 +303,17 @@ export interface SignupResponse {
   existed: boolean;
 }
 
+export interface NewsletterSubscribeInput {
+  email: string;
+  source?: string;
+  website?: string;
+}
+
+export interface NewsletterSubscribeResponse {
+  ok: true;
+  subscriber?: { email: string; source: string };
+}
+
 export interface ChatHistoryMessage {
   id: string;
   role: "user" | "agent";
@@ -641,6 +652,13 @@ export const api = {
         api_key: string;
         person: { id: string; name: string; email: string | null };
       }>("/signin", { method: "POST", body: input }),
+  },
+  newsletter: {
+    subscribe: (input: NewsletterSubscribeInput) =>
+      fetchJson<NewsletterSubscribeResponse>("/newsletter/subscribe", {
+        method: "POST",
+        body: input,
+      }),
   },
   me: {
     /** Identity + onboarding state for the welcome flow. */

--- a/packages/web/lib/community/adr-visual-report.ts
+++ b/packages/web/lib/community/adr-visual-report.ts
@@ -1,0 +1,95 @@
+export interface AdrVisualKpi {
+  id: string;
+  label: string;
+  value: string;
+  tone: "neutral" | "good" | "warning" | "critical";
+}
+
+export interface AdrEvidenceMixEntry {
+  sourceType: string;
+  count: number;
+  averageScore: number;
+}
+
+export interface AdrFunnelStep {
+  label: string;
+  count: number;
+}
+
+export interface AdrRiskSignal {
+  topic: string;
+  risk: string;
+}
+
+export interface AdrVisualReport {
+  sourceRun: string;
+  decision: {
+    title: string;
+    status: string;
+    summary: string;
+  };
+  kpis: AdrVisualKpi[];
+  evidenceMix: AdrEvidenceMixEntry[];
+  decisionFunnel: AdrFunnelStep[];
+  matrixCoverage: {
+    axes: number;
+    candidates: number;
+    totalCells: number;
+    filledCells: number;
+    emptyCells: number;
+    coveragePercent: number;
+  };
+  riskSignals: AdrRiskSignal[];
+}
+
+export const COMMUNITY_ADR_VISUAL_REPORT: AdrVisualReport = {
+  sourceRun: "design-patterns-community-brief",
+  decision: {
+    title: "Building Patterns Index",
+    status: "editorial",
+    summary:
+      "ADR-style curation compares the patterns behind shipped products, then turns the strongest lessons into reusable operating context for AI-native teams.",
+  },
+  kpis: [
+    { id: "signals", label: "Signals reviewed", value: "64", tone: "neutral" },
+    { id: "patterns", label: "Promoted patterns", value: "6", tone: "good" },
+    { id: "coverage", label: "Matrix coverage", value: "83%", tone: "good" },
+    { id: "operator_notes", label: "Operator notes", value: "18", tone: "neutral" },
+  ],
+  evidenceMix: [
+    { sourceType: "product_artifacts", count: 18, averageScore: 0.91 },
+    { sourceType: "engineering_writeups", count: 14, averageScore: 0.86 },
+    { sourceType: "design_teardowns", count: 12, averageScore: 0.79 },
+    { sourceType: "release_notes", count: 11, averageScore: 0.74 },
+    { sourceType: "community_observations", count: 9, averageScore: 0.68 },
+  ],
+  decisionFunnel: [
+    { label: "Signals", count: 64 },
+    { label: "Candidates", count: 18 },
+    { label: "Promoted", count: 6 },
+    { label: "Compared", count: 6 },
+    { label: "Operationalized", count: 3 },
+  ],
+  matrixCoverage: {
+    axes: 5,
+    candidates: 6,
+    totalCells: 30,
+    filledCells: 25,
+    emptyCells: 5,
+    coveragePercent: 83,
+  },
+  riskSignals: [
+    {
+      topic: "Transfer Risk",
+      risk: "A visible product pattern can fail when copied without its surrounding operating rhythm.",
+    },
+    {
+      topic: "Evidence Quality",
+      risk: "Launch posts overstate intent; prefer artifacts, changelogs, docs, and workflow traces.",
+    },
+    {
+      topic: "Agent Use",
+      risk: "Patterns should become prompts, memory, checks, or tasks only after the tradeoff is explicit.",
+    },
+  ],
+};

--- a/scripts/adr-slide-deck.test.ts
+++ b/scripts/adr-slide-deck.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import type { AdrVisualReport } from "./adr-visual-report.js";
+import { renderAdrSlideDeckHtml } from "./adr-slide-deck.js";
+
+function makeReport(): AdrVisualReport {
+  return {
+    version: "0.1.0",
+    generatedAt: "2026-05-26T00:00:00.000Z",
+    sourceRun: "demo",
+    decision: {
+      id: "demo",
+      title: "Demo <ADR>",
+      status: "proposed",
+      mode: "decision",
+      selectedTopology: "postgres",
+      recommendation: "postgres",
+      summary: "Summary <must be escaped>.",
+    },
+    kpis: [
+      { id: "evidence", label: "Evidence", value: "12", tone: "neutral" },
+      { id: "coverage", label: "Coverage", value: "90%", tone: "good" },
+    ],
+    candidates: [
+      {
+        id: "postgres",
+        label: "Postgres",
+        status: "promoted",
+        score: 1.25,
+        evidenceCount: 4,
+        supportCount: 2,
+        warningCount: 1,
+        rejectionCount: 0,
+        citations: [1, 2],
+      },
+    ],
+    evidenceMix: [{ sourceType: "private_corpus", count: 4, averageScore: 0.7 }],
+    decisionFunnel: [
+      { label: "Candidates", count: 3 },
+      { label: "Promoted", count: 1 },
+    ],
+    matrixCoverage: {
+      axes: 2,
+      candidates: 3,
+      totalCells: 6,
+      emptyCells: 1,
+      filledCells: 5,
+      coveragePercent: 83,
+    },
+    queryShapes: [],
+    riskSignals: [{ topic: "Risk", risk: "Watch the edge case." }],
+    mermaid: { decisionFunnel: "flowchart LR", evidenceMix: "pie showData" },
+  };
+}
+
+describe("renderAdrSlideDeckHtml", () => {
+  it("renders a fixed-stage deck and escapes report text", () => {
+    const html = renderAdrSlideDeckHtml(makeReport());
+
+    expect(html).toContain("width: 1920px");
+    expect(html).toContain("height: 1080px");
+    expect(html).toContain("class=\"deck-stage\"");
+    expect(html).toContain("Demo &lt;ADR&gt;");
+    expect(html).toContain("Summary &lt;must be escaped&gt;.");
+    expect(html).not.toContain("Demo <ADR>");
+  });
+
+  it("includes visual report sections", () => {
+    const html = renderAdrSlideDeckHtml(makeReport());
+
+    expect(html).toContain("Decision funnel");
+    expect(html).toContain("Evidence mix");
+    expect(html).toContain("Candidate scorecards");
+    expect(html).toContain("Coverage and risk");
+    expect(html).toContain("Rendering contract");
+  });
+});

--- a/scripts/adr-slide-deck.ts
+++ b/scripts/adr-slide-deck.ts
@@ -1,0 +1,851 @@
+/**
+ * Render an ADR visual report as a zero-dependency HTML slide deck.
+ *
+ * This is Beevibe's technical rendering layer around the frontend-slides
+ * workflow: ADR owns the evidence schema; this renderer owns the charts,
+ * scorecards, and fixed 1920x1080 stage.
+ *
+ * Usage:
+ *   pnpm adr:slides .adr-runs/retrieval-architecture-v3
+ *   pnpm adr:slides .adr-runs/retrieval-architecture-v3/visual-report.json --out deck.html
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import {
+  generateAdrVisualReport,
+  type AdrEvidenceMixEntry,
+  type AdrFunnelStep,
+  type AdrVisualCandidate,
+  type AdrVisualReport,
+} from "./adr-visual-report.js";
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+function pct(value: number): number {
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function topCandidates(report: AdrVisualReport): AdrVisualCandidate[] {
+  return report.candidates.slice(0, 8);
+}
+
+function renderKpiStrip(report: AdrVisualReport): string {
+  return report.kpis
+    .map(
+      (kpi) => `
+        <div class="kpi tone-${escapeHtml(kpi.tone)}">
+          <div class="kpi-label">${escapeHtml(kpi.label)}</div>
+          <div class="kpi-value">${escapeHtml(kpi.value)}</div>
+        </div>`,
+    )
+    .join("");
+}
+
+function renderFunnel(steps: AdrFunnelStep[]): string {
+  const maxCount = Math.max(1, ...steps.map((step) => step.count));
+  return steps
+    .map((step, index) => {
+      const width = pct((step.count / maxCount) * 100);
+      return `
+        <div class="funnel-row" style="--bar:${width}%">
+          <div class="funnel-index">${String(index + 1).padStart(2, "0")}</div>
+          <div class="funnel-label">${escapeHtml(step.label)}</div>
+          <div class="funnel-track"><div></div></div>
+          <div class="funnel-count">${escapeHtml(step.count)}</div>
+        </div>`;
+    })
+    .join("");
+}
+
+function renderEvidenceMix(entries: AdrEvidenceMixEntry[]): string {
+  const maxCount = Math.max(1, ...entries.map((entry) => entry.count));
+  return entries
+    .slice(0, 8)
+    .map((entry) => {
+      const width = pct((entry.count / maxCount) * 100);
+      return `
+        <div class="evidence-row" style="--bar:${width}%">
+          <div class="evidence-label">${escapeHtml(entry.sourceType.replace(/_/g, " "))}</div>
+          <div class="evidence-track"><div></div></div>
+          <div class="evidence-score">${escapeHtml(entry.count)}</div>
+        </div>`;
+    })
+    .join("");
+}
+
+function renderCandidateCards(candidates: AdrVisualCandidate[]): string {
+  return candidates
+    .slice(0, 6)
+    .map(
+      (candidate, index) => `
+        <article class="candidate-card">
+          <div class="candidate-rank">${String(index + 1).padStart(2, "0")}</div>
+          <div>
+            <h3>${escapeHtml(candidate.label)}</h3>
+            <p>${escapeHtml(candidate.status.replace(/_/g, " "))}</p>
+          </div>
+          <div class="candidate-score">${escapeHtml(candidate.score.toFixed(2))}</div>
+          <div class="candidate-meta">
+            <span>${escapeHtml(candidate.evidenceCount)} evidence</span>
+            <span>${escapeHtml(candidate.supportCount)} support</span>
+            <span>${escapeHtml(candidate.rejectionCount)} reject</span>
+          </div>
+        </article>`,
+    )
+    .join("");
+}
+
+function renderCoverageGrid(report: AdrVisualReport): string {
+  const cells = Math.min(80, Math.max(0, report.matrixCoverage.totalCells));
+  const filled = Math.min(cells, Math.max(0, report.matrixCoverage.filledCells));
+  return Array.from({ length: cells })
+    .map((_, index) => `<span class="${index < filled ? "filled" : ""}"></span>`)
+    .join("");
+}
+
+function renderRiskSignals(report: AdrVisualReport): string {
+  return report.riskSignals
+    .slice(0, 6)
+    .map(
+      (signal) => `
+        <article class="risk-card">
+          <h3>${escapeHtml(signal.topic)}</h3>
+          <p>${escapeHtml(signal.risk)}</p>
+        </article>`,
+    )
+    .join("");
+}
+
+export function renderAdrSlideDeckHtml(report: AdrVisualReport): string {
+  const safeTitle = escapeHtml(report.decision.title);
+  const candidates = topCandidates(report);
+  const topCandidate = candidates[0];
+  const statusLabel = report.decision.selectedTopology ?? report.decision.status;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${safeTitle} - ADR Deck</title>
+  <link rel="preconnect" href="https://api.fontshare.com">
+  <link rel="stylesheet" href="https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@500,700,800&f[]=sentient@400,500&display=swap">
+  <style>
+    :root {
+      --stage-bg: #11110f;
+      --slide-bg: #f7f0df;
+      --ink: #181713;
+      --muted: #6e675b;
+      --paper: #fffaf0;
+      --line: #28231a;
+      --accent: #f6c945;
+      --accent-2: #2f80ed;
+      --accent-3: #29a06f;
+      --danger: #db5c4b;
+      --font-display: "Cabinet Grotesk", sans-serif;
+      --font-serif: "Sentient", serif;
+    }
+
+    * { box-sizing: border-box; }
+
+    html, body {
+      width: 100%;
+      height: 100%;
+      margin: 0;
+      overflow: hidden;
+      background: var(--stage-bg, #000);
+    }
+
+    .deck-viewport {
+      position: fixed;
+      inset: 0;
+      overflow: hidden;
+      background:
+        radial-gradient(circle at 12% 18%, rgba(246, 201, 69, 0.18), transparent 34%),
+        radial-gradient(circle at 92% 84%, rgba(47, 128, 237, 0.16), transparent 34%),
+        var(--stage-bg);
+    }
+
+    .deck-stage {
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 1920px;
+      height: 1080px;
+      overflow: hidden;
+      transform-origin: 0 0;
+      background: var(--slide-bg);
+      box-shadow: 0 40px 110px rgba(0, 0, 0, 0.35);
+    }
+
+    .slide {
+      position: absolute;
+      inset: 0;
+      width: 1920px;
+      height: 1080px;
+      overflow: hidden;
+      display: block;
+      visibility: hidden;
+      opacity: 0;
+      pointer-events: none;
+      background:
+        linear-gradient(90deg, rgba(24, 23, 19, 0.05) 1px, transparent 1px),
+        linear-gradient(0deg, rgba(24, 23, 19, 0.04) 1px, transparent 1px),
+        var(--slide-bg);
+      background-size: 96px 96px;
+      color: var(--ink);
+      font-family: var(--font-display);
+      padding: 72px;
+    }
+
+    .slide.active,
+    .slide.visible {
+      visibility: visible;
+      opacity: 1;
+      pointer-events: auto;
+      z-index: 1;
+    }
+
+    img, video, canvas, svg {
+      max-width: 100%;
+      max-height: 100%;
+    }
+
+    .deck-controls {
+      position: fixed;
+      left: 50%;
+      bottom: 22px;
+      transform: translateX(-50%);
+      z-index: 1000;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      color: #f7f0df;
+      font: 600 13px var(--font-display);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      background: rgba(17, 17, 15, 0.72);
+      border: 1px solid rgba(247, 240, 223, 0.18);
+      border-radius: 999px;
+      padding: 10px 16px;
+      backdrop-filter: blur(18px);
+    }
+
+    @media print {
+      html, body {
+        width: 1920px;
+        height: auto;
+        overflow: visible;
+        background: #fff;
+      }
+
+      .deck-viewport {
+        position: static;
+        overflow: visible;
+        background: #fff;
+      }
+
+      .deck-stage {
+        position: static;
+        width: auto;
+        height: auto;
+        transform: none !important;
+        background: none;
+      }
+
+      .slide {
+        position: relative;
+        display: block !important;
+        visibility: visible !important;
+        opacity: 1 !important;
+        pointer-events: auto !important;
+        width: 1920px;
+        height: 1080px;
+        break-after: page;
+        page-break-after: always;
+      }
+
+      .slide:last-child {
+        break-after: auto;
+        page-break-after: auto;
+      }
+
+      .deck-controls {
+        display: none !important;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        transition-duration: 0.2s !important;
+      }
+    }
+
+    .reveal {
+      opacity: 0;
+      transform: translateY(28px);
+      transition: opacity 680ms cubic-bezier(0.16, 1, 0.3, 1),
+        transform 680ms cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    .slide.visible .reveal {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    .reveal:nth-child(2) { transition-delay: 90ms; }
+    .reveal:nth-child(3) { transition-delay: 180ms; }
+    .reveal:nth-child(4) { transition-delay: 270ms; }
+
+    .slide-label {
+      display: inline-flex;
+      align-items: center;
+      gap: 14px;
+      font-size: 22px;
+      font-weight: 800;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .slide-label::before {
+      content: "";
+      width: 64px;
+      height: 10px;
+      border-radius: 999px;
+      background: var(--accent);
+      border: 2px solid var(--line);
+    }
+
+    h1, h2, h3, p { margin: 0; }
+
+    h1 {
+      max-width: 1320px;
+      font-size: 132px;
+      line-height: 0.94;
+      letter-spacing: 0;
+      font-weight: 800;
+    }
+
+    h2 {
+      max-width: 1100px;
+      font-size: 82px;
+      line-height: 0.98;
+      letter-spacing: 0;
+      font-weight: 800;
+    }
+
+    .serif {
+      font-family: var(--font-serif);
+      font-weight: 400;
+    }
+
+    .muted {
+      color: var(--muted);
+    }
+
+    .title-slide {
+      display: grid;
+      grid-template-rows: auto 1fr auto;
+      gap: 54px;
+    }
+
+    .title-grid {
+      align-self: end;
+      display: grid;
+      grid-template-columns: 1fr 420px;
+      gap: 72px;
+      align-items: end;
+    }
+
+    .title-summary {
+      font: 400 38px/1.35 var(--font-serif);
+      color: var(--muted);
+    }
+
+    .stamp {
+      width: 360px;
+      height: 360px;
+      border: 6px solid var(--line);
+      border-radius: 28px;
+      background: var(--accent);
+      display: grid;
+      place-items: center;
+      transform: rotate(4deg);
+      box-shadow: 20px 20px 0 var(--line);
+    }
+
+    .stamp span {
+      font-size: 62px;
+      font-weight: 800;
+      text-align: center;
+      line-height: 0.92;
+      text-transform: uppercase;
+    }
+
+    .kpi-grid {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 18px;
+    }
+
+    .kpi {
+      min-height: 150px;
+      border: 3px solid var(--line);
+      border-radius: 18px;
+      padding: 24px;
+      background: var(--paper);
+      box-shadow: 8px 8px 0 var(--line);
+    }
+
+    .kpi-label {
+      font-size: 20px;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-weight: 800;
+    }
+
+    .kpi-value {
+      margin-top: 14px;
+      font-size: 58px;
+      line-height: 1;
+      font-weight: 800;
+    }
+
+    .tone-good .kpi-value { color: var(--accent-3); }
+    .tone-warning .kpi-value { color: #a36d00; }
+    .tone-critical .kpi-value { color: var(--danger); }
+
+    .split {
+      display: grid;
+      grid-template-columns: 0.86fr 1.14fr;
+      gap: 52px;
+      height: 100%;
+    }
+
+    .panel {
+      border: 3px solid var(--line);
+      border-radius: 22px;
+      background: rgba(255, 250, 240, 0.78);
+      padding: 34px;
+      box-shadow: 10px 10px 0 var(--line);
+    }
+
+    .funnel-list, .evidence-list {
+      display: grid;
+      gap: 22px;
+      margin-top: 42px;
+    }
+
+    .funnel-row, .evidence-row {
+      display: grid;
+      grid-template-columns: 70px 260px 1fr 80px;
+      align-items: center;
+      gap: 22px;
+      font-size: 28px;
+      font-weight: 800;
+    }
+
+    .evidence-row {
+      grid-template-columns: 360px 1fr 80px;
+    }
+
+    .funnel-index {
+      font-size: 24px;
+      color: var(--muted);
+    }
+
+    .funnel-track, .evidence-track {
+      height: 34px;
+      border: 3px solid var(--line);
+      border-radius: 999px;
+      background: var(--paper);
+      overflow: hidden;
+    }
+
+    .funnel-track div, .evidence-track div {
+      width: var(--bar);
+      height: 100%;
+      background: linear-gradient(90deg, var(--accent), #ff8d55);
+      border-right: 3px solid var(--line);
+    }
+
+    .evidence-track div {
+      background: linear-gradient(90deg, var(--accent-2), #69d2ff);
+    }
+
+    .candidate-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 22px;
+      margin-top: 42px;
+    }
+
+    .candidate-card {
+      position: relative;
+      min-height: 210px;
+      border: 3px solid var(--line);
+      border-radius: 22px;
+      background: var(--paper);
+      padding: 24px;
+      display: grid;
+      grid-template-columns: 72px 1fr 120px;
+      gap: 20px;
+      box-shadow: 8px 8px 0 var(--line);
+    }
+
+    .candidate-rank {
+      width: 60px;
+      height: 60px;
+      border-radius: 16px;
+      border: 3px solid var(--line);
+      background: var(--accent);
+      display: grid;
+      place-items: center;
+      font-size: 22px;
+      font-weight: 800;
+    }
+
+    .candidate-card h3 {
+      font-size: 36px;
+      line-height: 1;
+      font-weight: 800;
+    }
+
+    .candidate-card p {
+      margin-top: 10px;
+      font-size: 20px;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-weight: 800;
+    }
+
+    .candidate-score {
+      justify-self: end;
+      font-size: 46px;
+      font-weight: 800;
+    }
+
+    .candidate-meta {
+      grid-column: 2 / -1;
+      display: flex;
+      gap: 12px;
+      align-items: end;
+      flex-wrap: wrap;
+      font-size: 18px;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      font-weight: 800;
+    }
+
+    .coverage-grid {
+      display: grid;
+      grid-template-columns: repeat(10, 1fr);
+      gap: 12px;
+      margin-top: 42px;
+    }
+
+    .coverage-grid span {
+      aspect-ratio: 1;
+      border: 3px solid var(--line);
+      border-radius: 8px;
+      background: var(--paper);
+    }
+
+    .coverage-grid .filled {
+      background: var(--accent-3);
+    }
+
+    .big-number {
+      font-size: 180px;
+      line-height: 0.85;
+      font-weight: 800;
+      letter-spacing: -3px;
+    }
+
+    .risk-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 22px;
+      margin-top: 42px;
+    }
+
+    .risk-card {
+      min-height: 260px;
+      border: 3px solid var(--line);
+      border-radius: 22px;
+      background: var(--paper);
+      padding: 28px;
+      box-shadow: 8px 8px 0 var(--line);
+    }
+
+    .risk-card h3 {
+      font-size: 34px;
+      line-height: 1;
+      font-weight: 800;
+    }
+
+    .risk-card p {
+      margin-top: 20px;
+      font: 400 26px/1.32 var(--font-serif);
+      color: var(--muted);
+    }
+
+    .closing {
+      display: grid;
+      grid-template-columns: 1fr 540px;
+      gap: 72px;
+      align-items: center;
+      height: 100%;
+    }
+
+    .closing p {
+      margin-top: 34px;
+      max-width: 980px;
+      font: 400 40px/1.32 var(--font-serif);
+      color: var(--muted);
+    }
+
+    .technical-stack {
+      display: grid;
+      gap: 18px;
+    }
+
+    .stack-item {
+      border: 3px solid var(--line);
+      border-radius: 18px;
+      background: var(--paper);
+      padding: 26px;
+      font-size: 30px;
+      font-weight: 800;
+      box-shadow: 8px 8px 0 var(--line);
+    }
+  </style>
+</head>
+<body>
+  <div class="deck-viewport">
+    <main class="deck-stage" id="deckStage">
+      <section class="slide title-slide active">
+        <div class="slide-label reveal">ADR visual system</div>
+        <div class="title-grid">
+          <div>
+            <h1 class="reveal">${safeTitle}</h1>
+            <p class="title-summary reveal">${escapeHtml(report.decision.summary || "Evidence, tradeoffs, and visual reasoning from the ADR pipeline.")}</p>
+          </div>
+          <div class="stamp reveal"><span>${escapeHtml(statusLabel)}</span></div>
+        </div>
+        <div class="kpi-grid reveal">
+          ${renderKpiStrip(report)}
+        </div>
+      </section>
+
+      <section class="slide">
+        <div class="slide-label reveal">Decision funnel</div>
+        <div class="split">
+          <div class="panel reveal">
+            <h2>From noise to usable signal</h2>
+            <p class="title-summary" style="margin-top:32px;">ADR narrows raw research into evidence-backed options, ranked decisions, and implementation context.</p>
+          </div>
+          <div class="panel reveal">
+            <div class="funnel-list">
+              ${renderFunnel(report.decisionFunnel)}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="slide">
+        <div class="slide-label reveal">Evidence mix</div>
+        <div class="split">
+          <div class="panel reveal">
+            <h2>What kind of proof do we have?</h2>
+            <p class="title-summary" style="margin-top:32px;">The report separates mature OSS, engineering writeups, private corpus evidence, and weaker ambient signals.</p>
+          </div>
+          <div class="panel reveal">
+            <div class="evidence-list">
+              ${renderEvidenceMix(report.evidenceMix)}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="slide">
+        <div class="slide-label reveal">Candidate scorecards</div>
+        <h2 class="reveal">${topCandidate ? `Top option: ${escapeHtml(topCandidate.label)}` : "No promoted option yet"}</h2>
+        <div class="candidate-grid reveal">
+          ${renderCandidateCards(candidates)}
+        </div>
+      </section>
+
+      <section class="slide">
+        <div class="slide-label reveal">Coverage and risk</div>
+        <div class="split">
+          <div class="panel reveal">
+            <div class="big-number">${escapeHtml(report.matrixCoverage.coveragePercent)}%</div>
+            <p class="title-summary" style="margin-top:28px;">Matrix coverage across ${escapeHtml(report.matrixCoverage.axes)} axes and ${escapeHtml(report.matrixCoverage.candidates)} candidates.</p>
+            <div class="coverage-grid">${renderCoverageGrid(report)}</div>
+          </div>
+          <div class="panel reveal">
+            <h2>Risk signals</h2>
+            <div class="risk-grid" style="margin-top:32px;">
+              ${renderRiskSignals(report)}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="slide">
+        <div class="closing">
+          <div>
+            <div class="slide-label reveal">Rendering contract</div>
+            <h2 class="reveal">ADR writes the intelligence. Beevibe renders the artifact.</h2>
+            <p class="reveal">The deck is generated from visual-report JSON, so newsletters, community pages, and decision reviews all share the same source of truth.</p>
+          </div>
+          <div class="technical-stack reveal">
+            <div class="stack-item">ADR artifacts</div>
+            <div class="stack-item">visual-report.json</div>
+            <div class="stack-item">slide deck HTML</div>
+            <div class="stack-item">community/newsletter embed</div>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+  <div class="deck-controls"><span id="slideCounter">01 / 06</span><span>Use arrows</span></div>
+  <script>
+    class SlidePresentation {
+      constructor() {
+        this.slides = Array.from(document.querySelectorAll('.slide'));
+        this.currentSlide = 0;
+        this.stage = document.getElementById('deckStage');
+        this.counter = document.getElementById('slideCounter');
+        this.setupStageScale();
+        this.setupKeyboardNav();
+        this.setupTouchNav();
+        this.showSlide(0);
+      }
+
+      setupStageScale() {
+        const scale = () => {
+          const factor = Math.min(window.innerWidth / 1920, window.innerHeight / 1080);
+          const x = (window.innerWidth - 1920 * factor) / 2;
+          const y = (window.innerHeight - 1080 * factor) / 2;
+          this.stage.style.transform = 'translate(' + x + 'px, ' + y + 'px) scale(' + factor + ')';
+        };
+        scale();
+        window.addEventListener('resize', scale);
+      }
+
+      setupKeyboardNav() {
+        window.addEventListener('keydown', (event) => {
+          if (['ArrowRight', 'PageDown', ' '].includes(event.key)) {
+            event.preventDefault();
+            this.showSlide(this.currentSlide + 1);
+          }
+          if (['ArrowLeft', 'PageUp'].includes(event.key)) {
+            event.preventDefault();
+            this.showSlide(this.currentSlide - 1);
+          }
+          if (event.key === 'Home') this.showSlide(0);
+          if (event.key === 'End') this.showSlide(this.slides.length - 1);
+        });
+      }
+
+      setupTouchNav() {
+        let startX = 0;
+        window.addEventListener('touchstart', (event) => {
+          startX = event.changedTouches[0]?.clientX ?? 0;
+        }, { passive: true });
+        window.addEventListener('touchend', (event) => {
+          const endX = event.changedTouches[0]?.clientX ?? startX;
+          const delta = endX - startX;
+          if (Math.abs(delta) < 48) return;
+          this.showSlide(this.currentSlide + (delta < 0 ? 1 : -1));
+        }, { passive: true });
+      }
+
+      showSlide(index) {
+        this.currentSlide = Math.max(0, Math.min(index, this.slides.length - 1));
+        this.slides.forEach((slide, i) => {
+          slide.classList.toggle('active', i === this.currentSlide);
+          slide.classList.toggle('visible', i === this.currentSlide);
+        });
+        this.counter.textContent = String(this.currentSlide + 1).padStart(2, '0') + ' / ' + String(this.slides.length).padStart(2, '0');
+      }
+    }
+
+    new SlidePresentation();
+  </script>
+</body>
+</html>`;
+}
+
+async function loadReport(inputPath: string): Promise<{ report: AdrVisualReport; baseDir: string }> {
+  const resolved = path.resolve(inputPath);
+  const stat = await fs.stat(resolved);
+  if (stat.isDirectory()) {
+    const report = await generateAdrVisualReport({
+      runDir: resolved,
+      outputJsonPath: path.join(resolved, "visual-report.json"),
+      outputMarkdownPath: path.join(resolved, "visual-report.md"),
+    });
+    return { report, baseDir: resolved };
+  }
+  const raw = await fs.readFile(resolved, "utf-8");
+  return { report: JSON.parse(raw) as AdrVisualReport, baseDir: path.dirname(resolved) };
+}
+
+async function renderAdrSlideDeck(inputPath: string, outputPath?: string): Promise<string> {
+  const { report, baseDir } = await loadReport(inputPath);
+  const safeName = slugify(report.decision.id || report.sourceRun || "adr-report");
+  const target = outputPath ? path.resolve(outputPath) : path.join(baseDir, `${safeName}-deck.html`);
+  await fs.writeFile(target, renderAdrSlideDeckHtml(report));
+  return target;
+}
+
+function parseArgs(argv: string[]): { inputPath: string; outputPath?: string } {
+  const args = [...argv];
+  const inputPath = args.shift();
+  if (!inputPath || inputPath.startsWith("--")) {
+    throw new Error("Usage: pnpm adr:slides <run-dir|visual-report.json> [--out path]");
+  }
+  let outputPath: string | undefined;
+  while (args.length > 0) {
+    const arg = args.shift();
+    if (arg === "--out") outputPath = args.shift();
+    else throw new Error(`Unknown argument: ${arg ?? ""}`);
+  }
+  return { inputPath, outputPath };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const { inputPath, outputPath } = parseArgs(process.argv.slice(2));
+  renderAdrSlideDeck(inputPath, outputPath)
+    .then((target) => {
+      console.log(`slide deck: ${target}`);
+    })
+    .catch((err) => {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    });
+}

--- a/scripts/adr-visual-report.test.ts
+++ b/scripts/adr-visual-report.test.ts
@@ -1,0 +1,172 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  generateAdrVisualReport,
+  renderAdrVisualMarkdown,
+} from "./adr-visual-report.js";
+
+let workdir: string;
+
+beforeEach(async () => {
+  workdir = await fs.mkdtemp(path.join(os.tmpdir(), "adr-visual-report-test-"));
+});
+
+afterEach(async () => {
+  await fs.rm(workdir, { recursive: true, force: true });
+});
+
+async function writeJson(file: string, value: unknown): Promise<void> {
+  await fs.writeFile(path.join(workdir, file), `${JSON.stringify(value, null, 2)}\n`);
+}
+
+describe("generateAdrVisualReport", () => {
+  it("distills ADR artifacts into visual report primitives", async () => {
+    await writeJson("architecture.spec.json", {
+      decision: {
+        id: "auth_provider",
+        title: "Auth Provider",
+        status: "proposed",
+        mode: "decision",
+        selected_topology: "better_auth",
+        recommendation: "better_auth",
+        summary: "Pick a provider.",
+        ranked_options: [{ name: "better_auth" }],
+      },
+      evidence_summary: {
+        better_auth: { risks: ["Young ecosystem."] },
+      },
+      evidence: [
+        { source_type: "mature_oss", score: 0.8 },
+        { source_type: "engineering_writeup", score: 0.6 },
+      ],
+    });
+    await writeJson("comparison-matrix.json", {
+      axes: [
+        { id: "production_examples", label: "Production examples" },
+        {
+          id: "query_shape_password_login",
+          label: "Query shape: password login",
+          rationale: "Supports password login.",
+        },
+      ],
+      candidates: [{ name: "better_auth", label: "Better Auth" }],
+    });
+    await writeJson("knowledge-map.json", {
+      promoted_candidates: [
+        {
+          name: "better_auth",
+          label: "Better Auth",
+          promotion_status: "promoted",
+          evidence_count: 2,
+          score: 1.4,
+          citations: [1, 2],
+          support: [{ claim: "fast" }],
+          warnings: [],
+          rejections: [],
+        },
+      ],
+      insufficient_evidence_candidates: [],
+    });
+    await writeJson("state.json", {
+      evidence_count: 2,
+      promoted_candidate_count: 1,
+      comparison_matrix_empty_cells: 1,
+      estimated_usd: 0.1234,
+    });
+
+    const report = await generateAdrVisualReport({
+      runDir: workdir,
+      generatedAt: "2026-05-26T00:00:00.000Z",
+    });
+
+    expect(report.decision.title).toBe("Auth Provider");
+    expect(report.candidates[0]).toMatchObject({
+      id: "better_auth",
+      label: "Better Auth",
+      status: "promoted",
+      evidenceCount: 2,
+      supportCount: 1,
+    });
+    expect(report.evidenceMix).toEqual([
+      { sourceType: "mature_oss", count: 1, averageScore: 0.8 },
+      { sourceType: "engineering_writeup", count: 1, averageScore: 0.6 },
+    ]);
+    expect(report.matrixCoverage).toMatchObject({
+      axes: 2,
+      candidates: 1,
+      totalCells: 2,
+      emptyCells: 1,
+      filledCells: 1,
+      coveragePercent: 50,
+    });
+    expect(report.queryShapes).toHaveLength(1);
+    expect(report.riskSignals).toEqual([
+      { topic: "Better Auth", risk: "Young ecosystem." },
+    ]);
+    expect(report.mermaid.decisionFunnel).toContain("flowchart LR");
+  });
+
+  it("writes json and markdown outputs when paths are provided", async () => {
+    await writeJson("architecture.spec.json", {
+      decision: { id: "x", title: "X", ranked_options: [] },
+      evidence: [],
+    });
+    await writeJson("comparison-matrix.json", { axes: [], candidates: [] });
+
+    const outputJsonPath = path.join(workdir, "visual-report.json");
+    const outputMarkdownPath = path.join(workdir, "visual-report.md");
+
+    await generateAdrVisualReport({
+      runDir: workdir,
+      outputJsonPath,
+      outputMarkdownPath,
+      generatedAt: "2026-05-26T00:00:00.000Z",
+    });
+
+    expect(JSON.parse(await fs.readFile(outputJsonPath, "utf-8")).version).toBe(
+      "0.1.0",
+    );
+    expect(await fs.readFile(outputMarkdownPath, "utf-8")).toContain(
+      "## Decision Funnel",
+    );
+  });
+});
+
+describe("renderAdrVisualMarkdown", () => {
+  it("renders mermaid blocks", () => {
+    const markdown = renderAdrVisualMarkdown({
+      version: "0.1.0",
+      generatedAt: "2026-05-26T00:00:00.000Z",
+      sourceRun: "demo",
+      decision: {
+        id: "demo",
+        title: "Demo",
+        status: "proposed",
+        mode: "decision",
+        selectedTopology: null,
+        recommendation: null,
+        summary: "",
+      },
+      kpis: [],
+      candidates: [],
+      evidenceMix: [],
+      decisionFunnel: [],
+      matrixCoverage: {
+        axes: 0,
+        candidates: 0,
+        totalCells: 0,
+        emptyCells: 0,
+        filledCells: 0,
+        coveragePercent: 0,
+      },
+      queryShapes: [],
+      riskSignals: [],
+      mermaid: { decisionFunnel: "flowchart LR", evidenceMix: "pie showData" },
+    });
+
+    expect(markdown).toContain("```mermaid\nflowchart LR\n```");
+    expect(markdown).toContain("```mermaid\npie showData\n```");
+  });
+});

--- a/scripts/adr-visual-report.ts
+++ b/scripts/adr-visual-report.ts
@@ -1,0 +1,495 @@
+/**
+ * Build visual-report artifacts from an ADR run directory.
+ *
+ * The ADR runner already emits rich structured files (`architecture.spec.json`,
+ * `comparison-matrix.json`, `knowledge-map.json`, `state.json`, `evidence.json`).
+ * This script distills those into a compact visual contract that web/newsletter
+ * surfaces can render without re-learning every ADR internal file shape.
+ *
+ * Usage:
+ *   pnpm adr:visual .adr-runs/retrieval-architecture-v3
+ *   pnpm adr:visual .adr-runs/foo --json out.json --md out.md
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+type JsonRecord = Record<string, unknown>;
+
+export interface AdrVisualKpi {
+  id: string;
+  label: string;
+  value: string;
+  tone: "neutral" | "good" | "warning" | "critical";
+}
+
+export interface AdrVisualCandidate {
+  id: string;
+  label: string;
+  status: string;
+  score: number;
+  evidenceCount: number;
+  supportCount: number;
+  warningCount: number;
+  rejectionCount: number;
+  citations: number[];
+}
+
+export interface AdrEvidenceMixEntry {
+  sourceType: string;
+  count: number;
+  averageScore: number;
+}
+
+export interface AdrFunnelStep {
+  label: string;
+  count: number;
+}
+
+export interface AdrRiskSignal {
+  topic: string;
+  risk: string;
+}
+
+export interface AdrQueryShape {
+  id: string;
+  label: string;
+  rationale: string;
+}
+
+export interface AdrVisualReport {
+  version: "0.1.0";
+  generatedAt: string;
+  sourceRun: string;
+  decision: {
+    id: string;
+    title: string;
+    status: string;
+    mode: string;
+    selectedTopology: string | null;
+    recommendation: string | null;
+    summary: string;
+  };
+  kpis: AdrVisualKpi[];
+  candidates: AdrVisualCandidate[];
+  evidenceMix: AdrEvidenceMixEntry[];
+  decisionFunnel: AdrFunnelStep[];
+  matrixCoverage: {
+    axes: number;
+    candidates: number;
+    totalCells: number;
+    emptyCells: number;
+    filledCells: number;
+    coveragePercent: number;
+  };
+  queryShapes: AdrQueryShape[];
+  riskSignals: AdrRiskSignal[];
+  mermaid: {
+    decisionFunnel: string;
+    evidenceMix: string;
+  };
+}
+
+export interface GenerateAdrVisualReportOptions {
+  runDir: string;
+  outputJsonPath?: string;
+  outputMarkdownPath?: string;
+  generatedAt?: string;
+}
+
+async function readJsonFile(runDir: string, file: string): Promise<unknown> {
+  const raw = await fs.readFile(path.join(runDir, file), "utf-8");
+  return JSON.parse(raw) as unknown;
+}
+
+async function readOptionalJson(runDir: string, file: string): Promise<unknown | undefined> {
+  try {
+    return await readJsonFile(runDir, file);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return undefined;
+    throw err;
+  }
+}
+
+function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : {};
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function toTitle(value: string): string {
+  return value
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (m) => m.toUpperCase())
+    .trim();
+}
+
+function clampPercent(value: number): number {
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function collectCandidates(
+  knowledgeMap: JsonRecord,
+  comparisonMatrix: JsonRecord,
+): AdrVisualCandidate[] {
+  const fromKnowledge = [
+    ...asArray(knowledgeMap.promoted_candidates),
+    ...asArray(knowledgeMap.insufficient_evidence_candidates),
+  ].map(asRecord);
+
+  const byId = new Map<string, AdrVisualCandidate>();
+  for (const candidate of fromKnowledge) {
+    const id = asString(candidate.name);
+    if (!id) continue;
+    byId.set(id, {
+      id,
+      label: asString(candidate.label, toTitle(id)),
+      status: asString(candidate.promotion_status, "unknown"),
+      score: asNumber(candidate.score),
+      evidenceCount: asNumber(candidate.evidence_count),
+      supportCount: asArray(candidate.support).length,
+      warningCount: asArray(candidate.warnings).length,
+      rejectionCount: asArray(candidate.rejections).length,
+      citations: asArray(candidate.citations).filter((v): v is number => typeof v === "number"),
+    });
+  }
+
+  for (const candidate of asArray(comparisonMatrix.candidates).map(asRecord)) {
+    const id = asString(candidate.name);
+    if (!id || byId.has(id)) continue;
+    byId.set(id, {
+      id,
+      label: asString(candidate.label, toTitle(id)),
+      status: asString(candidate.promotion_status, "unknown"),
+      score: asNumber(candidate.score),
+      evidenceCount: asNumber(candidate.evidence_count),
+      supportCount: 0,
+      warningCount: 0,
+      rejectionCount: 0,
+      citations: asArray(candidate.citations).filter((v): v is number => typeof v === "number"),
+    });
+  }
+
+  return [...byId.values()].sort((a, b) => b.score - a.score);
+}
+
+function collectEvidenceMix(evidenceItems: unknown[]): AdrEvidenceMixEntry[] {
+  const buckets = new Map<string, { count: number; scoreTotal: number }>();
+  for (const item of evidenceItems.map(asRecord)) {
+    const sourceType = asString(item.source_type, "unknown");
+    const current = buckets.get(sourceType) ?? { count: 0, scoreTotal: 0 };
+    current.count += 1;
+    current.scoreTotal += asNumber(item.score);
+    buckets.set(sourceType, current);
+  }
+  return [...buckets.entries()]
+    .map(([sourceType, bucket]) => ({
+      sourceType,
+      count: bucket.count,
+      averageScore:
+        bucket.count > 0 ? Number((bucket.scoreTotal / bucket.count).toFixed(3)) : 0,
+    }))
+    .sort((a, b) => b.count - a.count || b.averageScore - a.averageScore);
+}
+
+function collectRisks(architectureSpec: JsonRecord): AdrRiskSignal[] {
+  const evidenceSummary = asRecord(architectureSpec.evidence_summary);
+  const risks: AdrRiskSignal[] = [];
+  for (const [topic, summary] of Object.entries(evidenceSummary)) {
+    const summaryRecord = asRecord(summary);
+    for (const risk of asArray(summaryRecord.risks)) {
+      if (typeof risk === "string" && risk.trim()) {
+        risks.push({ topic: toTitle(topic), risk: risk.trim() });
+      }
+    }
+  }
+  return risks.slice(0, 12);
+}
+
+function collectQueryShapes(comparisonMatrix: JsonRecord): AdrQueryShape[] {
+  return asArray(comparisonMatrix.axes)
+    .map(asRecord)
+    .filter((axis) => asString(axis.id).startsWith("query_shape_"))
+    .map((axis) => ({
+      id: asString(axis.id),
+      label: asString(axis.label, toTitle(asString(axis.id))),
+      rationale: asString(axis.rationale),
+    }));
+}
+
+function buildDecisionFunnel(
+  candidates: AdrVisualCandidate[],
+  architectureSpec: JsonRecord,
+  knowledgeMap: JsonRecord,
+): AdrFunnelStep[] {
+  const decision = asRecord(architectureSpec.decision);
+  return [
+    { label: "Candidates", count: candidates.length },
+    {
+      label: "Evidence-backed",
+      count: candidates.filter((candidate) => candidate.evidenceCount > 0).length,
+    },
+    {
+      label: "Promoted",
+      count: asArray(knowledgeMap.promoted_candidates).length,
+    },
+    {
+      label: "Ranked",
+      count: asArray(decision.ranked_options).length,
+    },
+    {
+      label: "Recommended",
+      count: asString(decision.recommendation) ? 1 : 0,
+    },
+  ];
+}
+
+function buildMermaidFunnel(steps: AdrFunnelStep[]): string {
+  const lines = ["flowchart LR"];
+  steps.forEach((step, index) => {
+    const nodeId = `S${index}`;
+    const label = `${step.label}: ${step.count}`.replace(/"/g, "'");
+    lines.push(`  ${nodeId}["${label}"]`);
+    if (index > 0) lines.push(`  S${index - 1} --> ${nodeId}`);
+  });
+  return lines.join("\n");
+}
+
+function buildMermaidEvidenceMix(entries: AdrEvidenceMixEntry[]): string {
+  const lines = ["pie showData", '  title Evidence mix'];
+  if (entries.length === 0) {
+    lines.push('  "none" : 1');
+    return lines.join("\n");
+  }
+  for (const entry of entries) {
+    const label = entry.sourceType.replace(/"/g, "'");
+    lines.push(`  "${label}" : ${entry.count}`);
+  }
+  return lines.join("\n");
+}
+
+export async function generateAdrVisualReport(
+  opts: GenerateAdrVisualReportOptions,
+): Promise<AdrVisualReport> {
+  const runDir = path.resolve(opts.runDir);
+  const [architectureRaw, matrixRaw, knowledgeRaw, stateRaw, evidenceRaw] =
+    await Promise.all([
+      readJsonFile(runDir, "architecture.spec.json"),
+      readJsonFile(runDir, "comparison-matrix.json"),
+      readOptionalJson(runDir, "knowledge-map.json"),
+      readOptionalJson(runDir, "state.json"),
+      readOptionalJson(runDir, "evidence.json"),
+    ]);
+
+  const architectureSpec = asRecord(architectureRaw);
+  const comparisonMatrix = asRecord(matrixRaw);
+  const knowledgeMap = asRecord(knowledgeRaw);
+  const state = asRecord(stateRaw);
+  const decision = asRecord(architectureSpec.decision);
+  const candidates = collectCandidates(knowledgeMap, comparisonMatrix);
+  const evidenceItems = asArray(evidenceRaw ?? architectureSpec.evidence);
+  const evidenceMix = collectEvidenceMix(evidenceItems);
+  const decisionFunnel = buildDecisionFunnel(candidates, architectureSpec, knowledgeMap);
+
+  const axes = asArray(comparisonMatrix.axes).length;
+  const candidateCount = asArray(comparisonMatrix.candidates).length || candidates.length;
+  const totalCells = axes * candidateCount;
+  const emptyCells = Math.min(
+    totalCells,
+    asNumber(state.comparison_matrix_empty_cells, totalCells > 0 ? totalCells : 0),
+  );
+  const filledCells = Math.max(0, totalCells - emptyCells);
+  const coveragePercent =
+    totalCells > 0 ? clampPercent((filledCells / totalCells) * 100) : 0;
+
+  const report: AdrVisualReport = {
+    version: "0.1.0",
+    generatedAt: opts.generatedAt ?? new Date().toISOString(),
+    sourceRun: path.basename(runDir),
+    decision: {
+      id: asString(decision.id, "unknown_decision"),
+      title: asString(decision.title, "Untitled ADR"),
+      status: asString(decision.status, "unknown"),
+      mode: asString(decision.mode, asString(state.decision_mode, "unknown")),
+      selectedTopology: asString(decision.selected_topology) || null,
+      recommendation: asString(decision.recommendation) || null,
+      summary: asString(decision.summary),
+    },
+    kpis: [
+      {
+        id: "evidence_count",
+        label: "Evidence",
+        value: String(evidenceItems.length || asNumber(state.evidence_count)),
+        tone: "neutral",
+      },
+      {
+        id: "promoted",
+        label: "Promoted",
+        value: String(asNumber(state.promoted_candidate_count)),
+        tone: asNumber(state.promoted_candidate_count) > 0 ? "good" : "warning",
+      },
+      {
+        id: "matrix_coverage",
+        label: "Matrix coverage",
+        value: `${coveragePercent}%`,
+        tone:
+          coveragePercent >= 70 ? "good" : coveragePercent >= 35 ? "warning" : "critical",
+      },
+      {
+        id: "estimated_cost",
+        label: "Run cost",
+        value: `$${asNumber(state.estimated_usd).toFixed(3)}`,
+        tone: "neutral",
+      },
+    ],
+    candidates,
+    evidenceMix,
+    decisionFunnel,
+    matrixCoverage: {
+      axes,
+      candidates: candidateCount,
+      totalCells,
+      emptyCells,
+      filledCells,
+      coveragePercent,
+    },
+    queryShapes: collectQueryShapes(comparisonMatrix),
+    riskSignals: collectRisks(architectureSpec),
+    mermaid: {
+      decisionFunnel: buildMermaidFunnel(decisionFunnel),
+      evidenceMix: buildMermaidEvidenceMix(evidenceMix),
+    },
+  };
+
+  if (opts.outputJsonPath) {
+    await fs.writeFile(opts.outputJsonPath, `${JSON.stringify(report, null, 2)}\n`);
+  }
+  if (opts.outputMarkdownPath) {
+    await fs.writeFile(opts.outputMarkdownPath, renderAdrVisualMarkdown(report));
+  }
+
+  return report;
+}
+
+export function renderAdrVisualMarkdown(report: AdrVisualReport): string {
+  const candidateRows = report.candidates
+    .slice(0, 10)
+    .map(
+      (candidate) =>
+        `| ${candidate.label} | ${candidate.status} | ${candidate.score.toFixed(3)} | ${candidate.evidenceCount} | ${candidate.supportCount}/${candidate.warningCount}/${candidate.rejectionCount} |`,
+    )
+    .join("\n");
+  const riskRows =
+    report.riskSignals.length > 0
+      ? report.riskSignals
+          .map((risk) => `- **${risk.topic}:** ${risk.risk}`)
+          .join("\n")
+      : "- No risk signals extracted.";
+
+  return `# ${report.decision.title} - Visual Report
+
+Source run: \`${report.sourceRun}\`
+
+Status: **${report.decision.status}**  
+Mode: **${report.decision.mode}**  
+Selected topology: **${report.decision.selectedTopology ?? "none"}**
+
+## Decision Funnel
+
+\`\`\`mermaid
+${report.mermaid.decisionFunnel}
+\`\`\`
+
+## Evidence Mix
+
+\`\`\`mermaid
+${report.mermaid.evidenceMix}
+\`\`\`
+
+## KPI Strip
+
+${report.kpis.map((kpi) => `- **${kpi.label}:** ${kpi.value}`).join("\n")}
+
+## Candidate Scorecards
+
+| Candidate | Status | Score | Evidence | Support/Warnings/Rejections |
+| --- | --- | ---: | ---: | ---: |
+${candidateRows || "| No candidates | - | 0 | 0 | 0/0/0 |"}
+
+## Matrix Coverage
+
+- Axes: ${report.matrixCoverage.axes}
+- Candidates: ${report.matrixCoverage.candidates}
+- Filled cells: ${report.matrixCoverage.filledCells}/${report.matrixCoverage.totalCells}
+- Coverage: ${report.matrixCoverage.coveragePercent}%
+
+## Risk Signals
+
+${riskRows}
+`;
+}
+
+function parseArgs(argv: string[]): {
+  runDir: string;
+  outputJsonPath?: string;
+  outputMarkdownPath?: string;
+  stdout: boolean;
+} {
+  const args = [...argv];
+  const runDir = args.shift();
+  if (!runDir || runDir.startsWith("--")) {
+    throw new Error("Usage: pnpm adr:visual <run-dir> [--json path] [--md path] [--stdout]");
+  }
+  let outputJsonPath: string | undefined;
+  let outputMarkdownPath: string | undefined;
+  let stdout = false;
+  while (args.length > 0) {
+    const arg = args.shift();
+    if (arg === "--json") outputJsonPath = args.shift();
+    else if (arg === "--md") outputMarkdownPath = args.shift();
+    else if (arg === "--stdout") stdout = true;
+    else throw new Error(`Unknown argument: ${arg ?? ""}`);
+  }
+  return { runDir, outputJsonPath, outputMarkdownPath, stdout };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const { runDir, outputJsonPath, outputMarkdownPath, stdout } = parseArgs(
+    process.argv.slice(2),
+  );
+  const resolvedRunDir = path.resolve(runDir);
+  const resolvedOutputJsonPath =
+    outputJsonPath ?? path.join(resolvedRunDir, "visual-report.json");
+  const resolvedOutputMarkdownPath =
+    outputMarkdownPath ?? path.join(resolvedRunDir, "visual-report.md");
+  generateAdrVisualReport({
+    runDir: resolvedRunDir,
+    outputJsonPath: resolvedOutputJsonPath,
+    outputMarkdownPath: resolvedOutputMarkdownPath,
+  })
+    .then((report) => {
+      if (stdout) console.log(JSON.stringify(report, null, 2));
+      else {
+        console.log(`visual report: ${resolvedOutputJsonPath}`);
+        console.log(`markdown brief: ${resolvedOutputMarkdownPath}`);
+      }
+    })
+    .catch((err) => {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary
- Add a public `/community` page for pattern curation, ADR-style visual reporting, and newsletter capture.
- Add public `POST /newsletter/subscribe` with a Postgres-backed `newsletter_subscriber` table.
- Add `pnpm adr:visual` and `pnpm adr:slides` so ADR run artifacts can become a visual report JSON/Markdown and a fixed-stage 1920x1080 HTML deck.

## What I found and used
- The installed `frontend-slides` skill provides the presentation model we want: zero-dependency HTML, fixed 1920x1080 stage, viewport scaling, and slide-first visual output.
- Existing ADR run folders already have enough structured artifacts (`architecture.spec.json`, `comparison-matrix.json`, `knowledge-map.json`, `evidence.json`, `state.json`) to render decision funnels, evidence mix, candidate scorecards, matrix coverage, and risk signals.
- The implementation keeps generated reports/decks out of the PR. No `.adr-runs` artifacts or mock run data are included.

## Validation
- `pnpm exec vitest run scripts/adr-slide-deck.test.ts scripts/adr-visual-report.test.ts`
- `pnpm --filter @beevibe/api test -- src/routes/newsletter.test.ts`
- `pnpm --filter @beevibe/web test -- lib/api/client-mutations.test.ts`
- `pnpm --filter @beevibe/api typecheck`
- `pnpm --filter @beevibe/web build`