### PR TITLE
daemon: --config-root flag for dev-only multi-instance

### DIFF
--- a/packages/daemon/README.md
+++ b/packages/daemon/README.md
@@ -93,6 +93,29 @@ Each workspace contains `mcp-config.json` (mode `0600`) with `Bearer <bv_a_…>`
 
 Skills cache: `~/.beevibe/skills/`, version-gated via `.version`. Refreshed on every `start`.
 
+## Multi-instance (dev only)
+
+Two daemons can run on one machine, authenticated as two different `bv_u_` accounts, by giving each its own `--config-root`. The api already supports this — the `daemon` table is keyed by `(owner_person_id, external_id)`, so two daemons with the same hostname but different owners coexist as separate rows.
+
+```bash
+# Terminal 1 — account A
+pnpm dev setup --config-root $HOME/.beevibe-A --api http://localhost:3000 --user-token bv_u_A…
+pnpm dev start --config-root $HOME/.beevibe-A
+
+# Terminal 2 — account B
+pnpm dev setup --config-root $HOME/.beevibe-B --api http://localhost:3000 --user-token bv_u_B…
+pnpm dev start --config-root $HOME/.beevibe-B
+```
+
+`BEEVIBE_CONFIG_ROOT` is an equivalent env-var entry point. Each instance writes its own `config.json`, skills cache, and workspaces under the override; defaults are unchanged (`~/.beevibe/...`) when neither the flag nor the env is set.
+
+**Hard restrictions:**
+
+- **Dev/source builds only.** Compiled binaries (brew/curl install path) and the npm-published bundle reject both `--config-root` and `BEEVIBE_CONFIG_ROOT` with exit code 2. The gate is the `__DEV_BUILD__` compile-time define set by `scripts/build-binaries.sh` and `scripts/prepare-publish.sh`, backed by a runtime check in `main.ts`. To run multi-instance, use `pnpm dev` against a source checkout.
+- **`update` operates on the shared binary.** `beevibe-daemon update` rewrites `process.execPath`, which is the same file both instances spawn from. Running `update` from one instance affects the other on its next launch. Acceptable for dev testing of the update flow; the running daemon keeps its open inode on POSIX so it doesn't crash mid-session.
+- **Device name is not auto-suffixed.** Both daemons register as `<user>@<hostname>` in the Runtimes panel by default. Use `--device-name "MBP (account-B)"` at `setup` time if you want them visually distinct.
+- **Same OS user only.** Different OS users on one machine already isolate via `homedir()`; this flag is for running two accounts as the SAME OS user.
+
 ## What it doesn't do
 
 - **No MCP proxy.** The CLI calls `/mcp` directly using the `bv_a_` token in `mcp-config.json`. The daemon's job stops at writing the file and supervising the subprocess.

--- a/packages/daemon/scripts/build-binaries.sh
+++ b/packages/daemon/scripts/build-binaries.sh
@@ -61,13 +61,19 @@ for entry in "${TARGETS[@]}"; do
   # ~/.beevibe/config.json — a repo-checkout .env has no business
   # leaking in. Disable both at build time so launching the daemon from
   # any directory is deterministic.
+  # __DEV_BUILD__=false flips the dev-only multi-instance gate
+  # (config.ts:isDevBuild()) to false, so the compiled binary rejects
+  # --config-root / BEEVIBE_CONFIG_ROOT with exit 2. tsx / tsc-built
+  # runs never have the define applied; `typeof __DEV_BUILD__` returns
+  # "undefined" there → isDevBuild() returns true.
   bun build src/main.ts \
     --compile \
     --no-compile-autoload-dotenv \
     --no-compile-autoload-bunfig \
     --target="$target" \
     --outfile="$OUTDIR/$outname" \
-    --define "BEEVIBE_DAEMON_VERSION=\"$VERSION\""
+    --define "BEEVIBE_DAEMON_VERSION=\"$VERSION\"" \
+    --define "__DEV_BUILD__=false"
 done
 
 echo ""

--- a/packages/daemon/scripts/build-binaries.sh
+++ b/packages/daemon/scripts/build-binaries.sh
@@ -61,11 +61,8 @@ for entry in "${TARGETS[@]}"; do
   # ~/.beevibe/config.json — a repo-checkout .env has no business
   # leaking in. Disable both at build time so launching the daemon from
   # any directory is deterministic.
-  # __DEV_BUILD__=false flips the dev-only multi-instance gate
-  # (config.ts:isDevBuild()) to false, so the compiled binary rejects
-  # --config-root / BEEVIBE_CONFIG_ROOT with exit 2. tsx / tsc-built
-  # runs never have the define applied; `typeof __DEV_BUILD__` returns
-  # "undefined" there → isDevBuild() returns true.
+  # __DEV_BUILD__=false rejects --config-root in this artifact (see
+  # config.ts:isDevBuild). Source / tsx runs have no define → dev.
   bun build src/main.ts \
     --compile \
     --no-compile-autoload-dotenv \

--- a/packages/daemon/scripts/prepare-publish.sh
+++ b/packages/daemon/scripts/prepare-publish.sh
@@ -40,11 +40,8 @@ VERSION="$(node -p "require('./package.json').version")"
 # Bundle: --target=node produces ES modules consumable by `node dist/main.js`.
 # --external ws keeps ws as a runtime dep (it has prebuilds) so it loads
 # from the installer's node_modules rather than being inlined.
-# __DEV_BUILD__=false flips the dev-only multi-instance gate
-# (config.ts:isDevBuild()) to false, so the npm-published bundle rejects
-# --config-root / BEEVIBE_CONFIG_ROOT with exit 2. Source-checkout runs
-# never have the define applied; `typeof __DEV_BUILD__` returns
-# "undefined" there → isDevBuild() returns true.
+# __DEV_BUILD__=false rejects --config-root in this artifact (see
+# config.ts:isDevBuild). Source / tsx runs have no define → dev.
 bun build src/main.ts \
   --target=node \
   --outfile="$OUTDIR/dist/main.js" \

--- a/packages/daemon/scripts/prepare-publish.sh
+++ b/packages/daemon/scripts/prepare-publish.sh
@@ -40,11 +40,17 @@ VERSION="$(node -p "require('./package.json').version")"
 # Bundle: --target=node produces ES modules consumable by `node dist/main.js`.
 # --external ws keeps ws as a runtime dep (it has prebuilds) so it loads
 # from the installer's node_modules rather than being inlined.
+# __DEV_BUILD__=false flips the dev-only multi-instance gate
+# (config.ts:isDevBuild()) to false, so the npm-published bundle rejects
+# --config-root / BEEVIBE_CONFIG_ROOT with exit 2. Source-checkout runs
+# never have the define applied; `typeof __DEV_BUILD__` returns
+# "undefined" there → isDevBuild() returns true.
 bun build src/main.ts \
   --target=node \
   --outfile="$OUTDIR/dist/main.js" \
   --external ws \
-  --define "BEEVIBE_DAEMON_VERSION=\"$VERSION\""
+  --define "BEEVIBE_DAEMON_VERSION=\"$VERSION\"" \
+  --define "__DEV_BUILD__=false"
 
 # Make the bundled entry executable since `bin` points at it.
 chmod +x "$OUTDIR/dist/main.js"

--- a/packages/daemon/src/config.test.ts
+++ b/packages/daemon/src/config.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Unit coverage for the dev-only config-root override.
+ *
+ * The flag is the entire surface area of the multi-instance feature:
+ * tested against `getConfigRoot` resolution order, `loadConfig` /
+ * `saveConfig` round-trip under an override, and the prod-build reject
+ * path that main.ts enforces via `isDevBuild()`.
+ */
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  getConfigPath,
+  getConfigRoot,
+  isDevBuild,
+  loadConfig,
+  saveConfig,
+  type DaemonConfig,
+} from "./config.js";
+
+const ENV_KEY = "BEEVIBE_CONFIG_ROOT";
+
+function sampleConfig(overrides: Partial<DaemonConfig> = {}): DaemonConfig {
+  return {
+    api_url: "http://localhost:3000",
+    external_id: "host.test",
+    daemon_id: "dmn_test",
+    daemon_token: "bv_d_test",
+    runtimes: [{ id: "rt_test", cli: "claude" }],
+    ...overrides,
+  };
+}
+
+describe("getConfigRoot", () => {
+  let originalEnv: string | undefined;
+  beforeEach(() => {
+    originalEnv = process.env[ENV_KEY];
+    delete process.env[ENV_KEY];
+  });
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = originalEnv;
+  });
+
+  it("defaults to ~/.beevibe when no override and no env", () => {
+    const root = getConfigRoot();
+    expect(root).toMatch(/\.beevibe$/);
+  });
+
+  it("BEEVIBE_CONFIG_ROOT env overrides the default", () => {
+    process.env[ENV_KEY] = "/tmp/from-env/.beevibe";
+    expect(getConfigRoot()).toBe("/tmp/from-env/.beevibe");
+  });
+
+  it("explicit arg overrides both env and default", () => {
+    process.env[ENV_KEY] = "/tmp/from-env/.beevibe";
+    expect(getConfigRoot("/tmp/from-flag/.beevibe")).toBe(
+      "/tmp/from-flag/.beevibe",
+    );
+  });
+
+  it("empty-string override is treated as 'no override' (falls through to env / default)", () => {
+    // Same defensive `length > 0` semantics as the WORKSPACE_ROOT
+    // fallback in LocalWorkspaceManager — empty-string means "unset",
+    // not "use empty path".
+    process.env[ENV_KEY] = "/tmp/from-env/.beevibe";
+    expect(getConfigRoot("")).toBe("/tmp/from-env/.beevibe");
+  });
+
+  it("getConfigPath returns <root>/config.json", () => {
+    expect(getConfigPath("/tmp/x/.beevibe")).toBe("/tmp/x/.beevibe/config.json");
+  });
+});
+
+describe("loadConfig + saveConfig with configRoot override", () => {
+  let tempA: string;
+  let tempB: string;
+
+  beforeEach(() => {
+    tempA = mkdtempSync(join(tmpdir(), "beevibe-cfg-test-a-"));
+    tempB = mkdtempSync(join(tmpdir(), "beevibe-cfg-test-b-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempA, { recursive: true, force: true });
+    rmSync(tempB, { recursive: true, force: true });
+  });
+
+  it("save + load round-trip under an explicit configRoot", () => {
+    const cfg = sampleConfig({ daemon_token: "bv_d_alpha" });
+    saveConfig(cfg, tempA);
+
+    expect(existsSync(join(tempA, "config.json"))).toBe(true);
+    const loaded = loadConfig(tempA);
+    expect(loaded).toEqual(cfg);
+  });
+
+  it("loadConfig returns undefined when the file doesn't exist", () => {
+    expect(loadConfig(tempA)).toBeUndefined();
+  });
+
+  it("two configRoots are isolated — one save does not affect the other", () => {
+    const cfgA = sampleConfig({ daemon_id: "dmn_A", daemon_token: "bv_d_A" });
+    const cfgB = sampleConfig({ daemon_id: "dmn_B", daemon_token: "bv_d_B" });
+
+    saveConfig(cfgA, tempA);
+    saveConfig(cfgB, tempB);
+
+    // Reading either root returns only its own config — the multi-account
+    // isolation invariant that motivates the whole feature.
+    expect(loadConfig(tempA)).toEqual(cfgA);
+    expect(loadConfig(tempB)).toEqual(cfgB);
+  });
+
+  it("config file is written with mode 0600 (credential protection)", () => {
+    saveConfig(sampleConfig(), tempA);
+    const path = join(tempA, "config.json");
+    const { mode } = statSync(path);
+    // POSIX permission bits — strip type bits.
+    expect((mode & 0o777).toString(8)).toBe("600");
+  });
+
+  it("malformed config throws a path-bearing error", () => {
+    const path = join(tempA, "config.json");
+    mkdirSync(tempA, { recursive: true });
+    writeFileSync(path, "not json");
+    expect(() => loadConfig(tempA)).toThrow(/malformed/);
+    expect(() => loadConfig(tempA)).toThrow(tempA);
+  });
+});
+
+describe("isDevBuild", () => {
+  // The runtime guard in main.ts treats isDevBuild() === false as the
+  // signal to reject --config-root / BEEVIBE_CONFIG_ROOT. In source/test
+  // runs the global is undeclared, so it must be true.
+  it("returns true in source / vitest runs (no __DEV_BUILD__ define applied)", () => {
+    expect(isDevBuild()).toBe(true);
+  });
+
+  it("returns false when a bundler set __DEV_BUILD__=false", () => {
+    // Simulate what `bun build --define __DEV_BUILD__=false` does — the
+    // identifier becomes a binding in the bundled module. We can't replay
+    // the bundler step in a unit test, so install the global manually:
+    // `typeof __DEV_BUILD__` resolves to `boolean` and the function reads
+    // the value, exercising the false-branch.
+    const g = globalThis as Record<string, unknown>;
+    const prev = g.__DEV_BUILD__;
+    try {
+      g.__DEV_BUILD__ = false;
+      expect(isDevBuild()).toBe(false);
+    } finally {
+      if (prev === undefined) delete g.__DEV_BUILD__;
+      else g.__DEV_BUILD__ = prev;
+    }
+  });
+
+  it("returns true when a bundler set __DEV_BUILD__=true (dev distribution)", () => {
+    const g = globalThis as Record<string, unknown>;
+    const prev = g.__DEV_BUILD__;
+    try {
+      g.__DEV_BUILD__ = true;
+      expect(isDevBuild()).toBe(true);
+    } finally {
+      if (prev === undefined) delete g.__DEV_BUILD__;
+      else g.__DEV_BUILD__ = prev;
+    }
+  });
+});

--- a/packages/daemon/src/config.test.ts
+++ b/packages/daemon/src/config.test.ts
@@ -1,11 +1,3 @@
-/**
- * Unit coverage for the dev-only config-root override.
- *
- * The flag is the entire surface area of the multi-instance feature:
- * tested against `getConfigRoot` resolution order, `loadConfig` /
- * `saveConfig` round-trip under an override, and the prod-build reject
- * path that main.ts enforces via `isDevBuild()`.
- */
 import {
   existsSync,
   mkdirSync,
@@ -18,6 +10,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  CONFIG_ROOT_ENV,
   getConfigPath,
   getConfigRoot,
   isDevBuild,
@@ -25,8 +18,6 @@ import {
   saveConfig,
   type DaemonConfig,
 } from "./config.js";
-
-const ENV_KEY = "BEEVIBE_CONFIG_ROOT";
 
 function sampleConfig(overrides: Partial<DaemonConfig> = {}): DaemonConfig {
   return {
@@ -42,12 +33,12 @@ function sampleConfig(overrides: Partial<DaemonConfig> = {}): DaemonConfig {
 describe("getConfigRoot", () => {
   let originalEnv: string | undefined;
   beforeEach(() => {
-    originalEnv = process.env[ENV_KEY];
-    delete process.env[ENV_KEY];
+    originalEnv = process.env[CONFIG_ROOT_ENV];
+    delete process.env[CONFIG_ROOT_ENV];
   });
   afterEach(() => {
-    if (originalEnv === undefined) delete process.env[ENV_KEY];
-    else process.env[ENV_KEY] = originalEnv;
+    if (originalEnv === undefined) delete process.env[CONFIG_ROOT_ENV];
+    else process.env[CONFIG_ROOT_ENV] = originalEnv;
   });
 
   it("defaults to ~/.beevibe when no override and no env", () => {
@@ -56,22 +47,19 @@ describe("getConfigRoot", () => {
   });
 
   it("BEEVIBE_CONFIG_ROOT env overrides the default", () => {
-    process.env[ENV_KEY] = "/tmp/from-env/.beevibe";
+    process.env[CONFIG_ROOT_ENV] = "/tmp/from-env/.beevibe";
     expect(getConfigRoot()).toBe("/tmp/from-env/.beevibe");
   });
 
   it("explicit arg overrides both env and default", () => {
-    process.env[ENV_KEY] = "/tmp/from-env/.beevibe";
+    process.env[CONFIG_ROOT_ENV] = "/tmp/from-env/.beevibe";
     expect(getConfigRoot("/tmp/from-flag/.beevibe")).toBe(
       "/tmp/from-flag/.beevibe",
     );
   });
 
-  it("empty-string override is treated as 'no override' (falls through to env / default)", () => {
-    // Same defensive `length > 0` semantics as the WORKSPACE_ROOT
-    // fallback in LocalWorkspaceManager — empty-string means "unset",
-    // not "use empty path".
-    process.env[ENV_KEY] = "/tmp/from-env/.beevibe";
+  it("empty-string override falls through to env / default", () => {
+    process.env[CONFIG_ROOT_ENV] = "/tmp/from-env/.beevibe";
     expect(getConfigRoot("")).toBe("/tmp/from-env/.beevibe");
   });
 
@@ -114,17 +102,13 @@ describe("loadConfig + saveConfig with configRoot override", () => {
     saveConfig(cfgA, tempA);
     saveConfig(cfgB, tempB);
 
-    // Reading either root returns only its own config — the multi-account
-    // isolation invariant that motivates the whole feature.
     expect(loadConfig(tempA)).toEqual(cfgA);
     expect(loadConfig(tempB)).toEqual(cfgB);
   });
 
   it("config file is written with mode 0600 (credential protection)", () => {
     saveConfig(sampleConfig(), tempA);
-    const path = join(tempA, "config.json");
-    const { mode } = statSync(path);
-    // POSIX permission bits — strip type bits.
+    const { mode } = statSync(join(tempA, "config.json"));
     expect((mode & 0o777).toString(8)).toBe("600");
   });
 
@@ -138,39 +122,25 @@ describe("loadConfig + saveConfig with configRoot override", () => {
 });
 
 describe("isDevBuild", () => {
-  // The runtime guard in main.ts treats isDevBuild() === false as the
-  // signal to reject --config-root / BEEVIBE_CONFIG_ROOT. In source/test
-  // runs the global is undeclared, so it must be true.
   it("returns true in source / vitest runs (no __DEV_BUILD__ define applied)", () => {
     expect(isDevBuild()).toBe(true);
   });
 
-  it("returns false when a bundler set __DEV_BUILD__=false", () => {
-    // Simulate what `bun build --define __DEV_BUILD__=false` does — the
-    // identifier becomes a binding in the bundled module. We can't replay
-    // the bundler step in a unit test, so install the global manually:
-    // `typeof __DEV_BUILD__` resolves to `boolean` and the function reads
-    // the value, exercising the false-branch.
-    const g = globalThis as Record<string, unknown>;
-    const prev = g.__DEV_BUILD__;
-    try {
-      g.__DEV_BUILD__ = false;
-      expect(isDevBuild()).toBe(false);
-    } finally {
-      if (prev === undefined) delete g.__DEV_BUILD__;
-      else g.__DEV_BUILD__ = prev;
-    }
-  });
-
-  it("returns true when a bundler set __DEV_BUILD__=true (dev distribution)", () => {
-    const g = globalThis as Record<string, unknown>;
-    const prev = g.__DEV_BUILD__;
-    try {
-      g.__DEV_BUILD__ = true;
-      expect(isDevBuild()).toBe(true);
-    } finally {
-      if (prev === undefined) delete g.__DEV_BUILD__;
-      else g.__DEV_BUILD__ = prev;
-    }
-  });
+  it.each([
+    { defined: false, expected: false },
+    { defined: true, expected: true },
+  ])(
+    "returns $expected when the bundler set __DEV_BUILD__=$defined",
+    ({ defined, expected }) => {
+      const g = globalThis as Record<string, unknown>;
+      const prev = g.__DEV_BUILD__;
+      try {
+        g.__DEV_BUILD__ = defined;
+        expect(isDevBuild()).toBe(expected);
+      } finally {
+        if (prev === undefined) delete g.__DEV_BUILD__;
+        else g.__DEV_BUILD__ = prev;
+      }
+    },
+  );
 });

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -1,14 +1,8 @@
 /**
- * On-disk daemon configuration. Lives in `<configRoot>/config.json` and
- * survives restarts. Set during `beevibe-daemon setup`; consulted by
- * every subsequent `beevibe-daemon start`.
- *
- * `configRoot` defaults to `~/.beevibe` and can be overridden per process
- * (dev builds only) via `--config-root` or `BEEVIBE_CONFIG_ROOT`. The
- * override exists so a developer can run two daemons on one machine
- * authenticated as different `bv_u_` accounts without the second `setup`
- * clobbering the first daemon's `bv_d_` token. Prod (Bun-compiled binary
- * or npm-bundle) rejects the flag and env via `isDevBuild()` in main.ts.
+ * On-disk daemon configuration. Lives in `<configRoot>/config.json`,
+ * which defaults to `~/.beevibe/config.json` and survives restarts.
+ * Set during `beevibe-daemon setup`; consulted by every subsequent
+ * `beevibe-daemon start`.
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -31,46 +25,30 @@ export interface DaemonConfig {
   runtimes: Array<{ id: string; cli: string }>;
 }
 
-/**
- * Baked in by `bun build --define __DEV_BUILD__=false` for the binary /
- * npm-publish artifacts (see scripts/build-binaries.sh,
- * scripts/prepare-publish.sh). Non-bundled runs (tsx, `tsc → node`,
- * vitest) never have the define applied, which is why `isDevBuild()`
- * probes via `typeof` — the global is undeclared in those contexts and
- * referencing it directly would ReferenceError.
- */
+/** Env-var entry point for the dev-only --config-root override. */
+export const CONFIG_ROOT_ENV = "BEEVIBE_CONFIG_ROOT";
+
+// Set to `false` by `bun build --define __DEV_BUILD__=false` in
+// scripts/build-binaries.sh + scripts/prepare-publish.sh. Non-bundled
+// runs leave it undeclared — `typeof` is what keeps tsx/vitest from
+// throwing ReferenceError. Same pattern as BEEVIBE_DAEMON_VERSION in
+// update.ts.
 declare const __DEV_BUILD__: boolean;
 
-/**
- * True when running from source (tsx / tsc-built dist / vitest). False
- * only in artifacts built by build-binaries.sh / prepare-publish.sh,
- * which pass `--define "__DEV_BUILD__=false"`.
- *
- * Multi-instance entry points (`--config-root`, `BEEVIBE_CONFIG_ROOT`)
- * gate on this — prod builds reject both with exit code 2 so an end
- * user can't accidentally fork a daemon's state.
- */
+/** True for source / tsx / tsc / vitest runs; false only for compiled-prod artifacts. */
 export function isDevBuild(): boolean {
-  // typeof on an undeclared global returns "undefined" rather than
-  // throwing — same global-probe pattern as BEEVIBE_DAEMON_VERSION in
-  // update.ts. Compiled-prod sets the define to `false` explicitly.
   return typeof __DEV_BUILD__ === "undefined" ? true : __DEV_BUILD__;
 }
 
 /**
- * Resolve the daemon's on-disk root directory. Precedence:
- *   1. explicit `override` arg (the `--config-root` flag)
- *   2. `BEEVIBE_CONFIG_ROOT` env var
- *   3. `~/.beevibe` (unchanged default)
- *
- * Default behavior is identical to the pre-flag world — with no
- * override and no env, paths resolve to `~/.beevibe/...` exactly as
- * before. The override path is dev-only; main.ts rejects it in
- * compiled-prod via `isDevBuild()`.
+ * Resolve the daemon's on-disk root. Precedence: explicit `override`
+ * → `BEEVIBE_CONFIG_ROOT` env → `~/.beevibe`. Empty strings on either
+ * input are treated as unset — guards against `WORKSPACE_ROOT=`-style
+ * .env leaks (same defensive pattern as LocalWorkspaceManager).
  */
 export function getConfigRoot(override?: string): string {
   if (override && override.length > 0) return override;
-  const fromEnv = process.env.BEEVIBE_CONFIG_ROOT;
+  const fromEnv = process.env[CONFIG_ROOT_ENV];
   if (fromEnv && fromEnv.length > 0) return fromEnv;
   return join(homedir(), ".beevibe");
 }

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -1,7 +1,14 @@
 /**
- * On-disk daemon configuration. Lives in `~/.beevibe/config.json` and
+ * On-disk daemon configuration. Lives in `<configRoot>/config.json` and
  * survives restarts. Set during `beevibe-daemon setup`; consulted by
  * every subsequent `beevibe-daemon start`.
+ *
+ * `configRoot` defaults to `~/.beevibe` and can be overridden per process
+ * (dev builds only) via `--config-root` or `BEEVIBE_CONFIG_ROOT`. The
+ * override exists so a developer can run two daemons on one machine
+ * authenticated as different `bv_u_` accounts without the second `setup`
+ * clobbering the first daemon's `bv_d_` token. Prod (Bun-compiled binary
+ * or npm-bundle) rejects the flag and env via `isDevBuild()` in main.ts.
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -24,25 +31,72 @@ export interface DaemonConfig {
   runtimes: Array<{ id: string; cli: string }>;
 }
 
-export const CONFIG_DIR = join(homedir(), ".beevibe");
-export const CONFIG_PATH = join(CONFIG_DIR, "config.json");
+/**
+ * Baked in by `bun build --define __DEV_BUILD__=false` for the binary /
+ * npm-publish artifacts (see scripts/build-binaries.sh,
+ * scripts/prepare-publish.sh). Non-bundled runs (tsx, `tsc → node`,
+ * vitest) never have the define applied, which is why `isDevBuild()`
+ * probes via `typeof` — the global is undeclared in those contexts and
+ * referencing it directly would ReferenceError.
+ */
+declare const __DEV_BUILD__: boolean;
 
-export function loadConfig(): DaemonConfig | undefined {
-  if (!existsSync(CONFIG_PATH)) return undefined;
+/**
+ * True when running from source (tsx / tsc-built dist / vitest). False
+ * only in artifacts built by build-binaries.sh / prepare-publish.sh,
+ * which pass `--define "__DEV_BUILD__=false"`.
+ *
+ * Multi-instance entry points (`--config-root`, `BEEVIBE_CONFIG_ROOT`)
+ * gate on this — prod builds reject both with exit code 2 so an end
+ * user can't accidentally fork a daemon's state.
+ */
+export function isDevBuild(): boolean {
+  // typeof on an undeclared global returns "undefined" rather than
+  // throwing — same global-probe pattern as BEEVIBE_DAEMON_VERSION in
+  // update.ts. Compiled-prod sets the define to `false` explicitly.
+  return typeof __DEV_BUILD__ === "undefined" ? true : __DEV_BUILD__;
+}
+
+/**
+ * Resolve the daemon's on-disk root directory. Precedence:
+ *   1. explicit `override` arg (the `--config-root` flag)
+ *   2. `BEEVIBE_CONFIG_ROOT` env var
+ *   3. `~/.beevibe` (unchanged default)
+ *
+ * Default behavior is identical to the pre-flag world — with no
+ * override and no env, paths resolve to `~/.beevibe/...` exactly as
+ * before. The override path is dev-only; main.ts rejects it in
+ * compiled-prod via `isDevBuild()`.
+ */
+export function getConfigRoot(override?: string): string {
+  if (override && override.length > 0) return override;
+  const fromEnv = process.env.BEEVIBE_CONFIG_ROOT;
+  if (fromEnv && fromEnv.length > 0) return fromEnv;
+  return join(homedir(), ".beevibe");
+}
+
+export function getConfigPath(override?: string): string {
+  return join(getConfigRoot(override), "config.json");
+}
+
+export function loadConfig(configRoot?: string): DaemonConfig | undefined {
+  const path = getConfigPath(configRoot);
+  if (!existsSync(path)) return undefined;
   try {
-    return JSON.parse(readFileSync(CONFIG_PATH, "utf8")) as DaemonConfig;
+    return JSON.parse(readFileSync(path, "utf8")) as DaemonConfig;
   } catch (err) {
     throw new Error(
-      `Daemon config at ${CONFIG_PATH} is malformed: ${
+      `Daemon config at ${path} is malformed: ${
         err instanceof Error ? err.message : String(err)
       }`,
     );
   }
 }
 
-export function saveConfig(cfg: DaemonConfig): void {
-  mkdirSync(dirname(CONFIG_PATH), { recursive: true, mode: 0o700 });
+export function saveConfig(cfg: DaemonConfig, configRoot?: string): void {
+  const path = getConfigPath(configRoot);
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
   // 0600 because daemon_token is an authentication credential — readable
   // only by the user that owns the daemon process.
-  writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2) + "\n", { mode: 0o600 });
+  writeFileSync(path, JSON.stringify(cfg, null, 2) + "\n", { mode: 0o600 });
 }

--- a/packages/daemon/src/main.ts
+++ b/packages/daemon/src/main.ts
@@ -11,14 +11,9 @@
  * with `--no-compile-autoload-dotenv --no-compile-autoload-bunfig`
  * (see packages/daemon/scripts/build-binaries.sh) so launching from
  * inside a beevibe checkout doesn't silently slurp the repo's .env.
- *
- * Dev-only `--config-root <path>` (or `BEEVIBE_CONFIG_ROOT` env) shifts
- * the on-disk root from `~/.beevibe` so two daemons authenticated as
- * different `bv_u_` accounts can coexist on one machine. Rejected in
- * compiled-prod via `isDevBuild()` — see config.ts.
  */
 
-import { isDevBuild } from "./config.js";
+import { CONFIG_ROOT_ENV, getConfigPath, isDevBuild } from "./config.js";
 import { runSetup } from "./setup.js";
 import { runStart } from "./start.js";
 import { runSync } from "./sync.js";
@@ -59,25 +54,19 @@ function parseFlags(argv: string[]): Flags {
 
 /**
  * Resolve the effective config-root override and enforce the dev-only
- * gate. Returns `undefined` when neither the flag nor the env are set
- * — that's the normal path, and `getConfigRoot(undefined)` falls
- * through to `~/.beevibe`.
- *
- * Compiled-prod (`isDevBuild() === false`): both the flag and the env
- * are rejected with exit code 2 and a clear message. This is the
- * belt-and-suspenders side of the gate; the compile-time
- * `__DEV_BUILD__=false` define is what theoretically lets the
- * bundler dead-code-eliminate the multi-instance code paths, but
- * bun build doesn't always DCE without `--minify`, so the runtime
- * guard is the load-bearing one.
+ * gate. Returns `undefined` when neither flag nor env is set, so
+ * downstream `getConfigRoot(undefined)` falls through to `~/.beevibe`.
+ * Compiled-prod rejects either knob with exit 2 — runtime guard
+ * because `bun build` without `--minify` may not DCE the dead branch.
  */
 function resolveConfigRoot(flag: string | undefined): string | undefined {
-  const env = process.env.BEEVIBE_CONFIG_ROOT;
-  const hasOverride = (flag && flag.length > 0) || (env && env.length > 0);
-  if (!hasOverride) return undefined;
+  const env = process.env[CONFIG_ROOT_ENV];
+  const hasFlag = flag && flag.length > 0;
+  const hasEnv = env && env.length > 0;
+  if (!hasFlag && !hasEnv) return undefined;
 
   if (!isDevBuild()) {
-    const source = flag ? "--config-root" : "BEEVIBE_CONFIG_ROOT";
+    const source = hasFlag ? "--config-root" : CONFIG_ROOT_ENV;
     console.error(
       `${source} is a dev-only knob and is not available in this build. ` +
         `Reinstall via npm/curl without the override, or use a source checkout ` +
@@ -86,7 +75,7 @@ function resolveConfigRoot(flag: string | undefined): string | undefined {
     process.exit(2);
   }
 
-  return flag && flag.length > 0 ? flag : env;
+  return hasFlag ? flag : env;
 }
 
 function printHelp(): void {
@@ -143,8 +132,7 @@ async function main(): Promise<void> {
     });
     console.log(`Registered as ${cfg.daemon_id}`);
     console.log(`Runtimes: ${cfg.runtimes.map((r) => `${r.cli} (${r.id})`).join(", ")}`);
-    const configLabel = configRoot ? `${configRoot}/config.json` : "~/.beevibe/config.json";
-    console.log(`Config saved to ${configLabel}`);
+    console.log(`Config saved to ${getConfigPath(configRoot)}`);
     return;
   }
 

--- a/packages/daemon/src/main.ts
+++ b/packages/daemon/src/main.ts
@@ -11,8 +11,14 @@
  * with `--no-compile-autoload-dotenv --no-compile-autoload-bunfig`
  * (see packages/daemon/scripts/build-binaries.sh) so launching from
  * inside a beevibe checkout doesn't silently slurp the repo's .env.
+ *
+ * Dev-only `--config-root <path>` (or `BEEVIBE_CONFIG_ROOT` env) shifts
+ * the on-disk root from `~/.beevibe` so two daemons authenticated as
+ * different `bv_u_` accounts can coexist on one machine. Rejected in
+ * compiled-prod via `isDevBuild()` — see config.ts.
  */
 
+import { isDevBuild } from "./config.js";
 import { runSetup } from "./setup.js";
 import { runStart } from "./start.js";
 import { runSync } from "./sync.js";
@@ -23,6 +29,7 @@ interface Flags {
   userToken?: string;
   deviceName?: string;
   externalId?: string;
+  configRoot?: string;
 }
 
 function parseFlags(argv: string[]): Flags {
@@ -42,9 +49,44 @@ function parseFlags(argv: string[]): Flags {
     } else if (arg === "--external-id" && next) {
       flags.externalId = next;
       i += 1;
+    } else if (arg === "--config-root" && next) {
+      flags.configRoot = next;
+      i += 1;
     }
   }
   return flags;
+}
+
+/**
+ * Resolve the effective config-root override and enforce the dev-only
+ * gate. Returns `undefined` when neither the flag nor the env are set
+ * — that's the normal path, and `getConfigRoot(undefined)` falls
+ * through to `~/.beevibe`.
+ *
+ * Compiled-prod (`isDevBuild() === false`): both the flag and the env
+ * are rejected with exit code 2 and a clear message. This is the
+ * belt-and-suspenders side of the gate; the compile-time
+ * `__DEV_BUILD__=false` define is what theoretically lets the
+ * bundler dead-code-eliminate the multi-instance code paths, but
+ * bun build doesn't always DCE without `--minify`, so the runtime
+ * guard is the load-bearing one.
+ */
+function resolveConfigRoot(flag: string | undefined): string | undefined {
+  const env = process.env.BEEVIBE_CONFIG_ROOT;
+  const hasOverride = (flag && flag.length > 0) || (env && env.length > 0);
+  if (!hasOverride) return undefined;
+
+  if (!isDevBuild()) {
+    const source = flag ? "--config-root" : "BEEVIBE_CONFIG_ROOT";
+    console.error(
+      `${source} is a dev-only knob and is not available in this build. ` +
+        `Reinstall via npm/curl without the override, or use a source checkout ` +
+        `(pnpm dev) if you need multi-instance.`,
+    );
+    process.exit(2);
+  }
+
+  return flag && flag.length > 0 ? flag : env;
 }
 
 function printHelp(): void {
@@ -66,6 +108,12 @@ function printHelp(): void {
       "",
       "update flags:",
       "  --yes, -y                  skip the install-this-update prompt",
+      "",
+      "dev-only flags (source builds only — rejected in compiled binaries):",
+      "  --config-root <path>       shift the daemon's on-disk root from ~/.beevibe.",
+      "                             Lets two daemons coexist on one machine as",
+      "                             different accounts. Also settable via the",
+      "                             BEEVIBE_CONFIG_ROOT env var.",
     ].join("\n"),
   );
 }
@@ -77,8 +125,10 @@ async function main(): Promise<void> {
     return;
   }
 
+  const flags = parseFlags(rest);
+  const configRoot = resolveConfigRoot(flags.configRoot);
+
   if (command === "setup") {
-    const flags = parseFlags(rest);
     if (!flags.api || !flags.userToken) {
       console.error("setup requires --api and --user-token");
       printHelp();
@@ -89,20 +139,22 @@ async function main(): Promise<void> {
       userToken: flags.userToken,
       deviceName: flags.deviceName,
       externalId: flags.externalId,
+      configRoot,
     });
     console.log(`Registered as ${cfg.daemon_id}`);
     console.log(`Runtimes: ${cfg.runtimes.map((r) => `${r.cli} (${r.id})`).join(", ")}`);
-    console.log("Config saved to ~/.beevibe/config.json");
+    const configLabel = configRoot ? `${configRoot}/config.json` : "~/.beevibe/config.json";
+    console.log(`Config saved to ${configLabel}`);
     return;
   }
 
   if (command === "start") {
-    await runStart();
+    await runStart({ configRoot });
     return;
   }
 
   if (command === "sync") {
-    const result = await runSync();
+    const result = await runSync({ configRoot });
     if (result.added.length === 0) {
       console.log("No new CLIs detected.");
     } else {

--- a/packages/daemon/src/multi-instance.e2e.test.ts
+++ b/packages/daemon/src/multi-instance.e2e.test.ts
@@ -1,0 +1,186 @@
+/**
+ * End-to-end test for the dev-only multi-instance config-root feature.
+ *
+ * Skipped by default — runs two real `runSetup` calls against a local
+ * HTTP stub of `/runtime/register`, exercising the full filesystem
+ * isolation invariant: two daemons authenticated as different accounts
+ * each write their own config.json and skills-cache under independent
+ * `configRoot`s. Enable by:
+ *
+ *   BEEVIBE_E2E_MULTI_INSTANCE=1 pnpm --filter @beevibe/daemon test
+ *
+ * Follows the `packages/sandbox/src/docker.e2e.test.ts` pattern — opt-in
+ * via env var so CI defaults stay fast.
+ */
+import { createServer, type Server } from "node:http";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { loadConfig } from "./config.js";
+import { runSetup } from "./setup.js";
+import { skillsCacheDir, syncSkillsCache } from "./skills-cache.js";
+import { ApiClient } from "./api-client.js";
+
+const ENABLED = process.env.BEEVIBE_E2E_MULTI_INSTANCE === "1";
+const describeOrSkip = ENABLED ? describe : describe.skip;
+
+interface RegistrationCall {
+  authorization?: string;
+  external_id: string;
+  device_name: string;
+}
+
+interface StubServer {
+  url: string;
+  registrations: RegistrationCall[];
+  shutdown: () => Promise<void>;
+}
+
+async function startStubApi(): Promise<StubServer> {
+  const registrations: RegistrationCall[] = [];
+  let daemonCounter = 0;
+  const server: Server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      const body = chunks.length > 0 ? JSON.parse(Buffer.concat(chunks).toString("utf8")) : {};
+      if (req.url === "/runtime/register" && req.method === "POST") {
+        registrations.push({
+          authorization: req.headers.authorization,
+          external_id: body.external_id,
+          device_name: body.device_name,
+        });
+        daemonCounter += 1;
+        res.writeHead(201, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify({
+            daemon_id: `dmn_e2e_${daemonCounter}`,
+            daemon_token: `bv_d_e2e_${daemonCounter}`,
+            runtimes: body.runtimes.map(
+              (r: { cli: string }, i: number) => ({ id: `rt_e2e_${daemonCounter}_${i}`, cli: r.cli }),
+            ),
+          }),
+        );
+        return;
+      }
+      if (req.url === "/runtime/skills" && req.method === "GET") {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify({
+            version: "v1-e2e",
+            skills: [
+              {
+                name: "beevibe-test",
+                files: [{ path: "SKILL.md", content: "stub skill body\n" }],
+              },
+            ],
+          }),
+        );
+        return;
+      }
+      res.writeHead(404).end();
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const addr = server.address();
+  if (!addr || typeof addr === "string") throw new Error("stub api did not bind");
+  return {
+    url: `http://127.0.0.1:${addr.port}`,
+    registrations,
+    shutdown: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}
+
+describeOrSkip("multi-instance daemon isolation (e2e)", () => {
+  let api: StubServer;
+  let rootA: string;
+  let rootB: string;
+
+  beforeAll(async () => {
+    api = await startStubApi();
+  });
+  afterAll(async () => {
+    await api.shutdown();
+  });
+
+  beforeEach(() => {
+    rootA = mkdtempSync(join(tmpdir(), "beevibe-mi-A-"));
+    rootB = mkdtempSync(join(tmpdir(), "beevibe-mi-B-"));
+  });
+  afterEach(() => {
+    rmSync(rootA, { recursive: true, force: true });
+    rmSync(rootB, { recursive: true, force: true });
+  });
+
+  it("two setups with different configRoots produce two isolated config.json files", async () => {
+    const cfgA = await runSetup({
+      apiUrl: api.url,
+      userToken: "bv_u_account_A",
+      configRoot: rootA,
+      detectedClis: [{ cli: "claude", cli_version: "1.0.0" }],
+    });
+    const cfgB = await runSetup({
+      apiUrl: api.url,
+      userToken: "bv_u_account_B",
+      configRoot: rootB,
+      detectedClis: [{ cli: "claude", cli_version: "1.0.0" }],
+    });
+
+    // Each setup must have written its config.json under its own root only.
+    expect(existsSync(join(rootA, "config.json"))).toBe(true);
+    expect(existsSync(join(rootB, "config.json"))).toBe(true);
+
+    // Tokens are distinct.
+    expect(cfgA.daemon_token).not.toBe(cfgB.daemon_token);
+    expect(cfgA.daemon_id).not.toBe(cfgB.daemon_id);
+
+    // loadConfig reads each root's own state — the cross-contamination
+    // bug being prevented.
+    const loadedA = loadConfig(rootA);
+    const loadedB = loadConfig(rootB);
+    expect(loadedA?.daemon_token).toBe(cfgA.daemon_token);
+    expect(loadedB?.daemon_token).toBe(cfgB.daemon_token);
+    expect(loadedA?.daemon_token).not.toBe(loadedB?.daemon_token);
+
+    // The on-disk JSON file under A must NOT mention B's token, and
+    // vice versa.
+    const rawA = readFileSync(join(rootA, "config.json"), "utf8");
+    const rawB = readFileSync(join(rootB, "config.json"), "utf8");
+    expect(rawA).toContain(cfgA.daemon_token);
+    expect(rawA).not.toContain(cfgB.daemon_token);
+    expect(rawB).toContain(cfgB.daemon_token);
+    expect(rawB).not.toContain(cfgA.daemon_token);
+
+    // The api saw two distinct registrations carrying each user's bv_u_.
+    expect(api.registrations).toHaveLength(2);
+    expect(api.registrations[0]?.authorization).toBe("Bearer bv_u_account_A");
+    expect(api.registrations[1]?.authorization).toBe("Bearer bv_u_account_B");
+  });
+
+  it("skills cache is namespaced per configRoot — no cross-write race", async () => {
+    const apiClient = new ApiClient({ apiUrl: api.url, daemonToken: "bv_d_test" });
+    const dirA = await syncSkillsCache(apiClient, rootA);
+    const dirB = await syncSkillsCache(apiClient, rootB);
+
+    expect(dirA).toBe(skillsCacheDir(rootA));
+    expect(dirB).toBe(skillsCacheDir(rootB));
+    expect(dirA).not.toBe(dirB);
+    expect(existsSync(join(dirA, ".version"))).toBe(true);
+    expect(existsSync(join(dirB, ".version"))).toBe(true);
+    expect(existsSync(join(dirA, "beevibe-test", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(dirB, "beevibe-test", "SKILL.md"))).toBe(true);
+  });
+});

--- a/packages/daemon/src/multi-instance.e2e.test.ts
+++ b/packages/daemon/src/multi-instance.e2e.test.ts
@@ -1,16 +1,9 @@
 /**
- * End-to-end test for the dev-only multi-instance config-root feature.
- *
- * Skipped by default — runs two real `runSetup` calls against a local
- * HTTP stub of `/runtime/register`, exercising the full filesystem
- * isolation invariant: two daemons authenticated as different accounts
- * each write their own config.json and skills-cache under independent
- * `configRoot`s. Enable by:
+ * E2E for the dev-only --config-root feature. Opt-in:
  *
  *   BEEVIBE_E2E_MULTI_INSTANCE=1 pnpm --filter @beevibe/daemon test
  *
- * Follows the `packages/sandbox/src/docker.e2e.test.ts` pattern — opt-in
- * via env var so CI defaults stay fast.
+ * Same opt-in pattern as packages/sandbox/src/docker.e2e.test.ts.
  */
 import { createServer, type Server } from "node:http";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
@@ -51,6 +44,9 @@ async function startStubApi(): Promise<StubServer> {
   const server: Server = createServer((req, res) => {
     const chunks: Buffer[] = [];
     req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("error", () => {
+      if (!res.headersSent) res.writeHead(400).end();
+    });
     req.on("end", () => {
       const body = chunks.length > 0 ? JSON.parse(Buffer.concat(chunks).toString("utf8")) : {};
       if (req.url === "/runtime/register" && req.method === "POST") {
@@ -139,24 +135,17 @@ describeOrSkip("multi-instance daemon isolation (e2e)", () => {
       detectedClis: [{ cli: "claude", cli_version: "1.0.0" }],
     });
 
-    // Each setup must have written its config.json under its own root only.
     expect(existsSync(join(rootA, "config.json"))).toBe(true);
     expect(existsSync(join(rootB, "config.json"))).toBe(true);
 
-    // Tokens are distinct.
     expect(cfgA.daemon_token).not.toBe(cfgB.daemon_token);
     expect(cfgA.daemon_id).not.toBe(cfgB.daemon_id);
 
-    // loadConfig reads each root's own state — the cross-contamination
-    // bug being prevented.
-    const loadedA = loadConfig(rootA);
-    const loadedB = loadConfig(rootB);
-    expect(loadedA?.daemon_token).toBe(cfgA.daemon_token);
-    expect(loadedB?.daemon_token).toBe(cfgB.daemon_token);
-    expect(loadedA?.daemon_token).not.toBe(loadedB?.daemon_token);
+    expect(loadConfig(rootA)?.daemon_token).toBe(cfgA.daemon_token);
+    expect(loadConfig(rootB)?.daemon_token).toBe(cfgB.daemon_token);
 
-    // The on-disk JSON file under A must NOT mention B's token, and
-    // vice versa.
+    // On-disk: each root's JSON references only its own token — the
+    // cross-contamination bug being prevented.
     const rawA = readFileSync(join(rootA, "config.json"), "utf8");
     const rawB = readFileSync(join(rootB, "config.json"), "utf8");
     expect(rawA).toContain(cfgA.daemon_token);
@@ -164,7 +153,6 @@ describeOrSkip("multi-instance daemon isolation (e2e)", () => {
     expect(rawB).toContain(cfgB.daemon_token);
     expect(rawB).not.toContain(cfgA.daemon_token);
 
-    // The api saw two distinct registrations carrying each user's bv_u_.
     expect(api.registrations).toHaveLength(2);
     expect(api.registrations[0]?.authorization).toBe("Bearer bv_u_account_A");
     expect(api.registrations[1]?.authorization).toBe("Bearer bv_u_account_B");

--- a/packages/daemon/src/setup.ts
+++ b/packages/daemon/src/setup.ts
@@ -26,10 +26,7 @@ export interface SetupOptions {
    * PATH for known CLI names.
    */
   detectedClis?: Array<{ cli: string; cli_version?: string }>;
-  /**
-   * Dev-only override for `~/.beevibe`. Threaded down from the
-   * `--config-root` flag in main.ts. Unset for normal use.
-   */
+  /** Dev-only `~/.beevibe` override; see config.ts:getConfigRoot. */
   configRoot?: string;
 }
 

--- a/packages/daemon/src/setup.ts
+++ b/packages/daemon/src/setup.ts
@@ -26,6 +26,11 @@ export interface SetupOptions {
    * PATH for known CLI names.
    */
   detectedClis?: Array<{ cli: string; cli_version?: string }>;
+  /**
+   * Dev-only override for `~/.beevibe`. Threaded down from the
+   * `--config-root` flag in main.ts. Unset for normal use.
+   */
+  configRoot?: string;
 }
 
 export async function runSetup(options: SetupOptions): Promise<DaemonConfig> {
@@ -73,7 +78,7 @@ export async function runSetup(options: SetupOptions): Promise<DaemonConfig> {
     daemon_token: body.daemon_token,
     runtimes: body.runtimes,
   };
-  saveConfig(config);
+  saveConfig(config, options.configRoot);
   return config;
 }
 

--- a/packages/daemon/src/skills-cache.ts
+++ b/packages/daemon/src/skills-cache.ts
@@ -11,9 +11,9 @@
  */
 
 import { promises as fs } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import type { ApiClient } from "./api-client.js";
+import { getConfigRoot } from "./config.js";
 
 interface RuntimeSkillFile {
   path: string;
@@ -28,15 +28,17 @@ interface RuntimeSkillsResponse {
   skills: RuntimeSkill[];
 }
 
-export function skillsCacheDir(): string {
-  return join(homedir(), ".beevibe", "skills");
+export function skillsCacheDir(configRoot?: string): string {
+  return join(getConfigRoot(configRoot), "skills");
 }
 
 const VERSION_FILE = ".version";
 
-export async function readCachedVersion(): Promise<string | undefined> {
+export async function readCachedVersion(
+  configRoot?: string,
+): Promise<string | undefined> {
   try {
-    return (await fs.readFile(join(skillsCacheDir(), VERSION_FILE), "utf8"))
+    return (await fs.readFile(join(skillsCacheDir(configRoot), VERSION_FILE), "utf8"))
       .trim();
   } catch {
     return undefined;
@@ -44,14 +46,17 @@ export async function readCachedVersion(): Promise<string | undefined> {
 }
 
 /**
- * Fetch /runtime/skills, write the bundle to `~/.beevibe/skills/`.
+ * Fetch /runtime/skills, write the bundle to `<configRoot>/skills/`.
  * No-op when the server's version matches the local cache. Returns the
- * resolved cache path (always equal to `skillsCacheDir()`).
+ * resolved cache path (always equal to `skillsCacheDir(configRoot)`).
  */
-export async function syncSkillsCache(api: ApiClient): Promise<string> {
-  const cache = skillsCacheDir();
+export async function syncSkillsCache(
+  api: ApiClient,
+  configRoot?: string,
+): Promise<string> {
+  const cache = skillsCacheDir(configRoot);
 
-  const cached = await readCachedVersion();
+  const cached = await readCachedVersion(configRoot);
   const res = await api.get<RuntimeSkillsResponse>("/runtime/skills");
   if (!res) {
     if (cached) return cache; // server flaky; keep what we have

--- a/packages/daemon/src/start.ts
+++ b/packages/daemon/src/start.ts
@@ -3,16 +3,25 @@
  * Holds the process until SIGINT/SIGTERM.
  */
 
+import { join } from "node:path";
 import { LocalWorkspaceManager } from "@beevibe/core/adapters/local-workspace";
 import { createDefaultRuntimeRegistry } from "@beevibe/core/adapters/runtime-registry";
 import { ApiClient } from "./api-client.js";
 import { Claimer } from "./claimer.js";
-import { loadConfig } from "./config.js";
+import { getConfigRoot, loadConfig } from "./config.js";
 import { syncSkillsCache } from "./skills-cache.js";
 import { Supervisor } from "./supervisor.js";
 
-export async function runStart(): Promise<void> {
-  const cfg = loadConfig();
+export interface StartOptions {
+  /**
+   * Dev-only override for `~/.beevibe`. Threaded down from the
+   * `--config-root` flag in main.ts. Unset for normal use.
+   */
+  configRoot?: string;
+}
+
+export async function runStart(options: StartOptions = {}): Promise<void> {
+  const cfg = loadConfig(options.configRoot);
   if (!cfg) {
     throw new Error(
       "No daemon config found. Run `beevibe-daemon setup --api <url> --user-token <bv_u_…>` first.",
@@ -24,24 +33,33 @@ export async function runStart(): Promise<void> {
     daemonToken: cfg.daemon_token,
   });
 
-  // Pull the latest skills bundle into ~/.beevibe/skills before any
+  // Pull the latest skills bundle into <configRoot>/skills before any
   // workspace sync runs. Per-agent tier filter happens in
   // LocalWorkspaceManager.ensureWorkspace.
-  const skillsSourceDir = await syncSkillsCache(api).catch((err: unknown) => {
-    console.warn(
-      "[daemon] skills sync failed; continuing without skills:",
-      err instanceof Error ? err.message : String(err),
-    );
-    return undefined;
-  });
+  const skillsSourceDir = await syncSkillsCache(api, options.configRoot).catch(
+    (err: unknown) => {
+      console.warn(
+        "[daemon] skills sync failed; continuing without skills:",
+        err instanceof Error ? err.message : String(err),
+      );
+      return undefined;
+    },
+  );
 
+  // With --config-root set, default workspaces to a sibling of the
+  // override so a second daemon's agent workspaces don't collide with
+  // the first's. WORKSPACE_ROOT still wins when set explicitly (CI,
+  // bespoke layouts).
+  const resolvedConfigRoot = getConfigRoot(options.configRoot);
   const runtimeRegistry = createDefaultRuntimeRegistry();
   const workspaceManager = new LocalWorkspaceManager({
     mcpServerUrl: `${cfg.api_url}/mcp`,
     runtimeRegistry,
     skillsSourceDir: skillsSourceDir ?? "/dev/null",
-    // env override lets tests / dev override ~/.beevibe/workspaces.
-    workspaceRoot: process.env.WORKSPACE_ROOT,
+    workspaceRoot:
+      process.env.WORKSPACE_ROOT && process.env.WORKSPACE_ROOT.length > 0
+        ? process.env.WORKSPACE_ROOT
+        : join(resolvedConfigRoot, "workspaces"),
   });
 
   const supervisor = new Supervisor();

--- a/packages/daemon/src/start.ts
+++ b/packages/daemon/src/start.ts
@@ -13,10 +13,7 @@ import { syncSkillsCache } from "./skills-cache.js";
 import { Supervisor } from "./supervisor.js";
 
 export interface StartOptions {
-  /**
-   * Dev-only override for `~/.beevibe`. Threaded down from the
-   * `--config-root` flag in main.ts. Unset for normal use.
-   */
+  /** Dev-only `~/.beevibe` override; see config.ts:getConfigRoot. */
   configRoot?: string;
 }
 
@@ -46,11 +43,8 @@ export async function runStart(options: StartOptions = {}): Promise<void> {
     },
   );
 
-  // With --config-root set, default workspaces to a sibling of the
-  // override so a second daemon's agent workspaces don't collide with
-  // the first's. WORKSPACE_ROOT still wins when set explicitly (CI,
-  // bespoke layouts).
-  const resolvedConfigRoot = getConfigRoot(options.configRoot);
+  // WORKSPACE_ROOT env wins (CI / bespoke layouts); otherwise default
+  // workspaces under the configRoot so a second daemon doesn't collide.
   const runtimeRegistry = createDefaultRuntimeRegistry();
   const workspaceManager = new LocalWorkspaceManager({
     mcpServerUrl: `${cfg.api_url}/mcp`,
@@ -59,7 +53,7 @@ export async function runStart(options: StartOptions = {}): Promise<void> {
     workspaceRoot:
       process.env.WORKSPACE_ROOT && process.env.WORKSPACE_ROOT.length > 0
         ? process.env.WORKSPACE_ROOT
-        : join(resolvedConfigRoot, "workspaces"),
+        : join(getConfigRoot(options.configRoot), "workspaces"),
   });
 
   const supervisor = new Supervisor();

--- a/packages/daemon/src/sync.ts
+++ b/packages/daemon/src/sync.ts
@@ -11,7 +11,7 @@
 
 import { KNOWN_CLIS } from "@beevibe/core";
 import { ApiClient } from "./api-client.js";
-import { loadConfig, saveConfig, CONFIG_PATH, type DaemonConfig } from "./config.js";
+import { getConfigPath, loadConfig, saveConfig, type DaemonConfig } from "./config.js";
 import { detectClis } from "./detect-clis.js";
 
 interface SyncResponse {
@@ -25,11 +25,19 @@ export interface SyncResult {
   runtimes: Array<{ id: string; cli: string }>;
 }
 
-export async function runSync(): Promise<SyncResult> {
-  const config = loadConfig();
+export interface SyncOptions {
+  /**
+   * Dev-only override for `~/.beevibe`. Threaded down from the
+   * `--config-root` flag in main.ts. Unset for normal use.
+   */
+  configRoot?: string;
+}
+
+export async function runSync(options: SyncOptions = {}): Promise<SyncResult> {
+  const config = loadConfig(options.configRoot);
   if (!config) {
     throw new Error(
-      `No daemon config at ${CONFIG_PATH}. Run 'beevibe-daemon setup' first.`,
+      `No daemon config at ${getConfigPath(options.configRoot)}. Run 'beevibe-daemon setup' first.`,
     );
   }
 
@@ -55,7 +63,7 @@ export async function runSync(): Promise<SyncResult> {
   const added = body.runtimes.filter((r) => !before.has(r.cli));
 
   const next: DaemonConfig = { ...config, runtimes: body.runtimes };
-  saveConfig(next);
+  saveConfig(next, options.configRoot);
 
   return { added, runtimes: body.runtimes };
 }

--- a/packages/daemon/src/sync.ts
+++ b/packages/daemon/src/sync.ts
@@ -26,10 +26,7 @@ export interface SyncResult {
 }
 
 export interface SyncOptions {
-  /**
-   * Dev-only override for `~/.beevibe`. Threaded down from the
-   * `--config-root` flag in main.ts. Unset for normal use.
-   */
+  /** Dev-only `~/.beevibe` override; see config.ts:getConfigRoot. */
   configRoot?: string;
 }
 


### PR DESCRIPTION
## Summary

Lets two daemons coexist on one machine as different `bv_u_` accounts by giving each its own `--config-root` (or `BEEVIBE_CONFIG_ROOT` env). The api side already supports this — the `daemon` table is keyed by `(owner_person_id, external_id)` — so the entire problem reduces to namespacing the daemon's on-disk state under `~/.beevibe/`. **No api/DB changes.**

- Adds `getConfigRoot()` + `isDevBuild()` helpers in `packages/daemon/src/config.ts` and threads `configRoot` through `setup`, `start`, `sync`, `skills-cache`.
- The flag and env are gated by `__DEV_BUILD__` — set to `false` via `bun build --define` in `scripts/build-binaries.sh` and `scripts/prepare-publish.sh`, with a belt-and-suspenders runtime guard in `main.ts` that `exits 2` with a clear error if either is used in a compiled-prod artifact. Source/tsx/tsc/vitest runs have no define applied, so `typeof __DEV_BUILD__` returns `"undefined"` and `isDevBuild()` returns `true`.
- README gains a "Multi-instance (dev only)" section with the expected dev workflow and the documented restrictions (dev-only, shared `update` binary, no auto device-name suffix, same-OS-user-only).

**Default behavior is unchanged.** With no `--config-root` and no `BEEVIBE_CONFIG_ROOT`, every path resolves to `~/.beevibe/...` exactly as today. Existing brew/curl/npm installs see zero behavior change.

## Why dev-only

Multi-instance is a developer-machine ergonomics knob — it should never run in production. The compile-time `__DEV_BUILD__` define lets `bun build` eliminate the dead branch (when `--minify` lands); the runtime guard is what's load-bearing today. Reasoning per design doc §B.4.

## Test plan

- [x] `pnpm --filter @beevibe/daemon typecheck` clean.
- [x] `pnpm --filter @beevibe/daemon test` — 20 tests pass (5 existing + 13 new `config.test.ts` + 2 new `multi-instance.e2e.test.ts` skipped by default).
- [x] `BEEVIBE_E2E_MULTI_INSTANCE=1 pnpm --filter @beevibe/daemon test` — 22 tests pass (e2e opt-in works).
- [x] `pnpm --filter @beevibe/daemon build` and `pnpm build` (full repo) clean.
- [x] `pnpm --filter @beevibe/daemon lint` — no new warnings.
- [x] Manual smoke against `dist/`: simulating `__DEV_BUILD__=false` makes `main.ts` reject `--config-root` with exit 2 + the documented error.
- [x] Manual smoke: with no override, `getConfigRoot()` resolves to `$HOME/.beevibe` byte-for-byte as before.

## Linked

- Task: `task_OQs1ytnCLQrK`
- Design doc / scoping: `wp_AlvN1hDFWp5C` (Multi-account daemons on one machine — scoping & design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)