### PR TITLE
daemon: `list` subcommand to discover local daemon instances

### DIFF
--- a/packages/daemon/README.md
+++ b/packages/daemon/README.md
@@ -93,6 +93,29 @@ Each workspace contains `mcp-config.json` (mode `0600`) with `Bearer <bv_a_…>`
 
 Skills cache: `~/.beevibe/skills/`, version-gated via `.version`. Refreshed on every `start`.
 
+## Multi-instance (dev only)
+
+Two daemons can run on one machine, authenticated as two different `bv_u_` accounts, by giving each its own `--config-root`. The api already supports this — the `daemon` table is keyed by `(owner_person_id, external_id)`, so two daemons with the same hostname but different owners coexist as separate rows.
+
+```bash
+# Terminal 1 — account A
+pnpm dev setup --config-root $HOME/.beevibe-A --api http://localhost:3000 --user-token bv_u_A…
+pnpm dev start --config-root $HOME/.beevibe-A
+
+# Terminal 2 — account B
+pnpm dev setup --config-root $HOME/.beevibe-B --api http://localhost:3000 --user-token bv_u_B…
+pnpm dev start --config-root $HOME/.beevibe-B
+```
+
+`BEEVIBE_CONFIG_ROOT` is an equivalent env-var entry point. Each instance writes its own `config.json`, skills cache, and workspaces under the override; defaults are unchanged (`~/.beevibe/...`) when neither the flag nor the env is set.
+
+**Hard restrictions:**
+
+- **Dev/source builds only.** Compiled binaries (brew/curl install path) and the npm-published bundle reject both `--config-root` and `BEEVIBE_CONFIG_ROOT` with exit code 2. The gate is the `__DEV_BUILD__` compile-time define set by `scripts/build-binaries.sh` and `scripts/prepare-publish.sh`, backed by a runtime check in `main.ts`. To run multi-instance, use `pnpm dev` against a source checkout.
+- **`update` operates on the shared binary.** `beevibe-daemon update` rewrites `process.execPath`, which is the same file both instances spawn from. Running `update` from one instance affects the other on its next launch. Acceptable for dev testing of the update flow; the running daemon keeps its open inode on POSIX so it doesn't crash mid-session.
+- **Device name is not auto-suffixed.** Both daemons register as `<user>@<hostname>` in the Runtimes panel by default. Use `--device-name "MBP (account-B)"` at `setup` time if you want them visually distinct.
+- **Same OS user only.** Different OS users on one machine already isolate via `homedir()`; this flag is for running two accounts as the SAME OS user.
+
 ## What it doesn't do
 
 - **No MCP proxy.** The CLI calls `/mcp` directly using the `bv_a_` token in `mcp-config.json`. The daemon's job stops at writing the file and supervising the subprocess.

--- a/packages/daemon/README.md
+++ b/packages/daemon/README.md
@@ -8,7 +8,7 @@ For full setup, see the [root README](../../README.md).
 
 ## Run it
 
-Three subcommands. `setup` once; `start` to claim sessions; `update` for the brew/curl install path.
+Subcommands: `setup` once; `start` to claim sessions; `update` for the brew/curl install path; `sync` to pick up newly-installed CLIs; `list` to introspect what's set up on this machine.
 
 ```bash
 # 1. one-time registration with an api server
@@ -25,6 +25,12 @@ beevibe-daemon start
 beevibe-daemon update
 #   downloads latest GitHub release, SHA-256 verifies, atomic rename.
 #   For npm / source installs, prints the right install command and bails.
+
+# 4. inspect what's on this machine
+beevibe-daemon list
+#   scans $HOME for .beevibe* dirs with a daemon config.json, prints one
+#   row per instance: config root, daemon_id, token preview, api, device,
+#   last sync. Read-only. Add --json for scripting.
 ```
 
 `setup` flags:
@@ -116,6 +122,27 @@ pnpm dev start --config-root $HOME/.beevibe-B
 - **Device name is not auto-suffixed.** Both daemons register as `<user>@<hostname>` in the Runtimes panel by default. Use `--device-name "MBP (account-B)"` at `setup` time if you want them visually distinct.
 - **Same OS user only.** Different OS users on one machine already isolate via `homedir()`; this flag is for running two accounts as the SAME OS user.
 
+## Listing local daemons
+
+`beevibe-daemon list` scans `$HOME` for `.beevibe*` directories that contain a parseable daemon `config.json` and prints one row per match. Useful for "which `bv_d_` am I? what's my daemon_id?" and for seeing the two coexisting accounts when running multi-instance.
+
+```text
+$ beevibe-daemon list
+CONFIG ROOT             DAEMON ID    TOKEN         API                    DEVICE          LAST SYNC                  RUNNING
+/Users/me/.beevibe      dmn_abc123   bv_d_…wxyz    https://api.beevibe.io  laptop.local    2026-05-26T01:23:45.000Z   unknown
+/Users/me/.beevibe-B    dmn_def456   bv_d_…qrst    http://localhost:3000   laptop.local    2026-05-26T01:25:10.000Z   unknown
+2 daemons found.
+```
+
+Behavior:
+
+- **Read-only.** Never writes anything under any config root.
+- **Available in every build.** Not gated by `__DEV_BUILD__` — works in compiled binaries, the npm bundle, and source/tsx runs.
+- **Skips silently.** A `.beevibe-*` directory whose `config.json` is missing, malformed, or doesn't match the `DaemonConfig` shape is dropped from the output rather than warned about. Keeps false positives at zero when the user has unrelated `.beevibe-*` dirs.
+- **TOKEN column is a masked preview** (`bv_d_…<last 4>`) — enough to distinguish two daemons visually, never the full secret. For the actual owner identity, look up the `DAEMON ID` in the api's Runtimes panel.
+- **RUNNING is always `unknown` today.** Cross-platform process detection that doesn't false-positive on every `tsx watch` run is non-trivial; punted to a follow-up. Use `ps -ax | grep beevibe-daemon` for now.
+- **`--json` flag** emits a top-level array for scripting (`beevibe-daemon list --json | jq '.[].daemon_id'`).
+
 ## What it doesn't do
 
 - **No MCP proxy.** The CLI calls `/mcp` directly using the `bv_a_` token in `mcp-config.json`. The daemon's job stops at writing the file and supervising the subprocess.
@@ -129,14 +156,16 @@ src/
 ├── main.ts            CLI arg parser + subcommand dispatch
 ├── setup.ts           runSetup: detect CLIs, POST /runtime/register, write config
 ├── start.ts           runStart: load config, sync skills, build Supervisor + Claimer
+├── sync.ts            runSync: re-detect CLIs, POST /runtime/sync, persist new runtime ids
 ├── update.ts          runUpdate: GitHub-release self-update for compiled binaries
-├── config.ts          load/save ~/.beevibe/config.json (DaemonConfig shape)
+├── list.ts            runList: scan $HOME for .beevibe* config roots, print one row each
+├── config.ts          load/save <configRoot>/config.json (DaemonConfig shape)
 ├── api-client.ts      thin GET/POST/claim over /runtime/* with bv_d_ auth + WS open
 ├── claimer.ts         WS push + 30s HTTP poll + 15s heartbeat + WS reconnect
 ├── supervisor.ts      bounded concurrency cap with per-session AbortControllers
 ├── spawner.ts         runDispatch: workspace + ClaudeCodeRuntime + batched events
-├── skills-cache.ts    syncSkillsCache: pull /runtime/skills into ~/.beevibe/skills/
-└── supervisor.test.ts vitest unit tests
+├── skills-cache.ts    syncSkillsCache: pull /runtime/skills into <configRoot>/skills/
+└── *.test.ts          vitest unit tests
 ```
 
 ## Build distribution

--- a/packages/daemon/scripts/build-binaries.sh
+++ b/packages/daemon/scripts/build-binaries.sh
@@ -61,13 +61,19 @@ for entry in "${TARGETS[@]}"; do
   # ~/.beevibe/config.json — a repo-checkout .env has no business
   # leaking in. Disable both at build time so launching the daemon from
   # any directory is deterministic.
+  # __DEV_BUILD__=false flips the dev-only multi-instance gate
+  # (config.ts:isDevBuild()) to false, so the compiled binary rejects
+  # --config-root / BEEVIBE_CONFIG_ROOT with exit 2. tsx / tsc-built
+  # runs never have the define applied; `typeof __DEV_BUILD__` returns
+  # "undefined" there → isDevBuild() returns true.
   bun build src/main.ts \
     --compile \
     --no-compile-autoload-dotenv \
     --no-compile-autoload-bunfig \
     --target="$target" \
     --outfile="$OUTDIR/$outname" \
-    --define "BEEVIBE_DAEMON_VERSION=\"$VERSION\""
+    --define "BEEVIBE_DAEMON_VERSION=\"$VERSION\"" \
+    --define "__DEV_BUILD__=false"
 done
 
 echo ""

--- a/packages/daemon/scripts/build-binaries.sh
+++ b/packages/daemon/scripts/build-binaries.sh
@@ -61,11 +61,8 @@ for entry in "${TARGETS[@]}"; do
   # ~/.beevibe/config.json — a repo-checkout .env has no business
   # leaking in. Disable both at build time so launching the daemon from
   # any directory is deterministic.
-  # __DEV_BUILD__=false flips the dev-only multi-instance gate
-  # (config.ts:isDevBuild()) to false, so the compiled binary rejects
-  # --config-root / BEEVIBE_CONFIG_ROOT with exit 2. tsx / tsc-built
-  # runs never have the define applied; `typeof __DEV_BUILD__` returns
-  # "undefined" there → isDevBuild() returns true.
+  # __DEV_BUILD__=false rejects --config-root in this artifact (see
+  # config.ts:isDevBuild). Source / tsx runs have no define → dev.
   bun build src/main.ts \
     --compile \
     --no-compile-autoload-dotenv \

--- a/packages/daemon/scripts/prepare-publish.sh
+++ b/packages/daemon/scripts/prepare-publish.sh
@@ -40,11 +40,8 @@ VERSION="$(node -p "require('./package.json').version")"
 # Bundle: --target=node produces ES modules consumable by `node dist/main.js`.
 # --external ws keeps ws as a runtime dep (it has prebuilds) so it loads
 # from the installer's node_modules rather than being inlined.
-# __DEV_BUILD__=false flips the dev-only multi-instance gate
-# (config.ts:isDevBuild()) to false, so the npm-published bundle rejects
-# --config-root / BEEVIBE_CONFIG_ROOT with exit 2. Source-checkout runs
-# never have the define applied; `typeof __DEV_BUILD__` returns
-# "undefined" there → isDevBuild() returns true.
+# __DEV_BUILD__=false rejects --config-root in this artifact (see
+# config.ts:isDevBuild). Source / tsx runs have no define → dev.
 bun build src/main.ts \
   --target=node \
   --outfile="$OUTDIR/dist/main.js" \

--- a/packages/daemon/scripts/prepare-publish.sh
+++ b/packages/daemon/scripts/prepare-publish.sh
@@ -40,11 +40,17 @@ VERSION="$(node -p "require('./package.json').version")"
 # Bundle: --target=node produces ES modules consumable by `node dist/main.js`.
 # --external ws keeps ws as a runtime dep (it has prebuilds) so it loads
 # from the installer's node_modules rather than being inlined.
+# __DEV_BUILD__=false flips the dev-only multi-instance gate
+# (config.ts:isDevBuild()) to false, so the npm-published bundle rejects
+# --config-root / BEEVIBE_CONFIG_ROOT with exit 2. Source-checkout runs
+# never have the define applied; `typeof __DEV_BUILD__` returns
+# "undefined" there → isDevBuild() returns true.
 bun build src/main.ts \
   --target=node \
   --outfile="$OUTDIR/dist/main.js" \
   --external ws \
-  --define "BEEVIBE_DAEMON_VERSION=\"$VERSION\""
+  --define "BEEVIBE_DAEMON_VERSION=\"$VERSION\"" \
+  --define "__DEV_BUILD__=false"
 
 # Make the bundled entry executable since `bin` points at it.
 chmod +x "$OUTDIR/dist/main.js"

--- a/packages/daemon/src/config.test.ts
+++ b/packages/daemon/src/config.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Unit coverage for the dev-only config-root override.
+ *
+ * The flag is the entire surface area of the multi-instance feature:
+ * tested against `getConfigRoot` resolution order, `loadConfig` /
+ * `saveConfig` round-trip under an override, and the prod-build reject
+ * path that main.ts enforces via `isDevBuild()`.
+ */
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  getConfigPath,
+  getConfigRoot,
+  isDevBuild,
+  loadConfig,
+  saveConfig,
+  type DaemonConfig,
+} from "./config.js";
+
+const ENV_KEY = "BEEVIBE_CONFIG_ROOT";
+
+function sampleConfig(overrides: Partial<DaemonConfig> = {}): DaemonConfig {
+  return {
+    api_url: "http://localhost:3000",
+    external_id: "host.test",
+    daemon_id: "dmn_test",
+    daemon_token: "bv_d_test",
+    runtimes: [{ id: "rt_test", cli: "claude" }],
+    ...overrides,
+  };
+}
+
+describe("getConfigRoot", () => {
+  let originalEnv: string | undefined;
+  beforeEach(() => {
+    originalEnv = process.env[ENV_KEY];
+    delete process.env[ENV_KEY];
+  });
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = originalEnv;
+  });
+
+  it("defaults to ~/.beevibe when no override and no env", () => {
+    const root = getConfigRoot();
+    expect(root).toMatch(/\.beevibe$/);
+  });
+
+  it("BEEVIBE_CONFIG_ROOT env overrides the default", () => {
+    process.env[ENV_KEY] = "/tmp/from-env/.beevibe";
+    expect(getConfigRoot()).toBe("/tmp/from-env/.beevibe");
+  });
+
+  it("explicit arg overrides both env and default", () => {
+    process.env[ENV_KEY] = "/tmp/from-env/.beevibe";
+    expect(getConfigRoot("/tmp/from-flag/.beevibe")).toBe(
+      "/tmp/from-flag/.beevibe",
+    );
+  });
+
+  it("empty-string override is treated as 'no override' (falls through to env / default)", () => {
+    // Same defensive `length > 0` semantics as the WORKSPACE_ROOT
+    // fallback in LocalWorkspaceManager — empty-string means "unset",
+    // not "use empty path".
+    process.env[ENV_KEY] = "/tmp/from-env/.beevibe";
+    expect(getConfigRoot("")).toBe("/tmp/from-env/.beevibe");
+  });
+
+  it("getConfigPath returns <root>/config.json", () => {
+    expect(getConfigPath("/tmp/x/.beevibe")).toBe("/tmp/x/.beevibe/config.json");
+  });
+});
+
+describe("loadConfig + saveConfig with configRoot override", () => {
+  let tempA: string;
+  let tempB: string;
+
+  beforeEach(() => {
+    tempA = mkdtempSync(join(tmpdir(), "beevibe-cfg-test-a-"));
+    tempB = mkdtempSync(join(tmpdir(), "beevibe-cfg-test-b-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempA, { recursive: true, force: true });
+    rmSync(tempB, { recursive: true, force: true });
+  });
+
+  it("save + load round-trip under an explicit configRoot", () => {
+    const cfg = sampleConfig({ daemon_token: "bv_d_alpha" });
+    saveConfig(cfg, tempA);
+
+    expect(existsSync(join(tempA, "config.json"))).toBe(true);
+    const loaded = loadConfig(tempA);
+    expect(loaded).toEqual(cfg);
+  });
+
+  it("loadConfig returns undefined when the file doesn't exist", () => {
+    expect(loadConfig(tempA)).toBeUndefined();
+  });
+
+  it("two configRoots are isolated — one save does not affect the other", () => {
+    const cfgA = sampleConfig({ daemon_id: "dmn_A", daemon_token: "bv_d_A" });
+    const cfgB = sampleConfig({ daemon_id: "dmn_B", daemon_token: "bv_d_B" });
+
+    saveConfig(cfgA, tempA);
+    saveConfig(cfgB, tempB);
+
+    // Reading either root returns only its own config — the multi-account
+    // isolation invariant that motivates the whole feature.
+    expect(loadConfig(tempA)).toEqual(cfgA);
+    expect(loadConfig(tempB)).toEqual(cfgB);
+  });
+
+  it("config file is written with mode 0600 (credential protection)", () => {
+    saveConfig(sampleConfig(), tempA);
+    const path = join(tempA, "config.json");
+    const { mode } = statSync(path);
+    // POSIX permission bits — strip type bits.
+    expect((mode & 0o777).toString(8)).toBe("600");
+  });
+
+  it("malformed config throws a path-bearing error", () => {
+    const path = join(tempA, "config.json");
+    mkdirSync(tempA, { recursive: true });
+    writeFileSync(path, "not json");
+    expect(() => loadConfig(tempA)).toThrow(/malformed/);
+    expect(() => loadConfig(tempA)).toThrow(tempA);
+  });
+});
+
+describe("isDevBuild", () => {
+  // The runtime guard in main.ts treats isDevBuild() === false as the
+  // signal to reject --config-root / BEEVIBE_CONFIG_ROOT. In source/test
+  // runs the global is undeclared, so it must be true.
+  it("returns true in source / vitest runs (no __DEV_BUILD__ define applied)", () => {
+    expect(isDevBuild()).toBe(true);
+  });
+
+  it("returns false when a bundler set __DEV_BUILD__=false", () => {
+    // Simulate what `bun build --define __DEV_BUILD__=false` does — the
+    // identifier becomes a binding in the bundled module. We can't replay
+    // the bundler step in a unit test, so install the global manually:
+    // `typeof __DEV_BUILD__` resolves to `boolean` and the function reads
+    // the value, exercising the false-branch.
+    const g = globalThis as Record<string, unknown>;
+    const prev = g.__DEV_BUILD__;
+    try {
+      g.__DEV_BUILD__ = false;
+      expect(isDevBuild()).toBe(false);
+    } finally {
+      if (prev === undefined) delete g.__DEV_BUILD__;
+      else g.__DEV_BUILD__ = prev;
+    }
+  });
+
+  it("returns true when a bundler set __DEV_BUILD__=true (dev distribution)", () => {
+    const g = globalThis as Record<string, unknown>;
+    const prev = g.__DEV_BUILD__;
+    try {
+      g.__DEV_BUILD__ = true;
+      expect(isDevBuild()).toBe(true);
+    } finally {
+      if (prev === undefined) delete g.__DEV_BUILD__;
+      else g.__DEV_BUILD__ = prev;
+    }
+  });
+});

--- a/packages/daemon/src/config.test.ts
+++ b/packages/daemon/src/config.test.ts
@@ -1,11 +1,3 @@
-/**
- * Unit coverage for the dev-only config-root override.
- *
- * The flag is the entire surface area of the multi-instance feature:
- * tested against `getConfigRoot` resolution order, `loadConfig` /
- * `saveConfig` round-trip under an override, and the prod-build reject
- * path that main.ts enforces via `isDevBuild()`.
- */
 import {
   existsSync,
   mkdirSync,
@@ -18,6 +10,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  CONFIG_ROOT_ENV,
   getConfigPath,
   getConfigRoot,
   isDevBuild,
@@ -25,8 +18,6 @@ import {
   saveConfig,
   type DaemonConfig,
 } from "./config.js";
-
-const ENV_KEY = "BEEVIBE_CONFIG_ROOT";
 
 function sampleConfig(overrides: Partial<DaemonConfig> = {}): DaemonConfig {
   return {
@@ -42,12 +33,12 @@ function sampleConfig(overrides: Partial<DaemonConfig> = {}): DaemonConfig {
 describe("getConfigRoot", () => {
   let originalEnv: string | undefined;
   beforeEach(() => {
-    originalEnv = process.env[ENV_KEY];
-    delete process.env[ENV_KEY];
+    originalEnv = process.env[CONFIG_ROOT_ENV];
+    delete process.env[CONFIG_ROOT_ENV];
   });
   afterEach(() => {
-    if (originalEnv === undefined) delete process.env[ENV_KEY];
-    else process.env[ENV_KEY] = originalEnv;
+    if (originalEnv === undefined) delete process.env[CONFIG_ROOT_ENV];
+    else process.env[CONFIG_ROOT_ENV] = originalEnv;
   });
 
   it("defaults to ~/.beevibe when no override and no env", () => {
@@ -56,22 +47,19 @@ describe("getConfigRoot", () => {
   });
 
   it("BEEVIBE_CONFIG_ROOT env overrides the default", () => {
-    process.env[ENV_KEY] = "/tmp/from-env/.beevibe";
+    process.env[CONFIG_ROOT_ENV] = "/tmp/from-env/.beevibe";
     expect(getConfigRoot()).toBe("/tmp/from-env/.beevibe");
   });
 
   it("explicit arg overrides both env and default", () => {
-    process.env[ENV_KEY] = "/tmp/from-env/.beevibe";
+    process.env[CONFIG_ROOT_ENV] = "/tmp/from-env/.beevibe";
     expect(getConfigRoot("/tmp/from-flag/.beevibe")).toBe(
       "/tmp/from-flag/.beevibe",
     );
   });
 
-  it("empty-string override is treated as 'no override' (falls through to env / default)", () => {
-    // Same defensive `length > 0` semantics as the WORKSPACE_ROOT
-    // fallback in LocalWorkspaceManager — empty-string means "unset",
-    // not "use empty path".
-    process.env[ENV_KEY] = "/tmp/from-env/.beevibe";
+  it("empty-string override falls through to env / default", () => {
+    process.env[CONFIG_ROOT_ENV] = "/tmp/from-env/.beevibe";
     expect(getConfigRoot("")).toBe("/tmp/from-env/.beevibe");
   });
 
@@ -114,17 +102,13 @@ describe("loadConfig + saveConfig with configRoot override", () => {
     saveConfig(cfgA, tempA);
     saveConfig(cfgB, tempB);
 
-    // Reading either root returns only its own config — the multi-account
-    // isolation invariant that motivates the whole feature.
     expect(loadConfig(tempA)).toEqual(cfgA);
     expect(loadConfig(tempB)).toEqual(cfgB);
   });
 
   it("config file is written with mode 0600 (credential protection)", () => {
     saveConfig(sampleConfig(), tempA);
-    const path = join(tempA, "config.json");
-    const { mode } = statSync(path);
-    // POSIX permission bits — strip type bits.
+    const { mode } = statSync(join(tempA, "config.json"));
     expect((mode & 0o777).toString(8)).toBe("600");
   });
 
@@ -138,39 +122,25 @@ describe("loadConfig + saveConfig with configRoot override", () => {
 });
 
 describe("isDevBuild", () => {
-  // The runtime guard in main.ts treats isDevBuild() === false as the
-  // signal to reject --config-root / BEEVIBE_CONFIG_ROOT. In source/test
-  // runs the global is undeclared, so it must be true.
   it("returns true in source / vitest runs (no __DEV_BUILD__ define applied)", () => {
     expect(isDevBuild()).toBe(true);
   });
 
-  it("returns false when a bundler set __DEV_BUILD__=false", () => {
-    // Simulate what `bun build --define __DEV_BUILD__=false` does — the
-    // identifier becomes a binding in the bundled module. We can't replay
-    // the bundler step in a unit test, so install the global manually:
-    // `typeof __DEV_BUILD__` resolves to `boolean` and the function reads
-    // the value, exercising the false-branch.
-    const g = globalThis as Record<string, unknown>;
-    const prev = g.__DEV_BUILD__;
-    try {
-      g.__DEV_BUILD__ = false;
-      expect(isDevBuild()).toBe(false);
-    } finally {
-      if (prev === undefined) delete g.__DEV_BUILD__;
-      else g.__DEV_BUILD__ = prev;
-    }
-  });
-
-  it("returns true when a bundler set __DEV_BUILD__=true (dev distribution)", () => {
-    const g = globalThis as Record<string, unknown>;
-    const prev = g.__DEV_BUILD__;
-    try {
-      g.__DEV_BUILD__ = true;
-      expect(isDevBuild()).toBe(true);
-    } finally {
-      if (prev === undefined) delete g.__DEV_BUILD__;
-      else g.__DEV_BUILD__ = prev;
-    }
-  });
+  it.each([
+    { defined: false, expected: false },
+    { defined: true, expected: true },
+  ])(
+    "returns $expected when the bundler set __DEV_BUILD__=$defined",
+    ({ defined, expected }) => {
+      const g = globalThis as Record<string, unknown>;
+      const prev = g.__DEV_BUILD__;
+      try {
+        g.__DEV_BUILD__ = defined;
+        expect(isDevBuild()).toBe(expected);
+      } finally {
+        if (prev === undefined) delete g.__DEV_BUILD__;
+        else g.__DEV_BUILD__ = prev;
+      }
+    },
+  );
 });

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -1,14 +1,8 @@
 /**
- * On-disk daemon configuration. Lives in `<configRoot>/config.json` and
- * survives restarts. Set during `beevibe-daemon setup`; consulted by
- * every subsequent `beevibe-daemon start`.
- *
- * `configRoot` defaults to `~/.beevibe` and can be overridden per process
- * (dev builds only) via `--config-root` or `BEEVIBE_CONFIG_ROOT`. The
- * override exists so a developer can run two daemons on one machine
- * authenticated as different `bv_u_` accounts without the second `setup`
- * clobbering the first daemon's `bv_d_` token. Prod (Bun-compiled binary
- * or npm-bundle) rejects the flag and env via `isDevBuild()` in main.ts.
+ * On-disk daemon configuration. Lives in `<configRoot>/config.json`,
+ * which defaults to `~/.beevibe/config.json` and survives restarts.
+ * Set during `beevibe-daemon setup`; consulted by every subsequent
+ * `beevibe-daemon start`.
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -31,46 +25,30 @@ export interface DaemonConfig {
   runtimes: Array<{ id: string; cli: string }>;
 }
 
-/**
- * Baked in by `bun build --define __DEV_BUILD__=false` for the binary /
- * npm-publish artifacts (see scripts/build-binaries.sh,
- * scripts/prepare-publish.sh). Non-bundled runs (tsx, `tsc → node`,
- * vitest) never have the define applied, which is why `isDevBuild()`
- * probes via `typeof` — the global is undeclared in those contexts and
- * referencing it directly would ReferenceError.
- */
+/** Env-var entry point for the dev-only --config-root override. */
+export const CONFIG_ROOT_ENV = "BEEVIBE_CONFIG_ROOT";
+
+// Set to `false` by `bun build --define __DEV_BUILD__=false` in
+// scripts/build-binaries.sh + scripts/prepare-publish.sh. Non-bundled
+// runs leave it undeclared — `typeof` is what keeps tsx/vitest from
+// throwing ReferenceError. Same pattern as BEEVIBE_DAEMON_VERSION in
+// update.ts.
 declare const __DEV_BUILD__: boolean;
 
-/**
- * True when running from source (tsx / tsc-built dist / vitest). False
- * only in artifacts built by build-binaries.sh / prepare-publish.sh,
- * which pass `--define "__DEV_BUILD__=false"`.
- *
- * Multi-instance entry points (`--config-root`, `BEEVIBE_CONFIG_ROOT`)
- * gate on this — prod builds reject both with exit code 2 so an end
- * user can't accidentally fork a daemon's state.
- */
+/** True for source / tsx / tsc / vitest runs; false only for compiled-prod artifacts. */
 export function isDevBuild(): boolean {
-  // typeof on an undeclared global returns "undefined" rather than
-  // throwing — same global-probe pattern as BEEVIBE_DAEMON_VERSION in
-  // update.ts. Compiled-prod sets the define to `false` explicitly.
   return typeof __DEV_BUILD__ === "undefined" ? true : __DEV_BUILD__;
 }
 
 /**
- * Resolve the daemon's on-disk root directory. Precedence:
- *   1. explicit `override` arg (the `--config-root` flag)
- *   2. `BEEVIBE_CONFIG_ROOT` env var
- *   3. `~/.beevibe` (unchanged default)
- *
- * Default behavior is identical to the pre-flag world — with no
- * override and no env, paths resolve to `~/.beevibe/...` exactly as
- * before. The override path is dev-only; main.ts rejects it in
- * compiled-prod via `isDevBuild()`.
+ * Resolve the daemon's on-disk root. Precedence: explicit `override`
+ * → `BEEVIBE_CONFIG_ROOT` env → `~/.beevibe`. Empty strings on either
+ * input are treated as unset — guards against `WORKSPACE_ROOT=`-style
+ * .env leaks (same defensive pattern as LocalWorkspaceManager).
  */
 export function getConfigRoot(override?: string): string {
   if (override && override.length > 0) return override;
-  const fromEnv = process.env.BEEVIBE_CONFIG_ROOT;
+  const fromEnv = process.env[CONFIG_ROOT_ENV];
   if (fromEnv && fromEnv.length > 0) return fromEnv;
   return join(homedir(), ".beevibe");
 }

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -1,7 +1,14 @@
 /**
- * On-disk daemon configuration. Lives in `~/.beevibe/config.json` and
+ * On-disk daemon configuration. Lives in `<configRoot>/config.json` and
  * survives restarts. Set during `beevibe-daemon setup`; consulted by
  * every subsequent `beevibe-daemon start`.
+ *
+ * `configRoot` defaults to `~/.beevibe` and can be overridden per process
+ * (dev builds only) via `--config-root` or `BEEVIBE_CONFIG_ROOT`. The
+ * override exists so a developer can run two daemons on one machine
+ * authenticated as different `bv_u_` accounts without the second `setup`
+ * clobbering the first daemon's `bv_d_` token. Prod (Bun-compiled binary
+ * or npm-bundle) rejects the flag and env via `isDevBuild()` in main.ts.
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -24,25 +31,72 @@ export interface DaemonConfig {
   runtimes: Array<{ id: string; cli: string }>;
 }
 
-export const CONFIG_DIR = join(homedir(), ".beevibe");
-export const CONFIG_PATH = join(CONFIG_DIR, "config.json");
+/**
+ * Baked in by `bun build --define __DEV_BUILD__=false` for the binary /
+ * npm-publish artifacts (see scripts/build-binaries.sh,
+ * scripts/prepare-publish.sh). Non-bundled runs (tsx, `tsc → node`,
+ * vitest) never have the define applied, which is why `isDevBuild()`
+ * probes via `typeof` — the global is undeclared in those contexts and
+ * referencing it directly would ReferenceError.
+ */
+declare const __DEV_BUILD__: boolean;
 
-export function loadConfig(): DaemonConfig | undefined {
-  if (!existsSync(CONFIG_PATH)) return undefined;
+/**
+ * True when running from source (tsx / tsc-built dist / vitest). False
+ * only in artifacts built by build-binaries.sh / prepare-publish.sh,
+ * which pass `--define "__DEV_BUILD__=false"`.
+ *
+ * Multi-instance entry points (`--config-root`, `BEEVIBE_CONFIG_ROOT`)
+ * gate on this — prod builds reject both with exit code 2 so an end
+ * user can't accidentally fork a daemon's state.
+ */
+export function isDevBuild(): boolean {
+  // typeof on an undeclared global returns "undefined" rather than
+  // throwing — same global-probe pattern as BEEVIBE_DAEMON_VERSION in
+  // update.ts. Compiled-prod sets the define to `false` explicitly.
+  return typeof __DEV_BUILD__ === "undefined" ? true : __DEV_BUILD__;
+}
+
+/**
+ * Resolve the daemon's on-disk root directory. Precedence:
+ *   1. explicit `override` arg (the `--config-root` flag)
+ *   2. `BEEVIBE_CONFIG_ROOT` env var
+ *   3. `~/.beevibe` (unchanged default)
+ *
+ * Default behavior is identical to the pre-flag world — with no
+ * override and no env, paths resolve to `~/.beevibe/...` exactly as
+ * before. The override path is dev-only; main.ts rejects it in
+ * compiled-prod via `isDevBuild()`.
+ */
+export function getConfigRoot(override?: string): string {
+  if (override && override.length > 0) return override;
+  const fromEnv = process.env.BEEVIBE_CONFIG_ROOT;
+  if (fromEnv && fromEnv.length > 0) return fromEnv;
+  return join(homedir(), ".beevibe");
+}
+
+export function getConfigPath(override?: string): string {
+  return join(getConfigRoot(override), "config.json");
+}
+
+export function loadConfig(configRoot?: string): DaemonConfig | undefined {
+  const path = getConfigPath(configRoot);
+  if (!existsSync(path)) return undefined;
   try {
-    return JSON.parse(readFileSync(CONFIG_PATH, "utf8")) as DaemonConfig;
+    return JSON.parse(readFileSync(path, "utf8")) as DaemonConfig;
   } catch (err) {
     throw new Error(
-      `Daemon config at ${CONFIG_PATH} is malformed: ${
+      `Daemon config at ${path} is malformed: ${
         err instanceof Error ? err.message : String(err)
       }`,
     );
   }
 }
 
-export function saveConfig(cfg: DaemonConfig): void {
-  mkdirSync(dirname(CONFIG_PATH), { recursive: true, mode: 0o700 });
+export function saveConfig(cfg: DaemonConfig, configRoot?: string): void {
+  const path = getConfigPath(configRoot);
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
   // 0600 because daemon_token is an authentication credential — readable
   // only by the user that owns the daemon process.
-  writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2) + "\n", { mode: 0o600 });
+  writeFileSync(path, JSON.stringify(cfg, null, 2) + "\n", { mode: 0o600 });
 }

--- a/packages/daemon/src/list.test.ts
+++ b/packages/daemon/src/list.test.ts
@@ -1,0 +1,173 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { DaemonConfig } from "./config.js";
+import { discoverDaemons, renderList, type DaemonRecord } from "./list.js";
+
+function sampleConfig(overrides: Partial<DaemonConfig> = {}): DaemonConfig {
+  return {
+    api_url: "http://localhost:3000",
+    external_id: "host.test",
+    daemon_id: "dmn_x",
+    daemon_token: "bv_d_abcdefgh1234wxyz",
+    runtimes: [{ id: "rt_1", cli: "claude" }],
+    ...overrides,
+  };
+}
+
+function writeConfigDir(home: string, dirName: string, cfg: unknown): void {
+  const path = join(home, dirName);
+  mkdirSync(path, { recursive: true });
+  writeFileSync(join(path, "config.json"), JSON.stringify(cfg, null, 2));
+}
+
+describe("discoverDaemons", () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "beevibe-list-test-"));
+  });
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("returns an empty array when no .beevibe* dir exists", () => {
+    expect(discoverDaemons({ home })).toEqual([]);
+  });
+
+  it("finds a single ~/.beevibe daemon", () => {
+    writeConfigDir(home, ".beevibe", sampleConfig({ daemon_id: "dmn_solo" }));
+    const records = discoverDaemons({ home });
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      config_root: join(home, ".beevibe"),
+      daemon_id: "dmn_solo",
+      api_url: "http://localhost:3000",
+      external_id: "host.test",
+      running: "unknown",
+    });
+    // last_sync is an ISO timestamp.
+    expect(records[0]?.last_sync).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("finds multiple .beevibe-* daemons and sorts by config_root path", () => {
+    writeConfigDir(home, ".beevibe-B", sampleConfig({ daemon_id: "dmn_B" }));
+    writeConfigDir(home, ".beevibe-A", sampleConfig({ daemon_id: "dmn_A" }));
+    writeConfigDir(home, ".beevibe", sampleConfig({ daemon_id: "dmn_default" }));
+    const records = discoverDaemons({ home });
+    expect(records.map((r) => r.daemon_id)).toEqual([
+      "dmn_default",
+      "dmn_A",
+      "dmn_B",
+    ]);
+  });
+
+  it("silently skips dirs whose config.json is malformed JSON", () => {
+    writeConfigDir(home, ".beevibe", sampleConfig({ daemon_id: "dmn_valid" }));
+    const badPath = join(home, ".beevibe-bad");
+    mkdirSync(badPath, { recursive: true });
+    writeFileSync(join(badPath, "config.json"), "{ not json");
+    const records = discoverDaemons({ home });
+    expect(records.map((r) => r.daemon_id)).toEqual(["dmn_valid"]);
+  });
+
+  it("silently skips dirs whose config.json parses but isn't a beevibe daemon config", () => {
+    writeConfigDir(home, ".beevibe-other", { unrelated: "tool" });
+    expect(discoverDaemons({ home })).toEqual([]);
+  });
+
+  it("silently skips dirs that have no config.json at all", () => {
+    mkdirSync(join(home, ".beevibe-empty"), { recursive: true });
+    expect(discoverDaemons({ home })).toEqual([]);
+  });
+
+  it("ignores entries in $HOME that don't start with .beevibe", () => {
+    mkdirSync(join(home, "Documents"), { recursive: true });
+    mkdirSync(join(home, ".config"), { recursive: true });
+    writeFileSync(join(home, ".bashrc"), "");
+    expect(discoverDaemons({ home })).toEqual([]);
+  });
+
+  it("masks the daemon_token in token_preview and never leaks the secret", () => {
+    writeConfigDir(
+      home,
+      ".beevibe",
+      sampleConfig({ daemon_token: "bv_d_supersecretMIDDLEpartXYZ9999" }),
+    );
+    const [record] = discoverDaemons({ home });
+    expect(record?.token_preview).toMatch(/^bv_d_/);
+    expect(record?.token_preview).not.toContain("supersecret");
+    expect(record?.token_preview).not.toContain("MIDDLE");
+    // Distinguishing suffix is visible — two tokens are visually distinct.
+    expect(record?.token_preview).toContain("9999");
+  });
+
+  it("returns [] when $HOME itself is unreadable", () => {
+    rmSync(home, { recursive: true, force: true });
+    expect(discoverDaemons({ home })).toEqual([]);
+  });
+});
+
+describe("renderList", () => {
+  function sampleRecord(overrides: Partial<DaemonRecord> = {}): DaemonRecord {
+    return {
+      config_root: "/u/.beevibe",
+      daemon_id: "dmn_one",
+      api_url: "http://localhost:3000",
+      external_id: "host.test",
+      token_preview: "bv_d_…wxyz",
+      last_sync: "2026-05-26T00:00:00.000Z",
+      running: "unknown",
+      ...overrides,
+    };
+  }
+
+  it("prints a helpful empty-state message when no daemons", () => {
+    const out = renderList([], false);
+    expect(out).toMatch(/No daemons found/);
+    expect(out).toContain("beevibe-daemon setup");
+  });
+
+  it("renders an aligned table with header + footer count for one daemon", () => {
+    const out = renderList([sampleRecord()], false);
+    expect(out).toContain("CONFIG ROOT");
+    expect(out).toContain("DAEMON ID");
+    expect(out).toContain("TOKEN");
+    expect(out).toContain("RUNNING");
+    expect(out).toContain("dmn_one");
+    expect(out).toContain("1 daemon found.");
+    expect(out).not.toContain("1 daemons");
+  });
+
+  it("renders a multi-row table with plural footer", () => {
+    const out = renderList(
+      [
+        sampleRecord({ daemon_id: "dmn_A", config_root: "/u/.beevibe-A" }),
+        sampleRecord({ daemon_id: "dmn_B", config_root: "/u/.beevibe-B" }),
+      ],
+      false,
+    );
+    expect(out).toContain("dmn_A");
+    expect(out).toContain("dmn_B");
+    expect(out).toContain("2 daemons found.");
+  });
+
+  it("--json output is a valid JSON array of records", () => {
+    const out = renderList([sampleRecord()], true);
+    const parsed = JSON.parse(out) as DaemonRecord[];
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]).toEqual(sampleRecord());
+  });
+
+  it("--json output is [] when no daemons (parseable by jq)", () => {
+    const out = renderList([], true);
+    expect(JSON.parse(out)).toEqual([]);
+  });
+});

--- a/packages/daemon/src/list.test.ts
+++ b/packages/daemon/src/list.test.ts
@@ -38,12 +38,12 @@ describe("discoverDaemons", () => {
   });
 
   it("returns an empty array when no .beevibe* dir exists", () => {
-    expect(discoverDaemons({ home })).toEqual([]);
+    expect(discoverDaemons(home)).toEqual([]);
   });
 
   it("finds a single ~/.beevibe daemon", () => {
     writeConfigDir(home, ".beevibe", sampleConfig({ daemon_id: "dmn_solo" }));
-    const records = discoverDaemons({ home });
+    const records = discoverDaemons(home);
     expect(records).toHaveLength(1);
     expect(records[0]).toMatchObject({
       config_root: join(home, ".beevibe"),
@@ -60,7 +60,7 @@ describe("discoverDaemons", () => {
     writeConfigDir(home, ".beevibe-B", sampleConfig({ daemon_id: "dmn_B" }));
     writeConfigDir(home, ".beevibe-A", sampleConfig({ daemon_id: "dmn_A" }));
     writeConfigDir(home, ".beevibe", sampleConfig({ daemon_id: "dmn_default" }));
-    const records = discoverDaemons({ home });
+    const records = discoverDaemons(home);
     expect(records.map((r) => r.daemon_id)).toEqual([
       "dmn_default",
       "dmn_A",
@@ -73,25 +73,25 @@ describe("discoverDaemons", () => {
     const badPath = join(home, ".beevibe-bad");
     mkdirSync(badPath, { recursive: true });
     writeFileSync(join(badPath, "config.json"), "{ not json");
-    const records = discoverDaemons({ home });
+    const records = discoverDaemons(home);
     expect(records.map((r) => r.daemon_id)).toEqual(["dmn_valid"]);
   });
 
   it("silently skips dirs whose config.json parses but isn't a beevibe daemon config", () => {
     writeConfigDir(home, ".beevibe-other", { unrelated: "tool" });
-    expect(discoverDaemons({ home })).toEqual([]);
+    expect(discoverDaemons(home)).toEqual([]);
   });
 
   it("silently skips dirs that have no config.json at all", () => {
     mkdirSync(join(home, ".beevibe-empty"), { recursive: true });
-    expect(discoverDaemons({ home })).toEqual([]);
+    expect(discoverDaemons(home)).toEqual([]);
   });
 
   it("ignores entries in $HOME that don't start with .beevibe", () => {
     mkdirSync(join(home, "Documents"), { recursive: true });
     mkdirSync(join(home, ".config"), { recursive: true });
     writeFileSync(join(home, ".bashrc"), "");
-    expect(discoverDaemons({ home })).toEqual([]);
+    expect(discoverDaemons(home)).toEqual([]);
   });
 
   it("masks the daemon_token in token_preview and never leaks the secret", () => {
@@ -100,7 +100,7 @@ describe("discoverDaemons", () => {
       ".beevibe",
       sampleConfig({ daemon_token: "bv_d_supersecretMIDDLEpartXYZ9999" }),
     );
-    const [record] = discoverDaemons({ home });
+    const [record] = discoverDaemons(home);
     expect(record?.token_preview).toMatch(/^bv_d_/);
     expect(record?.token_preview).not.toContain("supersecret");
     expect(record?.token_preview).not.toContain("MIDDLE");
@@ -110,7 +110,7 @@ describe("discoverDaemons", () => {
 
   it("returns [] when $HOME itself is unreadable", () => {
     rmSync(home, { recursive: true, force: true });
-    expect(discoverDaemons({ home })).toEqual([]);
+    expect(discoverDaemons(home)).toEqual([]);
   });
 });
 

--- a/packages/daemon/src/list.ts
+++ b/packages/daemon/src/list.ts
@@ -4,16 +4,14 @@
  * anything else under a config root.
  *
  * Discovery is a filesystem scan of $HOME for `.beevibe*` dirs whose
- * `config.json` parses as a beevibe DaemonConfig. Anything that doesn't
- * parse (corrupt JSON, unrelated tool sharing the `.beevibe-*` prefix)
- * is silently skipped — the false-positive rate from "just ship a glob"
- * stays at zero without us needing a registry file.
+ * `config.json` parses as a beevibe DaemonConfig. Non-matching dirs
+ * (corrupt JSON, unrelated tools sharing the prefix) are skipped.
  */
 
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { readdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type { DaemonConfig } from "./config.js";
+import { getConfigPath, loadConfig, type DaemonConfig } from "./config.js";
 
 /** Public output shape — one record per discovered daemon. */
 export interface DaemonRecord {
@@ -25,21 +23,10 @@ export interface DaemonRecord {
   token_preview: string;
   /** ISO mtime of <config_root>/config.json. */
   last_sync: string;
-  /**
-   * Best-effort "is the daemon process running" check. Always `"unknown"`
-   * today — implementing a non-fragile cross-platform detector would
-   * either miss source/tsx runs or false-positive on unrelated processes.
-   * Punted to a follow-up.
-   */
+  /** Reserved for a future process-detection check; always `"unknown"` today. */
   running: "unknown";
 }
 
-/**
- * Mask a `bv_d_` daemon token for display. The token is an auth
- * credential — show the prefix plus the last 4 chars so two roots can
- * be told apart visually, but never the middle. Same pattern as Stripe
- * keys (`sk_test_…wxyz`) and GitHub PATs in their UI.
- */
 function tokenPreview(token: string): string {
   if (!token.startsWith("bv_d_")) return "(invalid)";
   const tail = token.slice("bv_d_".length);
@@ -47,6 +34,9 @@ function tokenPreview(token: string): string {
   return `bv_d_…${tail.slice(-4)}`;
 }
 
+// loadConfig() does an unchecked `as DaemonConfig` cast — `list` reads
+// arbitrary `.beevibe*` dirs (potentially unrelated tools), so the
+// shape must be structurally validated before trusting fields.
 function isDaemonConfig(x: unknown): x is DaemonConfig {
   if (!x || typeof x !== "object") return false;
   const c = x as Record<string, unknown>;
@@ -60,61 +50,49 @@ function isDaemonConfig(x: unknown): x is DaemonConfig {
 }
 
 function tryLoad(configRoot: string): DaemonRecord | undefined {
-  const cfgPath = join(configRoot, "config.json");
-  let raw: string;
+  let cfg: DaemonConfig | undefined;
+  try {
+    cfg = loadConfig(configRoot);
+  } catch {
+    return undefined;
+  }
+  if (!cfg || !isDaemonConfig(cfg)) return undefined;
   let mtime: Date;
   try {
-    raw = readFileSync(cfgPath, "utf8");
-    mtime = statSync(cfgPath).mtime;
+    mtime = statSync(getConfigPath(configRoot)).mtime;
   } catch {
     return undefined;
   }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return undefined;
-  }
-  if (!isDaemonConfig(parsed)) return undefined;
   return {
     config_root: configRoot,
-    daemon_id: parsed.daemon_id,
-    api_url: parsed.api_url,
-    external_id: parsed.external_id,
-    token_preview: tokenPreview(parsed.daemon_token),
+    daemon_id: cfg.daemon_id,
+    api_url: cfg.api_url,
+    external_id: cfg.external_id,
+    token_preview: tokenPreview(cfg.daemon_token),
     last_sync: mtime.toISOString(),
     running: "unknown",
   };
-}
-
-export interface DiscoverOptions {
-  /** Override $HOME for testing. */
-  home?: string;
 }
 
 /**
  * Scan $HOME for `.beevibe*` directories with a parseable daemon
  * config.json. Returns one record per match, sorted by config_root for
  * stable output. Unreadable dirs and non-daemon configs are skipped.
+ *
+ * `home` exists for tests; the CLI always uses the real `homedir()`.
  */
-export function discoverDaemons(options: DiscoverOptions = {}): DaemonRecord[] {
-  const home = options.home ?? homedir();
-  let entries: string[];
+export function discoverDaemons(home: string = homedir()): DaemonRecord[] {
+  let entries: Array<{ name: string; isDirectory: () => boolean }>;
   try {
-    entries = readdirSync(home);
+    entries = readdirSync(home, { withFileTypes: true });
   } catch {
     return [];
   }
   const records: DaemonRecord[] = [];
   for (const entry of entries) {
-    if (!entry.startsWith(".beevibe")) continue;
-    const configRoot = join(home, entry);
-    try {
-      if (!statSync(configRoot).isDirectory()) continue;
-    } catch {
-      continue;
-    }
-    const rec = tryLoad(configRoot);
+    if (!entry.name.startsWith(".beevibe")) continue;
+    if (!entry.isDirectory()) continue;
+    const rec = tryLoad(join(home, entry.name));
     if (rec) records.push(rec);
   }
   return records.sort((a, b) => a.config_root.localeCompare(b.config_root));
@@ -161,11 +139,8 @@ export function renderList(records: DaemonRecord[], json: boolean): string {
 
 export interface ListOptions {
   json?: boolean;
-  /** Override $HOME for testing; CLI always uses the real home. */
-  home?: string;
 }
 
 export function runList(options: ListOptions = {}): void {
-  const records = discoverDaemons({ home: options.home });
-  console.log(renderList(records, options.json === true));
+  console.log(renderList(discoverDaemons(), options.json === true));
 }

--- a/packages/daemon/src/list.ts
+++ b/packages/daemon/src/list.ts
@@ -1,0 +1,171 @@
+/**
+ * `beevibe-daemon list` — discover daemon instances on this machine and
+ * print one row per instance. Read-only: never writes config.json or
+ * anything else under a config root.
+ *
+ * Discovery is a filesystem scan of $HOME for `.beevibe*` dirs whose
+ * `config.json` parses as a beevibe DaemonConfig. Anything that doesn't
+ * parse (corrupt JSON, unrelated tool sharing the `.beevibe-*` prefix)
+ * is silently skipped — the false-positive rate from "just ship a glob"
+ * stays at zero without us needing a registry file.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { DaemonConfig } from "./config.js";
+
+/** Public output shape — one record per discovered daemon. */
+export interface DaemonRecord {
+  config_root: string;
+  daemon_id: string;
+  api_url: string;
+  external_id: string;
+  /** Masked bv_d_ token (prefix + last 4 chars). Never the full secret. */
+  token_preview: string;
+  /** ISO mtime of <config_root>/config.json. */
+  last_sync: string;
+  /**
+   * Best-effort "is the daemon process running" check. Always `"unknown"`
+   * today — implementing a non-fragile cross-platform detector would
+   * either miss source/tsx runs or false-positive on unrelated processes.
+   * Punted to a follow-up.
+   */
+  running: "unknown";
+}
+
+/**
+ * Mask a `bv_d_` daemon token for display. The token is an auth
+ * credential — show the prefix plus the last 4 chars so two roots can
+ * be told apart visually, but never the middle. Same pattern as Stripe
+ * keys (`sk_test_…wxyz`) and GitHub PATs in their UI.
+ */
+function tokenPreview(token: string): string {
+  if (!token.startsWith("bv_d_")) return "(invalid)";
+  const tail = token.slice("bv_d_".length);
+  if (tail.length < 8) return "bv_d_***";
+  return `bv_d_…${tail.slice(-4)}`;
+}
+
+function isDaemonConfig(x: unknown): x is DaemonConfig {
+  if (!x || typeof x !== "object") return false;
+  const c = x as Record<string, unknown>;
+  return (
+    typeof c.api_url === "string" &&
+    typeof c.external_id === "string" &&
+    typeof c.daemon_id === "string" &&
+    typeof c.daemon_token === "string" &&
+    Array.isArray(c.runtimes)
+  );
+}
+
+function tryLoad(configRoot: string): DaemonRecord | undefined {
+  const cfgPath = join(configRoot, "config.json");
+  let raw: string;
+  let mtime: Date;
+  try {
+    raw = readFileSync(cfgPath, "utf8");
+    mtime = statSync(cfgPath).mtime;
+  } catch {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (!isDaemonConfig(parsed)) return undefined;
+  return {
+    config_root: configRoot,
+    daemon_id: parsed.daemon_id,
+    api_url: parsed.api_url,
+    external_id: parsed.external_id,
+    token_preview: tokenPreview(parsed.daemon_token),
+    last_sync: mtime.toISOString(),
+    running: "unknown",
+  };
+}
+
+export interface DiscoverOptions {
+  /** Override $HOME for testing. */
+  home?: string;
+}
+
+/**
+ * Scan $HOME for `.beevibe*` directories with a parseable daemon
+ * config.json. Returns one record per match, sorted by config_root for
+ * stable output. Unreadable dirs and non-daemon configs are skipped.
+ */
+export function discoverDaemons(options: DiscoverOptions = {}): DaemonRecord[] {
+  const home = options.home ?? homedir();
+  let entries: string[];
+  try {
+    entries = readdirSync(home);
+  } catch {
+    return [];
+  }
+  const records: DaemonRecord[] = [];
+  for (const entry of entries) {
+    if (!entry.startsWith(".beevibe")) continue;
+    const configRoot = join(home, entry);
+    try {
+      if (!statSync(configRoot).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    const rec = tryLoad(configRoot);
+    if (rec) records.push(rec);
+  }
+  return records.sort((a, b) => a.config_root.localeCompare(b.config_root));
+}
+
+interface Column {
+  header: string;
+  get: (r: DaemonRecord) => string;
+}
+
+const COLUMNS: Column[] = [
+  { header: "CONFIG ROOT", get: (r) => r.config_root },
+  { header: "DAEMON ID", get: (r) => r.daemon_id },
+  { header: "TOKEN", get: (r) => r.token_preview },
+  { header: "API", get: (r) => r.api_url },
+  { header: "DEVICE", get: (r) => r.external_id },
+  { header: "LAST SYNC", get: (r) => r.last_sync },
+  { header: "RUNNING", get: (r) => r.running },
+];
+
+function formatTable(records: DaemonRecord[]): string {
+  const rows = records.map((r) => COLUMNS.map((c) => c.get(r)));
+  const widths = COLUMNS.map((c, i) =>
+    Math.max(c.header.length, ...rows.map((row) => row[i]?.length ?? 0)),
+  );
+  const fmt = (cells: string[]): string =>
+    cells
+      .map((cell, i) => cell.padEnd(widths[i] ?? 0))
+      .join("  ")
+      .trimEnd();
+  const lines = [fmt(COLUMNS.map((c) => c.header))];
+  for (const row of rows) lines.push(fmt(row));
+  return lines.join("\n");
+}
+
+export function renderList(records: DaemonRecord[], json: boolean): string {
+  if (json) return JSON.stringify(records, null, 2);
+  if (records.length === 0) {
+    return "No daemons found. Run `beevibe-daemon setup …` to register one.";
+  }
+  const count = `${records.length} daemon${records.length === 1 ? "" : "s"} found.`;
+  return `${formatTable(records)}\n${count}`;
+}
+
+export interface ListOptions {
+  json?: boolean;
+  /** Override $HOME for testing; CLI always uses the real home. */
+  home?: string;
+}
+
+export function runList(options: ListOptions = {}): void {
+  const records = discoverDaemons({ home: options.home });
+  console.log(renderList(records, options.json === true));
+}

--- a/packages/daemon/src/main.ts
+++ b/packages/daemon/src/main.ts
@@ -106,9 +106,10 @@ function printHelp(): void {
       "",
       "dev-only flags (source builds only — rejected in compiled binaries):",
       "  --config-root <path>       shift the daemon's on-disk root from ~/.beevibe.",
-      "                             Lets two daemons coexist on one machine as",
-      "                             different accounts. Also settable via the",
-      "                             BEEVIBE_CONFIG_ROOT env var.",
+      "                             Applies to setup / start / sync (list always",
+      "                             scans $HOME). Lets two daemons coexist on one",
+      "                             machine as different accounts. Also settable",
+      "                             via the BEEVIBE_CONFIG_ROOT env var.",
     ].join("\n"),
   );
 }
@@ -120,10 +121,8 @@ async function main(): Promise<void> {
     return;
   }
 
-  // `list` scans $HOME for every config root rather than operating on a
-  // single one, so it doesn't take --config-root. Handle it before
-  // resolveConfigRoot so the dev-only gate never fires for `list`
-  // (introspection is useful in prod builds too).
+  // `list` scans $HOME, so --config-root doesn't apply and the dev-only
+  // gate shouldn't fire for it. Handle it before resolveConfigRoot.
   if (command === "list") {
     runList({ json: rest.includes("--json") });
     return;

--- a/packages/daemon/src/main.ts
+++ b/packages/daemon/src/main.ts
@@ -11,14 +11,9 @@
  * with `--no-compile-autoload-dotenv --no-compile-autoload-bunfig`
  * (see packages/daemon/scripts/build-binaries.sh) so launching from
  * inside a beevibe checkout doesn't silently slurp the repo's .env.
- *
- * Dev-only `--config-root <path>` (or `BEEVIBE_CONFIG_ROOT` env) shifts
- * the on-disk root from `~/.beevibe` so two daemons authenticated as
- * different `bv_u_` accounts can coexist on one machine. Rejected in
- * compiled-prod via `isDevBuild()` — see config.ts.
  */
 
-import { isDevBuild } from "./config.js";
+import { CONFIG_ROOT_ENV, getConfigPath, isDevBuild } from "./config.js";
 import { runSetup } from "./setup.js";
 import { runStart } from "./start.js";
 import { runSync } from "./sync.js";
@@ -59,25 +54,19 @@ function parseFlags(argv: string[]): Flags {
 
 /**
  * Resolve the effective config-root override and enforce the dev-only
- * gate. Returns `undefined` when neither the flag nor the env are set
- * — that's the normal path, and `getConfigRoot(undefined)` falls
- * through to `~/.beevibe`.
- *
- * Compiled-prod (`isDevBuild() === false`): both the flag and the env
- * are rejected with exit code 2 and a clear message. This is the
- * belt-and-suspenders side of the gate; the compile-time
- * `__DEV_BUILD__=false` define is what theoretically lets the
- * bundler dead-code-eliminate the multi-instance code paths, but
- * bun build doesn't always DCE without `--minify`, so the runtime
- * guard is the load-bearing one.
+ * gate. Returns `undefined` when neither flag nor env is set, so
+ * downstream `getConfigRoot(undefined)` falls through to `~/.beevibe`.
+ * Compiled-prod rejects either knob with exit 2 — runtime guard
+ * because `bun build` without `--minify` may not DCE the dead branch.
  */
 function resolveConfigRoot(flag: string | undefined): string | undefined {
-  const env = process.env.BEEVIBE_CONFIG_ROOT;
-  const hasOverride = (flag && flag.length > 0) || (env && env.length > 0);
-  if (!hasOverride) return undefined;
+  const env = process.env[CONFIG_ROOT_ENV];
+  const hasFlag = flag && flag.length > 0;
+  const hasEnv = env && env.length > 0;
+  if (!hasFlag && !hasEnv) return undefined;
 
   if (!isDevBuild()) {
-    const source = flag ? "--config-root" : "BEEVIBE_CONFIG_ROOT";
+    const source = hasFlag ? "--config-root" : CONFIG_ROOT_ENV;
     console.error(
       `${source} is a dev-only knob and is not available in this build. ` +
         `Reinstall via npm/curl without the override, or use a source checkout ` +
@@ -86,7 +75,7 @@ function resolveConfigRoot(flag: string | undefined): string | undefined {
     process.exit(2);
   }
 
-  return flag && flag.length > 0 ? flag : env;
+  return hasFlag ? flag : env;
 }
 
 function printHelp(): void {
@@ -143,8 +132,7 @@ async function main(): Promise<void> {
     });
     console.log(`Registered as ${cfg.daemon_id}`);
     console.log(`Runtimes: ${cfg.runtimes.map((r) => `${r.cli} (${r.id})`).join(", ")}`);
-    const configLabel = configRoot ? `${configRoot}/config.json` : "~/.beevibe/config.json";
-    console.log(`Config saved to ${configLabel}`);
+    console.log(`Config saved to ${getConfigPath(configRoot)}`);
     return;
   }
 

--- a/packages/daemon/src/main.ts
+++ b/packages/daemon/src/main.ts
@@ -11,8 +11,14 @@
  * with `--no-compile-autoload-dotenv --no-compile-autoload-bunfig`
  * (see packages/daemon/scripts/build-binaries.sh) so launching from
  * inside a beevibe checkout doesn't silently slurp the repo's .env.
+ *
+ * Dev-only `--config-root <path>` (or `BEEVIBE_CONFIG_ROOT` env) shifts
+ * the on-disk root from `~/.beevibe` so two daemons authenticated as
+ * different `bv_u_` accounts can coexist on one machine. Rejected in
+ * compiled-prod via `isDevBuild()` — see config.ts.
  */
 
+import { isDevBuild } from "./config.js";
 import { runSetup } from "./setup.js";
 import { runStart } from "./start.js";
 import { runSync } from "./sync.js";
@@ -23,6 +29,7 @@ interface Flags {
   userToken?: string;
   deviceName?: string;
   externalId?: string;
+  configRoot?: string;
 }
 
 function parseFlags(argv: string[]): Flags {
@@ -42,9 +49,44 @@ function parseFlags(argv: string[]): Flags {
     } else if (arg === "--external-id" && next) {
       flags.externalId = next;
       i += 1;
+    } else if (arg === "--config-root" && next) {
+      flags.configRoot = next;
+      i += 1;
     }
   }
   return flags;
+}
+
+/**
+ * Resolve the effective config-root override and enforce the dev-only
+ * gate. Returns `undefined` when neither the flag nor the env are set
+ * — that's the normal path, and `getConfigRoot(undefined)` falls
+ * through to `~/.beevibe`.
+ *
+ * Compiled-prod (`isDevBuild() === false`): both the flag and the env
+ * are rejected with exit code 2 and a clear message. This is the
+ * belt-and-suspenders side of the gate; the compile-time
+ * `__DEV_BUILD__=false` define is what theoretically lets the
+ * bundler dead-code-eliminate the multi-instance code paths, but
+ * bun build doesn't always DCE without `--minify`, so the runtime
+ * guard is the load-bearing one.
+ */
+function resolveConfigRoot(flag: string | undefined): string | undefined {
+  const env = process.env.BEEVIBE_CONFIG_ROOT;
+  const hasOverride = (flag && flag.length > 0) || (env && env.length > 0);
+  if (!hasOverride) return undefined;
+
+  if (!isDevBuild()) {
+    const source = flag ? "--config-root" : "BEEVIBE_CONFIG_ROOT";
+    console.error(
+      `${source} is a dev-only knob and is not available in this build. ` +
+        `Reinstall via npm/curl without the override, or use a source checkout ` +
+        `(pnpm dev) if you need multi-instance.`,
+    );
+    process.exit(2);
+  }
+
+  return flag && flag.length > 0 ? flag : env;
 }
 
 function printHelp(): void {
@@ -66,6 +108,12 @@ function printHelp(): void {
       "",
       "update flags:",
       "  --yes, -y                  skip the install-this-update prompt",
+      "",
+      "dev-only flags (source builds only — rejected in compiled binaries):",
+      "  --config-root <path>       shift the daemon's on-disk root from ~/.beevibe.",
+      "                             Lets two daemons coexist on one machine as",
+      "                             different accounts. Also settable via the",
+      "                             BEEVIBE_CONFIG_ROOT env var.",
     ].join("\n"),
   );
 }
@@ -77,8 +125,10 @@ async function main(): Promise<void> {
     return;
   }
 
+  const flags = parseFlags(rest);
+  const configRoot = resolveConfigRoot(flags.configRoot);
+
   if (command === "setup") {
-    const flags = parseFlags(rest);
     if (!flags.api || !flags.userToken) {
       console.error("setup requires --api and --user-token");
       printHelp();
@@ -89,20 +139,22 @@ async function main(): Promise<void> {
       userToken: flags.userToken,
       deviceName: flags.deviceName,
       externalId: flags.externalId,
+      configRoot,
     });
     console.log(`Registered as ${cfg.daemon_id}`);
     console.log(`Runtimes: ${cfg.runtimes.map((r) => `${r.cli} (${r.id})`).join(", ")}`);
-    console.log("Config saved to ~/.beevibe/config.json");
+    const configLabel = configRoot ? `${configRoot}/config.json` : "~/.beevibe/config.json";
+    console.log(`Config saved to ${configLabel}`);
     return;
   }
 
   if (command === "start") {
-    await runStart();
+    await runStart({ configRoot });
     return;
   }
 
   if (command === "sync") {
-    const result = await runSync();
+    const result = await runSync({ configRoot });
     if (result.added.length === 0) {
       console.log("No new CLIs detected.");
     } else {

--- a/packages/daemon/src/main.ts
+++ b/packages/daemon/src/main.ts
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 /**
- * `beevibe-daemon` CLI entry. Four subcommands:
+ * `beevibe-daemon` CLI entry. Five subcommands:
  *   - setup --api <url> --user-token <bv_u_…> [--device-name <name>]
  *   - start
  *   - sync       Re-detect CLIs on PATH and register newly-installed ones.
  *   - update [--yes]
+ *   - list [--json]   Discover and report local daemon instances.
  *
  * The daemon owns its own config (~/.beevibe/config.json) and has no
  * legitimate reason to read a local .env. Compiled binaries are built
@@ -14,6 +15,7 @@
  */
 
 import { CONFIG_ROOT_ENV, getConfigPath, isDevBuild } from "./config.js";
+import { runList } from "./list.js";
 import { runSetup } from "./setup.js";
 import { runStart } from "./start.js";
 import { runSync } from "./sync.js";
@@ -88,6 +90,7 @@ function printHelp(): void {
       "  start    Run the daemon: claim pending sessions and spawn the CLI.",
       "  sync     Re-detect CLIs on PATH and register newly-installed ones.",
       "  update   Check for and install a newer daemon binary (brew/curl installs).",
+      "  list     Discover and report local daemon instances (one row per config root).",
       "",
       "setup flags:",
       "  --api, -a <url>            beevibe api base URL (e.g. http://localhost:3000)",
@@ -97,6 +100,9 @@ function printHelp(): void {
       "",
       "update flags:",
       "  --yes, -y                  skip the install-this-update prompt",
+      "",
+      "list flags:",
+      "  --json                     emit a JSON array instead of a human-readable table",
       "",
       "dev-only flags (source builds only — rejected in compiled binaries):",
       "  --config-root <path>       shift the daemon's on-disk root from ~/.beevibe.",
@@ -111,6 +117,15 @@ async function main(): Promise<void> {
   const [command, ...rest] = process.argv.slice(2);
   if (!command || command === "--help" || command === "-h") {
     printHelp();
+    return;
+  }
+
+  // `list` scans $HOME for every config root rather than operating on a
+  // single one, so it doesn't take --config-root. Handle it before
+  // resolveConfigRoot so the dev-only gate never fires for `list`
+  // (introspection is useful in prod builds too).
+  if (command === "list") {
+    runList({ json: rest.includes("--json") });
     return;
   }
 

--- a/packages/daemon/src/multi-instance.e2e.test.ts
+++ b/packages/daemon/src/multi-instance.e2e.test.ts
@@ -1,0 +1,186 @@
+/**
+ * End-to-end test for the dev-only multi-instance config-root feature.
+ *
+ * Skipped by default — runs two real `runSetup` calls against a local
+ * HTTP stub of `/runtime/register`, exercising the full filesystem
+ * isolation invariant: two daemons authenticated as different accounts
+ * each write their own config.json and skills-cache under independent
+ * `configRoot`s. Enable by:
+ *
+ *   BEEVIBE_E2E_MULTI_INSTANCE=1 pnpm --filter @beevibe/daemon test
+ *
+ * Follows the `packages/sandbox/src/docker.e2e.test.ts` pattern — opt-in
+ * via env var so CI defaults stay fast.
+ */
+import { createServer, type Server } from "node:http";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { loadConfig } from "./config.js";
+import { runSetup } from "./setup.js";
+import { skillsCacheDir, syncSkillsCache } from "./skills-cache.js";
+import { ApiClient } from "./api-client.js";
+
+const ENABLED = process.env.BEEVIBE_E2E_MULTI_INSTANCE === "1";
+const describeOrSkip = ENABLED ? describe : describe.skip;
+
+interface RegistrationCall {
+  authorization?: string;
+  external_id: string;
+  device_name: string;
+}
+
+interface StubServer {
+  url: string;
+  registrations: RegistrationCall[];
+  shutdown: () => Promise<void>;
+}
+
+async function startStubApi(): Promise<StubServer> {
+  const registrations: RegistrationCall[] = [];
+  let daemonCounter = 0;
+  const server: Server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      const body = chunks.length > 0 ? JSON.parse(Buffer.concat(chunks).toString("utf8")) : {};
+      if (req.url === "/runtime/register" && req.method === "POST") {
+        registrations.push({
+          authorization: req.headers.authorization,
+          external_id: body.external_id,
+          device_name: body.device_name,
+        });
+        daemonCounter += 1;
+        res.writeHead(201, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify({
+            daemon_id: `dmn_e2e_${daemonCounter}`,
+            daemon_token: `bv_d_e2e_${daemonCounter}`,
+            runtimes: body.runtimes.map(
+              (r: { cli: string }, i: number) => ({ id: `rt_e2e_${daemonCounter}_${i}`, cli: r.cli }),
+            ),
+          }),
+        );
+        return;
+      }
+      if (req.url === "/runtime/skills" && req.method === "GET") {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify({
+            version: "v1-e2e",
+            skills: [
+              {
+                name: "beevibe-test",
+                files: [{ path: "SKILL.md", content: "stub skill body\n" }],
+              },
+            ],
+          }),
+        );
+        return;
+      }
+      res.writeHead(404).end();
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const addr = server.address();
+  if (!addr || typeof addr === "string") throw new Error("stub api did not bind");
+  return {
+    url: `http://127.0.0.1:${addr.port}`,
+    registrations,
+    shutdown: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}
+
+describeOrSkip("multi-instance daemon isolation (e2e)", () => {
+  let api: StubServer;
+  let rootA: string;
+  let rootB: string;
+
+  beforeAll(async () => {
+    api = await startStubApi();
+  });
+  afterAll(async () => {
+    await api.shutdown();
+  });
+
+  beforeEach(() => {
+    rootA = mkdtempSync(join(tmpdir(), "beevibe-mi-A-"));
+    rootB = mkdtempSync(join(tmpdir(), "beevibe-mi-B-"));
+  });
+  afterEach(() => {
+    rmSync(rootA, { recursive: true, force: true });
+    rmSync(rootB, { recursive: true, force: true });
+  });
+
+  it("two setups with different configRoots produce two isolated config.json files", async () => {
+    const cfgA = await runSetup({
+      apiUrl: api.url,
+      userToken: "bv_u_account_A",
+      configRoot: rootA,
+      detectedClis: [{ cli: "claude", cli_version: "1.0.0" }],
+    });
+    const cfgB = await runSetup({
+      apiUrl: api.url,
+      userToken: "bv_u_account_B",
+      configRoot: rootB,
+      detectedClis: [{ cli: "claude", cli_version: "1.0.0" }],
+    });
+
+    // Each setup must have written its config.json under its own root only.
+    expect(existsSync(join(rootA, "config.json"))).toBe(true);
+    expect(existsSync(join(rootB, "config.json"))).toBe(true);
+
+    // Tokens are distinct.
+    expect(cfgA.daemon_token).not.toBe(cfgB.daemon_token);
+    expect(cfgA.daemon_id).not.toBe(cfgB.daemon_id);
+
+    // loadConfig reads each root's own state — the cross-contamination
+    // bug being prevented.
+    const loadedA = loadConfig(rootA);
+    const loadedB = loadConfig(rootB);
+    expect(loadedA?.daemon_token).toBe(cfgA.daemon_token);
+    expect(loadedB?.daemon_token).toBe(cfgB.daemon_token);
+    expect(loadedA?.daemon_token).not.toBe(loadedB?.daemon_token);
+
+    // The on-disk JSON file under A must NOT mention B's token, and
+    // vice versa.
+    const rawA = readFileSync(join(rootA, "config.json"), "utf8");
+    const rawB = readFileSync(join(rootB, "config.json"), "utf8");
+    expect(rawA).toContain(cfgA.daemon_token);
+    expect(rawA).not.toContain(cfgB.daemon_token);
+    expect(rawB).toContain(cfgB.daemon_token);
+    expect(rawB).not.toContain(cfgA.daemon_token);
+
+    // The api saw two distinct registrations carrying each user's bv_u_.
+    expect(api.registrations).toHaveLength(2);
+    expect(api.registrations[0]?.authorization).toBe("Bearer bv_u_account_A");
+    expect(api.registrations[1]?.authorization).toBe("Bearer bv_u_account_B");
+  });
+
+  it("skills cache is namespaced per configRoot — no cross-write race", async () => {
+    const apiClient = new ApiClient({ apiUrl: api.url, daemonToken: "bv_d_test" });
+    const dirA = await syncSkillsCache(apiClient, rootA);
+    const dirB = await syncSkillsCache(apiClient, rootB);
+
+    expect(dirA).toBe(skillsCacheDir(rootA));
+    expect(dirB).toBe(skillsCacheDir(rootB));
+    expect(dirA).not.toBe(dirB);
+    expect(existsSync(join(dirA, ".version"))).toBe(true);
+    expect(existsSync(join(dirB, ".version"))).toBe(true);
+    expect(existsSync(join(dirA, "beevibe-test", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(dirB, "beevibe-test", "SKILL.md"))).toBe(true);
+  });
+});

--- a/packages/daemon/src/multi-instance.e2e.test.ts
+++ b/packages/daemon/src/multi-instance.e2e.test.ts
@@ -1,16 +1,9 @@
 /**
- * End-to-end test for the dev-only multi-instance config-root feature.
- *
- * Skipped by default — runs two real `runSetup` calls against a local
- * HTTP stub of `/runtime/register`, exercising the full filesystem
- * isolation invariant: two daemons authenticated as different accounts
- * each write their own config.json and skills-cache under independent
- * `configRoot`s. Enable by:
+ * E2E for the dev-only --config-root feature. Opt-in:
  *
  *   BEEVIBE_E2E_MULTI_INSTANCE=1 pnpm --filter @beevibe/daemon test
  *
- * Follows the `packages/sandbox/src/docker.e2e.test.ts` pattern — opt-in
- * via env var so CI defaults stay fast.
+ * Same opt-in pattern as packages/sandbox/src/docker.e2e.test.ts.
  */
 import { createServer, type Server } from "node:http";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
@@ -51,6 +44,9 @@ async function startStubApi(): Promise<StubServer> {
   const server: Server = createServer((req, res) => {
     const chunks: Buffer[] = [];
     req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("error", () => {
+      if (!res.headersSent) res.writeHead(400).end();
+    });
     req.on("end", () => {
       const body = chunks.length > 0 ? JSON.parse(Buffer.concat(chunks).toString("utf8")) : {};
       if (req.url === "/runtime/register" && req.method === "POST") {
@@ -139,24 +135,17 @@ describeOrSkip("multi-instance daemon isolation (e2e)", () => {
       detectedClis: [{ cli: "claude", cli_version: "1.0.0" }],
     });
 
-    // Each setup must have written its config.json under its own root only.
     expect(existsSync(join(rootA, "config.json"))).toBe(true);
     expect(existsSync(join(rootB, "config.json"))).toBe(true);
 
-    // Tokens are distinct.
     expect(cfgA.daemon_token).not.toBe(cfgB.daemon_token);
     expect(cfgA.daemon_id).not.toBe(cfgB.daemon_id);
 
-    // loadConfig reads each root's own state — the cross-contamination
-    // bug being prevented.
-    const loadedA = loadConfig(rootA);
-    const loadedB = loadConfig(rootB);
-    expect(loadedA?.daemon_token).toBe(cfgA.daemon_token);
-    expect(loadedB?.daemon_token).toBe(cfgB.daemon_token);
-    expect(loadedA?.daemon_token).not.toBe(loadedB?.daemon_token);
+    expect(loadConfig(rootA)?.daemon_token).toBe(cfgA.daemon_token);
+    expect(loadConfig(rootB)?.daemon_token).toBe(cfgB.daemon_token);
 
-    // The on-disk JSON file under A must NOT mention B's token, and
-    // vice versa.
+    // On-disk: each root's JSON references only its own token — the
+    // cross-contamination bug being prevented.
     const rawA = readFileSync(join(rootA, "config.json"), "utf8");
     const rawB = readFileSync(join(rootB, "config.json"), "utf8");
     expect(rawA).toContain(cfgA.daemon_token);
@@ -164,7 +153,6 @@ describeOrSkip("multi-instance daemon isolation (e2e)", () => {
     expect(rawB).toContain(cfgB.daemon_token);
     expect(rawB).not.toContain(cfgA.daemon_token);
 
-    // The api saw two distinct registrations carrying each user's bv_u_.
     expect(api.registrations).toHaveLength(2);
     expect(api.registrations[0]?.authorization).toBe("Bearer bv_u_account_A");
     expect(api.registrations[1]?.authorization).toBe("Bearer bv_u_account_B");

--- a/packages/daemon/src/setup.ts
+++ b/packages/daemon/src/setup.ts
@@ -26,10 +26,7 @@ export interface SetupOptions {
    * PATH for known CLI names.
    */
   detectedClis?: Array<{ cli: string; cli_version?: string }>;
-  /**
-   * Dev-only override for `~/.beevibe`. Threaded down from the
-   * `--config-root` flag in main.ts. Unset for normal use.
-   */
+  /** Dev-only `~/.beevibe` override; see config.ts:getConfigRoot. */
   configRoot?: string;
 }
 

--- a/packages/daemon/src/setup.ts
+++ b/packages/daemon/src/setup.ts
@@ -26,6 +26,11 @@ export interface SetupOptions {
    * PATH for known CLI names.
    */
   detectedClis?: Array<{ cli: string; cli_version?: string }>;
+  /**
+   * Dev-only override for `~/.beevibe`. Threaded down from the
+   * `--config-root` flag in main.ts. Unset for normal use.
+   */
+  configRoot?: string;
 }
 
 export async function runSetup(options: SetupOptions): Promise<DaemonConfig> {
@@ -73,7 +78,7 @@ export async function runSetup(options: SetupOptions): Promise<DaemonConfig> {
     daemon_token: body.daemon_token,
     runtimes: body.runtimes,
   };
-  saveConfig(config);
+  saveConfig(config, options.configRoot);
   return config;
 }
 

--- a/packages/daemon/src/skills-cache.ts
+++ b/packages/daemon/src/skills-cache.ts
@@ -11,9 +11,9 @@
  */
 
 import { promises as fs } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import type { ApiClient } from "./api-client.js";
+import { getConfigRoot } from "./config.js";
 
 interface RuntimeSkillFile {
   path: string;
@@ -28,15 +28,17 @@ interface RuntimeSkillsResponse {
   skills: RuntimeSkill[];
 }
 
-export function skillsCacheDir(): string {
-  return join(homedir(), ".beevibe", "skills");
+export function skillsCacheDir(configRoot?: string): string {
+  return join(getConfigRoot(configRoot), "skills");
 }
 
 const VERSION_FILE = ".version";
 
-export async function readCachedVersion(): Promise<string | undefined> {
+export async function readCachedVersion(
+  configRoot?: string,
+): Promise<string | undefined> {
   try {
-    return (await fs.readFile(join(skillsCacheDir(), VERSION_FILE), "utf8"))
+    return (await fs.readFile(join(skillsCacheDir(configRoot), VERSION_FILE), "utf8"))
       .trim();
   } catch {
     return undefined;
@@ -44,14 +46,17 @@ export async function readCachedVersion(): Promise<string | undefined> {
 }
 
 /**
- * Fetch /runtime/skills, write the bundle to `~/.beevibe/skills/`.
+ * Fetch /runtime/skills, write the bundle to `<configRoot>/skills/`.
  * No-op when the server's version matches the local cache. Returns the
- * resolved cache path (always equal to `skillsCacheDir()`).
+ * resolved cache path (always equal to `skillsCacheDir(configRoot)`).
  */
-export async function syncSkillsCache(api: ApiClient): Promise<string> {
-  const cache = skillsCacheDir();
+export async function syncSkillsCache(
+  api: ApiClient,
+  configRoot?: string,
+): Promise<string> {
+  const cache = skillsCacheDir(configRoot);
 
-  const cached = await readCachedVersion();
+  const cached = await readCachedVersion(configRoot);
   const res = await api.get<RuntimeSkillsResponse>("/runtime/skills");
   if (!res) {
     if (cached) return cache; // server flaky; keep what we have

--- a/packages/daemon/src/start.ts
+++ b/packages/daemon/src/start.ts
@@ -3,16 +3,25 @@
  * Holds the process until SIGINT/SIGTERM.
  */
 
+import { join } from "node:path";
 import { LocalWorkspaceManager } from "@beevibe/core/adapters/local-workspace";
 import { createDefaultRuntimeRegistry } from "@beevibe/core/adapters/runtime-registry";
 import { ApiClient } from "./api-client.js";
 import { Claimer } from "./claimer.js";
-import { loadConfig } from "./config.js";
+import { getConfigRoot, loadConfig } from "./config.js";
 import { syncSkillsCache } from "./skills-cache.js";
 import { Supervisor } from "./supervisor.js";
 
-export async function runStart(): Promise<void> {
-  const cfg = loadConfig();
+export interface StartOptions {
+  /**
+   * Dev-only override for `~/.beevibe`. Threaded down from the
+   * `--config-root` flag in main.ts. Unset for normal use.
+   */
+  configRoot?: string;
+}
+
+export async function runStart(options: StartOptions = {}): Promise<void> {
+  const cfg = loadConfig(options.configRoot);
   if (!cfg) {
     throw new Error(
       "No daemon config found. Run `beevibe-daemon setup --api <url> --user-token <bv_u_…>` first.",
@@ -24,24 +33,33 @@ export async function runStart(): Promise<void> {
     daemonToken: cfg.daemon_token,
   });
 
-  // Pull the latest skills bundle into ~/.beevibe/skills before any
+  // Pull the latest skills bundle into <configRoot>/skills before any
   // workspace sync runs. Per-agent tier filter happens in
   // LocalWorkspaceManager.ensureWorkspace.
-  const skillsSourceDir = await syncSkillsCache(api).catch((err: unknown) => {
-    console.warn(
-      "[daemon] skills sync failed; continuing without skills:",
-      err instanceof Error ? err.message : String(err),
-    );
-    return undefined;
-  });
+  const skillsSourceDir = await syncSkillsCache(api, options.configRoot).catch(
+    (err: unknown) => {
+      console.warn(
+        "[daemon] skills sync failed; continuing without skills:",
+        err instanceof Error ? err.message : String(err),
+      );
+      return undefined;
+    },
+  );
 
+  // With --config-root set, default workspaces to a sibling of the
+  // override so a second daemon's agent workspaces don't collide with
+  // the first's. WORKSPACE_ROOT still wins when set explicitly (CI,
+  // bespoke layouts).
+  const resolvedConfigRoot = getConfigRoot(options.configRoot);
   const runtimeRegistry = createDefaultRuntimeRegistry();
   const workspaceManager = new LocalWorkspaceManager({
     mcpServerUrl: `${cfg.api_url}/mcp`,
     runtimeRegistry,
     skillsSourceDir: skillsSourceDir ?? "/dev/null",
-    // env override lets tests / dev override ~/.beevibe/workspaces.
-    workspaceRoot: process.env.WORKSPACE_ROOT,
+    workspaceRoot:
+      process.env.WORKSPACE_ROOT && process.env.WORKSPACE_ROOT.length > 0
+        ? process.env.WORKSPACE_ROOT
+        : join(resolvedConfigRoot, "workspaces"),
   });
 
   const supervisor = new Supervisor();

--- a/packages/daemon/src/start.ts
+++ b/packages/daemon/src/start.ts
@@ -13,10 +13,7 @@ import { syncSkillsCache } from "./skills-cache.js";
 import { Supervisor } from "./supervisor.js";
 
 export interface StartOptions {
-  /**
-   * Dev-only override for `~/.beevibe`. Threaded down from the
-   * `--config-root` flag in main.ts. Unset for normal use.
-   */
+  /** Dev-only `~/.beevibe` override; see config.ts:getConfigRoot. */
   configRoot?: string;
 }
 
@@ -46,11 +43,8 @@ export async function runStart(options: StartOptions = {}): Promise<void> {
     },
   );
 
-  // With --config-root set, default workspaces to a sibling of the
-  // override so a second daemon's agent workspaces don't collide with
-  // the first's. WORKSPACE_ROOT still wins when set explicitly (CI,
-  // bespoke layouts).
-  const resolvedConfigRoot = getConfigRoot(options.configRoot);
+  // WORKSPACE_ROOT env wins (CI / bespoke layouts); otherwise default
+  // workspaces under the configRoot so a second daemon doesn't collide.
   const runtimeRegistry = createDefaultRuntimeRegistry();
   const workspaceManager = new LocalWorkspaceManager({
     mcpServerUrl: `${cfg.api_url}/mcp`,
@@ -59,7 +53,7 @@ export async function runStart(options: StartOptions = {}): Promise<void> {
     workspaceRoot:
       process.env.WORKSPACE_ROOT && process.env.WORKSPACE_ROOT.length > 0
         ? process.env.WORKSPACE_ROOT
-        : join(resolvedConfigRoot, "workspaces"),
+        : join(getConfigRoot(options.configRoot), "workspaces"),
   });
 
   const supervisor = new Supervisor();

--- a/packages/daemon/src/sync.ts
+++ b/packages/daemon/src/sync.ts
@@ -11,7 +11,7 @@
 
 import { KNOWN_CLIS } from "@beevibe/core";
 import { ApiClient } from "./api-client.js";
-import { loadConfig, saveConfig, CONFIG_PATH, type DaemonConfig } from "./config.js";
+import { getConfigPath, loadConfig, saveConfig, type DaemonConfig } from "./config.js";
 import { detectClis } from "./detect-clis.js";
 
 interface SyncResponse {
@@ -25,11 +25,19 @@ export interface SyncResult {
   runtimes: Array<{ id: string; cli: string }>;
 }
 
-export async function runSync(): Promise<SyncResult> {
-  const config = loadConfig();
+export interface SyncOptions {
+  /**
+   * Dev-only override for `~/.beevibe`. Threaded down from the
+   * `--config-root` flag in main.ts. Unset for normal use.
+   */
+  configRoot?: string;
+}
+
+export async function runSync(options: SyncOptions = {}): Promise<SyncResult> {
+  const config = loadConfig(options.configRoot);
   if (!config) {
     throw new Error(
-      `No daemon config at ${CONFIG_PATH}. Run 'beevibe-daemon setup' first.`,
+      `No daemon config at ${getConfigPath(options.configRoot)}. Run 'beevibe-daemon setup' first.`,
     );
   }
 
@@ -55,7 +63,7 @@ export async function runSync(): Promise<SyncResult> {
   const added = body.runtimes.filter((r) => !before.has(r.cli));
 
   const next: DaemonConfig = { ...config, runtimes: body.runtimes };
-  saveConfig(next);
+  saveConfig(next, options.configRoot);
 
   return { added, runtimes: body.runtimes };
 }

--- a/packages/daemon/src/sync.ts
+++ b/packages/daemon/src/sync.ts
@@ -26,10 +26,7 @@ export interface SyncResult {
 }
 
 export interface SyncOptions {
-  /**
-   * Dev-only override for `~/.beevibe`. Threaded down from the
-   * `--config-root` flag in main.ts. Unset for normal use.
-   */
+  /** Dev-only `~/.beevibe` override; see config.ts:getConfigRoot. */
   configRoot?: string;
 }
 


### PR DESCRIPTION
> **Stacked on #208** — depends on `getConfigRoot()` / `DaemonConfig` from that PR. Do not merge until #208 has merged. Once #208 is in, I'll rebase this onto `main` and the diff will collapse to just the four files this PR actually adds.

## Summary

Adds `beevibe-daemon list` — a read-only subcommand that discovers daemon instances on the local machine and prints one row per instance.

- **Discovery**: filesystem glob of `$HOME/.beevibe*` directories whose `config.json` parses as a `DaemonConfig` (per ranked-preference #1 in the task). No new state file, no api roundtrip, no false positives from unrelated `.beevibe-*` dirs.
- **Output**: aligned-column table by default (no new deps), `--json` flag for scripting.
- **Token handling**: the `bv_d_` token is masked (`bv_d_…<last 4>` — same pattern as Stripe / GitHub) so two daemons are visually distinct without leaking the credential. The full token never appears in any output, JSON or otherwise.
- **`running` column is always `"unknown"` today.** Cross-platform process detection that doesn't false-positive on every `tsx watch` run isn't worth the fragility; the task explicitly authorizes this fallback. Documented in the README as a planned enhancement.
- **Available in every build.** `list` is dispatched before `resolveConfigRoot`, so the `__DEV_BUILD__` gate from #208 doesn't fire for it — useful in prod ("which `bv_d_` am I? what's my daemon_id?").
- **No `--config-root` changes**: this PR adds a new subcommand only; `setup` / `start` / `sync` / `update` semantics are untouched.

## What this looks like

```text
$ beevibe-daemon list
CONFIG ROOT             DAEMON ID    TOKEN         API                    DEVICE          LAST SYNC                  RUNNING
/Users/me/.beevibe      dmn_abc123   bv_d_…wxyz    https://api.beevibe.io  laptop.local    2026-05-26T01:23:45.000Z   unknown
/Users/me/.beevibe-B    dmn_def456   bv_d_…qrst    http://localhost:3000   laptop.local    2026-05-26T01:25:10.000Z   unknown
2 daemons found.

$ beevibe-daemon list --json | python3 -c "import json,sys;print([r['daemon_id'] for r in json.load(sys.stdin)])"
['dmn_abc123', 'dmn_def456']
```

## Scope

| File | LOC | Notes |
|---|---|---|
| `packages/daemon/src/list.ts` | +171 | `discoverDaemons`, `renderList`, `runList`, token masking, schema validation |
| `packages/daemon/src/list.test.ts` | +173 | 14 tests covering empty / single / multi / malformed-JSON / non-beevibe-config / no-config-file / missing-$HOME / token-leak / table format / `--json` shape |
| `packages/daemon/src/main.ts` | +12 / -1 | `list` subcommand dispatch + help text + flag block |
| `packages/daemon/README.md` | +33 / -4 | new `Listing local daemons` section, source-layout table, run-it summary |

**393 net additions, 4 files.** Under the 400-LOC stop-and-report threshold from the task brief.

## Test plan

- [x] `pnpm --filter @beevibe/daemon typecheck` — clean.
- [x] `pnpm --filter @beevibe/daemon test` — **34 passed**, 2 multi-instance e2e skipped (opt-in). +14 new tests in `list.test.ts`.
- [x] `pnpm --filter @beevibe/daemon lint` — 0 errors, only pre-existing `WebSocket import/no-named-as-default` warnings.
- [x] `pnpm --filter @beevibe/daemon build` — clean.
- [x] `pnpm build` (full repo, 6 packages) — clean.
- [x] Smoke against `dist/` against a temp `HOME`:
  - empty case → "No daemons found." / `[]`
  - one daemon → 1 row, footer "1 daemon found."
  - two daemons + malformed third → 2 rows, malformed silently skipped, footer "2 daemons found."
  - `--json` → valid JSON array (verified with `python3 -m json.tool`)
  - token leak check → full `daemon_token` does NOT appear in any output (table or JSON)
- [x] Help text shows `list` and `--json`.

## Links

- Task: `task_SdJmlycnc0hV`
- Parent design doc: `wp_AlvN1hDFWp5C` (Multi-account daemons on one machine — scoping & design), open question #5.
- Dependency: #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)