### PR TITLE
feat(agents): agent templates + CTO Bee (Phase 2a of #211)

### DIFF
--- a/migrations/1781100000000_add-agent-template.sql
+++ b/migrations/1781100000000_add-agent-template.sql
@@ -1,0 +1,13 @@
+-- Agent templates — named, role-shaped agent configurations.
+--
+-- When set, the spawn pipeline pulls the template's system_prompt
+-- addition (via composeSystemPromptAppend) and merges the template's
+-- MCP servers into the workspace's mcp-config.json. The template
+-- itself lives in code at packages/core/src/templates/; the agent
+-- row only stores the name so the lookup stays under git review.
+--
+-- NULL means "no template — operator-tuned ad-hoc agent" (the only
+-- shape that existed before this column). Existing rows stay NULL
+-- and behave exactly as before.
+ALTER TABLE agent
+  ADD COLUMN agent_template TEXT;

--- a/packages/api/src/runtime/router.ts
+++ b/packages/api/src/runtime/router.ts
@@ -29,6 +29,7 @@ import type { MemoryAgent } from "@beevibe/core/services/memory";
 import {
   composeIntent,
   composeSystemPromptAppend,
+  getAgentTemplate,
   teamAgentRoutingDirective,
 } from "@beevibe/core/services/agent-session";
 import { transitionTaskOnClaim } from "@beevibe/core/services/dispatch-service";
@@ -562,6 +563,12 @@ async function composeDispatchPayload(
       ? teamAgentRoutingDirective(subordinates.map((s) => s.name))
       : "";
 
+  // Agent template — when set, pulls a role-shaped system prompt into
+  // composeSystemPromptAppend alongside team routing. Unknown values
+  // (e.g. a template removed from the registry but still on the row)
+  // resolve to null and behave like a plain agent.
+  const template = getAgentTemplate(agent.agent_template);
+
   // Persist briefing snapshot for the session detail page. Awaited (was
   // fire-and-forget) so /runtime/claim can't return before the snapshot
   // lands — eliminates a race where the session detail page would read
@@ -621,6 +628,7 @@ async function composeDispatchPayload(
         sessionKind: isChat ? "chat" : "task",
         appendOnboardingDirectives: isOnboarding,
         extra: teamRouting,
+        templateSystemPrompt: template?.system_prompt,
       },
     ),
     resume_session_id: priorSession?.cli_session_id,

--- a/packages/core/src/adapters/local-workspace/manager.ts
+++ b/packages/core/src/adapters/local-workspace/manager.ts
@@ -5,6 +5,7 @@ import type { Agent } from "../../domain/agent.js";
 import type { RuntimeRegistry, Workspace } from "../../ports/runtime.js";
 import type { WorkspaceManager } from "../../ports/workspace.js";
 import { syncSkills, tierFilterFor } from "../../services/skills/index.js";
+import { getAgentTemplate } from "../../templates/registry.js";
 
 /**
  * Filesystem-backed WorkspaceManager.
@@ -85,7 +86,12 @@ export class LocalWorkspaceManager implements WorkspaceManager {
       );
     }
     const configPath = join(path, "mcp-config.json");
-    const expected = buildMcpConfig(agent.api_key, this.config.mcpServerUrl);
+    const template = getAgentTemplate(agent.agent_template);
+    const expected = buildMcpConfig(
+      agent.api_key,
+      this.config.mcpServerUrl,
+      template?.mcp_servers,
+    );
     // Auto-refresh on drift: previously this was guarded by a bare
     // `existsSync` and a stale URL or rotated bv_a_ would persist until
     // the operator manually rm'd the file (documented but undiscoverable).
@@ -146,8 +152,23 @@ export class LocalWorkspaceManager implements WorkspaceManager {
  * `${BEEVIBE_SESSION_ID}` is a literal placeholder; the Claude CLI
  * interpolates from process env at config parse time, and the spawner
  * sets BEEVIBE_SESSION_ID on the subprocess env.
+ *
+ * `extraMcpServers` carries any agent-template-contributed servers
+ * (e.g. the `adr` server for the CTO Bee). Keys that collide with the
+ * universal `beevibe` slot are ignored — that slot is reserved.
  */
-export function buildMcpConfig(apiKey: string, mcpServerUrl: string): string {
+export function buildMcpConfig(
+  apiKey: string,
+  mcpServerUrl: string,
+  extraMcpServers?: Record<string, unknown>,
+): string {
+  const extras: Record<string, unknown> = {};
+  if (extraMcpServers) {
+    for (const [name, server] of Object.entries(extraMcpServers)) {
+      if (name === "beevibe") continue;
+      extras[name] = server;
+    }
+  }
   return (
     JSON.stringify(
       {
@@ -160,6 +181,7 @@ export function buildMcpConfig(apiKey: string, mcpServerUrl: string): string {
               "X-Beevibe-Session": "${BEEVIBE_SESSION_ID}",
             },
           },
+          ...extras,
         },
       },
       null,

--- a/packages/core/src/adapters/postgres/agent-repo.ts
+++ b/packages/core/src/adapters/postgres/agent-repo.ts
@@ -92,8 +92,8 @@ export class PostgresAgentRepository implements AgentRepository {
          id, name, owner_id, parent_agent_id, hierarchy_level,
          api_key, review_policy, runtime_config,
          max_task_sessions, max_mesh_sessions, max_negotiation_rounds,
-         preferred_runtime_id
-       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+         preferred_runtime_id, agent_template
+       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
        RETURNING *`,
       [
         input.id,
@@ -108,6 +108,7 @@ export class PostgresAgentRepository implements AgentRepository {
         input.max_mesh_sessions ?? null,
         input.max_negotiation_rounds ?? null,
         input.preferred_runtime_id ?? null,
+        input.agent_template ?? null,
       ],
     );
     return rowToAgent(rows[0]!);
@@ -126,6 +127,7 @@ export class PostgresAgentRepository implements AgentRepository {
       max_mesh_sessions: "max_mesh_sessions",
       max_negotiation_rounds: "max_negotiation_rounds",
       preferred_runtime_id: "preferred_runtime_id",
+      agent_template: "agent_template",
       archived_at: "archived_at",
     });
 
@@ -164,6 +166,7 @@ function rowToAgent(row: AgentRow): Agent {
     max_mesh_sessions: row.max_mesh_sessions ?? undefined,
     max_negotiation_rounds: row.max_negotiation_rounds ?? undefined,
     preferred_runtime_id: row.preferred_runtime_id ?? undefined,
+    agent_template: row.agent_template ?? undefined,
     archived_at: row.archived_at ?? undefined,
     created_at: row.created_at,
     updated_at: row.updated_at,

--- a/packages/core/src/adapters/postgres/row-types.ts
+++ b/packages/core/src/adapters/postgres/row-types.ts
@@ -26,6 +26,7 @@ export interface AgentRow {
   max_mesh_sessions: number | null;
   max_negotiation_rounds: number | null;
   preferred_runtime_id: string | null;
+  agent_template: string | null;
   archived_at: Date | null;
   created_at: Date;
   updated_at: Date;

--- a/packages/core/src/domain/agent.ts
+++ b/packages/core/src/domain/agent.ts
@@ -67,6 +67,14 @@ export interface Agent {
   /** Preferred runtime binding; null when no daemon registered for the agent's CLI. */
   preferred_runtime_id?: string;
   /**
+   * Optional template name keyed into {@link import('../templates').getAgentTemplate}.
+   * When set, the spawn pipeline pulls the template's system prompt addition
+   * (via `composeSystemPromptAppend`) and merges the template's MCP servers
+   * into the workspace's mcp-config.json. Stable across operator edits — the
+   * template lives in code, the choice lives in the agent row.
+   */
+  agent_template?: string;
+  /**
    * Soft-archive marker (Phase 9). Agents stay in the DB for mesh
    * history + audit; the web list views and the agent picker hide
    * any agent with archived_at set.

--- a/packages/core/src/services/agent-session.ts
+++ b/packages/core/src/services/agent-session.ts
@@ -23,6 +23,13 @@ export {
   composeSystemPromptAppend,
   teamAgentRoutingDirective,
 } from "./spawn-prep.js";
+export {
+  getAgentTemplate,
+  listAgentTemplates,
+  isKnownAgentTemplate,
+  CTO_BEE_TEMPLATE,
+} from "../templates/index.js";
+export type { AgentTemplate, TemplateMcpServer } from "../templates/types.js";
 
 export interface AgentSessionDeps {
   agentRepo: AgentRepository;

--- a/packages/core/src/services/spawn-prep.ts
+++ b/packages/core/src/services/spawn-prep.ts
@@ -438,6 +438,14 @@ export function composeSystemPromptAppend(
   briefingSystemPromptAppend: string,
   options: {
     /**
+     * Role-shaped prompt addition from the agent's template (when
+     * `agent.agent_template` resolves to a known template). Slotted
+     * just above the per-agent baseline so the static role identity
+     * caches well; operator's `system_prompt_addition` still wins
+     * when it overlaps because it's appended after.
+     */
+    templateSystemPrompt?: string;
+    /**
      * Which session surface is being spawned. Drives both the
      * lifecycle reminder variant AND whether CHAT_DIRECTIVES is
      * appended.
@@ -474,6 +482,7 @@ export function composeSystemPromptAppend(
     BEEVIBE_MEMORY_REMINDER,
     isChatSurface ? CHAT_DIRECTIVES : "",
     options.extra ?? "",
+    options.templateSystemPrompt ?? "",
     agentSystemPromptAddition ?? "",
     briefingSystemPromptAppend,
     options.appendOnboardingDirectives ? ONBOARDING_DIRECTIVES : "",

--- a/packages/core/src/templates/cto-bee.ts
+++ b/packages/core/src/templates/cto-bee.ts
@@ -1,0 +1,84 @@
+import type { AgentTemplate } from "./types.js";
+
+/**
+ * AI CTO Bee — an architecture-aware code reviewer.
+ *
+ * Pairs with the `architecture-deep-research` toolchain (the `adr` MCP
+ * server). The bee uses the team's discovered principles
+ * (`adr_principles`) to review PRs (`adr_review`) and can escalate to
+ * full architecture research (`adr_deep_research`) when a PR introduces
+ * a novel pattern the principles can't cover.
+ *
+ * The bee is hierarchy_level = "team" by default so it can route
+ * substantial deliverables (e.g. "draft a follow-up PR to fix the
+ * violations") to specialist subordinates as they're added. Specialist
+ * routing across the seven lens specialists ships in a follow-up.
+ */
+export const CTO_BEE_TEMPLATE: AgentTemplate = {
+  name: "cto-bee",
+  display_name: "AI CTO",
+  description:
+    "Architecture-aware code reviewer. Discovers your team's principles from the codebase, reviews PRs against them, and escalates novel patterns to deep research.",
+  default_hierarchy_level: "team",
+  system_prompt: `<cto_bee_role>
+You are the AI CTO for this user's codebase. You combine three modes
+of work, all rooted in the team's own principles (not generic best
+practices):
+
+1) **Discover principles.** When the user invokes you on a repo for
+   the first time (or asks to refresh principles), run
+   \`mcp__adr__adr_principles\` with \`mode: "init"\`. This scans the
+   repo, extracts patterns and anti-patterns the team already follows,
+   and writes \`.adr/principles.{json,md,html}\` plus a code-cited
+   product portrait. Open the HTML report for the user when you're
+   done.
+
+2) **Review PRs.** When the user asks "review PR 42" or names a diff,
+   call \`mcp__adr__adr_review\` with the PR number (or diff path /
+   staged). The tool returns ranked violations with file:line
+   citations against the team's principles. Summarize the top 3
+   high-severity issues in chat and offer to post inline comments via
+   \`--post\` if the user wants.
+
+3) **Escalate novel architecture.** When a PR introduces a pattern
+   no principle covers (new persistence layer, new auth flow, new
+   deploy target), recommend running \`mcp__adr__adr_deep_research\`.
+   That fires a multi-hour-equivalent investigation that produces an
+   ADR. Don't fire it automatically — these runs cost real money
+   ($1–5); always confirm with the user first.
+
+**What you DON'T do:**
+- Generic code review. Lint, dead code, style — that's the IDE's
+  job. You only speak when a discovered principle applies.
+- Invent principles. If you don't see one in
+  \`.adr/principles.json\`, you don't have one. Suggest the user
+  run \`adr_principles\` to discover more.
+- Hide the principle id. Every comment you make in chat or on a PR
+  should name the principle by id so the user can trace it to the
+  source code that produced it.
+
+**Cross-repo work.** Each repo has its own principles file. If the
+user switches repos mid-conversation, re-read \`.adr/principles.json\`
+from the new repo before you review anything — never extrapolate one
+repo's rules to another.
+
+**When asked "what do you do?"** — say it plainly:
+> I'm the AI CTO for this codebase. I read your team's own patterns
+> out of the code, then review PRs against them. When a PR does
+> something new the principles don't cover, I can fire a deep
+> research run to draft an ADR.
+
+Do not pitch yourself as a CodeRabbit replacement or generic linter.
+</cto_bee_role>`,
+  mcp_servers: {
+    adr: {
+      type: "stdio",
+      command: "npx",
+      args: [
+        "-y",
+        "--package=github:beevibe-ai/architecture-deep-research",
+        "adr-mcp",
+      ],
+    },
+  },
+};

--- a/packages/core/src/templates/index.ts
+++ b/packages/core/src/templates/index.ts
@@ -1,0 +1,7 @@
+export type { AgentTemplate, TemplateMcpServer } from "./types.js";
+export {
+  getAgentTemplate,
+  listAgentTemplates,
+  isKnownAgentTemplate,
+} from "./registry.js";
+export { CTO_BEE_TEMPLATE } from "./cto-bee.js";

--- a/packages/core/src/templates/registry.ts
+++ b/packages/core/src/templates/registry.ts
@@ -1,0 +1,29 @@
+import { CTO_BEE_TEMPLATE } from "./cto-bee.js";
+import type { AgentTemplate } from "./types.js";
+
+/**
+ * Registered agent templates. Keyed by `AgentTemplate.name` so callers
+ * can look up by the value stored in `agent.agent_template`.
+ *
+ * Adding a template:
+ *   1. Define it in its own file under this dir.
+ *   2. Add it here.
+ *   3. The compose pipeline picks it up automatically — no other call
+ *      sites need to change.
+ */
+const TEMPLATES: Readonly<Record<string, AgentTemplate>> = Object.freeze({
+  [CTO_BEE_TEMPLATE.name]: CTO_BEE_TEMPLATE,
+});
+
+export function getAgentTemplate(name: string | null | undefined): AgentTemplate | null {
+  if (!name) return null;
+  return TEMPLATES[name] ?? null;
+}
+
+export function listAgentTemplates(): readonly AgentTemplate[] {
+  return Object.values(TEMPLATES);
+}
+
+export function isKnownAgentTemplate(name: string | null | undefined): boolean {
+  return getAgentTemplate(name) != null;
+}

--- a/packages/core/src/templates/templates.test.ts
+++ b/packages/core/src/templates/templates.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { composeSystemPromptAppend } from "../services/spawn-prep.js";
+import { buildMcpConfig } from "../adapters/local-workspace/manager.js";
+import {
+  CTO_BEE_TEMPLATE,
+  getAgentTemplate,
+  isKnownAgentTemplate,
+  listAgentTemplates,
+} from "./index.js";
+
+describe("agent template registry", () => {
+  it("resolves cto-bee by name", () => {
+    const t = getAgentTemplate("cto-bee");
+    expect(t).not.toBeNull();
+    expect(t?.name).toBe("cto-bee");
+    expect(t?.display_name).toBe("AI CTO");
+  });
+
+  it("returns null for unknown templates so a stale agent_template row degrades gracefully", () => {
+    expect(getAgentTemplate("ghost-template")).toBeNull();
+    expect(getAgentTemplate(null)).toBeNull();
+    expect(getAgentTemplate(undefined)).toBeNull();
+    expect(getAgentTemplate("")).toBeNull();
+  });
+
+  it("isKnownAgentTemplate matches the registry", () => {
+    expect(isKnownAgentTemplate("cto-bee")).toBe(true);
+    expect(isKnownAgentTemplate("nope")).toBe(false);
+  });
+
+  it("lists every registered template", () => {
+    const names = listAgentTemplates().map((t) => t.name);
+    expect(names).toContain("cto-bee");
+  });
+});
+
+describe("CTO_BEE_TEMPLATE", () => {
+  it("wires the ADR MCP server", () => {
+    expect(CTO_BEE_TEMPLATE.mcp_servers?.adr).toMatchObject({
+      type: "stdio",
+      command: "npx",
+    });
+  });
+
+  it("declares team as the default hierarchy level so specialists can be routed to later", () => {
+    expect(CTO_BEE_TEMPLATE.default_hierarchy_level).toBe("team");
+  });
+
+  it("system prompt names the three modes (discover, review, escalate)", () => {
+    const p = CTO_BEE_TEMPLATE.system_prompt;
+    expect(p).toContain("adr_principles");
+    expect(p).toContain("adr_review");
+    expect(p).toContain("adr_deep_research");
+  });
+});
+
+describe("composeSystemPromptAppend with template", () => {
+  it("injects templateSystemPrompt above the per-agent baseline so per-agent overrides still win", () => {
+    const out = composeSystemPromptAppend("AGENT_BASELINE", "BRIEFING", {
+      sessionKind: "chat",
+      templateSystemPrompt: "TEMPLATE_ROLE_PROMPT",
+    });
+    const templateIdx = out.indexOf("TEMPLATE_ROLE_PROMPT");
+    const baselineIdx = out.indexOf("AGENT_BASELINE");
+    expect(templateIdx).toBeGreaterThan(-1);
+    expect(baselineIdx).toBeGreaterThan(templateIdx);
+  });
+
+  it("is a no-op when templateSystemPrompt is omitted (existing agents unaffected)", () => {
+    const without = composeSystemPromptAppend("BASELINE", "BRIEF", {
+      sessionKind: "task",
+    });
+    expect(without).not.toContain("TEMPLATE_ROLE_PROMPT");
+  });
+});
+
+describe("buildMcpConfig with extra servers", () => {
+  it("merges extras alongside the universal beevibe server", () => {
+    const config = JSON.parse(
+      buildMcpConfig("bv_a_test", "http://localhost:3001", {
+        adr: { type: "stdio", command: "npx", args: ["-y", "adr-mcp"] },
+      }),
+    );
+    expect(Object.keys(config.mcpServers).sort()).toEqual(["adr", "beevibe"]);
+    expect(config.mcpServers.beevibe.url).toBe("http://localhost:3001");
+    expect(config.mcpServers.adr.command).toBe("npx");
+  });
+
+  it("refuses to let a template override the beevibe slot", () => {
+    const config = JSON.parse(
+      buildMcpConfig("bv_a_test", "http://localhost:3001", {
+        beevibe: { type: "stdio", command: "rogue" },
+      }),
+    );
+    expect(config.mcpServers.beevibe.type).toBe("http");
+    expect(config.mcpServers.beevibe.url).toBe("http://localhost:3001");
+  });
+
+  it("matches the old single-arg shape when extras are omitted (backward-compat)", () => {
+    const oldShape = buildMcpConfig("bv_a_x", "http://x");
+    const newShapeNoExtras = buildMcpConfig("bv_a_x", "http://x", undefined);
+    expect(oldShape).toBe(newShapeNoExtras);
+  });
+});

--- a/packages/core/src/templates/types.ts
+++ b/packages/core/src/templates/types.ts
@@ -1,0 +1,63 @@
+/**
+ * Agent templates — named, role-shaped agent configurations.
+ *
+ * The default agent record carries a free-form `runtime_config.system_prompt_addition`
+ * and inherits the universal MCP server (`beevibe`). That's enough for ad-hoc
+ * agents the operator hand-tunes, but it's not enough for agents that have a
+ * defined job — a code reviewer, a research bee, a deploy guard. Those agents
+ * need a stable role identity that survives across operators, plus extra MCP
+ * servers wired in (e.g. the `adr` server for the CTO Bee).
+ *
+ * Templates resolve at spawn time:
+ *   1. `composeSystemPromptAppend` pulls the template's prompt into the
+ *      `extra` slot (alongside team routing) so it caches well.
+ *   2. `buildMcpConfig` merges the template's `mcp_servers` into the
+ *      workspace's mcp-config.json.
+ *
+ * Templates are NOT runtime-dynamic — they live as code in this package so
+ * the prompt + tool surface is reviewable in git. Operators select a
+ * template at agent-create time via `agent.agent_template`.
+ */
+
+/**
+ * Static MCP server entry merged into the workspace's mcp-config.json.
+ * Shape mirrors the existing `beevibe` entry written by `buildMcpConfig`.
+ */
+export type TemplateMcpServer =
+  | {
+      type: "http";
+      url: string;
+      headers?: Record<string, string>;
+    }
+  | {
+      type: "stdio";
+      command: string;
+      args?: readonly string[];
+      env?: Record<string, string>;
+    };
+
+export interface AgentTemplate {
+  /** Stable id used as `agent.agent_template`. kebab-case. */
+  readonly name: string;
+  /** Short label for UI. */
+  readonly display_name: string;
+  /** One-line summary. Surfaced in the agent picker. */
+  readonly description: string;
+  /**
+   * Role-shaped system prompt addition. Injected via
+   * `composeSystemPromptAppend`'s `extra` slot — same cache tier as team
+   * routing. Keep it stable; per-session detail belongs in the intent.
+   */
+  readonly system_prompt: string;
+  /**
+   * Extra MCP servers merged into mcp-config.json. The universal `beevibe`
+   * entry is always present and cannot be overridden here.
+   */
+  readonly mcp_servers?: Record<string, TemplateMcpServer>;
+  /**
+   * Default hierarchy level when creating an agent from this template.
+   * The template can be applied to an existing agent of a different
+   * level too — this is just the default suggestion in the UI.
+   */
+  readonly default_hierarchy_level?: "ic" | "team" | "org";
+}


### PR DESCRIPTION
## Summary

- Adds a **named, role-shaped agent primitive** (agent template) to `@beevibe/core`. A template bundles a stable role-identity system prompt, optional extra MCP servers, and a default hierarchy level — three things that previously had no home on the agent record.
- Ships **`cto-bee`** as the first concrete template: an architecture-aware code reviewer that wires the `adr` stdio MCP server and teaches the bee to discover principles, review PRs, and escalate novel patterns to deep research.
- One DB migration: `agent.agent_template TEXT NULL`. Existing agents stay NULL and behave exactly as before.

## What this unlocks

Phase 2a of the AI CTO PR reviewer plan. Once this lands, you can create an agent with `agent_template: \"cto-bee\"`, start a chat with it, and the bee has the right system prompt + the `adr_*` MCP tools wired in. The four leverage primitives Beevibe gives us that CodeRabbit can't replicate (persistent identity, agent runtime, MCP escalation, action surface) all hang off this primitive.

Cuts deferred to follow-ups (filed at issue-creation time):
- Repo-scoped workspace lifecycle / cross-PR memory — #212
- Specialist routing (per-lens subordinate bees) — #213
- \`/cto review <PR#>\` slash command — #214

## How the wiring goes

Three composable layers, all backward-compatible:

1. **Domain.** `agent.agent_template?: string` on the `Agent` interface + the `agent` table.
2. **Prompt.** `composeSystemPromptAppend` accepts a `templateSystemPrompt` slot; `composeDispatchPayload` reads `getAgentTemplate(agent.agent_template)` and threads it through. Slotted above the per-agent baseline so static identity caches well, but operator's `system_prompt_addition` still wins on overlap.
3. **MCP.** `LocalWorkspaceManager.ensureWorkspace` reads the same template and passes its `mcp_servers` to `buildMcpConfig`, which now accepts an optional third arg. Old single-arg callsites produce byte-identical output (verified by test). The universal `beevibe` slot is reserved — templates can't override it.

## Test plan

- [x] 12 new unit tests in `packages/core/src/templates/templates.test.ts` cover the registry, prompt-injection order (template above per-agent baseline), and MCP config merge (including the reserved-slot invariant)
- [x] Full monorepo build clean (`pnpm -r build`)
- [x] Touched-file unit suites green: `spawn-prep.test.ts` (22 tests), `manager.test.ts` (24 tests), new `templates.test.ts` (12 tests)
- [ ] Manual: create an agent with `agent_template: \"cto-bee\"` in dev, start a chat, confirm `mcp__adr__adr_principles` is available
- [ ] Migration applies cleanly against a fresh database

🤖 Generated with [Claude Code](https://claude.com/claude-code)