### PR TITLE
daemon: add ISO 8601 timestamps to logger

### DIFF
--- a/packages/daemon/src/claimer.ts
+++ b/packages/daemon/src/claimer.ts
@@ -15,6 +15,7 @@ import WebSocket from "ws";
 import { RUNTIME_HEARTBEAT_INTERVAL_MS, type RuntimeRegistry } from "@beevibe/core";
 import type { LocalWorkspaceManager } from "@beevibe/core/adapters/local-workspace";
 import type { ApiClient } from "./api-client.js";
+import { error, log, warn } from "./logger.js";
 import type { Supervisor } from "./supervisor.js";
 import { runDispatch, type DispatchPayload } from "./spawner.js";
 
@@ -103,7 +104,7 @@ export class Claimer {
 
     ws.on("open", () => {
       this.wsReconnectAttempts = 0;
-      console.log(
+      log(
         `[daemon] connected: ${this.cfg.runtimeIds.length} runtime(s) subscribed`,
       );
     });
@@ -130,7 +131,7 @@ export class Claimer {
     });
 
     ws.on("error", (err) => {
-      console.warn("[daemon] ws error:", err.message);
+      warn("[daemon] ws error:", err.message);
       // Triggers `close`; reconnect lives there.
     });
   }
@@ -143,7 +144,7 @@ export class Claimer {
       1_000 * Math.pow(2, this.wsReconnectAttempts - 1),
       this.wsReconnectMaxDelayMs,
     );
-    console.warn(`[daemon] ws disconnected; reconnecting in ${delay}ms`);
+    warn(`[daemon] ws disconnected; reconnecting in ${delay}ms`);
     this.wsReconnectTimer = setTimeout(() => {
       this.wsReconnectTimer = undefined;
       this.connectWs();
@@ -157,7 +158,7 @@ export class Claimer {
         runtime_ids: this.cfg.runtimeIds,
       });
     } catch (err) {
-      console.warn(
+      warn(
         "[daemon] heartbeat failed:",
         err instanceof Error ? err.message : String(err),
       );
@@ -186,7 +187,7 @@ export class Claimer {
       try {
         payload = await this.cfg.api.claim<DispatchPayload>(runtimeId);
       } catch (err) {
-        console.warn(
+        warn(
           `[daemon] claim failed for runtime=${runtimeId}:`,
           err instanceof Error ? err.message : String(err),
         );
@@ -196,7 +197,7 @@ export class Claimer {
       // Visibility: every claim shows up in the daemon's stdout. The
       // spawner logs the matching cwd + exit lines so one session id
       // can be grep'd end-to-end.
-      console.log(
+      log(
         `[daemon/claim] sess=${payload.session_id} agent=${payload.agent_id} runtime=${runtimeId}`,
       );
       const ctrl = this.cfg.supervisor.start(payload.session_id);
@@ -210,7 +211,7 @@ export class Claimer {
         ctrl.signal,
       )
         .catch((err: unknown) =>
-          console.error(
+          error(
             `[daemon] dispatch ${payload.session_id} failed:`,
             err instanceof Error ? err.message : String(err),
           ),

--- a/packages/daemon/src/logger.ts
+++ b/packages/daemon/src/logger.ts
@@ -1,0 +1,11 @@
+export function log(...args: unknown[]): void {
+  console.log(new Date().toISOString(), ...args);
+}
+
+export function warn(...args: unknown[]): void {
+  console.warn(new Date().toISOString(), ...args);
+}
+
+export function error(...args: unknown[]): void {
+  console.error(new Date().toISOString(), ...args);
+}

--- a/packages/daemon/src/main.ts
+++ b/packages/daemon/src/main.ts
@@ -14,6 +14,7 @@
  */
 
 import { CONFIG_ROOT_ENV, getConfigPath, isDevBuild } from "./config.js";
+import { error, log } from "./logger.js";
 import { runSetup } from "./setup.js";
 import { runStart } from "./start.js";
 import { runSync } from "./sync.js";
@@ -67,7 +68,7 @@ function resolveConfigRoot(flag: string | undefined): string | undefined {
 
   if (!isDevBuild()) {
     const source = hasFlag ? "--config-root" : CONFIG_ROOT_ENV;
-    console.error(
+    error(
       `${source} is a dev-only knob and is not available in this build. ` +
         `Reinstall via npm/curl without the override, or use a source checkout ` +
         `(pnpm dev) if you need multi-instance.`,
@@ -79,7 +80,7 @@ function resolveConfigRoot(flag: string | undefined): string | undefined {
 }
 
 function printHelp(): void {
-  console.log(
+  log(
     [
       "Usage: beevibe-daemon <command> [flags]",
       "",
@@ -119,7 +120,7 @@ async function main(): Promise<void> {
 
   if (command === "setup") {
     if (!flags.api || !flags.userToken) {
-      console.error("setup requires --api and --user-token");
+      error("setup requires --api and --user-token");
       printHelp();
       process.exit(2);
     }
@@ -130,9 +131,9 @@ async function main(): Promise<void> {
       externalId: flags.externalId,
       configRoot,
     });
-    console.log(`Registered as ${cfg.daemon_id}`);
-    console.log(`Runtimes: ${cfg.runtimes.map((r) => `${r.cli} (${r.id})`).join(", ")}`);
-    console.log(`Config saved to ${getConfigPath(configRoot)}`);
+    log(`Registered as ${cfg.daemon_id}`);
+    log(`Runtimes: ${cfg.runtimes.map((r) => `${r.cli} (${r.id})`).join(", ")}`);
+    log(`Config saved to ${getConfigPath(configRoot)}`);
     return;
   }
 
@@ -144,14 +145,14 @@ async function main(): Promise<void> {
   if (command === "sync") {
     const result = await runSync({ configRoot });
     if (result.added.length === 0) {
-      console.log("No new CLIs detected.");
+      log("No new CLIs detected.");
     } else {
-      console.log(
+      log(
         `Added ${result.added.length} runtime(s): ${result.added
           .map((r) => `${r.cli} (${r.id})`)
           .join(", ")}.`,
       );
-      console.log("Restart the daemon to pick up the new runtime(s).");
+      log("Restart the daemon to pick up the new runtime(s).");
     }
     return;
   }
@@ -162,12 +163,12 @@ async function main(): Promise<void> {
     return;
   }
 
-  console.error(`Unknown command: ${command}`);
+  error(`Unknown command: ${command}`);
   printHelp();
   process.exit(2);
 }
 
 main().catch((err) => {
-  console.error(err instanceof Error ? err.stack ?? err.message : String(err));
+  error(err instanceof Error ? err.stack ?? err.message : String(err));
   process.exit(1);
 });

--- a/packages/daemon/src/repo-runs.ts
+++ b/packages/daemon/src/repo-runs.ts
@@ -16,6 +16,7 @@
 import type { SessionEventKind, TerminalSessionStatus } from "@beevibe/core";
 import { runRepoAgent, type TranscriptEvent } from "@beevibe/sandbox/orchestrator";
 import type { ApiClient } from "./api-client.js";
+import { error, log, warn } from "./logger.js";
 import type { DispatchPayload, RunRepoArtifact } from "./spawner.js";
 
 export interface RunRepoDeps {
@@ -41,7 +42,7 @@ export async function runRepoDispatch(
     throw new Error("run_repo dispatch missing payload.run_repo");
   }
 
-  console.log(
+  log(
     `[daemon/repo-run] sess=${payload.session_id} repo_run=${rr.repo_run_id} repo=${rr.repo_url}`,
   );
 
@@ -61,7 +62,7 @@ export async function runRepoDispatch(
     try {
       await deps.api.post("/runtime/events", { events });
     } catch (err) {
-      console.warn(
+      warn(
         "[daemon/repo-run] /runtime/events POST failed:",
         err instanceof Error ? err.message : String(err),
       );
@@ -183,11 +184,11 @@ export async function runRepoDispatch(
   };
 
   if (status === "succeeded") {
-    console.log(
+    log(
       `[daemon/repo-run] sess=${payload.session_id} succeeded artifacts=${artifacts.length}`,
     );
   } else {
-    console.error(
+    error(
       `[daemon/repo-run] sess=${payload.session_id} status=${status}` +
         (result.error ? `\n  error:\n    ${result.error.split("\n").join("\n    ")}` : ""),
     );
@@ -196,7 +197,7 @@ export async function runRepoDispatch(
   try {
     await deps.api.post("/runtime/done", done);
   } catch (err) {
-    console.error(
+    error(
       "[daemon/repo-run] /runtime/done POST failed:",
       err instanceof Error ? err.message : String(err),
     );

--- a/packages/daemon/src/spawner.ts
+++ b/packages/daemon/src/spawner.ts
@@ -23,6 +23,7 @@ import type {
 } from "@beevibe/core";
 import type { LocalWorkspaceManager } from "@beevibe/core/adapters/local-workspace";
 import type { ApiClient } from "./api-client.js";
+import { error, log, warn } from "./logger.js";
 import { runRepoDispatch } from "./repo-runs.js";
 
 export interface DispatchPayload {
@@ -113,7 +114,7 @@ export async function runDispatch(
   // One log line per spawn, same `sess=` token as claimer.ts and the
   // exit line below, so one session id grep'd from a daemon log shows
   // the full lifecycle.
-  console.log(
+  log(
     `[daemon/spawn] sess=${payload.session_id} agent=${payload.agent_id} runtime=${payload.runtime_type} type=${payload.type} cwd=${ws.path}`,
   );
 
@@ -141,7 +142,7 @@ export async function runDispatch(
     try {
       await deps.api.post("/runtime/events", { events });
     } catch (err) {
-      console.warn(
+      warn(
         "[daemon/spawner] /runtime/events POST failed; events dropped:",
         err instanceof Error ? err.message : String(err),
       );
@@ -224,9 +225,9 @@ export async function runDispatch(
   };
 
   if (status === "succeeded") {
-    console.log(`[daemon/spawn] sess=${payload.session_id} exit=0`);
+    log(`[daemon/spawn] sess=${payload.session_id} exit=0`);
   } else {
-    console.error(
+    error(
       `[daemon/spawn] sess=${payload.session_id} status=${status} exit=${done.exit_code}` +
         (errorDetail ? `\n  error:\n    ${errorDetail.split("\n").join("\n    ")}` : ""),
     );
@@ -235,7 +236,7 @@ export async function runDispatch(
   try {
     await deps.api.post("/runtime/done", done);
   } catch (err) {
-    console.error(
+    error(
       "[daemon/spawner] /runtime/done POST failed:",
       err instanceof Error ? err.message : String(err),
     );

--- a/packages/daemon/src/start.ts
+++ b/packages/daemon/src/start.ts
@@ -9,6 +9,7 @@ import { createDefaultRuntimeRegistry } from "@beevibe/core/adapters/runtime-reg
 import { ApiClient } from "./api-client.js";
 import { Claimer } from "./claimer.js";
 import { getConfigRoot, loadConfig } from "./config.js";
+import { log, warn } from "./logger.js";
 import { syncSkillsCache } from "./skills-cache.js";
 import { Supervisor } from "./supervisor.js";
 
@@ -35,7 +36,7 @@ export async function runStart(options: StartOptions = {}): Promise<void> {
   // LocalWorkspaceManager.ensureWorkspace.
   const skillsSourceDir = await syncSkillsCache(api, options.configRoot).catch(
     (err: unknown) => {
-      console.warn(
+      warn(
         "[daemon] skills sync failed; continuing without skills:",
         err instanceof Error ? err.message : String(err),
       );
@@ -65,7 +66,7 @@ export async function runStart(options: StartOptions = {}): Promise<void> {
     runtimeIds: cfg.runtimes.map((r) => r.id),
   });
   claimer.start();
-  console.log(
+  log(
     `[daemon] started (${cfg.daemon_id} → ${cfg.api_url}, ${cfg.runtimes.length} runtime(s))`,
   );
 
@@ -73,7 +74,7 @@ export async function runStart(options: StartOptions = {}): Promise<void> {
   const stop = async (signal: string): Promise<void> => {
     if (stopped) return;
     stopped = true;
-    console.log(`[daemon] received ${signal}; stopping`);
+    log(`[daemon] received ${signal}; stopping`);
     await claimer.stop();
     process.exit(0);
   };
@@ -86,7 +87,7 @@ export async function runStart(options: StartOptions = {}): Promise<void> {
   // self-healing, so logging and continuing is the right behavior under
   // Node 20+'s default `--unhandled-rejections=throw`.
   process.on("unhandledRejection", (reason) => {
-    console.warn(
+    warn(
       "[daemon] unhandledRejection (continuing):",
       reason instanceof Error ? reason.message : String(reason),
     );

--- a/packages/daemon/src/update.ts
+++ b/packages/daemon/src/update.ts
@@ -27,6 +27,7 @@ import { join } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { createInterface } from "node:readline/promises";
+import { error, log } from "./logger.js";
 
 // Baked in by `bun build --compile --define BEEVIBE_DAEMON_VERSION="…"`
 // when produced by scripts/build-binaries.sh. The `typeof` guard below is
@@ -152,48 +153,48 @@ async function promptYesNo(question: string): Promise<boolean> {
 export async function runUpdate(opts: { skipPrompt?: boolean } = {}): Promise<void> {
   const current = currentVersion();
   if (!current) {
-    console.log("Could not determine current daemon version.");
-    console.log("If you installed via npm:  npm update -g @beevibe/daemon");
-    console.log("If you installed from source: git pull && pnpm install && pnpm build");
+    log("Could not determine current daemon version.");
+    log("If you installed via npm:  npm update -g @beevibe/daemon");
+    log("If you installed from source: git pull && pnpm install && pnpm build");
     process.exit(2);
   }
 
   if (!isCompiledBinary()) {
-    console.log(`Current version: ${current}`);
-    console.log("This binary was not produced by the standalone build path.");
-    console.log("If you installed via npm:  npm update -g @beevibe/daemon");
-    console.log("If you installed from source: git pull && pnpm install && pnpm build");
+    log(`Current version: ${current}`);
+    log("This binary was not produced by the standalone build path.");
+    log("If you installed via npm:  npm update -g @beevibe/daemon");
+    log("If you installed from source: git pull && pnpm install && pnpm build");
     return;
   }
 
   const asset = platformAsset();
   if (!asset) {
-    console.error(`Unsupported platform: ${process.platform}/${process.arch}`);
-    console.error("Pre-built binaries are only published for darwin-arm64, darwin-x64, linux-x64, linux-arm64.");
+    error(`Unsupported platform: ${process.platform}/${process.arch}`);
+    error("Pre-built binaries are only published for darwin-arm64, darwin-x64, linux-x64, linux-arm64.");
     process.exit(2);
   }
 
-  console.log(`Current version: ${current}`);
-  console.log("Checking for updates…");
+  log(`Current version: ${current}`);
+  log("Checking for updates…");
 
   const release = await fetchLatestRelease();
   if (!release) {
-    console.log("No releases published yet — nothing to update to.");
+    log("No releases published yet — nothing to update to.");
     return;
   }
   const latest = release.tag_name;
-  console.log(`Latest version: ${latest}`);
+  log(`Latest version: ${latest}`);
 
   if (compareSemver(current, latest) >= 0) {
-    console.log("Already on the latest version.");
+    log("Already on the latest version.");
     return;
   }
 
-  console.log(`Update available: ${current} → ${latest}`);
+  log(`Update available: ${current} → ${latest}`);
   if (!opts.skipPrompt) {
     const proceed = await promptYesNo("Install this update now?");
     if (!proceed) {
-      console.log("Update cancelled.");
+      log("Update cancelled.");
       return;
     }
   }
@@ -201,7 +202,7 @@ export async function runUpdate(opts: { skipPrompt?: boolean } = {}): Promise<vo
   const stagingDir = mkdtempSync(join(tmpdir(), "beevibe-daemon-update-"));
   const stagingPath = join(stagingDir, asset);
   try {
-    console.log(`Downloading ${asset}…`);
+    log(`Downloading ${asset}…`);
     const downloadUrl = `${DOWNLOAD_BASE}/${latest}/${asset}`;
     const [actualSha, expectedSha] = await Promise.all([
       downloadAndHash(downloadUrl, stagingPath),
@@ -209,9 +210,9 @@ export async function runUpdate(opts: { skipPrompt?: boolean } = {}): Promise<vo
     ]);
 
     if (actualSha !== expectedSha) {
-      console.error(`Checksum mismatch — refusing to install.`);
-      console.error(`  expected: ${expectedSha}`);
-      console.error(`  actual:   ${actualSha}`);
+      error(`Checksum mismatch — refusing to install.`);
+      error(`  expected: ${expectedSha}`);
+      error(`  actual:   ${actualSha}`);
       process.exit(3);
     }
 
@@ -220,14 +221,14 @@ export async function runUpdate(opts: { skipPrompt?: boolean } = {}): Promise<vo
       renameSync(stagingPath, process.execPath);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      console.error(`Failed to replace ${process.execPath}: ${msg}`);
-      console.error(`The new binary is at ${stagingPath} — install manually if needed.`);
+      error(`Failed to replace ${process.execPath}: ${msg}`);
+      error(`The new binary is at ${stagingPath} — install manually if needed.`);
       // Don't clean up the stagingDir if we leave the new binary behind
       // for manual install.
       return;
     }
 
-    console.log(`Updated to ${latest}. Restart the daemon to pick up the new binary.`);
+    log(`Updated to ${latest}. Restart the daemon to pick up the new binary.`);
   } finally {
     rmSync(stagingDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- Adds a tiny `packages/daemon/src/logger.ts` wrapper (`log` / `warn` / `error`) that prepends `new Date().toISOString()` to the existing `console.{log,warn,error}` args.
- Replaces all 55 `console.*` call sites under `packages/daemon/src/` (excluding `*.test.ts`) with the wrapper. Touched: `main.ts`, `claimer.ts`, `spawner.ts`, `start.ts`, `repo-runs.ts`, `update.ts`.
- Existing `[daemon]` / `[daemon/spawn]` / `[daemon/claim]` / `[daemon/repo-run]` prefixes stay in the args; the wrapper just prepends the timestamp.

## Why
Tail/grep across long-running daemon sessions is painful when every line is timestamp-free. ISO 8601 prefixes make `tail -f /tmp/beevibe-daemon.log | grep sess=abc` line up with claimer / spawner / done events in real time.

## Scope notes
- Daemon ONLY. The same gap exists in `packages/api/` and `packages/scheduler/` — explicitly out of scope here per the task spec (user opted out of a wider sweep).
- Test files left alone on purpose: vitest captures stdout/stderr and the existing tests assert on un-timestamped lines, so wrapping them would require test changes for no real benefit.
- No log-level, env-var gating, JSON output, or other features — pure timestamp prefix, 11 LOC of wrapper.
- `warn` / `error` keep going to stderr (the wrapper calls `console.warn` / `console.error` under the hood).

## Test plan
- [x] `pnpm --filter @beevibe/daemon build` — clean.
- [x] `pnpm --filter @beevibe/daemon test` — 20 passed / 2 skipped (existing suites: claimer, spawner, supervisor, config; e2e skipped as usual).
- [x] `rg "console\.(log|warn|error)" packages/daemon/src --type ts -g '!*.test.ts'` returns zero matches (the wrapper itself is the only producer).
- [ ] CI green on the PR (DCO + lint + workspace build/test).

Sample line shape after this change:
```
2026-05-28T17:59:24.203Z [daemon/spawn] sess=sess_123 agent=agent_123 runtime=opencode type=task cwd=/tmp/ws-opencode
```