### PR TITLE
fix(team-agent): respond-variant lifecycle + verify-before-acting on delegated work

### DIFF
--- a/packages/core/src/services/agent-session.test.ts
+++ b/packages/core/src/services/agent-session.test.ts
@@ -182,6 +182,49 @@ describe("AgentSession.run", () => {
     expect(out.status).toBe("succeeded");
   });
 
+  it.each([
+    ["mesh_ask" as const, "respond_ask"],
+    ["mesh_negotiate" as const, "respond_negotiate"],
+    ["blocker" as const, "revise_task"],
+  ])(
+    "%s session gets the respond lifecycle (NO update_progress imperative)",
+    async (type, terminalTool) => {
+      // Pre-fix bug: mesh sessions inherited BEEVIBE_LIFECYCLE_REMINDER_TASK
+      // and were told "Before exiting any task session, you MUST call
+      // mcp__beevibe__update_progress." On exit, with no own-task, they
+      // grabbed the caller's task_id from the intent and clobbered the
+      // caller's task state (most painful: a parent's blocker session
+      // calling update_progress(child_task, "done") right after
+      // revise_task, silently reverting needs_revision).
+      //
+      // Fix: route mesh_ask / mesh_negotiate / blocker → respond
+      // variant, which explicitly says "DO NOT call update_progress"
+      // and names the right terminal tool per shape.
+      vi.mocked(agentRepo.findById).mockResolvedValue(makeAgent());
+      vi.mocked(sessionRepo.create).mockImplementation(async (i) => makeSession(i.id));
+      vi.mocked(memoryAgent.prepareBriefing).mockResolvedValue({
+        systemPromptAppend: "",
+        userMessagePrefix: "",
+        snapshot: { block_count: 0, fact_count: 0, token_count: 0, blocks: [], facts: [] },
+      });
+      vi.mocked(runtime.execute).mockResolvedValue(makeRuntimeResult());
+      vi.mocked(sessionRepo.update).mockImplementation(async (id) => makeSession(id));
+
+      await service.run({
+        agentId: "agent_1",
+        intent: "<mesh-blocker task_id=\"task_X\">…</mesh-blocker>",
+        workspace: WORKSPACE,
+        type,
+      });
+
+      const append = vi.mocked(runtime.execute).mock.calls[0]![0].system_prompt_append;
+      expect(append).toContain("DO NOT call mcp__beevibe__update_progress");
+      expect(append).toContain(terminalTool);
+      // Negative: must not carry the task-only "MUST call update_progress" imperative.
+      expect(append).not.toMatch(/MUST call mcp__beevibe__update_progress/);
+    },
+  );
+
   it("creates the session row BEFORE calling runtime.execute (so onSpawn has an id)", async () => {
     const createdIds: string[] = [];
     vi.mocked(agentRepo.findById).mockResolvedValue(makeAgent());

--- a/packages/core/src/services/agent-session.ts
+++ b/packages/core/src/services/agent-session.ts
@@ -11,7 +11,11 @@ import type {
 import type { SessionEventRepository } from "../ports/session-event-repo.js";
 import type { SessionRepository } from "../ports/session-repo.js";
 import type { MemoryAgent } from "./memory/memory-agent.js";
-import { composeIntent, composeSystemPromptAppend } from "./spawn-prep.js";
+import {
+  composeIntent,
+  composeSystemPromptAppend,
+  type SessionSurfaceKind,
+} from "./spawn-prep.js";
 
 export {
   BEEVIBE_LIFECYCLE_REMINDER_TASK,
@@ -163,10 +167,32 @@ export class AgentSession {
         (err as Error).message,
       );
     }
+    // Lifecycle reminder routing mirrors the session.type written at
+    // row insert (line 138 above). Mesh responders (mesh_ask /
+    // mesh_negotiate / blocker) have no own-task and must NOT call
+    // update_progress on the caller's task — see
+    // BEEVIBE_LIFECYCLE_REMINDER_RESPOND. Pre-this-routing they fell
+    // through to the task reminder and routinely clobbered the
+    // caller's task state.
+    const sessionType: SessionType =
+      input.type ?? (input.taskId ? "task" : "chat");
+    const sessionKind: SessionSurfaceKind =
+      sessionType === "mesh_ask" ||
+      sessionType === "mesh_negotiate" ||
+      sessionType === "blocker"
+        ? "respond"
+        : sessionType === "chat"
+          ? "chat"
+          : "task";
     const system_prompt_append = composeSystemPromptAppend(
       agent.runtime_config.system_prompt_addition,
       briefing.systemPromptAppend,
-      input.extraSystemPromptAppend ? { extra: input.extraSystemPromptAppend } : {},
+      {
+        sessionKind,
+        ...(input.extraSystemPromptAppend
+          ? { extra: input.extraSystemPromptAppend }
+          : {}),
+      },
     );
     const intent = composeIntent(input.intent, briefing.userMessagePrefix);
 

--- a/packages/core/src/services/agent-session.ts
+++ b/packages/core/src/services/agent-session.ts
@@ -98,6 +98,35 @@ export interface AgentSessionRunInput {
 }
 
 /**
+ * Resolve the session.type to write at row insert AND to feed into the
+ * lifecycle-reminder router. Defaults: if no explicit type, `task` when
+ * a taskId is set, else `chat` — matches the legacy fallback.
+ */
+function deriveSessionType(
+  input: Pick<AgentSessionRunInput, "type" | "taskId">,
+): SessionType {
+  return input.type ?? (input.taskId ? "task" : "chat");
+}
+
+/**
+ * SessionType → SessionSurfaceKind. Lookup table (vs ternary) so TS
+ * flags any missing case when SessionType grows. Mesh responder shapes
+ * (mesh_ask / mesh_negotiate / blocker) route to `respond` — they have
+ * no own-task and must NOT receive the task lifecycle's "always call
+ * update_progress" imperative. `run_repo` never reaches this path in
+ * practice (sandbox orchestrator uses its own hardcoded prompt), but
+ * defensively maps to `respond` since the child also has no own-task.
+ */
+const SESSION_KIND_BY_TYPE: Record<SessionType, SessionSurfaceKind> = {
+  task: "task",
+  chat: "chat",
+  mesh_ask: "respond",
+  mesh_negotiate: "respond",
+  blocker: "respond",
+  run_repo: "respond",
+};
+
+/**
  * Orchestrates one CLI invocation end-to-end:
  *
  * 1. Load the agent (agent.runtime_config.system_prompt_addition is the
@@ -139,7 +168,7 @@ export class AgentSession {
         agent_id: input.agentId,
         task_id: input.taskId,
         prior_session_id: input.priorSessionId,
-        type: input.type ?? (input.taskId ? "task" : "chat"),
+        type: deriveSessionType(input),
         intent: input.intent,
         // Inline mesh / chat paths spawn the CLI immediately, so this row
         // skips the 'pending' state entirely. Required now that the DB
@@ -167,23 +196,10 @@ export class AgentSession {
         (err as Error).message,
       );
     }
-    // Lifecycle reminder routing mirrors the session.type written at
-    // row insert (line 138 above). Mesh responders (mesh_ask /
-    // mesh_negotiate / blocker) have no own-task and must NOT call
-    // update_progress on the caller's task — see
+    // Route mesh responders (no own-task) to the respond variant — see
     // BEEVIBE_LIFECYCLE_REMINDER_RESPOND. Pre-this-routing they fell
-    // through to the task reminder and routinely clobbered the
-    // caller's task state.
-    const sessionType: SessionType =
-      input.type ?? (input.taskId ? "task" : "chat");
-    const sessionKind: SessionSurfaceKind =
-      sessionType === "mesh_ask" ||
-      sessionType === "mesh_negotiate" ||
-      sessionType === "blocker"
-        ? "respond"
-        : sessionType === "chat"
-          ? "chat"
-          : "task";
+    // through to the task reminder and clobbered the caller's task.
+    const sessionKind = SESSION_KIND_BY_TYPE[deriveSessionType(input)];
     const system_prompt_append = composeSystemPromptAppend(
       agent.runtime_config.system_prompt_addition,
       briefing.systemPromptAppend,

--- a/packages/core/src/services/spawn-prep.test.ts
+++ b/packages/core/src/services/spawn-prep.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   BEEVIBE_LIFECYCLE_REMINDER_CHAT,
+  BEEVIBE_LIFECYCLE_REMINDER_RESPOND,
   BEEVIBE_LIFECYCLE_REMINDER_TASK,
   CHAT_DIRECTIVES,
   composeSystemPromptAppend,
@@ -68,6 +69,32 @@ describe("teamAgentRoutingDirective", () => {
     expect(out).toContain("mcp__beevibe__check_work_status");
     expect(out).toContain("mcp__beevibe__get_task");
     expect(out.toLowerCase()).toContain("never infer");
+  });
+
+  it("requires verifying work products before re-dispatching delegated work", () => {
+    // Failure mode: team agent re-dispatches a previously-delegated
+    // task believing "they hadn't started" without checking the
+    // subordinate's actual deliverables. Result: duplicate PRs /
+    // documents / artifacts for the same task. The fix is mandatory
+    // verification via list_work_products + get_work_product before
+    // any create_task that re-does prior work.
+    const out = teamAgentRoutingDirective(["frontend"]);
+    expect(out).toContain("Verify before acting on delegated work");
+    expect(out).toContain("mcp__beevibe__list_work_products");
+    expect(out).toContain("mcp__beevibe__get_work_product");
+    expect(out.toLowerCase()).toContain("requires evidence");
+  });
+
+  it("verification directive is generic across deliverable types (not engineering-only)", () => {
+    // Earlier draft was scoped to `gh pr list` which only catches the
+    // PR case. The current directive must enumerate the work-product
+    // type space so document/analysis/design/artifact deliveries get
+    // the same protection from duplicate re-dispatch.
+    const out = teamAgentRoutingDirective(["frontend"]).toLowerCase();
+    expect(out).not.toContain("gh pr list");
+    for (const t of ["document", "analysis", "design", "artifact"]) {
+      expect(out).toContain(t);
+    }
   });
 });
 
@@ -195,6 +222,45 @@ describe("composeSystemPromptAppend lifecycle branching", () => {
     expect(out).not.toContain(BEEVIBE_LIFECYCLE_REMINDER_TASK);
   });
 
+  it("uses the respond variant when sessionKind is 'respond'", () => {
+    // Mesh responders (mesh_ask / mesh_negotiate / blocker) have no
+    // own-task and must not be told "always call update_progress."
+    // Pre-fix they fell through to the task reminder and clobbered
+    // the caller's task state on exit.
+    const out = composeSystemPromptAppend(undefined, "<core_memory/>", {
+      sessionKind: "respond",
+    });
+    expect(out).toContain(BEEVIBE_LIFECYCLE_REMINDER_RESPOND);
+    expect(out).not.toContain(BEEVIBE_LIFECYCLE_REMINDER_TASK);
+    expect(out).not.toContain(BEEVIBE_LIFECYCLE_REMINDER_CHAT);
+  });
+
+  it("respond variant explicitly bans update_progress (the cross-task clobber)", () => {
+    // Load-bearing: this is exactly the rule that prevents a parent
+    // agent's blocker session from calling update_progress(child_task,
+    // "done") and reverting the needs_revision state revise_task just
+    // set. Removing this language re-opens the bug.
+    expect(BEEVIBE_LIFECYCLE_REMINDER_RESPOND).toMatch(
+      /DO NOT call mcp__beevibe__update_progress/,
+    );
+    expect(BEEVIBE_LIFECYCLE_REMINDER_RESPOND.toLowerCase()).toContain(
+      "no task of your own",
+    );
+  });
+
+  it("respond variant names the three mesh shapes + their terminal action", () => {
+    // The agent needs to know which tool closes its session for each
+    // intent shape — otherwise it falls back to inventing one (the
+    // bug attractor). Each shape → exactly one terminal tool.
+    expect(BEEVIBE_LIFECYCLE_REMINDER_RESPOND).toContain("mesh-ask");
+    expect(BEEVIBE_LIFECYCLE_REMINDER_RESPOND).toContain("respond_ask");
+    expect(BEEVIBE_LIFECYCLE_REMINDER_RESPOND).toContain("mesh-negotiate");
+    expect(BEEVIBE_LIFECYCLE_REMINDER_RESPOND).toContain("respond_negotiate");
+    expect(BEEVIBE_LIFECYCLE_REMINDER_RESPOND).toContain("mesh-blocker");
+    expect(BEEVIBE_LIFECYCLE_REMINDER_RESPOND).toContain("revise_task");
+    expect(BEEVIBE_LIFECYCLE_REMINDER_RESPOND).toContain("escalate_to_humans");
+  });
+
   it("task variant carries the task-tracking directives", () => {
     // Load-bearing task directives the variant must keep.
     expect(BEEVIBE_LIFECYCLE_REMINDER_TASK).toContain("update_progress");
@@ -256,13 +322,17 @@ describe("composeSystemPromptAppend lifecycle branching", () => {
     expect(CHAT_DIRECTIVES.toUpperCase()).toContain("BANNED");
   });
 
-  it("both variants share the outer <beevibe_lifecycle> tag so downstream parsing is stable", () => {
+  it("all variants share the outer <beevibe_lifecycle> tag so downstream parsing is stable", () => {
     // Anything parsing system-prompt sections by tag (telemetry,
     // future skill discovery, etc.) shouldn't have to branch on
     // variant — only the body changes.
-    expect(BEEVIBE_LIFECYCLE_REMINDER_TASK.startsWith("<beevibe_lifecycle>")).toBe(true);
-    expect(BEEVIBE_LIFECYCLE_REMINDER_TASK.trimEnd().endsWith("</beevibe_lifecycle>")).toBe(true);
-    expect(BEEVIBE_LIFECYCLE_REMINDER_CHAT.startsWith("<beevibe_lifecycle>")).toBe(true);
-    expect(BEEVIBE_LIFECYCLE_REMINDER_CHAT.trimEnd().endsWith("</beevibe_lifecycle>")).toBe(true);
+    for (const variant of [
+      BEEVIBE_LIFECYCLE_REMINDER_TASK,
+      BEEVIBE_LIFECYCLE_REMINDER_CHAT,
+      BEEVIBE_LIFECYCLE_REMINDER_RESPOND,
+    ]) {
+      expect(variant.startsWith("<beevibe_lifecycle>")).toBe(true);
+      expect(variant.trimEnd().endsWith("</beevibe_lifecycle>")).toBe(true);
+    }
   });
 });

--- a/packages/core/src/services/spawn-prep.ts
+++ b/packages/core/src/services/spawn-prep.ts
@@ -503,6 +503,18 @@ function rosterSection(names: readonly string[]): string {
  */
 export type SessionSurfaceKind = "task" | "chat" | "human_mcp" | "respond";
 
+/**
+ * SessionSurfaceKind → lifecycle reminder. `human_mcp` shares the chat
+ * reminder (chat lifecycle, different UI grammar). Lookup-table form so
+ * TS flags missing cases when SessionSurfaceKind grows.
+ */
+const LIFECYCLE_REMINDER_BY_KIND: Record<SessionSurfaceKind, string> = {
+  task: BEEVIBE_LIFECYCLE_REMINDER_TASK,
+  chat: BEEVIBE_LIFECYCLE_REMINDER_CHAT,
+  human_mcp: BEEVIBE_LIFECYCLE_REMINDER_CHAT,
+  respond: BEEVIBE_LIFECYCLE_REMINDER_RESPOND,
+};
+
 export function composeSystemPromptAppend(
   agentSystemPromptAddition: string | undefined,
   briefingSystemPromptAppend: string,
@@ -535,12 +547,7 @@ export function composeSystemPromptAppend(
     extra?: string;
   } = {},
 ): string {
-  const lifecycleReminder =
-    options.sessionKind === "respond"
-      ? BEEVIBE_LIFECYCLE_REMINDER_RESPOND
-      : options.sessionKind === "chat" || options.sessionKind === "human_mcp"
-        ? BEEVIBE_LIFECYCLE_REMINDER_CHAT
-        : BEEVIBE_LIFECYCLE_REMINDER_TASK;
+  const lifecycleReminder = LIFECYCLE_REMINDER_BY_KIND[options.sessionKind ?? "task"];
   // CHAT_DIRECTIVES is the beevibe chat UI grammar — only fires for
   // sessions actually rendered in our chat surface. human_mcp uses
   // chat lifecycle but skips this block.

--- a/packages/core/src/services/spawn-prep.ts
+++ b/packages/core/src/services/spawn-prep.ts
@@ -28,11 +28,13 @@
  * block; the agent is expected to drive the task to a terminal state via
  * `update_progress` and record deliverables as `work_product` rows).
  *
- * Chat sessions get the {@link BEEVIBE_LIFECYCLE_REMINDER_CHAT} variant
- * instead — selected by `composeSystemPromptAppend` based on the
- * `appendChatDirectives` flag. Mesh-ask / blocker-response sessions
- * currently fall through to the task variant; those are still
- * task-anchored (the answering agent is responding inside a task lifecycle).
+ * Chat sessions get {@link BEEVIBE_LIFECYCLE_REMINDER_CHAT}; mesh
+ * sessions (mesh_ask / mesh_negotiate / blocker) get
+ * {@link BEEVIBE_LIFECYCLE_REMINDER_RESPOND}. The "always call
+ * update_progress" rule below is task-only — callers/responders on the
+ * other surfaces have no own-task to close, and applying this rule
+ * there causes cross-task clobbering (the responder reaches for
+ * update_progress reflexively and writes onto the caller's task).
  */
 export const BEEVIBE_LIFECYCLE_REMINDER_TASK = `<beevibe_lifecycle>
 You are a beevibe agent (BEEVIBE_AGENT_ID env identifies you). Critical
@@ -95,6 +97,65 @@ behavioral rules for every task session:
  * cache prefix alongside the task variant; the prefix swap is per-session
  * so neither path pollutes the other's cache.
  */
+/**
+ * Lifecycle reminder for **mesh** sessions where one agent's session is
+ * spawned to respond to another agent's request. Three shapes:
+ *
+ *   - `mesh_ask` — intent has `<mesh-ask request_id=...>`. Contract:
+ *     call `respond_ask(request_id, ...)` exactly once and exit.
+ *   - `mesh_negotiate` — intent has `<mesh-negotiate negotiation_id=...
+ *     round=...>`. Contract: call `respond_negotiate(...)` for this
+ *     round and exit (rounds are managed by the logic layer).
+ *   - `blocker` — intent has `<mesh-blocker task_id=...>` +
+ *     `<context type="blocker_report">`. Contract: investigate, then
+ *     either `revise_task(task_id, feedback)` to unblock the
+ *     subordinate OR `escalate_to_humans`. The `task_id` in
+ *     `<mesh-blocker>` is the subordinate's task — NOT yours.
+ *
+ * Critical: responders have NO task of their own. State transitions on
+ * the referenced task are owned by the logic layer
+ * (`markBlocked` from the subordinate's `report_blocker`,
+ * `reviseTask` from `revise_task`) — responders must NOT call
+ * `update_progress`. Doing so clobbers state set by the logic layer
+ * (e.g., overwrites `needs_revision` with `done` after `revise_task`).
+ */
+export const BEEVIBE_LIFECYCLE_REMINDER_RESPOND = `<beevibe_lifecycle>
+You are a beevibe agent (BEEVIBE_AGENT_ID env identifies you) spawned to
+respond to another agent's request. This session has NO <task id="..."/>
+block in your intent — you have no task of your own to close. Whatever
+task_id appears in your intent (e.g. in <mesh-blocker task_id="…">) is
+the CALLER's task; state transitions on it are owned by the logic
+layer, NOT by you.
+
+1. Your contract is determined by your intent's mesh shape:
+   - <mesh-ask request_id="…"> → call
+     mcp__beevibe__respond_ask(request_id, ...) exactly once, then exit.
+   - <mesh-negotiate negotiation_id="…" round="N"> → call
+     mcp__beevibe__respond_negotiate(...) for this round, then exit
+     (the logic layer manages round transitions; you don't loop here).
+   - <mesh-blocker task_id="X"> → investigate, then either
+     mcp__beevibe__revise_task(task_id="X", feedback="…") to unblock
+     the subordinate OR mcp__beevibe__escalate_to_humans if you can't
+     resolve. Either is terminal; exit after.
+
+2. DO NOT call mcp__beevibe__update_progress in this session. The
+   caller's task state is mutated by the logic layer (markBlocked when
+   the subordinate reported the blocker, reviseTask when you fix it,
+   children-rollup when subtasks settle). Calling update_progress with
+   the task_id from your intent would overwrite that state — the most
+   common misfire is update_progress(caller_task, "done") right after
+   revise_task, which silently reverts the blocked → needs_revision
+   transition that just fired.
+
+3. The "always call update_progress at exit" rule applies to task
+   sessions only. It does not apply here. Exit cleanly after your
+   contract action above.
+
+4. Memory management (see <beevibe_memory>) still applies — durable
+   learnings from the response (e.g., "this subordinate gets blocked
+   on X repeatedly") are worth save_memory.
+</beevibe_lifecycle>`;
+
 export const BEEVIBE_LIFECYCLE_REMINDER_CHAT = `<beevibe_lifecycle>
 You are a beevibe agent (BEEVIBE_AGENT_ID env identifies you) responding
 in a 1:1 chat with the user. This session is conversational — there is
@@ -397,6 +458,13 @@ C) **Propose spawning a specialist** — when the work is substantive single-dom
 **Stop signal:** if you find yourself producing a substantial single-domain deliverable yourself (writing real production code, a full design doc, a finished analysis for one domain), you slipped into lane B without realizing — pull back and route.
 
 **Tracking delegated work:** Before stating the status, progress, or completion of any task you previously delegated, call mcp__beevibe__check_work_status or mcp__beevibe__get_task to confirm current state. Never infer from chat history or memory — task state changes asynchronously while you're not looking, and stale assumptions ("both still running" when one finished) are the most common tracking failure.
+
+**Verify before acting on delegated work:** Before calling mcp__beevibe__create_task to redo work you previously delegated, OR before judging that a previous delegation "didn't start" / "lost no progress" / "needs a fresh attempt," run BOTH:
+
+- mcp__beevibe__list_work_products(task_id) — every deliverable the subordinate already shipped surfaces here regardless of type (PR, document, analysis, design, artifact, preview, …).
+- mcp__beevibe__get_work_product(work_product_id) on any relevant row — read the body, url, and current state to confirm what was delivered and whether it's still usable.
+
+Work products survive task-status changes. A task that was cancelled, failed, or even erroneously marked done CAN still have shipped output. Treat "they hadn't started" as a claim that requires evidence, not a default. Re-dispatching without verifying is how duplicate work products (two PRs for the same task, two reports for the same analysis) get created.
 </team_agent_routing>`;
 }
 
@@ -433,7 +501,7 @@ function rosterSection(names: readonly string[]): string {
  *   6. briefing            — changes per-session (memory blocks update)
  *   7. onboarding          — one-shot, never re-fires (tail slot is fine)
  */
-export type SessionSurfaceKind = "task" | "chat" | "human_mcp";
+export type SessionSurfaceKind = "task" | "chat" | "human_mcp" | "respond";
 
 export function composeSystemPromptAppend(
   agentSystemPromptAddition: string | undefined,
@@ -452,6 +520,11 @@ export function composeSystemPromptAppend(
      *                 task tracking) but NO display tokens — the
      *                 human's local CLI runs in their terminal and
      *                 can't render our chips.
+     *   "respond"   — mesh responder lifecycle: agent was spawned to
+     *                 answer another agent (mesh_ask /
+     *                 mesh_negotiate / blocker). No own-task; exit
+     *                 after the contract action. Do NOT
+     *                 update_progress on the caller's task.
      *
      * Defaults to "task" so existing task-side callers don't need
      * to pass the flag.
@@ -462,11 +535,12 @@ export function composeSystemPromptAppend(
     extra?: string;
   } = {},
 ): string {
-  const usesChatLifecycle =
-    options.sessionKind === "chat" || options.sessionKind === "human_mcp";
-  const lifecycleReminder = usesChatLifecycle
-    ? BEEVIBE_LIFECYCLE_REMINDER_CHAT
-    : BEEVIBE_LIFECYCLE_REMINDER_TASK;
+  const lifecycleReminder =
+    options.sessionKind === "respond"
+      ? BEEVIBE_LIFECYCLE_REMINDER_RESPOND
+      : options.sessionKind === "chat" || options.sessionKind === "human_mcp"
+        ? BEEVIBE_LIFECYCLE_REMINDER_CHAT
+        : BEEVIBE_LIFECYCLE_REMINDER_TASK;
   // CHAT_DIRECTIVES is the beevibe chat UI grammar — only fires for
   // sessions actually rendered in our chat surface. human_mcp uses
   // chat lifecycle but skips this block.


### PR DESCRIPTION
Two prompt-only fixes targeting the team-agent failure modes that produced the duplicate-PRs incident (#209 + #210 implementing the same task).

## Fix 1 — Mesh responders fell through to the task lifecycle reminder

`agent-session.ts` always called `composeSystemPromptAppend` without `sessionKind`, so every spawn (task / chat / mesh_ask / mesh_negotiate / blocker) got `BEEVIBE_LIFECYCLE_REMINDER_TASK` and its *"you MUST call `update_progress` before exiting"* imperative. Responders have no own-task; on exit, the agent reflexively reached for `update_progress`, grabbed the only `task_id` in scope (the caller's), and clobbered the caller's task state. Worst case: a parent's blocker session called `update_progress(child_task, "done")` right after `revise_task`, silently reverting the `blocked → needs_revision` transition the logic layer just set.

### Changes

- New `BEEVIBE_LIFECYCLE_REMINDER_RESPOND` in `spawn-prep.ts`. Explicitly forbids `update_progress`, says *"no task of your own,"* names the terminal tool per intent shape: `respond_ask` for `<mesh-ask>`, `respond_negotiate` for `<mesh-negotiate>`, `revise_task` / `escalate_to_humans` for `<mesh-blocker>`.
- Extend `SessionSurfaceKind` with `"respond"`.
- In `agent-session.ts`, derive `sessionKind` from `session.type` and pass it to `composeSystemPromptAppend`:

  | session.type | sessionKind |
  |---|---|
  | task | task |
  | chat | chat |
  | mesh_ask, mesh_negotiate, blocker | **respond** (new) |

  This also fixes a latent bug: chat sessions were getting the task lifecycle reminder too. Routing now flows correctly for them.

## Fix 2 — Team agent re-dispatches without verifying work products

`teamAgentRoutingDirective` already had a *"Tracking delegated work"* section requiring `check_work_status` / `get_task` before **stating** progress. That rule covered reporting; it didn't cover **acting**. After the previous incident the team agent judged *"they hadn't started"* and called `create_task` to redo the work — without checking that PR #209 was already open from the first agent run. Result: two PRs for the same task.

### Changes

Add a parallel *"Verify before acting on delegated work"* section: before `create_task` for prior-delegated work, call `list_work_products(task_id)` + `get_work_product(id)` on relevant rows. Generic across deliverable types (PR, document, analysis, design, artifact, preview) — not engineering-only.

## Test plan

- [x] `pnpm vitest run src/services/spawn-prep.test.ts src/services/agent-session.test.ts` — 54/54 pass
  - 5 new spawn-prep tests: respond variant routing, banned `update_progress`, all three mesh shapes + terminal tools, verify-before-acting directive present + generic deliverable types, all-variants share `<beevibe_lifecycle>` tag
  - 3 new agent-session tests (`it.each` over mesh_ask / mesh_negotiate / blocker): system_prompt_append contains `"DO NOT call mcp__beevibe__update_progress"` and the right terminal-tool name, does NOT contain the task-only `"MUST call update_progress"`
- [x] `pnpm --filter @beevibe/core build` — clean
- [x] `pnpm --filter @beevibe/api typecheck` — clean (no consumers of the changed types break)

## Flows confirmed by code trace

Verified that mesh callees should never call `update_progress`:

- **mesh_ask**: `MeshServer.respondAsk` (api/src/mesh/server.ts:168) fires the asker's resolver. Caller's blocked promise resolves and caller continues. Callee exits — never touches caller's task.
- **mesh_negotiate**: `respondNegotiate` lifts the round's promise; logic layer handles round transitions and the escalation sentinel.
- **blocker**: `report_blocker` tool handler (api/src/tools/mesh.ts:355) calls `taskService.markBlocked(taskId)` — logic layer sets task=blocked. Parent's blocker session calls `revise_task(taskId, feedback)` → `taskService.reviseTask` sets task=needs_revision and dispatches the revision session. Parent exits — must NOT call `update_progress`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)