### PR TITLE
fix(mcp-config): 10-min per-tool-call timeout across Claude Code + codex

### DIFF
--- a/packages/core/src/adapters/codex/runtime.test.ts
+++ b/packages/core/src/adapters/codex/runtime.test.ts
@@ -156,6 +156,14 @@ describe("CodexRuntime.execute", () => {
     expect(lastOptions!.args).toContain(
       'mcp_servers.beevibe.default_tools_approval_mode="approve"',
     );
+    // Regression: codex's default per-tool-call timeout is shorter than
+    // the api's mesh-resolver wait (5 min for ask/negotiate). Without
+    // this override, the asker sees a premature timeout while the api
+    // is still waiting for the responder. 600s = 10 min, matching the
+    // Claude Code mcp-config.json `timeout` field.
+    expect(lastOptions!.args).toContain(
+      "mcp_servers.beevibe.tool_timeout_sec=600",
+    );
   });
 
   it("strips OPENAI_API_KEY / OPENAI_AUTH_TOKEN from the spawned env to preserve subscription auth", async () => {

--- a/packages/core/src/adapters/codex/runtime.ts
+++ b/packages/core/src/adapters/codex/runtime.ts
@@ -10,6 +10,7 @@ import type {
   Workspace,
 } from "../../ports/runtime.js";
 import { runCliProcess } from "../claude-code/spawn.js";
+import { MCP_TOOL_TIMEOUT_MS } from "../local-workspace/manager.js";
 import {
   extractCodexStepEvents,
   parseCodexEventLine,
@@ -86,6 +87,13 @@ export class CodexRuntime implements AgentRuntime {
         // Workspace-write keeps filesystem safety; this opens MCP only.
         "-c",
         `mcp_servers.beevibe.default_tools_approval_mode=${tomlString("approve")}`,
+        // Match Claude Code's mcp-config.json `timeout` field — see
+        // MCP_TOOL_TIMEOUT_MS doc-comment for why. Codex's TOML key is
+        // `tool_timeout_sec` (seconds, not ms), so convert. Without
+        // this, the asker side gives up before the api's mesh-resolver
+        // (5 min) has a chance to fire.
+        "-c",
+        `mcp_servers.beevibe.tool_timeout_sec=${MCP_TOOL_TIMEOUT_MS / 1000}`,
       );
     }
 

--- a/packages/core/src/adapters/local-workspace/index.ts
+++ b/packages/core/src/adapters/local-workspace/index.ts
@@ -1,2 +1,2 @@
-export { LocalWorkspaceManager, buildMcpConfig } from "./manager.js";
+export { LocalWorkspaceManager, buildMcpConfig, MCP_TOOL_TIMEOUT_MS } from "./manager.js";
 export type { LocalWorkspaceManagerConfig } from "./manager.js";

--- a/packages/core/src/adapters/local-workspace/manager.test.ts
+++ b/packages/core/src/adapters/local-workspace/manager.test.ts
@@ -219,6 +219,24 @@ describe("LocalWorkspaceManager", () => {
       );
     });
 
+    it("declares a 10-minute per-tool timeout to outlast the api's mesh-resolver wait", async () => {
+      // DEFAULT_ASK_TIMEOUT_MS in api/src/mesh/server.ts is 5 min; Claude
+      // Code's MCP client otherwise defaults to ~60-120s for HTTP and
+      // surfaces a premature "timed out" error to the asker. 10 min
+      // covers ask + negotiate rounds plus headroom. Reduce → re-open
+      // the asker-side premature-timeout bug. (Some 2.1.x versions may
+      // ignore this field per anthropics/claude-code#20335 — setting
+      // it has no downside, and is the only path that fixes it when
+      // honored.)
+      const ws = await manager.ensureWorkspace({
+        agent: makeAgent({ id: "agent_to" }),
+      });
+      const parsed = JSON.parse(
+        readFileSync(join(ws.path, "mcp-config.json"), "utf-8"),
+      );
+      expect(parsed.mcpServers.beevibe.timeout).toBe(10 * 60_000);
+    });
+
     it.skipIf(process.platform === "win32")(
       "mcp-config.json is written with mode 0o600 (file contains secrets)",
       async () => {

--- a/packages/core/src/adapters/local-workspace/manager.ts
+++ b/packages/core/src/adapters/local-workspace/manager.ts
@@ -138,6 +138,27 @@ export class LocalWorkspaceManager implements WorkspaceManager {
 }
 
 /**
+ * Per-server tool-call timeout the mcp-config.json declares for the
+ * beevibe HTTP MCP server. Default in Claude Code is ~60-120s, which
+ * is shorter than DEFAULT_ASK_TIMEOUT_MS (5 min) in
+ * `packages/api/src/mesh/server.ts`. Without this override, an agent
+ * calling `ask` waits for the api's resolver but the CLI's MCP client
+ * gives up first and surfaces "timed out after 120 seconds" to the
+ * agent even though the api is still happily waiting for the
+ * responder — and would resolve on a 3-minute answer that nobody is
+ * listening for anymore. 10 minutes covers ASK + NEGOTIATE rounds
+ * plus headroom.
+ *
+ * Known caveat (anthropics/claude-code#20335, #43791, #16837): the
+ * timeout field is reported to be ignored for some HTTP/SSE transport
+ * cases in 2.1.x. Setting it has no downside if ignored; if honored,
+ * it fixes the asker-side premature-timeout. Real fix is a non-
+ * blocking ask protocol (return request_id, poll for status) — this
+ * is a best-effort knob until that lands.
+ */
+const MCP_TOOL_TIMEOUT_MS = 10 * 60_000;
+
+/**
  * The mcp-config.json the spawner writes into each agent's workspace.
  * Exported so the daemon (`@beevibe/daemon`) can produce byte-identical
  * configs — the MCP server's parser sees one shape regardless of which
@@ -155,6 +176,7 @@ export function buildMcpConfig(apiKey: string, mcpServerUrl: string): string {
           beevibe: {
             type: "http",
             url: mcpServerUrl,
+            timeout: MCP_TOOL_TIMEOUT_MS,
             headers: {
               Authorization: `Bearer ${apiKey}`,
               "X-Beevibe-Session": "${BEEVIBE_SESSION_ID}",

--- a/packages/core/src/adapters/local-workspace/manager.ts
+++ b/packages/core/src/adapters/local-workspace/manager.ts
@@ -156,7 +156,7 @@ export class LocalWorkspaceManager implements WorkspaceManager {
  * blocking ask protocol (return request_id, poll for status) — this
  * is a best-effort knob until that lands.
  */
-const MCP_TOOL_TIMEOUT_MS = 10 * 60_000;
+export const MCP_TOOL_TIMEOUT_MS = 10 * 60_000;
 
 /**
  * The mcp-config.json the spawner writes into each agent's workspace.


### PR DESCRIPTION
## Summary

Each agent runtime has its own MCP config schema and its own default per-tool-call timeout — all of them shorter than the api's mesh-resolver wait (5 min for `ask` / `negotiate`). Without overrides, the asker side gives up first and surfaces a premature *"timed out after N seconds"* error to the agent even though the api is still waiting and would resolve on a 3-minute answer that nobody is listening for anymore.

Confirmed live in chat. Fixes both runtimes the daemon currently spawns:

| Runtime | Config | TOML/JSON key | Unit | Default | Fixed here |
|---|---|---|---|---|---|
| Claude Code | `mcp-config.json` (`buildMcpConfig` in `local-workspace/manager.ts`) | `mcpServers.beevibe.timeout` | ms | ~60–120s | ✓ first commit |
| Codex | inline `-c` TOML (`buildGlobalArgs` in `codex/runtime.ts`) | `mcp_servers.beevibe.tool_timeout_sec` | sec | unspecified, < 5 min | ✓ second commit |
| OpenCode | `opencode.json` (`buildOpenCodeConfig`) | `mcp_timeout` (location TBD) | ms | 30000 (!) | **follow-up** |

Both runtimes now write `MCP_TOOL_TIMEOUT_MS = 10 * 60_000` (exported from `local-workspace/manager.ts` so the value lives in one place). Codex divides by 1000 at emit time since its key is in seconds.

## Known caveats

- **Claude Code's `timeout` field may be ignored for HTTP/SSE transport in 2.1.x.** `anthropics/claude-code#20335`, `#43791`, `#16837`. Setting it has no downside when ignored; if honored, it fixes the asker-side premature-timeout.
- **Codex's `tool_timeout_sec`** appears in the binary's strings dump alongside `startup_timeout_sec` — confirmed schema key, but I haven't end-to-end-verified it actually changes timeout behavior with a 3-minute mesh response. Worth real-world testing on the user's machine before declaring victory.
- **OpenCode** has `mcp_timeout: 30000` (default 30s — even tighter than Claude Code) per the binary strings dump, but I'd need the JSON schema to confirm top-level vs per-server placement. Skipped to keep scope contained.

## Real fix (out of scope here)

A non-blocking ask protocol: `ask` returns immediately with a `request_id`, the agent polls `check_ask_status` for the answer. Removes the dependency on every runtime's MCP-client timeout entirely. This is the right structural change; the timeout knobs in this PR are best-effort palliatives until that lands.

## Test plan

- [x] `manager.test.ts` regression — `parsed.mcpServers.beevibe.timeout === 600000`
- [x] `codex/runtime.test.ts` regression — `args` contains `"mcp_servers.beevibe.tool_timeout_sec=600"`
- [x] `pnpm --filter @beevibe/core test src/adapters/local-workspace src/adapters/codex` — 38/38 pass (25 manager + 13 codex)
- [x] `pnpm --filter @beevibe/core build` — clean
- [ ] After merge: pull main into your prod and dev daemons, restart, trigger a 3-minute `ask` flow. Asker should NOT see a premature timeout. If it does for one of the runtimes specifically, the per-runtime issue is upstream and follow-up #3 (polling protocol) is the next move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)