### PR TITLE
feat(chat): persist intermediate steps in conversation history

### DIFF
--- a/packages/api/src/bootstrap.ts
+++ b/packages/api/src/bootstrap.ts
@@ -455,6 +455,7 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
     personRepo,
     runtimeRepo,
     sessionRepo,
+    sessionEventRepo,
     dispatchService,
     chatResolver,
     hub: daemonHub,

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -103,9 +103,14 @@ export interface HistoryStep {
   content: string;
 }
 
-/** Per-session cap on persisted steps attached to a message. */
+/**
+ * Per-session cap × per-event truncation bounds the response. Worst case
+ * is HISTORY_LIMIT/2 agent messages × STEPS_PER_MESSAGE_LIMIT events ×
+ * STEP_CONTENT_TRUNCATE bytes ≈ 2.5 MB; typical step content is far
+ * shorter so real payloads land in the 100–400 KB range. Tune both
+ * together if the chat-history response starts feeling sluggish.
+ */
 const STEPS_PER_MESSAGE_LIMIT = 100;
-/** Per-event content cap in the persisted-step DTO. */
 const STEP_CONTENT_TRUNCATE = 1000;
 
 // Generic 500 — internal error text stays in server logs, indexed by
@@ -565,7 +570,6 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
 
     const truncated = chain.sessions.slice(-Math.ceil(HISTORY_LIMIT / 2)); // each session = 2 messages
     const messages = chainToMessages({ head_id: chain.head_id, sessions: truncated });
-    await attachStepsToMessages(messages, deps.sessionEventRepo);
     const latest = chain.sessions[chain.sessions.length - 1]!;
     // Surface the tail session's id when it's still in flight so the
     // chat UI can resume its "agent is thinking" indicator after a
@@ -585,11 +589,14 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
     // configured CLI is different — the next turn WILL still run on the
     // pinned CLI (correct, because resume needs the original .jsonl),
     // but the user should know why their new runtime isn't being used.
-    const runtimeMismatch = await detectRuntimeMismatch(
-      deps,
-      latest.runtime_id,
-      agent.runtime_config.type,
-    );
+    //
+    // attachStepsToMessages and detectRuntimeMismatch both depend only
+    // on data already in scope (`messages` and `latest.runtime_id`);
+    // run them concurrently to keep the chat-history p50 down.
+    const [, runtimeMismatch] = await Promise.all([
+      attachStepsToMessages(messages, deps.sessionEventRepo),
+      detectRuntimeMismatch(deps, latest.runtime_id, agent.runtime_config.type),
+    ]);
 
     res.json({
       ok: true,

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -30,6 +30,8 @@ import {
   type KnownCli,
   type PersonRepository,
   type RuntimeRepository,
+  type SessionEventKind,
+  type SessionEventRepository,
   type SessionRepository,
 } from "@beevibe/core";
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
@@ -49,6 +51,12 @@ export interface ChatRoutesDeps {
   /** Needed by GET /chat to flag conversations pinned to an old CLI. */
   runtimeRepo: RuntimeRepository;
   sessionRepo: SessionRepository;
+  /**
+   * Used by GET /chat to attach the intermediate-step transcript
+   * (tool calls, reasoning, summaries) to each agent message so the
+   * persisted view matches what the user saw live.
+   */
+  sessionEventRepo: SessionEventRepository;
   /**
    * Phase 4 daemon-first chat path: dispatchService inserts a pending
    * session, the daemon (or executor for null-runtime agents) claims +
@@ -77,7 +85,28 @@ interface HistoryMessage {
   open_view?: { path: string; label?: string };
   suggested_actions?: SuggestedAction[];
   repo_cards?: RepoCard[];
+  /**
+   * Intermediate reasoning + tool-call transcript for the session that
+   * produced this agent message. Empty / absent for user messages and
+   * for legacy agent messages whose session has no recorded events.
+   * Same shape as the typing-indicator `recent_steps` so the same web
+   * component can render both live and persisted views.
+   */
+  steps?: HistoryStep[];
 }
+
+export interface HistoryStep {
+  event_id: string;
+  kind: SessionEventKind;
+  tool_name: string | null;
+  /** Truncated to STEP_CONTENT_TRUNCATE chars in the response. */
+  content: string;
+}
+
+/** Per-session cap on persisted steps attached to a message. */
+const STEPS_PER_MESSAGE_LIMIT = 100;
+/** Per-event content cap in the persisted-step DTO. */
+const STEP_CONTENT_TRUNCATE = 1000;
 
 // Generic 500 — internal error text stays in server logs, indexed by
 // request_id the client can paste into a bug report.
@@ -236,6 +265,40 @@ export function failureMessageFor(s: {
   const summary = s.result_summary?.trim();
   if (summary && !isBareCliExitMessage(summary)) return summary;
   return DAEMON_LOG_POINTER;
+}
+
+/**
+ * Attach intermediate-step transcripts (tool calls, agent reasoning,
+ * summaries) to each agent message in-place. Single batched query for
+ * every session id present on an agent message. Truncates long events
+ * to keep the response bounded.
+ */
+async function attachStepsToMessages(
+  messages: HistoryMessage[],
+  sessionEventRepo: SessionEventRepository,
+): Promise<void> {
+  const sessionIds = messages
+    .filter((m) => m.role === "agent" && m.session_id)
+    .map((m) => m.session_id!);
+  if (sessionIds.length === 0) return;
+  const eventsBySession = await sessionEventRepo.listForSessions(
+    sessionIds,
+    STEPS_PER_MESSAGE_LIMIT,
+  );
+  for (const message of messages) {
+    if (message.role !== "agent" || !message.session_id) continue;
+    const events = eventsBySession.get(message.session_id) ?? [];
+    if (events.length === 0) continue;
+    message.steps = events.map((e) => ({
+      event_id: e.id,
+      kind: e.kind,
+      tool_name: e.tool_name ?? null,
+      content:
+        e.content.length > STEP_CONTENT_TRUNCATE
+          ? e.content.slice(0, STEP_CONTENT_TRUNCATE) + "…"
+          : e.content,
+    }));
+  }
 }
 
 function chainToMessages(chain: ConversationChain): HistoryMessage[] {
@@ -502,6 +565,7 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
 
     const truncated = chain.sessions.slice(-Math.ceil(HISTORY_LIMIT / 2)); // each session = 2 messages
     const messages = chainToMessages({ head_id: chain.head_id, sessions: truncated });
+    await attachStepsToMessages(messages, deps.sessionEventRepo);
     const latest = chain.sessions[chain.sessions.length - 1]!;
     // Surface the tail session's id when it's still in flight so the
     // chat UI can resume its "agent is thinking" indicator after a

--- a/packages/core/src/adapters/postgres/session-event-repo.test.ts
+++ b/packages/core/src/adapters/postgres/session-event-repo.test.ts
@@ -1,0 +1,127 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_RUNTIME_CONFIG } from "../../domain/agent.js";
+import {
+  agentId,
+  personId,
+  sessionEventId,
+  sessionId,
+} from "../../domain/ids.js";
+import { createTestPool, truncateAll } from "../../test-helpers.js";
+import type { Pool } from "./client.js";
+import { PostgresAgentRepository } from "./agent-repo.js";
+import { PostgresPersonRepository } from "./person-repo.js";
+import { PostgresSessionEventRepository } from "./session-event-repo.js";
+import { PostgresSessionRepository } from "./session-repo.js";
+
+describe("PostgresSessionEventRepository", () => {
+  let pool: Pool;
+  let events: PostgresSessionEventRepository;
+  let sessions: PostgresSessionRepository;
+  let agents: PostgresAgentRepository;
+  let persons: PostgresPersonRepository;
+  let agent: string;
+
+  beforeAll(() => {
+    pool = createTestPool();
+    events = new PostgresSessionEventRepository(pool);
+    sessions = new PostgresSessionRepository(pool);
+    agents = new PostgresAgentRepository(pool);
+    persons = new PostgresPersonRepository(pool);
+  });
+
+  beforeEach(async () => {
+    await truncateAll(pool);
+    const p = await persons.create({ id: personId(), name: "P" });
+    const a = await agents.create({
+      id: agentId(),
+      name: "A",
+      owner_id: p.id,
+      hierarchy_level: "ic",
+      runtime_config: DEFAULT_RUNTIME_CONFIG,
+    });
+    agent = a.id;
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  async function makeSession(): Promise<string> {
+    const sid = sessionId();
+    await sessions.create({
+      id: sid,
+      agent_id: agent,
+      type: "chat",
+      status: "running",
+      intent: "x",
+    });
+    return sid;
+  }
+
+  async function seedEvents(sessionId: string, n: number, gapMs = 2): Promise<void> {
+    for (let i = 0; i < n; i++) {
+      await events.append({
+        id: sessionEventId(),
+        session_id: sessionId,
+        kind: i % 2 === 0 ? "tool_call" : "tool_result",
+        content: `e${i}`,
+        tool_name: i % 2 === 0 ? "Bash" : undefined,
+      });
+      if (i < n - 1) await new Promise((r) => setTimeout(r, gapMs));
+    }
+  }
+
+  describe("listForSessions", () => {
+    // Used by GET /chat and (planned) GET /room/:id to attach the
+    // intermediate-step transcript to each agent message without firing
+    // N+1 per-session queries. Single batched query; per-session cap.
+
+    it("returns an empty map when no session ids are given", async () => {
+      const out = await events.listForSessions([]);
+      expect(out.size).toBe(0);
+    });
+
+    it("returns an empty array for sessions that have no events", async () => {
+      const sid = await makeSession();
+      const out = await events.listForSessions([sid]);
+      expect(out.get(sid)).toEqual([]);
+    });
+
+    it("groups events by session_id with each group sorted oldest first", async () => {
+      const s1 = await makeSession();
+      const s2 = await makeSession();
+      await seedEvents(s1, 3);
+      await seedEvents(s2, 2);
+
+      const out = await events.listForSessions([s1, s2]);
+
+      const c1 = out.get(s1)?.map((e) => e.content) ?? [];
+      const c2 = out.get(s2)?.map((e) => e.content) ?? [];
+      expect(c1).toEqual(["e0", "e1", "e2"]);
+      expect(c2).toEqual(["e0", "e1"]);
+    });
+
+    it("caps events per session at limitPerSession, keeping the MOST RECENT N", async () => {
+      // Regression guard: a naive global LIMIT would drop late events
+      // on a chatty session in favor of early events on a quiet one.
+      // The implementation must rank per-session and keep the tail.
+      const s1 = await makeSession();
+      const s2 = await makeSession();
+      await seedEvents(s1, 5);
+      await seedEvents(s2, 1);
+
+      const out = await events.listForSessions([s1, s2], 3);
+
+      expect(out.get(s1)?.map((e) => e.content)).toEqual(["e2", "e3", "e4"]);
+      expect(out.get(s2)?.map((e) => e.content)).toEqual(["e0"]);
+    });
+
+    it("ignores session ids that don't exist (no rows returned, but the key is present)", async () => {
+      const real = await makeSession();
+      await seedEvents(real, 1);
+      const out = await events.listForSessions([real, "sess_nope"]);
+      expect(out.get(real)).toHaveLength(1);
+      expect(out.get("sess_nope")).toEqual([]);
+    });
+  });
+});

--- a/packages/core/src/adapters/postgres/session-event-repo.ts
+++ b/packages/core/src/adapters/postgres/session-event-repo.ts
@@ -60,4 +60,38 @@ export class PostgresSessionEventRepository implements SessionEventRepository {
     );
     return rows.map(rowToEvent);
   }
+
+  async listForSessions(
+    sessionIds: string[],
+    limitPerSession = 100,
+  ): Promise<Map<string, SessionEvent[]>> {
+    const out = new Map<string, SessionEvent[]>();
+    for (const sid of sessionIds) out.set(sid, []);
+    if (sessionIds.length === 0) return out;
+    // Per-session LIMIT via a windowed query: rank events by created_at
+    // within each session, then keep the most recent N. Output is
+    // ordered ASC overall but per-session ASC inside the cap.
+    const { rows } = await this.pool.query<EventRow>(
+      `WITH ranked AS (
+         SELECT *,
+                ROW_NUMBER() OVER (
+                  PARTITION BY session_id
+                  ORDER BY created_at DESC
+                ) AS rn
+           FROM session_event
+          WHERE session_id = ANY($1::text[])
+       )
+       SELECT id, session_id, kind, content, tool_name, created_at
+         FROM ranked
+        WHERE rn <= $2
+        ORDER BY session_id, created_at ASC`,
+      [sessionIds, limitPerSession],
+    );
+    for (const row of rows) {
+      const list = out.get(row.session_id) ?? [];
+      list.push(rowToEvent(row));
+      out.set(row.session_id, list);
+    }
+    return out;
+  }
 }

--- a/packages/core/src/ports/session-event-repo.ts
+++ b/packages/core/src/ports/session-event-repo.ts
@@ -8,4 +8,19 @@ export interface SessionEventRepository {
 
   /** Read all events for a session, oldest first (transcript order). */
   listBySession(sessionId: string, limit?: number): Promise<SessionEvent[]>;
+
+  /**
+   * Batch-fetch events for multiple sessions in one round-trip, oldest
+   * first within each session. Used by chat/room history endpoints to
+   * attach the intermediate-step transcript to each agent message
+   * without firing N+1 queries.
+   *
+   * `limitPerSession` caps how many events to return per session
+   * (most recent kept). Returns a Map keyed by session_id; sessions
+   * with no events get an empty array.
+   */
+  listForSessions(
+    sessionIds: string[],
+    limitPerSession?: number,
+  ): Promise<Map<string, SessionEvent[]>>;
 }

--- a/packages/web/app/(authed)/chat/chat-client.tsx
+++ b/packages/web/app/(authed)/chat/chat-client.tsx
@@ -660,15 +660,52 @@ function OpenViewCta({ open_view }: { open_view: { path: string; label?: string 
 }
 
 /**
- * Render the tool-call transcript for a persisted agent message. Mirrors
- * the live `<Thinking>` "Working" section so users see the same reasoning
- * trail in conversation history that they saw streaming live, instead of
- * losing it when the session ended.
- *
- * Only `tool_call` / `tool_result` events render here (same filter as the
- * live view). `agent` text deltas don't apply — the final agent message
- * is in the bubble above. `agent_reasoning` and `summary` are
- * intentionally omitted to keep the trail focused on observable actions.
+ * Labeled wrapper around `<ToolStepList>` used by both the live
+ * `<Thinking>` "Working" section and the persisted `<PersistedSteps>`
+ * "Reasoning" section. Same chrome (uppercase label + step list); only
+ * the label and the `withTopBorder` interaction with neighboring agent
+ * text differ.
+ */
+function StepsSection({
+  label,
+  steps,
+  totalSteps,
+  className,
+  withTopBorder,
+  tree,
+  parentSessionId,
+}: {
+  label: string;
+  steps: ChatStreamStep[];
+  totalSteps: number;
+  className?: string;
+  withTopBorder?: boolean;
+  tree?: ChatStreamTree;
+  parentSessionId?: string;
+}) {
+  return (
+    <div className={className}>
+      <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground/45">
+        {label}
+      </div>
+      <ToolStepList
+        steps={steps}
+        totalSteps={totalSteps}
+        {...(withTopBorder ? { withTopBorder: true } : {})}
+        {...(tree ? { tree } : {})}
+        {...(parentSessionId ? { parentSessionId } : {})}
+      />
+    </div>
+  );
+}
+
+/**
+ * Render the tool-call transcript for a persisted agent message — same
+ * chrome as the live `<Thinking>` "Working" section so users see the
+ * same trail in history that they saw streaming. Only `tool_call` /
+ * `tool_result` events render (same filter as live); `agent` is the
+ * final message text (in the bubble above), `summary` is omitted to
+ * keep the trail focused on observable actions.
  */
 function PersistedSteps({ steps }: { steps?: ChatHistoryStep[] }) {
   if (!steps || steps.length === 0) return null;
@@ -684,12 +721,12 @@ function PersistedSteps({ steps }: { steps?: ChatHistoryStep[] }) {
     received_at: 0,
   }));
   return (
-    <div className="mt-3">
-      <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground/45">
-        Reasoning
-      </div>
-      <ToolStepList steps={adapted} totalSteps={adapted.length} />
-    </div>
+    <StepsSection
+      label="Reasoning"
+      steps={adapted}
+      totalSteps={adapted.length}
+      className="mt-3"
+    />
   );
 }
 
@@ -758,18 +795,15 @@ function Thinking({
           </div>
         )}
         {recentTools.length > 0 ? (
-          <div className={cn(hasWorkingText ? "mt-3" : "mt-2")}>
-            <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground/45">
-              Working
-            </div>
-            <ToolStepList
-              steps={recentTools}
-              totalSteps={toolSteps.length}
-              withTopBorder={hasWorkingText}
-              tree={tree}
-              parentSessionId={rootSessionId}
-            />
-          </div>
+          <StepsSection
+            label="Working"
+            steps={recentTools}
+            totalSteps={toolSteps.length}
+            className={cn(hasWorkingText ? "mt-3" : "mt-2")}
+            withTopBorder={hasWorkingText}
+            {...(tree ? { tree } : {})}
+            {...(rootSessionId ? { parentSessionId: rootSessionId } : {})}
+          />
         ) : null}
       </div>
     </div>

--- a/packages/web/app/(authed)/chat/chat-client.tsx
+++ b/packages/web/app/(authed)/chat/chat-client.tsx
@@ -16,6 +16,7 @@ import { isApiConfigured } from "@/lib/api/config";
 import {
   api,
   type ChatConversationsResponse,
+  type ChatHistoryStep,
   type ChatRepoCard,
   type SuggestedAction,
 } from "@/lib/api/client";
@@ -497,6 +498,7 @@ function Bubble({
         )}
         {!isUser ? (
           <>
+            <PersistedSteps steps={message.steps} />
             {refIds.length > 0 ? <ReferenceCards ids={refIds} /> : null}
             {message.repo_cards && message.repo_cards.length > 0 ? (
               <RepoCards cards={message.repo_cards} />
@@ -654,6 +656,40 @@ function OpenViewCta({ open_view }: { open_view: { path: string; label?: string 
       {open_view.label ?? "Open this"}
       <ArrowRight className="h-3 w-3" />
     </Link>
+  );
+}
+
+/**
+ * Render the tool-call transcript for a persisted agent message. Mirrors
+ * the live `<Thinking>` "Working" section so users see the same reasoning
+ * trail in conversation history that they saw streaming live, instead of
+ * losing it when the session ended.
+ *
+ * Only `tool_call` / `tool_result` events render here (same filter as the
+ * live view). `agent` text deltas don't apply — the final agent message
+ * is in the bubble above. `agent_reasoning` and `summary` are
+ * intentionally omitted to keep the trail focused on observable actions.
+ */
+function PersistedSteps({ steps }: { steps?: ChatHistoryStep[] }) {
+  if (!steps || steps.length === 0) return null;
+  const toolSteps = steps.filter(
+    (s) => s.kind === "tool_call" || s.kind === "tool_result",
+  );
+  if (toolSteps.length === 0) return null;
+  const adapted: ChatStreamStep[] = toolSteps.map((s) => ({
+    event_id: s.event_id,
+    kind: s.kind as ChatStreamStep["kind"],
+    ...(s.tool_name ? { tool_name: s.tool_name } : {}),
+    content: s.content,
+    received_at: 0,
+  }));
+  return (
+    <div className="mt-3">
+      <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground/45">
+        Reasoning
+      </div>
+      <ToolStepList steps={adapted} totalSteps={adapted.length} />
+    </div>
   );
 }
 

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -322,13 +322,11 @@ export interface ChatHistoryMessage {
 
 export interface ChatHistoryStep {
   event_id: string;
-  /** Same kinds the SSE stream emits — see SessionEventKind in core. */
-  kind:
-    | "tool_call"
-    | "tool_result"
-    | "agent"
-    | "agent_reasoning"
-    | "summary";
+  /** Mirror of SessionEventKind in `@beevibe/core` — kept as a literal
+   *  string union here so this file stays import-free of core. If a new
+   *  kind is added there, add it here too (TS will not catch the drift).
+   */
+  kind: "agent" | "tool_call" | "tool_result" | "summary";
   tool_name: string | null;
   content: string;
 }

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -312,6 +312,25 @@ export interface ChatHistoryMessage {
   open_view?: { path: string; label?: string };
   suggested_actions?: SuggestedAction[];
   repo_cards?: ChatRepoCard[];
+  /**
+   * Intermediate reasoning + tool-call transcript for the session that
+   * produced this agent message. Absent for user messages and for
+   * legacy agent messages whose session has no recorded events.
+   */
+  steps?: ChatHistoryStep[];
+}
+
+export interface ChatHistoryStep {
+  event_id: string;
+  /** Same kinds the SSE stream emits — see SessionEventKind in core. */
+  kind:
+    | "tool_call"
+    | "tool_result"
+    | "agent"
+    | "agent_reasoning"
+    | "summary";
+  tool_name: string | null;
+  content: string;
 }
 
 export interface ChatHistoryResponse {

--- a/packages/web/lib/hooks/use-chat.ts
+++ b/packages/web/lib/hooks/use-chat.ts
@@ -6,6 +6,7 @@ import {
   api,
   type ChatHistoryMessage,
   type ChatHistoryResponse,
+  type ChatHistoryStep,
   type ChatRepoCard,
   type ChatTurnResponse,
   type SuggestedAction,
@@ -29,6 +30,14 @@ export interface ChatMessage {
   suggested_actions?: SuggestedAction[];
   /** Resolved `<repo_card>` directives — rendered as a structured repo list. */
   repo_cards?: ChatRepoCard[];
+  /**
+   * Intermediate reasoning + tool calls for this agent message's
+   * session, attached by the backend. Absent on user messages and on
+   * legacy agent messages whose session has no recorded events. The
+   * UI renders them above the message content to mirror the live
+   * Thinking view.
+   */
+  steps?: ChatHistoryStep[];
 }
 
 let nextLocalId = 0;
@@ -54,6 +63,7 @@ function fromHistory(m: ChatHistoryMessage): ChatMessage {
     ...(m.open_view ? { open_view: m.open_view } : {}),
     ...(m.suggested_actions ? { suggested_actions: m.suggested_actions } : {}),
     ...(m.repo_cards ? { repo_cards: m.repo_cards } : {}),
+    ...(m.steps && m.steps.length > 0 ? { steps: m.steps } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary

The chat UI currently loses the live `<Thinking>` trail (tool calls, reasoning steps) once a session ends or the user refreshes — only the final agent message persists. This PR makes the intermediate transcript part of the conversation history so users can scroll back and see *how* the agent arrived at its answer.

## Architecture

### Backend
- New `sessionEventRepo.listForSessions(ids, limitPerSession = 100)` — batch-fetches events for many sessions in one round-trip with **per-session capping** via a window function (`ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY created_at DESC)`). A naive global LIMIT would drop late events on a chatty session in favor of early events on a quiet one — the per-session cap is the load-bearing detail.
- `GET /chat`: after `chainToMessages`, calls `attachStepsToMessages` to fold each agent message's session events into the response. Content truncated to 1KB per event; 100 events max per session.
- `HistoryMessage` gains optional `steps?: HistoryStep[]`.
- Bootstrap wires `sessionEventRepo` into `ChatRoutesDeps`.

### Frontend
- `ChatHistoryMessage` and `ChatMessage` gain the matching `steps?` field.
- New `<PersistedSteps>` component in `chat-client.tsx` mirrors the live `<Thinking>` "Working" section: same `ToolStepList` renderer, same filter (`tool_call` + `tool_result`), labeled **"Reasoning"** to distinguish from the live "Working" indicator. Renders inside the agent bubble below the markdown content.

## Design decisions

| Question | Decision | Rationale |
|---|---|---|
| Where do steps render relative to the bubble? | **Below** the agent message text | Mirrors the live layout where users see the answer first, then the supporting tool trail below |
| Default state | Always visible | Matches what users see live. A collapsible toggle is a follow-up if it gets noisy on long histories |
| Which event kinds render? | `tool_call`, `tool_result` only | Same filter as live. `agent` is the final message (already shown); `agent_reasoning` + `summary` deliberately omitted to keep the trail focused on observable actions. Worth revisiting if users want reasoning blocks too |
| Per-session event cap | 100 | Captures every interesting reasoning trail; bounds the response for long sessions |
| Per-event content truncation | 1KB | Live view truncates to 200B (glance-only); persisted view, user actually wants to read |
| Scope | `/chat` only | `/rooms/[id]` has the identical pattern. Deferred to a focused follow-up |

## Test plan

- [x] `pnpm --filter @beevibe/core build` + `pnpm --filter @beevibe/api build` — clean
- [x] `pnpm --filter @beevibe/core typecheck` + `pnpm --filter @beevibe/web tsc --noEmit` — clean
- [x] Added `packages/core/src/adapters/postgres/session-event-repo.test.ts` — five new integration tests for `listForSessions`: empty input, no-event sessions, multi-session grouping with oldest-first order, **per-session cap keeping the MOST RECENT N** (regression guard for the naive-LIMIT bug), and missing-session handling. Tests didn't run locally because Docker postgres is down on my machine — will verify on CI.
- [ ] After merge + deploy: send a chat message that triggers multiple tool calls; wait for it to finish; refresh the page; the "Reasoning" section should still appear under the agent message with the full tool transcript

## Follow-ups

- Same fix for `/rooms/[id]` (identical architecture, just second endpoint + render site)
- Consider rendering `agent_reasoning` rows for transparency
- Collapsible "Show reasoning" toggle if the wall-of-tools becomes overwhelming on long histories

🤖 Generated with [Claude Code](https://claude.com/claude-code)