### PR TITLE
fix(chat): seed "latest" cache slot before stripping ?new=1 to stop mid-session blank

### DIFF
--- a/packages/web/lib/hooks/use-chat.ts
+++ b/packages/web/lib/hooks/use-chat.ts
@@ -212,9 +212,29 @@ export function useChat(opts: UseChatOptions = {}) {
       }
       // Conversation list (sidebar) needs to see the new chain.
       queryClient.invalidateQueries({ queryKey: queryKeys.chat.conversations() });
-      // The "latest" conversation slot may now be stale — when the chat
-      // surface drops the `?new=1` param it'll refetch and land on the
-      // chain we just created.
+      // HAND OFF the just-completed turn into the "latest" cache slot
+      // BEFORE ChatClient strips `?new=1` from the URL. Without this
+      // seed, the cleanup useEffect (chat-client.tsx, fires once
+      // `messages.length > 0 && !isSubmitting`) rewrites the URL,
+      // React Query flips `queryKey` from chat.history(FRESH_CACHE_ID)
+      // to chat.history(undefined), and the new slot is empty during
+      // refetch — producing the "mid-session blank" symptom (composer,
+      // messages, and thinking block all disappear together for a few
+      // seconds; refresh brings the in-flight state back but
+      // useChatStream's accumulated SSE steps are gone because the
+      // re-render reset its state).
+      //
+      // We invalidate AFTER seeding so the slot is marked stale and
+      // React Query will refetch in the background to confirm with
+      // server state; staleTime: Infinity keeps the seeded data
+      // displayed during that refetch, so there's no flicker.
+      const handed = queryClient.getQueryData<ChatHistoryResponse>(queryKey);
+      if (handed) {
+        queryClient.setQueryData(
+          queryKeys.chat.history(undefined),
+          handed,
+        );
+      }
       queryClient.invalidateQueries({
         queryKey: queryKeys.chat.history(undefined),
       });

--- a/packages/web/lib/hooks/use-chat.ts
+++ b/packages/web/lib/hooks/use-chat.ts
@@ -212,32 +212,22 @@ export function useChat(opts: UseChatOptions = {}) {
       }
       // Conversation list (sidebar) needs to see the new chain.
       queryClient.invalidateQueries({ queryKey: queryKeys.chat.conversations() });
-      // HAND OFF the just-completed turn into the "latest" cache slot
-      // BEFORE ChatClient strips `?new=1` from the URL. Without this
-      // seed, the cleanup useEffect (chat-client.tsx, fires once
-      // `messages.length > 0 && !isSubmitting`) rewrites the URL,
-      // React Query flips `queryKey` from chat.history(FRESH_CACHE_ID)
-      // to chat.history(undefined), and the new slot is empty during
-      // refetch — producing the "mid-session blank" symptom (composer,
-      // messages, and thinking block all disappear together for a few
-      // seconds; refresh brings the in-flight state back but
-      // useChatStream's accumulated SSE steps are gone because the
-      // re-render reset its state).
-      //
-      // We invalidate AFTER seeding so the slot is marked stale and
-      // React Query will refetch in the background to confirm with
-      // server state; staleTime: Infinity keeps the seeded data
-      // displayed during that refetch, so there's no flicker.
+      // Seed the "latest" cache slot before invalidating it, so the
+      // moment ChatClient's URL-strip useEffect (fires on
+      // `messages.length > 0 && !isSubmitting`) flips `queryKey`
+      // from FRESH_CACHE_ID → undefined, the new slot already has
+      // the just-completed turn. Without the seed, the slot is empty
+      // until refetch lands and the whole chat surface (composer,
+      // messages, thinking block) blanks for a beat — and the
+      // re-render wipes useChatStream's accumulated SSE steps.
+      // Pairing: seed populates the slot for the immediate read; the
+      // invalidate after marks it stale so React Query refetches in
+      // the background. `staleTime: Infinity` keeps the seeded data
+      // displayed during that refetch — no flicker.
+      const latestKey = queryKeys.chat.history(undefined);
       const handed = queryClient.getQueryData<ChatHistoryResponse>(queryKey);
-      if (handed) {
-        queryClient.setQueryData(
-          queryKeys.chat.history(undefined),
-          handed,
-        );
-      }
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.chat.history(undefined),
-      });
+      if (handed) queryClient.setQueryData(latestKey, handed);
+      queryClient.invalidateQueries({ queryKey: latestKey });
     },
     onError: (err) => {
       // agent_offline (503) is special: the api persisted the session row


### PR DESCRIPTION
## Summary

Mid-session vanishing bug: after the agent's response settles on `/chat?new=1`, the entire chat surface (composer, messages, thinking block) blanks for a few seconds, and the live SSE step transcript is **permanently lost**. Refresh restores the in-flight state from the server, but the live tool-call trail accumulated by `useChatStream` is gone because the parent component re-rendered.

## Root cause: cache-slot race

In `use-chat.ts:onSuccess`, the agent reply is written to the `__draft__` slot but only **invalidates** the `chat.history(undefined)` ("latest") slot — never **seeds** it.

```
t=0 user on /chat?new=1                   cacheId = "__draft__"
                                           React Query reads chat.history("__draft__")
t=1 mutation lands, onSuccess fires        chat.history("__draft__") gets the agent reply
                                           chat.history(undefined) gets INVALIDATED but not seeded
t=2 ChatClient cleanup useEffect strips    URL → /chat
    ?new=1 (messages.length > 0 &&
    !isSubmitting now true)
t=3 re-render: fresh=false, cacheId=undefined
                                           React Query flips queryKey to chat.history(undefined)
                                           — which has NO data, refetch in flight
t=4 history.data === undefined            messages=[], pendingSessionId=undefined, isPending=false
                                           ↓
                                          Composer, messages, thinking block all blank
t=5 refresh                                fresh GET /chat lands → in-flight state visible again
                                          BUT useChatStream's React state was wiped at t=3 → live
                                          tool transcript is gone for good
```

## Fix

In `onSuccess`, **copy the just-completed `__draft__` slot's data into the `chat.history(undefined)` slot BEFORE invalidating it**. When the URL strip flips the queryKey, the slot React Query lands on already has the data → no blank flash → `useChatStream`'s state isn't reset → live tool transcript stays intact.

Keep the `invalidateQueries` call after the seed so the slot stays marked stale and refetches in the background to confirm with server state; `staleTime: Infinity` keeps the seeded data visible during the refetch, so there's no flicker.

Only affects the fresh-surface lifecycle. Existing conversation surfaces (`/chat?c=<head_id>` and `/chat` with no params) don't trigger the URL strip — their cache slots stay stable and don't need the handoff.

## Why not the polling-floor approach I proposed earlier

I initially diagnosed the symptom as SSE drops and proposed a polling-floor architecture (new endpoint + polling hook + merge with SSE accumulator, ~150 LOC). The user pushed back asking if that was really the root cause — and it wasn't. A polling-floor would have:
- Not fixed the visible blank (it can't prevent the cache slot transition wiping the state)
- Only restored events on the next poll cycle (2-3s of broken UI)
- Added an always-on polling endpoint for a problem that's actually a 23-line React Query cache hand-off

Lesson: verify the cause before architecting. The 4 speculative causes I listed earlier (SSE buffering, component unmount, sessionId flicker, SSE reconnect) all sound plausible — but the actual symptom (composer also disappearing) ruled out the SSE-only hypotheses and pointed at the chat-history cache as the source.

## Test plan

- [x] `pnpm tsc --noEmit` on web — clean
- [ ] Manual: open `/chat?new=1`, send a message that triggers multiple tool calls, wait for the agent to finish — confirm the chat surface does NOT blank out, and the live tool transcript stays visible after the URL silently strips `?new=1`
- [ ] Edge case: existing conversation surface (`/chat?c=<head_id>`) still works the same as before (no behavior change for non-fresh surfaces)

## Notes

No new unit tests — `use-chat` is a React-Query-driven hook with no existing test fixture, and the bug is end-to-end (cache transition + URL change + parent re-render). Worth adding a test fixture later if more cache-slot logic accrues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)