### PR TITLE
feat(escalation): human review page with proposal backfill

### DIFF
--- a/packages/api/src/bootstrap.ts
+++ b/packages/api/src/bootstrap.ts
@@ -213,6 +213,7 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
   const escalationService = new EscalationService({
     escalationRepo,
     negotiationRepo,
+    negotiationRoundRepo,
     taskRepo,
     agentRepo,
     dispatchService,

--- a/packages/api/src/mesh/types.ts
+++ b/packages/api/src/mesh/types.ts
@@ -62,7 +62,8 @@ export class MeshMaxRoundsError extends Error {
     },
   ) {
     super(
-      `negotiation ${meta.negotiationId} hit max_rounds (${meta.rounds_completed}/${meta.max_rounds}); call escalate_to_humans`,
+      `negotiation ${meta.negotiationId} reached the ${meta.max_rounds}-exchange limit ` +
+        `(${meta.rounds_completed} messages exchanged); call escalate_to_humans`,
     );
     this.name = "MeshMaxRoundsError";
   }

--- a/packages/api/src/routes/escalation.test.ts
+++ b/packages/api/src/routes/escalation.test.ts
@@ -19,6 +19,7 @@ import {
   PostgresCoreMemoryRepository,
   PostgresEscalationRepository,
   PostgresNegotiationRepository,
+  PostgresNegotiationRoundRepository,
   PostgresPersonRepository,
   PostgresSessionRepository,
   PostgresTaskRepository,
@@ -50,6 +51,7 @@ describe("escalation routes — integration", () => {
   let taskRepo: PostgresTaskRepository;
   let workProductRepo: PostgresWorkProductRepository;
   let negotiationRepo: PostgresNegotiationRepository;
+  let negotiationRoundRepo: PostgresNegotiationRoundRepository;
   let escalationRepo: PostgresEscalationRepository;
   let escalationService: EscalationService;
 
@@ -62,10 +64,12 @@ describe("escalation routes — integration", () => {
     taskRepo = new PostgresTaskRepository(pool);
     workProductRepo = new PostgresWorkProductRepository(pool);
     negotiationRepo = new PostgresNegotiationRepository(pool);
+    negotiationRoundRepo = new PostgresNegotiationRoundRepository(pool);
     escalationRepo = new PostgresEscalationRepository(pool);
     escalationService = new EscalationService({
       escalationRepo,
       negotiationRepo,
+      negotiationRoundRepo,
       taskRepo,
       agentRepo,
     });
@@ -408,5 +412,90 @@ describe("escalation routes — integration", () => {
   it("missing token → 401", async () => {
     const res = await request(makeApp()).post("/escalation/esc_x/resolve");
     expect(res.status).toBe(401);
+  });
+
+  it("GET /:id returns both sides' proposals when both submitted", async () => {
+    const seed = await seedEscalation();
+    const res = await request(makeApp())
+      .get(`/escalation/${seed.escalation.id}`)
+      .set("Authorization", `Bearer ${seed.humanApiKey}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.escalation.id).toBe(seed.escalation.id);
+    expect(res.body.escalation.initiator_proposals).toHaveLength(2);
+    expect(res.body.escalation.counterparty_proposals).toHaveLength(2);
+    expect(res.body.escalation.initiator_agent_name).toBe("Team A");
+    expect(res.body.escalation.counterparty_agent_name).toBe("Team B");
+    expect(res.body.escalation.initiator_recovered).toBeUndefined();
+    expect(res.body.escalation.counterparty_recovered).toBeUndefined();
+  });
+
+  it("GET /:id backfills the un-submitted side from negotiation rounds", async () => {
+    const owner = await provisionUser(
+      { personRepo },
+      { id: personId(), name: "Owner", email: "owner-backfill@example.com" },
+    );
+    const teamA = await provisionAgent(
+      { agentRepo, coreMemoryRepo },
+      { id: agentId(), name: "Team A", owner_id: owner.person.id, hierarchy_level: "team", runtime_config: DEFAULT_RUNTIME_CONFIG },
+    );
+    const teamB = await provisionAgent(
+      { agentRepo, coreMemoryRepo },
+      { id: agentId(), name: "Team B", owner_id: owner.person.id, hierarchy_level: "team", runtime_config: DEFAULT_RUNTIME_CONFIG },
+    );
+    const sa = await sessionRepo.create({ id: sessionId(), agent_id: teamA.agent.id, type: "task", status: "succeeded", intent: "i" });
+    const sb = await sessionRepo.create({ id: sessionId(), agent_id: teamB.agent.id, type: "mesh_negotiate", status: "succeeded", intent: "j" });
+    const negotiation = await negotiationRepo.create({
+      id: negotiationId(),
+      initiator_agent_id: teamA.agent.id,
+      initiator_session_id: sa.id,
+      counterparty_agent_id: teamB.agent.id,
+      counterparty_session_id: sb.id,
+      max_rounds: 3,
+    });
+    await negotiationRepo.update(negotiation.id, { status: "escalated" });
+    await negotiationRoundRepo.create({ id: "round_a1", negotiation_id: negotiation.id, round_number: 1, from_agent_id: teamA.agent.id, decision: "propose", message: "A opening proposal" });
+    await negotiationRoundRepo.create({ id: "round_b2", negotiation_id: negotiation.id, round_number: 2, from_agent_id: teamB.agent.id, decision: "counter", message: "B counter" });
+    await negotiationRoundRepo.create({ id: "round_a3", negotiation_id: negotiation.id, round_number: 3, from_agent_id: teamA.agent.id, decision: "counter", message: "A latest position" });
+
+    // Counterparty escalated; initiator never filed (slot stays empty).
+    const esc = await escalationRepo.create({
+      id: escalationId(),
+      negotiation_id: negotiation.id,
+      initiator_session_id: sa.id,
+      counterparty_session_id: sb.id,
+      summary: "Stuck; counterparty escalated.",
+      initiator_open_questions: [],
+      escalated_by_role: "counterparty",
+    });
+    await escalationRepo.update(esc.id, {
+      counterparty_proposals: [{ title: "B plan", description: "do B" }],
+      counterparty_open_questions: [],
+      counterparty_submitted_at: new Date(),
+    });
+
+    const res = await request(makeApp())
+      .get(`/escalation/${esc.id}`)
+      .set("Authorization", `Bearer ${owner.apiKey}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.escalation.initiator_submitted_at == null).toBe(true);
+    expect(res.body.escalation.initiator_agent_name).toBe("Team A");
+    expect(res.body.escalation.counterparty_agent_name).toBe("Team B");
+    expect(res.body.escalation.initiator_recovered).toMatchObject({
+      from_round: 3,
+      decision: "counter",
+      message: "A latest position",
+    });
+    expect(res.body.escalation.counterparty_recovered).toBeUndefined();
+  });
+
+  it("GET /:id → 404 for unknown id", async () => {
+    const seed = await seedEscalation();
+    const res = await request(makeApp())
+      .get("/escalation/esc_does_not_exist")
+      .set("Authorization", `Bearer ${seed.humanApiKey}`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("escalation_not_found");
   });
 });

--- a/packages/api/src/routes/escalation.ts
+++ b/packages/api/src/routes/escalation.ts
@@ -91,6 +91,33 @@ export function createEscalationRouter(deps: EscalationRoutesDeps): Router {
   const router = Router();
   router.use(deps.authMiddleware);
 
+  router.get("/:id", async (req, res) => {
+    if (!requireHuman(req, res)) return;
+    const id = req.params.id;
+    if (!id) {
+      res.status(400).json({ error: "missing_escalation_id" });
+      return;
+    }
+    try {
+      const escalation = await deps.escalationService.getReview(id);
+      res.json({ ok: true, escalation });
+    } catch (err) {
+      if (err instanceof EscalationNotFoundError) {
+        res.status(404).json({ error: "escalation_not_found", message: err.message });
+        return;
+      }
+      if (err instanceof NegotiationNotFoundError) {
+        res.status(404).json({ error: "negotiation_not_found", message: err.message });
+        return;
+      }
+      console.error("[escalation route]", err);
+      res.status(500).json({
+        error: "internal_error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  });
+
   router.post("/:id/resolve", async (req, res) => {
     if (!requireHuman(req, res)) return;
     const id = req.params.id;

--- a/packages/api/src/routes/escalation.ts
+++ b/packages/api/src/routes/escalation.ts
@@ -17,7 +17,7 @@
  * executor picks both up within ≤30s.
  */
 
-import { Router, type RequestHandler } from "express";
+import { Router, type RequestHandler, type Response } from "express";
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import {
   type EscalationService,
@@ -87,6 +87,26 @@ function buildSelector(body: unknown):
   };
 }
 
+function handleEscalationError(err: unknown, res: Response): void {
+  if (err instanceof EscalationNotFoundError) {
+    res.status(404).json({ error: "escalation_not_found", message: err.message });
+    return;
+  }
+  if (err instanceof NegotiationNotFoundError) {
+    res.status(404).json({ error: "negotiation_not_found", message: err.message });
+    return;
+  }
+  if (err instanceof EscalationStateError) {
+    res.status(409).json({ error: "invalid_state", message: err.message });
+    return;
+  }
+  console.error("[escalation route]", err);
+  res.status(500).json({
+    error: "internal_error",
+    message: err instanceof Error ? err.message : String(err),
+  });
+}
+
 export function createEscalationRouter(deps: EscalationRoutesDeps): Router {
   const router = Router();
   router.use(deps.authMiddleware);
@@ -102,19 +122,7 @@ export function createEscalationRouter(deps: EscalationRoutesDeps): Router {
       const escalation = await deps.escalationService.getReview(id);
       res.json({ ok: true, escalation });
     } catch (err) {
-      if (err instanceof EscalationNotFoundError) {
-        res.status(404).json({ error: "escalation_not_found", message: err.message });
-        return;
-      }
-      if (err instanceof NegotiationNotFoundError) {
-        res.status(404).json({ error: "negotiation_not_found", message: err.message });
-        return;
-      }
-      console.error("[escalation route]", err);
-      res.status(500).json({
-        error: "internal_error",
-        message: err instanceof Error ? err.message : String(err),
-      });
+      handleEscalationError(err, res);
     }
   });
 
@@ -159,23 +167,7 @@ export function createEscalationRouter(deps: EscalationRoutesDeps): Router {
         note: "Both sides will resume via executor in ≤30s.",
       });
     } catch (err) {
-      if (err instanceof EscalationNotFoundError) {
-        res.status(404).json({ error: "escalation_not_found", message: err.message });
-        return;
-      }
-      if (err instanceof NegotiationNotFoundError) {
-        res.status(404).json({ error: "negotiation_not_found", message: err.message });
-        return;
-      }
-      if (err instanceof EscalationStateError) {
-        res.status(409).json({ error: "invalid_state", message: err.message });
-        return;
-      }
-      console.error("[escalation route]", err);
-      res.status(500).json({
-        error: "internal_error",
-        message: err instanceof Error ? err.message : String(err),
-      });
+      handleEscalationError(err, res);
     }
   });
 

--- a/packages/api/src/views/inbox.test.ts
+++ b/packages/api/src/views/inbox.test.ts
@@ -32,7 +32,7 @@ const escalationRow = {
   kind: "escalation_pending" as const,
   title: "Empty-state copy direction",
   detail: "ux specialist ↔ frontend specialist",
-  href: "/mesh#esc-esc_x",
+  href: "/escalations/esc_x",
   age_at: new Date("2026-05-04T08:00:00Z"),
 };
 
@@ -84,11 +84,11 @@ describe("listInbox", () => {
     expect(items).toEqual([]);
   });
 
-  it("includes /tasks/ paths for task kinds and /mesh#esc- for escalations", async () => {
+  it("includes /tasks/ paths for task kinds and /escalations/ for escalations", async () => {
     const pool = makeMockPool([reviewRow, blockedRow, escalationRow]);
     const items = await listInbox(pool, "per_w");
     expect(items[0]?.href).toBe("/tasks/task_a");
     expect(items[1]?.href).toBe("/tasks/task_b");
-    expect(items[2]?.href).toMatch(/^\/mesh#esc-/);
+    expect(items[2]?.href).toMatch(/^\/escalations\//);
   });
 });

--- a/packages/api/src/views/inbox.ts
+++ b/packages/api/src/views/inbox.ts
@@ -86,7 +86,7 @@ WITH inbox AS (
     'escalation_pending'::text               AS kind,
     LEFT(e.summary, ${TITLE_TRUNCATE})       AS title,
     ai.name || ' ↔ ' || ac.name              AS detail,
-    '/mesh#esc-' || e.id                     AS href,
+    '/escalations/' || e.id                  AS href,
     e.created_at                             AS age_at
   FROM escalation e
   JOIN negotiation n ON n.id = e.negotiation_id

--- a/packages/core/src/domain/escalation.ts
+++ b/packages/core/src/domain/escalation.ts
@@ -13,6 +13,8 @@
  * slots.
  */
 
+import type { NegotiationDecision } from "./negotiation.js";
+
 /**
  * A single proposal an agent submits during escalate_to_humans /
  * add_to_escalation. Plain content; no source tagging — that's the
@@ -72,4 +74,31 @@ export interface Escalation {
 
   created_at: Date;
   updated_at: Date;
+}
+
+/**
+ * A side's last negotiation-round message, surfaced as a fallback when that
+ * side never filed proposals into the escalation — e.g. its mesh client
+ * dropped before the escalation sentinel could land, so add_to_escalation
+ * never fired. Lets a human reviewer see both positions even when one slot
+ * is empty. The proposal text isn't lost; it lives in negotiation_round.
+ */
+export interface RecoveredPosition {
+  from_round: number;
+  decision: NegotiationDecision;
+  message: string;
+}
+
+/**
+ * An escalation prepared for human review: the stored row plus a recovered
+ * fallback (see RecoveredPosition) for any side that never submitted. Pure
+ * read-time composition — the underlying escalation row is never mutated.
+ */
+export interface EscalationReview extends Escalation {
+  /** Display names of the two agents, resolved from the negotiation. Falls
+   *  back to the agent id if the agent was since deleted. */
+  initiator_agent_name: string;
+  counterparty_agent_name: string;
+  initiator_recovered?: RecoveredPosition;
+  counterparty_recovered?: RecoveredPosition;
 }

--- a/packages/core/src/services/escalation-service.test.ts
+++ b/packages/core/src/services/escalation-service.test.ts
@@ -1,12 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Escalation, Proposal } from "../domain/escalation.js";
-import type { Negotiation } from "../domain/negotiation.js";
+import type { Agent } from "../domain/agent.js";
+import type { Negotiation, NegotiationRound } from "../domain/negotiation.js";
 import type { Task } from "../domain/task.js";
 import type { AgentRepository } from "../ports/agent-repo.js";
 import type { EscalationRepository } from "../ports/escalation-repo.js";
-import type { NegotiationRepository } from "../ports/negotiation-repo.js";
+import type {
+  NegotiationRepository,
+  NegotiationRoundRepository,
+} from "../ports/negotiation-repo.js";
 import type { TaskRepository } from "../ports/task-repo.js";
 import {
+  EscalationNotFoundError,
   EscalationService,
   EscalationStateError,
   NegotiationNotFoundError,
@@ -51,6 +56,7 @@ function makeEsc(overrides: Partial<Escalation> = {}): Escalation {
 
 let escalationRepo: EscalationRepository;
 let negotiationRepo: NegotiationRepository;
+let negotiationRoundRepo: NegotiationRoundRepository;
 let taskRepo: TaskRepository;
 let agentRepo: AgentRepository;
 let svc: EscalationService;
@@ -68,6 +74,11 @@ beforeEach(() => {
     findActiveBetween: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
+  };
+  negotiationRoundRepo = {
+    listByNegotiation: vi.fn(),
+    findLatest: vi.fn(),
+    create: vi.fn(),
   };
   taskRepo = {
     findById: vi.fn(),
@@ -106,7 +117,13 @@ beforeEach(() => {
     update: vi.fn(),
     delete: vi.fn(),
   };
-  svc = new EscalationService({ escalationRepo, negotiationRepo, taskRepo, agentRepo });
+  svc = new EscalationService({
+    escalationRepo,
+    negotiationRepo,
+    negotiationRoundRepo,
+    taskRepo,
+    agentRepo,
+  });
 });
 
 describe("EscalationService.create", () => {
@@ -423,5 +440,99 @@ describe("EscalationService.resolve", () => {
         selector: { source: "counterparty", source_index: 0 },
       }),
     ).rejects.toBeInstanceOf(EscalationStateError);
+  });
+});
+
+describe("EscalationService.getReview", () => {
+  function makeRound(overrides: Partial<NegotiationRound> = {}): NegotiationRound {
+    return {
+      id: "round_1",
+      negotiation_id: "neg_1",
+      round_number: 1,
+      from_agent_id: "agent_a",
+      decision: "propose",
+      message: "round message",
+      sent_at: new Date(),
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    vi.mocked(agentRepo.findById).mockImplementation(
+      async (id: string) =>
+        ({
+          id,
+          name: id === "agent_a" ? "Alice team" : id === "agent_b" ? "Bob team" : id,
+        }) as unknown as Agent,
+    );
+  });
+
+  it("backfills the un-submitted side from its last round (counterparty escalated)", async () => {
+    vi.mocked(escalationRepo.findById).mockResolvedValue(
+      makeEsc({
+        escalated_by_role: "counterparty",
+        counterparty_proposals: [{ title: "B", description: "b" }],
+        counterparty_submitted_at: new Date(),
+        initiator_submitted_at: undefined,
+      }),
+    );
+    vi.mocked(negotiationRepo.findById).mockResolvedValue(makeNeg());
+    vi.mocked(negotiationRoundRepo.listByNegotiation).mockResolvedValue([
+      makeRound({ round_number: 1, from_agent_id: "agent_a", decision: "propose", message: "A opening" }),
+      makeRound({ id: "round_2", round_number: 2, from_agent_id: "agent_b", decision: "counter", message: "B counter" }),
+      makeRound({ id: "round_3", round_number: 3, from_agent_id: "agent_a", decision: "counter", message: "A latest" }),
+    ]);
+
+    const review = await svc.getReview("esc_1");
+
+    expect(review.initiator_recovered).toEqual({
+      from_round: 3,
+      decision: "counter",
+      message: "A latest",
+    });
+    expect(review.counterparty_recovered).toBeUndefined();
+    expect(review.initiator_agent_name).toBe("Alice team");
+    expect(review.counterparty_agent_name).toBe("Bob team");
+  });
+
+  it("includes agent names without a round fetch when both sides submitted", async () => {
+    vi.mocked(escalationRepo.findById).mockResolvedValue(
+      makeEsc({
+        initiator_submitted_at: new Date(),
+        counterparty_submitted_at: new Date(),
+      }),
+    );
+    vi.mocked(negotiationRepo.findById).mockResolvedValue(makeNeg());
+
+    const review = await svc.getReview("esc_1");
+
+    expect(review.initiator_recovered).toBeUndefined();
+    expect(review.counterparty_recovered).toBeUndefined();
+    expect(review.initiator_agent_name).toBe("Alice team");
+    expect(review.counterparty_agent_name).toBe("Bob team");
+    expect(negotiationRoundRepo.listByNegotiation).not.toHaveBeenCalled();
+  });
+
+  it("leaves recovered undefined when the un-submitted side has no rounds", async () => {
+    vi.mocked(escalationRepo.findById).mockResolvedValue(
+      makeEsc({
+        escalated_by_role: "counterparty",
+        counterparty_submitted_at: new Date(),
+        initiator_submitted_at: undefined,
+      }),
+    );
+    vi.mocked(negotiationRepo.findById).mockResolvedValue(makeNeg());
+    vi.mocked(negotiationRoundRepo.listByNegotiation).mockResolvedValue([
+      makeRound({ round_number: 2, from_agent_id: "agent_b", decision: "counter", message: "B only" }),
+    ]);
+
+    const review = await svc.getReview("esc_1");
+
+    expect(review.initiator_recovered).toBeUndefined();
+  });
+
+  it("throws EscalationNotFoundError for a missing escalation", async () => {
+    vi.mocked(escalationRepo.findById).mockResolvedValue(undefined);
+    await expect(svc.getReview("esc_missing")).rejects.toThrow(EscalationNotFoundError);
   });
 });

--- a/packages/core/src/services/escalation-service.ts
+++ b/packages/core/src/services/escalation-service.ts
@@ -1,13 +1,18 @@
 import type {
   Escalation,
+  EscalationReview,
   Proposal,
+  RecoveredPosition,
   ResolutionProposal,
 } from "../domain/escalation.js";
 import type { NextDispatchContext } from "../domain/task.js";
 import { escalationId as makeEscalationId, taskId as makeTaskId } from "../domain/ids.js";
 import type { AgentRepository } from "../ports/agent-repo.js";
 import type { EscalationRepository } from "../ports/escalation-repo.js";
-import type { NegotiationRepository } from "../ports/negotiation-repo.js";
+import type {
+  NegotiationRepository,
+  NegotiationRoundRepository,
+} from "../ports/negotiation-repo.js";
 import type { TaskRepository } from "../ports/task-repo.js";
 import { buildIntent, type ResumeReason } from "./agent-session.js";
 import type { DispatchService } from "./dispatch-service.js";
@@ -47,6 +52,7 @@ export class NotPartyError extends Error {
 export interface EscalationServiceDeps {
   escalationRepo: EscalationRepository;
   negotiationRepo: NegotiationRepository;
+  negotiationRoundRepo: NegotiationRoundRepository;
   taskRepo: TaskRepository;
   agentRepo: AgentRepository;
   /**
@@ -236,6 +242,54 @@ export class EscalationService {
     });
 
     return updated;
+  }
+
+  /**
+   * Read an escalation prepared for human review. When a side never filed
+   * proposals (its `*_submitted_at` is unset — e.g. its mesh client dropped
+   * before the escalation sentinel landed, so add_to_escalation never fired)
+   * its last negotiation-round message is surfaced as a recovered fallback,
+   * so the human sees both positions even when one slot is empty. Read-time
+   * only — the escalation row is never mutated.
+   */
+  async getReview(escalationId: string): Promise<EscalationReview> {
+    const esc = await this.deps.escalationRepo.findById(escalationId);
+    if (!esc) throw new EscalationNotFoundError(escalationId);
+
+    const neg = await this.deps.negotiationRepo.findById(esc.negotiation_id);
+    if (!neg) throw new NegotiationNotFoundError(esc.negotiation_id);
+
+    const [initiatorAgent, counterpartyAgent] = await Promise.all([
+      this.deps.agentRepo.findById(neg.initiator_agent_id),
+      this.deps.agentRepo.findById(neg.counterparty_agent_id),
+    ]);
+
+    let initiatorRecovered: RecoveredPosition | undefined;
+    let counterpartyRecovered: RecoveredPosition | undefined;
+    const needInitiator = !esc.initiator_submitted_at;
+    const needCounterparty = !esc.counterparty_submitted_at;
+    if (needInitiator || needCounterparty) {
+      const rounds = await this.deps.negotiationRoundRepo.listByNegotiation(neg.id);
+      const lastFrom = (agentId: string): RecoveredPosition | undefined => {
+        for (let i = rounds.length - 1; i >= 0; i--) {
+          const r = rounds[i];
+          if (r && r.from_agent_id === agentId) {
+            return { from_round: r.round_number, decision: r.decision, message: r.message };
+          }
+        }
+        return undefined;
+      };
+      if (needInitiator) initiatorRecovered = lastFrom(neg.initiator_agent_id);
+      if (needCounterparty) counterpartyRecovered = lastFrom(neg.counterparty_agent_id);
+    }
+
+    return {
+      ...esc,
+      initiator_agent_name: initiatorAgent?.name ?? neg.initiator_agent_id,
+      counterparty_agent_name: counterpartyAgent?.name ?? neg.counterparty_agent_id,
+      initiator_recovered: initiatorRecovered,
+      counterparty_recovered: counterpartyRecovered,
+    };
   }
 
   /**

--- a/packages/web/app/(authed)/escalations/[id]/escalation-detail-client.tsx
+++ b/packages/web/app/(authed)/escalations/[id]/escalation-detail-client.tsx
@@ -12,6 +12,8 @@ import { DetailShell } from "@/components/detail/detail-shell";
 import { FooterField } from "@/components/detail/footer-field";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
+import { EscalationStatusPill } from "@/components/detail/status-pill";
+import { MutationError } from "@/components/mutation-error";
 import { formatRelativeTime } from "@/lib/format";
 import type { EscalationResolveInput } from "@/lib/api/client";
 import type {
@@ -21,6 +23,16 @@ import type {
 } from "@/lib/types/escalations";
 
 type Side = "initiator" | "counterparty";
+
+interface SideView {
+  label: string;
+  agentName: string;
+  escalated: boolean;
+  proposals?: EscalationProposal[];
+  openQuestions: string[];
+  submittedAt?: string;
+  recovered?: EscalationRecoveredPosition;
+}
 
 const MeshBackLink = () => (
   <Link
@@ -75,21 +87,26 @@ export function EscalationDetailClient({ escalationId }: { escalationId: string 
   return <EscalationDetailLoaded esc={data.escalation} />;
 }
 
-function EscalationStatusPill({ status }: { status: EscalationReviewDetail["status"] }) {
-  const styles =
-    status === "resolved"
-      ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
-      : status === "cancelled"
-        ? "bg-muted text-muted-foreground"
-        : "bg-amber-500/10 text-amber-600 dark:text-amber-400";
-  return (
-    <span className={`inline-flex items-center h-6 px-2 rounded text-xs font-medium ${styles}`}>
-      {status}
-    </span>
-  );
-}
-
 function EscalationDetailLoaded({ esc }: { esc: EscalationReviewDetail }) {
+  const initiator: SideView = {
+    label: "Initiator",
+    agentName: esc.initiator_agent_name,
+    escalated: esc.escalated_by_role === "initiator",
+    proposals: esc.initiator_proposals,
+    openQuestions: esc.initiator_open_questions,
+    submittedAt: esc.initiator_submitted_at,
+    recovered: esc.initiator_recovered,
+  };
+  const counterparty: SideView = {
+    label: "Counterparty",
+    agentName: esc.counterparty_agent_name,
+    escalated: esc.escalated_by_role === "counterparty",
+    proposals: esc.counterparty_proposals,
+    openQuestions: esc.counterparty_open_questions,
+    submittedAt: esc.counterparty_submitted_at,
+    recovered: esc.counterparty_recovered,
+  };
+
   return (
     <DetailShell nav={<MeshBackLink />}>
       <header className="mb-6">
@@ -115,24 +132,8 @@ function EscalationDetailLoaded({ esc }: { esc: EscalationReviewDetail }) {
       </header>
 
       <div className="grid grid-cols-2 gap-4 mb-6">
-        <SideCard
-          label="Initiator"
-          agentName={esc.initiator_agent_name}
-          escalated={esc.escalated_by_role === "initiator"}
-          proposals={esc.initiator_proposals}
-          openQuestions={esc.initiator_open_questions}
-          submittedAt={esc.initiator_submitted_at}
-          recovered={esc.initiator_recovered}
-        />
-        <SideCard
-          label="Counterparty"
-          agentName={esc.counterparty_agent_name}
-          escalated={esc.escalated_by_role === "counterparty"}
-          proposals={esc.counterparty_proposals}
-          openQuestions={esc.counterparty_open_questions}
-          submittedAt={esc.counterparty_submitted_at}
-          recovered={esc.counterparty_recovered}
-        />
+        <SideCard side={initiator} />
+        <SideCard side={counterparty} />
       </div>
 
       {esc.status === "pending" ? <ResolveForm esc={esc} /> : <ResolvedView esc={esc} />}
@@ -156,23 +157,8 @@ function EscalationDetailLoaded({ esc }: { esc: EscalationReviewDetail }) {
   );
 }
 
-function SideCard({
-  label,
-  agentName,
-  escalated,
-  proposals,
-  openQuestions,
-  submittedAt,
-  recovered,
-}: {
-  label: string;
-  agentName: string;
-  escalated: boolean;
-  proposals?: EscalationProposal[];
-  openQuestions: string[];
-  submittedAt?: string;
-  recovered?: EscalationRecoveredPosition;
-}) {
+function SideCard({ side }: { side: SideView }) {
+  const { label, agentName, escalated, proposals, openQuestions, submittedAt, recovered } = side;
   const hasProposals = (proposals?.length ?? 0) > 0;
   return (
     <section className="rounded-lg border border-border bg-card p-4">
@@ -264,34 +250,35 @@ function ResolveForm({ esc }: { esc: EscalationReviewDetail }) {
 
   const [mode, setMode] = useState<"pick" | "human">(pickable.length > 0 ? "pick" : "human");
   const [picked, setPicked] = useState(0);
-  const [title, setTitle] = useState(pickable[0]?.proposal.title ?? "");
-  const [description, setDescription] = useState(pickable[0]?.proposal.description ?? "");
+  // `undefined` = use the picked proposal's value; any string (incl. "") =
+  // the user overrode it. Avoids the title/description-shadow-the-proposal
+  // sync dance and makes "edited" a single boolean derived from these.
+  const [editedTitle, setEditedTitle] = useState<string | undefined>(undefined);
+  const [editedDescription, setEditedDescription] = useState<string | undefined>(undefined);
   const [notes, setNotes] = useState("");
+
+  const selected = pickable[picked];
+  const sourceTitle = mode === "pick" ? selected?.proposal.title ?? "" : "";
+  const sourceDescription = mode === "pick" ? selected?.proposal.description ?? "" : "";
+  const displayTitle = editedTitle ?? sourceTitle;
+  const displayDescription = editedDescription ?? sourceDescription;
+  const isEdited =
+    mode === "pick" && (editedTitle !== undefined || editedDescription !== undefined);
+  const canSubmit =
+    displayTitle.trim().length > 0 &&
+    displayDescription.trim().length > 0 &&
+    !resolve.isPending;
 
   const selectProposal = (i: number) => {
     setPicked(i);
-    setTitle(pickable[i]?.proposal.title ?? "");
-    setDescription(pickable[i]?.proposal.description ?? "");
+    setEditedTitle(undefined);
+    setEditedDescription(undefined);
   };
-
   const switchMode = (m: "pick" | "human") => {
     setMode(m);
-    if (m === "pick") {
-      selectProposal(picked);
-    } else {
-      setTitle("");
-      setDescription("");
-    }
+    setEditedTitle(undefined);
+    setEditedDescription(undefined);
   };
-
-  const selected = pickable[picked];
-  const isEdited =
-    mode === "pick" &&
-    !!selected &&
-    (title.trim() !== selected.proposal.title ||
-      description.trim() !== selected.proposal.description);
-  const canSubmit =
-    title.trim().length > 0 && description.trim().length > 0 && !resolve.isPending;
 
   const submit = () => {
     if (!canSubmit) return;
@@ -299,8 +286,8 @@ function ResolveForm({ esc }: { esc: EscalationReviewDetail }) {
     if (mode === "human") {
       input = {
         source: "human",
-        title: title.trim(),
-        description: description.trim(),
+        title: displayTitle.trim(),
+        description: displayDescription.trim(),
         resolution_notes: notes.trim() || undefined,
       };
     } else {
@@ -308,9 +295,9 @@ function ResolveForm({ esc }: { esc: EscalationReviewDetail }) {
       input = {
         source: selected.side,
         source_index: selected.index,
-        edited_title: title.trim() !== selected.proposal.title ? title.trim() : undefined,
+        edited_title: editedTitle !== undefined ? editedTitle.trim() : undefined,
         edited_description:
-          description.trim() !== selected.proposal.description ? description.trim() : undefined,
+          editedDescription !== undefined ? editedDescription.trim() : undefined,
         resolution_notes: notes.trim() || undefined,
       };
     }
@@ -319,6 +306,8 @@ function ResolveForm({ esc }: { esc: EscalationReviewDetail }) {
 
   const inputClass =
     "w-full rounded border border-border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring";
+  const labelClass =
+    "block text-[11px] uppercase tracking-wider text-muted-foreground font-medium mb-1";
 
   return (
     <section className="rounded-lg border border-border bg-card p-5 mb-6">
@@ -369,30 +358,26 @@ function ResolveForm({ esc }: { esc: EscalationReviewDetail }) {
 
       <div className="space-y-3">
         <div>
-          <label className="block text-[11px] uppercase tracking-wider text-muted-foreground font-medium mb-1">
-            Title
-          </label>
+          <label className={labelClass}>Title</label>
           <input
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
+            value={displayTitle}
+            onChange={(e) => setEditedTitle(e.target.value)}
             placeholder="Decision title"
             className={inputClass}
           />
         </div>
         <div>
-          <label className="block text-[11px] uppercase tracking-wider text-muted-foreground font-medium mb-1">
-            Description
-          </label>
+          <label className={labelClass}>Description</label>
           <textarea
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
+            value={displayDescription}
+            onChange={(e) => setEditedDescription(e.target.value)}
             placeholder="What both sides should do"
             rows={4}
             className={inputClass}
           />
         </div>
         <div>
-          <label className="block text-[11px] uppercase tracking-wider text-muted-foreground font-medium mb-1">
+          <label className={labelClass}>
             Notes <span className="text-muted-foreground/60 normal-case">(optional)</span>
           </label>
           <textarea
@@ -411,11 +396,7 @@ function ResolveForm({ esc }: { esc: EscalationReviewDetail }) {
         </p>
       ) : null}
 
-      {resolve.isError ? (
-        <div className="mt-3 text-xs text-status-failed">
-          Couldn&apos;t resolve: {resolve.error instanceof Error ? resolve.error.message : "error"}
-        </div>
-      ) : null}
+      <MutationError mutation={resolve} verb="resolve" />
 
       <div className="flex items-center justify-between mt-4">
         <p className="text-[11px] text-muted-foreground">Both sides resume via executor in ≤30s.</p>

--- a/packages/web/app/(authed)/escalations/[id]/escalation-detail-client.tsx
+++ b/packages/web/app/(authed)/escalations/[id]/escalation-detail-client.tsx
@@ -1,0 +1,502 @@
+"use client";
+
+import Link from "next/link";
+import { useState, type ReactNode } from "react";
+import { ArrowLeft, AlertTriangle, Info, Scale } from "lucide-react";
+import { useEscalation } from "@/lib/hooks/use-escalations";
+import { useResolveEscalation } from "@/lib/hooks/use-escalation-mutations";
+import { isApiConfigured } from "@/lib/api/config";
+import { ChatMarkdown } from "@/components/chat/markdown";
+import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
+import { DetailShell } from "@/components/detail/detail-shell";
+import { FooterField } from "@/components/detail/footer-field";
+import { EmptyState } from "@/components/empty-state";
+import { Skeleton } from "@/components/skeleton";
+import { formatRelativeTime } from "@/lib/format";
+import type { EscalationResolveInput } from "@/lib/api/client";
+import type {
+  EscalationProposal,
+  EscalationRecoveredPosition,
+  EscalationReviewDetail,
+} from "@/lib/types/escalations";
+
+type Side = "initiator" | "counterparty";
+
+const MeshBackLink = () => (
+  <Link
+    href="/mesh"
+    className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors mb-3"
+  >
+    <ArrowLeft className="h-3 w-3" />
+    Mesh
+  </Link>
+);
+
+export function EscalationDetailClient({ escalationId }: { escalationId: string }) {
+  const { data, isLoading, isError } = useEscalation(escalationId);
+
+  if (!isApiConfigured) {
+    return (
+      <DetailShell nav={<MeshBackLink />}>
+        <EmptyState
+          icon={Scale}
+          title="API not configured"
+          description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load this escalation."
+        />
+      </DetailShell>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <DetailShell nav={<MeshBackLink />}>
+        <Skeleton className="h-7 w-40 mb-4" />
+        <Skeleton className="h-24 w-full rounded-lg mb-6" />
+        <div className="grid grid-cols-2 gap-4">
+          <Skeleton className="h-48 w-full rounded-lg" />
+          <Skeleton className="h-48 w-full rounded-lg" />
+        </div>
+      </DetailShell>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <DetailShell nav={<MeshBackLink />}>
+        <EmptyState
+          icon={AlertTriangle}
+          title="Couldn't load escalation"
+          description={`Escalation ${escalationId} could not be fetched. Check the MCP server logs.`}
+        />
+      </DetailShell>
+    );
+  }
+
+  return <EscalationDetailLoaded esc={data.escalation} />;
+}
+
+function EscalationStatusPill({ status }: { status: EscalationReviewDetail["status"] }) {
+  const styles =
+    status === "resolved"
+      ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+      : status === "cancelled"
+        ? "bg-muted text-muted-foreground"
+        : "bg-amber-500/10 text-amber-600 dark:text-amber-400";
+  return (
+    <span className={`inline-flex items-center h-6 px-2 rounded text-xs font-medium ${styles}`}>
+      {status}
+    </span>
+  );
+}
+
+function EscalationDetailLoaded({ esc }: { esc: EscalationReviewDetail }) {
+  return (
+    <DetailShell nav={<MeshBackLink />}>
+      <header className="mb-6">
+        <div className="flex items-start justify-between gap-6 mb-3">
+          <div className="min-w-0">
+            <h1 className="text-base font-semibold tracking-tight leading-tight">Escalation</h1>
+            <p className="text-xs text-muted-foreground mt-0.5 truncate">
+              {esc.initiator_agent_name}
+              <span className="text-muted-foreground/50 mx-1.5">↔</span>
+              {esc.counterparty_agent_name}
+            </p>
+          </div>
+          <EscalationStatusPill status={esc.status} />
+        </div>
+        <section className="rounded-lg border border-border bg-card p-5">
+          <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-3 font-medium">
+            Summary
+          </h2>
+          <div className="text-foreground/90">
+            <ChatMarkdown content={esc.summary} />
+          </div>
+        </section>
+      </header>
+
+      <div className="grid grid-cols-2 gap-4 mb-6">
+        <SideCard
+          label="Initiator"
+          agentName={esc.initiator_agent_name}
+          escalated={esc.escalated_by_role === "initiator"}
+          proposals={esc.initiator_proposals}
+          openQuestions={esc.initiator_open_questions}
+          submittedAt={esc.initiator_submitted_at}
+          recovered={esc.initiator_recovered}
+        />
+        <SideCard
+          label="Counterparty"
+          agentName={esc.counterparty_agent_name}
+          escalated={esc.escalated_by_role === "counterparty"}
+          proposals={esc.counterparty_proposals}
+          openQuestions={esc.counterparty_open_questions}
+          submittedAt={esc.counterparty_submitted_at}
+          recovered={esc.counterparty_recovered}
+        />
+      </div>
+
+      {esc.status === "pending" ? <ResolveForm esc={esc} /> : <ResolvedView esc={esc} />}
+
+      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+        <FooterField label="ID">
+          <ClickToCopyId id={esc.id} />
+        </FooterField>
+        <FooterField label="Negotiation">
+          <Link href="/mesh" className="font-mono hover:text-foreground transition-colors">
+            {esc.negotiation_id}
+          </Link>
+        </FooterField>
+        <FooterField label="Escalated by">{esc.escalated_by_role}</FooterField>
+        <FooterField label="Created">{formatRelativeTime(esc.created_at)}</FooterField>
+        {esc.resolved_at ? (
+          <FooterField label="Resolved">{formatRelativeTime(esc.resolved_at)}</FooterField>
+        ) : null}
+      </footer>
+    </DetailShell>
+  );
+}
+
+function SideCard({
+  label,
+  agentName,
+  escalated,
+  proposals,
+  openQuestions,
+  submittedAt,
+  recovered,
+}: {
+  label: string;
+  agentName: string;
+  escalated: boolean;
+  proposals?: EscalationProposal[];
+  openQuestions: string[];
+  submittedAt?: string;
+  recovered?: EscalationRecoveredPosition;
+}) {
+  const hasProposals = (proposals?.length ?? 0) > 0;
+  return (
+    <section className="rounded-lg border border-border bg-card p-4">
+      <div className="flex items-center gap-2 mb-1">
+        <h3 className="text-[11px] uppercase tracking-wider text-muted-foreground font-medium">
+          {label}
+        </h3>
+        {escalated ? (
+          <span className="text-[10px] uppercase tracking-wider text-amber-600 dark:text-amber-400">
+            escalated
+          </span>
+        ) : null}
+        <span className="ml-auto text-[11px] text-muted-foreground/70 shrink-0">
+          {submittedAt ? formatRelativeTime(submittedAt) : "never filed"}
+        </span>
+      </div>
+      <div className="text-sm font-medium text-foreground mb-3 truncate">{agentName}</div>
+
+      {recovered ? (
+        <div className="mb-3 rounded-md border border-dashed border-border bg-muted/30 p-3">
+          <div className="flex items-center gap-1.5 mb-1.5 text-[11px] text-muted-foreground">
+            <Info className="h-3 w-3 shrink-0" />
+            Recovered from round {recovered.from_round} ({recovered.decision}) — this side never
+            filed.
+          </div>
+          <div className="text-sm text-foreground/90">
+            <ChatMarkdown content={recovered.message} />
+          </div>
+        </div>
+      ) : null}
+
+      {hasProposals ? (
+        <ul className="space-y-3">
+          {(proposals ?? []).map((p, i) => (
+            <li key={`${i}:${p.title}`} className="rounded-md border border-border/60 p-3">
+              <div className="text-sm font-medium mb-1">
+                <span className="text-muted-foreground tabular-nums mr-1.5">{i + 1}.</span>
+                {p.title}
+              </div>
+              <div className="text-xs text-foreground/80">
+                <ChatMarkdown content={p.description} />
+              </div>
+              {p.tradeoffs ? (
+                <p className="mt-1.5 text-[11px] text-muted-foreground">
+                  <span className="font-medium">Trade-offs:</span> {p.tradeoffs}
+                </p>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : !recovered ? (
+        <p className="text-sm text-muted-foreground italic">No proposals filed.</p>
+      ) : null}
+
+      {openQuestions.length > 0 ? (
+        <div className="mt-3">
+          <h4 className="text-[10px] uppercase tracking-wider text-muted-foreground/80 mb-1.5 font-medium">
+            Open questions
+          </h4>
+          <ul className="space-y-1">
+            {openQuestions.map((q) => (
+              <li key={q} className="text-xs text-foreground/80 flex gap-1.5">
+                <span className="text-muted-foreground/60">·</span>
+                <span>{q}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function ResolveForm({ esc }: { esc: EscalationReviewDetail }) {
+  const resolve = useResolveEscalation(esc.id);
+
+  const pickable: Array<{ side: Side; index: number; proposal: EscalationProposal }> = [
+    ...(esc.initiator_proposals ?? []).map((proposal, index) => ({
+      side: "initiator" as Side,
+      index,
+      proposal,
+    })),
+    ...(esc.counterparty_proposals ?? []).map((proposal, index) => ({
+      side: "counterparty" as Side,
+      index,
+      proposal,
+    })),
+  ];
+
+  const [mode, setMode] = useState<"pick" | "human">(pickable.length > 0 ? "pick" : "human");
+  const [picked, setPicked] = useState(0);
+  const [title, setTitle] = useState(pickable[0]?.proposal.title ?? "");
+  const [description, setDescription] = useState(pickable[0]?.proposal.description ?? "");
+  const [notes, setNotes] = useState("");
+
+  const selectProposal = (i: number) => {
+    setPicked(i);
+    setTitle(pickable[i]?.proposal.title ?? "");
+    setDescription(pickable[i]?.proposal.description ?? "");
+  };
+
+  const switchMode = (m: "pick" | "human") => {
+    setMode(m);
+    if (m === "pick") {
+      selectProposal(picked);
+    } else {
+      setTitle("");
+      setDescription("");
+    }
+  };
+
+  const selected = pickable[picked];
+  const isEdited =
+    mode === "pick" &&
+    !!selected &&
+    (title.trim() !== selected.proposal.title ||
+      description.trim() !== selected.proposal.description);
+  const canSubmit =
+    title.trim().length > 0 && description.trim().length > 0 && !resolve.isPending;
+
+  const submit = () => {
+    if (!canSubmit) return;
+    let input: EscalationResolveInput;
+    if (mode === "human") {
+      input = {
+        source: "human",
+        title: title.trim(),
+        description: description.trim(),
+        resolution_notes: notes.trim() || undefined,
+      };
+    } else {
+      if (!selected) return;
+      input = {
+        source: selected.side,
+        source_index: selected.index,
+        edited_title: title.trim() !== selected.proposal.title ? title.trim() : undefined,
+        edited_description:
+          description.trim() !== selected.proposal.description ? description.trim() : undefined,
+        resolution_notes: notes.trim() || undefined,
+      };
+    }
+    resolve.mutate(input);
+  };
+
+  const inputClass =
+    "w-full rounded border border-border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring";
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-5 mb-6">
+      <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-4 font-medium">
+        Resolution
+      </h2>
+
+      <div className="flex gap-2 mb-4">
+        <ModeButton
+          active={mode === "pick"}
+          disabled={pickable.length === 0}
+          onClick={() => switchMode("pick")}
+        >
+          Pick a proposal
+        </ModeButton>
+        <ModeButton active={mode === "human"} onClick={() => switchMode("human")}>
+          Write my own
+        </ModeButton>
+      </div>
+
+      {mode === "pick" ? (
+        <div className="space-y-1.5 mb-4">
+          {pickable.map((item, i) => (
+            <label
+              key={`${item.side}:${item.index}`}
+              className={`flex items-start gap-2 rounded-md border p-2.5 cursor-pointer transition-colors ${
+                picked === i ? "border-primary bg-primary/5" : "border-border/60 hover:bg-secondary/30"
+              }`}
+            >
+              <input
+                type="radio"
+                name="proposal"
+                checked={picked === i}
+                onChange={() => selectProposal(i)}
+                className="mt-0.5"
+              />
+              <div className="min-w-0">
+                <div className="text-[11px]">
+                  <span className="uppercase tracking-wider text-muted-foreground">{item.side}</span>
+                  <span className="text-muted-foreground/70 tabular-nums"> · #{item.index + 1}</span>
+                </div>
+                <div className="text-sm font-medium">{item.proposal.title}</div>
+              </div>
+            </label>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="space-y-3">
+        <div>
+          <label className="block text-[11px] uppercase tracking-wider text-muted-foreground font-medium mb-1">
+            Title
+          </label>
+          <input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Decision title"
+            className={inputClass}
+          />
+        </div>
+        <div>
+          <label className="block text-[11px] uppercase tracking-wider text-muted-foreground font-medium mb-1">
+            Description
+          </label>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="What both sides should do"
+            rows={4}
+            className={inputClass}
+          />
+        </div>
+        <div>
+          <label className="block text-[11px] uppercase tracking-wider text-muted-foreground font-medium mb-1">
+            Notes <span className="text-muted-foreground/60 normal-case">(optional)</span>
+          </label>
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="e.g. cap timeline at 4 weeks"
+            rows={2}
+            className={inputClass}
+          />
+        </div>
+      </div>
+
+      {isEdited ? (
+        <p className="mt-2 text-[11px] text-muted-foreground">
+          Edited from the original — the source proposal is preserved for audit.
+        </p>
+      ) : null}
+
+      {resolve.isError ? (
+        <div className="mt-3 text-xs text-status-failed">
+          Couldn&apos;t resolve: {resolve.error instanceof Error ? resolve.error.message : "error"}
+        </div>
+      ) : null}
+
+      <div className="flex items-center justify-between mt-4">
+        <p className="text-[11px] text-muted-foreground">Both sides resume via executor in ≤30s.</p>
+        <button
+          type="button"
+          disabled={!canSubmit}
+          onClick={submit}
+          className="h-9 px-4 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {resolve.isPending ? "Resolving…" : "Resolve & dispatch"}
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function ModeButton({
+  active,
+  disabled,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className={`h-8 px-3 rounded text-xs font-medium border transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed ${
+        active
+          ? "border-primary bg-primary/10 text-foreground"
+          : "border-border hover:bg-secondary text-muted-foreground"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function ResolvedView({ esc }: { esc: EscalationReviewDetail }) {
+  const r = esc.resolution_proposal;
+  const cancelled = esc.status === "cancelled";
+  return (
+    <section
+      className={`rounded-lg border p-5 mb-6 ${
+        cancelled ? "border-border bg-muted/30" : "border-emerald-500/30 bg-emerald-500/5"
+      }`}
+    >
+      <h2
+        className={`text-[11px] uppercase tracking-wider mb-3 font-medium ${
+          cancelled ? "text-muted-foreground" : "text-emerald-600 dark:text-emerald-400"
+        }`}
+      >
+        {cancelled ? "Cancelled" : "Resolution"}
+      </h2>
+      {r ? (
+        <>
+          <div className="text-sm font-medium mb-1">{r.title}</div>
+          <div className="text-sm text-foreground/90">
+            <ChatMarkdown content={r.description} />
+          </div>
+          <p className="mt-2 text-[11px] text-muted-foreground">
+            Source: {r.source}
+            {typeof r.source_index === "number" ? ` · #${r.source_index + 1}` : ""}
+          </p>
+        </>
+      ) : (
+        <p className="text-sm text-muted-foreground italic">No resolution recorded.</p>
+      )}
+      {esc.resolution_notes ? (
+        <div className="mt-3 pt-3 border-t border-border/40">
+          <h3 className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1 font-medium">
+            Notes
+          </h3>
+          <p className="text-sm text-foreground/80">{esc.resolution_notes}</p>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/packages/web/app/(authed)/escalations/[id]/loading.tsx
+++ b/packages/web/app/(authed)/escalations/[id]/loading.tsx
@@ -1,0 +1,21 @@
+import { Skeleton } from "@/components/skeleton";
+
+export default function EscalationDetailLoading() {
+  return (
+    <div className="flex-1 overflow-auto">
+      <div className="max-w-5xl mx-auto px-6 py-8">
+        <Skeleton className="h-4 w-16 mb-3" />
+        <div className="flex items-start justify-between gap-6 mb-4">
+          <Skeleton className="h-7 w-40" />
+          <Skeleton className="h-6 w-20 rounded" />
+        </div>
+        <Skeleton className="h-24 w-full rounded-lg mb-6" />
+        <div className="grid grid-cols-2 gap-4 mb-6">
+          <Skeleton className="h-48 w-full rounded-lg" />
+          <Skeleton className="h-48 w-full rounded-lg" />
+        </div>
+        <Skeleton className="h-56 w-full rounded-lg" />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/app/(authed)/escalations/[id]/page.tsx
+++ b/packages/web/app/(authed)/escalations/[id]/page.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from "next";
+import { EscalationDetailClient } from "./escalation-detail-client";
+
+export const metadata: Metadata = { title: "Escalation" };
+
+export default function EscalationDetailPage({ params }: { params: { id: string } }) {
+  return <EscalationDetailClient escalationId={params.id} />;
+}

--- a/packages/web/components/detail/status-pill.tsx
+++ b/packages/web/components/detail/status-pill.tsx
@@ -1,4 +1,4 @@
-import type { TaskStatus, SessionStatus } from "@beevibe/core";
+import type { TaskStatus, SessionStatus, EscalationStatus } from "@beevibe/core";
 import { cn } from "@/lib/utils";
 
 const TASK_PILL: Record<TaskStatus, { dot: string; bg: string; text: string; label: string }> = {
@@ -51,6 +51,29 @@ export function SessionStatusPill({ status, className }: { status: SessionStatus
       )}
     >
       {config.pulse ? <span className="animate-pulse-breathe h-1.5 w-1.5 rounded-full bg-status-running" /> : null}
+      {config.label}
+    </span>
+  );
+}
+
+const ESCALATION_PILL: Record<EscalationStatus, { dot: string; bg: string; text: string; label: string }> = {
+  pending: { dot: "bg-status-review", bg: "bg-status-review/10", text: "text-status-review", label: "pending" },
+  resolved: { dot: "bg-status-done", bg: "bg-status-done/10", text: "text-status-done", label: "resolved" },
+  cancelled: { dot: "bg-status-cancelled", bg: "bg-secondary", text: "text-muted-foreground", label: "cancelled" },
+};
+
+export function EscalationStatusPill({ status, className }: { status: EscalationStatus; className?: string }) {
+  const config = ESCALATION_PILL[status];
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 h-6 px-2 rounded text-xs font-medium",
+        config.bg,
+        config.text,
+        className,
+      )}
+    >
+      <span className={cn("h-1.5 w-1.5 rounded-full", config.dot)} />
       {config.label}
     </span>
   );

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -26,6 +26,7 @@ import type { SessionDisplay, SessionTreeResponse } from "@/lib/types/sessions";
 import type { FactCounts, MemoryFactDisplay } from "@/lib/types/memory-facts";
 import type { PromotionEvent } from "@/lib/types/promotion-events";
 import type { InboxItem } from "@/lib/types/inbox";
+import type { EscalationReviewDetail } from "@/lib/types/escalations";
 import type { Lifecycle } from "@/lib/tasks-grouping";
 
 export type TaskView = "all" | "mine";
@@ -671,6 +672,11 @@ export const api = {
       fetchJson<HealthResponse>("/health/runtime", { signal: opts.signal }),
   },
   escalations: {
+    get: (id: string, opts: ReadOptions = {}) =>
+      fetchJson<{ ok: true; escalation: EscalationReviewDetail }>(
+        `/escalation/${encodeURIComponent(id)}`,
+        { signal: opts.signal },
+      ),
     resolve: (id: string, input: EscalationResolveInput) =>
       fetchJson<{
         ok: true;

--- a/packages/web/lib/hooks/keys.ts
+++ b/packages/web/lib/hooks/keys.ts
@@ -46,6 +46,10 @@ export const queryKeys = {
     all: ["inbox"] as const,
     list: () => ["inbox", "list"] as const,
   },
+  escalations: {
+    all: ["escalations"] as const,
+    detail: (id: string) => ["escalations", "detail", id] as const,
+  },
   agentNetwork: {
     all: ["agent-network"] as const,
     self: () => ["agent-network", "self"] as const,

--- a/packages/web/lib/hooks/use-escalation-mutations.ts
+++ b/packages/web/lib/hooks/use-escalation-mutations.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api, type EscalationResolveInput } from "@/lib/api/client";
+import { queryKeys } from "./keys";
+
+export function useResolveEscalation(id: string) {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: (input: EscalationResolveInput) => api.escalations.resolve(id, input),
+    onSuccess: () => {
+      client.invalidateQueries({ queryKey: queryKeys.escalations.detail(id) });
+      // Resolving flips the escalation out of `pending`, which is the entire
+      // population of the inbox's escalation branch, and re-queues both
+      // sides' tasks (dashboard counts shift).
+      client.invalidateQueries({ queryKey: queryKeys.inbox.all });
+      client.invalidateQueries({ queryKey: queryKeys.dashboard.all });
+    },
+  });
+}

--- a/packages/web/lib/hooks/use-escalations.ts
+++ b/packages/web/lib/hooks/use-escalations.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api/client";
+import { isApiConfigured } from "@/lib/api/config";
+import { queryKeys } from "./keys";
+
+export function useEscalation(id: string | undefined) {
+  return useQuery({
+    queryKey: id ? queryKeys.escalations.detail(id) : queryKeys.escalations.all,
+    queryFn: ({ signal }) => api.escalations.get(id as string, { signal }),
+    enabled: isApiConfigured && !!id,
+  });
+}

--- a/packages/web/lib/types/escalations.ts
+++ b/packages/web/lib/types/escalations.ts
@@ -1,0 +1,60 @@
+// Serialized escalation shapes returned by GET /escalation/:id. Mirrors
+// @beevibe/core's EscalationReview but with ISO-string timestamps — the web
+// receives JSON over the wire and never sees Date objects.
+
+export interface EscalationProposal {
+  title: string;
+  description: string;
+  tradeoffs?: string;
+}
+
+export type NegotiationDecision = "propose" | "counter" | "accept" | "reject";
+
+/**
+ * A side's last negotiation-round message, surfaced when that side never
+ * filed proposals (e.g. its mesh client dropped before the escalation
+ * sentinel landed). Lets the reviewer see both positions.
+ */
+export interface EscalationRecoveredPosition {
+  from_round: number;
+  decision: NegotiationDecision;
+  message: string;
+}
+
+export interface EscalationResolution {
+  title: string;
+  description: string;
+  source: "initiator" | "counterparty" | "human";
+  source_index?: number;
+}
+
+export type EscalationStatus = "pending" | "resolved" | "cancelled";
+
+export interface EscalationReviewDetail {
+  id: string;
+  negotiation_id: string;
+  summary: string;
+  escalated_by_role: "initiator" | "counterparty";
+
+  initiator_agent_name: string;
+  counterparty_agent_name: string;
+
+  initiator_proposals?: EscalationProposal[];
+  initiator_open_questions: string[];
+  initiator_submitted_at?: string;
+  initiator_recovered?: EscalationRecoveredPosition;
+
+  counterparty_proposals?: EscalationProposal[];
+  counterparty_open_questions: string[];
+  counterparty_submitted_at?: string;
+  counterparty_recovered?: EscalationRecoveredPosition;
+
+  status: EscalationStatus;
+  resolution_proposal?: EscalationResolution;
+  resolution_notes?: string;
+  resolved_by?: string;
+  resolved_at?: string;
+
+  created_at: string;
+  updated_at: string;
+}

--- a/packages/web/lib/types/escalations.ts
+++ b/packages/web/lib/types/escalations.ts
@@ -1,60 +1,29 @@
-// Serialized escalation shapes returned by GET /escalation/:id. Mirrors
-// @beevibe/core's EscalationReview but with ISO-string timestamps — the web
-// receives JSON over the wire and never sees Date objects.
+// Serialized escalation shapes returned by GET /escalation/:id. The
+// non-date types are re-exported straight from @beevibe/core (single
+// source of truth); only the escalation row itself needs a serialized
+// mirror because JSON over the wire turns its timestamps into ISO
+// strings.
 
-export interface EscalationProposal {
-  title: string;
-  description: string;
-  tradeoffs?: string;
-}
+import type {
+  EscalationReview,
+  Proposal,
+  RecoveredPosition,
+} from "@beevibe/core";
 
-export type NegotiationDecision = "propose" | "counter" | "accept" | "reject";
+export type EscalationProposal = Proposal;
+export type EscalationRecoveredPosition = RecoveredPosition;
 
-/**
- * A side's last negotiation-round message, surfaced when that side never
- * filed proposals (e.g. its mesh client dropped before the escalation
- * sentinel landed). Lets the reviewer see both positions.
- */
-export interface EscalationRecoveredPosition {
-  from_round: number;
-  decision: NegotiationDecision;
-  message: string;
-}
-
-export interface EscalationResolution {
-  title: string;
-  description: string;
-  source: "initiator" | "counterparty" | "human";
-  source_index?: number;
-}
-
-export type EscalationStatus = "pending" | "resolved" | "cancelled";
-
-export interface EscalationReviewDetail {
-  id: string;
-  negotiation_id: string;
-  summary: string;
-  escalated_by_role: "initiator" | "counterparty";
-
-  initiator_agent_name: string;
-  counterparty_agent_name: string;
-
-  initiator_proposals?: EscalationProposal[];
-  initiator_open_questions: string[];
+export type EscalationReviewDetail = Omit<
+  EscalationReview,
+  | "initiator_submitted_at"
+  | "counterparty_submitted_at"
+  | "resolved_at"
+  | "created_at"
+  | "updated_at"
+> & {
   initiator_submitted_at?: string;
-  initiator_recovered?: EscalationRecoveredPosition;
-
-  counterparty_proposals?: EscalationProposal[];
-  counterparty_open_questions: string[];
   counterparty_submitted_at?: string;
-  counterparty_recovered?: EscalationRecoveredPosition;
-
-  status: EscalationStatus;
-  resolution_proposal?: EscalationResolution;
-  resolution_notes?: string;
-  resolved_by?: string;
   resolved_at?: string;
-
   created_at: string;
   updated_at: string;
-}
+};


### PR DESCRIPTION
## Summary
- **New escalation detail page** at `/escalations/:id`: side-by-side initiator/counterparty proposals + open questions, with a resolve form (pick a proposal — optionally edited — or write your own). Inbox escalations now route here instead of `/mesh#esc-`.
- **Read-time backfill**: `GET /escalation/:id` surfaces a side's last negotiation round when it never filed into the escalation (e.g. its mesh client dropped before the escalation sentinel landed), so the human always sees both positions even when one slot is empty. The review also resolves both agents' display names.
- **Wording fix**: `MeshMaxRoundsError` now names its units — `"5-exchange limit (10 messages)"` — instead of the confusing `"(10/5)"`.

## Test plan
- [x] Core unit `escalation-service`: 17/17 (getReview backfill + agent names)
- [x] API integration (real Postgres) `escalation` routes: 15/15 (GET, backfill, 404, resolve, auth)
- [x] API `inbox` view: 6/6 (updated `/escalations/:id` href)
- [x] Web typecheck + eslint clean
- [x] Live: `GET /escalation/:id` returns agent names + backfill; `/escalations/:id` page serves (200)
- [ ] Visual click-through of the resolve form (needs a logged-in browser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)