### PR TITLE
feat(mesh): negotiation detail page + per-kind row routing

### DIFF
--- a/packages/api/src/bootstrap.ts
+++ b/packages/api/src/bootstrap.ts
@@ -34,6 +34,7 @@ import {
 } from "@beevibe/core/services/memory";
 import { TaskService } from "@beevibe/core/services/task-service";
 import { EscalationService } from "@beevibe/core/services/escalation-service";
+import { NegotiationService } from "@beevibe/core/services/negotiation-service";
 import { DispatchService } from "@beevibe/core/services/dispatch-service";
 import { DaemonOrphanReaper } from "@beevibe/core/services/orphan-reaper";
 import { buildPostDispatchHook } from "@beevibe/core/services/post-dispatch";
@@ -48,6 +49,7 @@ import { createLearnedSkillsRouter } from "./routes/learned-skills.js";
 import { createFindRepoRouter } from "./routes/find-repo.js";
 import { createCapabilitiesRouter } from "./routes/capabilities.js";
 import { createEscalationRouter } from "./routes/escalation.js";
+import { createNegotiationRouter } from "./routes/negotiation.js";
 import { createViewRouter } from "./routes/view.js";
 import { createStreamRouter } from "./routes/stream.js";
 import { createChatRouter } from "./routes/chat.js";
@@ -219,6 +221,14 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
     dispatchService,
   });
 
+  // Read-only review of negotiations for the /negotiations/:id web page.
+  const negotiationService = new NegotiationService({
+    negotiationRepo,
+    negotiationRoundRepo,
+    agentRepo,
+    escalationRepo,
+  });
+
   // M6.4 mesh server: in-process A2A broker. Reuses LocalWorkspaceManager
   // + runtime registry from M5 (shared across executor + api per the M6
   // composition-root design — both processes can spawn target agent CLIs
@@ -352,6 +362,12 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
     pool,
   });
   server.getApp().use("/escalation", escalationRouter);
+
+  const negotiationRouter = createNegotiationRouter({
+    authMiddleware: server.getAuthMiddleware(),
+    negotiationService,
+  });
+  server.getApp().use("/negotiation", negotiationRouter);
 
   // Phase 8 — self-serve signup. UNAUTHENTICATED. MUST be mounted
   // BEFORE viewRouter (the read-only mount below has no path prefix

--- a/packages/api/src/routes/escalation.ts
+++ b/packages/api/src/routes/escalation.ts
@@ -24,8 +24,8 @@ import {
   type ResolveSelector,
   EscalationNotFoundError,
   EscalationStateError,
-  NegotiationNotFoundError,
 } from "@beevibe/core/services/escalation-service";
+import { NegotiationNotFoundError } from "@beevibe/core/services/negotiation-service";
 import { requireHuman } from "../auth/middleware.js";
 
 export interface EscalationRoutesDeps {

--- a/packages/api/src/routes/negotiation.test.ts
+++ b/packages/api/src/routes/negotiation.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Integration test: /negotiation/:id review endpoint.
+ * Real Postgres via DATABASE_URL_TEST. Seeds two team agents, a
+ * negotiation with rounds, and exercises the GET shape (names, rounds,
+ * escalation linkage, auth gates).
+ */
+
+import express from "express";
+import { json } from "express";
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  PostgresAgentRepository,
+  PostgresCoreMemoryRepository,
+  PostgresEscalationRepository,
+  PostgresNegotiationRepository,
+  PostgresNegotiationRoundRepository,
+  PostgresPersonRepository,
+  PostgresSessionRepository,
+  type Pool,
+} from "@beevibe/core/adapters/postgres";
+import { provisionAgent, provisionUser } from "@beevibe/core/auth";
+import { NegotiationService } from "@beevibe/core/services/negotiation-service";
+import {
+  DEFAULT_RUNTIME_CONFIG,
+  agentId,
+  escalationId,
+  negotiationId,
+  personId,
+  sessionId,
+} from "@beevibe/core";
+import { createTestPool, truncateAll } from "@beevibe/core/test-helpers";
+import { createAuthMiddleware } from "../auth/middleware.js";
+import { createNegotiationRouter } from "./negotiation.js";
+
+describe("negotiation routes — integration", () => {
+  let pool: Pool;
+  let agentRepo: PostgresAgentRepository;
+  let personRepo: PostgresPersonRepository;
+  let coreMemoryRepo: PostgresCoreMemoryRepository;
+  let sessionRepo: PostgresSessionRepository;
+  let negotiationRepo: PostgresNegotiationRepository;
+  let negotiationRoundRepo: PostgresNegotiationRoundRepository;
+  let escalationRepo: PostgresEscalationRepository;
+  let negotiationService: NegotiationService;
+
+  beforeAll(() => {
+    pool = createTestPool();
+    agentRepo = new PostgresAgentRepository(pool);
+    personRepo = new PostgresPersonRepository(pool);
+    coreMemoryRepo = new PostgresCoreMemoryRepository(pool);
+    sessionRepo = new PostgresSessionRepository(pool);
+    negotiationRepo = new PostgresNegotiationRepository(pool);
+    negotiationRoundRepo = new PostgresNegotiationRoundRepository(pool);
+    escalationRepo = new PostgresEscalationRepository(pool);
+    negotiationService = new NegotiationService({
+      negotiationRepo,
+      negotiationRoundRepo,
+      agentRepo,
+      escalationRepo,
+    });
+  });
+
+  beforeEach(async () => {
+    await truncateAll(pool);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  function makeApp() {
+    const app = express();
+    app.use(json());
+    app.use(
+      "/negotiation",
+      createNegotiationRouter({
+        authMiddleware: createAuthMiddleware({ agentRepo, personRepo }),
+        negotiationService,
+      }),
+    );
+    return app;
+  }
+
+  async function seedNegotiation(opts: { escalated?: boolean } = {}): Promise<{
+    humanApiKey: string;
+    ownerId: string;
+    initiator: { id: string };
+    counterparty: { id: string };
+    negotiationId: string;
+    escalationId?: string;
+  }> {
+    const owner = await provisionUser(
+      { personRepo },
+      { id: personId(), name: "Owner", email: `owner-${Date.now()}@example.com` },
+    );
+    const teamA = await provisionAgent(
+      { agentRepo, coreMemoryRepo },
+      {
+        id: agentId(),
+        name: "Team A",
+        owner_id: owner.person.id,
+        hierarchy_level: "team",
+        runtime_config: DEFAULT_RUNTIME_CONFIG,
+      },
+    );
+    const teamB = await provisionAgent(
+      { agentRepo, coreMemoryRepo },
+      {
+        id: agentId(),
+        name: "Team B",
+        owner_id: owner.person.id,
+        hierarchy_level: "team",
+        runtime_config: DEFAULT_RUNTIME_CONFIG,
+      },
+    );
+
+    const sa = await sessionRepo.create({
+      id: sessionId(),
+      agent_id: teamA.agent.id,
+      type: "task",
+      status: "succeeded",
+      intent: "i",
+    });
+    const sb = await sessionRepo.create({
+      id: sessionId(),
+      agent_id: teamB.agent.id,
+      type: "mesh_negotiate",
+      status: "succeeded",
+      intent: "j",
+    });
+
+    const neg = await negotiationRepo.create({
+      id: negotiationId(),
+      initiator_agent_id: teamA.agent.id,
+      initiator_session_id: sa.id,
+      counterparty_agent_id: teamB.agent.id,
+      counterparty_session_id: sb.id,
+      max_rounds: 5,
+    });
+
+    const t = Date.now();
+    await negotiationRoundRepo.create({
+      id: `round_${t}_1`,
+      negotiation_id: neg.id,
+      round_number: 1,
+      from_agent_id: teamA.agent.id,
+      decision: "propose",
+      message: "A opening proposal",
+    });
+    await negotiationRoundRepo.create({
+      id: `round_${t}_2`,
+      negotiation_id: neg.id,
+      round_number: 2,
+      from_agent_id: teamB.agent.id,
+      decision: "counter",
+      message: "B counter",
+    });
+
+    let esc: { id: string } | undefined;
+    if (opts.escalated) {
+      await negotiationRepo.update(neg.id, { status: "escalated" });
+      const escRow = await escalationRepo.create({
+        id: escalationId(),
+        negotiation_id: neg.id,
+        initiator_session_id: sa.id,
+        counterparty_session_id: sb.id,
+        summary: "Stuck.",
+        initiator_open_questions: [],
+        escalated_by_role: "counterparty",
+      });
+      esc = { id: escRow.id };
+    }
+
+    return {
+      humanApiKey: owner.apiKey,
+      ownerId: owner.person.id,
+      initiator: { id: teamA.agent.id },
+      counterparty: { id: teamB.agent.id },
+      negotiationId: neg.id,
+      escalationId: esc?.id,
+    };
+  }
+
+  it("GET /:id returns rounds + agent names; no escalation when active", async () => {
+    const seed = await seedNegotiation();
+
+    const res = await request(makeApp())
+      .get(`/negotiation/${seed.negotiationId}`)
+      .set("Authorization", `Bearer ${seed.humanApiKey}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.negotiation.id).toBe(seed.negotiationId);
+    expect(res.body.negotiation.initiator_agent_name).toBe("Team A");
+    expect(res.body.negotiation.counterparty_agent_name).toBe("Team B");
+    expect(res.body.negotiation.rounds).toHaveLength(2);
+    expect(res.body.negotiation.rounds[0].message).toBe("A opening proposal");
+    expect(res.body.negotiation.rounds[1].decision).toBe("counter");
+    expect(res.body.negotiation.escalation_id).toBeUndefined();
+    expect(res.body.negotiation.status).toBe("active");
+  });
+
+  it("GET /:id includes escalation_id when the negotiation was escalated", async () => {
+    const seed = await seedNegotiation({ escalated: true });
+
+    const res = await request(makeApp())
+      .get(`/negotiation/${seed.negotiationId}`)
+      .set("Authorization", `Bearer ${seed.humanApiKey}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.negotiation.status).toBe("escalated");
+    expect(res.body.negotiation.escalation_id).toBe(seed.escalationId);
+  });
+
+  it("GET /:id → 404 for unknown id", async () => {
+    const seed = await seedNegotiation();
+    const res = await request(makeApp())
+      .get("/negotiation/neg_does_not_exist")
+      .set("Authorization", `Bearer ${seed.humanApiKey}`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("negotiation_not_found");
+  });
+
+  it("agent caller (bv_a_) → 403", async () => {
+    const seed = await seedNegotiation();
+    const owner = await personRepo.findByApiKey(seed.humanApiKey);
+    expect(owner).toBeDefined();
+
+    const otherTeam = await provisionAgent(
+      { agentRepo, coreMemoryRepo },
+      {
+        id: agentId(),
+        name: "Other team",
+        owner_id: owner!.id,
+        hierarchy_level: "team",
+        runtime_config: DEFAULT_RUNTIME_CONFIG,
+      },
+    );
+
+    const res = await request(makeApp())
+      .get(`/negotiation/${seed.negotiationId}`)
+      .set("Authorization", `Bearer ${otherTeam.apiKey}`);
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("human_required");
+  });
+
+  it("missing token → 401", async () => {
+    const res = await request(makeApp()).get("/negotiation/neg_x");
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/api/src/routes/negotiation.ts
+++ b/packages/api/src/routes/negotiation.ts
@@ -1,0 +1,55 @@
+/**
+ * Human-facing negotiation review (read-only).
+ *
+ *   GET /negotiation/:id  → { ok: true, negotiation: NegotiationReview }
+ *
+ * Pairs with the /negotiations/:id web page — surfaces the full round
+ * transcript + agent names + linked escalation id (when escalated) so a
+ * human can click into a mesh row and see what's being discussed.
+ */
+
+import { Router, type RequestHandler, type Response } from "express";
+import {
+  type NegotiationService,
+  NegotiationNotFoundError,
+} from "@beevibe/core/services/negotiation-service";
+import { requireHuman } from "../auth/middleware.js";
+
+export interface NegotiationRoutesDeps {
+  authMiddleware: RequestHandler;
+  negotiationService: NegotiationService;
+}
+
+function handleNegotiationError(err: unknown, res: Response): void {
+  if (err instanceof NegotiationNotFoundError) {
+    res.status(404).json({ error: "negotiation_not_found", message: err.message });
+    return;
+  }
+  console.error("[negotiation route]", err);
+  res.status(500).json({
+    error: "internal_error",
+    message: err instanceof Error ? err.message : String(err),
+  });
+}
+
+export function createNegotiationRouter(deps: NegotiationRoutesDeps): Router {
+  const router = Router();
+  router.use(deps.authMiddleware);
+
+  router.get("/:id", async (req, res) => {
+    if (!requireHuman(req, res)) return;
+    const id = req.params.id;
+    if (!id) {
+      res.status(400).json({ error: "missing_negotiation_id" });
+      return;
+    }
+    try {
+      const negotiation = await deps.negotiationService.getReview(id);
+      res.json({ ok: true, negotiation });
+    } catch (err) {
+      handleNegotiationError(err, res);
+    }
+  });
+
+  return router;
+}

--- a/packages/api/src/routes/negotiation.ts
+++ b/packages/api/src/routes/negotiation.ts
@@ -8,7 +8,7 @@
  * human can click into a mesh row and see what's being discussed.
  */
 
-import { Router, type RequestHandler, type Response } from "express";
+import { Router, type RequestHandler } from "express";
 import {
   type NegotiationService,
   NegotiationNotFoundError,
@@ -18,18 +18,6 @@ import { requireHuman } from "../auth/middleware.js";
 export interface NegotiationRoutesDeps {
   authMiddleware: RequestHandler;
   negotiationService: NegotiationService;
-}
-
-function handleNegotiationError(err: unknown, res: Response): void {
-  if (err instanceof NegotiationNotFoundError) {
-    res.status(404).json({ error: "negotiation_not_found", message: err.message });
-    return;
-  }
-  console.error("[negotiation route]", err);
-  res.status(500).json({
-    error: "internal_error",
-    message: err instanceof Error ? err.message : String(err),
-  });
 }
 
 export function createNegotiationRouter(deps: NegotiationRoutesDeps): Router {
@@ -47,7 +35,15 @@ export function createNegotiationRouter(deps: NegotiationRoutesDeps): Router {
       const negotiation = await deps.negotiationService.getReview(id);
       res.json({ ok: true, negotiation });
     } catch (err) {
-      handleNegotiationError(err, res);
+      if (err instanceof NegotiationNotFoundError) {
+        res.status(404).json({ error: "negotiation_not_found", message: err.message });
+        return;
+      }
+      console.error("[negotiation route]", err);
+      res.status(500).json({
+        error: "internal_error",
+        message: err instanceof Error ? err.message : String(err),
+      });
     }
   });
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -70,6 +70,10 @@
       "types": "./dist/services/escalation-service.d.ts",
       "default": "./dist/services/escalation-service.js"
     },
+    "./services/negotiation-service": {
+      "types": "./dist/services/negotiation-service.d.ts",
+      "default": "./dist/services/negotiation-service.js"
+    },
     "./services/dispatch-service": {
       "types": "./dist/services/dispatch-service.d.ts",
       "default": "./dist/services/dispatch-service.js"

--- a/packages/core/src/domain/negotiation.ts
+++ b/packages/core/src/domain/negotiation.ts
@@ -53,3 +53,17 @@ export interface NegotiationRound {
   message: string;
   sent_at: Date;
 }
+
+/**
+ * A negotiation prepared for human review: the row plus the full round
+ * transcript, both agent display names, and the linked escalation id when
+ * the cap was hit. Resolved at read-time — the underlying row is never
+ * mutated.
+ */
+export interface NegotiationReview extends Negotiation {
+  initiator_agent_name: string;
+  counterparty_agent_name: string;
+  rounds: NegotiationRound[];
+  /** Set when status === 'escalated' and the escalation row exists. */
+  escalation_id?: string;
+}

--- a/packages/core/src/services/escalation-service.test.ts
+++ b/packages/core/src/services/escalation-service.test.ts
@@ -14,9 +14,9 @@ import {
   EscalationNotFoundError,
   EscalationService,
   EscalationStateError,
-  NegotiationNotFoundError,
   NotPartyError,
 } from "./escalation-service.js";
+import { NegotiationNotFoundError } from "./negotiation-service.js";
 
 function makeNeg(overrides: Partial<Negotiation> = {}): Negotiation {
   return {

--- a/packages/core/src/services/escalation-service.ts
+++ b/packages/core/src/services/escalation-service.ts
@@ -16,6 +16,7 @@ import type {
 import type { TaskRepository } from "../ports/task-repo.js";
 import { buildIntent, type ResumeReason } from "./agent-session.js";
 import type { DispatchService } from "./dispatch-service.js";
+import { NegotiationNotFoundError } from "./negotiation-service.js";
 
 export class EscalationNotFoundError extends Error {
   readonly code = "ESCALATION_NOT_FOUND";
@@ -30,14 +31,6 @@ export class EscalationStateError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "EscalationStateError";
-  }
-}
-
-export class NegotiationNotFoundError extends Error {
-  readonly code = "NEGOTIATION_NOT_FOUND";
-  constructor(id: string) {
-    super(`Negotiation ${id} not found`);
-    this.name = "NegotiationNotFoundError";
   }
 }
 

--- a/packages/core/src/services/negotiation-service.test.ts
+++ b/packages/core/src/services/negotiation-service.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Agent } from "../domain/agent.js";
+import type { Escalation } from "../domain/escalation.js";
+import type { Negotiation, NegotiationRound } from "../domain/negotiation.js";
+import type { AgentRepository } from "../ports/agent-repo.js";
+import type { EscalationRepository } from "../ports/escalation-repo.js";
+import type {
+  NegotiationRepository,
+  NegotiationRoundRepository,
+} from "../ports/negotiation-repo.js";
+import { NegotiationNotFoundError, NegotiationService } from "./negotiation-service.js";
+
+function makeNeg(overrides: Partial<Negotiation> = {}): Negotiation {
+  return {
+    id: "neg_1",
+    initiator_agent_id: "agent_a",
+    initiator_session_id: "sess_a",
+    counterparty_agent_id: "agent_b",
+    counterparty_session_id: "sess_b",
+    task_id: "task_1",
+    max_rounds: 5,
+    rounds_completed: 2,
+    status: "active",
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
+function makeRound(overrides: Partial<NegotiationRound> = {}): NegotiationRound {
+  return {
+    id: "round_1",
+    negotiation_id: "neg_1",
+    round_number: 1,
+    from_agent_id: "agent_a",
+    decision: "propose",
+    message: "round message",
+    sent_at: new Date(),
+    ...overrides,
+  };
+}
+
+let negotiationRepo: NegotiationRepository;
+let negotiationRoundRepo: NegotiationRoundRepository;
+let agentRepo: AgentRepository;
+let escalationRepo: EscalationRepository;
+let svc: NegotiationService;
+
+beforeEach(() => {
+  negotiationRepo = {
+    findById: vi.fn(),
+    findActiveBetween: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  };
+  negotiationRoundRepo = {
+    listByNegotiation: vi.fn(),
+    findLatest: vi.fn(),
+    create: vi.fn(),
+  };
+  agentRepo = {
+    findById: vi.fn(),
+    findByApiKey: vi.fn(),
+    findByOwnerId: vi.fn(),
+    findTopLevelForOwner: vi.fn(),
+    findSubordinates: vi.fn(),
+    findPeers: vi.fn(),
+    findParent: vi.fn(),
+    findByLevel: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+  escalationRepo = {
+    findById: vi.fn(),
+    findByNegotiation: vi.fn(),
+    listPending: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  };
+  svc = new NegotiationService({
+    negotiationRepo,
+    negotiationRoundRepo,
+    agentRepo,
+    escalationRepo,
+  });
+
+  vi.mocked(agentRepo.findById).mockImplementation(
+    async (id: string) =>
+      ({
+        id,
+        name: id === "agent_a" ? "Alice team" : id === "agent_b" ? "Bob team" : id,
+      }) as unknown as Agent,
+  );
+});
+
+describe("NegotiationService.getReview", () => {
+  it("returns rounds + agent names; no escalation when not escalated", async () => {
+    vi.mocked(negotiationRepo.findById).mockResolvedValue(makeNeg({ status: "active" }));
+    vi.mocked(negotiationRoundRepo.listByNegotiation).mockResolvedValue([
+      makeRound({ round_number: 1, from_agent_id: "agent_a", decision: "propose", message: "A1" }),
+      makeRound({ id: "round_2", round_number: 2, from_agent_id: "agent_b", decision: "counter", message: "B1" }),
+    ]);
+    vi.mocked(escalationRepo.findByNegotiation).mockResolvedValue(undefined);
+
+    const review = await svc.getReview("neg_1");
+
+    expect(review.initiator_agent_name).toBe("Alice team");
+    expect(review.counterparty_agent_name).toBe("Bob team");
+    expect(review.rounds).toHaveLength(2);
+    expect(review.rounds[0]?.message).toBe("A1");
+    expect(review.escalation_id).toBeUndefined();
+    expect(review.status).toBe("active");
+  });
+
+  it("includes escalation_id when the negotiation was escalated", async () => {
+    vi.mocked(negotiationRepo.findById).mockResolvedValue(makeNeg({ status: "escalated" }));
+    vi.mocked(negotiationRoundRepo.listByNegotiation).mockResolvedValue([]);
+    vi.mocked(escalationRepo.findByNegotiation).mockResolvedValue(
+      { id: "esc_1" } as unknown as Escalation,
+    );
+
+    const review = await svc.getReview("neg_1");
+
+    expect(review.escalation_id).toBe("esc_1");
+    expect(review.status).toBe("escalated");
+  });
+
+  it("falls back to the agent id when an agent was deleted", async () => {
+    vi.mocked(negotiationRepo.findById).mockResolvedValue(makeNeg());
+    vi.mocked(negotiationRoundRepo.listByNegotiation).mockResolvedValue([]);
+    vi.mocked(escalationRepo.findByNegotiation).mockResolvedValue(undefined);
+    vi.mocked(agentRepo.findById).mockResolvedValue(undefined);
+
+    const review = await svc.getReview("neg_1");
+
+    expect(review.initiator_agent_name).toBe("agent_a");
+    expect(review.counterparty_agent_name).toBe("agent_b");
+  });
+
+  it("throws NegotiationNotFoundError for a missing negotiation", async () => {
+    vi.mocked(negotiationRepo.findById).mockResolvedValue(undefined);
+    await expect(svc.getReview("neg_missing")).rejects.toThrow(NegotiationNotFoundError);
+  });
+});

--- a/packages/core/src/services/negotiation-service.ts
+++ b/packages/core/src/services/negotiation-service.ts
@@ -5,9 +5,13 @@ import type {
   NegotiationRepository,
   NegotiationRoundRepository,
 } from "../ports/negotiation-repo.js";
-import { NegotiationNotFoundError } from "./escalation-service.js";
-
-export { NegotiationNotFoundError };
+export class NegotiationNotFoundError extends Error {
+  readonly code = "NEGOTIATION_NOT_FOUND";
+  constructor(id: string) {
+    super(`Negotiation ${id} not found`);
+    this.name = "NegotiationNotFoundError";
+  }
+}
 
 export interface NegotiationServiceDeps {
   negotiationRepo: NegotiationRepository;

--- a/packages/core/src/services/negotiation-service.ts
+++ b/packages/core/src/services/negotiation-service.ts
@@ -1,0 +1,46 @@
+import type { NegotiationReview } from "../domain/negotiation.js";
+import type { AgentRepository } from "../ports/agent-repo.js";
+import type { EscalationRepository } from "../ports/escalation-repo.js";
+import type {
+  NegotiationRepository,
+  NegotiationRoundRepository,
+} from "../ports/negotiation-repo.js";
+import { NegotiationNotFoundError } from "./escalation-service.js";
+
+export { NegotiationNotFoundError };
+
+export interface NegotiationServiceDeps {
+  negotiationRepo: NegotiationRepository;
+  negotiationRoundRepo: NegotiationRoundRepository;
+  agentRepo: AgentRepository;
+  escalationRepo: EscalationRepository;
+}
+
+/**
+ * Read-only service for the human-facing negotiation review page. Fetches
+ * the row, its full round transcript, both agent display names, and the
+ * linked escalation id (when escalated) — all in parallel.
+ */
+export class NegotiationService {
+  constructor(private readonly deps: NegotiationServiceDeps) {}
+
+  async getReview(id: string): Promise<NegotiationReview> {
+    const neg = await this.deps.negotiationRepo.findById(id);
+    if (!neg) throw new NegotiationNotFoundError(id);
+
+    const [initiatorAgent, counterpartyAgent, rounds, escalation] = await Promise.all([
+      this.deps.agentRepo.findById(neg.initiator_agent_id),
+      this.deps.agentRepo.findById(neg.counterparty_agent_id),
+      this.deps.negotiationRoundRepo.listByNegotiation(neg.id),
+      this.deps.escalationRepo.findByNegotiation(neg.id),
+    ]);
+
+    return {
+      ...neg,
+      initiator_agent_name: initiatorAgent?.name ?? neg.initiator_agent_id,
+      counterparty_agent_name: counterpartyAgent?.name ?? neg.counterparty_agent_id,
+      rounds,
+      escalation_id: escalation?.id,
+    };
+  }
+}

--- a/packages/web/app/(authed)/escalations/[id]/escalation-detail-client.tsx
+++ b/packages/web/app/(authed)/escalations/[id]/escalation-detail-client.tsx
@@ -2,7 +2,8 @@
 
 import Link from "next/link";
 import { useState, type ReactNode } from "react";
-import { ArrowLeft, AlertTriangle, Info, Scale } from "lucide-react";
+import { AlertTriangle, Info, Scale } from "lucide-react";
+import { MeshBackLink } from "@/components/detail/mesh-back-link";
 import { useEscalation } from "@/lib/hooks/use-escalations";
 import { useResolveEscalation } from "@/lib/hooks/use-escalation-mutations";
 import { isApiConfigured } from "@/lib/api/config";
@@ -33,16 +34,6 @@ interface SideView {
   submittedAt?: string;
   recovered?: EscalationRecoveredPosition;
 }
-
-const MeshBackLink = () => (
-  <Link
-    href="/mesh"
-    className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors mb-3"
-  >
-    <ArrowLeft className="h-3 w-3" />
-    Mesh
-  </Link>
-);
 
 export function EscalationDetailClient({ escalationId }: { escalationId: string }) {
   const { data, isLoading, isError } = useEscalation(escalationId);

--- a/packages/web/app/(authed)/negotiations/[id]/loading.tsx
+++ b/packages/web/app/(authed)/negotiations/[id]/loading.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from "@/components/skeleton";
+
+export default function NegotiationDetailLoading() {
+  return (
+    <div className="flex-1 overflow-auto">
+      <div className="max-w-5xl mx-auto px-6 py-8">
+        <Skeleton className="h-4 w-16 mb-3" />
+        <div className="flex items-start justify-between gap-6 mb-4">
+          <Skeleton className="h-7 w-40" />
+          <Skeleton className="h-6 w-20 rounded" />
+        </div>
+        <div className="space-y-3">
+          <Skeleton className="h-32 w-full rounded-lg" />
+          <Skeleton className="h-32 w-full rounded-lg" />
+          <Skeleton className="h-32 w-full rounded-lg" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/app/(authed)/negotiations/[id]/negotiation-detail-client.tsx
+++ b/packages/web/app/(authed)/negotiations/[id]/negotiation-detail-client.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft, AlertTriangle, MessagesSquare, Scale } from "lucide-react";
+import { useNegotiation } from "@/lib/hooks/use-negotiations";
+import { isApiConfigured } from "@/lib/api/config";
+import { ChatMarkdown } from "@/components/chat/markdown";
+import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
+import { DetailShell } from "@/components/detail/detail-shell";
+import { FooterField } from "@/components/detail/footer-field";
+import { NegotiationStatusPill } from "@/components/detail/status-pill";
+import { EmptyState } from "@/components/empty-state";
+import { Skeleton } from "@/components/skeleton";
+import { formatRelativeTime } from "@/lib/format";
+import type {
+  NegotiationDecision,
+  NegotiationReviewDetail,
+  NegotiationRoundDetail,
+} from "@/lib/types/negotiations";
+
+const MeshBackLink = () => (
+  <Link
+    href="/mesh"
+    className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors mb-3"
+  >
+    <ArrowLeft className="h-3 w-3" />
+    Mesh
+  </Link>
+);
+
+export function NegotiationDetailClient({ negotiationId }: { negotiationId: string }) {
+  const { data, isLoading, isError } = useNegotiation(negotiationId);
+
+  if (!isApiConfigured) {
+    return (
+      <DetailShell nav={<MeshBackLink />}>
+        <EmptyState
+          icon={MessagesSquare}
+          title="API not configured"
+          description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load this negotiation."
+        />
+      </DetailShell>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <DetailShell nav={<MeshBackLink />}>
+        <Skeleton className="h-7 w-40 mb-4" />
+        <Skeleton className="h-24 w-full rounded-lg mb-6" />
+        <div className="space-y-3">
+          <Skeleton className="h-32 w-full rounded-lg" />
+          <Skeleton className="h-32 w-full rounded-lg" />
+        </div>
+      </DetailShell>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <DetailShell nav={<MeshBackLink />}>
+        <EmptyState
+          icon={AlertTriangle}
+          title="Couldn't load negotiation"
+          description={`Negotiation ${negotiationId} could not be fetched. Check the MCP server logs.`}
+        />
+      </DetailShell>
+    );
+  }
+
+  return <NegotiationDetailLoaded neg={data.negotiation} />;
+}
+
+const DECISION_BADGE: Record<NegotiationDecision, string> = {
+  propose: "bg-status-running/10 text-status-running",
+  counter: "bg-status-review/10 text-status-review",
+  accept: "bg-status-done/10 text-status-done",
+  reject: "bg-status-failed/10 text-status-failed",
+};
+
+function DecisionBadge({ decision }: { decision: NegotiationDecision }) {
+  return (
+    <span
+      className={`inline-flex items-center h-5 px-1.5 rounded text-[10px] uppercase tracking-wider font-medium ${DECISION_BADGE[decision]}`}
+    >
+      {decision}
+    </span>
+  );
+}
+
+function NegotiationDetailLoaded({ neg }: { neg: NegotiationReviewDetail }) {
+  const nameForAgent = (id: string) =>
+    id === neg.initiator_agent_id
+      ? neg.initiator_agent_name
+      : id === neg.counterparty_agent_id
+        ? neg.counterparty_agent_name
+        : id;
+
+  return (
+    <DetailShell nav={<MeshBackLink />}>
+      <header className="mb-6">
+        <div className="flex items-start justify-between gap-6 mb-3">
+          <div className="min-w-0">
+            <h1 className="text-base font-semibold tracking-tight leading-tight">Negotiation</h1>
+            <p className="text-xs text-muted-foreground mt-0.5 truncate">
+              {neg.initiator_agent_name}
+              <span className="text-muted-foreground/50 mx-1.5">↔</span>
+              {neg.counterparty_agent_name}
+            </p>
+          </div>
+          <NegotiationStatusPill status={neg.status} />
+        </div>
+
+        {neg.escalation_id ? (
+          <Link
+            href={`/escalations/${neg.escalation_id}`}
+            className="block rounded-lg border border-status-review/40 bg-status-review/5 p-3 hover:bg-status-review/10 transition-colors"
+          >
+            <div className="flex items-center gap-2">
+              <Scale className="h-3.5 w-3.5 text-status-review shrink-0" />
+              <span className="text-xs text-status-review font-medium">
+                Escalated to humans — see resolution
+              </span>
+              <span className="ml-auto text-[11px] text-muted-foreground font-mono">
+                {neg.escalation_id}
+              </span>
+            </div>
+          </Link>
+        ) : null}
+      </header>
+
+      <section>
+        <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-3 font-medium">
+          Rounds <span className="text-muted-foreground/70 tabular-nums">{neg.rounds.length}</span>
+        </h2>
+        {neg.rounds.length === 0 ? (
+          <p className="text-sm text-muted-foreground italic">No rounds recorded.</p>
+        ) : (
+          <ul className="space-y-3">
+            {neg.rounds.map((round) => (
+              <RoundCard
+                key={round.id}
+                round={round}
+                agentName={nameForAgent(round.from_agent_id)}
+              />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+        <FooterField label="ID">
+          <ClickToCopyId id={neg.id} />
+        </FooterField>
+        {neg.task_id ? (
+          <FooterField label="Task">
+            <Link
+              href={`/tasks/${neg.task_id}`}
+              className="font-mono hover:text-foreground transition-colors"
+            >
+              {neg.task_id}
+            </Link>
+          </FooterField>
+        ) : null}
+        <FooterField label="Rounds">
+          {neg.rounds_completed}/{neg.max_rounds}
+        </FooterField>
+        <FooterField label="Created">{formatRelativeTime(neg.created_at)}</FooterField>
+        {neg.updated_at !== neg.created_at ? (
+          <FooterField label="Updated">{formatRelativeTime(neg.updated_at)}</FooterField>
+        ) : null}
+      </footer>
+    </DetailShell>
+  );
+}
+
+function RoundCard({
+  round,
+  agentName,
+}: {
+  round: NegotiationRoundDetail;
+  agentName: string;
+}) {
+  return (
+    <li className="rounded-lg border border-border bg-card p-4">
+      <div className="flex items-center gap-2 mb-2">
+        <span className="text-[11px] uppercase tracking-wider text-muted-foreground tabular-nums">
+          Round {round.round_number}
+        </span>
+        <span className="text-sm font-medium text-foreground truncate">{agentName}</span>
+        <DecisionBadge decision={round.decision} />
+        <span className="ml-auto text-[11px] text-muted-foreground/70 shrink-0">
+          {formatRelativeTime(round.sent_at)}
+        </span>
+      </div>
+      <div className="text-sm text-foreground/90">
+        <ChatMarkdown content={round.message} />
+      </div>
+    </li>
+  );
+}

--- a/packages/web/app/(authed)/negotiations/[id]/negotiation-detail-client.tsx
+++ b/packages/web/app/(authed)/negotiations/[id]/negotiation-detail-client.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowLeft, AlertTriangle, MessagesSquare, Scale } from "lucide-react";
+import { AlertTriangle, MessagesSquare, Scale } from "lucide-react";
+import { MeshBackLink } from "@/components/detail/mesh-back-link";
 import { useNegotiation } from "@/lib/hooks/use-negotiations";
 import { isApiConfigured } from "@/lib/api/config";
 import { ChatMarkdown } from "@/components/chat/markdown";
@@ -17,16 +18,6 @@ import type {
   NegotiationReviewDetail,
   NegotiationRoundDetail,
 } from "@/lib/types/negotiations";
-
-const MeshBackLink = () => (
-  <Link
-    href="/mesh"
-    className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors mb-3"
-  >
-    <ArrowLeft className="h-3 w-3" />
-    Mesh
-  </Link>
-);
 
 export function NegotiationDetailClient({ negotiationId }: { negotiationId: string }) {
   const { data, isLoading, isError } = useNegotiation(negotiationId);

--- a/packages/web/app/(authed)/negotiations/[id]/page.tsx
+++ b/packages/web/app/(authed)/negotiations/[id]/page.tsx
@@ -1,0 +1,8 @@
+import type { Metadata } from "next";
+import { NegotiationDetailClient } from "./negotiation-detail-client";
+
+export const metadata: Metadata = { title: "Negotiation" };
+
+export default function NegotiationDetailPage({ params }: { params: { id: string } }) {
+  return <NegotiationDetailClient negotiationId={params.id} />;
+}

--- a/packages/web/components/detail/mesh-back-link.tsx
+++ b/packages/web/components/detail/mesh-back-link.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+
+export function MeshBackLink() {
+  return (
+    <Link
+      href="/mesh"
+      className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors mb-3"
+    >
+      <ArrowLeft className="h-3 w-3" />
+      Mesh
+    </Link>
+  );
+}

--- a/packages/web/components/detail/status-pill.tsx
+++ b/packages/web/components/detail/status-pill.tsx
@@ -6,7 +6,14 @@ import type {
 } from "@beevibe/core";
 import { cn } from "@/lib/utils";
 
-const TASK_PILL: Record<TaskStatus, { dot: string; bg: string; text: string; label: string }> = {
+interface DotPillConfig {
+  dot: string;
+  bg: string;
+  text: string;
+  label: string;
+}
+
+const TASK_PILL: Record<TaskStatus, DotPillConfig> = {
   review: { dot: "bg-status-review", bg: "bg-status-review/10", text: "text-status-review", label: "review" },
   blocked: { dot: "bg-status-blocked", bg: "bg-status-blocked/10", text: "text-status-blocked", label: "blocked" },
   in_progress: { dot: "bg-status-running animate-pulse-breathe", bg: "bg-status-running/10", text: "text-status-running", label: "in progress" },
@@ -27,8 +34,21 @@ const SESSION_PILL: Record<SessionStatus, { bg: string; text: string; label: str
   cancelled: { bg: "bg-secondary", text: "text-muted-foreground", label: "cancelled" },
 };
 
-export function TaskStatusPill({ status, className }: { status: TaskStatus; className?: string }) {
-  const config = TASK_PILL[status];
+const ESCALATION_PILL: Record<EscalationStatus, DotPillConfig> = {
+  pending: { dot: "bg-status-review", bg: "bg-status-review/10", text: "text-status-review", label: "pending" },
+  resolved: { dot: "bg-status-done", bg: "bg-status-done/10", text: "text-status-done", label: "resolved" },
+  cancelled: { dot: "bg-status-cancelled", bg: "bg-secondary", text: "text-muted-foreground", label: "cancelled" },
+};
+
+const NEGOTIATION_PILL: Record<NegotiationStatus, DotPillConfig> = {
+  active: { dot: "bg-status-running", bg: "bg-status-running/10", text: "text-status-running", label: "active" },
+  accepted: { dot: "bg-status-done", bg: "bg-status-done/10", text: "text-status-done", label: "accepted" },
+  rejected: { dot: "bg-status-failed", bg: "bg-status-failed/10", text: "text-status-failed", label: "rejected" },
+  escalated: { dot: "bg-status-review", bg: "bg-status-review/10", text: "text-status-review", label: "escalated" },
+  cancelled: { dot: "bg-status-cancelled", bg: "bg-secondary", text: "text-muted-foreground", label: "cancelled" },
+};
+
+function DotPill({ config, className }: { config: DotPillConfig; className?: string }) {
   return (
     <span
       className={cn(
@@ -42,6 +62,10 @@ export function TaskStatusPill({ status, className }: { status: TaskStatus; clas
       {config.label}
     </span>
   );
+}
+
+export function TaskStatusPill({ status, className }: { status: TaskStatus; className?: string }) {
+  return <DotPill config={TASK_PILL[status]} className={className} />;
 }
 
 export function SessionStatusPill({ status, className }: { status: SessionStatus; className?: string }) {
@@ -61,52 +85,12 @@ export function SessionStatusPill({ status, className }: { status: SessionStatus
   );
 }
 
-const ESCALATION_PILL: Record<EscalationStatus, { dot: string; bg: string; text: string; label: string }> = {
-  pending: { dot: "bg-status-review", bg: "bg-status-review/10", text: "text-status-review", label: "pending" },
-  resolved: { dot: "bg-status-done", bg: "bg-status-done/10", text: "text-status-done", label: "resolved" },
-  cancelled: { dot: "bg-status-cancelled", bg: "bg-secondary", text: "text-muted-foreground", label: "cancelled" },
-};
-
 export function EscalationStatusPill({ status, className }: { status: EscalationStatus; className?: string }) {
-  const config = ESCALATION_PILL[status];
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1.5 h-6 px-2 rounded text-xs font-medium",
-        config.bg,
-        config.text,
-        className,
-      )}
-    >
-      <span className={cn("h-1.5 w-1.5 rounded-full", config.dot)} />
-      {config.label}
-    </span>
-  );
+  return <DotPill config={ESCALATION_PILL[status]} className={className} />;
 }
 
-const NEGOTIATION_PILL: Record<NegotiationStatus, { dot: string; bg: string; text: string; label: string }> = {
-  active: { dot: "bg-status-running", bg: "bg-status-running/10", text: "text-status-running", label: "active" },
-  accepted: { dot: "bg-status-done", bg: "bg-status-done/10", text: "text-status-done", label: "accepted" },
-  rejected: { dot: "bg-status-failed", bg: "bg-status-failed/10", text: "text-status-failed", label: "rejected" },
-  escalated: { dot: "bg-status-review", bg: "bg-status-review/10", text: "text-status-review", label: "escalated" },
-  cancelled: { dot: "bg-status-cancelled", bg: "bg-secondary", text: "text-muted-foreground", label: "cancelled" },
-};
-
 export function NegotiationStatusPill({ status, className }: { status: NegotiationStatus; className?: string }) {
-  const config = NEGOTIATION_PILL[status];
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1.5 h-6 px-2 rounded text-xs font-medium",
-        config.bg,
-        config.text,
-        className,
-      )}
-    >
-      <span className={cn("h-1.5 w-1.5 rounded-full", config.dot)} />
-      {config.label}
-    </span>
-  );
+  return <DotPill config={NEGOTIATION_PILL[status]} className={className} />;
 }
 
 export function PriorityPill({ priority }: { priority: string }) {

--- a/packages/web/components/detail/status-pill.tsx
+++ b/packages/web/components/detail/status-pill.tsx
@@ -1,4 +1,9 @@
-import type { TaskStatus, SessionStatus, EscalationStatus } from "@beevibe/core";
+import type {
+  TaskStatus,
+  SessionStatus,
+  EscalationStatus,
+  NegotiationStatus,
+} from "@beevibe/core";
 import { cn } from "@/lib/utils";
 
 const TASK_PILL: Record<TaskStatus, { dot: string; bg: string; text: string; label: string }> = {
@@ -64,6 +69,31 @@ const ESCALATION_PILL: Record<EscalationStatus, { dot: string; bg: string; text:
 
 export function EscalationStatusPill({ status, className }: { status: EscalationStatus; className?: string }) {
   const config = ESCALATION_PILL[status];
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 h-6 px-2 rounded text-xs font-medium",
+        config.bg,
+        config.text,
+        className,
+      )}
+    >
+      <span className={cn("h-1.5 w-1.5 rounded-full", config.dot)} />
+      {config.label}
+    </span>
+  );
+}
+
+const NEGOTIATION_PILL: Record<NegotiationStatus, { dot: string; bg: string; text: string; label: string }> = {
+  active: { dot: "bg-status-running", bg: "bg-status-running/10", text: "text-status-running", label: "active" },
+  accepted: { dot: "bg-status-done", bg: "bg-status-done/10", text: "text-status-done", label: "accepted" },
+  rejected: { dot: "bg-status-failed", bg: "bg-status-failed/10", text: "text-status-failed", label: "rejected" },
+  escalated: { dot: "bg-status-review", bg: "bg-status-review/10", text: "text-status-review", label: "escalated" },
+  cancelled: { dot: "bg-status-cancelled", bg: "bg-secondary", text: "text-muted-foreground", label: "cancelled" },
+};
+
+export function NegotiationStatusPill({ status, className }: { status: NegotiationStatus; className?: string }) {
+  const config = NEGOTIATION_PILL[status];
   return (
     <span
       className={cn(

--- a/packages/web/components/mesh/activity-feed.tsx
+++ b/packages/web/components/mesh/activity-feed.tsx
@@ -189,10 +189,18 @@ function AskRow({ ask, dim, highlighted, selectedAgent, onEnter, onLeave }: RowP
     dim && "opacity-40",
   );
 
-  // Each mesh ask is anchored to the source task that initiated it; the task
-  // detail page is the canonical surface for the full conversation. Defensive
-  // fallback to unlinked when source_task_short_id is missing.
-  if (!ask.source_task_short_id) {
+  // Negotiations have a dedicated transcript page (`/negotiations/:id`);
+  // ask + blocker rows route to the source task (the task page renders the
+  // blocker text and is the natural context for an ask). Falls back to an
+  // unlinked div if neither hook is available.
+  const href =
+    ask.type === "negotiate"
+      ? `/negotiations/${ask.id}`
+      : ask.source_task_short_id
+        ? `/tasks/${ask.source_task_short_id}`
+        : null;
+
+  if (!href) {
     return (
       <li>
         <div className={className} onMouseEnter={onEnter} onMouseLeave={onLeave}>
@@ -205,7 +213,7 @@ function AskRow({ ask, dim, highlighted, selectedAgent, onEnter, onLeave }: RowP
   return (
     <li>
       <Link
-        href={`/tasks/${ask.source_task_short_id}`}
+        href={href}
         className={cn(className, "cursor-pointer")}
         onMouseEnter={onEnter}
         onMouseLeave={onLeave}

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -27,6 +27,7 @@ import type { FactCounts, MemoryFactDisplay } from "@/lib/types/memory-facts";
 import type { PromotionEvent } from "@/lib/types/promotion-events";
 import type { InboxItem } from "@/lib/types/inbox";
 import type { EscalationReviewDetail } from "@/lib/types/escalations";
+import type { NegotiationReviewDetail } from "@/lib/types/negotiations";
 import type { Lifecycle } from "@/lib/tasks-grouping";
 
 export type TaskView = "all" | "mine";
@@ -670,6 +671,13 @@ export const api = {
       ),
     health: (opts: ReadOptions = {}) =>
       fetchJson<HealthResponse>("/health/runtime", { signal: opts.signal }),
+  },
+  negotiations: {
+    get: (id: string, opts: ReadOptions = {}) =>
+      fetchJson<{ ok: true; negotiation: NegotiationReviewDetail }>(
+        `/negotiation/${encodeURIComponent(id)}`,
+        { signal: opts.signal },
+      ),
   },
   escalations: {
     get: (id: string, opts: ReadOptions = {}) =>

--- a/packages/web/lib/hooks/keys.ts
+++ b/packages/web/lib/hooks/keys.ts
@@ -50,6 +50,10 @@ export const queryKeys = {
     all: ["escalations"] as const,
     detail: (id: string) => ["escalations", "detail", id] as const,
   },
+  negotiations: {
+    all: ["negotiations"] as const,
+    detail: (id: string) => ["negotiations", "detail", id] as const,
+  },
   agentNetwork: {
     all: ["agent-network"] as const,
     self: () => ["agent-network", "self"] as const,

--- a/packages/web/lib/hooks/use-negotiations.ts
+++ b/packages/web/lib/hooks/use-negotiations.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api/client";
+import { isApiConfigured } from "@/lib/api/config";
+import { queryKeys } from "./keys";
+
+export function useNegotiation(id: string | undefined) {
+  return useQuery({
+    queryKey: id ? queryKeys.negotiations.detail(id) : queryKeys.negotiations.all,
+    queryFn: ({ signal }) => api.negotiations.get(id as string, { signal }),
+    enabled: isApiConfigured && !!id,
+  });
+}

--- a/packages/web/lib/mesh-display.ts
+++ b/packages/web/lib/mesh-display.ts
@@ -46,6 +46,10 @@ function askToDisplay(data: MeshAskData): MeshAsk {
     status: DISPLAY_STATUS[data.status],
     duration_label: formatDurationLabel(data.started_at, data.completed_at),
     intent: data.intent,
+    // Drives activity-feed's click-through to /tasks/:id. The field name is
+    // legacy ("short_id"); the route accepts the full task id and the SQL
+    // returns it on every mesh kind that has a source task.
+    source_task_short_id: data.source_task_id,
     chain_depth:
       data.rounds_completed !== undefined && data.max_rounds !== undefined
         ? `${data.rounds_completed}/${data.max_rounds}`

--- a/packages/web/lib/types/negotiations.ts
+++ b/packages/web/lib/types/negotiations.ts
@@ -1,0 +1,20 @@
+// Serialized negotiation review shape returned by GET /negotiation/:id.
+// Mirrors @beevibe/core's NegotiationReview but with timestamps as ISO
+// strings — the web only sees JSON over the wire.
+
+import type { NegotiationRound, NegotiationReview } from "@beevibe/core";
+
+export type { NegotiationStatus, NegotiationDecision } from "@beevibe/core";
+
+export type NegotiationRoundDetail = Omit<NegotiationRound, "sent_at"> & {
+  sent_at: string;
+};
+
+export type NegotiationReviewDetail = Omit<
+  NegotiationReview,
+  "rounds" | "created_at" | "updated_at"
+> & {
+  rounds: NegotiationRoundDetail[];
+  created_at: string;
+  updated_at: string;
+};


### PR DESCRIPTION
## Summary
- **New `/negotiations/[id]` page** renders the full round transcript with both team names, per-round decision badges, and a link to the linked escalation when escalated. Mirrors the `/escalations/[id]` pattern from #225.
- **Activity feed rows are clickable per kind**:
  - negotiate → `/negotiations/{id}`
  - ask + blocker → `/tasks/{source_task_id}`
  Fixes a latent bug: `mesh-display.ts` never populated the legacy `source_task_short_id` field, so all rows fell back to a static `<div>`.
- **Backend**: `GET /negotiation/:id` served by `NegotiationService.getReview` — fetches the row, both agent names, the full round list, and the linked escalation id (when escalated), all in parallel.
- **`NegotiationStatusPill`** added to `components/detail/status-pill.tsx`, record-based config matching the Task/Session/Escalation pills.

## Test plan
- [x] Core unit (`negotiation-service`): 4/4 (active + escalated + deleted-agent fallback + 404)
- [x] API integration (`negotiation` routes, real Postgres): 5/5 (rounds + names, escalation_id linkage, 404, 403 agent, 401 missing token)
- [x] Regression sweep: 17 escalation + 6 inbox tests still green
- [x] Web typecheck + lint clean
- [ ] Visual click-through: mesh page → click a negotiate row → see the round transcript

🤖 Generated with [Claude Code](https://claude.com/claude-code)