### PR TITLE
feat(mesh): time-window filter (24h / 7d / 30d / All)

### DIFF
--- a/packages/api/src/routes/view.ts
+++ b/packages/api/src/routes/view.ts
@@ -48,7 +48,7 @@ import { listAgents, getAgent } from "../views/agents.js";
 import { getSessionByShortId, getSessionTree, AmbiguousShortIdError } from "../views/sessions.js";
 import { listMemoryFactCounts, listMemoryFacts } from "../views/memory.js";
 import { getDashboardSummary } from "../views/dashboard.js";
-import { getMeshOverview, isMeshWindow } from "../views/mesh.js";
+import { DEFAULT_MESH_WINDOW, getMeshOverview, isMeshWindow } from "../views/mesh.js";
 import { listPromotions } from "../views/promotions.js";
 import { listActivity } from "../views/activity.js";
 import { getWorkProduct } from "../views/work-product.js";
@@ -502,7 +502,8 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
 
   router.get("/mesh", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const window = isMeshWindow(req.query.window) ? req.query.window : "24h";
+    const raw = req.query.window;
+    const window = isMeshWindow(raw) ? raw : DEFAULT_MESH_WINDOW;
     try {
       const overview = await getMeshOverview(deps.pool, window);
       res.json(overview);

--- a/packages/api/src/routes/view.ts
+++ b/packages/api/src/routes/view.ts
@@ -48,7 +48,7 @@ import { listAgents, getAgent } from "../views/agents.js";
 import { getSessionByShortId, getSessionTree, AmbiguousShortIdError } from "../views/sessions.js";
 import { listMemoryFactCounts, listMemoryFacts } from "../views/memory.js";
 import { getDashboardSummary } from "../views/dashboard.js";
-import { getMeshOverview } from "../views/mesh.js";
+import { getMeshOverview, isMeshWindow } from "../views/mesh.js";
 import { listPromotions } from "../views/promotions.js";
 import { listActivity } from "../views/activity.js";
 import { getWorkProduct } from "../views/work-product.js";
@@ -502,8 +502,9 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
 
   router.get("/mesh", async (req, res) => {
     if (!requireHuman(req, res)) return;
+    const window = isMeshWindow(req.query.window) ? req.query.window : "24h";
     try {
-      const overview = await getMeshOverview(deps.pool);
+      const overview = await getMeshOverview(deps.pool, window);
       res.json(overview);
     } catch (err) {
       handleError(err, res, "mesh overview");

--- a/packages/api/src/views/mesh.test.ts
+++ b/packages/api/src/views/mesh.test.ts
@@ -11,7 +11,7 @@
  *   5) SUMMARY_SQL        → total counts
  */
 import { describe, it, expect } from "vitest";
-import { getMeshOverview } from "./mesh.js";
+import { getMeshOverview, isMeshWindow } from "./mesh.js";
 import { makeMockPool } from "./test-helpers.js";
 
 const baseAsk = {
@@ -276,5 +276,28 @@ describe("getMeshOverview — nodes + edges + summary", () => {
     ]);
     const { summary } = await getMeshOverview(pool);
     expect(summary).toEqual({ asks_24h: 12, in_flight: 3, edge_count: 7 });
+  });
+
+  it("accepts an explicit window parameter without crashing", async () => {
+    const pool = makeMockPool([[], [], [], [], []]);
+    await expect(getMeshOverview(pool, "7d")).resolves.toBeDefined();
+    await expect(getMeshOverview(pool, "all")).resolves.toBeDefined();
+  });
+});
+
+describe("isMeshWindow", () => {
+  it("accepts the four valid windows", () => {
+    expect(isMeshWindow("24h")).toBe(true);
+    expect(isMeshWindow("7d")).toBe(true);
+    expect(isMeshWindow("30d")).toBe(true);
+    expect(isMeshWindow("all")).toBe(true);
+  });
+
+  it("rejects unknown strings and non-string inputs", () => {
+    expect(isMeshWindow("60d")).toBe(false);
+    expect(isMeshWindow("24H")).toBe(false);
+    expect(isMeshWindow("")).toBe(false);
+    expect(isMeshWindow(undefined)).toBe(false);
+    expect(isMeshWindow(7)).toBe(false);
   });
 });

--- a/packages/api/src/views/mesh.ts
+++ b/packages/api/src/views/mesh.ts
@@ -18,6 +18,12 @@
  *
  * The asks/edges/nodes/summary all union both sources so the activity feed +
  * graph + KPIs reflect the full mesh picture.
+ *
+ * The time window is parameterized via {@link MeshWindow}. The default is
+ * "24h" to match the prior behavior; `"all"` lifts the time predicate so
+ * everything ever recorded shows (still capped by the row LIMIT). The
+ * `asks_24h` summary KPI stays hardcoded at 24h regardless of window — it
+ * answers "what happened today", not "what's in the current view".
  */
 
 import type { Pool } from "@beevibe/core/adapters/postgres";
@@ -29,22 +35,53 @@ import type {
   GraphNodeData,
   GraphEdgeData,
   MeshSummaryData,
+  MeshWindow,
 } from "./types.js";
+import { MESH_WINDOWS } from "./types.js";
 
 const ASKS_LIMIT = 50;
-const WINDOW = "24 hours";
+const DEFAULT_WINDOW: MeshWindow = "24h";
 
-// Reused SQL fragments — interpolated into the queries below so the
-// negotiation/session window filters and the from="..." caller extraction
-// stay in sync across all 5 queries.
-const NEGO_WINDOW = `created_at >= NOW() - INTERVAL '${WINDOW}' OR status = 'active'`;
-const SESS_WINDOW = `type IN ('mesh_ask', 'blocker') AND (started_at >= NOW() - INTERVAL '${WINDOW}' OR status = 'running')`;
+const WINDOW_INTERVAL: Record<Exclude<MeshWindow, "all">, string> = {
+  "24h": "24 hours",
+  "7d": "7 days",
+  "30d": "30 days",
+};
+
+export function isMeshWindow(value: unknown): value is MeshWindow {
+  return typeof value === "string" && (MESH_WINDOWS as readonly string[]).includes(value);
+}
+
+/**
+ * Build the per-source WHERE-fragment pair for a given window. `negWindow`
+ * applies to `negotiation` rows (created_at + always-include-active);
+ * `sessWindow` to `session` rows (type filter + started_at + always-include-
+ * running). `"all"` drops the time predicate entirely (active/running rows
+ * were already always-included, so this only widens history).
+ */
+function buildWindowFragments(window: MeshWindow): {
+  negWindow: string;
+  sessWindow: string;
+} {
+  if (window === "all") {
+    return {
+      negWindow: "TRUE",
+      sessWindow: "type IN ('mesh_ask', 'blocker')",
+    };
+  }
+  const interval = WINDOW_INTERVAL[window];
+  return {
+    negWindow: `created_at >= NOW() - INTERVAL '${interval}' OR status = 'active'`,
+    sessWindow: `type IN ('mesh_ask', 'blocker') AND (started_at >= NOW() - INTERVAL '${interval}' OR status = 'running')`,
+  };
+}
+
 // Use the indexed `caller_agent_id` column with a regex fallback for any
 // pre-backfill row that slipped through (defense in depth — the migration
 // `1780100000000_add-session-caller-agent-id.sql` populated existing rows).
 const SESS_FROM = `COALESCE(caller_agent_id, substring(intent FROM 'from="([^"]+)"'))`;
 
-const NEGOTIATIONS_SQL = /* sql */ `
+const negotiationsSql = (negWindow: string) => /* sql */ `
 SELECT
   n.id,
   n.initiator_agent_id     AS caller_id,
@@ -63,7 +100,7 @@ JOIN agent ca ON ca.id = n.initiator_agent_id
 JOIN agent ta ON ta.id = n.counterparty_agent_id
 LEFT JOIN negotiation_round nr1
   ON nr1.negotiation_id = n.id AND nr1.round_number = 1
-WHERE n.created_at >= NOW() - INTERVAL '${WINDOW}' OR n.status = 'active'
+WHERE ${negWindow}
 ORDER BY n.created_at DESC
 LIMIT $1
 `;
@@ -73,7 +110,7 @@ LIMIT $1
  * the intent XML as `from="agent_xxx"` — extract via regex. Body is the
  * inner text up to the closing tag (we strip the wrapper for preview).
  */
-const MESH_SESSIONS_SQL = /* sql */ `
+const meshSessionsSql = (sessWindow: string) => /* sql */ `
 SELECT
   s.id,
   ${SESS_FROM}              AS caller_id,
@@ -89,7 +126,7 @@ SELECT
 FROM session s
 LEFT JOIN agent ca ON ca.id = ${SESS_FROM}
 JOIN agent ta ON ta.id = s.agent_id
-WHERE ${SESS_WINDOW}
+WHERE ${sessWindow}
 ORDER BY s.started_at DESC
 LIMIT $1
 `;
@@ -99,19 +136,19 @@ LIMIT $1
  * session rows so the graph reflects the full mesh picture.
  * `bool_or(is_live)` derives node liveness without a second pass.
  */
-const NODES_SQL = /* sql */ `
+const nodesSql = (negWindow: string, sessWindow: string) => /* sql */ `
 WITH endpoints AS (
   SELECT initiator_agent_id AS agent_id, (status = 'active') AS is_live
-  FROM negotiation WHERE ${NEGO_WINDOW}
+  FROM negotiation WHERE ${negWindow}
   UNION ALL
   SELECT counterparty_agent_id AS agent_id, (status = 'active') AS is_live
-  FROM negotiation WHERE ${NEGO_WINDOW}
+  FROM negotiation WHERE ${negWindow}
   UNION ALL
   SELECT agent_id, (status = 'running') AS is_live
-  FROM session WHERE ${SESS_WINDOW}
+  FROM session WHERE ${sessWindow}
   UNION ALL
   SELECT ${SESS_FROM} AS agent_id, (status = 'running') AS is_live
-  FROM session WHERE ${SESS_WINDOW} AND ${SESS_FROM} IS NOT NULL
+  FROM session WHERE ${sessWindow} AND ${SESS_FROM} IS NOT NULL
 )
 SELECT
   a.id,
@@ -126,15 +163,15 @@ ORDER BY
   a.name ASC
 `;
 
-const EDGES_SQL = /* sql */ `
+const edgesSql = (negWindow: string, sessWindow: string) => /* sql */ `
 WITH pairs AS (
   SELECT initiator_agent_id AS from_id, counterparty_agent_id AS to_id,
          (status = 'active') AS is_live
-  FROM negotiation WHERE ${NEGO_WINDOW}
+  FROM negotiation WHERE ${negWindow}
   UNION ALL
   SELECT ${SESS_FROM} AS from_id, agent_id AS to_id,
          (status = 'running') AS is_live
-  FROM session WHERE ${SESS_WINDOW} AND ${SESS_FROM} IS NOT NULL
+  FROM session WHERE ${sessWindow} AND ${SESS_FROM} IS NOT NULL
 )
 SELECT
   from_id,
@@ -146,20 +183,20 @@ GROUP BY from_id, to_id
 ORDER BY count DESC
 `;
 
-const SUMMARY_SQL = /* sql */ `
+const summarySql = (negWindow: string, sessWindow: string) => /* sql */ `
 WITH activity AS (
   SELECT (status = 'active') AS is_live, created_at,
          initiator_agent_id AS a, counterparty_agent_id AS b
-  FROM negotiation WHERE ${NEGO_WINDOW}
+  FROM negotiation WHERE ${negWindow}
   UNION ALL
   SELECT (status = 'running') AS is_live, started_at AS created_at,
          ${SESS_FROM} AS a, agent_id AS b
-  FROM session WHERE ${SESS_WINDOW}
+  FROM session WHERE ${sessWindow}
 )
 SELECT
-  COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '${WINDOW}')::int  AS asks_24h,
-  COUNT(*) FILTER (WHERE is_live)::int                                     AS in_flight,
-  COUNT(DISTINCT (a, b)) FILTER (WHERE a IS NOT NULL)::int                 AS edge_count
+  COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '24 hours')::int  AS asks_24h,
+  COUNT(*) FILTER (WHERE is_live)::int                                    AS in_flight,
+  COUNT(DISTINCT (a, b)) FILTER (WHERE a IS NOT NULL)::int                AS edge_count
 FROM activity
 `;
 
@@ -246,14 +283,19 @@ function extractMeshIntent(intent: string): string {
   return (match?.[1] ?? intent).trim() || "(no message)";
 }
 
-export async function getMeshOverview(pool: Pool): Promise<MeshOverview> {
+export async function getMeshOverview(
+  pool: Pool,
+  window: MeshWindow = DEFAULT_WINDOW,
+): Promise<MeshOverview> {
+  const { negWindow, sessWindow } = buildWindowFragments(window);
+
   const [negotiationsResult, meshSessionsResult, nodesResult, edgesResult, summaryResult] =
     await Promise.all([
-      pool.query<NegotiationsRow>(NEGOTIATIONS_SQL, [ASKS_LIMIT]),
-      pool.query<MeshSessionsRow>(MESH_SESSIONS_SQL, [ASKS_LIMIT]),
-      pool.query<NodesRow>(NODES_SQL),
-      pool.query<EdgesRow>(EDGES_SQL),
-      pool.query<SummaryRow>(SUMMARY_SQL),
+      pool.query<NegotiationsRow>(negotiationsSql(negWindow), [ASKS_LIMIT]),
+      pool.query<MeshSessionsRow>(meshSessionsSql(sessWindow), [ASKS_LIMIT]),
+      pool.query<NodesRow>(nodesSql(negWindow, sessWindow)),
+      pool.query<EdgesRow>(edgesSql(negWindow, sessWindow)),
+      pool.query<SummaryRow>(summarySql(negWindow, sessWindow)),
     ]);
 
   const negotiationAsks: MeshAskData[] = negotiationsResult.rows.map((r) => {

--- a/packages/api/src/views/mesh.ts
+++ b/packages/api/src/views/mesh.ts
@@ -19,11 +19,10 @@
  * The asks/edges/nodes/summary all union both sources so the activity feed +
  * graph + KPIs reflect the full mesh picture.
  *
- * The time window is parameterized via {@link MeshWindow}. The default is
- * "24h" to match the prior behavior; `"all"` lifts the time predicate so
- * everything ever recorded shows (still capped by the row LIMIT). The
- * `asks_24h` summary KPI stays hardcoded at 24h regardless of window — it
- * answers "what happened today", not "what's in the current view".
+ * The time window is parameterized via {@link MeshWindow}. `"all"` lifts
+ * the time predicate (still capped by the row LIMIT). `asks_24h` stays
+ * hardcoded at 24h — it answers "what happened today", not "what's in the
+ * current view".
  */
 
 import type { Pool } from "@beevibe/core/adapters/postgres";
@@ -40,7 +39,7 @@ import type {
 import { MESH_WINDOWS } from "./types.js";
 
 const ASKS_LIMIT = 50;
-const DEFAULT_WINDOW: MeshWindow = "24h";
+export const DEFAULT_MESH_WINDOW: MeshWindow = "24h";
 
 const WINDOW_INTERVAL: Record<Exclude<MeshWindow, "all">, string> = {
   "24h": "24 hours",
@@ -285,7 +284,7 @@ function extractMeshIntent(intent: string): string {
 
 export async function getMeshOverview(
   pool: Pool,
-  window: MeshWindow = DEFAULT_WINDOW,
+  window: MeshWindow = DEFAULT_MESH_WINDOW,
 ): Promise<MeshOverview> {
   const { negWindow, sessWindow } = buildWindowFragments(window);
 

--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -519,6 +519,14 @@ export interface MeshSummaryData {
   edge_count: number;
 }
 
+/**
+ * Time window the mesh page can show. Driven by the header pill row; the
+ * default is "24h" to match the prior behavior. `"all"` lifts the time
+ * filter entirely (still capped by the row LIMIT).
+ */
+export type MeshWindow = "24h" | "7d" | "30d" | "all";
+export const MESH_WINDOWS: readonly MeshWindow[] = ["24h", "7d", "30d", "all"];
+
 export interface MeshOverview {
   asks: MeshAskData[];
   graph: { nodes: GraphNodeData[]; edges: GraphEdgeData[] };

--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -520,12 +520,11 @@ export interface MeshSummaryData {
 }
 
 /**
- * Time window the mesh page can show. Driven by the header pill row; the
- * default is "24h" to match the prior behavior. `"all"` lifts the time
- * filter entirely (still capped by the row LIMIT).
+ * Time window the mesh page can show. Driven by the header pill row.
+ * `"all"` lifts the time filter entirely (still capped by the row LIMIT).
  */
-export type MeshWindow = "24h" | "7d" | "30d" | "all";
-export const MESH_WINDOWS: readonly MeshWindow[] = ["24h", "7d", "30d", "all"];
+export const MESH_WINDOWS = ["24h", "7d", "30d", "all"] as const;
+export type MeshWindow = (typeof MESH_WINDOWS)[number];
 
 export interface MeshOverview {
   asks: MeshAskData[];

--- a/packages/web/app/(authed)/mesh/mesh-client.tsx
+++ b/packages/web/app/(authed)/mesh/mesh-client.tsx
@@ -8,12 +8,14 @@ import { MeshAskSkeleton } from "@/components/skeletons";
 import { MeshActivityFeed } from "@/components/mesh/activity-feed";
 import { MeshGraphStatic } from "@/components/mesh/graph-static";
 import { ChainBudget } from "@/components/mesh/chain-budget";
+import { MeshWindowPills } from "@/components/mesh/window-pills";
 import { useMeshOverview } from "@/lib/hooks/use-mesh";
 import { isApiConfigured } from "@/lib/api/config";
-import type { MeshDisplay, MeshHover } from "@/lib/types/mesh";
+import type { MeshDisplay, MeshHover, MeshWindow } from "@/lib/types/mesh";
 
 export function MeshClient() {
-  const { data, isLoading, isError } = useMeshOverview();
+  const [meshWindow, setMeshWindow] = useState<MeshWindow>("24h");
+  const { data, isLoading, isError } = useMeshOverview({ window: meshWindow });
 
   return (
     <div className="flex-1 overflow-auto">
@@ -27,6 +29,7 @@ export function MeshClient() {
               chain so loops can&rsquo;t run away.
             </p>
           </div>
+          <MeshWindowPills value={meshWindow} onChange={setMeshWindow} />
         </div>
 
         <Body data={data} isLoading={isLoading} isError={isError} />

--- a/packages/web/components/mesh/window-pills.tsx
+++ b/packages/web/components/mesh/window-pills.tsx
@@ -3,13 +3,6 @@
 import { cn } from "@/lib/utils";
 import { MESH_WINDOWS, type MeshWindow } from "@/lib/types/mesh";
 
-const WINDOW_LABEL: Record<MeshWindow, string> = {
-  "24h": "24h",
-  "7d": "7d",
-  "30d": "30d",
-  all: "All time",
-};
-
 interface Props {
   value: MeshWindow;
   onChange: (value: MeshWindow) => void;
@@ -32,7 +25,7 @@ export function MeshWindowPills({ value, onChange }: Props) {
                 : "text-muted-foreground hover:text-foreground hover:bg-secondary",
             )}
           >
-            {WINDOW_LABEL[w]}
+            {w === "all" ? "All time" : w}
           </button>
         );
       })}

--- a/packages/web/components/mesh/window-pills.tsx
+++ b/packages/web/components/mesh/window-pills.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { MESH_WINDOWS, type MeshWindow } from "@/lib/types/mesh";
+
+const WINDOW_LABEL: Record<MeshWindow, string> = {
+  "24h": "24h",
+  "7d": "7d",
+  "30d": "30d",
+  all: "All time",
+};
+
+interface Props {
+  value: MeshWindow;
+  onChange: (value: MeshWindow) => void;
+}
+
+export function MeshWindowPills({ value, onChange }: Props) {
+  return (
+    <div className="flex items-center gap-1 text-xs shrink-0">
+      {MESH_WINDOWS.map((w) => {
+        const active = value === w;
+        return (
+          <button
+            key={w}
+            type="button"
+            onClick={() => onChange(w)}
+            className={cn(
+              "px-2 py-1 rounded transition-colors cursor-pointer",
+              active
+                ? "bg-secondary text-foreground font-medium"
+                : "text-muted-foreground hover:text-foreground hover:bg-secondary",
+            )}
+          >
+            {WINDOW_LABEL[w]}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/web/lib/api/client.test.ts
+++ b/packages/web/lib/api/client.test.ts
@@ -98,10 +98,10 @@ describe("api client (reads)", () => {
       expect(fetchJsonMock).toHaveBeenCalledWith("/promotion", { signal: undefined });
     });
 
-    it("mesh.overview() hits /mesh with optional since", async () => {
-      await api.mesh.overview({ since: "2026-04-30T00:00:00Z" });
+    it("mesh.overview() hits /mesh with optional window", async () => {
+      await api.mesh.overview({ window: "7d" });
       expect(fetchJsonMock).toHaveBeenCalledWith("/mesh", {
-        query: { since: "2026-04-30T00:00:00Z" },
+        query: { window: "7d" },
         signal: undefined,
       });
     });

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -19,6 +19,7 @@ import type {
   DashboardSummary,
   MeshOverview,
 } from "./types";
+import type { MeshWindow } from "@/lib/types/mesh";
 import type { TaskListItem } from "@/lib/types/tasks";
 import type { AgentDisplay } from "@/lib/types/agents";
 import type { AgentNetwork } from "@/lib/types/agent-network";
@@ -547,7 +548,7 @@ export const api = {
       }),
   },
   mesh: {
-    overview: (filter: { since?: string } = {}, opts: ReadOptions = {}) =>
+    overview: (filter: { window?: MeshWindow } = {}, opts: ReadOptions = {}) =>
       fetchJson<MeshOverview>("/mesh", { query: { ...filter }, signal: opts.signal }),
   },
   dashboard: {

--- a/packages/web/lib/hooks/keys.ts
+++ b/packages/web/lib/hooks/keys.ts
@@ -1,5 +1,6 @@
 import type { TaskListFilter } from "@/lib/api/client";
 import type { MemoryScope } from "@beevibe/core";
+import type { MeshWindow } from "@/lib/types/mesh";
 
 export const queryKeys = {
   tasks: {
@@ -27,7 +28,7 @@ export const queryKeys = {
   },
   mesh: {
     all: ["mesh"] as const,
-    overview: (filter: { since?: string }) => ["mesh", "overview", filter] as const,
+    overview: (filter: { window?: MeshWindow }) => ["mesh", "overview", filter] as const,
   },
   dashboard: {
     all: ["dashboard"] as const,

--- a/packages/web/lib/hooks/use-mesh.ts
+++ b/packages/web/lib/hooks/use-mesh.ts
@@ -2,9 +2,10 @@ import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
 import { overviewToDisplay } from "@/lib/mesh-display";
+import type { MeshWindow } from "@/lib/types/mesh";
 import { queryKeys } from "./keys";
 
-export function useMeshOverview(filter: { since?: string } = {}) {
+export function useMeshOverview(filter: { window?: MeshWindow } = {}) {
   return useQuery({
     queryKey: queryKeys.mesh.overview(filter),
     queryFn: ({ signal }) => api.mesh.overview(filter, { signal }),

--- a/packages/web/lib/types/mesh.ts
+++ b/packages/web/lib/types/mesh.ts
@@ -91,4 +91,7 @@ export type {
   GraphNodeData,
   GraphEdgeData,
   MeshSummaryData,
+  MeshWindow,
 } from "@beevibe/api/views/types";
+
+export { MESH_WINDOWS } from "@beevibe/api/views/types";


### PR DESCRIPTION
## Summary
Mesh page now has a pill row in the header so users can see activity beyond the previous hard-coded 24h slice.

```
Mesh activity                                  [24h]  7d   30d   All time
Agents ask each other when one agent's…
```

- **Backend**: `getMeshOverview` takes a `MeshWindow` (`24h | 7d | 30d | all`); the 5 SQL fragments are templated per window. `"all"` lifts the time predicate (active/running rows were already always-included). `asks_24h` in the summary KPI stays anchored to 24h regardless of page window — it answers "what happened today", not "what's in view".
- **Route**: `/mesh` validates `?window=` against `MESH_WINDOWS` and falls back to `"24h"` on unknown / missing.
- **Web**: `<MeshWindowPills>` matches the activity-feed filter style. `queryKey` includes the window so React Query caches each selection separately. The vestigial `since?` filter is renamed `window?` throughout the hook/client/keys.

## Test plan
- [x] Mesh view: `isMeshWindow` validates 4 valid / 5 invalid inputs; `getMeshOverview` accepts an explicit window without crashing.
- [x] Sweep: 49 api + 21 core + 141 web tests pass.
- [x] Web typecheck + lint clean.
- [ ] Visual: load `/mesh`, click `7d`, confirm activity rows expand to include older items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)