### PR TITLE
docs: clarify Beevibe Crystal setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,26 +31,32 @@ services, the local daemon processes, and the CLI binaries doing the work.
 
 ## Beevibe Crystal
 
-Beevibe Crystal turns a Claude Code session into a shareable, queryable
-capsule. It is the public artifact layer for Beevibe: instead of sending a
-raw transcript, you publish a link that teammates can ask questions about.
+Beevibe Crystal is the shareable artifact layer for Beevibe. It turns a
+Claude Code session into a capsule with a public viewer, mind map, and chat,
+so teammates can inspect the thinking instead of reading a raw transcript.
 
-Try it from the repo root:
+Run Crystal locally from the repo root:
 
 ```bash
 pnpm install
+export ANTHROPIC_API_KEY=sk-ant-...
 pnpm crystal:dev
 ```
 
-Then open <http://localhost:5273> or run `/crystal:publish` from Claude Code.
-See [packages/beevibe-crystal](./packages/beevibe-crystal) for details.
-
-To install the Claude Code command:
+Install the Claude Code command:
 
 ```bash
 claude plugin marketplace add beevibe-ai/claude-plugins
 claude plugin install crystal@beevibe
 ```
+
+Then open <http://localhost:5273>, or run `/crystal:publish` inside a Claude
+Code session to publish the current session.
+
+Crystal lives in this monorepo as `@beevibe/crystal`, but it is not part of
+the default Railway/Docker app deploy. The api, scheduler, and web images stay
+focused on the core Beevibe stack. See
+[packages/beevibe-crystal](./packages/beevibe-crystal) for details.
 
 ## Why Beevibe?
 

--- a/packages/beevibe-crystal/README.md
+++ b/packages/beevibe-crystal/README.md
@@ -10,9 +10,24 @@ session context behind it.
 If this is useful, star the parent project:
 <https://github.com/beevibe-ai/beevibe>
 
-## Two Ways To Publish
+## Quick Start
 
-### A. `/crystal:publish` (recommended)
+From the Beevibe repo root, start the local Crystal server and viewer:
+
+```bash
+pnpm install
+export ANTHROPIC_API_KEY=sk-ant-...   # required for visitor chat
+pnpm crystal:dev
+```
+
+The viewer runs on <http://localhost:5273>. The server stores capsules under
+`packages/beevibe-crystal/.capsules`.
+
+## Publish From Claude Code
+
+Crystal still works like a Claude Code plugin. The plugin source lives in this
+package at [`plugin/`](./plugin), while real users install it from the small
+Beevibe plugin marketplace repo so the install command stays clean.
 
 Install the Claude Code plugin once:
 
@@ -41,31 +56,18 @@ The installed plugin command at
 session's `.jsonl`, POSTs it to your local Crystal server, and prints the
 share URL.
 
-### B. Drag And Drop
+## Publish By Drag And Drop
 
 Open <http://localhost:5273>, drop a `.jsonl` file, and Crystal creates the
 same capsule. This is useful for republishing an archived session or importing
 a non-Claude-Code source later.
 
-## Run Locally
-
-From the Beevibe repo root:
-
-```bash
-pnpm install
-export ANTHROPIC_API_KEY=sk-ant-...   # required for visitor chat
-pnpm crystal:dev
-```
-
-Or run the two processes separately:
+You can also run the two local processes separately:
 
 ```bash
 pnpm crystal:server   # API on :5274
 pnpm crystal:viewer   # web on :5273
 ```
-
-Then either drop a file on `localhost:5273`, or run `/crystal:publish` in a
-Claude Code session.
 
 ## Env Vars
 


### PR DESCRIPTION
## Summary
- clarify the root README Crystal quick-start flow
- explain that the Claude Code plugin still lives in this package while users install it from the clean plugin marketplace
- note that Crystal is not part of the default Railway/Docker deploy

## Tests
- docs-only change