### PR TITLE
fix(crystal): don't leak server errors to capsule visitors

### DIFF
--- a/packages/beevibe-crystal/src/components/VisitorChat.jsx
+++ b/packages/beevibe-crystal/src/components/VisitorChat.jsx
@@ -119,7 +119,10 @@ function VisitorChatInner({ capsule, onActivity }, ref) {
     } catch (e) {
       setMessages(prior);
       setInput(q);
-      setError(e.message || String(e));
+      // Keep the technical detail (e.g. "server is missing ANTHROPIC_API_KEY")
+      // in the console for debugging, but never surface it to a visitor.
+      console.error("crystal chat failed:", e);
+      setError("This capsule can't answer right now. Try again in a bit.");
     } finally {
       setBusy(false);
     }
@@ -164,7 +167,7 @@ function VisitorChatInner({ capsule, onActivity }, ref) {
             )
           )
         )}
-        {error && <div className="cb-fail-text">Error: {error}</div>}
+        {error && <div className="cb-fail-text">{error}</div>}
         <div ref={endRef} aria-hidden />
       </div>
 


### PR DESCRIPTION
Found during a real-user test of a published capsule: a visitor asks a question, `POST /api/chat` returns 500, and the UI prints **`Error: server is missing ANTHROPIC_API_KEY`** verbatim — leaking an internal server detail to the public.

`VisitorChat.jsx` rendered the raw server response as the error message. This logs the technical detail to the console (still debuggable) and shows visitors a generic **"This capsule can't answer right now. Try again in a bit."**

Base is `feat/crystal-ball-import` (the crystal migration target), not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)