### PR TITLE
fix(crystal): inbox stuck on 'loading…' under StrictMode

### DIFF
--- a/packages/beevibe-crystal/src/components/VisitInbox.jsx
+++ b/packages/beevibe-crystal/src/components/VisitInbox.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 // Controlled body — Capsule.jsx owns the open/closed state and renders the
 // toggle in the page header. Pass `open=false` to render nothing.
@@ -6,11 +6,12 @@ export default function VisitInbox({ capsuleId, open }) {
   const [status, setStatus] = useState("idle"); // idle | loading | ok | error
   const [visits, setVisits] = useState([]);
   const [error, setError] = useState("");
-  const fetched = useRef(false);
 
   useEffect(() => {
-    if (!open || fetched.current) return;
-    fetched.current = true;
+    if (!open) return;
+    // No once-guard ref here: under React StrictMode the effect runs twice,
+    // and a ref guard would let the first (cancelled) run win and strand
+    // status on "loading" forever. The `cancelled` flag + deps handle it.
     setStatus("loading");
     let cancelled = false;
     (async () => {


### PR DESCRIPTION
**Repro:** open a published capsule's Inbox page (`/c/:id/inbox`). It shows `loading…` forever, even though `GET /api/capsules/:id/visits` returns **200** with the visits.

**Root cause:** `VisitInbox` guarded its fetch with a `useRef` once-flag. Under React StrictMode (dev), the effect runs twice:
1. Run 1 sets `fetched.current = true`, starts the fetch, registers cleanup.
2. StrictMode cleanup fires → `cancelled = true`.
3. Run 2 hits `if (fetched.current) return` and bails.
4. Run 1's fetch resolves but `if (cancelled) return` discards it → `status` never leaves `loading`.

**Fix:** drop the ref guard; the `cancelled` flag + effect deps are the StrictMode-safe pattern. Verified via browser: `/visits` 200 but UI stuck — this is the state bug, not the network.

Dev-only (StrictMode), but the pattern was fragile regardless. Base is `feat/crystal-ball-import`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)