### PR TITLE
fix(mesh): qualify window WHERE fragments with table aliases

### DIFF
--- a/packages/api/src/views/mesh.db.test.ts
+++ b/packages/api/src/views/mesh.db.test.ts
@@ -1,12 +1,9 @@
 /**
- * Real-Postgres regression test for `getMeshOverview` — catches SQL errors
- * (ambiguous columns, malformed fragments) that the mock-Pool unit tests
- * in mesh.test.ts cannot. Each window variant is executed against a freshly
- * seeded DB so any future refactor to the WHERE fragments must keep all
- * four shapes runnable.
+ * Real-Postgres tests for `getMeshOverview` — the mock-Pool tests in
+ * mesh.test.ts can't catch SQL errors like ambiguous columns.
  */
 
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   PostgresAgentRepository,
   PostgresCoreMemoryRepository,
@@ -21,6 +18,7 @@ import {
   DEFAULT_RUNTIME_CONFIG,
   agentId,
   negotiationId,
+  negotiationRoundId,
   personId,
   sessionId,
 } from "@beevibe/core";
@@ -30,56 +28,37 @@ import { MESH_WINDOWS } from "./types.js";
 
 describe("getMeshOverview — integration", () => {
   let pool: Pool;
-  let agentRepo: PostgresAgentRepository;
-  let personRepo: PostgresPersonRepository;
-  let coreMemoryRepo: PostgresCoreMemoryRepository;
-  let sessionRepo: PostgresSessionRepository;
-  let negotiationRepo: PostgresNegotiationRepository;
-  let negotiationRoundRepo: PostgresNegotiationRoundRepository;
+  let initiatorId: string;
+  let counterpartyId: string;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     pool = createTestPool();
-    agentRepo = new PostgresAgentRepository(pool);
-    personRepo = new PostgresPersonRepository(pool);
-    coreMemoryRepo = new PostgresCoreMemoryRepository(pool);
-    sessionRepo = new PostgresSessionRepository(pool);
-    negotiationRepo = new PostgresNegotiationRepository(pool);
-    negotiationRoundRepo = new PostgresNegotiationRoundRepository(pool);
-  });
+    const agentRepo = new PostgresAgentRepository(pool);
+    const personRepo = new PostgresPersonRepository(pool);
+    const coreMemoryRepo = new PostgresCoreMemoryRepository(pool);
+    const sessionRepo = new PostgresSessionRepository(pool);
+    const negotiationRepo = new PostgresNegotiationRepository(pool);
+    const negotiationRoundRepo = new PostgresNegotiationRoundRepository(pool);
 
-  beforeEach(async () => {
     await truncateAll(pool);
-  });
 
-  afterAll(async () => {
-    await pool.end();
-  });
-
-  async function seedMeshActivity(): Promise<{ initiatorId: string; counterpartyId: string }> {
     const owner = await provisionUser(
       { personRepo },
       { id: personId(), name: "Owner", email: `owner-${Date.now()}@example.com` },
     );
-    const a = await provisionAgent(
-      { agentRepo, coreMemoryRepo },
-      {
-        id: agentId(),
-        name: "Team A",
-        owner_id: owner.person.id,
-        hierarchy_level: "team",
-        runtime_config: DEFAULT_RUNTIME_CONFIG,
-      },
-    );
-    const b = await provisionAgent(
-      { agentRepo, coreMemoryRepo },
-      {
-        id: agentId(),
-        name: "Team B",
-        owner_id: owner.person.id,
-        hierarchy_level: "team",
-        runtime_config: DEFAULT_RUNTIME_CONFIG,
-      },
-    );
+    const provisionTeam = (name: string) =>
+      provisionAgent(
+        { agentRepo, coreMemoryRepo },
+        {
+          id: agentId(),
+          name,
+          owner_id: owner.person.id,
+          hierarchy_level: "team",
+          runtime_config: DEFAULT_RUNTIME_CONFIG,
+        },
+      );
+    const a = await provisionTeam("Team A");
+    const b = await provisionTeam("Team B");
 
     const sa = await sessionRepo.create({
       id: sessionId(),
@@ -105,7 +84,7 @@ describe("getMeshOverview — integration", () => {
       max_rounds: 5,
     });
     await negotiationRoundRepo.create({
-      id: `round_${Date.now()}_1`,
+      id: negotiationRoundId(),
       negotiation_id: neg.id,
       round_number: 1,
       from_agent_id: a.agent.id,
@@ -123,16 +102,20 @@ describe("getMeshOverview — integration", () => {
       caller_agent_id: a.agent.id,
     });
 
-    return { initiatorId: a.agent.id, counterpartyId: b.agent.id };
-  }
+    initiatorId = a.agent.id;
+    counterpartyId = b.agent.id;
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
 
   it.each([...MESH_WINDOWS])("runs cleanly with window=%s", async (window) => {
-    const seed = await seedMeshActivity();
     const overview = await getMeshOverview(pool, window);
 
     expect(overview.asks.length).toBeGreaterThanOrEqual(2);
     const ids = overview.graph.nodes.map((n) => n.id).sort();
-    expect(ids).toEqual([seed.initiatorId, seed.counterpartyId].sort());
+    expect(ids).toEqual([initiatorId, counterpartyId].sort());
     expect(overview.graph.edges.length).toBeGreaterThan(0);
     expect(overview.summary.in_flight).toBeGreaterThan(0);
   });

--- a/packages/api/src/views/mesh.db.test.ts
+++ b/packages/api/src/views/mesh.db.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Real-Postgres regression test for `getMeshOverview` — catches SQL errors
+ * (ambiguous columns, malformed fragments) that the mock-Pool unit tests
+ * in mesh.test.ts cannot. Each window variant is executed against a freshly
+ * seeded DB so any future refactor to the WHERE fragments must keep all
+ * four shapes runnable.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  PostgresAgentRepository,
+  PostgresCoreMemoryRepository,
+  PostgresNegotiationRepository,
+  PostgresNegotiationRoundRepository,
+  PostgresPersonRepository,
+  PostgresSessionRepository,
+  type Pool,
+} from "@beevibe/core/adapters/postgres";
+import { provisionAgent, provisionUser } from "@beevibe/core/auth";
+import {
+  DEFAULT_RUNTIME_CONFIG,
+  agentId,
+  negotiationId,
+  personId,
+  sessionId,
+} from "@beevibe/core";
+import { createTestPool, truncateAll } from "@beevibe/core/test-helpers";
+import { getMeshOverview } from "./mesh.js";
+import { MESH_WINDOWS } from "./types.js";
+
+describe("getMeshOverview — integration", () => {
+  let pool: Pool;
+  let agentRepo: PostgresAgentRepository;
+  let personRepo: PostgresPersonRepository;
+  let coreMemoryRepo: PostgresCoreMemoryRepository;
+  let sessionRepo: PostgresSessionRepository;
+  let negotiationRepo: PostgresNegotiationRepository;
+  let negotiationRoundRepo: PostgresNegotiationRoundRepository;
+
+  beforeAll(() => {
+    pool = createTestPool();
+    agentRepo = new PostgresAgentRepository(pool);
+    personRepo = new PostgresPersonRepository(pool);
+    coreMemoryRepo = new PostgresCoreMemoryRepository(pool);
+    sessionRepo = new PostgresSessionRepository(pool);
+    negotiationRepo = new PostgresNegotiationRepository(pool);
+    negotiationRoundRepo = new PostgresNegotiationRoundRepository(pool);
+  });
+
+  beforeEach(async () => {
+    await truncateAll(pool);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  async function seedMeshActivity(): Promise<{ initiatorId: string; counterpartyId: string }> {
+    const owner = await provisionUser(
+      { personRepo },
+      { id: personId(), name: "Owner", email: `owner-${Date.now()}@example.com` },
+    );
+    const a = await provisionAgent(
+      { agentRepo, coreMemoryRepo },
+      {
+        id: agentId(),
+        name: "Team A",
+        owner_id: owner.person.id,
+        hierarchy_level: "team",
+        runtime_config: DEFAULT_RUNTIME_CONFIG,
+      },
+    );
+    const b = await provisionAgent(
+      { agentRepo, coreMemoryRepo },
+      {
+        id: agentId(),
+        name: "Team B",
+        owner_id: owner.person.id,
+        hierarchy_level: "team",
+        runtime_config: DEFAULT_RUNTIME_CONFIG,
+      },
+    );
+
+    const sa = await sessionRepo.create({
+      id: sessionId(),
+      agent_id: a.agent.id,
+      type: "task",
+      status: "succeeded",
+      intent: "i",
+    });
+    const sb = await sessionRepo.create({
+      id: sessionId(),
+      agent_id: b.agent.id,
+      type: "mesh_negotiate",
+      status: "succeeded",
+      intent: "j",
+    });
+
+    const neg = await negotiationRepo.create({
+      id: negotiationId(),
+      initiator_agent_id: a.agent.id,
+      initiator_session_id: sa.id,
+      counterparty_agent_id: b.agent.id,
+      counterparty_session_id: sb.id,
+      max_rounds: 5,
+    });
+    await negotiationRoundRepo.create({
+      id: `round_${Date.now()}_1`,
+      negotiation_id: neg.id,
+      round_number: 1,
+      from_agent_id: a.agent.id,
+      decision: "propose",
+      message: "Opening proposal",
+    });
+
+    await sessionRepo.create({
+      id: sessionId(),
+      agent_id: b.agent.id,
+      type: "mesh_ask",
+      status: "running",
+      started_at: new Date(),
+      intent: `<mesh-ask from="${a.agent.id}">What is the SLA?</mesh-ask>`,
+      caller_agent_id: a.agent.id,
+    });
+
+    return { initiatorId: a.agent.id, counterpartyId: b.agent.id };
+  }
+
+  it.each([...MESH_WINDOWS])("runs cleanly with window=%s", async (window) => {
+    const seed = await seedMeshActivity();
+    const overview = await getMeshOverview(pool, window);
+
+    expect(overview.asks.length).toBeGreaterThanOrEqual(2);
+    const ids = overview.graph.nodes.map((n) => n.id).sort();
+    expect(ids).toEqual([seed.initiatorId, seed.counterpartyId].sort());
+    expect(overview.graph.edges.length).toBeGreaterThan(0);
+    expect(overview.summary.in_flight).toBeGreaterThan(0);
+  });
+});

--- a/packages/api/src/views/mesh.ts
+++ b/packages/api/src/views/mesh.ts
@@ -57,6 +57,11 @@ export function isMeshWindow(value: unknown): value is MeshWindow {
  * `sessWindow` to `session` rows (type filter + started_at + always-include-
  * running). `"all"` drops the time predicate entirely (active/running rows
  * were already always-included, so this only widens history).
+ *
+ * Columns are qualified with `n.` / `s.` so the fragment is safe to drop into
+ * queries that also `JOIN agent` — `agent.created_at` collides with
+ * `negotiation.created_at` otherwise. The corresponding FROM clauses below
+ * therefore alias `negotiation n` and `session s`.
  */
 function buildWindowFragments(window: MeshWindow): {
   negWindow: string;
@@ -65,13 +70,13 @@ function buildWindowFragments(window: MeshWindow): {
   if (window === "all") {
     return {
       negWindow: "TRUE",
-      sessWindow: "type IN ('mesh_ask', 'blocker')",
+      sessWindow: "s.type IN ('mesh_ask', 'blocker')",
     };
   }
   const interval = WINDOW_INTERVAL[window];
   return {
-    negWindow: `created_at >= NOW() - INTERVAL '${interval}' OR status = 'active'`,
-    sessWindow: `type IN ('mesh_ask', 'blocker') AND (started_at >= NOW() - INTERVAL '${interval}' OR status = 'running')`,
+    negWindow: `n.created_at >= NOW() - INTERVAL '${interval}' OR n.status = 'active'`,
+    sessWindow: `s.type IN ('mesh_ask', 'blocker') AND (s.started_at >= NOW() - INTERVAL '${interval}' OR s.status = 'running')`,
   };
 }
 
@@ -137,17 +142,17 @@ LIMIT $1
  */
 const nodesSql = (negWindow: string, sessWindow: string) => /* sql */ `
 WITH endpoints AS (
-  SELECT initiator_agent_id AS agent_id, (status = 'active') AS is_live
-  FROM negotiation WHERE ${negWindow}
+  SELECT n.initiator_agent_id AS agent_id, (n.status = 'active') AS is_live
+  FROM negotiation n WHERE ${negWindow}
   UNION ALL
-  SELECT counterparty_agent_id AS agent_id, (status = 'active') AS is_live
-  FROM negotiation WHERE ${negWindow}
+  SELECT n.counterparty_agent_id AS agent_id, (n.status = 'active') AS is_live
+  FROM negotiation n WHERE ${negWindow}
   UNION ALL
-  SELECT agent_id, (status = 'running') AS is_live
-  FROM session WHERE ${sessWindow}
+  SELECT s.agent_id, (s.status = 'running') AS is_live
+  FROM session s WHERE ${sessWindow}
   UNION ALL
-  SELECT ${SESS_FROM} AS agent_id, (status = 'running') AS is_live
-  FROM session WHERE ${sessWindow} AND ${SESS_FROM} IS NOT NULL
+  SELECT ${SESS_FROM} AS agent_id, (s.status = 'running') AS is_live
+  FROM session s WHERE ${sessWindow} AND ${SESS_FROM} IS NOT NULL
 )
 SELECT
   a.id,
@@ -164,13 +169,13 @@ ORDER BY
 
 const edgesSql = (negWindow: string, sessWindow: string) => /* sql */ `
 WITH pairs AS (
-  SELECT initiator_agent_id AS from_id, counterparty_agent_id AS to_id,
-         (status = 'active') AS is_live
-  FROM negotiation WHERE ${negWindow}
+  SELECT n.initiator_agent_id AS from_id, n.counterparty_agent_id AS to_id,
+         (n.status = 'active') AS is_live
+  FROM negotiation n WHERE ${negWindow}
   UNION ALL
-  SELECT ${SESS_FROM} AS from_id, agent_id AS to_id,
-         (status = 'running') AS is_live
-  FROM session WHERE ${sessWindow} AND ${SESS_FROM} IS NOT NULL
+  SELECT ${SESS_FROM} AS from_id, s.agent_id AS to_id,
+         (s.status = 'running') AS is_live
+  FROM session s WHERE ${sessWindow} AND ${SESS_FROM} IS NOT NULL
 )
 SELECT
   from_id,
@@ -184,13 +189,13 @@ ORDER BY count DESC
 
 const summarySql = (negWindow: string, sessWindow: string) => /* sql */ `
 WITH activity AS (
-  SELECT (status = 'active') AS is_live, created_at,
-         initiator_agent_id AS a, counterparty_agent_id AS b
-  FROM negotiation WHERE ${negWindow}
+  SELECT (n.status = 'active') AS is_live, n.created_at,
+         n.initiator_agent_id AS a, n.counterparty_agent_id AS b
+  FROM negotiation n WHERE ${negWindow}
   UNION ALL
-  SELECT (status = 'running') AS is_live, started_at AS created_at,
-         ${SESS_FROM} AS a, agent_id AS b
-  FROM session WHERE ${sessWindow}
+  SELECT (s.status = 'running') AS is_live, s.started_at AS created_at,
+         ${SESS_FROM} AS a, s.agent_id AS b
+  FROM session s WHERE ${sessWindow}
 )
 SELECT
   COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '24 hours')::int  AS asks_24h,


### PR DESCRIPTION
## Summary

- PR #227's `buildWindowFragments` used bare `created_at` / `status`, which collide with the `agent ca` + `agent ta` joins inside `negotiationsSql`. Postgres aborts with `column reference "created_at" is ambiguous` for every non-"all" window, so the mesh page shows "Couldn't load mesh activity" on 24h / 7d / 30d while "All time" (whose fragment is just `TRUE`) loads fine.
- Qualify the negotiation columns with `n.` and session columns with `s.`, and alias `FROM negotiation n` / `FROM session s` in the `nodesSql`, `edgesSql`, and `summarySql` CTEs so the qualified fragment resolves cleanly there too.
- Add `packages/api/src/views/mesh.db.test.ts` — a real-Postgres regression test that runs `getMeshOverview` for each of the four windows against a seeded DB, since the existing mock-Pool unit tests never execute the SQL.

## Repro on `main`

```sql
SELECT n.id FROM negotiation n
JOIN agent ca ON ca.id = n.initiator_agent_id
JOIN agent ta ON ta.id = n.counterparty_agent_id
LEFT JOIN negotiation_round nr1 ON nr1.negotiation_id = n.id AND nr1.round_number = 1
WHERE created_at >= NOW() - INTERVAL '24 hours' OR status = 'active'
LIMIT 1;
-- ERROR: column reference "created_at" is ambiguous
```

## Test plan

- [x] `pnpm --filter @beevibe/api test` — 390 passed (incl. 4 new windowed integration cases)
- [x] `pnpm --filter @beevibe/api typecheck` — clean
- [ ] Load `/mesh` after deploy and switch among 24h / 7d / 30d / All; each should render activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)