### PR TITLE
fix(chat): keep streaming surface up after 504 chat_turn_timeout

### DIFF
--- a/packages/web/lib/hooks/use-chat.test.tsx
+++ b/packages/web/lib/hooks/use-chat.test.tsx
@@ -3,13 +3,10 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 
+// `fresh: true` disables the history query (enabled: !fresh), so we only
+// need to mock the send path here.
 vi.mock("@/lib/api/client", () => ({
-  api: {
-    chat: {
-      history: vi.fn(),
-      send: vi.fn(),
-    },
-  },
+  api: { chat: { send: vi.fn() } },
 }));
 
 vi.mock("@/lib/api/config", () => ({
@@ -22,7 +19,6 @@ import { ApiError } from "@/lib/api/http";
 import { queryKeys } from "./keys";
 
 const sendMock = vi.mocked(api.chat.send);
-const historyMock = vi.mocked(api.chat.history);
 
 function makeWrapper() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -34,7 +30,6 @@ function makeWrapper() {
 
 beforeEach(() => {
   sendMock.mockReset();
-  historyMock.mockReset();
 });
 
 afterEach(() => {

--- a/packages/web/lib/hooks/use-chat.test.tsx
+++ b/packages/web/lib/hooks/use-chat.test.tsx
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+vi.mock("@/lib/api/client", () => ({
+  api: {
+    chat: {
+      history: vi.fn(),
+      send: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/api/config", () => ({
+  isApiConfigured: true,
+}));
+
+import { useChat, isInFlightAfterError } from "./use-chat";
+import { api, type ChatHistoryResponse } from "@/lib/api/client";
+import { ApiError } from "@/lib/api/http";
+import { queryKeys } from "./keys";
+
+const sendMock = vi.mocked(api.chat.send);
+const historyMock = vi.mocked(api.chat.history);
+
+function makeWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  }
+  return { client, Wrapper };
+}
+
+beforeEach(() => {
+  sendMock.mockReset();
+  historyMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("isInFlightAfterError", () => {
+  it("accepts 503 agent_offline + 504 chat_turn_timeout", () => {
+    expect(isInFlightAfterError(new ApiError("x", 503, { error: "agent_offline" }))).toBe(true);
+    expect(isInFlightAfterError(new ApiError("x", 504, { error: "chat_turn_timeout" }))).toBe(true);
+  });
+
+  it("rejects other api errors and non-ApiError values", () => {
+    expect(isInFlightAfterError(new ApiError("x", 400, { error: "message_required" }))).toBe(false);
+    expect(isInFlightAfterError(new ApiError("x", 429, { error: "chat_rate_limit" }))).toBe(false);
+    // 504 with a different errorCode (or no body) is treated as a real failure.
+    expect(isInFlightAfterError(new ApiError("x", 504, undefined))).toBe(false);
+    expect(isInFlightAfterError(new Error("network down"))).toBe(false);
+    expect(isInFlightAfterError(undefined)).toBe(false);
+  });
+});
+
+describe("useChat — 504 chat_turn_timeout recovery", () => {
+  it("keeps the user message + in_flight_session_id and suppresses the banner", async () => {
+    // Fresh surface: history is disabled (enabled: !fresh), so api.chat.history
+    // never gets called. The slot is owned by onMutate / onSuccess / onError.
+    const { client, Wrapper } = makeWrapper();
+    sendMock.mockRejectedValueOnce(
+      new ApiError("HTTP 504 Gateway Timeout", 504, { error: "chat_turn_timeout" }),
+    );
+
+    const { result } = renderHook(() => useChat({ fresh: true }), { wrapper: Wrapper });
+
+    act(() => {
+      result.current.send("hi team");
+    });
+
+    await waitFor(() => expect(sendMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.isSubmitting).toBe(false));
+
+    // User message survives the error path.
+    expect(result.current.messages).toHaveLength(1);
+    expect(result.current.messages[0]?.role).toBe("user");
+    expect(result.current.messages[0]?.content).toBe("hi team");
+
+    // Banner is suppressed; thinking indicator still on via server-in-flight.
+    expect(result.current.error).toBeNull();
+    expect(result.current.pendingSessionId).toMatch(/^sess_/);
+    expect(result.current.isPending).toBe(true);
+
+    // `latest` cache slot was seeded for the upcoming ?new=1 strip.
+    const latest = client.getQueryData<ChatHistoryResponse>(queryKeys.chat.history(undefined));
+    expect(latest?.messages).toHaveLength(1);
+    expect(latest?.in_flight_session_id).toBeDefined();
+  });
+
+  it("rolls back the optimistic user message on a non-recoverable error", async () => {
+    const { Wrapper } = makeWrapper();
+    sendMock.mockRejectedValueOnce(
+      new ApiError("HTTP 429 Too Many Requests", 429, { error: "chat_rate_limit" }),
+    );
+
+    const { result } = renderHook(() => useChat({ fresh: true }), { wrapper: Wrapper });
+
+    act(() => {
+      result.current.send("hi team");
+    });
+
+    await waitFor(() => expect(sendMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.isSubmitting).toBe(false));
+
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.error).toBeInstanceOf(ApiError);
+    expect(result.current.pendingSessionId).toBeUndefined();
+  });
+});

--- a/packages/web/lib/hooks/use-chat.ts
+++ b/packages/web/lib/hooks/use-chat.ts
@@ -79,6 +79,26 @@ export interface UseChatOptions {
  */
 const FRESH_CACHE_ID = "__draft__";
 
+/**
+ * Errors the POST /chat handler returns when the session is already
+ * persisted server-side and the daemon will keep running it to completion.
+ * Either way, the eventual `session.updated` SSE invalidates chat history
+ * and the agent reply lands without the user needing to retry — so we
+ * preserve the optimistic user message and keep the thinking indicator on
+ * instead of rolling everything back.
+ *
+ *   - 503 `agent_offline` — no daemon connected yet; session is queued.
+ *   - 504 `chat_turn_timeout` — POST exceeded CHAT_TURN_TIMEOUT_MS (90s);
+ *     daemon is still running the agent and will resolve in the background.
+ *     This is the common case for long mesh chains.
+ */
+export function isInFlightAfterError(err: unknown): boolean {
+  if (!(err instanceof ApiError)) return false;
+  if (err.status === 503 && err.errorCode === "agent_offline") return true;
+  if (err.status === 504 && err.errorCode === "chat_turn_timeout") return true;
+  return false;
+}
+
 /** Empty response shape used to seed a fresh-cache entry. */
 const FRESH_HISTORY: ChatHistoryResponse = {
   ok: true,
@@ -230,14 +250,20 @@ export function useChat(opts: UseChatOptions = {}) {
       queryClient.invalidateQueries({ queryKey: latestKey });
     },
     onError: (err) => {
-      // agent_offline (503) is special: the api persisted the session row
-      // before rejecting, so the turn is queued, not lost. Keep the user
-      // message AND in_flight_session_id visible — refresh would show
-      // them anyway from the server, and rolling back here creates a
-      // flicker of "vanished, then back on refresh". When the daemon
-      // reconnects and the session completes, session.updated SSE
-      // invalidates chat queries and the response auto-appears.
-      if (err instanceof ApiError && err.errorCode === "agent_offline") return;
+      // "In flight after error" errors (see isInFlightAfterError) mean
+      // the session is persisted server-side and the daemon will keep
+      // running. Keep the user message AND in_flight_session_id visible —
+      // rolling back creates a "vanished, then back on refresh" flicker.
+      // Also hand the slot off to `latest` so the ?new=1 URL strip
+      // (cleanup effect in chat-client.tsx) doesn't flash through an
+      // empty latest slot on its way to the SSE-recovered reply.
+      if (isInFlightAfterError(err)) {
+        const latestKey = queryKeys.chat.history(undefined);
+        const handed = queryClient.getQueryData<ChatHistoryResponse>(queryKey);
+        if (handed) queryClient.setQueryData(latestKey, handed);
+        queryClient.invalidateQueries({ queryKey: latestKey });
+        return;
+      }
 
       // Other errors (429 rate limit, 400 validation, etc.) reject the
       // turn before persistence — roll back the optimistic user message
@@ -284,15 +310,12 @@ export function useChat(opts: UseChatOptions = {}) {
   const serverInFlightSessionId = history.data?.in_flight_session_id;
   const inFlightSessionId = localSendingSessionId ?? serverInFlightSessionId;
 
-  // agent_offline is benign: the api persisted the session row and a
-  // daemon will claim it when one comes online. The optimistic user
-  // message + spinner already convey "in flight"; surfacing the 503
-  // as a red banner is misleading (the response DOES arrive — via the
-  // SSE invalidation once the queued session completes).
-  const isOfflineQueued =
-    mutation.error instanceof ApiError &&
-    mutation.error.errorCode === "agent_offline";
-  const exposedError = isOfflineQueued ? null : mutation.error;
+  // Errors classified as "in flight after error" are benign: the api
+  // persisted the session row and the daemon will deliver the reply via
+  // SSE. The optimistic user message + spinner already convey "in flight";
+  // surfacing the 503/504 as a red banner is misleading (the response DOES
+  // arrive — via the SSE invalidation once the session completes).
+  const exposedError = isInFlightAfterError(mutation.error) ? null : mutation.error;
 
   return {
     messages,

--- a/packages/web/lib/hooks/use-chat.ts
+++ b/packages/web/lib/hooks/use-chat.ts
@@ -172,6 +172,22 @@ export function useChat(opts: UseChatOptions = {}) {
   // source of truth for what to chain onto next.
   const priorSessionId = history.data?.prior_session_id ?? undefined;
 
+  // Copy whatever's now in the current cache slot into the `latest`
+  // slot, then mark `latest` stale so a background refetch lands. Used
+  // by both onSuccess (after the agent reply) and the in-flight-after-
+  // error branch of onError (504/503): the moment ChatClient's URL-strip
+  // useEffect flips `queryKey` FRESH_CACHE_ID → undefined, the new slot
+  // already has data. Without this seed, the slot is empty until the
+  // refetch lands and the chat surface blanks for a beat — wiping
+  // useChatStream's accumulated SSE steps. `staleTime: Infinity` keeps
+  // the seeded data displayed during the background refetch.
+  const handLatestSlot = () => {
+    const latestKey = queryKeys.chat.history(undefined);
+    const handed = queryClient.getQueryData<ChatHistoryResponse>(queryKey);
+    if (handed) queryClient.setQueryData(latestKey, handed);
+    queryClient.invalidateQueries({ queryKey: latestKey });
+  };
+
   const mutation = useMutation<
     ChatTurnResponse,
     Error,
@@ -232,36 +248,15 @@ export function useChat(opts: UseChatOptions = {}) {
       }
       // Conversation list (sidebar) needs to see the new chain.
       queryClient.invalidateQueries({ queryKey: queryKeys.chat.conversations() });
-      // Seed the "latest" cache slot before invalidating it, so the
-      // moment ChatClient's URL-strip useEffect (fires on
-      // `messages.length > 0 && !isSubmitting`) flips `queryKey`
-      // from FRESH_CACHE_ID → undefined, the new slot already has
-      // the just-completed turn. Without the seed, the slot is empty
-      // until refetch lands and the whole chat surface (composer,
-      // messages, thinking block) blanks for a beat — and the
-      // re-render wipes useChatStream's accumulated SSE steps.
-      // Pairing: seed populates the slot for the immediate read; the
-      // invalidate after marks it stale so React Query refetches in
-      // the background. `staleTime: Infinity` keeps the seeded data
-      // displayed during that refetch — no flicker.
-      const latestKey = queryKeys.chat.history(undefined);
-      const handed = queryClient.getQueryData<ChatHistoryResponse>(queryKey);
-      if (handed) queryClient.setQueryData(latestKey, handed);
-      queryClient.invalidateQueries({ queryKey: latestKey });
+      handLatestSlot();
     },
     onError: (err) => {
       // "In flight after error" errors (see isInFlightAfterError) mean
       // the session is persisted server-side and the daemon will keep
       // running. Keep the user message AND in_flight_session_id visible —
       // rolling back creates a "vanished, then back on refresh" flicker.
-      // Also hand the slot off to `latest` so the ?new=1 URL strip
-      // (cleanup effect in chat-client.tsx) doesn't flash through an
-      // empty latest slot on its way to the SSE-recovered reply.
       if (isInFlightAfterError(err)) {
-        const latestKey = queryKeys.chat.history(undefined);
-        const handed = queryClient.getQueryData<ChatHistoryResponse>(queryKey);
-        if (handed) queryClient.setQueryData(latestKey, handed);
-        queryClient.invalidateQueries({ queryKey: latestKey });
+        handLatestSlot();
         return;
       }
 


### PR DESCRIPTION
## Summary

POST `/chat` aborts after `CHAT_TURN_TIMEOUT_MS` (90s) with `504 chat_turn_timeout`, but the daemon keeps running and emits `session.updated` once it completes — the reply lands via SSE invalidation. Until now `onError` rolled back the user message and cleared `in_flight_session_id`, collapsing `messages.length` to 0 and dumping the user into the HeroEmptyChat mid-stream.

Most reproducible when the team turn legitimately exceeds 90s (e.g., a chain of mesh asks).

## Fix

- Treat 504 `chat_turn_timeout` the same as 503 `agent_offline`: preserve the user message, keep `in_flight_session_id` stamped so the thinking indicator stays on, and suppress the red banner.
- Hand the cache slot off to `latest` the same way `onSuccess` does so the `?new=1` URL strip lands on a pre-seeded slot instead of flashing through an empty one.
- Extract `isInFlightAfterError(err)` so the `onError` branch and the banner-suppression check share one definition.

## Test plan

- [x] `pnpm --filter @beevibe/web test` — 145 passed (incl. 4 new in `use-chat.test.tsx`)
- [x] `pnpm --filter @beevibe/web typecheck` — clean
- [ ] After deploy: in a long mesh-ask chain that takes >90s, the chat surface stays on the user message + thinking indicator + live steps instead of flashing back to the new-chat surface; the agent reply appears via SSE once the daemon completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)