### PR TITLE
feat(crystal): one-paste key setup + Cloudflare quick-try flow

### DIFF
--- a/packages/beevibe-crystal/README.md
+++ b/packages/beevibe-crystal/README.md
@@ -12,16 +12,22 @@ If this is useful, star the parent project:
 
 ## Quick Start
 
-From the Beevibe repo root, start the local Crystal server and viewer:
+Paste your Anthropic API key once (in your terminal — never in a Claude chat,
+since Crystal publishes the session), then start a public tunnel:
 
 ```bash
 pnpm install
-export ANTHROPIC_API_KEY=sk-ant-...   # required for visitor chat
-pnpm crystal:dev
+pnpm crystal:setup    # prompts for your key → ~/.beevibe/crystal/config.json (0600)
+pnpm crystal:serve    # server + viewer behind a Cloudflare quick tunnel → public URL
 ```
 
-The viewer runs on <http://localhost:5273>. The server stores capsules under
-`packages/beevibe-crystal/.capsules`.
+`crystal:serve` prints a `https://*.trycloudflare.com` URL anyone can open. It's
+ephemeral — the URL lives only while the process runs. Then run `/crystal:publish`
+in a Claude Code session and the capsule link uses that public URL.
+
+Local only (no tunnel): `pnpm crystal:dev` — viewer on <http://localhost:5273>,
+capsules stored under `packages/beevibe-crystal/.capsules`. Check key status any
+time with `pnpm crystal:doctor`.
 
 ## Publish From Claude Code
 

--- a/packages/beevibe-crystal/crystal-doctor.mjs
+++ b/packages/beevibe-crystal/crystal-doctor.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+// crystal-doctor — paste your Anthropic API key once; the Crystal server reads it.
+//
+// Two modes:
+//   crystal-doctor          audit-only: reports whether a key is configured.
+//                           Exit 0 if ready, 1 if not. Non-interactive.
+//   crystal-doctor setup    interactive: prompts you to paste your key and
+//                           writes it to ~/.beevibe/crystal/config.json (0600).
+//
+// The key is pasted HERE, in your terminal — never into a Claude Code chat.
+// That matters: Crystal publishes your session, so a key typed into the chat
+// would end up inside the capsule you share. This keeps it out of band.
+//
+// The server reads ~/.beevibe/crystal/config.json on startup and falls back to
+// env vars, so once you run setup you never have to export anything.
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import readline from "node:readline/promises";
+
+const CONFIG_DIR = path.join(os.homedir(), ".beevibe", "crystal");
+const CONFIG_PATH = path.join(CONFIG_DIR, "config.json");
+const KEY = "ANTHROPIC_API_KEY";
+const KEY_URL = "https://console.anthropic.com/settings/keys";
+
+async function loadConfig() {
+  try {
+    return JSON.parse(await readFile(CONFIG_PATH, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+function mask(value) {
+  if (!value) return null;
+  return value.length <= 8 ? "*".repeat(value.length) : `${value.slice(0, 6)}…${value.slice(-4)}`;
+}
+
+async function setup() {
+  const config = await loadConfig();
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  console.log("Beevibe Crystal — API key setup");
+  console.log(`Writing to: ${CONFIG_PATH}\n`);
+
+  const envKey = process.env[KEY]?.trim();
+  if (envKey) {
+    console.log(`Note: ${KEY} is set in your environment (${mask(envKey)}); it overrides this file.\n`);
+  }
+
+  const existing = (config[KEY] || "").trim();
+  if (existing) {
+    const keep = (await rl.question(`${KEY} already saved (${mask(existing)}). Keep it? [Y/n]: `)).trim().toLowerCase();
+    if (keep !== "n" && keep !== "no") {
+      rl.close();
+      console.log("Kept the existing key. Nothing changed.");
+      return;
+    }
+  }
+
+  console.log(`Get a key at ${KEY_URL}`);
+  const value = (await rl.question("Paste your Anthropic API key (leave blank to skip): ")).trim();
+  rl.close();
+
+  if (!value) {
+    console.log("No key entered — nothing saved.");
+    return;
+  }
+
+  config[KEY] = value;
+  await mkdir(CONFIG_DIR, { recursive: true });
+  await writeFile(CONFIG_PATH, JSON.stringify(config, null, 2) + "\n", { mode: 0o600 });
+  console.log(`\n✓ Saved to ${CONFIG_PATH} (read/write for you only).`);
+  console.log("Restart the Crystal server if it's already running so it picks up the key.");
+}
+
+async function audit() {
+  const config = await loadConfig();
+  const envKey = process.env[KEY]?.trim();
+  const configKey = (config[KEY] || "").trim();
+  const value = envKey || configKey;
+  const source = envKey ? "env" : configKey ? "config" : null;
+
+  console.log(`Config file: ${CONFIG_PATH}`);
+  if (value) {
+    console.log(`${KEY}: set (${mask(value)}, from ${source})`);
+    console.log("Crystal is ready to answer visitor questions.");
+    process.exit(0);
+  }
+  console.log(`${KEY}: NOT set`);
+  console.log("Run `pnpm crystal:setup` (or `node crystal-doctor.mjs setup`) to paste your key.");
+  process.exit(1);
+}
+
+const mode = process.argv[2];
+if (mode === "setup") {
+  await setup();
+} else {
+  await audit();
+}

--- a/packages/beevibe-crystal/crystal-serve.mjs
+++ b/packages/beevibe-crystal/crystal-serve.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+// crystal-serve — one command to try Crystal publicly.
+//
+// Brings up the local server + viewer behind a Cloudflare quick tunnel and
+// prints a public https://*.trycloudflare.com URL you can share with anyone.
+//
+// Ephemeral by design: the URL lives only while this process runs, and rotates
+// on the next start. Good for "quickly try and use"; for a stable URL you host
+// the server somewhere durable and set CRYSTAL_VIEWER_URL yourself.
+//
+// Requires cloudflared (`brew install cloudflared`) and a configured key
+// (`pnpm crystal:setup`).
+
+import { spawn } from "node:child_process";
+
+const VIEWER_PORT = Number(process.env.PORT_VIEWER || 5273);
+const TUNNEL_TIMEOUT_MS = 30_000;
+const children = [];
+
+function shutdown(code = 0) {
+  for (const child of children) {
+    try { child.kill(); } catch { /* already gone */ }
+  }
+  process.exit(code);
+}
+process.on("SIGINT", () => shutdown(0));
+process.on("SIGTERM", () => shutdown(0));
+
+function startTunnel() {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("cloudflared", ["tunnel", "--url", `http://localhost:${VIEWER_PORT}`], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let settled = false;
+    const scan = (buf) => {
+      const match = String(buf).match(/https:\/\/[a-z0-9-]+\.trycloudflare\.com/);
+      if (match && !settled) {
+        settled = true;
+        resolve({ proc, url: match[0] });
+      }
+    };
+    proc.stdout.on("data", scan);
+    proc.stderr.on("data", scan);
+    proc.on("error", (err) =>
+      reject(new Error(`cloudflared failed to start: ${err.message}. Install it with 'brew install cloudflared'.`))
+    );
+    proc.on("exit", (code) => {
+      if (!settled) reject(new Error(`cloudflared exited (code ${code}) before printing a tunnel URL.`));
+    });
+    setTimeout(() => {
+      if (!settled) reject(new Error("Timed out waiting for the Cloudflare tunnel URL."));
+    }, TUNNEL_TIMEOUT_MS);
+  });
+}
+
+console.log("Starting Cloudflare quick tunnel…");
+let tunnel;
+try {
+  tunnel = await startTunnel();
+} catch (err) {
+  console.error(err.message);
+  shutdown(1);
+}
+children.push(tunnel.proc);
+const publicUrl = tunnel.url;
+
+// The server bakes CRYSTAL_VIEWER_URL into the share links it returns, so point
+// it at the tunnel. The viewer proxies /api back to the local server.
+const env = { ...process.env, CRYSTAL_VIEWER_URL: publicUrl };
+children.push(spawn("node", ["server.mjs"], { stdio: "inherit", env }));
+children.push(spawn("npx", ["vite"], { stdio: "inherit", env }));
+
+console.log(`\n✦ Crystal is live (ephemeral): ${publicUrl}`);
+console.log("   Run /crystal:publish in a Claude Code session — capsule links will use this URL.");
+console.log("   Stop with Ctrl-C. The URL dies when this process exits.\n");

--- a/packages/beevibe-crystal/package.json
+++ b/packages/beevibe-crystal/package.json
@@ -16,9 +16,12 @@
     "dev": "concurrently -n server,viewer -c blue,magenta \"pnpm run server\" \"pnpm run viewer\"",
     "server": "node server.mjs",
     "viewer": "vite",
+    "setup": "node crystal-doctor.mjs setup",
+    "doctor": "node crystal-doctor.mjs",
+    "serve": "node crystal-serve.mjs",
     "build": "vite build",
     "typecheck": "pnpm run lint",
-    "lint": "node --check server.mjs && node --check vite.config.js",
+    "lint": "node --check server.mjs && node --check vite.config.js && node --check crystal-doctor.mjs && node --check crystal-serve.mjs",
     "preview": "vite preview",
     "clean": "rm -rf dist .capsules"
   },

--- a/packages/beevibe-crystal/plugin/commands/publish.md
+++ b/packages/beevibe-crystal/plugin/commands/publish.md
@@ -8,15 +8,30 @@ When the user invokes `/crystal:publish` (or asks any of the trigger phrases abo
 
 ## Step 0 — Pre-flight (one-line bash, no narration)
 
-Confirm the server is reachable. The default is local; override with `CRYSTAL_BALL_SERVER_URL`.
+Confirm the server is reachable **and** has an API key (visitor chat needs it). The
+default is local; override with `CRYSTAL_BALL_SERVER_URL`.
 
 ```bash
 CRYSTAL_SERVER="${CRYSTAL_BALL_SERVER_URL:-http://127.0.0.1:5274}"
-curl -fsS --max-time 2 "$CRYSTAL_SERVER/api/health" >/dev/null \
-  || { echo "Beevibe Crystal server not reachable at $CRYSTAL_SERVER. Start it with 'pnpm crystal:server' in the Beevibe repo, or set CRYSTAL_BALL_SERVER_URL to a hosted instance."; exit 1; }
+HEALTH="$(curl -fsS --max-time 2 "$CRYSTAL_SERVER/api/health" 2>/dev/null)" || {
+  echo "Beevibe Crystal server not reachable at $CRYSTAL_SERVER.";
+  echo "Quick public try:  pnpm crystal:serve   (server + Cloudflare tunnel + a public URL)";
+  echo "Local only:        pnpm crystal:server";
+  echo "Or set CRYSTAL_BALL_SERVER_URL to a hosted instance.";
+  exit 1;
+}
+echo "$HEALTH" | grep -q '"hasKey":true' || {
+  echo "Crystal server is up but has no Anthropic API key — visitor chat won't answer.";
+  echo "Paste your key in your TERMINAL (not in this chat — a key typed here would be";
+  echo "saved inside the capsule you publish):  pnpm crystal:setup";
+  echo "Then restart the server.";
+  exit 1;
+}
 ```
 
-If the server isn't up, surface the message verbatim to the user and stop. Don't try to auto-start it — they may want to publish to a hosted instance.
+If either check fails, surface the message verbatim to the user and stop. Don't try
+to auto-start the server or ask for the key here — the key must be entered out of
+band via `pnpm crystal:setup` so it never lands in the published session.
 
 ## Step 1 — Find the current session file
 

--- a/packages/beevibe-crystal/server.mjs
+++ b/packages/beevibe-crystal/server.mjs
@@ -13,6 +13,8 @@
 
 import http from "node:http";
 import fs from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import crypto from "node:crypto";
 import { fileURLToPath } from "node:url";
@@ -22,6 +24,21 @@ import { ID_RE, isCapsule, textOfContent } from "./src/lib/schema.js";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const STORE_DIR = path.join(HERE, ".capsules");
+
+// Backfill config from ~/.beevibe/crystal/config.json (written by
+// `pnpm crystal:setup`) so a user who pasted their key once never has to
+// export it. Env always wins, matching adr-doctor's precedence.
+const CONFIG_PATH = path.join(os.homedir(), ".beevibe", "crystal", "config.json");
+try {
+  const cfg = JSON.parse(readFileSync(CONFIG_PATH, "utf8"));
+  for (const k of ["ANTHROPIC_API_KEY", "CRYSTAL_BALL_MODEL", "CRYSTAL_BALL_MAX_TOKENS", "CRYSTAL_VIEWER_URL"]) {
+    if (!process.env[k]?.trim() && cfg[k] != null && String(cfg[k]).trim()) {
+      process.env[k] = String(cfg[k]);
+    }
+  }
+} catch {
+  // No config file (or unreadable) — env-only operation is fine.
+}
 const PORT = Number(process.env.PORT || 5274);
 const VIEWER_URL = (process.env.CRYSTAL_VIEWER_URL || "http://localhost:5273").replace(/\/$/, "");
 const MODEL = process.env.CRYSTAL_BALL_MODEL || "claude-sonnet-4-5";


### PR DESCRIPTION
Makes Crystal quick to **try and use** for this release: no env exports, no durable hosting — paste your key once and get a public link via a Cloudflare quick tunnel.

### What's new
- **`pnpm crystal:setup`** (`crystal-doctor.mjs`) — prompts for your Anthropic key **in the terminal** and saves it to `~/.beevibe/crystal/config.json` (mode 0600). Mirrors `adr-doctor`'s UX. Audit mode (`pnpm crystal:doctor`) reports status.
- **server reads the config** on startup (env wins), so once you've run setup you never export anything.
- **`pnpm crystal:serve`** (`crystal-serve.mjs`) — server + viewer behind a Cloudflare quick tunnel, prints a public `*.trycloudflare.com` URL and bakes it into share links. Ephemeral by design.
- **publish skill preflight** now also checks `hasKey` and, if missing, points users to `pnpm crystal:setup` **in their terminal**.

### Why terminal-only for the key
Crystal publishes the session. A key pasted into the Claude chat would end up *inside the capsule you share*. `adr-doctor`'s out-of-band terminal prompt avoids that, so we mirror it.

### Verified
- syntax-checked all entry files
- `crystal:setup` writes a 0600 config; `crystal:doctor` reads it back (exit 0); the server's backfill yields `hasKey: true` — all tested with a throwaway `HOME`.

Base: `feat/crystal-ball-import`. Follow-up: sync the same preflight wording into the `beevibe-ai/claude-plugins` copy of the skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)