### PR TITLE
feat(session): conversation_id + active-sessions filter excludes chat

### DIFF
--- a/migrations/1781200000000_add-session-conversation-id.sql
+++ b/migrations/1781200000000_add-session-conversation-id.sql
@@ -61,6 +61,21 @@ UPDATE session
   FROM heads h
  WHERE session.id = h.id;
 
+-- Defensive fallback: any chat row whose conversation_id is still NULL
+-- after the recursive walk is a member of a chat-only cycle in
+-- prior_session_id (data corruption — chains should only point backward
+-- in time). The recursive CTE skips cycles because neither node
+-- qualifies for the base case (each has a chat prior), and the
+-- inductive step never seeds them. Without this fallback the cycle
+-- members vanish from DETAIL_SQL_RECENT_CHAT_THREADS (which filters
+-- `conversation_id IS NOT NULL`); groupIntoConversations in JS would
+-- have surfaced them via its visited-set bail. Stamping each survivor
+-- as its own thread head matches that JS contract.
+UPDATE session
+   SET conversation_id = id
+ WHERE type = 'chat'
+   AND conversation_id IS NULL;
+
 -- Partial index for the agent detail "recent chat threads" rollup
 -- (GROUP BY conversation_id WHERE agent_id=$1 AND type='chat') and the
 -- planned chat history lookup that will replace the JS walk. Restricting

--- a/migrations/1781200000000_add-session-conversation-id.sql
+++ b/migrations/1781200000000_add-session-conversation-id.sql
@@ -1,0 +1,72 @@
+-- Materialize the chat-conversation thread identifier as a column.
+--
+-- Today the chat history endpoint groups chat turns into conversation
+-- chains by walking `prior_session_id` backwards in JS
+-- (see `groupIntoConversations` in packages/api/src/routes/chat.ts).
+-- That works for one bounded list but doesn't compose: the agent detail
+-- "recent sessions" view can't collapse chat turns into one card per
+-- thread without re-running the walk, and the dashboard's "active
+-- sessions" metric oscillates between turns because each turn is its own
+-- short-lived `running` row.
+--
+-- Stamping the head id directly onto every row in a chain lets:
+--   - the agents view GROUP BY conversation_id with a single SQL query;
+--   - the dashboard filter to `type != 'chat'` while still treating a
+--     multi-turn conversation as a meaningful entity elsewhere;
+--   - the chat surface drop the JS walk in favor of an indexed lookup.
+--
+-- For chat sessions: `conversation_id` is the id of the first turn in
+-- the thread; subsequent turns inherit it via the INSERT SQL in
+-- packages/core/src/adapters/postgres/session-repo.ts. NULL for non-chat
+-- sessions — task/mesh/blocker/run_repo aren't part of a conversation
+-- thread.
+
+ALTER TABLE session
+  ADD COLUMN conversation_id TEXT;
+
+-- Backfill: walk each chat session's prior_session_id chain back to the
+-- head and stamp conversation_id = head_id.
+--
+-- Base case: chat sessions whose prior_session_id is null OR points
+-- outside the chat type (data-integrity tolerance — should not happen
+-- in practice, but mirrors groupIntoConversations's "pointer outside
+-- input window → this row is its own head" behaviour).
+--
+-- Inductive case: chat sessions whose prior is also chat inherit the
+-- prior's head_id. The `depth` column is a defensive cycle guard;
+-- `prior_session_id` should only point backward in time but
+-- groupIntoConversations already defends against corrupted chains and
+-- this migration must not loop if production data has any.
+WITH RECURSIVE heads(id, head_id, depth) AS (
+  SELECT s.id, s.id, 0
+    FROM session s
+   WHERE s.type = 'chat'
+     AND (
+       s.prior_session_id IS NULL
+       OR NOT EXISTS (
+         SELECT 1 FROM session p
+          WHERE p.id = s.prior_session_id
+            AND p.type = 'chat'
+       )
+     )
+  UNION ALL
+  SELECT child.id, h.head_id, h.depth + 1
+    FROM session child
+    JOIN heads h ON child.prior_session_id = h.id
+   WHERE child.type = 'chat'
+     AND h.depth < 1000
+)
+UPDATE session
+   SET conversation_id = h.head_id
+  FROM heads h
+ WHERE session.id = h.id;
+
+-- Partial index for the agent detail "recent chat threads" rollup
+-- (GROUP BY conversation_id WHERE agent_id=$1 AND type='chat') and the
+-- planned chat history lookup that will replace the JS walk. Restricting
+-- to chat rows with a populated conversation_id keeps the index small —
+-- task/mesh sessions stay on `idx_session_agent_status` / the other
+-- general indexes.
+CREATE INDEX IF NOT EXISTS idx_session_agent_conversation
+  ON session(agent_id, conversation_id, created_at DESC)
+  WHERE type = 'chat' AND conversation_id IS NOT NULL;

--- a/packages/api/src/views/agents.test.ts
+++ b/packages/api/src/views/agents.test.ts
@@ -60,11 +60,14 @@ describe("listAgents", () => {
 
 describe("getAgent", () => {
   it("returns undefined when missing", async () => {
-    const pool = makeMockPool([[], [], [], [], []]);
+    // getAgent fires 6 queries in parallel — agent, blocks, recent
+    // sessions, recent chat threads, mesh hints, delta metrics.
+    const pool = makeMockPool([[], [], [], [], [], []]);
     expect(await getAgent(pool, "agt_missing")).toBeUndefined();
   });
 
-  it("aggregates blocks, recent sessions, mesh hints, and delta metrics", async () => {
+  it("aggregates blocks, recent sessions, chat threads, mesh hints, and delta metrics", async () => {
+    const lastTurnAt = new Date("2026-05-30T10:00:00Z");
     const pool = makeMockPool([
       [
         {
@@ -105,6 +108,15 @@ describe("getAgent", () => {
       ],
       [
         {
+          conversation_id: "sess_chat0001",
+          turn_count: 4,
+          last_at: lastTurnAt,
+          intent_first: "hey what's the status of the migration?",
+          last_status: "succeeded",
+        },
+      ],
+      [
+        {
           id: "neg_1",
           target_name: "Charlie",
           created_at: new Date(),
@@ -125,8 +137,53 @@ describe("getAgent", () => {
     expect(detail?.recent_sessions).toHaveLength(1);
     expect(detail?.recent_sessions[0]?.short_id).toBe("qwerty");
     expect(detail?.recent_sessions[0]?.title).toBe("Bill rewrite");
+    expect(detail?.recent_chat_threads).toHaveLength(1);
+    expect(detail?.recent_chat_threads[0]?.conversation_id).toBe("sess_chat0001");
+    expect(detail?.recent_chat_threads[0]?.turn_count).toBe(4);
+    expect(detail?.recent_chat_threads[0]?.title).toBe(
+      "hey what's the status of the migration?",
+    );
+    expect(detail?.recent_chat_threads[0]?.last_status).toBe("succeeded");
     expect(detail?.outgoing_mesh_hints).toHaveLength(1);
     expect(detail?.outgoing_mesh_hints[0]?.target).toBe("Charlie");
     expect(detail?.owner_label).toBe("Wendy");
+  });
+
+  it("truncates the chat thread title to 80 chars", async () => {
+    const longIntent = "x".repeat(200);
+    const pool = makeMockPool([
+      [
+        {
+          id: "agt_x",
+          name: "X",
+          owner_id: "per_w",
+          owner_label: "Wendy",
+          parent_agent_id: null,
+          hierarchy_level: "ic",
+          review_policy: null,
+          runtime_config: { type: "claude" },
+          created_at: new Date(),
+          updated_at: new Date(),
+          sessions_count: 0,
+          facts_learned: 0,
+        },
+      ],
+      [],
+      [],
+      [
+        {
+          conversation_id: "sess_long",
+          turn_count: 1,
+          last_at: new Date(),
+          intent_first: longIntent,
+          last_status: "running",
+        },
+      ],
+      [],
+      [],
+    ]);
+    const detail = await getAgent(pool, "agt_x");
+    expect(detail?.recent_chat_threads[0]?.title.length).toBe(80);
+    expect(detail?.recent_chat_threads[0]?.title.endsWith("…")).toBe(true);
   });
 });

--- a/packages/api/src/views/agents.ts
+++ b/packages/api/src/views/agents.ts
@@ -13,6 +13,7 @@ import type {
   AgentDetail,
   CoreBlockDisplay,
   RecentSession,
+  RecentChatThread,
   OutgoingMeshHint,
   AgentMetrics,
 } from "./types.js";
@@ -127,6 +128,10 @@ WHERE agent_id = $1
 ORDER BY block_name ASC
 `;
 
+// Excludes chat sessions — each chat turn is its own session row and on
+// heavily-chatted agents those rows used to drown out actual task work
+// in this list. Chat conversations are surfaced separately as collapsed
+// thread cards via DETAIL_SQL_RECENT_CHAT_THREADS below.
 const DETAIL_SQL_RECENT_SESSIONS = /* sql */ `
 SELECT
   s.id, s.intent, s.status, s.task_id, s.created_at,
@@ -134,7 +139,36 @@ SELECT
 FROM session s
 LEFT JOIN task t ON t.id = s.task_id
 WHERE s.agent_id = $1
+  AND s.type != 'chat'
 ORDER BY s.created_at DESC
+LIMIT 5
+`;
+
+// Recent chat conversations, collapsed by `conversation_id`. One card
+// per thread with turn count + last-turn timestamp. The migration
+// (1781200000000_add-session-conversation-id.sql) backfilled
+// conversation_id for every chat row by walking prior_session_id; new
+// turns inherit it via the postgres SessionRepository INSERT, so this
+// query reliably groups by it.
+//
+// `intent_first` shows the first message of the thread (most useful as
+// a title); `last_status` lets the UI flag still-running threads.
+// Soft-deleted threads are excluded so a recently-deleted conversation
+// doesn't reappear on the agent's detail page.
+const DETAIL_SQL_RECENT_CHAT_THREADS = /* sql */ `
+SELECT
+  conversation_id,
+  COUNT(*)::int AS turn_count,
+  MAX(created_at) AS last_at,
+  (ARRAY_AGG(intent ORDER BY created_at ASC))[1] AS intent_first,
+  (ARRAY_AGG(status ORDER BY created_at DESC))[1] AS last_status
+FROM session
+WHERE agent_id = $1
+  AND type = 'chat'
+  AND conversation_id IS NOT NULL
+  AND deleted_at IS NULL
+GROUP BY conversation_id
+ORDER BY last_at DESC
 LIMIT 5
 `;
 
@@ -207,6 +241,14 @@ interface RecentSessionRow {
   task_title: string | null;
 }
 
+interface RecentChatThreadRow {
+  conversation_id: string;
+  turn_count: number;
+  last_at: Date;
+  intent_first: string;
+  last_status: SessionStatus;
+}
+
 interface MeshHintRow {
   id: string;
   target_name: string;
@@ -233,14 +275,21 @@ export async function getAgent(
   pool: Pool,
   id: string,
 ): Promise<AgentDetail | undefined> {
-  const [agentResult, blockResult, recentResult, meshResult, deltaResult] =
-    await Promise.all([
-      pool.query<AgentRow>(DETAIL_SQL_AGENT, [id]),
-      pool.query<BlockRow>(DETAIL_SQL_BLOCKS, [id]),
-      pool.query<RecentSessionRow>(DETAIL_SQL_RECENT_SESSIONS, [id]),
-      pool.query<MeshHintRow>(DETAIL_SQL_MESH_HINTS, [id]),
-      pool.query<DeltaMetricsRow>(DETAIL_SQL_DELTA_METRICS, [id]),
-    ]);
+  const [
+    agentResult,
+    blockResult,
+    recentResult,
+    chatThreadResult,
+    meshResult,
+    deltaResult,
+  ] = await Promise.all([
+    pool.query<AgentRow>(DETAIL_SQL_AGENT, [id]),
+    pool.query<BlockRow>(DETAIL_SQL_BLOCKS, [id]),
+    pool.query<RecentSessionRow>(DETAIL_SQL_RECENT_SESSIONS, [id]),
+    pool.query<RecentChatThreadRow>(DETAIL_SQL_RECENT_CHAT_THREADS, [id]),
+    pool.query<MeshHintRow>(DETAIL_SQL_MESH_HINTS, [id]),
+    pool.query<DeltaMetricsRow>(DETAIL_SQL_DELTA_METRICS, [id]),
+  ]);
   const agentRow = agentResult.rows[0];
   if (!agentRow) return undefined;
   const deltaRow = deltaResult.rows[0];
@@ -263,6 +312,17 @@ export async function getAgent(
     age: formatRelativeShort(s.created_at),
   }));
 
+  const recent_chat_threads: RecentChatThread[] = chatThreadResult.rows.map((t) => ({
+    conversation_id: t.conversation_id,
+    title:
+      t.intent_first.length <= 80
+        ? t.intent_first
+        : t.intent_first.slice(0, 79) + "…",
+    turn_count: Number(t.turn_count),
+    age: formatRelativeShort(t.last_at),
+    last_status: recentSessionStatus(t.last_status),
+  }));
+
   const outgoing_mesh_hints: OutgoingMeshHint[] = meshResult.rows.map((m) => ({
     target: m.target_name,
     intent: (m.opening_message ?? "(no message)").slice(0, 80),
@@ -282,6 +342,7 @@ export async function getAgent(
     core_blocks,
     metrics,
     recent_sessions,
+    recent_chat_threads,
     outgoing_mesh_hints,
   };
 }

--- a/packages/api/src/views/dashboard.test.ts
+++ b/packages/api/src/views/dashboard.test.ts
@@ -194,6 +194,16 @@ describe("getDashboardSummary", () => {
     );
     expect(kpiTrendSql).toBeDefined();
     expect(kpiTrendSql).toContain("type != 'chat'");
+
+    // FLEET_SQL's active_agents CTE drives the per-hierarchy "X
+    // active / Y total" bar. Without the chat filter it'd flicker the
+    // bar for chat-heavy agents on every LLM round-trip — same root
+    // cause as the gauge bug, different widget.
+    const fleetSql = sqlSeen.find(
+      (s) => s.includes("active_agents") && s.includes("FROM session"),
+    );
+    expect(fleetSql).toBeDefined();
+    expect(fleetSql).toContain("type != 'chat'");
   });
 
   it("handles 0 totals without dividing by zero", async () => {

--- a/packages/api/src/views/dashboard.test.ts
+++ b/packages/api/src/views/dashboard.test.ts
@@ -165,6 +165,37 @@ describe("getDashboardSummary", () => {
     expect(summary.kpis.find((k) => k.kind === "active_sessions")?.value).toBe(10);
   });
 
+  it("RUNNING_SESSIONS_SQL filters out chat — preserves the gauge across chat-turn churn", async () => {
+    // Spy on the SQL text to lock in the chat-exclusion filter. Without
+    // it, a chat-heavy agent caused the gauge to oscillate between 0
+    // and N every time an LLM round-trip flipped a short-lived
+    // type='chat' row from running to succeeded.
+    const sqlSeen: string[] = [];
+    const query = vi.fn(async (sql: unknown) => {
+      const text = String(sql);
+      sqlSeen.push(text);
+      if (text.includes("FROM days") && text.includes("active_sessions")) return { rows: makeKpiTrendRows() };
+      if (text.includes("FROM days")) return { rows: makeTrendRows() };
+      return { rows: [] };
+    });
+    const pool = { query } as unknown as Pool;
+    await getDashboardSummary(pool);
+    const runningSessionsSql = sqlSeen.find(
+      (s) =>
+        s.includes("COUNT(*)::int AS n") &&
+        s.includes("FROM session") &&
+        s.includes("status = 'running'"),
+    );
+    expect(runningSessionsSql).toBeDefined();
+    expect(runningSessionsSql).toContain("type != 'chat'");
+
+    const kpiTrendSql = sqlSeen.find(
+      (s) => s.includes("sessions_per_day") && s.includes("FROM session"),
+    );
+    expect(kpiTrendSql).toBeDefined();
+    expect(kpiTrendSql).toContain("type != 'chat'");
+  });
+
   it("handles 0 totals without dividing by zero", async () => {
     const pool = makeMockPool([[], [], makeTrendRows(), [], makeKpiTrendRows()]);
     const { status_total, status_breakdown, fleet_total, fleet } = await getDashboardSummary(pool);

--- a/packages/api/src/views/dashboard.ts
+++ b/packages/api/src/views/dashboard.ts
@@ -93,8 +93,18 @@ LEFT JOIN active_agents aa ON aa.agent_id = a.id
 GROUP BY a.hierarchy_level
 `;
 
+// Active-sessions KPI semantic: count of sessions whose work is
+// long-running enough to be a meaningful "is anything actively running"
+// signal. Chat turns are short-lived (LLM round-trip then terminal), so
+// including them made the gauge oscillate between 0 and N mid-
+// conversation — see PR description for the bug report. Excluding only
+// `type = 'chat'` keeps task / mesh_ask / mesh_negotiate / blocker /
+// run_repo in the count, which all represent meaningful in-flight work.
 const RUNNING_SESSIONS_SQL = /* sql */ `
-SELECT COUNT(*)::int AS n FROM session WHERE status = 'running'
+SELECT COUNT(*)::int AS n
+  FROM session
+ WHERE status = 'running'
+   AND type != 'chat'
 `;
 
 const TREND_SQL = /* sql */ `
@@ -131,9 +141,14 @@ WITH days AS (
   FROM generate_series(0, $1 - 1) AS i
 ),
 sessions_per_day AS (
+  -- Excludes chat to match the RUNNING_SESSIONS_SQL gauge semantic
+  -- (chat turns oscillate the live value and do not represent
+  -- meaningful in-flight work). The sparkline shown next to the
+  -- active_sessions KPI value must agree with the value itself.
   SELECT (started_at AT TIME ZONE 'UTC')::date AS day, COUNT(*)::int AS n
   FROM session
   WHERE started_at >= CURRENT_DATE - $1::int
+    AND type != 'chat'
   GROUP BY day
 ),
 review_per_day AS (

--- a/packages/api/src/views/dashboard.ts
+++ b/packages/api/src/views/dashboard.ts
@@ -80,9 +80,17 @@ FROM task
 GROUP BY status
 `;
 
+// `active_agents` matches the RUNNING_SESSIONS_SQL semantic — an agent
+// is "active" when it has at least one long-running (non-chat) session
+// in flight. Including chat here would let a chat-heavy agent flicker
+// between active and idle on every LLM round-trip, the same bug that
+// motivated the chat exclusion on the active_sessions KPI.
 const FLEET_SQL = /* sql */ `
 WITH active_agents AS (
-  SELECT DISTINCT agent_id FROM session WHERE status = 'running'
+  SELECT DISTINCT agent_id
+    FROM session
+   WHERE status = 'running'
+     AND type != 'chat'
 )
 SELECT
   a.hierarchy_level AS hier,

--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -123,6 +123,34 @@ export interface RecentSession {
   age: string;
 }
 
+/**
+ * Recent chat conversation surfaced on the agent detail page as one
+ * collapsed card per thread. Each thread groups N chat-turn sessions
+ * sharing the same `conversation_id` (the head turn's session id —
+ * stamped by the postgres SessionRepository INSERT, backfilled by
+ * migration 1781200000000). The web renders this as an expandable card
+ * showing the first message as the title and `turn_count` turns inside.
+ *
+ * Distinct from `RecentSession` (which now excludes chat) — task
+ * sessions render as today, one row per session.
+ */
+export interface RecentChatThread {
+  /** Head session id of the thread; stable across all turns. */
+  conversation_id: string;
+  /** First message of the thread, truncated to 80 chars. */
+  title: string;
+  /** How many chat sessions are in the thread. */
+  turn_count: number;
+  /** Relative-time label for the most recent turn, e.g. "2m". */
+  age: string;
+  /**
+   * Status of the latest turn. Drives the in-flight pip — when a chat
+   * turn is mid-LLM-call, the card shows "running"; on succeeded /
+   * failed / cancelled it goes idle.
+   */
+  last_status: "running" | "succeeded" | "review";
+}
+
 export interface OutgoingMeshHint {
   target: string;
   intent: string;
@@ -153,7 +181,14 @@ export interface AgentMetrics {
 export interface AgentDetail extends AgentDisplay {
   core_blocks: CoreBlockDisplay[];
   metrics: AgentMetrics;
+  /**
+   * Recent non-chat sessions (task / mesh / blocker / run_repo). Chat
+   * sessions are surfaced via `recent_chat_threads` so heavy chat usage
+   * doesn't drown out actual task work in this list.
+   */
   recent_sessions: RecentSession[];
+  /** Recent chat conversations, collapsed by `conversation_id`. */
+  recent_chat_threads: RecentChatThread[];
   outgoing_mesh_hints: OutgoingMeshHint[];
 }
 

--- a/packages/core/src/adapters/postgres/row-types.ts
+++ b/packages/core/src/adapters/postgres/row-types.ts
@@ -73,6 +73,7 @@ export interface SessionRow {
   room_id: string | null;
   caller_agent_id: string | null;
   parent_session_id: string | null;
+  conversation_id: string | null;
   started_at: Date | null;
   completed_at: Date | null;
   created_at: Date;

--- a/packages/core/src/adapters/postgres/session-repo.test.ts
+++ b/packages/core/src/adapters/postgres/session-repo.test.ts
@@ -217,6 +217,60 @@ describe("PostgresSessionRepository", () => {
     expect(same.status).toBe("running");
   });
 
+  describe("conversation_id", () => {
+    // The thread identifier lives in SQL: the INSERT CASE picks
+    //   explicit-from-caller → prior.conversation_id → own id (chat) → NULL
+    // so every call site lands the right value without each caller
+    // having to remember the policy.
+
+    it("is NULL for non-chat sessions", async () => {
+      const s = await sessions.create(newSession({ type: "task", task_id: task }));
+      expect(s.conversation_id).toBeUndefined();
+    });
+
+    it("first chat turn (no prior) stamps conversation_id = own id", async () => {
+      const head = await sessions.create(newSession({ type: "chat", intent: "hi" }));
+      expect(head.conversation_id).toBe(head.id);
+    });
+
+    it("second chat turn inherits the prior's conversation_id", async () => {
+      const turn1 = await sessions.create(newSession({ type: "chat", intent: "hi" }));
+      const turn2 = await sessions.create(
+        newSession({
+          type: "chat",
+          intent: "follow up",
+          prior_session_id: turn1.id,
+        }),
+      );
+      expect(turn2.conversation_id).toBe(turn1.id);
+      // The third turn keeps the same head, not turn2's id — verifies
+      // chains of arbitrary depth converge on the head, not the last
+      // pointer.
+      const turn3 = await sessions.create(
+        newSession({
+          type: "chat",
+          intent: "again",
+          prior_session_id: turn2.id,
+        }),
+      );
+      expect(turn3.conversation_id).toBe(turn1.id);
+    });
+
+    it("explicit conversation_id wins over the auto-resolution", async () => {
+      // Caller-provided wins. Used by tests / future callers that pre-
+      // compute the value (analogous to sessionIdOverride).
+      const head = await sessions.create(newSession({ type: "chat", intent: "hi" }));
+      const grafted = await sessions.create(
+        newSession({
+          type: "chat",
+          intent: "spliced in",
+          conversation_id: head.id,
+        }),
+      );
+      expect(grafted.conversation_id).toBe(head.id);
+    });
+  });
+
   describe("softDeleteChatChain", () => {
     it("walks the chain backwards and stamps every session as deleted", async () => {
       const turn1 = await sessions.create(newSession({ type: "chat", intent: "hi" }));

--- a/packages/core/src/adapters/postgres/session-repo.test.ts
+++ b/packages/core/src/adapters/postgres/session-repo.test.ts
@@ -228,6 +228,20 @@ describe("PostgresSessionRepository", () => {
       expect(s.conversation_id).toBeUndefined();
     });
 
+    it("is NULL for non-chat sessions even when caller passes an explicit conversation_id", async () => {
+      // Guards against a task / mesh / blocker row leaking into the
+      // chat-thread rollup index. The type check must short-circuit
+      // before the explicit-override branch.
+      const s = await sessions.create(
+        newSession({
+          type: "task",
+          task_id: task,
+          conversation_id: "sess_someone_elses_chat",
+        }),
+      );
+      expect(s.conversation_id).toBeUndefined();
+    });
+
     it("first chat turn (no prior) stamps conversation_id = own id", async () => {
       const head = await sessions.create(newSession({ type: "chat", intent: "hi" }));
       expect(head.conversation_id).toBe(head.id);

--- a/packages/core/src/adapters/postgres/session-repo.ts
+++ b/packages/core/src/adapters/postgres/session-repo.ts
@@ -268,7 +268,9 @@ export class PostgresSessionRepository implements SessionRepository {
     //      subselect returns NULL when prior_session_id is NULL or the
     //      prior row is gone — soft-deleted or pruned);
     //   3. else this is a new thread — stamp the row's own id.
-    // For non-chat sessions, conversation_id stays NULL.
+    // Non-chat sessions ALWAYS get NULL — the type check guards the
+    // whole expression so a caller passing an explicit conversation_id
+    // on a task / mesh row can't leak it into the chat-thread index.
     const { rows } = await this.pool.query<SessionRow>(
       `INSERT INTO session (
          id, agent_id, task_id, prior_session_id,
@@ -289,8 +291,8 @@ export class PostgresSessionRepository implements SessionRepository {
          $16, COALESCE($17, 'daemon'), $18, $19,
          $20,
          CASE
-           WHEN $22::text IS NOT NULL THEN $22::text
            WHEN $5 = 'chat' THEN COALESCE(
+             $22::text,
              (SELECT conversation_id FROM session WHERE id = $4),
              $1
            )

--- a/packages/core/src/adapters/postgres/session-repo.ts
+++ b/packages/core/src/adapters/postgres/session-repo.ts
@@ -260,6 +260,15 @@ export class PostgresSessionRepository implements SessionRepository {
   }
 
   async create(input: NewSession): Promise<Session> {
+    // conversation_id resolution policy lives in the INSERT itself so
+    // every call site (DispatchService, AgentSession's legacy inline
+    // path, tests) gets it for free. For chat sessions:
+    //   1. an explicit caller-provided conversation_id wins;
+    //   2. else inherit from the prior session's conversation_id (the
+    //      subselect returns NULL when prior_session_id is NULL or the
+    //      prior row is gone — soft-deleted or pruned);
+    //   3. else this is a new thread — stamp the row's own id.
+    // For non-chat sessions, conversation_id stays NULL.
     const { rows } = await this.pool.query<SessionRow>(
       `INSERT INTO session (
          id, agent_id, task_id, prior_session_id,
@@ -269,6 +278,7 @@ export class PostgresSessionRepository implements SessionRepository {
          result_summary, exit_code, error, usage,
          runtime_id, spawn_mode, room_id, caller_agent_id,
          parent_session_id,
+         conversation_id,
          started_at, completed_at
        ) VALUES (
          $1, $2, $3, $4,
@@ -278,6 +288,14 @@ export class PostgresSessionRepository implements SessionRepository {
          $12, $13, $14, $15,
          $16, COALESCE($17, 'daemon'), $18, $19,
          $20,
+         CASE
+           WHEN $22::text IS NOT NULL THEN $22::text
+           WHEN $5 = 'chat' THEN COALESCE(
+             (SELECT conversation_id FROM session WHERE id = $4),
+             $1
+           )
+           ELSE NULL
+         END,
          $21, NULL
        )
        RETURNING *`,
@@ -303,6 +321,7 @@ export class PostgresSessionRepository implements SessionRepository {
         input.caller_agent_id ?? null,
         input.parent_session_id ?? null,
         input.started_at ?? null,
+        input.conversation_id ?? null,
       ],
     );
     return rowToSession(rows[0]!);
@@ -368,6 +387,7 @@ function rowToSession(row: SessionRow): Session {
     room_id: row.room_id ?? undefined,
     caller_agent_id: row.caller_agent_id ?? undefined,
     parent_session_id: row.parent_session_id ?? undefined,
+    conversation_id: row.conversation_id ?? undefined,
     started_at: row.started_at ?? undefined,
     completed_at: row.completed_at ?? undefined,
     created_at: row.created_at,

--- a/packages/core/src/domain/session.ts
+++ b/packages/core/src/domain/session.ts
@@ -170,6 +170,19 @@ export interface Session {
    * same task) and `caller_agent_id` (mesh ask/negotiate initiator).
    */
   parent_session_id?: string;
+  /**
+   * Chat conversation thread id — the session id of the FIRST turn in
+   * the thread. Subsequent turns in the same conversation inherit this
+   * value via the INSERT SQL in the postgres SessionRepository
+   * (COALESCE(explicit, prior.conversation_id, own id) when
+   * type='chat'). NULL for non-chat sessions; they don't participate in
+   * a conversation thread.
+   *
+   * Materializes the head id that `groupIntoConversations` used to walk
+   * for in JS, so the views layer can GROUP BY conversation_id without
+   * pulling every chat row into application code.
+   */
+  conversation_id?: string;
   started_at?: Date;
   completed_at?: Date;
   created_at: Date;


### PR DESCRIPTION
Closes the agent-detail-page UX bugs from task_QiF5qPU4trst.

## Summary

- **Problem 1**: Every chat turn was its own session row. On a heavily-chatted agent, chat rows drowned out actual task work in the "recent sessions" list.
- **Problem 2**: The dashboard's "active sessions" gauge dropped to 0 between chat turns because short-lived chat sessions kept flipping running→succeeded mid-conversation.

## Approach

### Schema — \`conversation_id\` column on \`session\` (migration 1781200000000)

The chat history endpoint already groups chat turns into conversations by walking \`prior_session_id\` backwards in JS (\`groupIntoConversations\` in \`packages/api/src/routes/chat.ts\`). This PR materializes the head id of that walk as a column so the views layer can \`GROUP BY conversation_id\` at the DB level.

- New column \`conversation_id text\` on \`session\` (NULL for non-chat types).
- Backfill via recursive CTE walking \`prior_session_id\` chains; depth-limited at 1000 as a defensive guard against any corrupted data (\`groupIntoConversations\` already tolerates cycles, and the migration must not loop if production data has any).
- Partial index \`idx_session_agent_conversation\` on \`(agent_id, conversation_id, created_at DESC) WHERE type = 'chat'\` for the rollup query.

### Reused \`type\` rather than adding \`kind\`

Per the task's "grep before adding a new column" guidance — \`session.type\` already discriminates \`task | mesh_ask | mesh_negotiate | blocker | chat | run_repo\`. No new column needed.

### INSERT-side policy

\`conversation_id\` resolution lives in the INSERT \`CASE\` in the postgres \`SessionRepository.create\`, so every call site (\`DispatchService\`, \`AgentSession\`'s legacy inline path, tests) gets the right value without per-caller policy:

\`\`\`
explicit caller-provided > prior.conversation_id > own id (chat only) > NULL
\`\`\`

### Recent-sessions view collapse

\`packages/api/src/views/agents.ts\`:

- \`DETAIL_SQL_RECENT_SESSIONS\` now filters \`type != 'chat'\` so task / mesh / blocker / run_repo rows render unchanged.
- New \`DETAIL_SQL_RECENT_CHAT_THREADS\` groups chat sessions by \`conversation_id\` and returns turn count, last-turn timestamp, first-turn intent, and last-turn status — one card per thread.
- \`AgentDetail\` gains a \`recent_chat_threads: RecentChatThread[]\` field. \`RecentSession\` shape is unchanged.

**UI follow-up — out of scope here**: rendering the collapsed thread cards (expandable to show individual turns) lives in \`packages/web\`, which I don't own. The API change is non-breaking — \`recent_sessions\` keeps its existing shape, just without chat noise. I'll mesh-ask the web owner to consume \`recent_chat_threads\` in a follow-up PR.

### Active-sessions metric — chosen semantic

Per the task: "filter to \`kind = 'task'\` OR otherwise exclude chat — whichever you pick".

**Chose: \`type != 'chat'\`** rather than strict \`type = 'task'\`. Rationale: task, mesh_ask, mesh_negotiate, blocker, run_repo are all legitimately long-running work whose presence in the gauge is meaningful. Only chat oscillates short-lived. Excluding chat alone preserves the most signal.

Applied to both:
- \`RUNNING_SESSIONS_SQL\` — the live value
- \`KPI_TREND_SQL\` \`sessions_per_day\` — the sparkline shown next to the value

## Test plan

- [x] \`packages/api/src/views/dashboard.test.ts\` — new test asserts both \`RUNNING_SESSIONS_SQL\` and \`KPI_TREND_SQL\` carry \`type != 'chat'\`. All 21 existing dashboard tests pass.
- [x] \`packages/api/src/views/agents.test.ts\` — \`getAgent\` now fires 6 parallel queries (added chat thread rollup). Tests cover the new \`recent_chat_threads\` mapping and 80-char title truncation. 5 tests pass.
- [x] \`packages/core/src/adapters/postgres/session-repo.test.ts\` — new \`conversation_id\` suite covers: NULL for non-chat, head = own id, deep chain inheritance, explicit override wins. (DB-backed; runs in CI — no local docker.)
- [x] \`pnpm --filter @beevibe/core build\` clean
- [x] \`pnpm --filter @beevibe/api typecheck\` clean
- [x] \`pnpm --filter @beevibe/web typecheck\` clean
- [ ] Local DB integration tests — no local postgres in this workspace; running in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)