### PR TITLE
feat(watch-tasks): team-agent wake-up on dispatched task completion

### DIFF
--- a/migrations/1781300000000_add-task-watch.sql
+++ b/migrations/1781300000000_add-task-watch.sql
@@ -1,6 +1,6 @@
 -- task_watch — team agent declares "wake me when these dispatched tasks
--- finish" before ending its session. The next migration (M2) attaches
--- the AFTER-UPDATE trigger on `task` that fans matching watches into
+-- finish" before ending its session. A separate trigger migration
+-- attaches the AFTER-UPDATE on `task` that fans matching watches into
 -- new sessions; this migration only lands the table + indexes so the
 -- repo + adapter are testable on their own.
 --
@@ -12,7 +12,8 @@
 -- mode               — 'all' (every task terminal) | 'any' (first one).
 -- task_ids           — non-empty array of task ids the agent is waiting
 --                      on. GIN-indexed (partial on waiting rows) so the
---                      M2 trigger can locate candidates quickly.
+--                      trigger's `task_ids @> ARRAY[NEW.id]` lookup is
+--                      index-served, not seq-scanned.
 -- status             — 'waiting' until the trigger fires or the agent
 --                      calls unwatch. Terminal states: 'fired' (wake
 --                      session inserted) | 'aborted' (agent cancelled).

--- a/migrations/1781300000000_add-task-watch.sql
+++ b/migrations/1781300000000_add-task-watch.sql
@@ -1,0 +1,45 @@
+-- task_watch — team agent declares "wake me when these dispatched tasks
+-- finish" before ending its session. The next migration (M2) attaches
+-- the AFTER-UPDATE trigger on `task` that fans matching watches into
+-- new sessions; this migration only lands the table + indexes so the
+-- repo + adapter are testable on their own.
+--
+-- waiter_session_id  — the session that called watch_tasks. The wake
+--                      session chains off this via prior_session_id so
+--                      claude --resume restores full agent context.
+-- agent_id           — denormalized waiter session's agent for
+--                      cheap auth checks at unwatch time.
+-- mode               — 'all' (every task terminal) | 'any' (first one).
+-- task_ids           — non-empty array of task ids the agent is waiting
+--                      on. GIN-indexed (partial on waiting rows) so the
+--                      M2 trigger can locate candidates quickly.
+-- status             — 'waiting' until the trigger fires or the agent
+--                      calls unwatch. Terminal states: 'fired' (wake
+--                      session inserted) | 'aborted' (agent cancelled).
+-- fired_session_id   — the wake session inserted by the trigger; set
+--                      atomically alongside status='fired'.
+
+CREATE TABLE task_watch (
+  id                text PRIMARY KEY,
+  waiter_session_id text NOT NULL REFERENCES session(id),
+  agent_id          text NOT NULL REFERENCES agent(id),
+  mode              text NOT NULL CHECK (mode IN ('all', 'any')),
+  task_ids          text[] NOT NULL CHECK (cardinality(task_ids) > 0),
+  reason            text,
+  status            text NOT NULL DEFAULT 'waiting'
+                    CHECK (status IN ('waiting', 'fired', 'aborted')),
+  created_at        timestamptz NOT NULL DEFAULT NOW(),
+  fired_at          timestamptz,
+  fired_session_id  text REFERENCES session(id)
+);
+
+CREATE INDEX task_watch_waiting_idx
+  ON task_watch (status)
+  WHERE status = 'waiting';
+
+CREATE INDEX task_watch_task_ids_waiting_idx
+  ON task_watch USING GIN (task_ids)
+  WHERE status = 'waiting';
+
+CREATE INDEX task_watch_waiter_session_idx
+  ON task_watch (waiter_session_id);

--- a/migrations/1781400000000_add-task-watch-trigger.sql
+++ b/migrations/1781400000000_add-task-watch-trigger.sql
@@ -1,0 +1,186 @@
+-- M2 of the watch_tasks feature: trigger that fans terminal task
+-- transitions into wake sessions. The waiting `task_watch` row is the
+-- agent's explicit "wake me when these finish" subscription; this
+-- trigger fires on the matching task UPDATE, builds an intent message
+-- describing what completed, inserts a new pending session that
+-- continues the waiter's chain via prior_session_id, and stamps the
+-- watch row 'fired' with the new session id — all in the same
+-- transaction as the task status change.
+--
+-- Why a trigger and not the api layer:
+--   - Wakes survive api restarts (mesh's in-memory resolvers don't).
+--   - Atomic with the task UPDATE — no half-state where the task is
+--     terminal but the wake hasn't landed.
+--   - Works for any path that flips task.status (api routes,
+--     update_progress, dispatch retry, manual psql).
+--
+-- Intent shapes match the plan's wake templates:
+--   mode='all' fires only when every task in task_ids reaches a
+--     terminal status (done | failed | cancelled). Intent lists each
+--     task with its outcome.
+--   mode='any' fires on the first terminal task; intent leads with
+--     the firing task and lists the others as still-running context.
+--
+-- bv_build_watch_intent is split out so the M3 service-layer
+-- already-terminal race can call it for symmetry. Same text either way.
+
+-- Build the wake-session intent for a watch + the task that just fired
+-- it. Caller is expected to be inside a fire-eligible state machine
+-- (trigger or service); the function itself doesn't validate.
+CREATE OR REPLACE FUNCTION bv_build_watch_intent(
+  p_watch_id        TEXT,
+  p_firing_task_id  TEXT
+) RETURNS TEXT AS $$
+DECLARE
+  w               RECORD;
+  firing_task     RECORD;
+  intent          TEXT;
+  task_list       TEXT;
+  others_list     TEXT;
+  others_count    INT;
+  firing_suffix   TEXT;
+BEGIN
+  SELECT * INTO w FROM task_watch WHERE id = p_watch_id;
+
+  IF w.mode = 'all' THEN
+    SELECT string_agg(
+      format(
+        '  - %s — %s%s',
+        COALESCE(t.title, '(untitled)'),
+        t.status,
+        CASE
+          WHEN t.status = 'done' AND COALESCE(t.result_summary, '') <> '' THEN
+            '. Result: ' || t.result_summary
+          WHEN t.status = 'failed' AND COALESCE(t.result_summary, '') <> '' THEN
+            ': ' || t.result_summary
+          ELSE ''
+        END
+      ),
+      E'\n'
+      ORDER BY t.created_at
+    )
+    INTO task_list
+    FROM task t
+    WHERE t.id = ANY(w.task_ids);
+
+    intent := cardinality(w.task_ids)::text || ' tasks completed:' || E'\n'
+              || COALESCE(task_list, '') || E'\n'
+              || 'Decide next steps.';
+  ELSE
+    -- mode='any'
+    SELECT * INTO firing_task FROM task WHERE id = p_firing_task_id;
+
+    firing_suffix := CASE
+      WHEN firing_task.status = 'done' AND COALESCE(firing_task.result_summary, '') <> '' THEN
+        '. Result: ' || firing_task.result_summary
+      WHEN firing_task.status = 'failed' AND COALESCE(firing_task.result_summary, '') <> '' THEN
+        ': ' || firing_task.result_summary
+      ELSE ''
+    END;
+
+    SELECT string_agg(
+      format('  - %s — %s', COALESCE(t.title, '(untitled)'), t.status),
+      E'\n'
+      ORDER BY t.created_at
+    ), COUNT(*)
+    INTO others_list, others_count
+    FROM task t
+    WHERE t.id = ANY(w.task_ids)
+      AND t.id <> p_firing_task_id;
+
+    intent := 'Task '
+              || COALESCE(firing_task.title, '(untitled)')
+              || ' — ' || firing_task.status
+              || firing_suffix
+              || E'\n';
+
+    IF others_count > 0 THEN
+      intent := intent
+                || 'Other watched tasks still running:' || E'\n'
+                || others_list || E'\n';
+    END IF;
+
+    intent := intent || 'Decide next steps.';
+  END IF;
+
+  RETURN intent;
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION bv_check_task_watches() RETURNS trigger AS $$
+DECLARE
+  watch_rec      RECORD;
+  waiter_rec     RECORD;
+  all_terminal   BOOL;
+  new_session_id TEXT;
+  wake_intent    TEXT;
+BEGIN
+  -- Iterate every WAITING watch that references this task.
+  -- `FOR UPDATE` so two concurrent task UPDATEs touching the same
+  -- watch can't both fire it (the loser sees status='fired' or waits
+  -- for the winner to commit).
+  FOR watch_rec IN
+    SELECT * FROM task_watch
+     WHERE status = 'waiting'
+       AND NEW.id = ANY(task_ids)
+     FOR UPDATE
+  LOOP
+    -- mode='all': fire only when every watched task is terminal.
+    IF watch_rec.mode = 'all' THEN
+      SELECT NOT EXISTS (
+        SELECT 1 FROM task
+         WHERE id = ANY(watch_rec.task_ids)
+           AND status NOT IN ('done', 'failed', 'cancelled')
+      ) INTO all_terminal;
+
+      IF NOT all_terminal THEN
+        CONTINUE;
+      END IF;
+    END IF;
+    -- mode='any' always fires on the first terminal child.
+
+    SELECT * FROM session WHERE id = watch_rec.waiter_session_id
+      INTO waiter_rec;
+    wake_intent := bv_build_watch_intent(watch_rec.id, NEW.id);
+    new_session_id := 'sess_' ||
+      substring(replace(gen_random_uuid()::text, '-', ''), 1, 12);
+
+    INSERT INTO session (
+      id, agent_id, task_id, prior_session_id,
+      type, status, intent, conversation_id
+    ) VALUES (
+      new_session_id,
+      waiter_rec.agent_id,
+      waiter_rec.task_id,
+      waiter_rec.id,
+      waiter_rec.type,
+      'pending',
+      wake_intent,
+      CASE
+        WHEN waiter_rec.type = 'chat' THEN COALESCE(
+          waiter_rec.conversation_id,
+          waiter_rec.id
+        )
+        ELSE NULL
+      END
+    );
+
+    UPDATE task_watch
+       SET status = 'fired',
+           fired_at = NOW(),
+           fired_session_id = new_session_id
+     WHERE id = watch_rec.id;
+  END LOOP;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE TRIGGER trg_task_watch_check
+  AFTER UPDATE ON task
+  FOR EACH ROW
+  WHEN (NEW.status IN ('done', 'failed', 'cancelled')
+        AND NEW.status IS DISTINCT FROM OLD.status)
+  EXECUTE FUNCTION bv_check_task_watches();

--- a/migrations/1781400000000_add-task-watch-trigger.sql
+++ b/migrations/1781400000000_add-task-watch-trigger.sql
@@ -1,11 +1,10 @@
--- M2 of the watch_tasks feature: trigger that fans terminal task
--- transitions into wake sessions. The waiting `task_watch` row is the
--- agent's explicit "wake me when these finish" subscription; this
--- trigger fires on the matching task UPDATE, builds an intent message
--- describing what completed, inserts a new pending session that
--- continues the waiter's chain via prior_session_id, and stamps the
--- watch row 'fired' with the new session id — all in the same
--- transaction as the task status change.
+-- Trigger that fans terminal task transitions into wake sessions.
+-- A waiting `task_watch` row is an agent's explicit "wake me when these
+-- finish" subscription; this trigger fires on the matching task UPDATE,
+-- builds an intent message describing what completed, inserts a new
+-- pending session that continues the waiter's chain via prior_session_id,
+-- and stamps the watch row 'fired' with the new session id — all in the
+-- same transaction as the task status change.
 --
 -- Why a trigger and not the api layer:
 --   - Wakes survive api restarts (mesh's in-memory resolvers don't).
@@ -21,8 +20,26 @@
 --   mode='any' fires on the first terminal task; intent leads with
 --     the firing task and lists the others as still-running context.
 --
--- bv_build_watch_intent is split out so the M3 service-layer
--- already-terminal race can call it for symmetry. Same text either way.
+-- `bv_build_watch_intent` is split out so the service-layer
+-- already-terminal path can call it for symmetry. Same text either way.
+
+-- Per-task one-line suffix shared by both modes — keeps the result/error
+-- formatting in one place.
+CREATE OR REPLACE FUNCTION bv_task_result_suffix(
+  p_status   TEXT,
+  p_summary  TEXT
+) RETURNS TEXT AS $$
+BEGIN
+  IF p_status = 'done' AND COALESCE(p_summary, '') <> '' THEN
+    RETURN '. Result: ' || p_summary;
+  ELSIF p_status = 'failed' AND COALESCE(p_summary, '') <> '' THEN
+    RETURN ': ' || p_summary;
+  ELSE
+    RETURN '';
+  END IF;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
 
 -- Build the wake-session intent for a watch + the task that just fired
 -- it. Caller is expected to be inside a fire-eligible state machine
@@ -38,9 +55,14 @@ DECLARE
   task_list       TEXT;
   others_list     TEXT;
   others_count    INT;
-  firing_suffix   TEXT;
+  reason_prefix   TEXT;
 BEGIN
   SELECT * INTO w FROM task_watch WHERE id = p_watch_id;
+
+  reason_prefix := CASE
+    WHEN COALESCE(w.reason, '') <> '' THEN 'Wake reason: ' || w.reason || E'\n\n'
+    ELSE ''
+  END;
 
   IF w.mode = 'all' THEN
     SELECT string_agg(
@@ -48,13 +70,7 @@ BEGIN
         '  - %s — %s%s',
         COALESCE(t.title, '(untitled)'),
         t.status,
-        CASE
-          WHEN t.status = 'done' AND COALESCE(t.result_summary, '') <> '' THEN
-            '. Result: ' || t.result_summary
-          WHEN t.status = 'failed' AND COALESCE(t.result_summary, '') <> '' THEN
-            ': ' || t.result_summary
-          ELSE ''
-        END
+        bv_task_result_suffix(t.status, t.result_summary)
       ),
       E'\n'
       ORDER BY t.created_at
@@ -63,20 +79,13 @@ BEGIN
     FROM task t
     WHERE t.id = ANY(w.task_ids);
 
-    intent := cardinality(w.task_ids)::text || ' tasks completed:' || E'\n'
+    intent := reason_prefix
+              || cardinality(w.task_ids)::text || ' tasks completed:' || E'\n'
               || COALESCE(task_list, '') || E'\n'
               || 'Decide next steps.';
   ELSE
     -- mode='any'
     SELECT * INTO firing_task FROM task WHERE id = p_firing_task_id;
-
-    firing_suffix := CASE
-      WHEN firing_task.status = 'done' AND COALESCE(firing_task.result_summary, '') <> '' THEN
-        '. Result: ' || firing_task.result_summary
-      WHEN firing_task.status = 'failed' AND COALESCE(firing_task.result_summary, '') <> '' THEN
-        ': ' || firing_task.result_summary
-      ELSE ''
-    END;
 
     SELECT string_agg(
       format('  - %s — %s', COALESCE(t.title, '(untitled)'), t.status),
@@ -88,10 +97,11 @@ BEGIN
     WHERE t.id = ANY(w.task_ids)
       AND t.id <> p_firing_task_id;
 
-    intent := 'Task '
+    intent := reason_prefix
+              || 'Task '
               || COALESCE(firing_task.title, '(untitled)')
               || ' — ' || firing_task.status
-              || firing_suffix
+              || bv_task_result_suffix(firing_task.status, firing_task.result_summary)
               || E'\n';
 
     IF others_count > 0 THEN
@@ -116,14 +126,15 @@ DECLARE
   new_session_id TEXT;
   wake_intent    TEXT;
 BEGIN
-  -- Iterate every WAITING watch that references this task.
-  -- `FOR UPDATE` so two concurrent task UPDATEs touching the same
-  -- watch can't both fire it (the loser sees status='fired' or waits
-  -- for the winner to commit).
+  -- Iterate every WAITING watch that references this task. The
+  -- `task_ids @> ARRAY[NEW.id]` form (vs `NEW.id = ANY(task_ids)`) is
+  -- what Postgres plans against the partial GIN on `task_ids` defined
+  -- in the earlier migration. `FOR UPDATE` so two concurrent task
+  -- UPDATEs touching the same watch can't both fire it.
   FOR watch_rec IN
     SELECT * FROM task_watch
      WHERE status = 'waiting'
-       AND NEW.id = ANY(task_ids)
+       AND task_ids @> ARRAY[NEW.id]
      FOR UPDATE
   LOOP
     -- mode='all': fire only when every watched task is terminal.

--- a/packages/api/src/bootstrap.ts
+++ b/packages/api/src/bootstrap.ts
@@ -17,6 +17,7 @@ import {
   PostgresSessionRepository,
   PostgresSkillOutcomeRepository,
   PostgresTaskRepository,
+  PostgresTaskWatchRepository,
   PostgresWorkProductRepository,
   createPool,
 } from "@beevibe/core/adapters/postgres";
@@ -36,6 +37,7 @@ import { TaskService } from "@beevibe/core/services/task-service";
 import { EscalationService } from "@beevibe/core/services/escalation-service";
 import { NegotiationService } from "@beevibe/core/services/negotiation-service";
 import { DispatchService } from "@beevibe/core/services/dispatch-service";
+import { WatchService } from "@beevibe/core/services/watch-service";
 import { DaemonOrphanReaper } from "@beevibe/core/services/orphan-reaper";
 import { buildPostDispatchHook } from "@beevibe/core/services/post-dispatch";
 import type { Session } from "@beevibe/core";
@@ -143,6 +145,7 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
   const repoRunRepo = new PostgresRepoRunRepository(pool);
   const learnedSkillRepo = new PostgresLearnedSkillRepository(pool);
   const skillOutcomeRepo = new PostgresSkillOutcomeRepository(pool);
+  const taskWatchRepo = new PostgresTaskWatchRepository(pool);
 
   const skillsDir =
     cfg.skillsSourceDir ?? path.resolve(process.cwd(), "skills");
@@ -164,6 +167,17 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
     workProductRepo,
     agentRepo,
     sessionRepo,
+  });
+
+  // Backs the team-tier watch_tasks / unwatch tools — register a
+  // task_watch row; when matching tasks transition terminal the M2 DB
+  // trigger inserts a wake session in the waiter's chain so the agent
+  // gets re-invoked via --resume.
+  const watchService = new WatchService({
+    pool,
+    sessionRepo,
+    taskRepo,
+    watchRepo: taskWatchRepo,
   });
 
   // Phase 4 — daemon-facing surface. Hub tracks live WS clients indexed
@@ -337,6 +351,7 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
     learnedSkillRepo,
     embeddings: embed,
     personRepo,
+    watchService,
   });
   server.getApp().use("/mcp", mcpRouter);
 

--- a/packages/api/src/routes/mcp.test.ts
+++ b/packages/api/src/routes/mcp.test.ts
@@ -133,7 +133,8 @@ describe.skipIf(!HAS_LIVE_API_KEYS)("/mcp router — integration", () => {
       });
 
       // Initialize was called inside connect. Inspect server info + tools.
-      // Team-tier caller gets 26 tools: 2 memory + 16 hierarchy + 6 mesh + 2 capability network.
+      // Team-tier caller gets 28 tools: 2 memory + 16 hierarchy + 6 mesh
+      // + 2 capability network + 2 watch (watch_tasks/unwatch).
       const tools = await client.listTools();
       expect(tools.tools.map((t) => t.name).sort()).toEqual([
         "add_to_escalation",
@@ -158,10 +159,12 @@ describe.skipIf(!HAS_LIVE_API_KEYS)("/mcp router — integration", () => {
         "revise_task",
         "save_memory",
         "search_context",
+        "unwatch",
         "update_core_memory",
         "update_progress",
         "update_work_product",
         "use_repo",
+        "watch_tasks",
       ]);
 
       // Server-info has no/empty instructions for agent callers (briefing is
@@ -194,7 +197,7 @@ describe.skipIf(!HAS_LIVE_API_KEYS)("/mcp router — integration", () => {
       const mcpSid = transport.sessionId;
       expect(mcpSid).toBeTruthy();
 
-      // tools/list — human caller, agent is team-tier → 26 tools.
+      // tools/list — human caller, agent is team-tier → 28 tools.
       const tools = await client.listTools();
       const names = tools.tools.map((t) => t.name);
       expect(names).toContain("save_memory");
@@ -209,7 +212,9 @@ describe.skipIf(!HAS_LIVE_API_KEYS)("/mcp router — integration", () => {
       expect(names).toContain("get_work_product");
       expect(names).toContain("find_repo");
       expect(names).toContain("use_repo");
-      expect(tools.tools.length).toBe(26);
+      expect(names).toContain("watch_tasks");
+      expect(names).toContain("unwatch");
+      expect(tools.tools.length).toBe(28);
 
       // tools/call save_memory — should write a fact stamped with the auto-
       // created beevibe chat session id. We don't know the sid client-side;

--- a/packages/api/src/routes/mcp.ts
+++ b/packages/api/src/routes/mcp.ts
@@ -28,6 +28,7 @@ import { sessionId as makeBeevibeSid } from "@beevibe/core";
 import type { TaskService } from "@beevibe/core/services/task-service";
 import type { EscalationService } from "@beevibe/core/services/escalation-service";
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import type { WatchService } from "@beevibe/core/services/watch-service";
 import type { MeshServer } from "../mesh/server.js";
 import { assembleTools } from "../tools/assemble.js";
 import { buildInstructions } from "../tools/instructions.js";
@@ -61,6 +62,8 @@ export interface McpRouterDeps {
   embeddings: EmbeddingService;
   /** Used to read the caller's owner's capability_network_enabled flag. */
   personRepo: PersonRepository;
+  /** Backs team-tier `watch_tasks` / `unwatch`. */
+  watchService: WatchService;
 }
 
 /** Tracked per-MCP-session state. mcpSid ↔ transport + server. */
@@ -282,6 +285,7 @@ async function handleMcpRequest(
       repoRunRepo: deps.repoRunRepo,
       learnedSkillRepo: deps.learnedSkillRepo,
       embeddings: deps.embeddings,
+      watchService: deps.watchService,
     },
   );
 

--- a/packages/api/src/tools/assemble.test.ts
+++ b/packages/api/src/tools/assemble.test.ts
@@ -26,6 +26,7 @@ import type {
 import type { TaskService } from "@beevibe/core/services/task-service";
 import type { EscalationService } from "@beevibe/core/services/escalation-service";
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import type { WatchService } from "@beevibe/core/services/watch-service";
 import type { MeshServer } from "../mesh/server.js";
 import {
   assembleTools,
@@ -67,6 +68,7 @@ function buildMinimalServices(): AssembleToolsServices {
       embed: vi.fn(async () => [1, 0]),
       embedBatch: vi.fn(async (texts: string[]) => texts.map(() => [1, 0])),
     },
+    watchService: {} as unknown as WatchService,
   };
 }
 
@@ -95,9 +97,9 @@ function icCtx(
 }
 
 describe("assembleTools — daemon (full surface)", () => {
-  it("team caller gets the full team surface (26 tools, includes find_repo + use_repo)", () => {
+  it("team caller gets the full team surface (28 tools, includes find_repo + use_repo + watch_tasks/unwatch)", () => {
     const tools = assembleTools(teamCtx(), buildMinimalServices());
-    expect(tools.length).toBe(26);
+    expect(tools.length).toBe(28);
     const names = new Set(tools.map((t) => t.name));
     expect(names.has("create_task")).toBe(true);
     expect(names.has("update_work_product")).toBe(true);
@@ -107,9 +109,11 @@ describe("assembleTools — daemon (full surface)", () => {
     expect(names.has("create_subordinate_agent")).toBe(true);
     expect(names.has("find_repo")).toBe(true);
     expect(names.has("use_repo")).toBe(true);
+    expect(names.has("watch_tasks")).toBe(true);
+    expect(names.has("unwatch")).toBe(true);
   });
 
-  it("ic caller gets the IC surface (15 tools, includes find_repo + use_repo)", () => {
+  it("ic caller gets the IC surface (15 tools, includes find_repo + use_repo; NO watch_tasks)", () => {
     const tools = assembleTools(icCtx(), buildMinimalServices());
     expect(tools.length).toBe(15);
     const names = new Set(tools.map((t) => t.name));
@@ -118,6 +122,8 @@ describe("assembleTools — daemon (full surface)", () => {
     expect(names.has("report_blocker")).toBe(true);
     expect(names.has("find_repo")).toBe(true);
     expect(names.has("use_repo")).toBe(true);
+    expect(names.has("watch_tasks")).toBe(false);
+    expect(names.has("unwatch")).toBe(false);
   });
 
   it("owner with capability_network_enabled=false gets neither find_repo nor use_repo", () => {

--- a/packages/api/src/tools/assemble.ts
+++ b/packages/api/src/tools/assemble.ts
@@ -15,6 +15,7 @@ import type { CoreMemory, FactStore, MemoryAgent } from "@beevibe/core/services/
 import type { TaskService } from "@beevibe/core/services/task-service";
 import type { EscalationService } from "@beevibe/core/services/escalation-service";
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import type { WatchService } from "@beevibe/core/services/watch-service";
 import type { MeshServer } from "../mesh/server.js";
 import { buildIcMeshTools, buildTeamMeshTools } from "./mesh.js";
 import { buildHierarchyTools } from "./hierarchy.js";
@@ -22,6 +23,7 @@ import { createSaveMemoryTool } from "./save-memory.js";
 import { createUpdateCoreMemoryTool } from "./update-core-memory.js";
 import { createUseRepoTool } from "./use-repo.js";
 import { createFindRepoTool } from "./find-repo.js";
+import { buildWatchTools } from "./watch.js";
 import type { AgentTool } from "./types.js";
 
 export interface AssembleToolsServices {
@@ -46,6 +48,8 @@ export interface AssembleToolsServices {
   learnedSkillRepo: LearnedSkillRepository;
   /** Capability Network: powers find_repo's semantic relevance gate. */
   embeddings: EmbeddingService;
+  /** Team-tier `watch_tasks` / `unwatch` — wake-up on dispatched task completion. */
+  watchService: WatchService;
 }
 
 /**
@@ -202,11 +206,22 @@ export function assembleTools(
       ]
     : [];
 
+  // watch_tasks / unwatch are team-only — ICs run one task to completion
+  // and don't typically need to wait on dispatched children.
+  const watchTools: AgentTool[] =
+    ctx.caller.hierarchyLevel === "ic"
+      ? []
+      : buildWatchTools(
+          { agentId: ctx.caller.agentId, sessionId: ctx.beevibeSid },
+          { watchService: services.watchService },
+        );
+
   const all = [
     ...memoryTools,
     ...hierarchyTools,
     ...meshTools,
     ...capabilityTools,
+    ...watchTools,
   ];
   if (ctx.spawnMode === "server_fallback_mesh") {
     return filterForServerFallback(all);

--- a/packages/api/src/tools/watch.ts
+++ b/packages/api/src/tools/watch.ts
@@ -1,0 +1,192 @@
+/**
+ * watch_tasks + unwatch — team-tier MCP tools that back the
+ * task-completion wake-up feature. Both are thin adapters over
+ * WatchService; the service does the auth check, the watch insert,
+ * the already-terminal-race fire, and the unwatch state machine.
+ *
+ * The MCP tool descriptions are the agent-facing source of truth for
+ * the contract (modes, ordering, what "fires" means). The system
+ * prompt addition in spawn-prep (M4) just nudges agents to call
+ * watch_tasks; the *how* lives here so the agent sees it at the
+ * decide-to-call moment.
+ */
+
+import type { TaskWatchMode } from "@beevibe/core";
+import {
+  WatchAuthError,
+  WatchNotFoundError,
+  WatchValidationError,
+  type WatchService,
+} from "@beevibe/core/services/watch-service";
+import type { AgentTool, AgentToolResult } from "./types.js";
+
+export interface WatchToolContext {
+  agentId: string;
+  /** Beevibe session id (the MCP caller). Without this watch_tasks can't
+   *  identify the waiter, so the handler returns an error. */
+  sessionId?: string;
+}
+
+export interface WatchToolServices {
+  watchService: WatchService;
+}
+
+const VALID_MODES: readonly TaskWatchMode[] = ["all", "any"];
+
+function isMode(value: unknown): value is TaskWatchMode {
+  return typeof value === "string" && (VALID_MODES as readonly string[]).includes(value);
+}
+
+function errResult(error: string, message: string): AgentToolResult {
+  return { content: { error, message }, isError: true };
+}
+
+function caughtError(err: unknown): AgentToolResult {
+  if (err instanceof WatchAuthError) return errResult("watch_auth", err.message);
+  if (err instanceof WatchValidationError) {
+    return errResult("watch_validation", err.message);
+  }
+  if (err instanceof WatchNotFoundError) {
+    return errResult("watch_not_found", err.message);
+  }
+  if (err instanceof Error) return errResult("watch_error", err.message);
+  return errResult("watch_error", String(err));
+}
+
+function buildWatchTasksTool(
+  ctx: WatchToolContext,
+  services: WatchToolServices,
+): AgentTool {
+  return {
+    name: "watch_tasks",
+    description:
+      "Register a wake-up for one or more tasks you dispatched. When the " +
+      "watch fires, you'll be re-invoked in a new session that resumes " +
+      "this conversation with a system message describing what " +
+      "completed. Call this before ending your turn when you plan to " +
+      "react to dispatched work's result — without it, the tasks run " +
+      "but you won't be re-invoked.\n\n" +
+      "Modes:\n" +
+      "  • \"all\" — fire when EVERY task reaches a terminal status " +
+      "(done | failed | cancelled). Use when your next step needs every " +
+      "result.\n" +
+      "  • \"any\" — fire on the FIRST task to reach a terminal status. " +
+      "Use when you want to react as soon as any signal arrives.\n\n" +
+      "The watch is one-shot. Returns { watch_id, fired_immediately }. " +
+      "If the condition was already met at call time, fired_immediately " +
+      "is true and the next session spawns synchronously.",
+    schema: {
+      type: "object",
+      properties: {
+        task_ids: {
+          type: "array",
+          items: { type: "string" },
+          minItems: 1,
+          description:
+            "Ids returned by create_task; must belong to your conversation chain.",
+        },
+        mode: {
+          type: "string",
+          enum: ["all", "any"],
+          description: "Fire condition; defaults to 'all'.",
+        },
+        reason: {
+          type: "string",
+          description:
+            "Short note for your future self; appears in the wake intent.",
+        },
+      },
+      required: ["task_ids"],
+    },
+    handler: async (input) => {
+      try {
+        const taskIds = Array.isArray(input.task_ids)
+          ? input.task_ids.filter((x): x is string => typeof x === "string")
+          : [];
+        if (taskIds.length === 0) {
+          return errResult(
+            "watch_validation",
+            "task_ids must be a non-empty array of strings",
+          );
+        }
+        const mode: TaskWatchMode = isMode(input.mode) ? input.mode : "all";
+        const reason =
+          typeof input.reason === "string" && input.reason.trim().length > 0
+            ? input.reason.trim()
+            : undefined;
+        if (!ctx.sessionId) {
+          return errResult(
+            "watch_validation",
+            "watch_tasks must be called inside a session context",
+          );
+        }
+
+        const result = await services.watchService.watchTasks({
+          callerAgentId: ctx.agentId,
+          callerSessionId: ctx.sessionId,
+          taskIds,
+          mode,
+          reason,
+        });
+        return {
+          content: {
+            watch_id: result.watchId,
+            fired_immediately: result.firedImmediately,
+          },
+        };
+      } catch (err) {
+        return caughtError(err);
+      }
+    },
+  };
+}
+
+function buildUnwatchTool(
+  ctx: WatchToolContext,
+  services: WatchToolServices,
+): AgentTool {
+  return {
+    name: "unwatch",
+    description:
+      "Cancel a pending task_watch you previously registered. Use when " +
+      "you've changed your mind and no longer need the wake-up. " +
+      "Idempotent — returns ok whether the watch was waiting, fired, " +
+      "or aborted.",
+    schema: {
+      type: "object",
+      properties: {
+        watch_id: {
+          type: "string",
+          description: "Id returned by watch_tasks.",
+        },
+      },
+      required: ["watch_id"],
+    },
+    handler: async (input) => {
+      try {
+        const watchId =
+          typeof input.watch_id === "string" ? input.watch_id : "";
+        if (!watchId) {
+          return errResult(
+            "watch_validation",
+            "watch_id must be a non-empty string",
+          );
+        }
+        await services.watchService.unwatch({
+          callerAgentId: ctx.agentId,
+          watchId,
+        });
+        return { content: { ok: true } };
+      } catch (err) {
+        return caughtError(err);
+      }
+    },
+  };
+}
+
+export function buildWatchTools(
+  ctx: WatchToolContext,
+  services: WatchToolServices,
+): AgentTool[] {
+  return [buildWatchTasksTool(ctx, services), buildUnwatchTool(ctx, services)];
+}

--- a/packages/api/src/tools/watch.ts
+++ b/packages/api/src/tools/watch.ts
@@ -5,13 +5,12 @@
  * the already-terminal-race fire, and the unwatch state machine.
  *
  * The MCP tool descriptions are the agent-facing source of truth for
- * the contract (modes, ordering, what "fires" means). The system
- * prompt addition in spawn-prep (M4) just nudges agents to call
- * watch_tasks; the *how* lives here so the agent sees it at the
- * decide-to-call moment.
+ * the contract (modes, ordering, what "fires" means). The system-
+ * prompt nudge in spawn-prep tells agents to call watch_tasks; the
+ * *how* lives here so the agent sees it at the decide-to-call moment.
  */
 
-import type { TaskWatchMode } from "@beevibe/core";
+import { TASK_WATCH_MODES, type TaskWatchMode } from "@beevibe/core";
 import {
   WatchAuthError,
   WatchNotFoundError,
@@ -31,10 +30,11 @@ export interface WatchToolServices {
   watchService: WatchService;
 }
 
-const VALID_MODES: readonly TaskWatchMode[] = ["all", "any"];
-
 function isMode(value: unknown): value is TaskWatchMode {
-  return typeof value === "string" && (VALID_MODES as readonly string[]).includes(value);
+  return (
+    typeof value === "string" &&
+    (TASK_WATCH_MODES as readonly string[]).includes(value)
+  );
 }
 
 function errResult(error: string, message: string): AgentToolResult {
@@ -87,7 +87,7 @@ function buildWatchTasksTool(
         },
         mode: {
           type: "string",
-          enum: ["all", "any"],
+          enum: [...TASK_WATCH_MODES],
           description: "Fire condition; defaults to 'all'.",
         },
         reason: {

--- a/packages/api/src/views/watch-fire.db.test.ts
+++ b/packages/api/src/views/watch-fire.db.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Real-Postgres tests for the M2 `trg_task_watch_check` trigger.
+ * Drives task.status transitions and asserts that matching task_watch
+ * rows fire (insert a new wake session + flip to status='fired') under
+ * the mode='all' / mode='any' contract.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  PostgresAgentRepository,
+  PostgresCoreMemoryRepository,
+  PostgresPersonRepository,
+  PostgresSessionRepository,
+  PostgresTaskRepository,
+  PostgresTaskWatchRepository,
+  type Pool,
+} from "@beevibe/core/adapters/postgres";
+import { provisionAgent, provisionUser } from "@beevibe/core/auth";
+import {
+  DEFAULT_RUNTIME_CONFIG,
+  agentId,
+  personId,
+  sessionId,
+  taskId,
+  taskWatchId,
+} from "@beevibe/core";
+import { createTestPool, truncateAll } from "@beevibe/core/test-helpers";
+
+describe("trg_task_watch_check — integration", () => {
+  let pool: Pool;
+  let watches: PostgresTaskWatchRepository;
+  let agents: PostgresAgentRepository;
+  let persons: PostgresPersonRepository;
+  let coreMemories: PostgresCoreMemoryRepository;
+  let sessions: PostgresSessionRepository;
+  let tasks: PostgresTaskRepository;
+
+  let waiterSessionId: string;
+  let teamAgentId: string;
+  let icAgentId: string;
+
+  beforeAll(() => {
+    pool = createTestPool();
+    watches = new PostgresTaskWatchRepository(pool);
+    agents = new PostgresAgentRepository(pool);
+    persons = new PostgresPersonRepository(pool);
+    coreMemories = new PostgresCoreMemoryRepository(pool);
+    sessions = new PostgresSessionRepository(pool);
+    tasks = new PostgresTaskRepository(pool);
+  });
+
+  beforeEach(async () => {
+    await truncateAll(pool);
+
+    const owner = await provisionUser(
+      { personRepo: persons },
+      { id: personId(), name: "Owner", email: `owner-${Date.now()}@example.com` },
+    );
+    const team = await provisionAgent(
+      { agentRepo: agents, coreMemoryRepo: coreMemories },
+      {
+        id: agentId(),
+        name: "Team",
+        owner_id: owner.person.id,
+        hierarchy_level: "team",
+        runtime_config: DEFAULT_RUNTIME_CONFIG,
+      },
+    );
+    const ic = await provisionAgent(
+      { agentRepo: agents, coreMemoryRepo: coreMemories },
+      {
+        id: agentId(),
+        name: "IC",
+        owner_id: owner.person.id,
+        hierarchy_level: "ic",
+        runtime_config: DEFAULT_RUNTIME_CONFIG,
+        parent_agent_id: team.agent.id,
+      },
+    );
+    const waiter = await sessions.create({
+      id: sessionId(),
+      agent_id: team.agent.id,
+      type: "chat",
+      status: "succeeded",
+      intent: "watch test",
+    });
+    waiterSessionId = waiter.id;
+    teamAgentId = team.agent.id;
+    icAgentId = ic.agent.id;
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  async function createTask(title: string): Promise<string> {
+    const t = await tasks.create({
+      id: taskId(),
+      title,
+      description: title.toLowerCase(),
+      priority: "medium",
+      assignee_id: icAgentId,
+      creator_id: teamAgentId,
+      creator_type: "agent",
+      status: "in_progress",
+    });
+    return t.id;
+  }
+
+  async function createWatch(
+    taskIds: string[],
+    mode: "all" | "any",
+  ): Promise<string> {
+    const w = await watches.create({
+      id: taskWatchId(),
+      waiter_session_id: waiterSessionId,
+      agent_id: teamAgentId,
+      mode,
+      task_ids: taskIds,
+    });
+    return w.id;
+  }
+
+  async function findWakeSession(watchId: string) {
+    const watch = await watches.findById(watchId);
+    if (!watch?.fired_session_id) return undefined;
+    return sessions.findById(watch.fired_session_id);
+  }
+
+  it("mode='all': first task done -> no fire; second done -> fire", async () => {
+    const a = await createTask("Backend");
+    const b = await createTask("Frontend");
+    const w = await createWatch([a, b], "all");
+
+    await tasks.updateProgress(a, "done", "shipped a");
+    const afterFirst = await watches.findById(w);
+    expect(afterFirst?.status).toBe("waiting");
+
+    await tasks.updateProgress(b, "done", "shipped b");
+    const afterSecond = await watches.findById(w);
+    expect(afterSecond?.status).toBe("fired");
+    expect(afterSecond?.fired_session_id).toBeDefined();
+
+    const wake = await findWakeSession(w);
+    expect(wake?.agent_id).toBe(teamAgentId);
+    expect(wake?.prior_session_id).toBe(waiterSessionId);
+    expect(wake?.type).toBe("chat");
+    expect(wake?.status).toBe("pending");
+    expect(wake?.intent).toContain("2 tasks completed:");
+    expect(wake?.intent).toContain("Backend — done. Result: shipped a");
+    expect(wake?.intent).toContain("Frontend — done. Result: shipped b");
+    expect(wake?.intent).toContain("Decide next steps.");
+  });
+
+  it("mode='any': first done -> fire; second done does not re-fire", async () => {
+    const a = await createTask("Backend");
+    const b = await createTask("Frontend");
+    const w = await createWatch([a, b], "any");
+
+    await tasks.updateProgress(a, "done", "shipped a");
+    const afterFirst = await watches.findById(w);
+    expect(afterFirst?.status).toBe("fired");
+    const firstFiredSession = afterFirst?.fired_session_id;
+    expect(firstFiredSession).toBeDefined();
+
+    await tasks.updateProgress(b, "done", "shipped b");
+    const afterSecond = await watches.findById(w);
+    expect(afterSecond?.fired_session_id).toBe(firstFiredSession);
+
+    const wake = await findWakeSession(w);
+    expect(wake?.intent).toContain("Task Backend — done. Result: shipped a");
+    expect(wake?.intent).toContain("Other watched tasks still running:");
+    expect(wake?.intent).toContain("Frontend — in_progress");
+  });
+
+  it("mode='any' with one task: no 'others still running' block", async () => {
+    const a = await createTask("Solo");
+    const w = await createWatch([a], "any");
+
+    await tasks.updateProgress(a, "done", "shipped");
+    const wake = await findWakeSession(w);
+    expect(wake?.intent).toContain("Task Solo — done. Result: shipped");
+    expect(wake?.intent).not.toContain("Other watched tasks still running:");
+    expect(wake?.intent).toContain("Decide next steps.");
+  });
+
+  it("failed terminal status fires the watch", async () => {
+    const a = await createTask("Backend");
+    const w = await createWatch([a], "all");
+
+    await tasks.updateProgress(a, "failed", "auth tokens broke");
+    const fired = await watches.findById(w);
+    expect(fired?.status).toBe("fired");
+    const wake = await findWakeSession(w);
+    expect(wake?.intent).toContain("Backend — failed: auth tokens broke");
+  });
+
+  it("cancelled terminal status fires the watch", async () => {
+    const a = await createTask("Backend");
+    const w = await createWatch([a], "all");
+
+    await tasks.update(a, { status: "cancelled" });
+    const fired = await watches.findById(w);
+    expect(fired?.status).toBe("fired");
+    const wake = await findWakeSession(w);
+    expect(wake?.intent).toContain("Backend — cancelled");
+    expect(wake?.intent).not.toContain("Result:");
+  });
+
+  it("blocked -> done sequence: only the done transition fires", async () => {
+    const a = await createTask("Backend");
+    const w = await createWatch([a], "all");
+
+    await tasks.markBlocked(a, icAgentId, "needs credentials");
+    expect((await watches.findById(w))?.status).toBe("waiting");
+
+    await tasks.updateProgress(a, "done", "credentials provisioned");
+    expect((await watches.findById(w))?.status).toBe("fired");
+  });
+
+  it("needs_revision -> in_progress -> done: only the done transition fires", async () => {
+    const a = await createTask("Backend");
+    const w = await createWatch([a], "all");
+
+    await tasks.update(a, { status: "needs_revision" });
+    await tasks.update(a, { status: "in_progress" });
+    expect((await watches.findById(w))?.status).toBe("waiting");
+
+    await tasks.updateProgress(a, "done", "fixed");
+    expect((await watches.findById(w))?.status).toBe("fired");
+  });
+
+  it("in_progress -> in_progress (no status change) does not fire", async () => {
+    const a = await createTask("Backend");
+    const w = await createWatch([a], "all");
+
+    await tasks.update(a, { status: "in_progress" });
+    expect((await watches.findById(w))?.status).toBe("waiting");
+  });
+
+  it("aborted watch is not fired by a subsequent terminal transition", async () => {
+    const a = await createTask("Backend");
+    const w = await createWatch([a], "all");
+
+    await watches.markAborted(w);
+    await tasks.updateProgress(a, "done", "shipped");
+    const final = await watches.findById(w);
+    expect(final?.status).toBe("aborted");
+    expect(final?.fired_session_id).toBeUndefined();
+  });
+
+  it("wake inherits waiter's task_id when set (task-session continuation)", async () => {
+    // A team agent in a task session that dispatches sub-tasks. Its
+    // wake should continue the same task lineage.
+    const parentTask = await createTask("Parent");
+    const taskWaiter = await sessions.create({
+      id: sessionId(),
+      agent_id: teamAgentId,
+      type: "task",
+      status: "succeeded",
+      intent: "running parent task",
+      task_id: parentTask,
+    });
+    const child = await createTask("Child");
+    const w = await watches.create({
+      id: taskWatchId(),
+      waiter_session_id: taskWaiter.id,
+      agent_id: teamAgentId,
+      mode: "all",
+      task_ids: [child],
+    });
+
+    await tasks.updateProgress(child, "done", "ok");
+    const fired = await watches.findById(w.id);
+    expect(fired?.status).toBe("fired");
+    const wake = await sessions.findById(fired!.fired_session_id!);
+    expect(wake?.task_id).toBe(parentTask);
+    expect(wake?.type).toBe("task");
+    expect(wake?.conversation_id).toBeUndefined();
+  });
+});

--- a/packages/api/src/views/watch-fire.db.test.ts
+++ b/packages/api/src/views/watch-fire.db.test.ts
@@ -1,8 +1,8 @@
 /**
- * Real-Postgres tests for the M2 `trg_task_watch_check` trigger.
- * Drives task.status transitions and asserts that matching task_watch
- * rows fire (insert a new wake session + flip to status='fired') under
- * the mode='all' / mode='any' contract.
+ * Real-Postgres tests for the `trg_task_watch_check` trigger. Drives
+ * task.status transitions and asserts that matching task_watch rows
+ * fire (insert a new wake session + flip to status='fired') under the
+ * mode='all' / mode='any' contract.
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -171,6 +171,24 @@ describe("trg_task_watch_check — integration", () => {
     expect(wake?.intent).toContain("Task Backend — done. Result: shipped a");
     expect(wake?.intent).toContain("Other watched tasks still running:");
     expect(wake?.intent).toContain("Frontend — in_progress");
+  });
+
+  it("watch.reason is surfaced as a 'Wake reason:' prefix in the intent", async () => {
+    const a = await createTask("Backend");
+    const w = await watches.create({
+      id: taskWatchId(),
+      waiter_session_id: waiterSessionId,
+      agent_id: teamAgentId,
+      mode: "all",
+      task_ids: [a],
+      reason: "checking deploy progress",
+    });
+
+    await tasks.updateProgress(a, "done", "shipped");
+    const fired = await watches.findById(w.id);
+    const wake = await sessions.findById(fired!.fired_session_id!);
+    expect(wake?.intent).toMatch(/^Wake reason: checking deploy progress\n\n/);
+    expect(wake?.intent).toContain("Backend — done. Result: shipped");
   });
 
   it("mode='any' with one task: no 'others still running' block", async () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -86,6 +86,10 @@
       "types": "./dist/services/post-dispatch.d.ts",
       "default": "./dist/services/post-dispatch.js"
     },
+    "./services/watch-service": {
+      "types": "./dist/services/watch-service.d.ts",
+      "default": "./dist/services/watch-service.js"
+    },
     "./services/skills": {
       "types": "./dist/services/skills/index.d.ts",
       "default": "./dist/services/skills/index.js"

--- a/packages/core/src/adapters/postgres/index.ts
+++ b/packages/core/src/adapters/postgres/index.ts
@@ -11,6 +11,7 @@ export type {
   NegotiationRow,
   NegotiationRoundRow,
   EscalationRow,
+  TaskWatchRow,
 } from "./row-types.js";
 export { PostgresPersonRepository } from "./person-repo.js";
 export { PostgresAgentRepository } from "./agent-repo.js";
@@ -36,3 +37,4 @@ export {
   PostgresSkillOutcomeRepository,
   newSkillOutcomeId,
 } from "./repo-run-repo.js";
+export { PostgresTaskWatchRepository } from "./task-watch-repo.js";

--- a/packages/core/src/adapters/postgres/row-types.ts
+++ b/packages/core/src/adapters/postgres/row-types.ts
@@ -196,3 +196,16 @@ export interface EscalationRow {
   created_at: Date;
   updated_at: Date;
 }
+
+export interface TaskWatchRow {
+  id: string;
+  waiter_session_id: string;
+  agent_id: string;
+  mode: string;
+  task_ids: string[];
+  reason: string | null;
+  status: string;
+  created_at: Date;
+  fired_at: Date | null;
+  fired_session_id: string | null;
+}

--- a/packages/core/src/adapters/postgres/task-repo.ts
+++ b/packages/core/src/adapters/postgres/task-repo.ts
@@ -25,6 +25,15 @@ export class PostgresTaskRepository implements TaskRepository {
     return rows[0] ? rowToTask(rows[0]) : undefined;
   }
 
+  async findByIds(ids: string[]): Promise<Task[]> {
+    if (ids.length === 0) return [];
+    const { rows } = await this.pool.query<TaskRow>(
+      `SELECT * FROM task WHERE id = ANY($1::text[])`,
+      [ids],
+    );
+    return rows.map(rowToTask);
+  }
+
   async list(filter?: TaskListFilter): Promise<Task[]> {
     const clauses: string[] = [];
     const values: unknown[] = [];

--- a/packages/core/src/adapters/postgres/task-watch-repo.test.ts
+++ b/packages/core/src/adapters/postgres/task-watch-repo.test.ts
@@ -1,0 +1,272 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_RUNTIME_CONFIG } from "../../domain/agent.js";
+import {
+  agentId,
+  personId,
+  sessionId,
+  taskId,
+  taskWatchId,
+} from "../../domain/ids.js";
+import { createTestPool, truncateAll } from "../../test-helpers.js";
+import type { Pool } from "./client.js";
+import { PostgresAgentRepository } from "./agent-repo.js";
+import { PostgresPersonRepository } from "./person-repo.js";
+import { PostgresSessionRepository } from "./session-repo.js";
+import { PostgresTaskRepository } from "./task-repo.js";
+import { PostgresTaskWatchRepository } from "./task-watch-repo.js";
+
+describe("PostgresTaskWatchRepository", () => {
+  let pool: Pool;
+  let watches: PostgresTaskWatchRepository;
+  let agents: PostgresAgentRepository;
+  let persons: PostgresPersonRepository;
+  let sessions: PostgresSessionRepository;
+  let tasks: PostgresTaskRepository;
+
+  let waiterSession: string;
+  let agentIdValue: string;
+  let taskA: string;
+  let taskB: string;
+
+  beforeAll(() => {
+    pool = createTestPool();
+    watches = new PostgresTaskWatchRepository(pool);
+    agents = new PostgresAgentRepository(pool);
+    persons = new PostgresPersonRepository(pool);
+    sessions = new PostgresSessionRepository(pool);
+    tasks = new PostgresTaskRepository(pool);
+  });
+
+  beforeEach(async () => {
+    await truncateAll(pool);
+    const owner = await persons.create({ id: personId(), name: "Owner" });
+    const team = await agents.create({
+      id: agentId(),
+      name: "Team",
+      owner_id: owner.id,
+      hierarchy_level: "team",
+      runtime_config: DEFAULT_RUNTIME_CONFIG,
+    });
+    const ic = await agents.create({
+      id: agentId(),
+      name: "IC",
+      owner_id: owner.id,
+      hierarchy_level: "ic",
+      runtime_config: DEFAULT_RUNTIME_CONFIG,
+      parent_agent_id: team.id,
+    });
+    const waiter = await sessions.create({
+      id: sessionId(),
+      agent_id: team.id,
+      type: "chat",
+      status: "running",
+      intent: "watch test",
+    });
+    waiterSession = waiter.id;
+    agentIdValue = team.id;
+    const a = await tasks.create({
+      id: taskId(),
+      title: "A",
+      description: "a",
+      priority: "medium",
+      assignee_id: ic.id,
+      creator_id: team.id,
+      creator_type: "agent",
+    });
+    const b = await tasks.create({
+      id: taskId(),
+      title: "B",
+      description: "b",
+      priority: "medium",
+      assignee_id: ic.id,
+      creator_id: team.id,
+      creator_type: "agent",
+    });
+    taskA = a.id;
+    taskB = b.id;
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("create + findById round-trips with defaults", async () => {
+    const id = taskWatchId();
+    const created = await watches.create({
+      id,
+      waiter_session_id: waiterSession,
+      agent_id: agentIdValue,
+      mode: "all",
+      task_ids: [taskA, taskB],
+      reason: "checking deploy",
+    });
+
+    expect(created.status).toBe("waiting");
+    expect(created.fired_at).toBeUndefined();
+    expect(created.fired_session_id).toBeUndefined();
+    expect(created.task_ids).toEqual([taskA, taskB]);
+    expect(created.mode).toBe("all");
+    expect(created.reason).toBe("checking deploy");
+
+    const found = await watches.findById(id);
+    expect(found?.id).toBe(id);
+    expect(found?.task_ids).toEqual([taskA, taskB]);
+  });
+
+  it("rejects an empty task_ids array", async () => {
+    await expect(
+      watches.create({
+        id: taskWatchId(),
+        waiter_session_id: waiterSession,
+        agent_id: agentIdValue,
+        mode: "all",
+        task_ids: [],
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("listByWaiterSession returns watches newest-first", async () => {
+    const olderId = taskWatchId();
+    await watches.create({
+      id: olderId,
+      waiter_session_id: waiterSession,
+      agent_id: agentIdValue,
+      mode: "all",
+      task_ids: [taskA],
+    });
+    // Sleep 5ms so created_at values are distinguishable.
+    await new Promise((r) => setTimeout(r, 5));
+    const newerId = taskWatchId();
+    await watches.create({
+      id: newerId,
+      waiter_session_id: waiterSession,
+      agent_id: agentIdValue,
+      mode: "any",
+      task_ids: [taskB],
+    });
+
+    const list = await watches.listByWaiterSession(waiterSession);
+    expect(list.map((w) => w.id)).toEqual([newerId, olderId]);
+  });
+
+  it("listWaitingForTask matches via array containment", async () => {
+    const wantsAB = await watches.create({
+      id: taskWatchId(),
+      waiter_session_id: waiterSession,
+      agent_id: agentIdValue,
+      mode: "all",
+      task_ids: [taskA, taskB],
+    });
+    const wantsBOnly = await watches.create({
+      id: taskWatchId(),
+      waiter_session_id: waiterSession,
+      agent_id: agentIdValue,
+      mode: "any",
+      task_ids: [taskB],
+    });
+
+    const hitsForA = await watches.listWaitingForTask(taskA);
+    expect(hitsForA.map((w) => w.id)).toEqual([wantsAB.id]);
+
+    const hitsForB = await watches.listWaitingForTask(taskB);
+    expect(hitsForB.map((w) => w.id).sort()).toEqual(
+      [wantsAB.id, wantsBOnly.id].sort(),
+    );
+  });
+
+  it("listWaitingForTask excludes fired and aborted watches", async () => {
+    const willFire = await watches.create({
+      id: taskWatchId(),
+      waiter_session_id: waiterSession,
+      agent_id: agentIdValue,
+      mode: "any",
+      task_ids: [taskA],
+    });
+    const willAbort = await watches.create({
+      id: taskWatchId(),
+      waiter_session_id: waiterSession,
+      agent_id: agentIdValue,
+      mode: "any",
+      task_ids: [taskA],
+    });
+    // We need a session id to stand in for the wake session; reuse the
+    // waiter session id — the repo doesn't enforce uniqueness here.
+    await watches.markFired(willFire.id, waiterSession);
+    await watches.markAborted(willAbort.id);
+
+    const stillWaiting = await watches.create({
+      id: taskWatchId(),
+      waiter_session_id: waiterSession,
+      agent_id: agentIdValue,
+      mode: "any",
+      task_ids: [taskA],
+    });
+    const hits = await watches.listWaitingForTask(taskA);
+    expect(hits.map((w) => w.id)).toEqual([stillWaiting.id]);
+  });
+
+  it("markFired stamps fired_at + fired_session_id and is idempotent on re-call", async () => {
+    const id = taskWatchId();
+    await watches.create({
+      id,
+      waiter_session_id: waiterSession,
+      agent_id: agentIdValue,
+      mode: "all",
+      task_ids: [taskA],
+    });
+    const fired = await watches.markFired(id, waiterSession);
+    expect(fired.status).toBe("fired");
+    expect(fired.fired_at).toBeInstanceOf(Date);
+    expect(fired.fired_session_id).toBe(waiterSession);
+
+    // Idempotent: a second call does NOT clobber the original fired_at or
+    // overwrite fired_session_id with a different value.
+    await new Promise((r) => setTimeout(r, 5));
+    const refired = await watches.markFired(id, "sess_other");
+    expect(refired.fired_at?.getTime()).toBe(fired.fired_at?.getTime());
+    expect(refired.fired_session_id).toBe(waiterSession);
+  });
+
+  it("markFired throws when the watch was aborted (race with unwatch)", async () => {
+    const id = taskWatchId();
+    await watches.create({
+      id,
+      waiter_session_id: waiterSession,
+      agent_id: agentIdValue,
+      mode: "all",
+      task_ids: [taskA],
+    });
+    await watches.markAborted(id);
+    await expect(watches.markFired(id, waiterSession)).rejects.toThrow(
+      /not in a fire-able state/,
+    );
+  });
+
+  it("markAborted is idempotent on re-call but refuses on a fired watch", async () => {
+    const id = taskWatchId();
+    await watches.create({
+      id,
+      waiter_session_id: waiterSession,
+      agent_id: agentIdValue,
+      mode: "all",
+      task_ids: [taskA],
+    });
+    const aborted = await watches.markAborted(id);
+    expect(aborted.status).toBe("aborted");
+    const aborted2 = await watches.markAborted(id);
+    expect(aborted2.status).toBe("aborted");
+
+    const fireId = taskWatchId();
+    await watches.create({
+      id: fireId,
+      waiter_session_id: waiterSession,
+      agent_id: agentIdValue,
+      mode: "all",
+      task_ids: [taskA],
+    });
+    await watches.markFired(fireId, waiterSession);
+    await expect(watches.markAborted(fireId)).rejects.toThrow(
+      /not in an abortable state/,
+    );
+  });
+});

--- a/packages/core/src/adapters/postgres/task-watch-repo.ts
+++ b/packages/core/src/adapters/postgres/task-watch-repo.ts
@@ -1,0 +1,122 @@
+import type {
+  TaskWatch,
+  TaskWatchMode,
+  TaskWatchStatus,
+} from "../../domain/task-watch.js";
+import type {
+  NewTaskWatch,
+  TaskWatchRepository,
+} from "../../ports/task-watch-repo.js";
+import type { Pool } from "./client.js";
+import type { TaskWatchRow } from "./row-types.js";
+
+export class PostgresTaskWatchRepository implements TaskWatchRepository {
+  constructor(private pool: Pool) {}
+
+  async findById(id: string): Promise<TaskWatch | undefined> {
+    const { rows } = await this.pool.query<TaskWatchRow>(
+      `SELECT * FROM task_watch WHERE id = $1 LIMIT 1`,
+      [id],
+    );
+    return rows[0] ? rowToTaskWatch(rows[0]) : undefined;
+  }
+
+  async listByWaiterSession(waiterSessionId: string): Promise<TaskWatch[]> {
+    const { rows } = await this.pool.query<TaskWatchRow>(
+      `SELECT * FROM task_watch
+        WHERE waiter_session_id = $1
+        ORDER BY created_at DESC`,
+      [waiterSessionId],
+    );
+    return rows.map(rowToTaskWatch);
+  }
+
+  async listWaitingForTask(taskId: string): Promise<TaskWatch[]> {
+    const { rows } = await this.pool.query<TaskWatchRow>(
+      `SELECT * FROM task_watch
+        WHERE status = 'waiting'
+          AND $1 = ANY(task_ids)
+        ORDER BY created_at ASC`,
+      [taskId],
+    );
+    return rows.map(rowToTaskWatch);
+  }
+
+  async create(input: NewTaskWatch): Promise<TaskWatch> {
+    if (input.task_ids.length === 0) {
+      throw new Error("task_watch.task_ids must be non-empty");
+    }
+    const { rows } = await this.pool.query<TaskWatchRow>(
+      `INSERT INTO task_watch (
+         id, waiter_session_id, agent_id, mode, task_ids, reason, status
+       ) VALUES (
+         $1, $2, $3, $4, $5, $6, COALESCE($7, 'waiting')
+       )
+       RETURNING *`,
+      [
+        input.id,
+        input.waiter_session_id,
+        input.agent_id,
+        input.mode,
+        input.task_ids,
+        input.reason ?? null,
+        input.status ?? null,
+      ],
+    );
+    return rowToTaskWatch(rows[0]!);
+  }
+
+  async markFired(id: string, firedSessionId: string): Promise<TaskWatch> {
+    // Idempotent fired→fired re-call: don't overwrite the original
+    // `fired_at` / `fired_session_id`. Refuse waiting→fired races where
+    // the row was aborted in between by failing the WHERE.
+    const { rows } = await this.pool.query<TaskWatchRow>(
+      `UPDATE task_watch
+          SET status = 'fired',
+              fired_at = COALESCE(fired_at, NOW()),
+              fired_session_id = COALESCE(fired_session_id, $2)
+        WHERE id = $1
+          AND status IN ('waiting', 'fired')
+        RETURNING *`,
+      [id, firedSessionId],
+    );
+    if (!rows[0]) {
+      throw new Error(
+        `task_watch ${id} not in a fire-able state (missing or aborted)`,
+      );
+    }
+    return rowToTaskWatch(rows[0]);
+  }
+
+  async markAborted(id: string): Promise<TaskWatch> {
+    const { rows } = await this.pool.query<TaskWatchRow>(
+      `UPDATE task_watch
+          SET status = 'aborted'
+        WHERE id = $1
+          AND status IN ('waiting', 'aborted')
+        RETURNING *`,
+      [id],
+    );
+    if (!rows[0]) {
+      throw new Error(
+        `task_watch ${id} not in an abortable state (missing or already fired)`,
+      );
+    }
+    return rowToTaskWatch(rows[0]);
+  }
+}
+
+function rowToTaskWatch(row: TaskWatchRow): TaskWatch {
+  return {
+    id: row.id,
+    waiter_session_id: row.waiter_session_id,
+    agent_id: row.agent_id,
+    mode: row.mode as TaskWatchMode,
+    task_ids: row.task_ids,
+    reason: row.reason ?? undefined,
+    status: row.status as TaskWatchStatus,
+    created_at: row.created_at,
+    fired_at: row.fired_at ?? undefined,
+    fired_session_id: row.fired_session_id ?? undefined,
+  };
+}

--- a/packages/core/src/adapters/postgres/task-watch-repo.ts
+++ b/packages/core/src/adapters/postgres/task-watch-repo.ts
@@ -32,10 +32,12 @@ export class PostgresTaskWatchRepository implements TaskWatchRepository {
   }
 
   async listWaitingForTask(taskId: string): Promise<TaskWatch[]> {
+    // `task_ids @> ARRAY[$1]` (not `$1 = ANY(task_ids)`) is the form Postgres
+    // plans against the partial GIN on `task_ids WHERE status='waiting'`.
     const { rows } = await this.pool.query<TaskWatchRow>(
       `SELECT * FROM task_watch
         WHERE status = 'waiting'
-          AND $1 = ANY(task_ids)
+          AND task_ids @> ARRAY[$1]
         ORDER BY created_at ASC`,
       [taskId],
     );

--- a/packages/core/src/domain/ids.ts
+++ b/packages/core/src/domain/ids.ts
@@ -27,3 +27,4 @@ export const agentProvisionEventId = (): string => generateId("ape");
 export const repoRunId = (): string => generateId("repo");
 export const learnedSkillId = (): string => generateId("skill");
 export const skillOutcomeId = (): string => generateId("sout");
+export const taskWatchId = (): string => generateId("watch");

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -12,3 +12,4 @@ export * from "./daemon.js";
 export * from "./runtime.js";
 export * from "./room.js";
 export * from "./repo-run.js";
+export * from "./task-watch.js";

--- a/packages/core/src/domain/task-watch.ts
+++ b/packages/core/src/domain/task-watch.ts
@@ -1,0 +1,34 @@
+/**
+ * Task-watch domain. A team agent registers a `task_watch` row before
+ * ending its session to declare "wake me when these dispatched tasks
+ * finish." When a watched task transitions to a terminal status (done,
+ * failed, cancelled), the M2 DB trigger inserts a new session in the
+ * waiter's `prior_session_id` chain so the agent resumes with full
+ * context via `claude --resume`.
+ *
+ * Blockers are NOT this mechanism's concern — the existing mesh server
+ * already spawns dedicated sessions for the team to handle blockers
+ * and asks. Watches stay `waiting` through blocker/needs_revision and
+ * only fire on the eventual terminal transition.
+ */
+
+export type TaskWatchMode = "all" | "any";
+export type TaskWatchStatus = "waiting" | "fired" | "aborted";
+
+export interface TaskWatch {
+  id: string;
+  /** Session that called watch_tasks; the wake session chains off this via prior_session_id. */
+  waiter_session_id: string;
+  /** Owner agent (the waiter session's agent). Stamped at create to simplify auth checks. */
+  agent_id: string;
+  mode: TaskWatchMode;
+  /** Task ids the agent is waiting on; non-empty. */
+  task_ids: string[];
+  /** Short freeform note surfaced in the wake intent for the agent's future self. */
+  reason?: string;
+  status: TaskWatchStatus;
+  created_at: Date;
+  fired_at?: Date;
+  /** The wake session inserted by the trigger; set when status === 'fired'. */
+  fired_session_id?: string;
+}

--- a/packages/core/src/domain/task-watch.ts
+++ b/packages/core/src/domain/task-watch.ts
@@ -2,7 +2,7 @@
  * Task-watch domain. A team agent registers a `task_watch` row before
  * ending its session to declare "wake me when these dispatched tasks
  * finish." When a watched task transitions to a terminal status (done,
- * failed, cancelled), the M2 DB trigger inserts a new session in the
+ * failed, cancelled), a DB trigger inserts a new session in the
  * waiter's `prior_session_id` chain so the agent resumes with full
  * context via `claude --resume`.
  *
@@ -14,6 +14,8 @@
 
 export type TaskWatchMode = "all" | "any";
 export type TaskWatchStatus = "waiting" | "fired" | "aborted";
+
+export const TASK_WATCH_MODES: readonly TaskWatchMode[] = ["all", "any"] as const;
 
 export interface TaskWatch {
   id: string;

--- a/packages/core/src/domain/task.ts
+++ b/packages/core/src/domain/task.ts
@@ -23,6 +23,20 @@ export const TASK_STATUSES: readonly TaskStatus[] = [
   "cancelled",
 ] as const;
 
+/**
+ * Task statuses that signal "this task has run its course" — done /
+ * failed / cancelled. Distinct from the narrower TERMINAL set used by
+ * task-service for status-patch guards (which excludes 'failed' so
+ * retries can move out of it). Watch_tasks fires on transitions into
+ * this set; downstream services that need the same "no further work
+ * expected" semantics should import from here rather than redeclaring.
+ */
+export const TERMINAL_TASK_STATUSES: readonly TaskStatus[] = [
+  "done",
+  "failed",
+  "cancelled",
+] as const;
+
 export type TaskPriority = "low" | "medium" | "high" | "critical";
 
 export const TASK_PRIORITIES: readonly TaskPriority[] = ["low", "medium", "high", "critical"] as const;

--- a/packages/core/src/ports/index.ts
+++ b/packages/core/src/ports/index.ts
@@ -18,3 +18,4 @@ export * from "./escalation-repo.js";
 export * from "./room-repo.js";
 export * from "./agent-provision-event-repo.js";
 export * from "./repo-run-repo.js";
+export * from "./task-watch-repo.js";

--- a/packages/core/src/ports/task-repo.ts
+++ b/packages/core/src/ports/task-repo.ts
@@ -17,6 +17,13 @@ export interface TaskListFilter {
 export interface TaskRepository {
   findById(id: string): Promise<Task | undefined>;
 
+  /**
+   * Bulk lookup. Returns rows for the ids that exist, in input order; missing
+   * ids are silently dropped. Single SELECT, used by callers that fan out
+   * per-id reads (e.g. WatchService's already-terminal check).
+   */
+  findByIds(ids: string[]): Promise<Task[]>;
+
   list(filter?: TaskListFilter): Promise<Task[]>;
 
   listByAssignee(assigneeId: string): Promise<Task[]>;

--- a/packages/core/src/ports/task-watch-repo.ts
+++ b/packages/core/src/ports/task-watch-repo.ts
@@ -1,0 +1,25 @@
+import type { TaskWatch, TaskWatchStatus } from "../domain/task-watch.js";
+
+export type NewTaskWatch = Omit<
+  TaskWatch,
+  "status" | "created_at" | "fired_at" | "fired_session_id"
+> & {
+  status?: TaskWatchStatus;
+};
+
+export interface TaskWatchRepository {
+  findById(id: string): Promise<TaskWatch | undefined>;
+  /** Watches the given waiter session registered, newest first. */
+  listByWaiterSession(waiterSessionId: string): Promise<TaskWatch[]>;
+  /** Waiting watches whose `task_ids` contains `taskId`; used by the M2 trigger / service to enumerate candidates on a status transition. */
+  listWaitingForTask(taskId: string): Promise<TaskWatch[]>;
+  create(input: NewTaskWatch): Promise<TaskWatch>;
+  /**
+   * Mark a watch as fired and link the wake session. Idempotent on the
+   * fired→fired re-call (returns the existing row). Throws if the watch
+   * is in `aborted` state to surface a race with `unwatch`.
+   */
+  markFired(id: string, firedSessionId: string): Promise<TaskWatch>;
+  /** Mark a waiting watch as aborted (agent-driven `unwatch`). Idempotent. */
+  markAborted(id: string): Promise<TaskWatch>;
+}

--- a/packages/core/src/services/spawn-prep.ts
+++ b/packages/core/src/services/spawn-prep.ts
@@ -54,13 +54,13 @@ behavioral rules for every task session:
    this session (team/org tier), you are a parent task — DO NOT call
    update_progress(done) yourself. The platform's children-rollup
    auto-completes the parent when all subtasks settle. If you need
-   to react to a subtask's outcome (downstream work depends on its
-   result, or you want to vet it before declaring the parent done),
-   also call mcp__beevibe__watch_tasks([task_ids], mode='all'|'any',
-   reason) before ending your turn — mode='all' waits for every
-   subtask, mode='any' wakes on the first. Skip the watch if the
-   subtask is well-defined end-state and the children-rollup is
-   enough on its own.
+   to react to a subtask's outcome (downstream work in this session
+   depends on its result, or you want to dispatch follow-up work
+   based on what it produced), also call
+   mcp__beevibe__watch_tasks([task_ids], mode='all'|'any', reason)
+   before ending your turn — mode='all' waits for every subtask,
+   mode='any' wakes on the first. Skip the watch if the subtask is
+   self-contained and the children-rollup is all you need.
 
 4. When you produce a deliverable for the task (PR, written analysis,
    design doc, etc.), record it via mcp__beevibe__create_work_product so

--- a/packages/core/src/services/spawn-prep.ts
+++ b/packages/core/src/services/spawn-prep.ts
@@ -53,7 +53,12 @@ behavioral rules for every task session:
 3. Exception: if you delegated work via mcp__beevibe__create_task during
    this session (team/org tier), you are a parent task — DO NOT call
    update_progress(done) yourself. The platform's children-rollup
-   auto-completes the parent when all subtasks settle.
+   auto-completes the parent when all subtasks settle. Pair the
+   dispatch with mcp__beevibe__watch_tasks([task_ids],
+   mode='all'|'any', reason) before ending your turn so you're
+   re-invoked when those subtasks finish and can react to their
+   results — mode='all' waits for every subtask, mode='any' wakes on
+   the first.
 
 4. When you produce a deliverable for the task (PR, written analysis,
    design doc, etc.), record it via mcp__beevibe__create_work_product so
@@ -175,6 +180,12 @@ work_product to record.
    has the deep guidance — invoke via the Skill tool. Note that
    beevibe-pre-task-setup is git-workspace setup for tasks; it does NOT
    apply here.
+
+4. If you dispatched work during this chat and want to be re-invoked
+   when it finishes so you can react to the results, call
+   mcp__beevibe__watch_tasks([task_ids], mode='all'|'any', reason)
+   before ending your reply — mode='all' waits for every task,
+   mode='any' wakes on the first.
 </beevibe_lifecycle>`;
 
 export const BEEVIBE_MEMORY_REMINDER = `<beevibe_memory>

--- a/packages/core/src/services/spawn-prep.ts
+++ b/packages/core/src/services/spawn-prep.ts
@@ -53,12 +53,14 @@ behavioral rules for every task session:
 3. Exception: if you delegated work via mcp__beevibe__create_task during
    this session (team/org tier), you are a parent task — DO NOT call
    update_progress(done) yourself. The platform's children-rollup
-   auto-completes the parent when all subtasks settle. Pair the
-   dispatch with mcp__beevibe__watch_tasks([task_ids],
-   mode='all'|'any', reason) before ending your turn so you're
-   re-invoked when those subtasks finish and can react to their
-   results — mode='all' waits for every subtask, mode='any' wakes on
-   the first.
+   auto-completes the parent when all subtasks settle. If you need
+   to react to a subtask's outcome (downstream work depends on its
+   result, or you want to vet it before declaring the parent done),
+   also call mcp__beevibe__watch_tasks([task_ids], mode='all'|'any',
+   reason) before ending your turn — mode='all' waits for every
+   subtask, mode='any' wakes on the first. Skip the watch if the
+   subtask is well-defined end-state and the children-rollup is
+   enough on its own.
 
 4. When you produce a deliverable for the task (PR, written analysis,
    design doc, etc.), record it via mcp__beevibe__create_work_product so

--- a/packages/core/src/services/task-service.ts
+++ b/packages/core/src/services/task-service.ts
@@ -1,4 +1,9 @@
-import type { NextDispatchContext, Task, TaskStatus } from "../domain/task.js";
+import {
+  TERMINAL_TASK_STATUSES,
+  type NextDispatchContext,
+  type Task,
+  type TaskStatus,
+} from "../domain/task.js";
 import type { WorkProduct, WorkProductListItem } from "../domain/work-product.js";
 import type { AgentRepository } from "../ports/agent-repo.js";
 import type { SessionRepository } from "../ports/session-repo.js";
@@ -42,8 +47,12 @@ const PARENT_AGENT_REVISE_FROM: readonly TaskStatus[] = ["blocked"];
 /** Cancellation from these requires `force: true`. */
 const TERMINAL_STATUSES: readonly TaskStatus[] = ["done", "cancelled"];
 
-/** A task is "complete" for the parent-rollup check when it is in one of these. */
-const COMPLETE_STATUSES: readonly TaskStatus[] = ["done", "cancelled", "failed"];
+/**
+ * A task is "complete" for the parent-rollup check when it has reached a
+ * terminal status — shared with WatchService so both layers agree on which
+ * statuses count as "done with this work" (whether or not it succeeded).
+ */
+const COMPLETE_STATUSES = TERMINAL_TASK_STATUSES;
 
 export interface TaskServiceDeps {
   taskRepo: TaskRepository;

--- a/packages/core/src/services/watch-service.test.ts
+++ b/packages/core/src/services/watch-service.test.ts
@@ -1,0 +1,330 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_RUNTIME_CONFIG } from "../domain/agent.js";
+import {
+  agentId,
+  personId,
+  sessionId,
+  taskId,
+} from "../domain/ids.js";
+import { createTestPool, truncateAll } from "../test-helpers.js";
+import type { Pool } from "../adapters/postgres/client.js";
+import { PostgresAgentRepository } from "../adapters/postgres/agent-repo.js";
+import { PostgresPersonRepository } from "../adapters/postgres/person-repo.js";
+import { PostgresSessionRepository } from "../adapters/postgres/session-repo.js";
+import { PostgresTaskRepository } from "../adapters/postgres/task-repo.js";
+import { PostgresTaskWatchRepository } from "../adapters/postgres/task-watch-repo.js";
+import {
+  WatchAuthError,
+  WatchNotFoundError,
+  WatchService,
+  WatchValidationError,
+} from "./watch-service.js";
+
+describe("WatchService — integration", () => {
+  let pool: Pool;
+  let agents: PostgresAgentRepository;
+  let persons: PostgresPersonRepository;
+  let sessions: PostgresSessionRepository;
+  let tasks: PostgresTaskRepository;
+  let watches: PostgresTaskWatchRepository;
+  let svc: WatchService;
+
+  let teamAgentId: string;
+  let icAgentId: string;
+  let waiterSessionId: string;
+
+  beforeAll(() => {
+    pool = createTestPool();
+    agents = new PostgresAgentRepository(pool);
+    persons = new PostgresPersonRepository(pool);
+    sessions = new PostgresSessionRepository(pool);
+    tasks = new PostgresTaskRepository(pool);
+    watches = new PostgresTaskWatchRepository(pool);
+    svc = new WatchService({
+      pool,
+      sessionRepo: sessions,
+      taskRepo: tasks,
+      watchRepo: watches,
+    });
+  });
+
+  beforeEach(async () => {
+    await truncateAll(pool);
+    const owner = await persons.create({ id: personId(), name: "Owner" });
+    const team = await agents.create({
+      id: agentId(),
+      name: "Team",
+      owner_id: owner.id,
+      hierarchy_level: "team",
+      runtime_config: DEFAULT_RUNTIME_CONFIG,
+    });
+    const ic = await agents.create({
+      id: agentId(),
+      name: "IC",
+      owner_id: owner.id,
+      hierarchy_level: "ic",
+      runtime_config: DEFAULT_RUNTIME_CONFIG,
+      parent_agent_id: team.id,
+    });
+    const waiter = await sessions.create({
+      id: sessionId(),
+      agent_id: team.id,
+      type: "chat",
+      status: "succeeded",
+      intent: "watch test",
+    });
+    teamAgentId = team.id;
+    icAgentId = ic.id;
+    waiterSessionId = waiter.id;
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  /** Dispatch a task by inserting a task row + an IC session parented to the
+   *  given waiter session — mirrors what create_task does. */
+  async function dispatchTask(
+    title: string,
+    parentSessionId: string,
+    opts: { status?: "in_progress" | "done" | "failed" | "cancelled" } = {},
+  ): Promise<string> {
+    const t = await tasks.create({
+      id: taskId(),
+      title,
+      description: title.toLowerCase(),
+      priority: "medium",
+      assignee_id: icAgentId,
+      creator_id: teamAgentId,
+      creator_type: "agent",
+      status: opts.status ?? "in_progress",
+    });
+    await sessions.create({
+      id: sessionId(),
+      agent_id: icAgentId,
+      task_id: t.id,
+      parent_session_id: parentSessionId,
+      type: "task",
+      status: "running",
+      intent: `<task id="${t.id}"/>`,
+    });
+    return t.id;
+  }
+
+  describe("watchTasks", () => {
+    it("creates a waiting watch on dispatched tasks in the chain", async () => {
+      const a = await dispatchTask("A", waiterSessionId);
+      const b = await dispatchTask("B", waiterSessionId);
+
+      const result = await svc.watchTasks({
+        callerAgentId: teamAgentId,
+        callerSessionId: waiterSessionId,
+        taskIds: [a, b],
+        mode: "all",
+      });
+
+      expect(result.firedImmediately).toBe(false);
+      const watch = await watches.findById(result.watchId);
+      expect(watch?.status).toBe("waiting");
+      expect(watch?.task_ids).toEqual([a, b]);
+    });
+
+    it("auth: rejects when caller_agent_id mismatches the waiter session", async () => {
+      const a = await dispatchTask("A", waiterSessionId);
+      await expect(
+        svc.watchTasks({
+          callerAgentId: icAgentId,
+          callerSessionId: waiterSessionId,
+          taskIds: [a],
+          mode: "all",
+        }),
+      ).rejects.toThrow(WatchAuthError);
+    });
+
+    it("auth: rejects when the waiter session does not exist", async () => {
+      const a = await dispatchTask("A", waiterSessionId);
+      await expect(
+        svc.watchTasks({
+          callerAgentId: teamAgentId,
+          callerSessionId: "sess_nonexistent",
+          taskIds: [a],
+          mode: "all",
+        }),
+      ).rejects.toThrow(WatchAuthError);
+    });
+
+    it("auth: rejects when a task was dispatched outside the chain", async () => {
+      // Another team session (a different conversation) dispatches the task.
+      const otherWaiter = await sessions.create({
+        id: sessionId(),
+        agent_id: teamAgentId,
+        type: "chat",
+        status: "succeeded",
+        intent: "another conversation",
+      });
+      const orphanTask = await dispatchTask("Orphan", otherWaiter.id);
+      await expect(
+        svc.watchTasks({
+          callerAgentId: teamAgentId,
+          callerSessionId: waiterSessionId,
+          taskIds: [orphanTask],
+          mode: "all",
+        }),
+      ).rejects.toThrow(/not dispatched in your conversation chain/);
+    });
+
+    it("auth: accepts tasks dispatched in an EARLIER turn of the same chain", async () => {
+      // First chat turn dispatches the task, then a second turn calls
+      // watch_tasks; the chain walk should let it through.
+      const a = await dispatchTask("A", waiterSessionId);
+      const turn2 = await sessions.create({
+        id: sessionId(),
+        agent_id: teamAgentId,
+        type: "chat",
+        status: "succeeded",
+        intent: "turn 2",
+        prior_session_id: waiterSessionId,
+      });
+      const result = await svc.watchTasks({
+        callerAgentId: teamAgentId,
+        callerSessionId: turn2.id,
+        taskIds: [a],
+        mode: "all",
+      });
+      const watch = await watches.findById(result.watchId);
+      expect(watch?.task_ids).toEqual([a]);
+    });
+
+    it("rejects empty task_ids", async () => {
+      await expect(
+        svc.watchTasks({
+          callerAgentId: teamAgentId,
+          callerSessionId: waiterSessionId,
+          taskIds: [],
+          mode: "all",
+        }),
+      ).rejects.toThrow(WatchValidationError);
+    });
+
+    it("fires immediately when mode='any' and at least one task is already terminal", async () => {
+      const a = await dispatchTask("A", waiterSessionId, { status: "done" });
+      const b = await dispatchTask("B", waiterSessionId);
+      // Set result_summary so the intent formatter has something to include.
+      await tasks.update(a, { result_summary: "shipped a" });
+
+      const result = await svc.watchTasks({
+        callerAgentId: teamAgentId,
+        callerSessionId: waiterSessionId,
+        taskIds: [a, b],
+        mode: "any",
+      });
+
+      expect(result.firedImmediately).toBe(true);
+      const watch = await watches.findById(result.watchId);
+      expect(watch?.status).toBe("fired");
+      const wake = await sessions.findById(watch!.fired_session_id!);
+      expect(wake?.prior_session_id).toBe(waiterSessionId);
+      expect(wake?.status).toBe("pending");
+      expect(wake?.intent).toContain("Task A — done. Result: shipped a");
+      expect(wake?.intent).toContain("Other watched tasks still running");
+    });
+
+    it("fires immediately when mode='all' and every task is already terminal", async () => {
+      const a = await dispatchTask("A", waiterSessionId, { status: "done" });
+      const b = await dispatchTask("B", waiterSessionId, { status: "failed" });
+      await tasks.update(a, { result_summary: "shipped a" });
+      await tasks.update(b, { result_summary: "tests broke" });
+
+      const result = await svc.watchTasks({
+        callerAgentId: teamAgentId,
+        callerSessionId: waiterSessionId,
+        taskIds: [a, b],
+        mode: "all",
+      });
+
+      expect(result.firedImmediately).toBe(true);
+      const watch = await watches.findById(result.watchId);
+      const wake = await sessions.findById(watch!.fired_session_id!);
+      expect(wake?.intent).toContain("2 tasks completed:");
+      expect(wake?.intent).toContain("A — done. Result: shipped a");
+      expect(wake?.intent).toContain("B — failed: tests broke");
+    });
+
+    it("does not fire when mode='all' and only some tasks are terminal", async () => {
+      const a = await dispatchTask("A", waiterSessionId, { status: "done" });
+      const b = await dispatchTask("B", waiterSessionId);
+
+      const result = await svc.watchTasks({
+        callerAgentId: teamAgentId,
+        callerSessionId: waiterSessionId,
+        taskIds: [a, b],
+        mode: "all",
+      });
+
+      expect(result.firedImmediately).toBe(false);
+      const watch = await watches.findById(result.watchId);
+      expect(watch?.status).toBe("waiting");
+    });
+  });
+
+  describe("unwatch", () => {
+    it("aborts a waiting watch", async () => {
+      const a = await dispatchTask("A", waiterSessionId);
+      const { watchId } = await svc.watchTasks({
+        callerAgentId: teamAgentId,
+        callerSessionId: waiterSessionId,
+        taskIds: [a],
+        mode: "all",
+      });
+      await svc.unwatch({ callerAgentId: teamAgentId, watchId });
+      const watch = await watches.findById(watchId);
+      expect(watch?.status).toBe("aborted");
+    });
+
+    it("is idempotent on an already-aborted watch", async () => {
+      const a = await dispatchTask("A", waiterSessionId);
+      const { watchId } = await svc.watchTasks({
+        callerAgentId: teamAgentId,
+        callerSessionId: waiterSessionId,
+        taskIds: [a],
+        mode: "all",
+      });
+      await svc.unwatch({ callerAgentId: teamAgentId, watchId });
+      await expect(
+        svc.unwatch({ callerAgentId: teamAgentId, watchId }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("refuses to abort a fired watch", async () => {
+      const a = await dispatchTask("A", waiterSessionId, { status: "done" });
+      const { watchId } = await svc.watchTasks({
+        callerAgentId: teamAgentId,
+        callerSessionId: waiterSessionId,
+        taskIds: [a],
+        mode: "all",
+      });
+      await expect(
+        svc.unwatch({ callerAgentId: teamAgentId, watchId }),
+      ).rejects.toThrow(WatchValidationError);
+    });
+
+    it("auth: rejects when caller does not own the watch", async () => {
+      const a = await dispatchTask("A", waiterSessionId);
+      const { watchId } = await svc.watchTasks({
+        callerAgentId: teamAgentId,
+        callerSessionId: waiterSessionId,
+        taskIds: [a],
+        mode: "all",
+      });
+      await expect(
+        svc.unwatch({ callerAgentId: icAgentId, watchId }),
+      ).rejects.toThrow(WatchAuthError);
+    });
+
+    it("throws WatchNotFoundError for an unknown id", async () => {
+      await expect(
+        svc.unwatch({ callerAgentId: teamAgentId, watchId: "watch_missing" }),
+      ).rejects.toThrow(WatchNotFoundError);
+    });
+  });
+});

--- a/packages/core/src/services/watch-service.ts
+++ b/packages/core/src/services/watch-service.ts
@@ -1,0 +1,206 @@
+/**
+ * WatchService — backs the `watch_tasks` + `unwatch` MCP tools. Inserts
+ * a `task_watch` row representing the agent's "wake me when these
+ * finish" subscription; the M2 trigger handles the fire when watched
+ * tasks transition terminal afterwards. The already-terminal path —
+ * agent calls watch_tasks but the tasks are *already* done/failed/
+ * cancelled — is handled here in TS, calling the same SQL intent
+ * formatter the trigger uses so the wake intent is byte-identical
+ * regardless of which path fired.
+ */
+
+import {
+  sessionId as newSessionId,
+  taskWatchId,
+  type Session,
+  type Task,
+  type TaskWatchMode,
+} from "../domain/index.js";
+import type { Pool } from "../adapters/postgres/client.js";
+import type { SessionRepository } from "../ports/session-repo.js";
+import type { TaskRepository } from "../ports/task-repo.js";
+import type { TaskWatchRepository } from "../ports/task-watch-repo.js";
+
+export interface WatchServiceDeps {
+  pool: Pool;
+  sessionRepo: SessionRepository;
+  taskRepo: TaskRepository;
+  watchRepo: TaskWatchRepository;
+}
+
+export interface WatchTasksInput {
+  callerAgentId: string;
+  callerSessionId: string;
+  taskIds: string[];
+  mode: TaskWatchMode;
+  reason?: string;
+}
+
+export interface WatchTasksResult {
+  watchId: string;
+  firedImmediately: boolean;
+}
+
+export interface UnwatchInput {
+  callerAgentId: string;
+  watchId: string;
+}
+
+const TERMINAL_TASK_STATUSES = new Set(["done", "failed", "cancelled"]);
+
+export class WatchAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WatchAuthError";
+  }
+}
+
+export class WatchValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WatchValidationError";
+  }
+}
+
+export class WatchNotFoundError extends Error {
+  constructor(id: string) {
+    super(`task_watch ${id} not found`);
+    this.name = "WatchNotFoundError";
+  }
+}
+
+export class WatchService {
+  constructor(private deps: WatchServiceDeps) {}
+
+  async watchTasks(input: WatchTasksInput): Promise<WatchTasksResult> {
+    if (input.taskIds.length === 0) {
+      throw new WatchValidationError("task_ids must be non-empty");
+    }
+
+    const waiter = await this.deps.sessionRepo.findById(input.callerSessionId);
+    if (!waiter) {
+      throw new WatchAuthError(
+        `caller session ${input.callerSessionId} not found`,
+      );
+    }
+    if (waiter.agent_id !== input.callerAgentId) {
+      throw new WatchAuthError(
+        "caller session does not belong to caller agent",
+      );
+    }
+
+    const inScope = await this.findTasksInChain(waiter.id, input.taskIds);
+    const missing = input.taskIds.filter((id) => !inScope.has(id));
+    if (missing.length > 0) {
+      throw new WatchAuthError(
+        `task(s) not dispatched in your conversation chain: ${missing.join(", ")}`,
+      );
+    }
+
+    const watch = await this.deps.watchRepo.create({
+      id: taskWatchId(),
+      waiter_session_id: waiter.id,
+      agent_id: waiter.agent_id,
+      mode: input.mode,
+      task_ids: input.taskIds,
+      reason: input.reason,
+    });
+
+    const tasks = await Promise.all(
+      input.taskIds.map((id) => this.deps.taskRepo.findById(id)),
+    );
+    const terminalTasks = tasks.filter(
+      (t): t is Task => !!t && TERMINAL_TASK_STATUSES.has(t.status),
+    );
+    const shouldFire =
+      input.mode === "any"
+        ? terminalTasks.length > 0
+        : tasks.every((t) => !!t) && terminalTasks.length === tasks.length;
+
+    if (shouldFire) {
+      const firingTask = terminalTasks[0]!;
+      const wake = await this.fireWatch(waiter, watch.id, firingTask.id);
+      await this.deps.watchRepo.markFired(watch.id, wake.id);
+      return { watchId: watch.id, firedImmediately: true };
+    }
+
+    return { watchId: watch.id, firedImmediately: false };
+  }
+
+  async unwatch(input: UnwatchInput): Promise<void> {
+    const watch = await this.deps.watchRepo.findById(input.watchId);
+    if (!watch) throw new WatchNotFoundError(input.watchId);
+    if (watch.agent_id !== input.callerAgentId) {
+      throw new WatchAuthError("watch does not belong to caller");
+    }
+    if (watch.status === "aborted") return; // idempotent
+    if (watch.status === "fired") {
+      throw new WatchValidationError(
+        `cannot unwatch a watch that already fired (wake session ${watch.fired_session_id})`,
+      );
+    }
+    await this.deps.watchRepo.markAborted(input.watchId);
+  }
+
+  /**
+   * Collect the task ids whose dispatching session (session.parent_session_id)
+   * is anywhere in the waiter's `prior_session_id` chain. Single recursive
+   * CTE walk; returns the subset that's in scope so the caller can diff
+   * against the input list to identify cross-conversation watches.
+   */
+  private async findTasksInChain(
+    waiterSessionId: string,
+    taskIds: string[],
+  ): Promise<Set<string>> {
+    const { rows } = await this.deps.pool.query<{ task_id: string }>(
+      `WITH RECURSIVE chain(id) AS (
+         SELECT id FROM session WHERE id = $1
+         UNION ALL
+         SELECT s.prior_session_id
+         FROM session s
+         JOIN chain c ON c.id = s.id
+         WHERE s.prior_session_id IS NOT NULL
+       )
+       SELECT DISTINCT s.task_id
+         FROM session s
+        WHERE s.task_id = ANY($2::text[])
+          AND s.parent_session_id IN (SELECT id FROM chain)`,
+      [waiterSessionId, taskIds],
+    );
+    return new Set(rows.map((r) => r.task_id));
+  }
+
+  /**
+   * Insert the wake session for an already-terminal watch. Calls the
+   * SQL intent formatter `bv_build_watch_intent` so chat-side fires
+   * and trigger-side fires produce byte-identical wake messages.
+   */
+  private async fireWatch(
+    waiter: Session,
+    watchId: string,
+    firingTaskId: string,
+  ): Promise<Session> {
+    const intent = await this.formatWakeIntent(watchId, firingTaskId);
+    return this.deps.sessionRepo.create({
+      id: newSessionId(),
+      agent_id: waiter.agent_id,
+      task_id: waiter.task_id,
+      prior_session_id: waiter.id,
+      type: waiter.type,
+      intent,
+      status: "pending",
+      // Other Session fields are optional and default to undefined / null.
+    });
+  }
+
+  private async formatWakeIntent(
+    watchId: string,
+    firingTaskId: string,
+  ): Promise<string> {
+    const { rows } = await this.deps.pool.query<{ intent: string }>(
+      `SELECT bv_build_watch_intent($1, $2) AS intent`,
+      [watchId, firingTaskId],
+    );
+    return rows[0]!.intent;
+  }
+}

--- a/packages/core/src/services/watch-service.ts
+++ b/packages/core/src/services/watch-service.ts
@@ -1,7 +1,7 @@
 /**
  * WatchService — backs the `watch_tasks` + `unwatch` MCP tools. Inserts
  * a `task_watch` row representing the agent's "wake me when these
- * finish" subscription; the M2 trigger handles the fire when watched
+ * finish" subscription; a DB trigger handles the fire when watched
  * tasks transition terminal afterwards. The already-terminal path —
  * agent calls watch_tasks but the tasks are *already* done/failed/
  * cancelled — is handled here in TS, calling the same SQL intent
@@ -10,6 +10,7 @@
  */
 
 import {
+  TERMINAL_TASK_STATUSES,
   sessionId as newSessionId,
   taskWatchId,
   type Session,
@@ -46,7 +47,7 @@ export interface UnwatchInput {
   watchId: string;
 }
 
-const TERMINAL_TASK_STATUSES = new Set(["done", "failed", "cancelled"]);
+const TERMINAL_SET = new Set<string>(TERMINAL_TASK_STATUSES);
 
 export class WatchAuthError extends Error {
   constructor(message: string) {
@@ -106,11 +107,11 @@ export class WatchService {
       reason: input.reason,
     });
 
-    const tasks = await Promise.all(
-      input.taskIds.map((id) => this.deps.taskRepo.findById(id)),
-    );
+    const fetched = await this.deps.taskRepo.findByIds(input.taskIds);
+    const byId = new Map(fetched.map((t) => [t.id, t]));
+    const tasks = input.taskIds.map((id) => byId.get(id));
     const terminalTasks = tasks.filter(
-      (t): t is Task => !!t && TERMINAL_TASK_STATUSES.has(t.status),
+      (t): t is Task => !!t && TERMINAL_SET.has(t.status),
     );
     const shouldFire =
       input.mode === "any"

--- a/packages/core/src/test-helpers.ts
+++ b/packages/core/src/test-helpers.ts
@@ -14,6 +14,7 @@ loadEnv({ path: repoRootEnv });
 
 // Children before parents — saves CASCADE work on every TRUNCATE.
 const ALL_TABLES = [
+  "task_watch",
   "escalation",
   "negotiation_round",
   "negotiation",

--- a/scripts/test-watch-tasks.sh
+++ b/scripts/test-watch-tasks.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# E2E smoke for watch_tasks against a running local stack. Verifies:
+#   1. INSERT task_watch with mode='all' on a pair of in_progress tasks
+#      does not fire on the first done transition; fires on the second.
+#   2. The wake row has prior_session_id pointing at the waiter,
+#      status='pending', and a structured intent that lists both tasks.
+#
+# Prereqs:
+#   - Docker postgres running with beevibe DB migrated (pnpm dev brings
+#     this up).
+#   - psql available on $PATH (or fall back to `docker exec`).
+#
+# This is a DB-level smoke — it does NOT call the LLM. WatchService /
+# watch_tasks tool / lifecycle prompt coverage lives in the vitest
+# integration suites (watch-fire.db.test.ts + watch-service.test.ts +
+# mcp.test.ts + assemble.test.ts). What this script proves end-to-end
+# is that the trigger fires under real psql traffic with the same
+# defaults pnpm dev applies — guards against migration drift that the
+# vitest beevibe_test DB can't catch.
+
+set -euo pipefail
+
+PSQL() {
+  docker exec -i beevibe-postgres psql -U beevibe -d beevibe -At -F'|' "$@"
+}
+
+uniq() { date +%s%N | tail -c 13; }
+PERSON_ID="person_e2ew_$(uniq)"
+TEAM_ID="agent_e2ew_$(uniq)"
+IC_ID="agent_e2ew_$(uniq)2"
+WAITER_ID="sess_e2ew_$(uniq)"
+TASK_A="task_e2ew_$(uniq)A"
+TASK_B="task_e2ew_$(uniq)B"
+IC_A="sess_e2ew_$(uniq)A"
+IC_B="sess_e2ew_$(uniq)B"
+WATCH_ID="watch_e2ew_$(uniq)"
+
+echo "==> Seeding fixture"
+PSQL <<SQL >/dev/null
+INSERT INTO person (id, name) VALUES ('$PERSON_ID', 'e2e-watch-tasks');
+
+INSERT INTO agent (id, name, owner_id, hierarchy_level, runtime_config)
+VALUES (
+  '$TEAM_ID', 'team', '$PERSON_ID', 'team',
+  '{"type":"claude-code","model":"claude-opus-4-7"}'::jsonb
+);
+INSERT INTO agent (id, name, owner_id, hierarchy_level, parent_agent_id, runtime_config)
+VALUES (
+  '$IC_ID', 'ic', '$PERSON_ID', 'ic', '$TEAM_ID',
+  '{"type":"claude-code","model":"claude-opus-4-7"}'::jsonb
+);
+
+INSERT INTO session (id, agent_id, type, status, intent, conversation_id)
+VALUES ('$WAITER_ID', '$TEAM_ID', 'chat', 'succeeded', 'waiter', '$WAITER_ID');
+
+INSERT INTO task (id, title, description, priority, status, assignee_id, creator_id, creator_type)
+VALUES ('$TASK_A', 'Backend', 'b', 'medium', 'in_progress', '$IC_ID', '$TEAM_ID', 'agent'),
+       ('$TASK_B', 'Frontend', 'f', 'medium', 'in_progress', '$IC_ID', '$TEAM_ID', 'agent');
+
+INSERT INTO session (id, agent_id, task_id, parent_session_id, type, status, intent)
+VALUES ('$IC_A', '$IC_ID', '$TASK_A', '$WAITER_ID', 'task', 'running', '<task id="$TASK_A"/>'),
+       ('$IC_B', '$IC_ID', '$TASK_B', '$WAITER_ID', 'task', 'running', '<task id="$TASK_B"/>');
+
+INSERT INTO task_watch (id, waiter_session_id, agent_id, mode, task_ids)
+VALUES ('$WATCH_ID', '$WAITER_ID', '$TEAM_ID', 'all', ARRAY['$TASK_A','$TASK_B']);
+SQL
+
+echo "==> Marking task A done (should NOT fire mode='all')"
+PSQL <<SQL >/dev/null
+UPDATE task SET status = 'done', result_summary = 'shipped backend' WHERE id = '$TASK_A';
+SQL
+
+STATUS_AFTER_FIRST=$(PSQL -c "SELECT status FROM task_watch WHERE id='$WATCH_ID'")
+if [[ "$STATUS_AFTER_FIRST" != "waiting" ]]; then
+  echo "FAIL: watch fired on first done; status=$STATUS_AFTER_FIRST"
+  exit 1
+fi
+echo "    OK: watch still waiting"
+
+echo "==> Marking task B done (should fire)"
+PSQL <<SQL >/dev/null
+UPDATE task SET status = 'done', result_summary = 'shipped frontend' WHERE id = '$TASK_B';
+SQL
+
+STATUS_AFTER_SECOND=$(PSQL -c "SELECT status FROM task_watch WHERE id='$WATCH_ID'")
+if [[ "$STATUS_AFTER_SECOND" != "fired" ]]; then
+  echo "FAIL: watch did not fire after both tasks done; status=$STATUS_AFTER_SECOND"
+  exit 1
+fi
+echo "    OK: watch fired"
+
+FIRED_SID=$(PSQL -c "SELECT fired_session_id FROM task_watch WHERE id='$WATCH_ID'")
+if [[ -z "$FIRED_SID" ]]; then
+  echo "FAIL: fired_session_id is null"
+  exit 1
+fi
+
+WAKE_STATUS=$(PSQL -c "SELECT status FROM session WHERE id='$FIRED_SID'")
+WAKE_TYPE=$(PSQL -c "SELECT type FROM session WHERE id='$FIRED_SID'")
+WAKE_PRIOR=$(PSQL -c "SELECT prior_session_id FROM session WHERE id='$FIRED_SID'")
+WAKE_AGENT=$(PSQL -c "SELECT agent_id FROM session WHERE id='$FIRED_SID'")
+
+if [[ "$WAKE_STATUS" != "pending"
+      || "$WAKE_TYPE"   != "chat"
+      || "$WAKE_PRIOR"  != "$WAITER_ID"
+      || "$WAKE_AGENT"  != "$TEAM_ID" ]]; then
+  echo "FAIL: wake session shape mismatch"
+  echo "  expected: status=pending type=chat prior=$WAITER_ID agent=$TEAM_ID"
+  echo "  actual:   status=$WAKE_STATUS type=$WAKE_TYPE prior=$WAKE_PRIOR agent=$WAKE_AGENT"
+  exit 1
+fi
+echo "    OK: wake session shape ($WAKE_STATUS/$WAKE_TYPE, chained to waiter)"
+
+WAKE_INTENT=$(PSQL -c "SELECT intent FROM session WHERE id='$FIRED_SID'")
+for needle in "2 tasks completed" "Backend" "Frontend" "Decide next steps."; do
+  if [[ "$WAKE_INTENT" != *"$needle"* ]]; then
+    echo "FAIL: wake intent missing '$needle'"
+    echo "  got: $WAKE_INTENT"
+    exit 1
+  fi
+done
+echo "    OK: wake intent lists both tasks"
+
+echo "==> Cleanup"
+PSQL <<SQL >/dev/null
+DELETE FROM task_watch WHERE id = '$WATCH_ID';
+DELETE FROM session WHERE id IN ('$IC_A','$IC_B','$WAITER_ID','$FIRED_SID');
+DELETE FROM task WHERE id IN ('$TASK_A','$TASK_B');
+DELETE FROM agent WHERE id IN ('$TEAM_ID','$IC_ID');
+DELETE FROM person WHERE id = '$PERSON_ID';
+SQL
+
+echo "==> All checks passed."


### PR DESCRIPTION
## Summary

Team agents can now declare "wake me when these dispatched tasks finish" via the new `watch_tasks` MCP tool, instead of going silent after `create_task` and forcing the human to re-prompt for status. The mechanism uses a `task_watch` table + a Postgres trigger on `task.status` transitions; when the fire condition is met, a new chat (or task) session is inserted in the same `prior_session_id` chain so the daemon spawns `claude --resume` and the agent reacts with full context.

Plan (in conversation) approved before any code landed; this PR is the four-milestone build.

## Walk-through

```
turn 1: user "ship feature Z"
        team agent runs → create_task(X), create_task(Y), watch_tasks([X,Y], 'all')
        team agent replies "I dispatched both, will let you know when both done"
        session ends

backend events fire (no user involvement):
        IC1 completes task X → task.status='done' → trigger evaluates watch
            mode='all', only X done → keeps waiting
        IC2 completes task Y → task.status='done' → trigger evaluates watch
            all terminal → INSERT new chat session in the waiter's chain
            with intent: "2 tasks completed: ..."
        daemon claims the pending session → spawns claude --resume <waiter.cli_session_id>
        team agent runs again, sees the wake intent, decides next step

turn 2 (autonomous): team agent posts to chat: "Both done; running integration tests..."
        — appears in chat history without the user typing anything
```

## Milestones

Each milestone is its own commit with its own build/test gate.

- **M1** — `task_watch` table + indexes + `TaskWatch` domain + `PostgresTaskWatchRepository`. 8 repo integration tests against `beevibe_test`.
- **M2** — `bv_check_task_watches()` PL/pgSQL trigger + `bv_build_watch_intent()` formatter. Fires on `task.status` transitions into `done|failed|cancelled` (deliberately skips `blocked` — mesh already wakes the team for blockers — and `needs_revision` — team initiated). 10 real-Postgres trigger tests covering both modes, every terminal status, and `blocked→done` / `needs_revision→in_progress→done` sequences (only the final terminal transition fires).
- **M3** — `WatchService` + the `watch_tasks` and `unwatch` MCP tools. Auth scope is the waiter's CLI-session chain — i.e. any session in the waiter's `prior_session_id` lineage (recursive CTE walk, one round-trip). Already-terminal race is handled in TS by calling the same `bv_build_watch_intent` SQL function the trigger uses, so a watch placed AFTER its targets terminated still produces a byte-identical wake. Team-only tool gate in `assemble.ts`. 14 service-level integration tests.
- **M4** — Lifecycle prompts: `BEEVIBE_LIFECYCLE_REMINDER_TASK` extends its parent-task rule with the watch_tasks pairing; `BEEVIBE_LIFECYCLE_REMINDER_CHAT` adds a parallel rule (phrased to honor the existing "no routing duplication" + block-ordering test invariants). Plus `scripts/test-watch-tasks.sh` — a DB-level bash smoke that drives the trigger end-to-end against the dev postgres to catch migration drift the vitest DB can't.

## Decisions baked in (not v1 surface to revisit later)

- **No wake cap.** The loop ends naturally when the agent stops calling `watch_tasks`. Per-session caps (CHAT_TURN_TIMEOUT_MS, mesh max rounds) bound per-wake cost.
- **One-shot watches.** A fired watch is done. If the agent wants to be re-notified later (e.g. after handling a blocker), it calls `watch_tasks` again.
- **Trigger on `task.status`, not session.** Tasks are the authoritative completion signal — sessions can stay `running` through blockers/asks while the task transitions separately.
- **Team-only.** ICs see neither `watch_tasks` nor `unwatch` in v1. Flipping that later is a one-line gate change in `assemble.ts`.

Known v1 cost the plan accepted: the wake intent will render as a user-styled bubble in chat (`chainToMessages` always pushes intent as `role=user`). Styling that as a "system check-in" is deferred — the agent reacts correctly today, the appearance is just slightly off.

## Test plan

- [x] `pnpm --filter @beevibe/core build` — clean
- [x] `pnpm --filter @beevibe/core test` — 617 passed (incl. 22 new: repo + service)
- [x] `pnpm --filter @beevibe/api typecheck` — clean
- [x] `pnpm --filter @beevibe/api test` — 402 passed (incl. 10 new watch-fire trigger tests + assemble/mcp count updates)
- [x] `bash scripts/test-watch-tasks.sh` — green end-to-end against the local dev postgres
- [ ] After deploy: open a chat, ask the team agent to dispatch two tasks and watch them. Mark both done via `update_progress`. Confirm an autonomous agent message appears in chat reacting to the completions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)