### PR TITLE
fix(watch-tasks): inherit runtime_id on the wake + hide system wakes from user-bubble rendering

### DIFF
--- a/migrations/1781400000000_add-task-watch-trigger.sql
+++ b/migrations/1781400000000_add-task-watch-trigger.sql
@@ -1,3 +1,9 @@
+-- SUPERSEDED in part by 1781500000000_fix-task-watch-wake-runtime-and-marker.sql,
+-- which CREATE OR REPLACEs both functions below to (a) inherit runtime_id
+-- onto the wake session row and (b) wrap the intent in <system-wake>...
+-- </system-wake>. This file is the deployed shape kept for historical record;
+-- tune the superseding file when changing the trigger.
+
 -- Trigger that fans terminal task transitions into wake sessions.
 -- A waiting `task_watch` row is an agent's explicit "wake me when these
 -- finish" subscription; this trigger fires on the matching task UPDATE,

--- a/migrations/1781500000000_fix-task-watch-wake-runtime-and-marker.sql
+++ b/migrations/1781500000000_fix-task-watch-wake-runtime-and-marker.sql
@@ -1,0 +1,166 @@
+-- Two production fixes for the watch_tasks wake path.
+--
+-- 1. Inherit `runtime_id` on the wake session row.
+--
+--    The original trigger inserted the wake with runtime_id unset (NULL).
+--    Chat conversations are runtime-pinned: every session in a chain
+--    inherits the head's runtime_id so the same daemon picks up every
+--    turn (the CLI session file lives on the user's machine — only THAT
+--    daemon can claude --resume it). A NULL runtime_id is the
+--    server-fallback signal; the scheduler's worker poll claimed wakes
+--    and tried to run claude in the server process, which failed with
+--    no useful error → chat history rendered the "Couldn't reach your
+--    team agent" pointer. Inheriting waiter_rec.runtime_id routes the
+--    wake to the user's daemon as the rest of the chain already does.
+--
+-- 2. Wrap the wake intent in `<system-wake>...</system-wake>`.
+--
+--    chainToMessages pushes every session's intent as a user bubble.
+--    Without a marker, the system-generated wake message appears in
+--    chat as if the user had typed it. The wrap lets chainToMessages
+--    skip the user-bubble push for wake turns while leaving the agent's
+--    reply visible. The wrapped tag is also what the agent sees via
+--    claude --resume — it's a clear "this came from the system" cue,
+--    similar to <mesh-ask> and <mesh-blocker>.
+
+CREATE OR REPLACE FUNCTION bv_build_watch_intent(
+  p_watch_id        TEXT,
+  p_firing_task_id  TEXT
+) RETURNS TEXT AS $$
+DECLARE
+  w               RECORD;
+  firing_task     RECORD;
+  body            TEXT;
+  task_list       TEXT;
+  others_list     TEXT;
+  others_count    INT;
+  reason_prefix   TEXT;
+BEGIN
+  SELECT * INTO w FROM task_watch WHERE id = p_watch_id;
+
+  reason_prefix := CASE
+    WHEN COALESCE(w.reason, '') <> '' THEN 'Wake reason: ' || w.reason || E'\n\n'
+    ELSE ''
+  END;
+
+  IF w.mode = 'all' THEN
+    SELECT string_agg(
+      format(
+        '  - %s — %s%s',
+        COALESCE(t.title, '(untitled)'),
+        t.status,
+        bv_task_result_suffix(t.status, t.result_summary)
+      ),
+      E'\n'
+      ORDER BY t.created_at
+    )
+    INTO task_list
+    FROM task t
+    WHERE t.id = ANY(w.task_ids);
+
+    body := reason_prefix
+            || cardinality(w.task_ids)::text || ' tasks completed:' || E'\n'
+            || COALESCE(task_list, '') || E'\n'
+            || 'Decide next steps.';
+  ELSE
+    SELECT * INTO firing_task FROM task WHERE id = p_firing_task_id;
+
+    SELECT string_agg(
+      format('  - %s — %s', COALESCE(t.title, '(untitled)'), t.status),
+      E'\n'
+      ORDER BY t.created_at
+    ), COUNT(*)
+    INTO others_list, others_count
+    FROM task t
+    WHERE t.id = ANY(w.task_ids)
+      AND t.id <> p_firing_task_id;
+
+    body := reason_prefix
+            || 'Task '
+            || COALESCE(firing_task.title, '(untitled)')
+            || ' — ' || firing_task.status
+            || bv_task_result_suffix(firing_task.status, firing_task.result_summary)
+            || E'\n';
+
+    IF others_count > 0 THEN
+      body := body
+              || 'Other watched tasks still running:' || E'\n'
+              || others_list || E'\n';
+    END IF;
+
+    body := body || 'Decide next steps.';
+  END IF;
+
+  -- Wrap so chainToMessages can detect the system-generated turn and
+  -- avoid rendering it as a user bubble. The agent reads the content
+  -- between the tags via --resume; the wrapper is a small "this came
+  -- from the system" cue rather than an instruction.
+  RETURN '<system-wake>' || E'\n' || body || E'\n' || '</system-wake>';
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION bv_check_task_watches() RETURNS trigger AS $$
+DECLARE
+  watch_rec      RECORD;
+  waiter_rec     RECORD;
+  all_terminal   BOOL;
+  new_session_id TEXT;
+  wake_intent    TEXT;
+BEGIN
+  FOR watch_rec IN
+    SELECT * FROM task_watch
+     WHERE status = 'waiting'
+       AND task_ids @> ARRAY[NEW.id]
+     FOR UPDATE
+  LOOP
+    IF watch_rec.mode = 'all' THEN
+      SELECT NOT EXISTS (
+        SELECT 1 FROM task
+         WHERE id = ANY(watch_rec.task_ids)
+           AND status NOT IN ('done', 'failed', 'cancelled')
+      ) INTO all_terminal;
+
+      IF NOT all_terminal THEN
+        CONTINUE;
+      END IF;
+    END IF;
+
+    SELECT * FROM session WHERE id = watch_rec.waiter_session_id
+      INTO waiter_rec;
+    wake_intent := bv_build_watch_intent(watch_rec.id, NEW.id);
+    new_session_id := 'sess_' ||
+      substring(replace(gen_random_uuid()::text, '-', ''), 1, 12);
+
+    INSERT INTO session (
+      id, agent_id, task_id, prior_session_id,
+      type, status, intent, conversation_id,
+      runtime_id
+    ) VALUES (
+      new_session_id,
+      waiter_rec.agent_id,
+      waiter_rec.task_id,
+      waiter_rec.id,
+      waiter_rec.type,
+      'pending',
+      wake_intent,
+      CASE
+        WHEN waiter_rec.type = 'chat' THEN COALESCE(
+          waiter_rec.conversation_id,
+          waiter_rec.id
+        )
+        ELSE NULL
+      END,
+      waiter_rec.runtime_id
+    );
+
+    UPDATE task_watch
+       SET status = 'fired',
+           fired_at = NOW(),
+           fired_session_id = new_session_id
+     WHERE id = watch_rec.id;
+  END LOOP;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/packages/api/src/routes/chat-internals.test.ts
+++ b/packages/api/src/routes/chat-internals.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { failureMessageFor, groupIntoConversations, type ChatSession } from "./chat.js";
+import {
+  chainToMessages,
+  failureMessageFor,
+  groupIntoConversations,
+  type ChatSession,
+} from "./chat.js";
 
 function makeSession(overrides: Partial<ChatSession> & Pick<ChatSession, "id">): ChatSession {
   return {
@@ -146,5 +151,55 @@ describe("failureMessageFor", () => {
   it("returns the daemon-log pointer when both fields are empty", () => {
     const out = failureMessageFor({});
     expect(out).toContain("beevibe-daemon start");
+  });
+});
+
+describe("chainToMessages", () => {
+  it("pushes a normal turn as user + agent bubbles", () => {
+    const s = makeSession({
+      id: "sess_u1",
+      intent: "ship it",
+      status: "succeeded",
+      result_summary: "shipped",
+    });
+    const out = chainToMessages({ head_id: s.id, sessions: [s] });
+    expect(out.map((m) => m.role)).toEqual(["user", "agent"]);
+    expect(out[0]?.content).toBe("ship it");
+    expect(out[1]?.content).toBe("shipped");
+  });
+
+  it("skips the user bubble for a <system-wake>-wrapped intent", () => {
+    // Trigger-inserted wake turn: the intent was system-generated, not
+    // typed by the user. Only the agent's reply should show in chat.
+    const s = makeSession({
+      id: "sess_wake",
+      intent:
+        "<system-wake>\n1 tasks completed:\n  - X — done. Result: ok\nDecide next steps.\n</system-wake>",
+      status: "succeeded",
+      result_summary: "Acknowledged.",
+    });
+    const out = chainToMessages({ head_id: s.id, sessions: [s] });
+    expect(out.map((m) => m.role)).toEqual(["agent"]);
+    expect(out[0]?.content).toBe("Acknowledged.");
+  });
+
+  it("mixed chain: skips wake bubbles, keeps user-typed bubbles", () => {
+    const turn1 = makeSession({
+      id: "sess_1",
+      intent: "ship it",
+      result_summary: "Dispatched A, B.",
+      status: "succeeded",
+    });
+    const wake = makeSession({
+      id: "sess_wake",
+      intent: "<system-wake>\n2 tasks completed:\n  - A — done\n  - B — done\nDecide next steps.\n</system-wake>",
+      result_summary: "Both done; running tests.",
+      status: "succeeded",
+    });
+    const out = chainToMessages({ head_id: turn1.id, sessions: [turn1, wake] });
+    expect(out.map((m) => m.role)).toEqual(["user", "agent", "agent"]);
+    expect(out[0]?.content).toBe("ship it");
+    expect(out[1]?.content).toBe("Dispatched A, B.");
+    expect(out[2]?.content).toBe("Both done; running tests.");
   });
 });

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -238,10 +238,16 @@ export function failureMessageFor(s: {
   return DAEMON_LOG_POINTER;
 }
 
-function chainToMessages(chain: ConversationChain): HistoryMessage[] {
+export function chainToMessages(chain: ConversationChain): HistoryMessage[] {
   const messages: HistoryMessage[] = [];
   for (const s of chain.sessions) {
-    messages.push({ id: `u_${s.id}`, role: "user", content: s.intent });
+    // Skip the user-bubble push for system-generated wake turns
+    // (watch_tasks fires). The agent still reads the wake intent via
+    // claude --resume; the chat history just shouldn't render a
+    // fake "user message" the user never typed.
+    if (!s.intent.startsWith("<system-wake>")) {
+      messages.push({ id: `u_${s.id}`, role: "user", content: s.intent });
+    }
     if (s.status === "failed") {
       messages.push({
         id: `a_${s.id}`,

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -24,6 +24,7 @@
 import { randomUUID } from "node:crypto";
 import { Router, type RequestHandler, type Response } from "express";
 import {
+  SYSTEM_WAKE_INTENT_OPEN,
   isInFlightSessionStatus,
   isKnownCli,
   type AgentRepository,
@@ -245,7 +246,7 @@ export function chainToMessages(chain: ConversationChain): HistoryMessage[] {
     // (watch_tasks fires). The agent still reads the wake intent via
     // claude --resume; the chat history just shouldn't render a
     // fake "user message" the user never typed.
-    if (!s.intent.startsWith("<system-wake>")) {
+    if (!s.intent.startsWith(SYSTEM_WAKE_INTENT_OPEN)) {
       messages.push({ id: `u_${s.id}`, role: "user", content: s.intent });
     }
     if (s.status === "failed") {

--- a/packages/api/src/views/watch-fire.db.test.ts
+++ b/packages/api/src/views/watch-fire.db.test.ts
@@ -187,8 +187,69 @@ describe("trg_task_watch_check — integration", () => {
     await tasks.updateProgress(a, "done", "shipped");
     const fired = await watches.findById(w.id);
     const wake = await sessions.findById(fired!.fired_session_id!);
-    expect(wake?.intent).toMatch(/^Wake reason: checking deploy progress\n\n/);
+    expect(wake?.intent).toContain("Wake reason: checking deploy progress");
     expect(wake?.intent).toContain("Backend — done. Result: shipped");
+  });
+
+  it("wraps the wake intent in <system-wake> so chainToMessages can skip the user bubble", async () => {
+    const a = await createTask("Backend");
+    const w = await createWatch([a], "all");
+    await tasks.updateProgress(a, "done", "shipped");
+    const wake = await findWakeSession(w);
+    expect(wake?.intent.startsWith("<system-wake>")).toBe(true);
+    expect(wake?.intent.endsWith("</system-wake>")).toBe(true);
+  });
+
+  it("inherits waiter.runtime_id on the wake session (runtime-pinning)", async () => {
+    // Seed a daemon + runtime + a chat waiter pinned to that runtime;
+    // the wake session must inherit the same runtime_id so the user's
+    // daemon claims it instead of the server-fallback worker.
+    const suffix = Date.now();
+    const ownerRow = await pool.query<{ owner_id: string }>(
+      `SELECT owner_id FROM agent WHERE id = $1`,
+      [teamAgentId],
+    );
+    const personId_ = ownerRow.rows[0]!.owner_id;
+    const daemonId = `dmn_pin_${suffix}`;
+    const rt = `rt_pin_${suffix}`;
+    await pool.query(
+      `INSERT INTO daemon (id, owner_person_id, external_id, device_name, token_hash)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [daemonId, personId_, `ext_${suffix}`, `dev_${suffix}`, `hash_${suffix}`],
+    );
+    await pool.query(
+      `INSERT INTO runtime (id, daemon_id, cli, capabilities)
+       VALUES ($1, $2, 'claude', '{}'::jsonb)`,
+      [rt, daemonId],
+    );
+    const pinnedWaiter = await sessions.create({
+      id: sessionId(),
+      agent_id: teamAgentId,
+      type: "chat",
+      status: "succeeded",
+      intent: "pinned",
+      runtime_id: rt,
+    });
+    const a = await createTask("Backend");
+    // Reparent the task's IC session under the pinned waiter (the auth
+    // check on the watch is satisfied by parent_session_id ∈ chain).
+    await pool.query(
+      `UPDATE session SET parent_session_id = $1 WHERE task_id = $2 AND parent_session_id IS NOT NULL`,
+      [pinnedWaiter.id, a],
+    );
+    const w = await watches.create({
+      id: taskWatchId(),
+      waiter_session_id: pinnedWaiter.id,
+      agent_id: teamAgentId,
+      mode: "all",
+      task_ids: [a],
+    });
+
+    await tasks.updateProgress(a, "done", "shipped");
+    const wake = await sessions.findById(
+      (await watches.findById(w.id))!.fired_session_id!,
+    );
+    expect(wake?.runtime_id).toBe(rt);
   });
 
   it("mode='any' with one task: no 'others still running' block", async () => {

--- a/packages/api/src/views/watch-fire.db.test.ts
+++ b/packages/api/src/views/watch-fire.db.test.ts
@@ -18,13 +18,19 @@ import {
 import { provisionAgent, provisionUser } from "@beevibe/core/auth";
 import {
   DEFAULT_RUNTIME_CONFIG,
+  SYSTEM_WAKE_INTENT_CLOSE,
+  SYSTEM_WAKE_INTENT_OPEN,
   agentId,
   personId,
   sessionId,
   taskId,
   taskWatchId,
 } from "@beevibe/core";
-import { createTestPool, truncateAll } from "@beevibe/core/test-helpers";
+import {
+  createTestPool,
+  seedPinnedRuntime,
+  truncateAll,
+} from "@beevibe/core/test-helpers";
 
 describe("trg_task_watch_check — integration", () => {
   let pool: Pool;
@@ -38,6 +44,7 @@ describe("trg_task_watch_check — integration", () => {
   let waiterSessionId: string;
   let teamAgentId: string;
   let icAgentId: string;
+  let ownerPersonId: string;
 
   beforeAll(() => {
     pool = createTestPool();
@@ -87,6 +94,7 @@ describe("trg_task_watch_check — integration", () => {
     waiterSessionId = waiter.id;
     teamAgentId = team.agent.id;
     icAgentId = ic.agent.id;
+    ownerPersonId = owner.person.id;
   });
 
   afterAll(async () => {
@@ -196,39 +204,22 @@ describe("trg_task_watch_check — integration", () => {
     const w = await createWatch([a], "all");
     await tasks.updateProgress(a, "done", "shipped");
     const wake = await findWakeSession(w);
-    expect(wake?.intent.startsWith("<system-wake>")).toBe(true);
-    expect(wake?.intent.endsWith("</system-wake>")).toBe(true);
+    expect(wake?.intent.startsWith(SYSTEM_WAKE_INTENT_OPEN)).toBe(true);
+    expect(wake?.intent.endsWith(SYSTEM_WAKE_INTENT_CLOSE)).toBe(true);
   });
 
   it("inherits waiter.runtime_id on the wake session (runtime-pinning)", async () => {
     // Seed a daemon + runtime + a chat waiter pinned to that runtime;
     // the wake session must inherit the same runtime_id so the user's
     // daemon claims it instead of the server-fallback worker.
-    const suffix = Date.now();
-    const ownerRow = await pool.query<{ owner_id: string }>(
-      `SELECT owner_id FROM agent WHERE id = $1`,
-      [teamAgentId],
-    );
-    const personId_ = ownerRow.rows[0]!.owner_id;
-    const daemonId = `dmn_pin_${suffix}`;
-    const rt = `rt_pin_${suffix}`;
-    await pool.query(
-      `INSERT INTO daemon (id, owner_person_id, external_id, device_name, token_hash)
-       VALUES ($1, $2, $3, $4, $5)`,
-      [daemonId, personId_, `ext_${suffix}`, `dev_${suffix}`, `hash_${suffix}`],
-    );
-    await pool.query(
-      `INSERT INTO runtime (id, daemon_id, cli, capabilities)
-       VALUES ($1, $2, 'claude', '{}'::jsonb)`,
-      [rt, daemonId],
-    );
+    const { runtimeId } = await seedPinnedRuntime(pool, { personId: ownerPersonId });
     const pinnedWaiter = await sessions.create({
       id: sessionId(),
       agent_id: teamAgentId,
       type: "chat",
       status: "succeeded",
       intent: "pinned",
-      runtime_id: rt,
+      runtime_id: runtimeId,
     });
     const a = await createTask("Backend");
     // Reparent the task's IC session under the pinned waiter (the auth
@@ -249,7 +240,7 @@ describe("trg_task_watch_check — integration", () => {
     const wake = await sessions.findById(
       (await watches.findById(w.id))!.fired_session_id!,
     );
-    expect(wake?.runtime_id).toBe(rt);
+    expect(wake?.runtime_id).toBe(runtimeId);
   });
 
   it("mode='any' with one task: no 'others still running' block", async () => {

--- a/packages/core/src/domain/task-watch.ts
+++ b/packages/core/src/domain/task-watch.ts
@@ -17,6 +17,16 @@ export type TaskWatchStatus = "waiting" | "fired" | "aborted";
 
 export const TASK_WATCH_MODES: readonly TaskWatchMode[] = ["all", "any"] as const;
 
+/**
+ * Opening / closing tags the watch trigger wraps every wake intent in.
+ * `chat.chainToMessages` checks the opening tag to detect a system-
+ * generated turn and skip the user-bubble push. Keep in sync with the
+ * literal in the PL/pgSQL `bv_build_watch_intent` function — they're a
+ * wire contract between the SQL fire path and the TS renderer.
+ */
+export const SYSTEM_WAKE_INTENT_OPEN = "<system-wake>";
+export const SYSTEM_WAKE_INTENT_CLOSE = "</system-wake>";
+
 export interface TaskWatch {
   id: string;
   /** Session that called watch_tasks; the wake session chains off this via prior_session_id. */

--- a/packages/core/src/services/watch-service.test.ts
+++ b/packages/core/src/services/watch-service.test.ts
@@ -1,12 +1,16 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { DEFAULT_RUNTIME_CONFIG } from "../domain/agent.js";
 import {
+  SYSTEM_WAKE_INTENT_CLOSE,
+  SYSTEM_WAKE_INTENT_OPEN,
+} from "../domain/task-watch.js";
+import {
   agentId,
   personId,
   sessionId,
   taskId,
 } from "../domain/ids.js";
-import { createTestPool, truncateAll } from "../test-helpers.js";
+import { createTestPool, seedPinnedRuntime, truncateAll } from "../test-helpers.js";
 import type { Pool } from "../adapters/postgres/client.js";
 import { PostgresAgentRepository } from "../adapters/postgres/agent-repo.js";
 import { PostgresPersonRepository } from "../adapters/postgres/person-repo.js";
@@ -32,6 +36,7 @@ describe("WatchService — integration", () => {
   let teamAgentId: string;
   let icAgentId: string;
   let waiterSessionId: string;
+  let ownerPersonId: string;
 
   beforeAll(() => {
     pool = createTestPool();
@@ -76,6 +81,7 @@ describe("WatchService — integration", () => {
     teamAgentId = team.id;
     icAgentId = ic.id;
     waiterSessionId = waiter.id;
+    ownerPersonId = owner.id;
   });
 
   afterAll(async () => {
@@ -249,8 +255,8 @@ describe("WatchService — integration", () => {
       expect(wake?.intent).toContain("A — done. Result: shipped a");
       expect(wake?.intent).toContain("B — failed: tests broke");
       // Wrapped so chainToMessages can detect and skip the user-bubble.
-      expect(wake?.intent.startsWith("<system-wake>")).toBe(true);
-      expect(wake?.intent.endsWith("</system-wake>")).toBe(true);
+      expect(wake?.intent.startsWith(SYSTEM_WAKE_INTENT_OPEN)).toBe(true);
+      expect(wake?.intent.endsWith(SYSTEM_WAKE_INTENT_CLOSE)).toBe(true);
     });
 
     it("inherits the waiter's runtime_id on the already-terminal fire path", async () => {
@@ -258,31 +264,14 @@ describe("WatchService — integration", () => {
       // the SQL trigger. Both paths must pin the wake to the same
       // runtime so a chat conversation's daemon claims the wake instead
       // of the server-fallback worker.
-      const suffix = Date.now();
-      const ownerRow = await pool.query<{ owner_id: string }>(
-        `SELECT owner_id FROM agent WHERE id = $1`,
-        [teamAgentId],
-      );
-      const personId_ = ownerRow.rows[0]!.owner_id;
-      const daemonIdValue = `dmn_pin_${suffix}`;
-      const rt = `rt_pin_${suffix}`;
-      await pool.query(
-        `INSERT INTO daemon (id, owner_person_id, external_id, device_name, token_hash)
-         VALUES ($1, $2, $3, $4, $5)`,
-        [daemonIdValue, personId_, `ext_${suffix}`, `dev_${suffix}`, `hash_${suffix}`],
-      );
-      await pool.query(
-        `INSERT INTO runtime (id, daemon_id, cli, capabilities)
-         VALUES ($1, $2, 'claude', '{}'::jsonb)`,
-        [rt, daemonIdValue],
-      );
+      const { runtimeId } = await seedPinnedRuntime(pool, { personId: ownerPersonId });
       const pinnedWaiter = await sessions.create({
         id: sessionId(),
         agent_id: teamAgentId,
         type: "chat",
         status: "succeeded",
         intent: "pinned",
-        runtime_id: rt,
+        runtime_id: runtimeId,
       });
       const a = await dispatchTask("A", pinnedWaiter.id, { status: "done" });
       await tasks.update(a, { result_summary: "shipped" });
@@ -297,7 +286,7 @@ describe("WatchService — integration", () => {
       expect(result.firedImmediately).toBe(true);
       const watch = await watches.findById(result.watchId);
       const wake = await sessions.findById(watch!.fired_session_id!);
-      expect(wake?.runtime_id).toBe(rt);
+      expect(wake?.runtime_id).toBe(runtimeId);
     });
 
     it("does not fire when mode='all' and only some tasks are terminal", async () => {

--- a/packages/core/src/services/watch-service.test.ts
+++ b/packages/core/src/services/watch-service.test.ts
@@ -248,6 +248,56 @@ describe("WatchService — integration", () => {
       expect(wake?.intent).toContain("2 tasks completed:");
       expect(wake?.intent).toContain("A — done. Result: shipped a");
       expect(wake?.intent).toContain("B — failed: tests broke");
+      // Wrapped so chainToMessages can detect and skip the user-bubble.
+      expect(wake?.intent.startsWith("<system-wake>")).toBe(true);
+      expect(wake?.intent.endsWith("</system-wake>")).toBe(true);
+    });
+
+    it("inherits the waiter's runtime_id on the already-terminal fire path", async () => {
+      // Already-terminal race goes through WatchService.fireWatch, NOT
+      // the SQL trigger. Both paths must pin the wake to the same
+      // runtime so a chat conversation's daemon claims the wake instead
+      // of the server-fallback worker.
+      const suffix = Date.now();
+      const ownerRow = await pool.query<{ owner_id: string }>(
+        `SELECT owner_id FROM agent WHERE id = $1`,
+        [teamAgentId],
+      );
+      const personId_ = ownerRow.rows[0]!.owner_id;
+      const daemonIdValue = `dmn_pin_${suffix}`;
+      const rt = `rt_pin_${suffix}`;
+      await pool.query(
+        `INSERT INTO daemon (id, owner_person_id, external_id, device_name, token_hash)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [daemonIdValue, personId_, `ext_${suffix}`, `dev_${suffix}`, `hash_${suffix}`],
+      );
+      await pool.query(
+        `INSERT INTO runtime (id, daemon_id, cli, capabilities)
+         VALUES ($1, $2, 'claude', '{}'::jsonb)`,
+        [rt, daemonIdValue],
+      );
+      const pinnedWaiter = await sessions.create({
+        id: sessionId(),
+        agent_id: teamAgentId,
+        type: "chat",
+        status: "succeeded",
+        intent: "pinned",
+        runtime_id: rt,
+      });
+      const a = await dispatchTask("A", pinnedWaiter.id, { status: "done" });
+      await tasks.update(a, { result_summary: "shipped" });
+
+      const result = await svc.watchTasks({
+        callerAgentId: teamAgentId,
+        callerSessionId: pinnedWaiter.id,
+        taskIds: [a],
+        mode: "all",
+      });
+
+      expect(result.firedImmediately).toBe(true);
+      const watch = await watches.findById(result.watchId);
+      const wake = await sessions.findById(watch!.fired_session_id!);
+      expect(wake?.runtime_id).toBe(rt);
     });
 
     it("does not fire when mode='all' and only some tasks are terminal", async () => {

--- a/packages/core/src/services/watch-service.ts
+++ b/packages/core/src/services/watch-service.ts
@@ -190,7 +190,12 @@ export class WatchService {
       // Chat / task chains are runtime-pinned so claude --resume hits the
       // same daemon (and the same on-disk CLI session file) every turn.
       // The trigger does the same; this is the service-side mirror for the
-      // already-terminal race.
+      // already-terminal race. We intentionally use raw inheritance — NOT
+      // dispatchService's resolveRuntimeId fallback chain (override →
+      // prior → agent.preferred_runtime_id) — because the wake's semantic
+      // is "match the chain exactly". If the chain was deliberately null-
+      // routed (server-fallback), falling through to the agent's
+      // preferred runtime would silently re-route mid-conversation.
       runtime_id: waiter.runtime_id,
       type: waiter.type,
       intent,

--- a/packages/core/src/services/watch-service.ts
+++ b/packages/core/src/services/watch-service.ts
@@ -187,10 +187,14 @@ export class WatchService {
       agent_id: waiter.agent_id,
       task_id: waiter.task_id,
       prior_session_id: waiter.id,
+      // Chat / task chains are runtime-pinned so claude --resume hits the
+      // same daemon (and the same on-disk CLI session file) every turn.
+      // The trigger does the same; this is the service-side mirror for the
+      // already-terminal race.
+      runtime_id: waiter.runtime_id,
       type: waiter.type,
       intent,
       status: "pending",
-      // Other Session fields are optional and default to undefined / null.
     });
   }
 

--- a/packages/core/src/test-helpers.ts
+++ b/packages/core/src/test-helpers.ts
@@ -47,3 +47,31 @@ export async function truncateAll(pool: Pool): Promise<void> {
     `TRUNCATE ${ALL_TABLES.join(", ")} RESTART IDENTITY CASCADE`,
   );
 }
+
+/**
+ * Insert a daemon + runtime row pair so an integration test can pin a
+ * session to a non-null `runtime_id`. Used by tests that need to assert
+ * runtime-aware behavior (claim routing, watch-tasks wake inheritance,
+ * etc.) without dragging in the daemon HTTP onboarding flow. Returns
+ * the new ids; deleting the rows is unnecessary if the test relies on
+ * `truncateAll` between cases.
+ */
+export async function seedPinnedRuntime(
+  pool: Pool,
+  opts: { personId: string; suffix?: string },
+): Promise<{ daemonId: string; runtimeId: string }> {
+  const suffix = opts.suffix ?? Date.now().toString();
+  const daemonId = `dmn_pin_${suffix}`;
+  const runtimeId = `rt_pin_${suffix}`;
+  await pool.query(
+    `INSERT INTO daemon (id, owner_person_id, external_id, device_name, token_hash)
+     VALUES ($1, $2, $3, $4, $5)`,
+    [daemonId, opts.personId, `ext_${suffix}`, `dev_${suffix}`, `hash_${suffix}`],
+  );
+  await pool.query(
+    `INSERT INTO runtime (id, daemon_id, cli, capabilities)
+     VALUES ($1, $2, 'claude', '{}'::jsonb)`,
+    [runtimeId, daemonId],
+  );
+  return { daemonId, runtimeId };
+}


### PR DESCRIPTION
## Summary

Two post-deploy fixes for #240 surfaced during the first user-facing chat trial.

### 1. Wake session was unpinned → server-fallback worker claimed it → couldn't run `claude --resume` on the user's machine → "Couldn't reach your team agent"

Chat / task chains are runtime-pinned: every session in the chain inherits the head's `runtime_id` so the same daemon (the one holding the CLI session file on the user's local machine) is what picks up the next turn. `dispatchService.dispatchTask()` does this for normal continuations (`session-repo.ts:114` — `resolveRuntimeId(input, agent, prior?.runtime_id)`); my trigger and the `WatchService.fireWatch` TS twin did NOT, so the wake row landed with `runtime_id = NULL`. NULL is the server-fallback signal — the scheduler's worker poll claimed the wake and tried to spawn claude in the API process, which obviously can't open the user's local CLI session file. Spawn failed with no useful error string, `chainToMessages` fell through to the `DAEMON_LOG_POINTER`, and the user saw "Couldn't reach your team agent..."

Fix: inherit `waiter_rec.runtime_id` on the wake INSERT — in both the trigger's PL/pgSQL and `WatchService.fireWatch` (already-terminal race path).

### 2. Wake intent rendered as user bubble in chat

`chainToMessages` pushes every session's `intent` as `role='user'`. The trigger-inserted wake intent was system-generated, but the user saw it as a "message they never typed" sitting above the agent's reply. Confusing UX.

Fix: wrap the wake intent in `<system-wake>...</system-wake>` (same shape as `<mesh-ask>` / `<mesh-blocker>` already in this codebase). `chainToMessages` detects the wrapper and skips the user-bubble push, leaving the agent's reply visible on its own. The agent still reads the wrapped content via `claude --resume` — the wrapper is a clear "this came from the system" cue.

## Implementation

- New migration `1781500000000_fix-task-watch-wake-runtime-and-marker.sql` — `CREATE OR REPLACE` of `bv_check_task_watches` (adds runtime_id) and `bv_build_watch_intent` (adds wrapper). The original `1781400000000_...sql` is untouched because it represents the deployed shape.
- `watch-service.ts`: `fireWatch` now passes `waiter.runtime_id`.
- `chat.ts`: `chainToMessages` skips the user-bubble push for `<system-wake>`-prefixed intents.

## Test plan

- [x] `pnpm --filter @beevibe/core test` — 618 passed (incl. 1 new for already-terminal runtime_id inheritance)
- [x] `pnpm --filter @beevibe/api test` — 408 passed (incl. 2 new in watch-fire.db.test for trigger runtime_id + wrap, 3 new in chat-internals.test for chainToMessages skip-wake behavior)
- [x] `pnpm --filter @beevibe/api typecheck` — clean
- [x] `bash scripts/test-watch-tasks.sh` — green end-to-end
- [ ] After deploy: dispatch tasks + watch from the chat surface; mark them done; the team agent's autonomous reply appears in chat with NO preceding "fake user message", and the daemon claims the wake (no "Couldn't reach your team agent" message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)