### PR TITLE
feat(chat): render watch-fired event as a system pill in chat history

### DIFF
--- a/packages/api/src/routes/chat-internals.test.ts
+++ b/packages/api/src/routes/chat-internals.test.ts
@@ -168,9 +168,7 @@ describe("chainToMessages", () => {
     expect(out[1]?.content).toBe("shipped");
   });
 
-  it("skips the user bubble for a <system-wake>-wrapped intent", () => {
-    // Trigger-inserted wake turn: the intent was system-generated, not
-    // typed by the user. Only the agent's reply should show in chat.
+  it("emits a system message for a <system-wake>-wrapped intent (wrap + 'Decide next steps.' stripped)", () => {
     const s = makeSession({
       id: "sess_wake",
       intent:
@@ -179,11 +177,33 @@ describe("chainToMessages", () => {
       result_summary: "Acknowledged.",
     });
     const out = chainToMessages({ head_id: s.id, sessions: [s] });
-    expect(out.map((m) => m.role)).toEqual(["agent"]);
-    expect(out[0]?.content).toBe("Acknowledged.");
+    expect(out.map((m) => m.role)).toEqual(["system", "agent"]);
+    expect(out[0]?.content).toBe(
+      "1 tasks completed:\n  - X — done. Result: ok",
+    );
+    expect(out[0]?.session_id).toBe("sess_wake");
+    expect(out[1]?.content).toBe("Acknowledged.");
   });
 
-  it("mixed chain: skips wake bubbles, keeps user-typed bubbles", () => {
+  it("emits only the system message for a pending wake (no agent reply yet)", () => {
+    // Streaming scenario: wake session was just inserted by the trigger
+    // and the agent is currently running. The system message must surface
+    // so the user can see what triggered the imminent reply.
+    const s = makeSession({
+      id: "sess_wake",
+      intent:
+        "<system-wake>\n2 tasks completed:\n  - A — done\n  - B — done\nDecide next steps.\n</system-wake>",
+      status: "running",
+      result_summary: undefined,
+    });
+    const out = chainToMessages({ head_id: s.id, sessions: [s] });
+    expect(out.map((m) => m.role)).toEqual(["system"]);
+    expect(out[0]?.content).toContain("2 tasks completed:");
+    expect(out[0]?.content).not.toContain("Decide next steps.");
+    expect(out[0]?.content).not.toContain("<system-wake>");
+  });
+
+  it("mixed chain: system messages alongside normal user/agent turns", () => {
     const turn1 = makeSession({
       id: "sess_1",
       intent: "ship it",
@@ -192,14 +212,29 @@ describe("chainToMessages", () => {
     });
     const wake = makeSession({
       id: "sess_wake",
-      intent: "<system-wake>\n2 tasks completed:\n  - A — done\n  - B — done\nDecide next steps.\n</system-wake>",
+      intent:
+        "<system-wake>\n2 tasks completed:\n  - A — done\n  - B — done\nDecide next steps.\n</system-wake>",
       result_summary: "Both done; running tests.",
       status: "succeeded",
     });
     const out = chainToMessages({ head_id: turn1.id, sessions: [turn1, wake] });
-    expect(out.map((m) => m.role)).toEqual(["user", "agent", "agent"]);
+    expect(out.map((m) => m.role)).toEqual(["user", "agent", "system", "agent"]);
     expect(out[0]?.content).toBe("ship it");
     expect(out[1]?.content).toBe("Dispatched A, B.");
-    expect(out[2]?.content).toBe("Both done; running tests.");
+    expect(out[2]?.content).toContain("2 tasks completed:");
+    expect(out[3]?.content).toBe("Both done; running tests.");
+  });
+
+  it("preserves a 'Wake reason:' prefix in the system message", () => {
+    const s = makeSession({
+      id: "sess_wake",
+      intent:
+        "<system-wake>\nWake reason: deploy progress check\n\n1 tasks completed:\n  - X — done\nDecide next steps.\n</system-wake>",
+      status: "succeeded",
+      result_summary: "ack",
+    });
+    const out = chainToMessages({ head_id: s.id, sessions: [s] });
+    const system = out.find((m) => m.role === "system");
+    expect(system?.content.startsWith("Wake reason: deploy progress check")).toBe(true);
   });
 });

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -24,6 +24,7 @@
 import { randomUUID } from "node:crypto";
 import { Router, type RequestHandler, type Response } from "express";
 import {
+  SYSTEM_WAKE_INTENT_CLOSE,
   SYSTEM_WAKE_INTENT_OPEN,
   isInFlightSessionStatus,
   isKnownCli,
@@ -71,13 +72,34 @@ export interface ChatRoutesDeps {
 
 interface HistoryMessage {
   id: string;
-  role: "user" | "agent";
+  /**
+   * `system` is used for autonomous trigger messages — currently just the
+   * watch_tasks fire ("Watch fired — 2 tasks completed: …"). It tells the
+   * chat surface "the agent's next reply is responding to THIS, not to a
+   * user message," so the UI can render a compact pill above the agent
+   * bubble. The agent never produces system messages directly — they're
+   * derived from the wake session's `<system-wake>`-wrapped intent.
+   */
+  role: "user" | "agent" | "system";
   content: string;
   session_id?: string;
   view_refs?: string[];
   open_view?: { path: string; label?: string };
   suggested_actions?: SuggestedAction[];
   repo_cards?: RepoCard[];
+}
+
+/**
+ * Extract the user-facing summary out of a `<system-wake>`-wrapped intent.
+ * Drops the wrapper tags and the trailing "Decide next steps." prompt
+ * (agent-facing instruction, noise to the human reader).
+ */
+function extractWakeSummary(intent: string): string {
+  return intent
+    .replace(new RegExp(`^${SYSTEM_WAKE_INTENT_OPEN}\\s*`), "")
+    .replace(new RegExp(`\\s*${SYSTEM_WAKE_INTENT_CLOSE}\\s*$`), "")
+    .replace(/\n+Decide next steps\.\s*$/, "")
+    .trim();
 }
 
 // Generic 500 — internal error text stays in server logs, indexed by
@@ -242,11 +264,19 @@ export function failureMessageFor(s: {
 export function chainToMessages(chain: ConversationChain): HistoryMessage[] {
   const messages: HistoryMessage[] = [];
   for (const s of chain.sessions) {
-    // Skip the user-bubble push for system-generated wake turns
-    // (watch_tasks fires). The agent still reads the wake intent via
-    // claude --resume; the chat history just shouldn't render a
-    // fake "user message" the user never typed.
-    if (!s.intent.startsWith(SYSTEM_WAKE_INTENT_OPEN)) {
+    if (s.intent.startsWith(SYSTEM_WAKE_INTENT_OPEN)) {
+      // System-generated wake turn (watch_tasks fired). Emit a `system`
+      // message with the trigger summary so the chat surface can show
+      // the user *why* the agent is suddenly running — and keep the
+      // record on reload. The agent reads the full wrapped intent via
+      // claude --resume; the user only needs the summary.
+      messages.push({
+        id: `w_${s.id}`,
+        role: "system",
+        content: extractWakeSummary(s.intent),
+        session_id: s.id,
+      });
+    } else {
       messages.push({ id: `u_${s.id}`, role: "user", content: s.intent });
     }
     if (s.status === "failed") {

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -95,11 +95,14 @@ interface HistoryMessage {
  * (agent-facing instruction, noise to the human reader).
  */
 function extractWakeSummary(intent: string): string {
-  return intent
-    .replace(new RegExp(`^${SYSTEM_WAKE_INTENT_OPEN}\\s*`), "")
-    .replace(new RegExp(`\\s*${SYSTEM_WAKE_INTENT_CLOSE}\\s*$`), "")
-    .replace(/\n+Decide next steps\.\s*$/, "")
-    .trim();
+  let s = intent;
+  if (s.startsWith(SYSTEM_WAKE_INTENT_OPEN)) {
+    s = s.slice(SYSTEM_WAKE_INTENT_OPEN.length);
+  }
+  if (s.endsWith(SYSTEM_WAKE_INTENT_CLOSE)) {
+    s = s.slice(0, -SYSTEM_WAKE_INTENT_CLOSE.length);
+  }
+  return s.replace(/\n+Decide next steps\.\s*$/, "").trim();
 }
 
 // Generic 500 — internal error text stays in server logs, indexed by

--- a/packages/web/app/(authed)/chat/chat-client.tsx
+++ b/packages/web/app/(authed)/chat/chat-client.tsx
@@ -8,6 +8,7 @@ import {
   AlertTriangle,
   ArrowRight,
   ArrowUp,
+  Eye,
   MessageSquare,
   Star,
 } from "lucide-react";
@@ -210,6 +211,9 @@ export function ChatClient() {
                 {messages.map((m, i) => {
                   const prev = messages[i - 1];
                   const isFirstInGroup = !prev || prev.role !== m.role;
+                  if (m.role === "system") {
+                    return <SystemPill key={m.id} content={m.content} />;
+                  }
                   return (
                     <Bubble
                       key={m.id}
@@ -434,6 +438,40 @@ function HeroSection({ title, children }: { title: string; children: React.React
     <div>
       <h2 className="text-xs text-muted-foreground/70 mb-2 px-1">{title}</h2>
       {children}
+    </div>
+  );
+}
+
+/**
+ * System-trigger annotation rendered as a compact pill between bubbles.
+ * Currently sourced from `<system-wake>` intents produced by the
+ * watch_tasks DB trigger ("Watch fired — 2 tasks completed: …"). Tells
+ * the user *why* the agent is suddenly running, without competing with
+ * a real agent reply for visual weight.
+ *
+ * The content is the extracted wake summary (server-side strips the
+ * wrapper tags and the trailing "Decide next steps."). We render the
+ * first line as the headline and the rest as a compact monospace body.
+ */
+function SystemPill({ content }: { content: string }) {
+  const lines = content.split("\n");
+  const headline = lines[0] ?? "";
+  const body = lines.slice(1).join("\n").trim();
+  return (
+    <div className="flex w-full justify-start mt-4">
+      <div className="w-7 mr-2 shrink-0" />
+      <div className="max-w-[78%] rounded-lg border border-border/40 bg-secondary/30 px-3 py-2 text-xs text-muted-foreground">
+        <div className="flex items-center gap-1.5 font-medium text-foreground/85">
+          <Eye className="h-3 w-3 shrink-0" />
+          <span>Watch fired</span>
+          <span className="text-muted-foreground/70 font-normal">— {headline}</span>
+        </div>
+        {body ? (
+          <div className="mt-1 whitespace-pre-wrap font-mono text-[11px] leading-5 text-muted-foreground/85">
+            {body}
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/packages/web/app/(authed)/chat/chat-client.tsx
+++ b/packages/web/app/(authed)/chat/chat-client.tsx
@@ -8,7 +8,7 @@ import {
   AlertTriangle,
   ArrowRight,
   ArrowUp,
-  Eye,
+  Bell,
   MessageSquare,
   Star,
 } from "lucide-react";
@@ -448,13 +448,14 @@ function HeroSection({ title, children }: { title: string; children: React.React
  * watch_tasks DB trigger ("Watch fired — 2 tasks completed: …"). Tells
  * the user *why* the agent is suddenly running, without competing with
  * a real agent reply for visual weight.
- *
- * The content is the extracted wake summary (server-side strips the
- * wrapper tags and the trailing "Decide next steps."). We render the
- * first line as the headline and the rest as a compact monospace body.
  */
 function SystemPill({ content }: { content: string }) {
-  const lines = content.split("\n");
+  // The server-extracted wake summary may start with a "Wake reason: <text>"
+  // line followed by a blank line. Split it out so the task summary stays
+  // the headline; otherwise we'd stack "Watch fired — Wake reason:" and
+  // demote the actual completion list into the body.
+  const { reason, summary } = splitWakeReason(content);
+  const lines = summary.split("\n");
   const headline = lines[0] ?? "";
   const body = lines.slice(1).join("\n").trim();
   return (
@@ -462,18 +463,37 @@ function SystemPill({ content }: { content: string }) {
       <div className="w-7 mr-2 shrink-0" />
       <div className="max-w-[78%] rounded-lg border border-border/40 bg-secondary/30 px-3 py-2 text-xs text-muted-foreground">
         <div className="flex items-center gap-1.5 font-medium text-foreground/85">
-          <Eye className="h-3 w-3 shrink-0" />
+          <Bell className="h-3 w-3 shrink-0" />
           <span>Watch fired</span>
-          <span className="text-muted-foreground/70 font-normal">— {headline}</span>
+          {headline ? (
+            <span className="text-muted-foreground/70 font-normal">— {headline}</span>
+          ) : null}
         </div>
+        {reason ? (
+          <div className="mt-0.5 text-[11px] italic text-muted-foreground/85">
+            {reason}
+          </div>
+        ) : null}
         {body ? (
-          <div className="mt-1 whitespace-pre-wrap font-mono text-[11px] leading-5 text-muted-foreground/85">
+          <div className="mt-1 whitespace-pre-wrap text-[11px] leading-5 text-muted-foreground/85">
             {body}
           </div>
         ) : null}
       </div>
     </div>
   );
+}
+
+/**
+ * Pull an optional `Wake reason: <text>` prefix off the summary so the UI
+ * can render it as a subtitle. Returns the rest of the summary unchanged
+ * (matches the server's emission contract — see `extractWakeSummary` in
+ * `packages/api/src/routes/chat.ts`).
+ */
+export function splitWakeReason(content: string): { reason?: string; summary: string } {
+  const m = content.match(/^Wake reason: ([^\n]+)\n+/);
+  if (!m) return { summary: content };
+  return { reason: m[1]!.trim(), summary: content.slice(m[0].length) };
 }
 
 function Bubble({

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -308,7 +308,12 @@ export interface SignupResponse {
 
 export interface ChatHistoryMessage {
   id: string;
-  role: "user" | "agent";
+  /**
+   * `system` marks autonomous trigger annotations (e.g. watch_tasks fired —
+   * "2 tasks completed: …"). Rendered as a compact pill between user/agent
+   * bubbles so the user can see *why* the agent is suddenly running.
+   */
+  role: "user" | "agent" | "system";
   content: string;
   session_id?: string;
   view_refs?: string[];

--- a/packages/web/lib/hooks/use-chat.ts
+++ b/packages/web/lib/hooks/use-chat.ts
@@ -17,7 +17,11 @@ import { queryKeys } from "./keys";
 export interface ChatMessage {
   /** Stable key for React; not persisted. */
   id: string;
-  role: "user" | "agent";
+  /**
+   * `system` is used for autonomous trigger annotations (currently just
+   * watch_tasks fires). UI renders them as compact pills between bubbles.
+   */
+  role: "user" | "agent" | "system";
   content: string;
   /** Set on agent messages so the UI can link to the session detail page. */
   session_id?: string;


### PR DESCRIPTION
## Summary

Before this, when `watch_tasks` fired the user just saw the agent thinking ball appear and the reply stream in — no signal that the agent was responding to a system-triggered wake. The wake intent was wrapped in `<system-wake>...</system-wake>` by the trigger and `chainToMessages` just skipped pushing anything for it, so the chat history was silent.

Surface a third message role for these events:

```
┌──────────────────────────────────────────────────────────────┐
│  user: ship feature Z                                        │
│  agent: I'll dispatch and watch                              │
│                                                              │
│  👁 Watch fired — 2 tasks completed:                          │
│        - Backend  — done. Result: shipped                    │
│        - Frontend — done. Result: deployed                   │
│                                                              │
│  agent: (thinking ball + streaming reply)                    │
└──────────────────────────────────────────────────────────────┘
```

The pill renders during streaming AND persists in history on reload.

## How it works

- `HistoryMessage.role` adds `system`. `chainToMessages` now emits a system message (instead of dropping the turn) when a session's intent starts with the system-wake wrapper. Content is the extracted summary — wrap tags stripped, trailing `Decide next steps.` (agent-facing prompt) dropped. `Wake reason:` prefix preserved when present.
- Web client mirrors the type: `ChatHistoryMessage.role` and `ChatMessage.role` both add `system`.
- New `SystemPill` component renders system messages as a compact left-aligned pill (Eye icon, "Watch fired — \<headline>" label, optional monospace body for the bullet list). Visually subordinate to user/agent bubbles so it reads as annotation, not participant.
- `messages.map` branches: `system → SystemPill`, otherwise → `Bubble`. The thinking block keeps rendering after the messages array, so during streaming the user sees the pill explaining the wake immediately above the streaming agent reply.

## Test plan

- [x] `pnpm --filter @beevibe/api test` — 410 passed (incl. 4 new chat-internals cases covering completed wake, pending wake during streaming, mixed chain ordering, and `Wake reason:` prefix preservation)
- [x] `pnpm --filter @beevibe/web test` — 145 passed
- [x] `pnpm --filter @beevibe/api typecheck` + `pnpm --filter @beevibe/web typecheck` — both clean
- [ ] After deploy: open a chat, dispatch + watch tasks, mark them done; the "Watch fired" pill appears in chat above the autonomous agent reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)