### PR TITLE
refactor(memory): write-side guidance around session_search routing

### DIFF
--- a/packages/api/src/tools/save-memory.ts
+++ b/packages/api/src/tools/save-memory.ts
@@ -69,14 +69,29 @@ export function createSaveMemoryTool(
   return {
     name: "save_memory",
     description:
-      "Save a fact, learning, or insight to long-term archival memory for " +
-      "retrieval across all future sessions. Store self-contained facts that " +
-      "stand alone when retrieved later (no \"we\", \"the user\", \"recently\" " +
-      "— name specific entities and use definite language). One sentence per " +
-      "call; for multiple facts, call the tool multiple times. The save date " +
-      "is auto-stamped — future retrievals show saved=YYYY-MM-DD so old facts " +
-      "can be judged for staleness. Persists across sessions; retrievable via " +
-      "the briefing's vector recall and via search_context.",
+      "Save a curated, generalized fact for retrieval in every future briefing.\n\n" +
+      "WHEN TO SAVE (proactively, mid-session — don't wait for the turn to end):\n" +
+      "- You learned a durable fact, convention, or quirk about your domain\n" +
+      "- You hit a gotcha or surprising pattern that generalizes beyond this session\n" +
+      "- You discovered a stable team preference, workflow rule, or constraint\n\n" +
+      "DO NOT SAVE — use session_search to recall these later:\n" +
+      "- Session-specific identifiers (PR/issue/ticket numbers, document IDs, file paths)\n" +
+      "- Task progress and completed-work logs (\"Phase X done\", \"shipped Y\")\n" +
+      "- One-shot session details (today's errors, a single meeting note, a specific lookup)\n" +
+      "- Anything tied to a specific past conversation\n" +
+      "Saving these bloats archival and pollutes the briefing's top-k.\n\n" +
+      "DECLARATIVE-NOT-IMPERATIVE — write facts, not instructions to yourself:\n" +
+      "  ✓ \"User prefers concise replies\"        ✗ \"Always respond concisely\"\n" +
+      "  ✓ \"Project uses Linear, not Jira\"        ✗ \"Always create issues in Linear\"\n" +
+      "Imperative phrasing gets re-read as a directive in later sessions and can " +
+      "override the user's current request.\n\n" +
+      "FORMAT: one self-contained sentence. No \"we\" / \"the user\" / \"recently\" " +
+      "— name specific entities, use definite language. For multiple facts, call " +
+      "the tool multiple times.\n\n" +
+      "The save date is auto-stamped — future retrievals show saved=YYYY-MM-DD so " +
+      "old facts can be judged for staleness. Persists across sessions; retrievable " +
+      "via the briefing's vector recall and via search_context.\n\n" +
+      "The most valuable memory makes the next session start already knowing.",
     schema: SAVE_MEMORY_SCHEMA as Record<string, unknown>,
     handler: async (input) => {
       const content = input.content;

--- a/packages/api/src/tools/update-core-memory.ts
+++ b/packages/api/src/tools/update-core-memory.ts
@@ -95,10 +95,28 @@ export function createUpdateCoreMemoryTool(
   return {
     name: "update_core_memory",
     description:
-      "Edit one of your core-memory blocks. These blocks ride in every " +
-      "future session's system prompt — treat as expensive real estate. " +
-      "The block's current contents are already visible in your " +
-      "<core_memory> render; read them there before composing the edit. " +
+      "Update your core-memory blocks when the stable state you want loaded " +
+      "into every future session changes.\n\n" +
+      "## WHEN TO UPDATE\n\n" +
+      "- Persona shift: your role, expertise, or specialization meaningfully " +
+      "changed (rare — verify it's not just one session's framing).\n" +
+      "- Durable constraint added or removed: a hard rule that should apply " +
+      "to ALL your future work, not just this project.\n" +
+      "- Stable scope shift: you're operating across new domains long-term, " +
+      "or sunsetting an old area of focus.\n" +
+      "- Accumulating-list update: a new teammate, a new team under your org.\n\n" +
+      "For generalized facts you'd want briefing-ready, use `save_memory` " +
+      "(archival). For session-specific details or events, leave them for " +
+      "`session_search` — they're already in the transcript.\n\n" +
+      "## BLOCK ROUTING\n\n" +
+      "Each block has a narrow purpose — content for one block doesn't belong " +
+      "in another. Read each block's `description` attribute in your " +
+      "<core_memory> render before writing; the `block_name` enum below lists " +
+      "what's available at your tier.\n\n" +
+      "## COST\n\n" +
+      "These blocks ride in every future session's system prompt — treat as " +
+      "expensive real estate. The block's current contents are already visible " +
+      "in your <core_memory> render; read them there before composing the edit. " +
       "This tool does not return current contents.\n\n" +
       "## Choosing between `append` and `replace`\n\n" +
       "Use `append` ONLY when the block is an accumulating list — every " +
@@ -126,9 +144,11 @@ export function createUpdateCoreMemoryTool(
       "block. The block is current state, not a log. Dated facts belong " +
       "in archival memory via `save_memory`, which auto-stamps the date.\n\n" +
       "If unsure between core and archival, prefer `save_memory` " +
-      "(archival is cheap and forgiving). Promote to core only when a " +
-      "fact has already surfaced across multiple sessions AND belongs " +
-      "in every future briefing.\n\n" +
+      "(archival is cheap and forgiving). If the info is tied to a specific " +
+      "past session, leave it for `session_search` — the transcript already " +
+      "has it. Promote to core only when a fact has already surfaced across " +
+      "multiple sessions AND belongs in every future briefing.\n\n" +
+      "The most valuable memory makes the next session start already knowing.\n\n" +
       "## Examples\n\n" +
       "GOOD — surgical fix (one substring → another):\n" +
       "  update_core_memory(\n" +

--- a/packages/core/src/services/spawn-prep.ts
+++ b/packages/core/src/services/spawn-prep.ts
@@ -206,119 +206,58 @@ work_product to record.
 </beevibe_lifecycle>`;
 
 export const BEEVIBE_MEMORY_REMINDER = `<beevibe_memory>
-You have three persistent memory layers — actively manage them THROUGHOUT
-the session, not just at the end. Mid-session memory updates compound
-across tasks; deferring them loses information when your conversation
-history is gone.
+You have three persistent memory layers — manage them proactively across the
+session, not just at the end.
 
-Layer 1 — core memory (small, in-context per session, rendered into your
-system prompt at session start as <core_memory>...</core_memory>):
-- Edit via mcp__beevibe__update_core_memory(block_name, operation, content,
-  old_content?). operation ∈ {append, replace} — see the tool's
-  description for the append-vs-replace decision criterion (append is
-  for accumulating-list blocks only; narrative blocks must be rewritten
-  via a consolidating replace).
-- Use for STABLE shifts: persona consolidations, long-term constraint
-  changes, durable patterns that should appear in every future
-  session's briefing.
-- Treat as expensive real estate — every byte is in every future system
-  prompt.
+LAYERS (read = automatic, write = your job):
+1) Core memory — small, bounded, ALWAYS in your <core_memory> system prompt
+   block. Stable state that loads into every future session. Write via
+   mcp__beevibe__update_core_memory.
+2) Archival memory — vector-indexed facts. Top-k auto-pulled into your
+   <archival_memory> briefing block; query the rest mid-session via
+   mcp__beevibe__search_context. Write via mcp__beevibe__save_memory.
+3) Session search — full past conversation transcripts (Postgres FTS).
+   Nothing to write; transcripts persist automatically. Query via
+   mcp__beevibe__session_search — see its description for discovery /
+   scroll / read / browse shapes and the filters.
 
-Layer 2 — archival memory (vector-indexed, unbounded; the briefing's
-top-k hits arrive in your USER prompt as <archival_memory>...</archival_memory>):
-- Add via mcp__beevibe__save_memory(content, fact_type). One fact per call.
-  fact_type ∈ {belief, pattern, gotcha, preference, decision}.
-- Query mid-session via mcp__beevibe__search_context(query) for facts not
-  in your briefing's top-k.
-- Use for ONE-SHOT learnings: decision rationales, gotchas, surprising
-  patterns, niche facts. Cheap; default home.
+CROSS-TOOL ROUTING — the most important question when you're about to save:
+  "Could I find this via session_search later if I needed it?"
+  YES → don't save. The transcript IS the save. Session-specific decisions,
+        identifiers (PR/issue/ticket numbers, file paths), "Phase X done",
+        event or error transcripts, today's task context all belong here.
+  NO, and it's stable state you want loaded into every future session →
+        update_core_memory.
+  NO, and it's a generalized fact you'd want briefing-ready → save_memory.
 
-Layer 3 — past conversation transcripts (Postgres FTS over what was
-actually said in prior sessions; recall via mcp__beevibe__session_search):
-- Discovery: session_search(query="...") returns matched past sessions
-  with snippet + ±5-message window + first-3 / last-3 bookends
-  (goal → match → resolution) — no LLM cost.
-- Scroll: session_search(session_id, around_message_id) widens the
-  window when discovery's ±5 isn't enough.
-- Read: session_search(session_id) dumps a whole conversation.
-- Browse: session_search() with no args lists recent activity.
-- Filters: session_type, status, agent_id, task_id, since/until.
-  The killer use case is filters={status:"failed"} to surface past
-  mistakes on similar work.
-- Scope is your tier (ic=own; team=own+subordinates; org=own+all
-  descendants). Your active conversation is excluded automatically.
+PRIORITY (when you do save):
+- Stable state about you, your scope, or your work → core
+- Generalized knowledge about your domain → archival
+The most valuable memory makes the next session start already knowing.
 
-Distinguishing the three layers — they don't replace each other:
-- core_memory: stable identity / constraints, in every system prompt.
-- save_memory + search_context: distilled facts (beliefs, gotchas,
-  decisions) the model wrote down for later.
-- session_search: what was literally said, when. Use it when you need
-  the transcript, not a fact distilled from it.
+DECLARATIVE-NOT-IMPERATIVE — write facts, not instructions to yourself:
+"User prefers concise replies" ✓ — "Always respond concisely" ✗.
+"Project uses Linear, not Jira" ✓ — "Always create issues in Linear" ✗.
+Imperative phrasing gets re-read as a directive in later sessions and can
+override the user's current request.
 
-Do NOT save these to memory — search past sessions instead:
-- Task progress, completed-work logs, "submitted PR Y", "Phase N done"
-- PR numbers, issue numbers, commit SHAs, file counts
-- Anything that will be stale in a week — if a fact won't outlast the
-  current sprint, it doesn't belong in memory. Use session_search to
-  recall it from past transcripts.
+You are a persistent specialist working across multiple projects over time.
+Keep enduring expertise distinct from current-project specifics in your core
+memory blocks — see update_core_memory for per-block routing.
 
-Write memories as declarative facts, not instructions to yourself.
-"User prefers concise responses" ✓ — "Always respond concisely" ✗.
-"Project uses pytest with xdist" ✓ — "Run tests with pytest -n 4" ✗.
-Imperative phrasing gets re-read as a directive in later sessions and
-can cause repeated work or override the user's current request.
+BEFORE SEARCHING: check your <core_memory> blocks and the <archival_memory>
+briefing block first — never search_context for facts already in your context.
+For "what did we discuss / decide / try before" questions, reach for
+session_search FIRST — past transcripts carry what was actually said when;
+search_context only returns what was distilled into facts.
 
-When to update memory (proactively, mid-session):
-- You resolved something tricky, hit a gotcha, or found a transferable
-  pattern about the codebase/domain → save_memory. Pick fact_type per
-  the tool's enum description — each type has explicit "don't save
-  this" guards (e.g. preference only for durable rules, not one-off
-  requests; pattern only for transferable knowledge, not notes-to-self
-  about your own behavior).
-- Your role/domain shifted → update_core_memory(persona/domain, ...).
+If search_context returns empty and the question is about a completed task,
+list_work_products(task_id) then get_work_product(id) to read the source of
+truth before concluding you can't answer.
 
-Before writing to a core memory block, READ THE BLOCK'S "description"
-attribute in your <core_memory> render. Each block has a narrow purpose
-— content for one block doesn't belong in another. Common mistakes:
-- Project-specific paths/repos → "active_context", NOT "domain"
-- Hard rules / conventions → "constraints", NOT "persona"
-- Codebase findings → archival memory (save_memory), NOT "domain"
-
-Agents are persistent SPECIALISTS — they work across multiple projects
-over time. The "domain" block holds enduring cross-project expertise;
-"active_context" holds the CURRENT project's specifics (rewrite on
-project shifts). Don't conflate the two.
-
-Before searching: check if the answer is already in your <core_memory>
-blocks or the <archival_memory> block from your session-start briefing —
-never call search_context for facts already in your in-context memory.
-For questions like "what did we discuss / decide / try before", reach
-for session_search FIRST — past transcripts carry what was actually
-said when; search_context only returns what was distilled into facts.
-
-If search returns empty and the question is about a completed task,
-list_work_products(task_id), then get_work_product(id) on the relevant
-row to read its full body BEFORE concluding you can't answer. Memory
-is a cache; the work product is the source of truth for what the task
-produced. Treating "no archival hit" as "no answer" makes you fail on
-questions the work product itself can answer.
-
-Promotion ladder (archival is the default, core is reserved):
-- save_memory writes archival — cheap and forgiving; that's where new
-  facts should go.
-- update_core_memory edits core — every byte ends up in every future
-  session's system prompt. Reserve for facts that have ALREADY surfaced
-  across multiple sessions AND belong in every future briefing.
-- Default rule when in doubt: save_memory. Promote later if the fact
-  keeps recurring.
-
-Staleness — retrieved facts carry saved=YYYY-MM-DD on the <fact> tag
-(both in your briefing and in search_context results). If a fact is
-months old, treat it as advisory: the world may have moved on. Verify
-against current state (read the code, ask, or check the DB) before
-relying on it. When you re-confirm an old fact, save_memory a fresh
-version with current date so future retrievals get the more recent
-write.
+STALENESS: retrieved facts carry saved=YYYY-MM-DD. Treat months-old facts as
+advisory — verify against current state. When you re-confirm an old fact,
+save_memory a fresh version so the next retrieval reflects current state.
 </beevibe_memory>`;
 
 /**


### PR DESCRIPTION
## Summary

Three coordinated text changes that move the cross-tool routing rule into the agent's actual decision-time surface, then make each tool description carry its own corner cases. Inspired by Hermes Agent's memory tool design (`hermes-agent/tools/memory_tool.py`, `agent/prompt_builder.py`).

**Why now:** with `session_search` live (#245), the existing `BEEVIBE_MEMORY_REMINDER` instructions like *"Cheap; default home"* and *"Default rule when in doubt: save_memory"* are actively wrong — they train the model to over-save things that are transcript-recoverable, bloating archival and polluting the briefing's top-k. And `save_memory`'s description is a stub (~9 lines, no WHEN, no SKIP, no session_search redirect) while `update_core_memory` carries deep PR #204 hardening — the asymmetry pushes the model to default to archival when uncertain.

## What changed

**`BEEVIBE_MEMORY_REMINDER` (`spawn-prep.ts`)** — ~165 lines → ~50:
- Drop "Cheap; default home" + "Promotion ladder" (broken cross-tool routing).
- Replace with a three-branch `CROSS-TOOL ROUTING` decision tree leading with *"Could I find this via session_search later?"*.
- Add a `PRIORITY` ladder: stable state → core, generalized knowledge → archival.
- Drop the IC-specific block-routing table — moved into `update_core_memory` where the tier-aware `block_name` enum handles per-tier routing.
- Drop per-tool mechanics (append-vs-replace, fact_type enum) — they live in tool descriptions and were drifting from them.
- Generalize examples beyond engineering (beevibe agents can be any role).

**`save_memory` (`save-memory.ts`)** — ~9 lines → ~28:
- Add `WHEN TO SAVE` triggers, role-agnostic.
- Add `DO NOT SAVE` with session_search redirect (PR/issue numbers, task progress, one-shot details).
- Add `DECLARATIVE-NOT-IMPERATIVE` with before/after examples.
- Keep the existing "definite language, no 'we'/'recently'" rule under `FORMAT`.
- Keep auto-stamp + retrieval mechanics.

**`update_core_memory` (`update-core-memory.ts`)** — opener + tail edits:
- Lead with `WHEN TO UPDATE` (persona shift, durable constraint, stable scope shift, accumulating-list update) instead of "expensive real estate" gatekeeping.
- Add a generic `BLOCK ROUTING` section pointing to the tier-aware enum.
- Move the "expensive real estate" framing into a `COST` subsection later.
- Add a session_search branch to the "if unsure" routing paragraph.
- Keep PR #204's append-vs-replace mechanics + GOOD/BAD examples verbatim.

Both write tools end with the same slogan: *"The most valuable memory makes the next session start already knowing."*

## Design principle

The split follows what the agent reads when. **System prompt** (`BEEVIBE_MEMORY_REMINDER`) carries cross-tool routing — read once at session start, cache-warm, primes the decision tree. **Tool descriptions** carry corner cases — read by the model when composing a tool call, exactly the moment the decision criteria need to fire. Duplicating routing rules between the two creates drift; consolidating each on its proper surface keeps them aligned.

## Test plan

- [x] `pnpm --filter @beevibe/core build` — clean
- [x] `pnpm --filter @beevibe/api typecheck` — clean
- [x] `pnpm --filter @beevibe/core test` non-DB suites — all passing (spawn-prep, fact-store, memory-agent, etc.)
- [x] `pnpm --filter @beevibe/api test save-memory update-core-memory` — 12/12 passing
- [ ] Smoke test in chat: confirm agent picks `save_memory` for codebase facts and skips it for PR numbers (which should go to session_search)

🤖 Generated with [Claude Code](https://claude.com/claude-code)