### PR TITLE
feat(scripts): memory-activity-report — Layer A telemetry for memory writes

### DIFF
--- a/scripts/memory-activity-report.ts
+++ b/scripts/memory-activity-report.ts
@@ -34,7 +34,7 @@ import { fileURLToPath } from "node:url";
 const here = dirname(fileURLToPath(import.meta.url));
 loadEnv({ path: resolve(here, "../.env") });
 
-import { Pool } from "pg";
+import { createPool } from "../packages/core/src/adapters/postgres/index.js";
 
 // ─────────────────────────────────────────────────────────────────────────
 // CLI args
@@ -44,18 +44,43 @@ const args = process.argv.slice(2);
 
 function arg(name: string): string | undefined {
   const idx = args.indexOf(`--${name}`);
-  return idx >= 0 ? args[idx + 1] : undefined;
+  if (idx < 0) return undefined;
+  const next = args[idx + 1];
+  // Guard against the user omitting the value: `--since --weeks 4` would
+  // otherwise capture "--weeks" as the date.
+  return next && !next.startsWith("--") ? next : undefined;
 }
 
-const WEEKS = Math.max(1, parseInt(arg("weeks") ?? "12", 10));
-const SINCE = arg("since"); // ISO date for before/after split
-
-if (!process.env.DATABASE_URL) {
-  console.error("Set DATABASE_URL (see .env or export it).");
+function die(message: string): never {
+  console.error(message);
   process.exit(1);
 }
 
-const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+const WEEKS = (() => {
+  const raw = arg("weeks") ?? "12";
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1) {
+    die(`--weeks must be a positive integer (got: ${raw}).`);
+  }
+  return n;
+})();
+
+const SINCE = (() => {
+  const raw = arg("since");
+  if (!raw) return undefined;
+  // Validate up front so we fail with a clear CLI-level message rather
+  // than seven reports in with an opaque Postgres timestamp parse error.
+  if (Number.isNaN(Date.parse(raw))) {
+    die(`--since must be an ISO date (got: ${raw}). Example: 2026-06-14`);
+  }
+  return raw;
+})();
+
+if (!process.env.DATABASE_URL) {
+  die("Set DATABASE_URL (see .env or export it).");
+}
+
+const pool = createPool({ connectionString: process.env.DATABASE_URL });
 
 // ─────────────────────────────────────────────────────────────────────────
 // Tiny print helpers (no table library — keep it scriptable)
@@ -87,7 +112,16 @@ function printRows(rows: Record<string, unknown>[]): void {
 
 function render(v: unknown): string {
   if (v === null || v === undefined) return "—";
-  if (v instanceof Date) return v.toISOString().slice(0, 10);
+  if (v instanceof Date) {
+    // node-postgres parses `::date` columns as JS Date at LOCAL midnight,
+    // so `.toISOString()` (which is UTC) shifts the day back by the
+    // local UTC offset for anyone east of UTC. Read the local components
+    // directly to keep the displayed date == the row's stored date.
+    const y = v.getFullYear();
+    const m = String(v.getMonth() + 1).padStart(2, "0");
+    const d = String(v.getDate()).padStart(2, "0");
+    return `${y}-${m}-${d}`;
+  }
   return String(v);
 }
 

--- a/scripts/memory-activity-report.ts
+++ b/scripts/memory-activity-report.ts
@@ -1,0 +1,295 @@
+/**
+ * memory-activity-report.ts — Layer A telemetry for memory write behavior.
+ *
+ * Activity-level eval signal for memory tooling. Answers questions like:
+ *   - How many archival writes per week, and which fact_types dominate?
+ *   - Which agents are dormant vs heavy writers?
+ *   - How many core blocks have ever been edited after creation?
+ *   - Did fact-type distribution shift after a given date? (before/after for
+ *     prompt-change rollouts — e.g. PR #247 merged 2026-06-14.)
+ *
+ * Not a quality metric — an activity metric. Use this as the cheap first
+ * signal; Layers B (LLM-as-judge over real sessions) and C (synthetic
+ * fixtures) cover quality.
+ *
+ * Usage:
+ *   pnpm tsx scripts/memory-activity-report.ts                       # 12-week default
+ *   pnpm tsx scripts/memory-activity-report.ts --weeks 4             # last N weeks
+ *   pnpm tsx scripts/memory-activity-report.ts --since 2026-06-14    # ±14d split around date
+ *
+ * Limitations (worth knowing before you read the numbers):
+ *   - memory_fact has full INSERT history, so archival writes are exact.
+ *   - core_memory_block has only `updated_at` (current state, no event log).
+ *     Time-series rate of core writes is NOT recoverable from current
+ *     schema. We surface the snapshot proxies (`ever_updated`,
+ *     `updated_in_30d`) but they undercount churn — a block updated 5
+ *     times in 30d shows as 1. A follow-up migration adding a
+ *     `core_memory_write_event` trigger would close that gap going forward.
+ */
+
+import { config as loadEnv } from "dotenv";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+loadEnv({ path: resolve(here, "../.env") });
+
+import { Pool } from "pg";
+
+// ─────────────────────────────────────────────────────────────────────────
+// CLI args
+// ─────────────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+
+function arg(name: string): string | undefined {
+  const idx = args.indexOf(`--${name}`);
+  return idx >= 0 ? args[idx + 1] : undefined;
+}
+
+const WEEKS = Math.max(1, parseInt(arg("weeks") ?? "12", 10));
+const SINCE = arg("since"); // ISO date for before/after split
+
+if (!process.env.DATABASE_URL) {
+  console.error("Set DATABASE_URL (see .env or export it).");
+  process.exit(1);
+}
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+// ─────────────────────────────────────────────────────────────────────────
+// Tiny print helpers (no table library — keep it scriptable)
+// ─────────────────────────────────────────────────────────────────────────
+
+function rule(title: string): void {
+  console.log(`\n${"━".repeat(76)}`);
+  console.log(`  ${title}`);
+  console.log(`${"━".repeat(76)}`);
+}
+
+function printRows(rows: Record<string, unknown>[]): void {
+  if (!rows.length) {
+    console.log("  (no rows)");
+    return;
+  }
+  const keys = Object.keys(rows[0]!);
+  const widths = keys.map((k) =>
+    Math.max(k.length, ...rows.map((r) => render(r[k]).length)),
+  );
+  console.log("  " + keys.map((k, i) => k.padEnd(widths[i]!)).join("  "));
+  console.log("  " + keys.map((_, i) => "─".repeat(widths[i]!)).join("  "));
+  for (const r of rows) {
+    console.log(
+      "  " + keys.map((k, i) => render(r[k]).padEnd(widths[i]!)).join("  "),
+    );
+  }
+}
+
+function render(v: unknown): string {
+  if (v === null || v === undefined) return "—";
+  if (v instanceof Date) return v.toISOString().slice(0, 10);
+  return String(v);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Reports
+// ─────────────────────────────────────────────────────────────────────────
+
+async function archivalActivityByWeek(): Promise<void> {
+  rule(`ARCHIVAL WRITES BY WEEK — last ${WEEKS} weeks`);
+  const { rows } = await pool.query(
+    `SELECT date_trunc('week', created_at AT TIME ZONE 'UTC')::date AS week,
+            COUNT(*)                                                AS total,
+            COUNT(*) FILTER (WHERE fact_type = 'belief')            AS belief,
+            COUNT(*) FILTER (WHERE fact_type = 'pattern')           AS pattern,
+            COUNT(*) FILTER (WHERE fact_type = 'gotcha')            AS gotcha,
+            COUNT(*) FILTER (WHERE fact_type = 'preference')        AS preference,
+            COUNT(*) FILTER (WHERE fact_type = 'decision')          AS decision,
+            COUNT(DISTINCT agent_id)                                AS active_agents
+       FROM memory_fact
+      WHERE created_at >= NOW() - $1::interval
+   GROUP BY week
+   ORDER BY week DESC`,
+    [`${WEEKS} weeks`],
+  );
+  printRows(rows);
+}
+
+async function archivalByScopeAndType(): Promise<void> {
+  rule(`ARCHIVAL BY SCOPE × FACT_TYPE — last ${WEEKS} weeks`);
+  const { rows } = await pool.query(
+    `SELECT scope, fact_type, COUNT(*) AS writes
+       FROM memory_fact
+      WHERE created_at >= NOW() - $1::interval
+   GROUP BY scope, fact_type
+   ORDER BY scope, writes DESC`,
+    [`${WEEKS} weeks`],
+  );
+  printRows(rows);
+}
+
+async function topActiveAgents(): Promise<void> {
+  rule("TOP AGENTS BY ARCHIVAL ACTIVITY — last 30 days (max 20)");
+  const { rows } = await pool.query(
+    `SELECT a.id, a.name, a.hierarchy_level                  AS tier,
+            COUNT(mf.id)                                     AS writes_30d,
+            COUNT(DISTINCT mf.fact_type)                     AS type_variety,
+            MAX(mf.created_at)::date                         AS last_write
+       FROM agent a
+       LEFT JOIN memory_fact mf
+              ON mf.agent_id = a.id
+             AND mf.created_at >= NOW() - INTERVAL '30 days'
+   GROUP BY a.id, a.name, a.hierarchy_level
+     HAVING COUNT(mf.id) > 0
+   ORDER BY writes_30d DESC
+      LIMIT 20`,
+  );
+  printRows(rows);
+}
+
+async function dormantAgents(): Promise<void> {
+  rule("AGENTS WITH NO ARCHIVAL WRITES IN 30 DAYS (max 20, newest first)");
+  const { rows } = await pool.query(
+    `SELECT a.id, a.name, a.hierarchy_level                  AS tier,
+            (SELECT MAX(created_at)::date FROM memory_fact
+              WHERE agent_id = a.id)                         AS last_write_ever,
+            a.created_at::date                               AS agent_created
+       FROM agent a
+      WHERE NOT EXISTS (
+              SELECT 1 FROM memory_fact mf
+               WHERE mf.agent_id = a.id
+                 AND mf.created_at > NOW() - INTERVAL '30 days')
+   ORDER BY a.created_at DESC
+      LIMIT 20`,
+  );
+  printRows(rows);
+}
+
+async function coreSnapshot(): Promise<void> {
+  rule("CORE MEMORY — current-state snapshot (no write history available)");
+  const { rows } = await pool.query(
+    `SELECT a.hierarchy_level                                         AS tier,
+            cmb.block_name,
+            COUNT(*)                                                  AS blocks,
+            COUNT(*) FILTER (WHERE LENGTH(cmb.content) > 0)           AS non_empty,
+            COUNT(*) FILTER (WHERE cmb.updated_at > cmb.created_at)   AS ever_updated,
+            COUNT(*) FILTER (WHERE cmb.updated_at > NOW() - INTERVAL '30 days'
+                                AND cmb.updated_at > cmb.created_at)  AS updated_30d,
+            ROUND(AVG(LENGTH(cmb.content)))                           AS avg_chars
+       FROM core_memory_block cmb
+       JOIN agent a ON a.id = cmb.agent_id
+   GROUP BY a.hierarchy_level, cmb.block_name
+   ORDER BY a.hierarchy_level, cmb.block_name`,
+  );
+  printRows(rows);
+}
+
+async function archivalToCoreRatio(): Promise<void> {
+  rule("ARCHIVAL-TO-CORE-TOUCH RATIO — last 30 days, per agent (max 25)");
+  console.log(
+    "  High ratio = lots of archival writes, never touches core (the bias problem).",
+  );
+  console.log(
+    "  Low ratio with non-zero core_touched_30d = balanced manager.\n",
+  );
+  const { rows } = await pool.query(
+    `SELECT a.id, a.name, a.hierarchy_level                  AS tier,
+            arch.cnt                                         AS archival_30d,
+            core.cnt                                         AS core_touched_30d,
+            CASE WHEN core.cnt > 0
+                 THEN ROUND(arch.cnt::numeric / core.cnt, 1) END
+                                                             AS ratio
+       FROM agent a
+       LEFT JOIN LATERAL (
+         SELECT COUNT(*) AS cnt FROM memory_fact
+          WHERE agent_id = a.id AND created_at > NOW() - INTERVAL '30 days'
+       ) arch ON TRUE
+       LEFT JOIN LATERAL (
+         SELECT COUNT(*) AS cnt FROM core_memory_block
+          WHERE agent_id = a.id
+            AND updated_at > NOW() - INTERVAL '30 days'
+            AND updated_at > created_at
+       ) core ON TRUE
+      WHERE arch.cnt > 0 OR core.cnt > 0
+   ORDER BY arch.cnt DESC NULLS LAST
+      LIMIT 25`,
+  );
+  printRows(rows);
+}
+
+async function beforeAfter(): Promise<void> {
+  if (!SINCE) return;
+
+  rule(`BEFORE / AFTER SPLIT — boundary = ${SINCE}, ±14 days each side`);
+  console.log(
+    "  Use to evaluate a prompt-change rollout (e.g. PR #247 merged 2026-06-14).\n",
+  );
+
+  const { rows: byType } = await pool.query(
+    `WITH win AS (
+       SELECT * FROM memory_fact
+        WHERE created_at >= $1::timestamptz - INTERVAL '14 days'
+          AND created_at  < $1::timestamptz + INTERVAL '14 days'
+     ),
+     totals AS (
+       SELECT
+         COUNT(*) FILTER (WHERE created_at <  $1::timestamptz) AS pre_total,
+         COUNT(*) FILTER (WHERE created_at >= $1::timestamptz) AS post_total
+         FROM win
+     )
+     SELECT
+       fact_type,
+       COUNT(*) FILTER (WHERE created_at <  $1::timestamptz)  AS pre,
+       COUNT(*) FILTER (WHERE created_at >= $1::timestamptz)  AS post,
+       ROUND(100.0 * COUNT(*) FILTER (WHERE created_at <  $1::timestamptz)
+             / NULLIF((SELECT pre_total  FROM totals), 0), 1) AS pre_pct,
+       ROUND(100.0 * COUNT(*) FILTER (WHERE created_at >= $1::timestamptz)
+             / NULLIF((SELECT post_total FROM totals), 0), 1) AS post_pct
+       FROM win
+   GROUP BY fact_type
+   ORDER BY fact_type`,
+    [SINCE],
+  );
+  console.log("  ── fact_type mix");
+  printRows(byType);
+
+  const { rows: agg } = await pool.query(
+    `WITH win AS (
+       SELECT * FROM memory_fact
+        WHERE created_at >= $1::timestamptz - INTERVAL '14 days'
+          AND created_at  < $1::timestamptz + INTERVAL '14 days'
+     )
+     SELECT
+       COUNT(DISTINCT agent_id) FILTER (WHERE created_at <  $1::timestamptz) AS agents_pre,
+       COUNT(DISTINCT agent_id) FILTER (WHERE created_at >= $1::timestamptz) AS agents_post,
+       COUNT(*) FILTER (WHERE created_at <  $1::timestamptz)                 AS writes_pre,
+       COUNT(*) FILTER (WHERE created_at >= $1::timestamptz)                 AS writes_post
+       FROM win`,
+    [SINCE],
+  );
+  console.log("\n  ── aggregate");
+  printRows(agg);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Run
+// ─────────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  try {
+    await archivalActivityByWeek();
+    await archivalByScopeAndType();
+    await topActiveAgents();
+    await dormantAgents();
+    await coreSnapshot();
+    await archivalToCoreRatio();
+    await beforeAfter();
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

A standalone TS script (`scripts/memory-activity-report.ts`) that surfaces activity-level signal on memory write behavior — the **Layer A** evaluation from the design discussion in #247's follow-up thread.

Six reports plus an optional pre/post split:

1. **Archival writes by week × fact_type** — main rate-over-time view
2. **Archival by scope × fact_type** — does ic/team/org pick different types?
3. **Top agents by archival activity** (last 30d)
4. **Dormant agents** (no archival writes in 30d)
5. **Core memory current state** snapshot (best we can do without a write log)
6. **Archival-to-core-touch ratio** per agent — surfaces the "always saves to archival, never touches core" bias that #247's prompt rewrites were meant to address

Plus an optional `--since <iso-date>` flag that adds a ±14-day pre/post split around a date, for evaluating prompt-change rollouts. Concrete use: run `--since 2026-06-14` in a couple weeks to measure #247's effect on fact-type distribution and write volume.

## Usage

```bash
pnpm tsx scripts/memory-activity-report.ts                       # default 12-week view
pnpm tsx scripts/memory-activity-report.ts --weeks 4             # narrower window
pnpm tsx scripts/memory-activity-report.ts --since 2026-06-14    # before/after split
```

Reads `DATABASE_URL` from `.env`. No new tables, no migrations — pure query-only against existing schema.

## Known limitation, called out in the script's docblock

`core_memory_block` has no write event log — only `updated_at` on the current row. So core write activity can only be reported as snapshot proxies (`ever_updated`, `updated_30d`) which **undercount churn** — a block updated 5 times in 30 days shows as 1.

A follow-up migration adding a `core_memory_write_event` trigger (mirroring `memory_promotion_event`'s shape) would close that gap going forward. Not in this PR to keep scope tight; happy to do as a follow-up.

## Where this sits in the bigger eval picture

Activity ≠ quality. This is the cheap first signal:

- **Layer A** (this PR): "what got written, by who, when, of what type"
- **Layer B** (TODO): LLM-as-judge over real sessions — "did the agent save the right things?"
- **Layer C** (TODO): Synthetic fixtures — deterministic regression eval in CI

A gives us the before/after delta for #247 within minutes. B and C come later when the methodology is worth investing in.

## Test plan

- [x] Wiring verified locally (script loads `.env`, connects on the right port, fails cleanly with `ECONNREFUSED` when DB is down).
- [ ] Run against a populated dev DB and eyeball each report's output shape.
- [ ] Run `--since 2026-06-14` in ~2 weeks to read #247's effect on fact_type distribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)