### PR TITLE
feat(memory): /memory/eval dashboard — Layer A telemetry surface

### DIFF
--- a/packages/api/src/routes/view.ts
+++ b/packages/api/src/routes/view.ts
@@ -513,10 +513,13 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
     // a 500 from the eventual Postgres parse error.
     let since: string | undefined;
     if (typeof sinceRaw === "string" && sinceRaw.trim()) {
-      if (Number.isNaN(Date.parse(sinceRaw))) {
+      // Match the UI's <input type="date"> format exactly. Date.parse is
+      // too permissive ("2026" and "0" both pass) and would leak garbage
+      // into the Postgres timestamptz cast.
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(sinceRaw) || Number.isNaN(Date.parse(sinceRaw))) {
         res.status(400).json({
           error: "invalid_since",
-          message: "since must be an ISO date (e.g. 2026-06-14)",
+          message: "since must be a YYYY-MM-DD date (e.g. 2026-06-14)",
         });
         return;
       }

--- a/packages/api/src/routes/view.ts
+++ b/packages/api/src/routes/view.ts
@@ -48,6 +48,7 @@ import { listAgents, getAgent } from "../views/agents.js";
 import { getSessionByShortId, getSessionTree, AmbiguousShortIdError } from "../views/sessions.js";
 import { listMemoryFactCounts, listMemoryFacts } from "../views/memory.js";
 import { getDashboardSummary } from "../views/dashboard.js";
+import { getMemoryActivity } from "../views/memory-activity.js";
 import { DEFAULT_MESH_WINDOW, getMeshOverview, isMeshWindow } from "../views/mesh.js";
 import { listPromotions } from "../views/promotions.js";
 import { listActivity } from "../views/activity.js";
@@ -497,6 +498,35 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
       res.json(summary);
     } catch (err) {
       handleError(err, res, "dashboard summary");
+    }
+  });
+
+  router.get("/memory/activity", async (req, res) => {
+    if (!requireHuman(req, res)) return;
+    const weeksRaw = req.query.weeks;
+    const sinceRaw = req.query.since;
+    const weeks =
+      typeof weeksRaw === "string" && weeksRaw.trim()
+        ? Number(weeksRaw)
+        : 12;
+    // Validate `since` up front so a malformed date returns 400 rather than
+    // a 500 from the eventual Postgres parse error.
+    let since: string | undefined;
+    if (typeof sinceRaw === "string" && sinceRaw.trim()) {
+      if (Number.isNaN(Date.parse(sinceRaw))) {
+        res.status(400).json({
+          error: "invalid_since",
+          message: "since must be an ISO date (e.g. 2026-06-14)",
+        });
+        return;
+      }
+      since = sinceRaw;
+    }
+    try {
+      const summary = await getMemoryActivity(deps.pool, { weeks, since });
+      res.json(summary);
+    } catch (err) {
+      handleError(err, res, "memory activity");
     }
   });
 

--- a/packages/api/src/views/memory-activity.ts
+++ b/packages/api/src/views/memory-activity.ts
@@ -156,14 +156,18 @@ interface AgentRow {
 
 async function queryTopAgents(pool: Pool): Promise<AgentActivityRow[]> {
   const { rows } = await pool.query<AgentRow>(
-    `SELECT a.id, a.name, a.hierarchy_level                  AS tier,
-            COUNT(mf.id)                                     AS writes_30d,
-            COUNT(DISTINCT mf.fact_type)                     AS type_variety,
-            MAX(mf.created_at)::date                         AS last_write
+    // `AT TIME ZONE 'UTC'` keeps last_write's day match the weekly bucket's
+    // day for facts written near a TZ boundary. archived_at filter mirrors
+    // views/agents.ts so archived agents don't surface as "top writers".
+    `SELECT a.id, a.name, a.hierarchy_level                          AS tier,
+            COUNT(mf.id)                                             AS writes_30d,
+            COUNT(DISTINCT mf.fact_type)                             AS type_variety,
+            (MAX(mf.created_at) AT TIME ZONE 'UTC')::date            AS last_write
        FROM agent a
        JOIN memory_fact mf
               ON mf.agent_id = a.id
              AND mf.created_at >= NOW() - INTERVAL '30 days'
+      WHERE a.archived_at IS NULL
    GROUP BY a.id, a.name, a.hierarchy_level
    ORDER BY writes_30d DESC
       LIMIT 20`,
@@ -188,12 +192,13 @@ interface DormantRow {
 
 async function queryDormantAgents(pool: Pool): Promise<DormantAgentRow[]> {
   const { rows } = await pool.query<DormantRow>(
-    `SELECT a.id, a.name, a.hierarchy_level                  AS tier,
-            (SELECT MAX(created_at)::date FROM memory_fact
-              WHERE agent_id = a.id)                         AS last_write_ever,
-            a.created_at::date                               AS agent_created
+    `SELECT a.id, a.name, a.hierarchy_level                          AS tier,
+            (SELECT (MAX(created_at) AT TIME ZONE 'UTC')::date
+               FROM memory_fact WHERE agent_id = a.id)               AS last_write_ever,
+            (a.created_at AT TIME ZONE 'UTC')::date                  AS agent_created
        FROM agent a
-      WHERE NOT EXISTS (
+      WHERE a.archived_at IS NULL
+        AND NOT EXISTS (
               SELECT 1 FROM memory_fact mf
                WHERE mf.agent_id = a.id
                  AND mf.created_at > NOW() - INTERVAL '30 days')
@@ -231,6 +236,7 @@ async function queryCoreSnapshot(pool: Pool): Promise<CoreSnapshotRow[]> {
             ROUND(AVG(LENGTH(cmb.content)))                           AS avg_chars
        FROM core_memory_block cmb
        JOIN agent a ON a.id = cmb.agent_id
+      WHERE a.archived_at IS NULL
    GROUP BY a.hierarchy_level, cmb.block_name
    ORDER BY a.hierarchy_level, cmb.block_name`,
   );
@@ -269,7 +275,8 @@ async function queryArchivalToCoreRatio(pool: Pool): Promise<AgentRatioRow[]> {
             AND updated_at > NOW() - INTERVAL '30 days'
             AND updated_at > created_at
        ) core ON TRUE
-      WHERE arch.cnt > 0 OR core.cnt > 0
+      WHERE a.archived_at IS NULL
+        AND (arch.cnt > 0 OR core.cnt > 0)
    ORDER BY arch.cnt DESC
       LIMIT 25`,
   );

--- a/packages/api/src/views/memory-activity.ts
+++ b/packages/api/src/views/memory-activity.ts
@@ -1,0 +1,419 @@
+/**
+ * Memory-activity view — Layer A telemetry for the /memory/eval dashboard.
+ *
+ * Six parallel queries that surface "what got written, by whom, when, of
+ * what type" plus an optional before/after split. Activity-level signal —
+ * not a quality metric. Mirrors the queries in `scripts/memory-activity-
+ * report.ts` (the developer-side ad-hoc tool); this view is the dashboard
+ * surface for the same data.
+ *
+ * Known limitation: core_memory_block has no write event log, only
+ * `updated_at` on the current row. `core_snapshot` and `core_touched_30d`
+ * use snapshot proxies that undercount churn (a block updated 5× in 30d
+ * shows as 1). A follow-up trigger-backed event table would close that gap.
+ */
+
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import type {
+  AgentRatioRow,
+  AgentActivityRow,
+  BeforeAfterData,
+  CoreSnapshotRow,
+  DormantAgentRow,
+  MemoryActivitySummary,
+  MemoryActivityKpis,
+  ScopeTypeRow,
+  WeeklyArchivalRow,
+} from "./types.js";
+
+export interface MemoryActivityOptions {
+  /** Window for weekly trend + scope×type breakdown. Clamped 1..52. */
+  weeks: number;
+  /** ISO date for before/after split. When absent, before_after is omitted. */
+  since?: string;
+}
+
+export async function getMemoryActivity(
+  pool: Pool,
+  opts: MemoryActivityOptions,
+): Promise<MemoryActivitySummary> {
+  const weeks = clampInt(opts.weeks, 1, 52, 12);
+  const weeksInterval = `${weeks} weeks`;
+
+  const [
+    weekly,
+    byScopeType,
+    topAgents,
+    dormant,
+    coreSnapshot,
+    ratio,
+    kpis,
+    beforeAfter,
+  ] = await Promise.all([
+    queryWeeklyArchival(pool, weeksInterval),
+    queryScopeTypeBreakdown(pool, weeksInterval),
+    queryTopAgents(pool),
+    queryDormantAgents(pool),
+    queryCoreSnapshot(pool),
+    queryArchivalToCoreRatio(pool),
+    queryKpis(pool),
+    opts.since ? queryBeforeAfter(pool, opts.since) : Promise.resolve(undefined),
+  ]);
+
+  return {
+    weeks,
+    since: opts.since ?? null,
+    kpis,
+    weekly_archival: weekly,
+    by_scope_and_type: byScopeType,
+    top_agents: topAgents,
+    dormant_agents: dormant,
+    core_snapshot: coreSnapshot,
+    archival_to_core_per_agent: ratio,
+    before_after: beforeAfter,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Queries
+// ─────────────────────────────────────────────────────────────────────────
+
+interface WeeklyRow {
+  week: Date;
+  total: string;
+  belief: string;
+  pattern: string;
+  gotcha: string;
+  preference: string;
+  decision: string;
+  active_agents: string;
+}
+
+async function queryWeeklyArchival(
+  pool: Pool,
+  interval: string,
+): Promise<WeeklyArchivalRow[]> {
+  const { rows } = await pool.query<WeeklyRow>(
+    `SELECT date_trunc('week', created_at AT TIME ZONE 'UTC')::date AS week,
+            COUNT(*)                                                AS total,
+            COUNT(*) FILTER (WHERE fact_type = 'belief')            AS belief,
+            COUNT(*) FILTER (WHERE fact_type = 'pattern')           AS pattern,
+            COUNT(*) FILTER (WHERE fact_type = 'gotcha')            AS gotcha,
+            COUNT(*) FILTER (WHERE fact_type = 'preference')        AS preference,
+            COUNT(*) FILTER (WHERE fact_type = 'decision')          AS decision,
+            COUNT(DISTINCT agent_id)                                AS active_agents
+       FROM memory_fact
+      WHERE created_at >= NOW() - $1::interval
+   GROUP BY week
+   ORDER BY week ASC`,
+    [interval],
+  );
+  return rows.map((r) => ({
+    week: localDate(r.week),
+    total: Number(r.total),
+    belief: Number(r.belief),
+    pattern: Number(r.pattern),
+    gotcha: Number(r.gotcha),
+    preference: Number(r.preference),
+    decision: Number(r.decision),
+    active_agents: Number(r.active_agents),
+  }));
+}
+
+interface ScopeTypeQueryRow {
+  scope: "ic" | "team" | "org";
+  fact_type: string;
+  writes: string;
+}
+
+async function queryScopeTypeBreakdown(
+  pool: Pool,
+  interval: string,
+): Promise<ScopeTypeRow[]> {
+  const { rows } = await pool.query<ScopeTypeQueryRow>(
+    `SELECT scope, fact_type, COUNT(*) AS writes
+       FROM memory_fact
+      WHERE created_at >= NOW() - $1::interval
+   GROUP BY scope, fact_type
+   ORDER BY scope, writes DESC`,
+    [interval],
+  );
+  return rows.map((r) => ({
+    scope: r.scope,
+    fact_type: r.fact_type,
+    writes: Number(r.writes),
+  }));
+}
+
+interface AgentRow {
+  id: string;
+  name: string;
+  tier: string;
+  writes_30d: string;
+  type_variety: string;
+  last_write: Date;
+}
+
+async function queryTopAgents(pool: Pool): Promise<AgentActivityRow[]> {
+  const { rows } = await pool.query<AgentRow>(
+    `SELECT a.id, a.name, a.hierarchy_level                  AS tier,
+            COUNT(mf.id)                                     AS writes_30d,
+            COUNT(DISTINCT mf.fact_type)                     AS type_variety,
+            MAX(mf.created_at)::date                         AS last_write
+       FROM agent a
+       JOIN memory_fact mf
+              ON mf.agent_id = a.id
+             AND mf.created_at >= NOW() - INTERVAL '30 days'
+   GROUP BY a.id, a.name, a.hierarchy_level
+   ORDER BY writes_30d DESC
+      LIMIT 20`,
+  );
+  return rows.map((r) => ({
+    agent_id: r.id,
+    name: r.name,
+    tier: r.tier,
+    writes_30d: Number(r.writes_30d),
+    type_variety: Number(r.type_variety),
+    last_write: localDate(r.last_write),
+  }));
+}
+
+interface DormantRow {
+  id: string;
+  name: string;
+  tier: string;
+  last_write_ever: Date | null;
+  agent_created: Date;
+}
+
+async function queryDormantAgents(pool: Pool): Promise<DormantAgentRow[]> {
+  const { rows } = await pool.query<DormantRow>(
+    `SELECT a.id, a.name, a.hierarchy_level                  AS tier,
+            (SELECT MAX(created_at)::date FROM memory_fact
+              WHERE agent_id = a.id)                         AS last_write_ever,
+            a.created_at::date                               AS agent_created
+       FROM agent a
+      WHERE NOT EXISTS (
+              SELECT 1 FROM memory_fact mf
+               WHERE mf.agent_id = a.id
+                 AND mf.created_at > NOW() - INTERVAL '30 days')
+   ORDER BY a.created_at DESC
+      LIMIT 20`,
+  );
+  return rows.map((r) => ({
+    agent_id: r.id,
+    name: r.name,
+    tier: r.tier,
+    last_write_ever: r.last_write_ever ? localDate(r.last_write_ever) : null,
+    agent_created: localDate(r.agent_created),
+  }));
+}
+
+interface CoreRow {
+  tier: string;
+  block_name: string;
+  blocks: string;
+  non_empty: string;
+  ever_updated: string;
+  updated_30d: string;
+  avg_chars: string | null;
+}
+
+async function queryCoreSnapshot(pool: Pool): Promise<CoreSnapshotRow[]> {
+  const { rows } = await pool.query<CoreRow>(
+    `SELECT a.hierarchy_level                                         AS tier,
+            cmb.block_name,
+            COUNT(*)                                                  AS blocks,
+            COUNT(*) FILTER (WHERE LENGTH(cmb.content) > 0)           AS non_empty,
+            COUNT(*) FILTER (WHERE cmb.updated_at > cmb.created_at)   AS ever_updated,
+            COUNT(*) FILTER (WHERE cmb.updated_at > NOW() - INTERVAL '30 days'
+                                AND cmb.updated_at > cmb.created_at)  AS updated_30d,
+            ROUND(AVG(LENGTH(cmb.content)))                           AS avg_chars
+       FROM core_memory_block cmb
+       JOIN agent a ON a.id = cmb.agent_id
+   GROUP BY a.hierarchy_level, cmb.block_name
+   ORDER BY a.hierarchy_level, cmb.block_name`,
+  );
+  return rows.map((r) => ({
+    tier: r.tier,
+    block_name: r.block_name,
+    blocks: Number(r.blocks),
+    non_empty: Number(r.non_empty),
+    ever_updated: Number(r.ever_updated),
+    updated_30d: Number(r.updated_30d),
+    avg_chars: r.avg_chars === null ? 0 : Number(r.avg_chars),
+  }));
+}
+
+interface RatioRow {
+  id: string;
+  name: string;
+  tier: string;
+  archival_30d: string;
+  core_touched_30d: string;
+}
+
+async function queryArchivalToCoreRatio(pool: Pool): Promise<AgentRatioRow[]> {
+  const { rows } = await pool.query<RatioRow>(
+    `SELECT a.id, a.name, a.hierarchy_level                  AS tier,
+            arch.cnt                                         AS archival_30d,
+            core.cnt                                         AS core_touched_30d
+       FROM agent a
+       LEFT JOIN LATERAL (
+         SELECT COUNT(*) AS cnt FROM memory_fact
+          WHERE agent_id = a.id AND created_at > NOW() - INTERVAL '30 days'
+       ) arch ON TRUE
+       LEFT JOIN LATERAL (
+         SELECT COUNT(*) AS cnt FROM core_memory_block
+          WHERE agent_id = a.id
+            AND updated_at > NOW() - INTERVAL '30 days'
+            AND updated_at > created_at
+       ) core ON TRUE
+      WHERE arch.cnt > 0 OR core.cnt > 0
+   ORDER BY arch.cnt DESC
+      LIMIT 25`,
+  );
+  return rows.map((r) => {
+    const archival = Number(r.archival_30d);
+    const core = Number(r.core_touched_30d);
+    return {
+      agent_id: r.id,
+      name: r.name,
+      tier: r.tier,
+      archival_30d: archival,
+      core_touched_30d: core,
+      // null when no core touches — caller renders as "—" rather than ∞.
+      ratio: core > 0 ? Math.round((archival / core) * 10) / 10 : null,
+    };
+  });
+}
+
+interface KpiRow {
+  archival_writes_30d: string;
+  core_touched_30d: string;
+  active_agents_30d: string;
+}
+
+async function queryKpis(pool: Pool): Promise<MemoryActivityKpis> {
+  const { rows } = await pool.query<KpiRow>(
+    `SELECT
+       (SELECT COUNT(*) FROM memory_fact
+         WHERE created_at > NOW() - INTERVAL '30 days')        AS archival_writes_30d,
+       (SELECT COUNT(*) FROM core_memory_block
+         WHERE updated_at > NOW() - INTERVAL '30 days'
+           AND updated_at > created_at)                         AS core_touched_30d,
+       (SELECT COUNT(DISTINCT agent_id) FROM memory_fact
+         WHERE created_at > NOW() - INTERVAL '30 days')        AS active_agents_30d`,
+  );
+  const r = rows[0]!;
+  const archival = Number(r.archival_writes_30d);
+  const core = Number(r.core_touched_30d);
+  return {
+    archival_writes_30d: archival,
+    core_touched_30d: core,
+    active_agents_30d: Number(r.active_agents_30d),
+    archival_to_core_ratio:
+      core > 0 ? Math.round((archival / core) * 10) / 10 : null,
+  };
+}
+
+interface BeforeAfterTypeRow {
+  fact_type: string;
+  pre: string;
+  post: string;
+  pre_pct: string | null;
+  post_pct: string | null;
+}
+
+interface BeforeAfterAggRow {
+  agents_pre: string;
+  agents_post: string;
+  writes_pre: string;
+  writes_post: string;
+}
+
+async function queryBeforeAfter(
+  pool: Pool,
+  since: string,
+): Promise<BeforeAfterData> {
+  const [byType, agg] = await Promise.all([
+    pool.query<BeforeAfterTypeRow>(
+      `WITH win AS (
+         SELECT * FROM memory_fact
+          WHERE created_at >= $1::timestamptz - INTERVAL '14 days'
+            AND created_at  < $1::timestamptz + INTERVAL '14 days'
+       ),
+       totals AS (
+         SELECT
+           COUNT(*) FILTER (WHERE created_at <  $1::timestamptz) AS pre_total,
+           COUNT(*) FILTER (WHERE created_at >= $1::timestamptz) AS post_total
+           FROM win
+       )
+       SELECT
+         fact_type,
+         COUNT(*) FILTER (WHERE created_at <  $1::timestamptz)  AS pre,
+         COUNT(*) FILTER (WHERE created_at >= $1::timestamptz)  AS post,
+         ROUND(100.0 * COUNT(*) FILTER (WHERE created_at <  $1::timestamptz)
+               / NULLIF((SELECT pre_total  FROM totals), 0), 1) AS pre_pct,
+         ROUND(100.0 * COUNT(*) FILTER (WHERE created_at >= $1::timestamptz)
+               / NULLIF((SELECT post_total FROM totals), 0), 1) AS post_pct
+         FROM win
+     GROUP BY fact_type
+     ORDER BY fact_type`,
+      [since],
+    ),
+    pool.query<BeforeAfterAggRow>(
+      `WITH win AS (
+         SELECT * FROM memory_fact
+          WHERE created_at >= $1::timestamptz - INTERVAL '14 days'
+            AND created_at  < $1::timestamptz + INTERVAL '14 days'
+       )
+       SELECT
+         COUNT(DISTINCT agent_id) FILTER (WHERE created_at <  $1::timestamptz) AS agents_pre,
+         COUNT(DISTINCT agent_id) FILTER (WHERE created_at >= $1::timestamptz) AS agents_post,
+         COUNT(*) FILTER (WHERE created_at <  $1::timestamptz)                 AS writes_pre,
+         COUNT(*) FILTER (WHERE created_at >= $1::timestamptz)                 AS writes_post
+         FROM win`,
+      [since],
+    ),
+  ]);
+
+  const a = agg.rows[0]!;
+  return {
+    since,
+    by_type: byType.rows.map((r) => ({
+      fact_type: r.fact_type,
+      pre: Number(r.pre),
+      post: Number(r.post),
+      pre_pct: r.pre_pct === null ? null : Number(r.pre_pct),
+      post_pct: r.post_pct === null ? null : Number(r.post_pct),
+    })),
+    agg: {
+      agents_pre: Number(a.agents_pre),
+      agents_post: Number(a.agents_post),
+      writes_pre: Number(a.writes_pre),
+      writes_post: Number(a.writes_post),
+    },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+function clampInt(value: number, min: number, max: number, fallback: number): number {
+  if (!Number.isFinite(value) || value < min) return fallback;
+  return Math.min(Math.max(Math.trunc(value), min), max);
+}
+
+/**
+ * node-postgres parses `::date` columns as JS Date at LOCAL midnight, so
+ * `.toISOString()` (UTC) would shift the day by the local offset. Read the
+ * local components and emit "YYYY-MM-DD".
+ */
+function localDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}

--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -490,6 +490,113 @@ export interface DashboardSummary {
   usage_summary: UsageSummaryData;
 }
 
+// ── Memory activity (Layer A eval) ──────────────────────────────────────────
+//
+// Powers the /memory/eval dashboard. Activity-level signal — what got
+// written, by whom, when, of what type — plus an optional ±14d before/after
+// split for evaluating prompt-change rollouts. Pure data composer; web
+// formats display fields.
+
+export interface MemoryActivityKpis {
+  archival_writes_30d: number;
+  /** Distinct core blocks with updated_at within 30d. Snapshot proxy. */
+  core_touched_30d: number;
+  active_agents_30d: number;
+  /** archival_writes_30d / core_touched_30d, rounded to 1 decimal. null if denominator is 0. */
+  archival_to_core_ratio: number | null;
+}
+
+export interface WeeklyArchivalRow {
+  /** Week-start (Monday) in YYYY-MM-DD. */
+  week: string;
+  total: number;
+  belief: number;
+  pattern: number;
+  gotcha: number;
+  preference: number;
+  decision: number;
+  active_agents: number;
+}
+
+export interface ScopeTypeRow {
+  scope: "ic" | "team" | "org";
+  fact_type: string;
+  writes: number;
+}
+
+export interface AgentActivityRow {
+  agent_id: string;
+  name: string;
+  tier: string;
+  writes_30d: number;
+  type_variety: number;
+  /** YYYY-MM-DD. */
+  last_write: string;
+}
+
+export interface DormantAgentRow {
+  agent_id: string;
+  name: string;
+  tier: string;
+  /** YYYY-MM-DD, or null if agent has never written archival. */
+  last_write_ever: string | null;
+  agent_created: string;
+}
+
+export interface CoreSnapshotRow {
+  tier: string;
+  block_name: string;
+  blocks: number;
+  non_empty: number;
+  ever_updated: number;
+  updated_30d: number;
+  avg_chars: number;
+}
+
+export interface AgentRatioRow {
+  agent_id: string;
+  name: string;
+  tier: string;
+  archival_30d: number;
+  core_touched_30d: number;
+  /** null when core_touched_30d == 0 (caller renders as "—" rather than ∞). */
+  ratio: number | null;
+}
+
+export interface BeforeAfterData {
+  /** The boundary date, as passed in by the caller. */
+  since: string;
+  by_type: Array<{
+    fact_type: string;
+    pre: number;
+    post: number;
+    pre_pct: number | null;
+    post_pct: number | null;
+  }>;
+  agg: {
+    agents_pre: number;
+    agents_post: number;
+    writes_pre: number;
+    writes_post: number;
+  };
+}
+
+export interface MemoryActivitySummary {
+  /** Echoed back so the web doesn't need to track local state. */
+  weeks: number;
+  /** Echoed back; null when ?since= wasn't provided. */
+  since: string | null;
+  kpis: MemoryActivityKpis;
+  weekly_archival: WeeklyArchivalRow[];
+  by_scope_and_type: ScopeTypeRow[];
+  top_agents: AgentActivityRow[];
+  dormant_agents: DormantAgentRow[];
+  core_snapshot: CoreSnapshotRow[];
+  archival_to_core_per_agent: AgentRatioRow[];
+  /** Present only when ?since= was provided. */
+  before_after?: BeforeAfterData;
+}
+
 // ── Mesh ────────────────────────────────────────────────────────────────────
 //
 // Mesh data DTO. Like the dashboard, the web composes display fields

--- a/packages/web/app/(authed)/memory/eval/eval-client.tsx
+++ b/packages/web/app/(authed)/memory/eval/eval-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { AlertTriangle, ArrowLeft, BarChart3 } from "lucide-react";
 import { useMemoryActivity } from "@/lib/hooks/use-memory-activity";
@@ -22,32 +22,24 @@ import type {
 const FACT_TYPES = ["belief", "pattern", "gotcha", "preference", "decision"] as const;
 type FactType = (typeof FACT_TYPES)[number];
 
-// Stable colour assignment per fact_type. Tailwind palette stand-ins so the
-// chart doesn't need a runtime colour generator.
-const TYPE_FILL: Record<FactType, string> = {
-  belief: "fill-sky-500/70",
-  pattern: "fill-violet-500/70",
-  gotcha: "fill-amber-500/80",
-  preference: "fill-emerald-500/70",
-  decision: "fill-rose-500/70",
-};
-
-const TYPE_DOT: Record<FactType, string> = {
-  belief: "bg-sky-500/70",
-  pattern: "bg-violet-500/70",
-  gotcha: "bg-amber-500/80",
-  preference: "bg-emerald-500/70",
-  decision: "bg-rose-500/70",
+// Use the same design tokens that drive FactTypeTag on /memory so the
+// chart's colour assignment matches what users see on individual facts.
+// Tailwind extends fill-* with the color palette, so `fill-type-{ft}-fg`
+// resolves to the same HSL var as `bg-type-{ft}-fg`.
+const TYPE_COLOR: Record<FactType, { fill: string; dot: string }> = {
+  belief: { fill: "fill-type-belief-fg", dot: "bg-type-belief-fg" },
+  pattern: { fill: "fill-type-pattern-fg", dot: "bg-type-pattern-fg" },
+  gotcha: { fill: "fill-type-gotcha-fg", dot: "bg-type-gotcha-fg" },
+  preference: { fill: "fill-type-preference-fg", dot: "bg-type-preference-fg" },
+  decision: { fill: "fill-type-decision-fg", dot: "bg-type-decision-fg" },
 };
 
 export function MemoryEvalClient() {
   const [weeks, setWeeks] = useState(12);
   const [since, setSince] = useState<string>("");
 
-  const params = useMemo(
-    () => ({ weeks, since: since || undefined }),
-    [weeks, since],
-  );
+  // queryKey uses structural equality, so no useMemo wrap needed.
+  const params = { weeks, since: since || undefined };
 
   const { data, isLoading, isError } = useMemoryActivity(params);
 
@@ -304,7 +296,7 @@ function WeeklyChart({ rows }: { rows: WeeklyArchivalRow[] }) {
                       y={y}
                       width={barW}
                       height={hh}
-                      className={TYPE_FILL[ft]}
+                      className={TYPE_COLOR[ft].fill}
                     >
                       <title>{`${r.week} · ${ft}: ${v}`}</title>
                     </rect>
@@ -333,7 +325,7 @@ function Legend() {
     <div className="flex flex-wrap gap-3 text-[10px] text-muted-foreground mt-2">
       {FACT_TYPES.map((ft) => (
         <span key={ft} className="inline-flex items-center gap-1.5">
-          <span className={`h-2 w-2 rounded-sm ${TYPE_DOT[ft]}`} />
+          <span className={`h-2 w-2 rounded-sm ${TYPE_COLOR[ft].dot}`} />
           {ft}
         </span>
       ))}

--- a/packages/web/app/(authed)/memory/eval/eval-client.tsx
+++ b/packages/web/app/(authed)/memory/eval/eval-client.tsx
@@ -1,0 +1,673 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { AlertTriangle, ArrowLeft, BarChart3 } from "lucide-react";
+import { useMemoryActivity } from "@/lib/hooks/use-memory-activity";
+import { isApiConfigured } from "@/lib/api/config";
+import { EmptyState } from "@/components/empty-state";
+import { Skeleton } from "@/components/skeleton";
+import type {
+  AgentActivityRow,
+  AgentRatioRow,
+  BeforeAfterData,
+  CoreSnapshotRow,
+  DormantAgentRow,
+  MemoryActivityKpis,
+  MemoryActivitySummary,
+  ScopeTypeRow,
+  WeeklyArchivalRow,
+} from "@/lib/api/types";
+
+const FACT_TYPES = ["belief", "pattern", "gotcha", "preference", "decision"] as const;
+type FactType = (typeof FACT_TYPES)[number];
+
+// Stable colour assignment per fact_type. Tailwind palette stand-ins so the
+// chart doesn't need a runtime colour generator.
+const TYPE_FILL: Record<FactType, string> = {
+  belief: "fill-sky-500/70",
+  pattern: "fill-violet-500/70",
+  gotcha: "fill-amber-500/80",
+  preference: "fill-emerald-500/70",
+  decision: "fill-rose-500/70",
+};
+
+const TYPE_DOT: Record<FactType, string> = {
+  belief: "bg-sky-500/70",
+  pattern: "bg-violet-500/70",
+  gotcha: "bg-amber-500/80",
+  preference: "bg-emerald-500/70",
+  decision: "bg-rose-500/70",
+};
+
+export function MemoryEvalClient() {
+  const [weeks, setWeeks] = useState(12);
+  const [since, setSince] = useState<string>("");
+
+  const params = useMemo(
+    () => ({ weeks, since: since || undefined }),
+    [weeks, since],
+  );
+
+  const { data, isLoading, isError } = useMemoryActivity(params);
+
+  if (!isApiConfigured) {
+    return (
+      <EmptyState
+        icon={BarChart3}
+        title="Memory eval not connected"
+        description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load Layer A activity telemetry."
+      />
+    );
+  }
+  if (isError) {
+    return (
+      <EmptyState
+        icon={AlertTriangle}
+        title="Couldn't load memory activity"
+        description="Check that the api server is reachable."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-10">
+      <Header
+        weeks={weeks}
+        onWeeksChange={setWeeks}
+        since={since}
+        onSinceChange={setSince}
+      />
+      {isLoading || !data ? <LoadingState /> : <Body data={data} />}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Header + controls
+// ─────────────────────────────────────────────────────────────────────────
+
+function Header({
+  weeks,
+  onWeeksChange,
+  since,
+  onSinceChange,
+}: {
+  weeks: number;
+  onWeeksChange: (n: number) => void;
+  since: string;
+  onSinceChange: (s: string) => void;
+}) {
+  return (
+    <header className="space-y-4">
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <Link
+          href="/memory"
+          className="inline-flex items-center gap-1 hover:text-foreground transition-colors"
+        >
+          <ArrowLeft className="h-3 w-3" />
+          Memory
+        </Link>
+        <span>/</span>
+        <span className="text-foreground">Eval</span>
+      </div>
+      <div>
+        <h1 className="text-lg font-semibold tracking-tight">Memory eval</h1>
+        <p className="mt-1 text-sm text-muted-foreground max-w-prose">
+          Activity-level signal on what got written, by whom, when, and of what
+          type. Not a quality metric — the cheap first cut on whether memory
+          tooling is doing what we want.
+        </p>
+      </div>
+      <div className="flex flex-wrap items-center gap-4 text-xs">
+        <label className="flex items-center gap-2">
+          <span className="text-muted-foreground">Window</span>
+          <select
+            value={weeks}
+            onChange={(e) => onWeeksChange(Number(e.target.value))}
+            className="bg-background border border-border rounded px-2 py-1"
+          >
+            {[4, 8, 12, 26, 52].map((w) => (
+              <option key={w} value={w}>
+                {w} weeks
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-2">
+          <span className="text-muted-foreground">Compare around</span>
+          <input
+            type="date"
+            value={since}
+            onChange={(e) => onSinceChange(e.target.value)}
+            className="bg-background border border-border rounded px-2 py-1"
+          />
+          {since ? (
+            <button
+              type="button"
+              onClick={() => onSinceChange("")}
+              className="text-muted-foreground hover:text-foreground"
+            >
+              clear
+            </button>
+          ) : null}
+        </label>
+      </div>
+    </header>
+  );
+}
+
+function LoadingState() {
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {[0, 1, 2, 3].map((i) => (
+          <Skeleton key={i} className="h-20 rounded-lg" />
+        ))}
+      </div>
+      <Skeleton className="h-60 rounded-lg" />
+      <Skeleton className="h-48 rounded-lg" />
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Body — all sections
+// ─────────────────────────────────────────────────────────────────────────
+
+function Body({ data }: { data: MemoryActivitySummary }) {
+  return (
+    <>
+      <KpiRow kpis={data.kpis} />
+      <WeeklyChart rows={data.weekly_archival} />
+      <ScopeTypeSection rows={data.by_scope_and_type} />
+      <div className="grid md:grid-cols-2 gap-6">
+        <TopAgentsTable rows={data.top_agents} />
+        <DormantAgentsTable rows={data.dormant_agents} />
+      </div>
+      <CoreSnapshotTable rows={data.core_snapshot} />
+      <RatioTable rows={data.archival_to_core_per_agent} />
+      {data.before_after ? <BeforeAfterPanel data={data.before_after} /> : null}
+    </>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// KPI tiles
+// ─────────────────────────────────────────────────────────────────────────
+
+function KpiRow({ kpis }: { kpis: MemoryActivityKpis }) {
+  const tiles = [
+    { label: "Archival writes · 30d", value: fmt(kpis.archival_writes_30d) },
+    { label: "Core blocks touched · 30d", value: fmt(kpis.core_touched_30d) },
+    { label: "Active writing agents · 30d", value: fmt(kpis.active_agents_30d) },
+    {
+      label: "Archival ÷ core touches",
+      value: kpis.archival_to_core_ratio === null
+        ? "—"
+        : kpis.archival_to_core_ratio.toString(),
+      caption:
+        kpis.archival_to_core_ratio === null
+          ? "no core touches"
+          : "higher = more archival-biased",
+    },
+  ];
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      {tiles.map((t) => (
+        <div key={t.label} className="rounded-lg glass-surface p-4">
+          <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1.5">
+            {t.label}
+          </div>
+          <div className="text-2xl font-semibold tabular-nums">{t.value}</div>
+          {"caption" in t && t.caption ? (
+            <div className="text-[10px] text-muted-foreground mt-1">
+              {t.caption}
+            </div>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Weekly trend — stacked SVG bars per fact_type
+// ─────────────────────────────────────────────────────────────────────────
+
+function WeeklyChart({ rows }: { rows: WeeklyArchivalRow[] }) {
+  if (!rows.length) {
+    return (
+      <Card title="Archival writes · weekly" subtitle="no writes in window" />
+    );
+  }
+  const max = Math.max(1, ...rows.map((r) => r.total));
+  const w = 700;
+  const h = 200;
+  const padL = 40;
+  const padR = 16;
+  const padT = 16;
+  const padB = 28;
+  const innerW = w - padL - padR;
+  const innerH = h - padT - padB;
+  const slot = innerW / rows.length;
+  const barW = Math.min(40, slot * 0.7);
+  const total = rows.reduce((a, r) => a + r.total, 0);
+
+  return (
+    <Card title="Archival writes · weekly" subtitle={`${total} total`}>
+      <div className="overflow-x-auto">
+        <svg
+          viewBox={`0 0 ${w} ${h}`}
+          className="w-full h-auto text-muted-foreground"
+        >
+          {/* Y-axis ticks */}
+          {[0, 0.5, 1].map((t) => {
+            const y = padT + innerH * (1 - t);
+            return (
+              <g key={t}>
+                <line
+                  x1={padL}
+                  x2={w - padR}
+                  y1={y}
+                  y2={y}
+                  className="stroke-border/40"
+                  strokeDasharray="2 3"
+                />
+                <text
+                  x={padL - 6}
+                  y={y}
+                  className="fill-current text-[10px]"
+                  textAnchor="end"
+                  dominantBaseline="middle"
+                >
+                  {Math.round(max * t)}
+                </text>
+              </g>
+            );
+          })}
+          {/* Stacked bars */}
+          {rows.map((r, i) => {
+            const x = padL + slot * i + (slot - barW) / 2;
+            let y = padT + innerH;
+            return (
+              <g key={r.week}>
+                {FACT_TYPES.map((ft) => {
+                  const v = r[ft] as number;
+                  if (!v) return null;
+                  const hh = (v / max) * innerH;
+                  y -= hh;
+                  return (
+                    <rect
+                      key={ft}
+                      x={x}
+                      y={y}
+                      width={barW}
+                      height={hh}
+                      className={TYPE_FILL[ft]}
+                    >
+                      <title>{`${r.week} · ${ft}: ${v}`}</title>
+                    </rect>
+                  );
+                })}
+                <text
+                  x={x + barW / 2}
+                  y={h - padB + 14}
+                  className="fill-current text-[9px]"
+                  textAnchor="middle"
+                >
+                  {r.week.slice(5)}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+      <Legend />
+    </Card>
+  );
+}
+
+function Legend() {
+  return (
+    <div className="flex flex-wrap gap-3 text-[10px] text-muted-foreground mt-2">
+      {FACT_TYPES.map((ft) => (
+        <span key={ft} className="inline-flex items-center gap-1.5">
+          <span className={`h-2 w-2 rounded-sm ${TYPE_DOT[ft]}`} />
+          {ft}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Scope × fact_type breakdown
+// ─────────────────────────────────────────────────────────────────────────
+
+function ScopeTypeSection({ rows }: { rows: ScopeTypeRow[] }) {
+  // Pivot to scope × fact_type matrix.
+  const scopes: Array<"ic" | "team" | "org"> = ["ic", "team", "org"];
+  const byScope: Record<string, Record<string, number>> = {};
+  for (const r of rows) {
+    byScope[r.scope] = byScope[r.scope] ?? {};
+    byScope[r.scope]![r.fact_type] = r.writes;
+  }
+  return (
+    <Card title="Archival writes · scope × fact_type">
+      <table className="w-full text-xs">
+        <thead className="text-muted-foreground text-[10px] uppercase tracking-wider">
+          <tr className="border-b border-border/40">
+            <th className="text-left py-1.5">Scope</th>
+            {FACT_TYPES.map((ft) => (
+              <th key={ft} className="text-right py-1.5">
+                {ft}
+              </th>
+            ))}
+            <th className="text-right py-1.5">Total</th>
+          </tr>
+        </thead>
+        <tbody className="tabular-nums">
+          {scopes.map((scope) => {
+            const row = byScope[scope] ?? {};
+            const total = Object.values(row).reduce((a, b) => a + b, 0);
+            return (
+              <tr key={scope} className="border-b border-border/20 last:border-0">
+                <td className="py-1.5 text-foreground">{scope}</td>
+                {FACT_TYPES.map((ft) => (
+                  <td key={ft} className="text-right py-1.5">
+                    {row[ft] ? fmt(row[ft]!) : "—"}
+                  </td>
+                ))}
+                <td className="text-right py-1.5 font-semibold">
+                  {total ? fmt(total) : "—"}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </Card>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Top + dormant agents
+// ─────────────────────────────────────────────────────────────────────────
+
+function TopAgentsTable({ rows }: { rows: AgentActivityRow[] }) {
+  return (
+    <Card title="Top writers · 30d" subtitle="by archival count">
+      {rows.length === 0 ? (
+        <EmptyHint>No agents wrote archival in the last 30 days.</EmptyHint>
+      ) : (
+        <table className="w-full text-xs">
+          <thead className="text-muted-foreground text-[10px] uppercase tracking-wider">
+            <tr className="border-b border-border/40">
+              <th className="text-left py-1.5">Agent</th>
+              <th className="text-left py-1.5">Tier</th>
+              <th className="text-right py-1.5">Writes</th>
+              <th className="text-right py-1.5">Types</th>
+              <th className="text-right py-1.5">Last</th>
+            </tr>
+          </thead>
+          <tbody className="tabular-nums">
+            {rows.map((r) => (
+              <tr key={r.agent_id} className="border-b border-border/20 last:border-0">
+                <td className="py-1.5 text-foreground truncate max-w-[160px]">
+                  <Link
+                    href={`/agents/${r.agent_id}`}
+                    className="hover:underline"
+                  >
+                    {r.name}
+                  </Link>
+                </td>
+                <td className="py-1.5 text-muted-foreground">{r.tier}</td>
+                <td className="text-right py-1.5">{fmt(r.writes_30d)}</td>
+                <td className="text-right py-1.5">{r.type_variety}</td>
+                <td className="text-right py-1.5 text-muted-foreground">{r.last_write}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </Card>
+  );
+}
+
+function DormantAgentsTable({ rows }: { rows: DormantAgentRow[] }) {
+  return (
+    <Card title="Dormant · 0 writes in 30d" subtitle="newest agents first">
+      {rows.length === 0 ? (
+        <EmptyHint>All agents wrote archival in the last 30 days.</EmptyHint>
+      ) : (
+        <table className="w-full text-xs">
+          <thead className="text-muted-foreground text-[10px] uppercase tracking-wider">
+            <tr className="border-b border-border/40">
+              <th className="text-left py-1.5">Agent</th>
+              <th className="text-left py-1.5">Tier</th>
+              <th className="text-right py-1.5">Last write</th>
+              <th className="text-right py-1.5">Created</th>
+            </tr>
+          </thead>
+          <tbody className="tabular-nums">
+            {rows.map((r) => (
+              <tr key={r.agent_id} className="border-b border-border/20 last:border-0">
+                <td className="py-1.5 text-foreground truncate max-w-[160px]">
+                  <Link
+                    href={`/agents/${r.agent_id}`}
+                    className="hover:underline"
+                  >
+                    {r.name}
+                  </Link>
+                </td>
+                <td className="py-1.5 text-muted-foreground">{r.tier}</td>
+                <td className="text-right py-1.5 text-muted-foreground">
+                  {r.last_write_ever ?? "never"}
+                </td>
+                <td className="text-right py-1.5 text-muted-foreground">{r.agent_created}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </Card>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Core snapshot + ratio
+// ─────────────────────────────────────────────────────────────────────────
+
+function CoreSnapshotTable({ rows }: { rows: CoreSnapshotRow[] }) {
+  return (
+    <Card
+      title="Core memory · current state"
+      subtitle="snapshot proxies (undercount churn)"
+    >
+      {rows.length === 0 ? (
+        <EmptyHint>No core memory blocks exist yet.</EmptyHint>
+      ) : (
+        <table className="w-full text-xs">
+          <thead className="text-muted-foreground text-[10px] uppercase tracking-wider">
+            <tr className="border-b border-border/40">
+              <th className="text-left py-1.5">Tier</th>
+              <th className="text-left py-1.5">Block</th>
+              <th className="text-right py-1.5">Blocks</th>
+              <th className="text-right py-1.5">Non-empty</th>
+              <th className="text-right py-1.5">Ever updated</th>
+              <th className="text-right py-1.5">Updated 30d</th>
+              <th className="text-right py-1.5">Avg chars</th>
+            </tr>
+          </thead>
+          <tbody className="tabular-nums">
+            {rows.map((r) => (
+              <tr
+                key={`${r.tier}:${r.block_name}`}
+                className="border-b border-border/20 last:border-0"
+              >
+                <td className="py-1.5 text-muted-foreground">{r.tier}</td>
+                <td className="py-1.5 text-foreground">{r.block_name}</td>
+                <td className="text-right py-1.5">{fmt(r.blocks)}</td>
+                <td className="text-right py-1.5">{fmt(r.non_empty)}</td>
+                <td className="text-right py-1.5">{fmt(r.ever_updated)}</td>
+                <td className="text-right py-1.5">{fmt(r.updated_30d)}</td>
+                <td className="text-right py-1.5 text-muted-foreground">
+                  {fmt(r.avg_chars)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </Card>
+  );
+}
+
+function RatioTable({ rows }: { rows: AgentRatioRow[] }) {
+  return (
+    <Card
+      title="Archival ÷ core · per agent (30d)"
+      subtitle="high ratio = bias toward archival, never touches core"
+    >
+      {rows.length === 0 ? (
+        <EmptyHint>No memory writes in the last 30 days.</EmptyHint>
+      ) : (
+        <table className="w-full text-xs">
+          <thead className="text-muted-foreground text-[10px] uppercase tracking-wider">
+            <tr className="border-b border-border/40">
+              <th className="text-left py-1.5">Agent</th>
+              <th className="text-left py-1.5">Tier</th>
+              <th className="text-right py-1.5">Archival</th>
+              <th className="text-right py-1.5">Core touched</th>
+              <th className="text-right py-1.5">Ratio</th>
+            </tr>
+          </thead>
+          <tbody className="tabular-nums">
+            {rows.map((r) => (
+              <tr key={r.agent_id} className="border-b border-border/20 last:border-0">
+                <td className="py-1.5 text-foreground truncate max-w-[200px]">
+                  <Link href={`/agents/${r.agent_id}`} className="hover:underline">
+                    {r.name}
+                  </Link>
+                </td>
+                <td className="py-1.5 text-muted-foreground">{r.tier}</td>
+                <td className="text-right py-1.5">{fmt(r.archival_30d)}</td>
+                <td className="text-right py-1.5">{fmt(r.core_touched_30d)}</td>
+                <td className="text-right py-1.5 font-semibold">
+                  {r.ratio === null ? "—" : r.ratio}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </Card>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Before / after split
+// ─────────────────────────────────────────────────────────────────────────
+
+function BeforeAfterPanel({ data }: { data: BeforeAfterData }) {
+  return (
+    <Card
+      title={`Before / after · boundary ${data.since}`}
+      subtitle="±14 days each side"
+    >
+      <div className="grid md:grid-cols-2 gap-6">
+        <div>
+          <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">
+            Aggregate
+          </div>
+          <table className="w-full text-xs tabular-nums">
+            <tbody>
+              {[
+                ["Writes", data.agg.writes_pre, data.agg.writes_post],
+                ["Active agents", data.agg.agents_pre, data.agg.agents_post],
+              ].map(([label, pre, post]) => (
+                <tr key={String(label)} className="border-b border-border/20 last:border-0">
+                  <td className="py-1.5 text-muted-foreground">{label}</td>
+                  <td className="text-right py-1.5">pre {fmt(Number(pre))}</td>
+                  <td className="text-right py-1.5">post {fmt(Number(post))}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <div>
+          <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">
+            fact_type mix
+          </div>
+          <table className="w-full text-xs tabular-nums">
+            <thead className="text-muted-foreground text-[10px] uppercase tracking-wider">
+              <tr className="border-b border-border/40">
+                <th className="text-left py-1.5">Type</th>
+                <th className="text-right py-1.5">pre</th>
+                <th className="text-right py-1.5">post</th>
+                <th className="text-right py-1.5">pre %</th>
+                <th className="text-right py-1.5">post %</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.by_type.map((r) => (
+                <tr key={r.fact_type} className="border-b border-border/20 last:border-0">
+                  <td className="py-1.5 text-foreground">{r.fact_type}</td>
+                  <td className="text-right py-1.5">{fmt(r.pre)}</td>
+                  <td className="text-right py-1.5">{fmt(r.post)}</td>
+                  <td className="text-right py-1.5 text-muted-foreground">
+                    {r.pre_pct === null ? "—" : `${r.pre_pct}%`}
+                  </td>
+                  <td className="text-right py-1.5 text-muted-foreground">
+                    {r.post_pct === null ? "—" : `${r.post_pct}%`}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Card shell + tiny helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+function Card({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-lg glass-surface p-5 space-y-3">
+      <div className="flex items-baseline justify-between">
+        <h2 className="text-[10px] uppercase tracking-wider text-muted-foreground">
+          {title}
+        </h2>
+        {subtitle ? (
+          <span className="text-[10px] text-muted-foreground">{subtitle}</span>
+        ) : null}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function EmptyHint({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="text-xs text-muted-foreground py-4 text-center">
+      {children}
+    </div>
+  );
+}
+
+function fmt(n: number): string {
+  return n.toLocaleString();
+}

--- a/packages/web/app/(authed)/memory/eval/page.tsx
+++ b/packages/web/app/(authed)/memory/eval/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+import { MemoryEvalClient } from "./eval-client";
+
+export const metadata: Metadata = { title: "Memory · Eval" };
+
+export default function MemoryEvalPage() {
+  return (
+    <div className="flex-1 overflow-auto">
+      <div className="max-w-6xl mx-auto pt-8 pb-12 px-6">
+        <MemoryEvalClient />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/app/(authed)/memory/memory-client.tsx
+++ b/packages/web/app/(authed)/memory/memory-client.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useMemo, useRef, useState } from "react";
+import Link from "next/link";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   AlertTriangle,
   ArrowUpDown,
+  BarChart3,
   BookText,
   Bot,
   ChevronDown,
@@ -53,6 +55,16 @@ export function MemoryClient() {
 
   return (
     <>
+      <div className="flex items-center justify-end mb-3">
+        <Link
+          href="/memory/eval"
+          className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors rounded-md border border-border px-2.5 py-1.5"
+        >
+          <BarChart3 className="h-3.5 w-3.5" />
+          Eval
+        </Link>
+      </div>
+
       <ScopeTabs current={scope} counts={counts} onChange={setScope} />
 
       <div className="flex items-center gap-2 mb-3">

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -17,6 +17,7 @@ import type {
   TaskDetail,
   AgentDetail,
   DashboardSummary,
+  MemoryActivitySummary,
   MeshOverview,
 } from "./types";
 import type { MeshWindow } from "@/lib/types/mesh";
@@ -536,6 +537,22 @@ export const api = {
         `/memory/fact/${encodeURIComponent(factId)}`,
         { method: "DELETE" },
       ),
+    /**
+     * Layer A activity telemetry — powers /memory/eval. `weeks` controls
+     * the weekly trend + scope×type breakdown window. `since` (ISO date)
+     * is optional; when present, the response includes a ±14d before/
+     * after split for evaluating prompt-change rollouts.
+     */
+    activity: (
+      opts: ReadOptions & { weeks?: number; since?: string } = {},
+    ) =>
+      fetchJson<MemoryActivitySummary>("/memory/activity", {
+        query: {
+          ...(opts.weeks ? { weeks: String(opts.weeks) } : {}),
+          ...(opts.since ? { since: opts.since } : {}),
+        },
+        signal: opts.signal,
+      }),
   },
   // Surfaces below depend on backend slices that haven't shipped yet
   // (dashboard/mesh need a data/display split; threads/promotions lack a

--- a/packages/web/lib/api/types.ts
+++ b/packages/web/lib/api/types.ts
@@ -12,4 +12,13 @@ export type {
   AgentDisplay,
   DashboardSummary,
   MeshOverview,
+  MemoryActivitySummary,
+  MemoryActivityKpis,
+  WeeklyArchivalRow,
+  ScopeTypeRow,
+  AgentActivityRow,
+  DormantAgentRow,
+  CoreSnapshotRow,
+  AgentRatioRow,
+  BeforeAfterData,
 } from "@beevibe/api/views/types";

--- a/packages/web/lib/hooks/keys.ts
+++ b/packages/web/lib/hooks/keys.ts
@@ -21,6 +21,8 @@ export const queryKeys = {
     all: ["memory"] as const,
     facts: (filter: { scope?: MemoryScope }) => ["memory", "facts", filter] as const,
     counts: () => ["memory", "counts"] as const,
+    activity: (params: { weeks?: number; since?: string }) =>
+      ["memory", "activity", params] as const,
   },
   promotions: {
     all: ["promotions"] as const,

--- a/packages/web/lib/hooks/use-memory-activity.ts
+++ b/packages/web/lib/hooks/use-memory-activity.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api/client";
+import { isApiConfigured } from "@/lib/api/config";
+import { queryKeys } from "./keys";
+
+export function useMemoryActivity(params: {
+  weeks?: number;
+  since?: string;
+}) {
+  return useQuery({
+    queryKey: queryKeys.memory.activity(params),
+    queryFn: ({ signal }) =>
+      api.memory.activity({
+        signal,
+        weeks: params.weeks,
+        since: params.since,
+      }),
+    enabled: isApiConfigured,
+  });
+}


### PR DESCRIPTION
## Summary

Move the memory-activity report from a manually-run script (#248) to a tracked dashboard surface at `/memory/eval`, accessible via an "Eval" button on the existing `/memory` page.

## What it shows

All six reports from the script, plus the optional before/after split:

1. **KPI tiles** — archival writes 30d, core blocks touched 30d, active writing agents 30d, archival÷core touch ratio
2. **Weekly archival trend** — stacked SVG bars by fact_type (no chart library dep)
3. **Scope × fact_type breakdown** — ic/team/org × the 5 fact types
4. **Top agents (30d) + Dormant agents** — side-by-side
5. **Core memory current-state snapshot** — per tier × block_name
6. **Archival-to-core ratio per agent** — surfaces the "always saves archival, never touches core" bias
7. **Before / after panel** — appears when you pick a date in the "compare around" picker; shows ±14d pre/post mix + aggregate writes

Controls: window selector (4 / 8 / 12 / 26 / 52 weeks) + ISO date picker for before/after.

## Architecture

**Backend:**
- `packages/api/src/views/memory-activity.ts` — composer fans 7 queries in parallel via `Promise.all`, mirrors `dashboard.ts` shape
- `GET /memory/activity?weeks=12&since=ISO` in `routes/view.ts`. Validates `since` up front; bad date returns 400, not 500
- Types in `views/types.ts`: `MemoryActivitySummary` + `MemoryActivityKpis` + 6 row types + `BeforeAfterData`

**Frontend:**
- Types re-exported via `lib/api/types.ts` (single source of truth)
- `api.memory.activity({weeks, since})` client method
- `queryKeys.memory.activity(params)` scopes cache by both params
- `useMemoryActivity` hook matches `useDashboard` shape
- `app/(authed)/memory/eval/page.tsx` + `eval-client.tsx` render all sections
- "Eval" button added top-right of `/memory`

## Known limitation (called out in the composer's docblock)

`core_memory_block` has no write event log; `core_touched_30d` and the snapshot use `updated_at` snapshot proxies which **undercount churn** (a block updated 5× in 30d shows as 1). A follow-up trigger-backed event table closes the gap going forward.

## Relationship to PR #248

PR #248 (the script) stays as a developer-side ad-hoc tool — useful for SQL exploration that doesn't warrant opening a browser. This PR is the user-facing answer to "metric I can track from my dashboard." Both can land independently; neither depends on the other.

## Test plan

- [x] `pnpm --filter @beevibe/api typecheck` clean
- [x] `pnpm --filter @beevibe/api build` clean (needed for web to see new types)
- [x] `pnpm --filter @beevibe/api test memory` — 18/18 passing
- [x] `pnpm --filter @beevibe/web typecheck` clean
- [x] `pnpm --filter @beevibe/web test` — 176/176 passing
- [ ] Visual smoke: `pnpm dev`, click "Eval" on `/memory`, verify each section renders and the date picker shows the before/after panel
- [ ] Try `?weeks=4` / `?weeks=52` window changes
- [ ] Try `--since 2026-06-14` (when ≥14d post-merge of #247) to read the prompt-rewrite effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)