### PR TITLE
feat(chat): render chained chat turns as one conversation

### DIFF
--- a/packages/api/src/routes/view.ts
+++ b/packages/api/src/routes/view.ts
@@ -45,7 +45,12 @@ import {
   type Lifecycle,
 } from "../views/tasks-grouping.js";
 import { listAgents, getAgent } from "../views/agents.js";
-import { getSessionByShortId, getSessionTree, AmbiguousShortIdError } from "../views/sessions.js";
+import {
+  getSessionByShortId,
+  getConversationByShortId,
+  getSessionTree,
+  AmbiguousShortIdError,
+} from "../views/sessions.js";
 import { listMemoryFactCounts, listMemoryFacts } from "../views/memory.js";
 import { getDashboardSummary } from "../views/dashboard.js";
 import { DEFAULT_MESH_WINDOW, getMeshOverview, isMeshWindow } from "../views/mesh.js";
@@ -450,6 +455,39 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
         return;
       }
       handleError(err, res, "session detail");
+    }
+  });
+
+  /**
+   * Whole-conversation detail: given the short_id of any chat turn (in
+   * practice the head turn's, the URL key the agent detail page links to),
+   * returns every chained turn sharing the `conversation_id` as one thread.
+   * Non-chat sessions resolve to a single-turn conversation, so the detail
+   * page renders them unchanged.
+   */
+  router.get("/session/:shortId/conversation", async (req, res) => {
+    if (!requireHuman(req, res)) return;
+    const shortId = req.params.shortId;
+    if (!shortId) {
+      res.status(400).json({ error: "missing_short_id" });
+      return;
+    }
+    try {
+      const conversation = await getConversationByShortId(deps.pool, shortId);
+      if (!conversation) {
+        res.status(404).json({ error: "session_not_found" });
+        return;
+      }
+      res.json(conversation);
+    } catch (err) {
+      if (err instanceof AmbiguousShortIdError) {
+        res.status(409).json({
+          error: "ambiguous_short_id",
+          message: err.message,
+        });
+        return;
+      }
+      handleError(err, res, "conversation detail");
     }
   });
 

--- a/packages/api/src/routes/view.ts
+++ b/packages/api/src/routes/view.ts
@@ -432,64 +432,52 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
     }
   });
 
-  router.get("/session/:shortId", async (req, res) => {
-    if (!requireHuman(req, res)) return;
-    const shortId = req.params.shortId;
-    if (!shortId) {
-      res.status(400).json({ error: "missing_short_id" });
-      return;
-    }
-    try {
-      const session = await getSessionByShortId(deps.pool, shortId);
-      if (!session) {
-        res.status(404).json({ error: "session_not_found" });
+  // Both short_id session routes share the same shape: require human →
+  // validate short_id → fetch → 404 on miss, 409 on ambiguous prefix.
+  // Factored so the single-session and whole-conversation lookups stay in
+  // lockstep (e.g. if the error contract or auth check changes).
+  const shortIdRoute =
+    <T>(
+      fetch: (pool: Pool, shortId: string) => Promise<T | undefined>,
+      errorLabel: string,
+    ): RequestHandler =>
+    async (req, res) => {
+      if (!requireHuman(req, res)) return;
+      // Express 5 types a bare params value as `string | string[]`; a single
+      // `:shortId` segment is always a string at runtime, but narrow it so
+      // the type matches `fetch`'s `string` param.
+      const shortId = req.params.shortId;
+      if (typeof shortId !== "string" || !shortId) {
+        res.status(400).json({ error: "missing_short_id" });
         return;
       }
-      res.json(session);
-    } catch (err) {
-      if (err instanceof AmbiguousShortIdError) {
-        res.status(409).json({
-          error: "ambiguous_short_id",
-          message: err.message,
-        });
-        return;
+      try {
+        const result = await fetch(deps.pool, shortId);
+        if (!result) {
+          res.status(404).json({ error: "session_not_found" });
+          return;
+        }
+        res.json(result);
+      } catch (err) {
+        if (err instanceof AmbiguousShortIdError) {
+          res.status(409).json({ error: "ambiguous_short_id", message: err.message });
+          return;
+        }
+        handleError(err, res, errorLabel);
       }
-      handleError(err, res, "session detail");
-    }
-  });
+    };
 
-  /**
-   * Whole-conversation detail: given the short_id of any chat turn (in
-   * practice the head turn's, the URL key the agent detail page links to),
-   * returns every chained turn sharing the `conversation_id` as one thread.
-   * Non-chat sessions resolve to a single-turn conversation, so the detail
-   * page renders them unchanged.
-   */
-  router.get("/session/:shortId/conversation", async (req, res) => {
-    if (!requireHuman(req, res)) return;
-    const shortId = req.params.shortId;
-    if (!shortId) {
-      res.status(400).json({ error: "missing_short_id" });
-      return;
-    }
-    try {
-      const conversation = await getConversationByShortId(deps.pool, shortId);
-      if (!conversation) {
-        res.status(404).json({ error: "session_not_found" });
-        return;
-      }
-      res.json(conversation);
-    } catch (err) {
-      if (err instanceof AmbiguousShortIdError) {
-        res.status(409).json({
-          error: "ambiguous_short_id",
-          message: err.message,
-        });
-        return;
-      }
-      handleError(err, res, "conversation detail");
-    }
-  });
+  router.get("/session/:shortId", shortIdRoute(getSessionByShortId, "session detail"));
+
+  // Whole-conversation detail: given the short_id of any chat turn (in
+  // practice the head turn's, the URL key the agent detail page links to),
+  // returns every chained turn sharing the `conversation_id` as one thread.
+  // Non-chat sessions resolve to a single-turn conversation, so the detail
+  // page renders them unchanged.
+  router.get(
+    "/session/:shortId/conversation",
+    shortIdRoute(getConversationByShortId, "conversation detail"),
+  );
 
   /**
    * Hydration fallback for the chat tree UI. Given a full session id

--- a/packages/api/src/views/agents.test.ts
+++ b/packages/api/src/views/agents.test.ts
@@ -139,6 +139,7 @@ describe("getAgent", () => {
     expect(detail?.recent_sessions[0]?.title).toBe("Bill rewrite");
     expect(detail?.recent_chat_threads).toHaveLength(1);
     expect(detail?.recent_chat_threads[0]?.conversation_id).toBe("sess_chat0001");
+    expect(detail?.recent_chat_threads[0]?.short_id).toBe("chat00");
     expect(detail?.recent_chat_threads[0]?.turn_count).toBe(4);
     expect(detail?.recent_chat_threads[0]?.title).toBe(
       "hey what's the status of the migration?",

--- a/packages/api/src/views/agents.ts
+++ b/packages/api/src/views/agents.ts
@@ -314,6 +314,7 @@ export async function getAgent(
 
   const recent_chat_threads: RecentChatThread[] = chatThreadResult.rows.map((t) => ({
     conversation_id: t.conversation_id,
+    short_id: deriveShortId(t.conversation_id),
     title:
       t.intent_first.length <= 80
         ? t.intent_first

--- a/packages/api/src/views/sessions.test.ts
+++ b/packages/api/src/views/sessions.test.ts
@@ -231,6 +231,56 @@ describe("getConversationByShortId", () => {
     expect(conv?.task_id).toBe("task_001");
     expect(conv?.turns).toHaveLength(1);
   });
+
+  it("aggregates per-turn usage into one conversation-level total", async () => {
+    const head = "sess_usagehead1";
+    const turns = [
+      {
+        ...sampleRow(head),
+        type: "chat",
+        usage: {
+          cost_usd: 0.01,
+          input_tokens: 100,
+          output_tokens: 50,
+          cache_creation_input_tokens: 200,
+          cache_read_input_tokens: 0,
+          model: "claude-opus-4-8",
+        },
+      },
+      {
+        ...sampleRow("sess_usageturn2"),
+        type: "chat",
+        usage: {
+          cost_usd: 0.02,
+          input_tokens: 0,
+          output_tokens: 70,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 300,
+          model: "claude-opus-4-8",
+        },
+      },
+    ];
+    const pool = makeMockPool([[resolveRow(head, head, "chat")], turns]);
+    const conv = await getConversationByShortId(pool, "usageh");
+    expect(conv?.usage?.cost_usd).toBeCloseTo(0.03, 5);
+    expect(conv?.usage?.input_tokens).toBe(100);
+    expect(conv?.usage?.output_tokens).toBe(120);
+    expect(conv?.usage?.cache_creation_tokens).toBe(200);
+    expect(conv?.usage?.cache_read_tokens).toBe(300);
+    expect(conv?.usage?.total_input_tokens).toBe(600); // 100 + 200 + 300
+    expect(conv?.usage?.cache_hit_ratio).toBeCloseTo(300 / 600, 5);
+    expect(conv?.usage?.model).toBe("claude-opus-4-8");
+  });
+
+  it("omits conversation usage when no turn carried any", async () => {
+    const head = "sess_nousagehd";
+    const pool = makeMockPool([
+      [resolveRow(head, head, "chat")],
+      [{ ...sampleRow(head), type: "chat", usage: null }],
+    ]);
+    const conv = await getConversationByShortId(pool, "nousag");
+    expect(conv?.usage).toBeUndefined();
+  });
 });
 
 function resolveRow(

--- a/packages/api/src/views/sessions.test.ts
+++ b/packages/api/src/views/sessions.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   AmbiguousShortIdError,
+  getConversationByShortId,
   getSessionByShortId,
   toSessionUsageDisplay,
 } from "./sessions.js";
@@ -158,6 +159,88 @@ describe("getSessionByShortId — usage plumbing", () => {
     expect(session?.usage).toBeUndefined();
   });
 });
+
+describe("getConversationByShortId", () => {
+  it("returns undefined when no matching session", async () => {
+    const pool = makeMockPool([[], []]);
+    expect(await getConversationByShortId(pool, "abc123")).toBeUndefined();
+  });
+
+  it("rejects malformed short_ids without hitting the DB", async () => {
+    const pool = makeMockPool([[], []]);
+    expect(await getConversationByShortId(pool, "abc/../etc")).toBeUndefined();
+    expect(pool._spy.mock.calls).toHaveLength(0);
+  });
+
+  it("throws AmbiguousShortIdError when the resolve query matches 2+ rows", async () => {
+    const pool = makeMockPool([
+      [
+        resolveRow("sess_abc1230001", "sess_abc1230001"),
+        resolveRow("sess_abc1230002", "sess_abc1230002"),
+      ],
+    ]);
+    await expect(getConversationByShortId(pool, "abc123")).rejects.toBeInstanceOf(
+      AmbiguousShortIdError,
+    );
+  });
+
+  it("collapses all chat turns sharing a conversation_id into one chronological thread", async () => {
+    const head = "sess_head00aaaa";
+    const turns = [
+      { ...sampleRow(head), type: "chat", status: "succeeded", intent: "first question" },
+      {
+        ...sampleRow("sess_turn02bbbb"),
+        type: "chat",
+        status: "succeeded",
+        intent: "second question",
+      },
+      {
+        ...sampleRow("sess_turn03cccc"),
+        type: "chat",
+        status: "running",
+        intent: "third question",
+      },
+    ];
+    const pool = makeMockPool([[resolveRow(head, head, "chat")], turns]);
+    const conv = await getConversationByShortId(pool, "head00");
+    expect(conv?.conversation_id).toBe(head);
+    expect(conv?.short_id).toBe("head00");
+    expect(conv?.type).toBe("chat");
+    expect(conv?.task_id).toBeUndefined();
+    expect(conv?.agent_label).toBe("Beta");
+    expect(conv?.turns).toHaveLength(3);
+    expect(conv?.turns.map((t) => t.intent)).toEqual([
+      "first question",
+      "second question",
+      "third question",
+    ]);
+    // status reflects the LATEST turn (chronological tail), not the head.
+    expect(conv?.status).toBe("running");
+  });
+
+  it("resolves a non-chat session (null conversation_id) to a single-turn conversation on its own id", async () => {
+    const id = "sess_task00aaaa";
+    const pool = makeMockPool([
+      [resolveRow(id, null, "task", "task_001")],
+      [{ ...sampleRow(id), type: "task", status: "running" }],
+    ]);
+    const conv = await getConversationByShortId(pool, "task00");
+    expect(conv?.conversation_id).toBe(id);
+    expect(conv?.short_id).toBe("task00");
+    expect(conv?.type).toBe("task");
+    expect(conv?.task_id).toBe("task_001");
+    expect(conv?.turns).toHaveLength(1);
+  });
+});
+
+function resolveRow(
+  id: string,
+  conversation_id: string | null,
+  type = "chat",
+  task_id: string | null = null,
+) {
+  return { id, conversation_id, type, task_id, agent_id: "agt_team" };
+}
 
 function sampleRow(id: string) {
   return {

--- a/packages/api/src/views/sessions.ts
+++ b/packages/api/src/views/sessions.ts
@@ -30,6 +30,7 @@ import {
   formatDurationLabel,
 } from "./format.js";
 import type {
+  ConversationDisplay,
   SessionDisplay,
   SessionBriefing,
   SessionTreeNode,
@@ -70,7 +71,11 @@ interface TranscriptEventRow {
   tool_name: string | null;
 }
 
-const SESSION_BY_ID_PREFIX_SQL = /* sql */ `
+// Shared SELECT + joins + transcript aggregation for the session-detail
+// row shape (`SessionDetailRow`). Callers append their own WHERE / ORDER /
+// LIMIT. Reused by the single-session lookup and the conversation lookup
+// so the json_agg subquery (and its 500-event cap) lives in one place.
+const SESSION_DETAIL_SELECT = /* sql */ `
 SELECT
   s.id, s.agent_id, s.task_id, s.type, s.status, s.intent,
   s.workspace_path, s.cli_session_id, s.started_at, s.completed_at,
@@ -105,6 +110,10 @@ JOIN agent a ON a.id = s.agent_id
 LEFT JOIN task t ON t.id = s.task_id
 LEFT JOIN runtime r ON r.id = s.runtime_id
 LEFT JOIN daemon d ON d.id = r.daemon_id
+`;
+
+const SESSION_BY_ID_PREFIX_SQL = /* sql */ `
+${SESSION_DETAIL_SELECT}
 WHERE s.id LIKE $1 || '%'
 LIMIT 2
 `;
@@ -134,6 +143,79 @@ export async function getSessionByShortId(
   if (rows.length === 0) return undefined;
   if (rows.length > 1) throw new AmbiguousShortIdError(shortId);
   return rowToSessionDisplay(rows[0]!);
+}
+
+// Resolve a short_id to the conversation grouping key. Chat turns carry a
+// `conversation_id` (head turn's id); non-chat sessions have NULL, so we
+// fall back to the row's own id — a single-turn "conversation".
+const CONVERSATION_RESOLVE_SQL = /* sql */ `
+SELECT id, conversation_id, type, task_id, agent_id
+FROM session
+WHERE id LIKE $1 || '%'
+LIMIT 2
+`;
+
+// All turns in a conversation, chronological. `COALESCE(conversation_id, id)`
+// matches chat turns (shared conversation_id) and lone non-chat sessions
+// (matched on their own id) alike.
+const CONVERSATION_TURNS_SQL = /* sql */ `
+${SESSION_DETAIL_SELECT}
+WHERE COALESCE(s.conversation_id, s.id) = $1
+ORDER BY s.created_at ASC, s.id ASC
+`;
+
+interface ConversationResolveRow {
+  id: string;
+  conversation_id: string | null;
+  type: SessionType;
+  task_id: string | null;
+  agent_id: string;
+}
+
+/**
+ * Look up a whole chat conversation by the 6-char short_id of ANY turn in
+ * it (in practice the head turn's short_id, the URL key we link to). Returns
+ * every turn sharing the `conversation_id`, chronological, each with its own
+ * transcript. Non-chat sessions resolve to a single-turn conversation.
+ *
+ * Returns `undefined` for no match; throws `AmbiguousShortIdError` when 2+
+ * session rows share the prefix (mirrors `getSessionByShortId`).
+ */
+export async function getConversationByShortId(
+  pool: Pool,
+  shortId: string,
+): Promise<ConversationDisplay | undefined> {
+  if (!/^[a-z0-9]+$/i.test(shortId)) return undefined;
+  const prefix = `sess_${shortId}`;
+  const resolved = await pool.query<ConversationResolveRow>(
+    CONVERSATION_RESOLVE_SQL,
+    [prefix],
+  );
+  if (resolved.rows.length === 0) return undefined;
+  if (resolved.rows.length > 1) throw new AmbiguousShortIdError(shortId);
+  const target = resolved.rows[0]!;
+  const convKey = target.conversation_id ?? target.id;
+
+  const { rows } = await pool.query<SessionDetailRow>(CONVERSATION_TURNS_SQL, [
+    convKey,
+  ]);
+  const turns = rows.map(rowToSessionDisplay);
+  // The resolve query already proved the row exists, so `turns` is
+  // non-empty in practice; guard so `turns[len-1]` is safe regardless.
+  if (turns.length === 0) return undefined;
+  const lastTurn = turns[turns.length - 1]!;
+
+  return {
+    conversation_id: convKey,
+    short_id: deriveShortId(convKey),
+    agent_id: target.agent_id,
+    agent_label: turns[0]!.agent_label,
+    agent_hierarchy: turns[0]!.agent_hierarchy,
+    type: target.type,
+    ...(target.task_id ? { task_id: target.task_id } : {}),
+    status: lastTurn.status,
+    turns,
+  };
 }
 
 interface SessionTreeRow {

--- a/packages/api/src/views/sessions.ts
+++ b/packages/api/src/views/sessions.ts
@@ -204,6 +204,7 @@ export async function getConversationByShortId(
   // non-empty in practice; guard so `turns[len-1]` is safe regardless.
   if (turns.length === 0) return undefined;
   const lastTurn = turns[turns.length - 1]!;
+  const usage = toSessionUsageDisplay(sumTurnUsage(rows));
 
   return {
     conversation_id: convKey,
@@ -215,6 +216,28 @@ export async function getConversationByShortId(
     ...(target.task_id ? { task_id: target.task_id } : {}),
     status: lastTurn.status,
     turns,
+    ...(usage ? { usage } : {}),
+  };
+}
+
+/**
+ * Sum the raw per-turn `SessionUsage` into one conversation-level total.
+ * Returns null when no turn carried usage. The summed shape is fed back
+ * through `toSessionUsageDisplay` so the cache-hit ratio + display mapping
+ * use the exact same formula as a single session — no second source of truth.
+ */
+function sumTurnUsage(rows: SessionDetailRow[]): SessionUsage | null {
+  const used = rows.map((r) => r.usage).filter((u): u is SessionUsage => Boolean(u));
+  if (used.length === 0) return null;
+  const sum = (pick: (u: SessionUsage) => number | undefined) =>
+    used.reduce((acc, u) => acc + (pick(u) ?? 0), 0);
+  return {
+    cost_usd: sum((u) => u.cost_usd),
+    input_tokens: sum((u) => u.input_tokens),
+    output_tokens: sum((u) => u.output_tokens),
+    cache_creation_input_tokens: sum((u) => u.cache_creation_input_tokens),
+    cache_read_input_tokens: sum((u) => u.cache_read_input_tokens),
+    model: used[used.length - 1]!.model,
   };
 }
 

--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -333,6 +333,13 @@ export interface ConversationDisplay {
   status: SessionStatus;
   /** Turns in chronological order (oldest first), each with its transcript. */
   turns: SessionDisplay[];
+  /**
+   * Cost + tokens summed across every turn, so the detail page renders one
+   * conversation-level usage panel. Absent when no turn carried usage.
+   * Aggregated server-side (same cache-hit formula as per-session usage)
+   * rather than recomputed in the browser.
+   */
+  usage?: SessionUsageDisplay;
 }
 
 /**

--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -137,6 +137,13 @@ export interface RecentSession {
 export interface RecentChatThread {
   /** Head session id of the thread; stable across all turns. */
   conversation_id: string;
+  /**
+   * 6-char short_id of the head turn (`deriveShortId(conversation_id)`) —
+   * the URL key the web uses to link to the conversation detail page at
+   * `/sessions/<short_id>`. Precomputed here so the web doesn't re-derive
+   * it (and can't drift from the server's `short_id` convention).
+   */
+  short_id: string;
   /** First message of the thread, truncated to 80 chars. */
   title: string;
   /** How many chat sessions are in the thread. */
@@ -291,6 +298,41 @@ export interface SessionDisplay {
    * formula.
    */
   usage?: SessionUsageDisplay;
+}
+
+/**
+ * A whole chat conversation — every chat-turn session sharing one
+ * `conversation_id`, rendered as a single continuous thread on the
+ * session detail page. Returned by `GET /session/:shortId/conversation`.
+ *
+ * Each chat turn is its own `session` row (chained by `prior_session_id`,
+ * resuming the same CLI session). This collapses N of them into one view:
+ * the `turns` array is chronological (oldest first), each turn a full
+ * `SessionDisplay` with its own transcript + usage.
+ *
+ * Non-chat sessions (`conversation_id` is NULL — task / mesh / blocker /
+ * negotiate) resolve to a single-turn conversation containing just that
+ * session, so the detail page renders them unchanged.
+ */
+export interface ConversationDisplay {
+  /** Grouping key: head turn's id for chat; the session's own id otherwise. */
+  conversation_id: string;
+  /** 6-char short_id of the head turn — the URL key for this conversation. */
+  short_id: string;
+  agent_id: string;
+  agent_label: string;
+  agent_hierarchy: HierarchyLevel;
+  /**
+   * Type of the addressed session. Lets the detail page keep the
+   * task-session redirect (`type === 'task'` → task-scoped page).
+   */
+  type: SessionType;
+  /** Set when `type === 'task'`; drives the task-scoped redirect. */
+  task_id?: string;
+  /** Status of the latest turn — drives the in-flight pip on the header. */
+  status: SessionStatus;
+  /** Turns in chronological order (oldest first), each with its transcript. */
+  turns: SessionDisplay[];
 }
 
 /**

--- a/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
+++ b/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
@@ -16,6 +16,7 @@ import { CliMcpInstructions } from "@/components/cli-mcp-instructions";
 import { HierChip } from "@/components/hier-chip";
 import { CoreBlockCard } from "@/components/agents/core-block-card";
 import { RecentSessionRow } from "@/components/agents/recent-session-row";
+import { RecentChatThreadRow } from "@/components/agents/recent-chat-thread-row";
 import { RuntimePicker } from "@/components/agents/pickers/runtime-picker";
 import { ModelPicker } from "@/components/agents/pickers/model-picker";
 import { ReviewPolicyPicker } from "@/components/agents/pickers/review-policy-picker";
@@ -224,6 +225,28 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
                   <RecentSessionRow
                     key={s.short_id ?? i}
                     session={s}
+                    variant="comfortable"
+                  />
+                ))}
+              </ul>
+            )}
+          </section>
+
+          <section>
+            <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-3 font-medium">
+              Recent chats{" "}
+              <span className="text-muted-foreground/70 tabular-nums">
+                {agent.recent_chat_threads.length}
+              </span>
+            </h2>
+            {agent.recent_chat_threads.length === 0 ? (
+              <p className="text-sm text-muted-foreground italic">No recent chats.</p>
+            ) : (
+              <ul className="space-y-2">
+                {agent.recent_chat_threads.map((t) => (
+                  <RecentChatThreadRow
+                    key={t.conversation_id}
+                    thread={t}
                     variant="comfortable"
                   />
                 ))}

--- a/packages/web/app/(authed)/sessions/[sid]/chat-session-detail-client.tsx
+++ b/packages/web/app/(authed)/sessions/[sid]/chat-session-detail-client.tsx
@@ -17,7 +17,6 @@ import { UsagePanel } from "@/components/sessions/usage-panel";
 import type {
   ConversationDisplay,
   SessionDisplay,
-  SessionUsageDisplay,
   TranscriptEntry,
 } from "@/lib/types/sessions";
 import { cn } from "@/lib/utils";
@@ -112,9 +111,8 @@ function BackToChat() {
 }
 
 function ConversationBody({ conversation }: { conversation: ConversationDisplay }) {
-  const { turns } = conversation;
+  const { turns, usage } = conversation;
   const multiTurn = turns.length > 1;
-  const usage = aggregateUsage(turns);
   const lastTurn = turns[turns.length - 1];
 
   return (
@@ -263,36 +261,4 @@ function ToolTranscript({ entries }: { entries: TranscriptEntry[] }) {
       ))}
     </ol>
   );
-}
-
-/**
- * Sum per-turn usage into one conversation-level total so the page shows a
- * single cost/token panel. Cache-hit ratio is recomputed from the summed
- * slices (same formula as the server's `computeCacheHitRatio`). Returns
- * undefined when no turn carried usage (older sessions pre-usage-capture).
- */
-function aggregateUsage(turns: SessionDisplay[]): SessionUsageDisplay | undefined {
-  const used = turns
-    .map((t) => t.usage)
-    .filter((u): u is SessionUsageDisplay => Boolean(u));
-  if (used.length === 0) return undefined;
-
-  const sum = (pick: (u: SessionUsageDisplay) => number) =>
-    used.reduce((acc, u) => acc + pick(u), 0);
-  const input_tokens = sum((u) => u.input_tokens);
-  const output_tokens = sum((u) => u.output_tokens);
-  const cache_creation_tokens = sum((u) => u.cache_creation_tokens);
-  const cache_read_tokens = sum((u) => u.cache_read_tokens);
-  const total_input_tokens = input_tokens + cache_creation_tokens + cache_read_tokens;
-
-  return {
-    cost_usd: sum((u) => u.cost_usd),
-    cache_hit_ratio: total_input_tokens > 0 ? cache_read_tokens / total_input_tokens : 0,
-    input_tokens,
-    output_tokens,
-    cache_creation_tokens,
-    cache_read_tokens,
-    total_input_tokens,
-    model: used[used.length - 1]!.model,
-  };
 }

--- a/packages/web/app/(authed)/sessions/[sid]/chat-session-detail-client.tsx
+++ b/packages/web/app/(authed)/sessions/[sid]/chat-session-detail-client.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { AlertTriangle, ArrowLeft, Terminal, Wrench } from "lucide-react";
-import { useSession } from "@/lib/hooks/use-sessions";
+import { AlertTriangle, ArrowLeft, ChevronRight, Terminal, Wrench } from "lucide-react";
+import { useConversation } from "@/lib/hooks/use-sessions";
 import { isApiConfigured } from "@/lib/api/config";
 import { DetailShell } from "@/components/detail/detail-shell";
 import { EmptyState } from "@/components/empty-state";
@@ -14,20 +14,27 @@ import { ChatMarkdown } from "@/components/chat/markdown";
 import { HierChip } from "@/components/hier-chip";
 import { Avatar } from "@/components/avatar";
 import { UsagePanel } from "@/components/sessions/usage-panel";
-import type { SessionDisplay, TranscriptEntry } from "@/lib/types/sessions";
+import type {
+  ConversationDisplay,
+  SessionDisplay,
+  SessionUsageDisplay,
+  TranscriptEntry,
+} from "@/lib/types/sessions";
 import { cn } from "@/lib/utils";
 
 /**
- * Per-session detail for chat (and any non-task session). Shows the
- * single turn as a chat-shaped layout — user intent + agent reply with
- * markdown — plus the tool transcript collapsed below for debugging.
+ * Detail view for a chat conversation (and any non-task session). A chat is
+ * a chain of per-turn sessions sharing one `conversation_id`; this page
+ * collapses them into one continuous thread — each turn rendered as the
+ * user's message, the agent's tool steps, then the agent's reply, in
+ * chronological order. Non-chat sessions (mesh_ask, blocker, negotiate)
+ * resolve to a single turn and render unchanged.
  *
  * Task-spawned sessions have their own task-scoped detail page at
- * `/tasks/[id]/sessions/[sid]`. This route handles everything else:
- * chat, mesh_ask, blocker, negotiate.
+ * `/tasks/[id]/sessions/[sid]`, so we redirect those out.
  */
 export function ChatSessionDetailClient({ sessionShortId }: { sessionShortId: string }) {
-  const { data, isLoading, isError } = useSession(sessionShortId);
+  const { data, isLoading, isError } = useConversation(sessionShortId);
 
   const nav = <BackToChat />;
 
@@ -85,7 +92,7 @@ export function ChatSessionDetailClient({ sessionShortId }: { sessionShortId: st
 
   return (
     <DetailShell nav={nav}>
-      <ChatSessionBody session={data} />
+      <ConversationBody conversation={data} />
     </DetailShell>
   );
 }
@@ -104,99 +111,129 @@ function BackToChat() {
   );
 }
 
-function ChatSessionBody({ session }: { session: SessionDisplay }) {
-  // Pull the agent's final visible response out of the transcript: prefer
-  // the `summary` event (the persisted final after directive-stripping),
-  // fall back to the last `agent` text block.
-  const summary = [...session.transcript].reverse().find((e) => e.kind === "summary");
-  const lastAgent = [...session.transcript].reverse().find((e) => e.kind === "agent");
-  const finalResponse = summary?.content ?? lastAgent?.content ?? "";
-
-  // Tool steps for the collapsible transcript section below the bubbles.
-  const toolSteps = session.transcript.filter(
-    (e) => e.kind === "tool_call" || e.kind === "tool_result",
-  );
+function ConversationBody({ conversation }: { conversation: ConversationDisplay }) {
+  const { turns } = conversation;
+  const multiTurn = turns.length > 1;
+  const usage = aggregateUsage(turns);
+  const lastTurn = turns[turns.length - 1];
 
   return (
     <>
       <header className="mb-6">
         <div className="flex items-start gap-3">
           <Avatar
-            initial={session.agent_label.charAt(0).toUpperCase()}
-            kind={session.agent_hierarchy}
-            label={session.agent_label}
+            initial={conversation.agent_label.charAt(0).toUpperCase()}
+            kind={conversation.agent_hierarchy}
+            label={conversation.agent_label}
             size={40}
-            presence={session.status === "running" ? "running" : "idle"}
+            presence={conversation.status === "running" ? "running" : "idle"}
           />
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-1">
-              <h1 className="text-base font-semibold tracking-tight leading-tight">One turn</h1>
-              <SessionStatusPill status={session.status} />
+              <h1 className="text-base font-semibold tracking-tight leading-tight">
+                {multiTurn ? "Conversation" : "One turn"}
+              </h1>
+              <SessionStatusPill status={conversation.status} />
             </div>
             <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <span className="text-foreground/85">{session.agent_label}</span>
-              <HierChip hier={session.agent_hierarchy} />
+              <span className="text-foreground/85">{conversation.agent_label}</span>
+              <HierChip hier={conversation.agent_hierarchy} />
+              {multiTurn ? (
+                <>
+                  <span className="text-muted-foreground/50">·</span>
+                  <span className="tabular-nums">{turns.length} turns</span>
+                </>
+              ) : null}
               <span className="text-muted-foreground/50">·</span>
-              <span className="tabular-nums">{session.duration_label}</span>
-              <span className="text-muted-foreground/50">·</span>
-              <span className="text-foreground/70">{session.type}</span>
+              <span className="text-foreground/70">{conversation.type}</span>
             </div>
           </div>
         </div>
       </header>
 
+      <div className="space-y-6">
+        {turns.map((turn) => (
+          <ChatTurn key={turn.id} turn={turn} />
+        ))}
+      </div>
+
+      {usage ? <UsagePanel usage={usage} /> : null}
+
+      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+        <FooterField label="Conversation ID">
+          <ClickToCopyId id={conversation.conversation_id} />
+        </FooterField>
+        {lastTurn?.cli_session ? (
+          <FooterField label="CLI session" truncate>
+            <span className="font-mono">{lastTurn.cli_session}</span>
+          </FooterField>
+        ) : null}
+        {lastTurn?.worktree ? (
+          <FooterField label="Worktree" truncate>
+            <span className="font-mono">{lastTurn.worktree}</span>
+          </FooterField>
+        ) : null}
+        <FooterField label="Type">{conversation.type}</FooterField>
+      </footer>
+    </>
+  );
+}
+
+/**
+ * One turn of the conversation, in chronological order:
+ *   1. the user's message (intent),
+ *   2. the agent's tool steps — collapsed by default, placed ABOVE the
+ *      reply because the tools ran before the agent produced its answer,
+ *   3. the agent's final visible reply.
+ */
+function ChatTurn({ turn }: { turn: SessionDisplay }) {
+  // Pull the agent's final visible response: prefer the `summary` event (the
+  // persisted final after directive-stripping), fall back to the last
+  // `agent` text block.
+  const summary = [...turn.transcript].reverse().find((e) => e.kind === "summary");
+  const lastAgent = [...turn.transcript].reverse().find((e) => e.kind === "agent");
+  const finalResponse = summary?.content ?? lastAgent?.content ?? "";
+
+  const toolSteps = turn.transcript.filter(
+    (e) => e.kind === "tool_call" || e.kind === "tool_result",
+  );
+
+  return (
+    <div>
       {/* User intent — the message that started this turn */}
-      <div className="mb-3 flex justify-end">
+      <div className="mb-2 flex justify-end">
         <div className="max-w-[80%] rounded-lg px-3 py-2 text-sm whitespace-pre-wrap bg-primary text-primary-foreground">
-          {session.intent}
+          {turn.intent}
         </div>
       </div>
 
+      {/* Tool steps — collapsed, above the reply to reflect the time order */}
+      {toolSteps.length > 0 ? (
+        <details className="group mb-2">
+          <summary className="flex items-center gap-1.5 cursor-pointer select-none list-none text-xs font-medium text-muted-foreground uppercase tracking-wide hover:text-foreground [&::-webkit-details-marker]:hidden">
+            <ChevronRight className="h-3 w-3 transition-transform group-open:rotate-90" />
+            <Wrench className="h-3 w-3" />
+            {toolSteps.length} tool {toolSteps.length === 1 ? "step" : "steps"}
+          </summary>
+          <div className="mt-2">
+            <ToolTranscript entries={toolSteps} />
+          </div>
+        </details>
+      ) : null}
+
       {/* Agent's final visible response */}
       {finalResponse ? (
-        <div className="mb-6 flex flex-col items-start">
+        <div className="flex flex-col items-start">
           <div className="max-w-[80%] rounded-lg px-3 py-2 bg-secondary text-foreground border border-border">
             <ChatMarkdown content={finalResponse} />
           </div>
         </div>
       ) : (
-        <div className="mb-6 text-xs text-muted-foreground italic">
-          (no response — session {session.status})
+        <div className="text-xs text-muted-foreground italic">
+          (no response — turn {turn.status})
         </div>
       )}
-
-      {toolSteps.length > 0 ? (
-        <section className="mt-8">
-          <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2 flex items-center gap-1.5">
-            <Wrench className="h-3 w-3" />
-            Tool transcript
-            <span className="ml-1 tabular-nums text-muted-foreground/60">
-              {toolSteps.length}
-            </span>
-          </h2>
-          <ToolTranscript entries={toolSteps} />
-        </section>
-      ) : null}
-
-      {session.usage ? <UsagePanel usage={session.usage} /> : null}
-
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
-        <FooterField label="Session ID">
-          <ClickToCopyId id={session.id} />
-        </FooterField>
-        {session.cli_session ? (
-          <FooterField label="CLI session" truncate>
-            <span className="font-mono">{session.cli_session}</span>
-          </FooterField>
-        ) : null}
-        {session.worktree ? (
-          <FooterField label="Worktree" truncate>
-            <span className="font-mono">{session.worktree}</span>
-          </FooterField>
-        ) : null}
-        <FooterField label="Type">{session.type}</FooterField>
-      </footer>
-    </>
+    </div>
   );
 }
 
@@ -226,4 +263,36 @@ function ToolTranscript({ entries }: { entries: TranscriptEntry[] }) {
       ))}
     </ol>
   );
+}
+
+/**
+ * Sum per-turn usage into one conversation-level total so the page shows a
+ * single cost/token panel. Cache-hit ratio is recomputed from the summed
+ * slices (same formula as the server's `computeCacheHitRatio`). Returns
+ * undefined when no turn carried usage (older sessions pre-usage-capture).
+ */
+function aggregateUsage(turns: SessionDisplay[]): SessionUsageDisplay | undefined {
+  const used = turns
+    .map((t) => t.usage)
+    .filter((u): u is SessionUsageDisplay => Boolean(u));
+  if (used.length === 0) return undefined;
+
+  const sum = (pick: (u: SessionUsageDisplay) => number) =>
+    used.reduce((acc, u) => acc + pick(u), 0);
+  const input_tokens = sum((u) => u.input_tokens);
+  const output_tokens = sum((u) => u.output_tokens);
+  const cache_creation_tokens = sum((u) => u.cache_creation_tokens);
+  const cache_read_tokens = sum((u) => u.cache_read_tokens);
+  const total_input_tokens = input_tokens + cache_creation_tokens + cache_read_tokens;
+
+  return {
+    cost_usd: sum((u) => u.cost_usd),
+    cache_hit_ratio: total_input_tokens > 0 ? cache_read_tokens / total_input_tokens : 0,
+    input_tokens,
+    output_tokens,
+    cache_creation_tokens,
+    cache_read_tokens,
+    total_input_tokens,
+    model: used[used.length - 1]!.model,
+  };
 }

--- a/packages/web/components/agents/agent-detail-panel.tsx
+++ b/packages/web/components/agents/agent-detail-panel.tsx
@@ -7,6 +7,7 @@ import { Avatar } from "@/components/avatar";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { CoreBlockCard } from "@/components/agents/core-block-card";
 import { RecentSessionRow } from "@/components/agents/recent-session-row";
+import { RecentChatThreadRow } from "@/components/agents/recent-chat-thread-row";
 import { EmptyState } from "@/components/empty-state";
 import { HierChip } from "@/components/hier-chip";
 import { Skeleton } from "@/components/skeleton";
@@ -211,6 +212,20 @@ function PanelLoaded({ agent }: { agent: AgentDetail }) {
           <ul className="space-y-1.5">
             {agent.recent_sessions.map((s, i) => (
               <RecentSessionRow key={s.short_id ?? i} session={s} variant="compact" />
+            ))}
+          </ul>
+        ) : null}
+      </Section>
+
+      <Section
+        title="Recent chats"
+        count={agent.recent_chat_threads.length}
+        empty="No recent chats."
+      >
+        {agent.recent_chat_threads.length > 0 ? (
+          <ul className="space-y-1.5">
+            {agent.recent_chat_threads.map((t) => (
+              <RecentChatThreadRow key={t.conversation_id} thread={t} variant="compact" />
             ))}
           </ul>
         ) : null}

--- a/packages/web/components/agents/recent-chat-thread-row.tsx
+++ b/packages/web/components/agents/recent-chat-thread-row.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+import type { RecentChatThread } from "@beevibe/api/views/types";
+
+/**
+ * Status → dot color/animation map. Mirrors `recent-session-row.tsx`:
+ * `running` (latest turn mid-LLM-call) gets the breathing pulse; the
+ * rest land on the muted "done" green. Keyed off `last_status`.
+ */
+const THREAD_DOT: Record<RecentChatThread["last_status"], string> = {
+  running: "bg-status-running animate-pulse-breathe",
+  review: "bg-status-review",
+  succeeded: "bg-status-done",
+};
+
+/**
+ * One collapsed chat-conversation card on the agent detail page. Groups N
+ * chat-turn sessions sharing a `conversation_id` into a single row — the
+ * head turn's first message as the title, a turn-count chip, and the
+ * most-recent-turn age. Links to the read-only conversation detail page,
+ * which expands the whole thread.
+ *
+ * `compact` — peek panel (right rail). `comfortable` — full detail page.
+ * Mirrors `RecentSessionRow`'s variants so the two lists read as siblings.
+ */
+type Variant = "compact" | "comfortable";
+
+const VARIANT_STYLES: Record<Variant, { row: string; meta: string }> = {
+  compact: {
+    row: "flex items-center gap-2 rounded-md border border-border/70 bg-background/40 px-2.5 py-1.5 text-xs",
+    meta: "text-[10px]",
+  },
+  comfortable: {
+    row: "flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-sm",
+    meta: "text-xs",
+  },
+};
+
+const LINKED_HOVER =
+  "hover:bg-secondary/50 hover:border-border/80 transition-colors cursor-pointer";
+
+export function RecentChatThreadRow({
+  thread,
+  variant,
+}: {
+  thread: RecentChatThread;
+  variant: Variant;
+}) {
+  const styles = VARIANT_STYLES[variant];
+  return (
+    <li>
+      <Link
+        href={`/sessions/${thread.short_id}`}
+        className={cn(styles.row, LINKED_HOVER)}
+      >
+        <span
+          className={cn("h-1.5 w-1.5 rounded-full shrink-0", THREAD_DOT[thread.last_status])}
+          aria-hidden
+        />
+        <span className="flex-1 min-w-0 truncate">{thread.title}</span>
+        <span className={cn("text-muted-foreground tabular-nums shrink-0", styles.meta)}>
+          {thread.turn_count} {thread.turn_count === 1 ? "turn" : "turns"}
+        </span>
+        <span className={cn("text-muted-foreground tabular-nums shrink-0", styles.meta)}>
+          {thread.age}
+        </span>
+      </Link>
+    </li>
+  );
+}

--- a/packages/web/components/agents/recent-chat-thread-row.tsx
+++ b/packages/web/components/agents/recent-chat-thread-row.tsx
@@ -3,60 +3,37 @@
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import type { RecentChatThread } from "@beevibe/api/views/types";
-
-/**
- * Status → dot color/animation map. Mirrors `recent-session-row.tsx`:
- * `running` (latest turn mid-LLM-call) gets the breathing pulse; the
- * rest land on the muted "done" green. Keyed off `last_status`.
- */
-const THREAD_DOT: Record<RecentChatThread["last_status"], string> = {
-  running: "bg-status-running animate-pulse-breathe",
-  review: "bg-status-review",
-  succeeded: "bg-status-done",
-};
+import {
+  RECENT_ROW_DOT,
+  RECENT_ROW_LINKED_HOVER,
+  RECENT_ROW_VARIANT_STYLES,
+  type RecentRowVariant,
+} from "@/components/agents/recent-row-styles";
 
 /**
  * One collapsed chat-conversation card on the agent detail page. Groups N
  * chat-turn sessions sharing a `conversation_id` into a single row — the
  * head turn's first message as the title, a turn-count chip, and the
  * most-recent-turn age. Links to the read-only conversation detail page,
- * which expands the whole thread.
- *
- * `compact` — peek panel (right rail). `comfortable` — full detail page.
- * Mirrors `RecentSessionRow`'s variants so the two lists read as siblings.
+ * which expands the whole thread. Sibling of `RecentSessionRow` (shared
+ * dot/variant styling).
  */
-type Variant = "compact" | "comfortable";
-
-const VARIANT_STYLES: Record<Variant, { row: string; meta: string }> = {
-  compact: {
-    row: "flex items-center gap-2 rounded-md border border-border/70 bg-background/40 px-2.5 py-1.5 text-xs",
-    meta: "text-[10px]",
-  },
-  comfortable: {
-    row: "flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-sm",
-    meta: "text-xs",
-  },
-};
-
-const LINKED_HOVER =
-  "hover:bg-secondary/50 hover:border-border/80 transition-colors cursor-pointer";
-
 export function RecentChatThreadRow({
   thread,
   variant,
 }: {
   thread: RecentChatThread;
-  variant: Variant;
+  variant: RecentRowVariant;
 }) {
-  const styles = VARIANT_STYLES[variant];
+  const styles = RECENT_ROW_VARIANT_STYLES[variant];
   return (
     <li>
       <Link
         href={`/sessions/${thread.short_id}`}
-        className={cn(styles.row, LINKED_HOVER)}
+        className={cn(styles.row, RECENT_ROW_LINKED_HOVER)}
       >
         <span
-          className={cn("h-1.5 w-1.5 rounded-full shrink-0", THREAD_DOT[thread.last_status])}
+          className={cn("h-1.5 w-1.5 rounded-full shrink-0", RECENT_ROW_DOT[thread.last_status])}
           aria-hidden
         />
         <span className="flex-1 min-w-0 truncate">{thread.title}</span>

--- a/packages/web/components/agents/recent-row-styles.ts
+++ b/packages/web/components/agents/recent-row-styles.ts
@@ -1,0 +1,47 @@
+import type { RecentSession } from "@beevibe/api/views/types";
+
+/**
+ * Shared styling for the agent detail page's recent-activity rows —
+ * `RecentSessionRow` (task/mesh/blocker) and `RecentChatThreadRow` (chat
+ * conversations). The two lists are deliberate siblings; keeping the dot
+ * map + variant styles here is what makes them read alike.
+ */
+
+/** Status union shared by both rows (RecentChatThread.last_status matches). */
+export type RecentRowStatus = RecentSession["status"];
+
+/**
+ * Status → dot color/animation. `running` gets the breathing pulse to read
+ * as live; `review` uses the review accent; everything else (`succeeded`)
+ * lands on the muted "done" green.
+ */
+export const RECENT_ROW_DOT: Record<RecentRowStatus, string> = {
+  running: "bg-status-running animate-pulse-breathe",
+  review: "bg-status-review",
+  succeeded: "bg-status-done",
+};
+
+/**
+ * `compact` — peek panel (right rail): tighter padding, smaller meta text,
+ *   lighter background to fit the panel's nested context.
+ * `comfortable` — full agent detail page: roomier padding, base text, solid
+ *   card background.
+ */
+export type RecentRowVariant = "compact" | "comfortable";
+
+export const RECENT_ROW_VARIANT_STYLES: Record<
+  RecentRowVariant,
+  { row: string; meta: string }
+> = {
+  compact: {
+    row: "flex items-center gap-2 rounded-md border border-border/70 bg-background/40 px-2.5 py-1.5 text-xs",
+    meta: "text-[10px]",
+  },
+  comfortable: {
+    row: "flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-sm",
+    meta: "text-xs",
+  },
+};
+
+export const RECENT_ROW_LINKED_HOVER =
+  "hover:bg-secondary/50 hover:border-border/80 transition-colors cursor-pointer";

--- a/packages/web/components/agents/recent-session-row.tsx
+++ b/packages/web/components/agents/recent-session-row.tsx
@@ -3,55 +3,33 @@
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import type { RecentSession } from "@/lib/types/agents";
+import {
+  RECENT_ROW_DOT,
+  RECENT_ROW_LINKED_HOVER,
+  RECENT_ROW_VARIANT_STYLES,
+  type RecentRowVariant,
+} from "@/components/agents/recent-row-styles";
 
 /**
- * Status → dot color/animation map. `running` gets the breathing pulse
- * to read as live; `review` uses the review accent; everything else
- * (`succeeded`) lands on the muted "done" green.
- */
-const RECENT_SESSION_DOT: Record<RecentSession["status"], string> = {
-  running: "bg-status-running animate-pulse-breathe",
-  review: "bg-status-review",
-  succeeded: "bg-status-done",
-};
-
-/**
- * `compact` — peek panel (520px right rail): tighter padding, smaller
- *   text + meta, lighter background to fit the panel's nested context.
- * `comfortable` — full agent detail page: roomier padding, base text,
- *   solid card background.
+ * One recent non-chat session (task / mesh / blocker / run_repo) on the
+ * agent detail page. Chat conversations are surfaced separately as
+ * collapsed thread cards via `RecentChatThreadRow`.
  *
  * Both wrap the row in a Link when `short_id` is present (always in
  * practice; the unlinked branch is defense against future shapes).
  */
-type Variant = "compact" | "comfortable";
-
-const VARIANT_STYLES: Record<Variant, { row: string; meta: string }> = {
-  compact: {
-    row: "flex items-center gap-2 rounded-md border border-border/70 bg-background/40 px-2.5 py-1.5 text-xs",
-    meta: "text-[10px]",
-  },
-  comfortable: {
-    row: "flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-sm",
-    meta: "text-xs",
-  },
-};
-
-const LINKED_HOVER =
-  "hover:bg-secondary/50 hover:border-border/80 transition-colors cursor-pointer";
-
 export function RecentSessionRow({
   session,
   variant,
 }: {
   session: RecentSession;
-  variant: Variant;
+  variant: RecentRowVariant;
 }) {
-  const styles = VARIANT_STYLES[variant];
+  const styles = RECENT_ROW_VARIANT_STYLES[variant];
   const inner = (
     <>
       <span
-        className={cn("h-1.5 w-1.5 rounded-full shrink-0", RECENT_SESSION_DOT[session.status])}
+        className={cn("h-1.5 w-1.5 rounded-full shrink-0", RECENT_ROW_DOT[session.status])}
         aria-hidden
       />
       <span className="flex-1 min-w-0 truncate">{session.title}</span>
@@ -72,7 +50,7 @@ export function RecentSessionRow({
 
   return (
     <li>
-      <Link href={`/sessions/${session.short_id}`} className={cn(styles.row, LINKED_HOVER)}>
+      <Link href={`/sessions/${session.short_id}`} className={cn(styles.row, RECENT_ROW_LINKED_HOVER)}>
         {inner}
       </Link>
     </li>

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -23,7 +23,11 @@ import type { MeshWindow } from "@/lib/types/mesh";
 import type { TaskListItem } from "@/lib/types/tasks";
 import type { AgentDisplay } from "@/lib/types/agents";
 import type { AgentNetwork } from "@/lib/types/agent-network";
-import type { SessionDisplay, SessionTreeResponse } from "@/lib/types/sessions";
+import type {
+  ConversationDisplay,
+  SessionDisplay,
+  SessionTreeResponse,
+} from "@/lib/types/sessions";
 import type { FactCounts, MemoryFactDisplay } from "@/lib/types/memory-facts";
 import type { PromotionEvent } from "@/lib/types/promotion-events";
 import type { InboxItem } from "@/lib/types/inbox";
@@ -500,6 +504,17 @@ export const api = {
       fetchJson<SessionDisplay>(`/session/${encodeURIComponent(shortId)}`, {
         signal: opts.signal,
       }),
+    /**
+     * Whole chat conversation for the session detail page. Path param is
+     * the 6-char short_id of any turn (in practice the head turn's, the
+     * key the agent detail page links to). Returns every chained turn
+     * sharing the `conversation_id`; non-chat sessions return a single turn.
+     */
+    conversation: (shortId: string, opts: ReadOptions = {}) =>
+      fetchJson<ConversationDisplay>(
+        `/session/${encodeURIComponent(shortId)}/conversation`,
+        { signal: opts.signal },
+      ),
     /**
      * Hydration fallback for useChatStreamTree. Path param is the FULL
      * session id (e.g. `sess_abc123def...`), not the short_id — the SSE

--- a/packages/web/lib/hooks/keys.ts
+++ b/packages/web/lib/hooks/keys.ts
@@ -16,6 +16,7 @@ export const queryKeys = {
   sessions: {
     all: ["sessions"] as const,
     detail: (shortId: string) => ["sessions", "detail", shortId] as const,
+    conversation: (shortId: string) => ["sessions", "conversation", shortId] as const,
   },
   memory: {
     all: ["memory"] as const,

--- a/packages/web/lib/hooks/use-sessions.ts
+++ b/packages/web/lib/hooks/use-sessions.ts
@@ -10,3 +10,19 @@ export function useSession(shortId: string | undefined) {
     enabled: isApiConfigured && !!shortId,
   });
 }
+
+/**
+ * Whole chat conversation for the session detail page — every chained
+ * turn sharing the addressed session's `conversation_id`. Non-chat
+ * sessions resolve to a single-turn conversation, so the detail page
+ * renders them unchanged.
+ */
+export function useConversation(shortId: string | undefined) {
+  return useQuery({
+    queryKey: shortId
+      ? queryKeys.sessions.conversation(shortId)
+      : queryKeys.sessions.all,
+    queryFn: ({ signal }) => api.sessions.conversation(shortId as string, { signal }),
+    enabled: isApiConfigured && !!shortId,
+  });
+}

--- a/packages/web/lib/types/sessions.ts
+++ b/packages/web/lib/types/sessions.ts
@@ -1,4 +1,5 @@
 export type {
+  ConversationDisplay,
   SessionDisplay,
   SessionBriefing,
   SessionUsageDisplay,


### PR DESCRIPTION
## Why

Each chat **turn** (one user message → one agent reply) is its own `session` row, chained by `prior_session_id` and sharing a `conversation_id` (the head turn's id). The UI treated these as isolated sessions:

- The agent detail page's **Recent sessions** list *excludes* chat (commit `4f1edc4`), so chat activity was invisible there.
- The **session detail page** showed exactly one turn ("One turn"), not the conversation.

This surfaces a continued chat as **one conversation** across both surfaces. The backend already materialized `conversation_id` and a `recent_chat_threads` query — most of this is wiring + one new read endpoint.

## What

**Agent detail — "Recent chats"**
- Render the existing `recent_chat_threads` as a new section (full page + peek panel), one card per conversation linking to its head turn.
- Add `short_id` to the `RecentChatThread` DTO so the web links without re-deriving it.

**New endpoint — `GET /session/:shortId/conversation`**
- `getConversationByShortId` returns every turn sharing the `conversation_id`, chronological, each a full `SessionDisplay` with its own transcript. Reuses `rowToSessionDisplay` + an extracted shared SQL fragment.
- Non-chat sessions (`conversation_id` NULL) resolve to a single-turn conversation, so mesh/blocker/negotiate pages render unchanged. The `type === 'task'` redirect to the task-scoped page is preserved.

**Session detail page**
- Renders the whole thread. Per turn: user message → **collapsible tool steps (above the reply**, reflecting chronological order) → agent reply.
- "Conversation · N turns" header + a single **aggregated usage panel** (cost/tokens summed across turns; cache-hit recomputed).

## Testing

- `+5` conversation-view unit tests; `RecentChatThread.short_id` assertion. All api view (123) + web (176) unit suites green.
- Verified **end-to-end on localhost with Playwright** (13/13 checks): seeded a 3-turn chat, confirmed the "Recent chats" card (3 turns) on the agent page, the conversation page rendering all turns with tool-step expanders above each reply, collapse/expand behavior, and the aggregated usage panel ($0.0390 across 3 turns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
