### PR TITLE
feat(chat): stream working steps on top, collapse into a dropdown on completion

### DIFF
--- a/packages/web/app/(authed)/chat/chat-client.tsx
+++ b/packages/web/app/(authed)/chat/chat-client.tsx
@@ -33,7 +33,7 @@ import type { TranscriptEntry } from "@/lib/types/sessions";
 import { useMe } from "@/lib/hooks/use-me";
 import { useAgents } from "@/lib/hooks/use-agents";
 import { queryKeys } from "@/lib/hooks/keys";
-import { formatRelativeTime } from "@/lib/format";
+import { deriveShortId, formatRelativeTime } from "@/lib/format";
 import { defaultTryGoal, formatStars } from "@/lib/capabilities";
 import { cn } from "@/lib/utils";
 import { Avatar } from "@/components/avatar";
@@ -121,21 +121,17 @@ export function ChatClient() {
   const chatTreeEnabled = process.env.NEXT_PUBLIC_CHAT_TREE_UI === "1";
   const liveTree = useChatStreamTree(chatTreeEnabled ? pendingSessionId : undefined);
   const liveStreamFlat = useChatStream(chatTreeEnabled ? undefined : pendingSessionId);
-  const liveSteps: ChatStreamStep[] = chatTreeEnabled
-    ? pendingSessionId
-      ? liveTree.steps[pendingSessionId] ?? EMPTY_STEPS
-      : EMPTY_STEPS
-    : liveStreamFlat.steps;
-  // Per-session step map for rendering each completed turn's working trace
-  // as a collapsed disclosure. `liveMap` holds steps streamed this session;
-  // `persistedStepsBySession` (below) holds the persisted transcript so the
-  // trace survives reload / opening an older conversation.
+  // Per-session step map keyed by full session id. `liveMap` holds steps
+  // streamed this session — used both for the in-flight "Working" box and a
+  // just-finished turn's trace; `persistedStepsBySession` (below) holds the
+  // persisted transcript so the trace survives reload / opening an older chat.
   const liveMap = chatTreeEnabled ? liveTree.steps : liveStreamFlat.stepsBySession;
+  const liveSteps = pendingSessionId ? liveMap[pendingSessionId] ?? EMPTY_STEPS : EMPTY_STEPS;
 
   // Fetch the loaded chain's persisted per-turn transcripts so a finished
   // turn's working trace renders even when its live SSE steps aren't in
   // memory (cold load, prior history). Keyed by full turn/session id.
-  const headShortId = conversationId ? conversationId.slice(5, 11) : undefined;
+  const headShortId = conversationId ? deriveShortId(conversationId) : undefined;
   const conversation = useConversation(headShortId);
   const persistedStepsBySession = useMemo(() => {
     const map: Record<string, ChatStreamStep[]> = {};
@@ -668,7 +664,7 @@ function WorkedDisclosure({
     (s) => s.kind === "tool_call" || s.kind === "tool_result",
   );
   if (toolSteps.length === 0) return null;
-  const count = toolSteps.filter((s) => s.kind === "tool_call").length || toolSteps.length;
+  const count = toolSteps.filter((s) => s.kind === "tool_call").length;
   return (
     <details className="group w-full mb-1">
       <summary className="flex items-center gap-1.5 cursor-pointer select-none list-none text-[10px] uppercase tracking-wide text-muted-foreground/45 hover:text-muted-foreground/70 [&::-webkit-details-marker]:hidden">

--- a/packages/web/app/(authed)/chat/chat-client.tsx
+++ b/packages/web/app/(authed)/chat/chat-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
@@ -9,6 +9,7 @@ import {
   ArrowRight,
   ArrowUp,
   Bell,
+  ChevronRight,
   MessageSquare,
   Star,
 } from "lucide-react";
@@ -27,6 +28,8 @@ import {
   type ChatStreamStep,
   type ChatStreamTree,
 } from "@/lib/chat-stream";
+import { useConversation } from "@/lib/hooks/use-sessions";
+import type { TranscriptEntry } from "@/lib/types/sessions";
 import { useMe } from "@/lib/hooks/use-me";
 import { useAgents } from "@/lib/hooks/use-agents";
 import { queryKeys } from "@/lib/hooks/keys";
@@ -49,6 +52,22 @@ function useTeamAgent() {
 }
 
 const EMPTY_STEPS: ChatStreamStep[] = [];
+
+/**
+ * Map a persisted `TranscriptEntry` to the `ChatStreamStep` shape the live
+ * SSE stream produces, so completed turns render through the same
+ * `ToolStepList` as the live working box. `received_at: 0` matches the
+ * polled-step mapping in the room view — ordering comes from array index.
+ */
+const toStreamStep =
+  (turnId: string) =>
+  (entry: TranscriptEntry, i: number): ChatStreamStep => ({
+    event_id: `${turnId}-${i}`,
+    kind: entry.kind,
+    ...(entry.tool_name ? { tool_name: entry.tool_name } : {}),
+    content: entry.content,
+    received_at: 0,
+  });
 
 const PROMPT_SUGGESTIONS = [
   "What's on the team's plate today?",
@@ -81,11 +100,19 @@ export function ChatClient() {
   const conversationParam = searchParams?.get("c") ?? undefined;
   const isFresh = searchParams?.get("new") === "1";
 
-  const { messages, send, isPending, isSubmitting, error, pendingSessionId, runtimeMismatch } =
-    useChat({
-      conversationId: conversationParam,
-      fresh: isFresh,
-    });
+  const {
+    messages,
+    send,
+    isPending,
+    isSubmitting,
+    error,
+    pendingSessionId,
+    runtimeMismatch,
+    conversationId,
+  } = useChat({
+    conversationId: conversationParam,
+    fresh: isFresh,
+  });
 
   // Tree mode subscribes to both `session.step` and `session.spawned`
   // events for the team session AND every IC it spawns via create_task.
@@ -93,12 +120,37 @@ export function ChatClient() {
   // is a true escape hatch during rollout.
   const chatTreeEnabled = process.env.NEXT_PUBLIC_CHAT_TREE_UI === "1";
   const liveTree = useChatStreamTree(chatTreeEnabled ? pendingSessionId : undefined);
-  const liveStepsFlat = useChatStream(chatTreeEnabled ? undefined : pendingSessionId);
+  const liveStreamFlat = useChatStream(chatTreeEnabled ? undefined : pendingSessionId);
   const liveSteps: ChatStreamStep[] = chatTreeEnabled
     ? pendingSessionId
       ? liveTree.steps[pendingSessionId] ?? EMPTY_STEPS
       : EMPTY_STEPS
-    : liveStepsFlat;
+    : liveStreamFlat.steps;
+  // Per-session step map for rendering each completed turn's working trace
+  // as a collapsed disclosure. `liveMap` holds steps streamed this session;
+  // `persistedStepsBySession` (below) holds the persisted transcript so the
+  // trace survives reload / opening an older conversation.
+  const liveMap = chatTreeEnabled ? liveTree.steps : liveStreamFlat.stepsBySession;
+
+  // Fetch the loaded chain's persisted per-turn transcripts so a finished
+  // turn's working trace renders even when its live SSE steps aren't in
+  // memory (cold load, prior history). Keyed by full turn/session id.
+  const headShortId = conversationId ? conversationId.slice(5, 11) : undefined;
+  const conversation = useConversation(headShortId);
+  const persistedStepsBySession = useMemo(() => {
+    const map: Record<string, ChatStreamStep[]> = {};
+    for (const turn of conversation.data?.turns ?? []) {
+      map[turn.id] = turn.transcript.map(toStreamStep(turn.id));
+    }
+    return map;
+  }, [conversation.data]);
+
+  // Persisted wins when present (full untruncated content, richer recall
+  // blocks); live is the immediate fallback for a turn that just finished
+  // before the conversation query refetches — so no empty-dropdown flicker.
+  const stepsFor = (sessionId: string): ChatStreamStep[] | undefined =>
+    persistedStepsBySession[sessionId] ?? liveMap[sessionId];
+
   const transcriptRef = useRef<HTMLDivElement | null>(null);
   const teamAgent = useTeamAgent();
 
@@ -222,6 +274,12 @@ export function ChatClient() {
                       onSuggest={submit}
                       teamAgent={teamAgent}
                       isFirstInGroup={isFirstInGroup}
+                      steps={
+                        m.role === "agent" && m.session_id
+                          ? stepsFor(m.session_id)
+                          : undefined
+                      }
+                      tree={chatTreeEnabled ? liveTree : undefined}
                     />
                   );
                 })}
@@ -504,6 +562,8 @@ function Bubble({
   onSuggest,
   teamAgent,
   isFirstInGroup,
+  steps,
+  tree,
 }: {
   message: ChatMessage;
   showSuggestions?: boolean;
@@ -515,6 +575,10 @@ function Bubble({
     specialization?: string;
   };
   isFirstInGroup: boolean;
+  /** Completed turn's working trace, rendered as a collapsed disclosure above the reply. */
+  steps?: ChatStreamStep[];
+  /** Tree of spawned IC sessions, for inline transcripts in the disclosure (tree mode only). */
+  tree?: ChatStreamTree;
 }) {
   const isUser = message.role === "user";
   const refIds = !isUser ? message.view_refs ?? [] : [];
@@ -551,9 +615,21 @@ function Bubble({
             <div className="text-sm whitespace-pre-wrap">{message.content}</div>
           </div>
         ) : (
-          <div className="py-1 text-sm leading-6 text-foreground/90">
-            <ChatMarkdown content={message.content} inverted={false} />
-          </div>
+          <>
+            {/* Collapsed working trace, above the reply — the tool steps ran
+                before the agent produced its answer (chrono order), and
+                they no longer vanish when the turn completes. */}
+            {steps ? (
+              <WorkedDisclosure
+                steps={steps}
+                tree={tree}
+                parentSessionId={message.session_id}
+              />
+            ) : null}
+            <div className="py-1 text-sm leading-6 text-foreground/90">
+              <ChatMarkdown content={message.content} inverted={false} />
+            </div>
+          </>
         )}
         {!isUser ? (
           <>
@@ -569,6 +645,45 @@ function Bubble({
         ) : null}
       </div>
     </div>
+  );
+}
+
+/**
+ * A finished turn's working trace, collapsed into a drop-down above the
+ * reply. Expands to the same `ToolStepList` the live working box uses, so
+ * live and completed traces read identically (category icons, inline IC
+ * transcripts, session_search recall blocks). Renders nothing when the turn
+ * made no tool calls.
+ */
+function WorkedDisclosure({
+  steps,
+  tree,
+  parentSessionId,
+}: {
+  steps: ChatStreamStep[];
+  tree?: ChatStreamTree;
+  parentSessionId?: string;
+}) {
+  const toolSteps = steps.filter(
+    (s) => s.kind === "tool_call" || s.kind === "tool_result",
+  );
+  if (toolSteps.length === 0) return null;
+  const count = toolSteps.filter((s) => s.kind === "tool_call").length || toolSteps.length;
+  return (
+    <details className="group w-full mb-1">
+      <summary className="flex items-center gap-1.5 cursor-pointer select-none list-none text-[10px] uppercase tracking-wide text-muted-foreground/45 hover:text-muted-foreground/70 [&::-webkit-details-marker]:hidden">
+        <ChevronRight className="h-3 w-3 transition-transform group-open:rotate-90" />
+        Worked · {count} step{count === 1 ? "" : "s"}
+      </summary>
+      <div className="mt-1.5">
+        <ToolStepList
+          steps={toolSteps}
+          totalSteps={toolSteps.length}
+          tree={tree}
+          parentSessionId={parentSessionId}
+        />
+      </div>
+    </details>
   );
 }
 
@@ -772,6 +887,24 @@ function Thinking({
         />
       </div>
       <div className="max-w-[78%] min-w-0 py-1">
+        {/* Working box on top — the tool steps stream in as the agent works,
+            and the reply text renders below them (chrono order, ChatGPT
+            shape). When the turn completes this whole block is replaced by
+            the agent Bubble, which re-renders the same steps as a collapsed
+            WorkedDisclosure above its reply. */}
+        {recentTools.length > 0 ? (
+          <div className="mb-3">
+            <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground/45">
+              Working
+            </div>
+            <ToolStepList
+              steps={recentTools}
+              totalSteps={toolSteps.length}
+              tree={tree}
+              parentSessionId={rootSessionId}
+            />
+          </div>
+        ) : null}
         {hasWorkingText ? (
           <div className="text-sm leading-6 text-foreground/90">
             <ChatMarkdown content={streamingText} />
@@ -781,20 +914,6 @@ function Thinking({
             <ChatLoader compact />
           </div>
         )}
-        {recentTools.length > 0 ? (
-          <div className={cn(hasWorkingText ? "mt-3" : "mt-2")}>
-            <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground/45">
-              Working
-            </div>
-            <ToolStepList
-              steps={recentTools}
-              totalSteps={toolSteps.length}
-              withTopBorder={hasWorkingText}
-              tree={tree}
-              parentSessionId={rootSessionId}
-            />
-          </div>
-        ) : null}
       </div>
     </div>
   );

--- a/packages/web/app/(authed)/rooms/[id]/room-detail-client.tsx
+++ b/packages/web/app/(authed)/rooms/[id]/room-detail-client.tsx
@@ -497,7 +497,7 @@ function TypingBubble({ typing: t }: { typing: NonNullable<RoomDetail["typing"]>
   //     buffer; empty when the SSE detector has fallen back to polling
   // Audience sees Read / Bash / ask / save_memory / search_memory
   // calls land live (or every 3s in polling-only mode).
-  const sseSteps = useChatStream(t.session_id);
+  const sseSteps = useChatStream(t.session_id).steps;
   const polled: ChatStreamStep[] = (t.recent_steps ?? []).map((s) => ({
     event_id: s.event_id,
     kind: s.kind,

--- a/packages/web/lib/chat-stream.ts
+++ b/packages/web/lib/chat-stream.ts
@@ -30,12 +30,26 @@ function parseStep(ev: BvEvent): ChatStreamStep | undefined {
   };
 }
 
+export interface ChatStream {
+  /** Steps for the subscribed `sessionId` (empty when none). */
+  steps: ChatStreamStep[];
+  /**
+   * Every session this hook instance has accumulated steps for, keyed by
+   * full session id. Persists across turns (each completed turn keeps its
+   * steps here), so a finished chat turn can still render its working
+   * trace as a collapsed disclosure looked up by the agent message's
+   * `session_id`.
+   */
+  stepsBySession: Record<string, ChatStreamStep[]>;
+}
+
 /**
  * Stream of `session.step` events scoped to one session id. Returns the
- * accumulated step list (new chat turn → fresh array, since the new
- * sessionId triggers a new state slot via React's per-render closure).
+ * accumulated step list for that session (new chat turn → fresh array,
+ * since the new sessionId triggers a new state slot via React's per-render
+ * closure) plus the full per-session map for looking up completed turns.
  */
-export function useChatStream(sessionId: string | undefined): ChatStreamStep[] {
+export function useChatStream(sessionId: string | undefined): ChatStream {
   // Keying state by sessionId means each turn gets its own fresh `steps`
   // array — no separate reset effect to race with the resubscription.
   const [stepsBySession, setStepsBySession] = useState<Record<string, ChatStreamStep[]>>({});
@@ -55,7 +69,10 @@ export function useChatStream(sessionId: string | undefined): ChatStreamStep[] {
   );
   useSseEvents(onEvent);
 
-  return sessionId ? stepsBySession[sessionId] ?? EMPTY : EMPTY;
+  return {
+    steps: sessionId ? stepsBySession[sessionId] ?? EMPTY : EMPTY,
+    stepsBySession,
+  };
 }
 
 const EMPTY: ChatStreamStep[] = [];

--- a/packages/web/lib/format.ts
+++ b/packages/web/lib/format.ts
@@ -35,9 +35,18 @@ export function formatRelativeTime(
   return `${Math.floor(diffMonth / 12)}y ago`;
 }
 
+/**
+ * The 6-char short id used in routes and lookups — strip the typed-id
+ * prefix (`sess_`, `agent_`, …) and take the first 6 chars. Mirrors the
+ * backend's `deriveShortId` (packages/api/src/views/format.ts) so the web
+ * doesn't hard-code the prefix length in multiple places.
+ */
+export function deriveShortId(id: string): string {
+  return id.replace(/^[a-z]+_/, "").slice(0, 6);
+}
+
 export function shortId(id: string): string {
-  const trimmed = id.replace(/^[a-z]+_/, "");
-  return `#${trimmed.slice(0, 6)}`;
+  return `#${deriveShortId(id)}`;
 }
 
 /** Cap a string at `n` chars, adding an ellipsis suffix when truncated. */
@@ -77,8 +86,7 @@ export function idSuffix(id: string): string {
 }
 
 export function sessionHref(sid: string, taskId?: string): string {
-  // The full id starts with "sess_"; route URLs use the 6-char suffix.
-  const sessionShort = sid.startsWith("sess_") ? sid.slice(5, 11) : sid.slice(0, 6);
+  const sessionShort = deriveShortId(sid);
   if (taskId) return `/tasks/${taskId}/sessions/${sessionShort}`;
   return `/sessions/${sessionShort}`;
 }

--- a/packages/web/lib/hooks/use-chat.ts
+++ b/packages/web/lib/hooks/use-chat.ts
@@ -335,6 +335,13 @@ export function useChat(opts: UseChatOptions = {}) {
     error: exposedError,
     /** Renamed from pendingSessionId — semantics unchanged at the call site. */
     pendingSessionId: inFlightSessionId,
+    /**
+     * Head id of the loaded chain (full `sess_xxx`), or undefined for a
+     * brand-new surface with no persisted history yet. The chat page derives
+     * its short_id to fetch the conversation's persisted per-turn transcripts
+     * (so a finished turn's working trace survives reload).
+     */
+    conversationId: history.data?.conversation_id ?? undefined,
     /** History query state, for showing a "loading prior conversation…" indicator. */
     isLoadingHistory: history.isLoading,
     /**

--- a/packages/web/lib/hooks/use-sessions.ts
+++ b/packages/web/lib/hooks/use-sessions.ts
@@ -24,5 +24,10 @@ export function useConversation(shortId: string | undefined) {
       : queryKeys.sessions.all,
     queryFn: ({ signal }) => api.sessions.conversation(shortId as string, { signal }),
     enabled: isApiConfigured && !!shortId,
+    // A completed turn's transcript is immutable, so this potentially-large
+    // fetch (every turn × up to 500 events) needn't refetch on focus/idle.
+    // In-flight turns surface live via SSE, not this query. Cold loads still
+    // refetch on mount.
+    staleTime: 60_000,
   });
 }

--- a/packages/web/lib/tool-format.test.ts
+++ b/packages/web/lib/tool-format.test.ts
@@ -138,3 +138,29 @@ describe("formatTool — session_search shape detection", () => {
     expect(formatTool("session_search", "[]").label).toBe("Browsed recent sessions");
   });
 });
+
+describe("formatTool — empty-args blobs render no stray detail", () => {
+  // find_subordinates() takes no args, so describeToolInput emits "{}".
+  // Without cleanup that rendered as "Surveyed the team {}" — the stray
+  // braces are noise, so the detail should be blank.
+  it("find_subordinates with empty '{}' args → 'Surveyed the team', no detail", () => {
+    const display = formatTool("mcp__beevibe__find_subordinates", "{}");
+    expect(display.label).toBe("Surveyed the team");
+    expect(display.detail).toBe("");
+    expect(display.category).toBe("team");
+  });
+
+  it("find_peers / find_up also drop the empty-object detail", () => {
+    expect(formatTool("find_peers", "{}").detail).toBe("");
+    expect(formatTool("find_up", "{ }").detail).toBe("");
+  });
+
+  it("empty object/array args carry no detail for any tool", () => {
+    expect(formatTool("get_agent_profile", "{}").detail).toBe("");
+    expect(formatTool("create_task", "[]").detail).toBe("");
+  });
+
+  it("non-empty args still render a detail", () => {
+    expect(formatTool("Bash", "ls -la").detail).toBe("ls -la");
+  });
+});

--- a/packages/web/lib/tool-format.ts
+++ b/packages/web/lib/tool-format.ts
@@ -46,6 +46,11 @@ export function normalizeToolName(toolName: string | undefined): string {
 }
 
 function cleanToolDetail(content: string): string {
+  // Empty-args blobs (`{}`, `[]`) carry no information — describeToolInput
+  // emits "{}" for no-arg tools like find_subordinates. Render no detail
+  // rather than a stray "{}" next to the verb.
+  const raw = content.trim();
+  if (raw === "" || /^\{\s*\}$/.test(raw) || /^\[\s*\]$/.test(raw)) return "";
   const detail = content
     .trim()
     .replace(/mcp__[^_]+__/g, "")


### PR DESCRIPTION
## What & why

The live chat page rendered each turn the wrong way round: the streaming reply sat on **top** and the "Working" tool steps **below** it — and when the turn finished, the steps **vanished**, leaving only the bare reply bubble. This reshapes it to the ChatGPT pattern.

- **Working box on top**, reply streams **below** it during the turn.
- On completion the working box **collapses into a `Worked · N steps` drop-down** above the reply (expand to review the steps) instead of disappearing.
- **Survives reload / opening an older conversation**: each turn's persisted transcript is fetched via the existing `GET /session/:shortId/conversation` and merged with the live SSE stream (persisted wins for full content; live is the no-flicker fallback for a turn that just finished).

No backend change — the live SSE `session.step` content and the persisted transcript come from the same `session_event.content` column, so both render through the existing `ToolStepList`.

## Changes
- `lib/chat-stream.ts` — `useChatStream` returns `{ steps, stepsBySession }` so a finished turn keeps its trace (looked up by the agent message's `session_id`).
- `rooms/[id]/room-detail-client.tsx` — call-site reads `.steps` (behavior unchanged).
- `lib/hooks/use-chat.ts` — exposes `conversationId` (chain head) for fetching transcripts.
- `chat/chat-client.tsx` — inverted `Thinking` block; new `WorkedDisclosure` (reuses `ToolStepList`); persisted+live step merge wired into each agent bubble.
- `lib/tool-format.ts` (+ test) — `cleanToolDetail` drops empty-args blobs (`{}`/`[]`), so no-arg tools like `find_subordinates` render `Surveyed the team` instead of `Surveyed the team {}`.

## Verification
- `pnpm --filter @beevibe/web typecheck` + `lint` clean; `tool-format` unit tests **20/20** (4 new).
- **Playwright (persisted + reload):** 8/8 — 3 collapsed drop-downs (one per turn), each above its reply, expand to show tool rows, **survive a full reload**.
- **Playwright (live):** drove a real turn through an isolated test daemon — Working box streams on top → collapses to `Worked · 2 steps`; and a `find_subordinates` turn confirmed the row renders cleanly (no stray `{}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)