### PR TITLE
feat(memory-eval): calendar popover for "compare around"; default to today

### DIFF
--- a/packages/web/app/(authed)/memory/eval/eval-client.tsx
+++ b/packages/web/app/(authed)/memory/eval/eval-client.tsx
@@ -7,6 +7,7 @@ import { useMemoryActivity } from "@/lib/hooks/use-memory-activity";
 import { isApiConfigured } from "@/lib/api/config";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
+import { DatePicker, todayIso } from "@/components/date-picker";
 import type {
   AgentActivityRow,
   AgentRatioRow,
@@ -36,7 +37,9 @@ const TYPE_COLOR: Record<FactType, { fill: string; dot: string }> = {
 
 export function MemoryEvalClient() {
   const [weeks, setWeeks] = useState(12);
-  const [since, setSince] = useState<string>("");
+  // Default to today so the before/after panel is discoverable on first
+  // load. Users can clear or pick a different boundary from the calendar.
+  const [since, setSince] = useState<string>(() => todayIso());
 
   // queryKey uses structural equality, so no useMemo wrap needed.
   const params = { weeks, since: since || undefined };
@@ -126,24 +129,15 @@ function Header({
             ))}
           </select>
         </label>
-        <label className="flex items-center gap-2">
+        <div className="flex items-center gap-2">
           <span className="text-muted-foreground">Compare around</span>
-          <input
-            type="date"
+          <DatePicker
             value={since}
-            onChange={(e) => onSinceChange(e.target.value)}
-            className="bg-background border border-border rounded px-2 py-1"
+            onChange={onSinceChange}
+            onClear={() => onSinceChange("")}
+            ariaLabel="Compare around date"
           />
-          {since ? (
-            <button
-              type="button"
-              onClick={() => onSinceChange("")}
-              className="text-muted-foreground hover:text-foreground"
-            >
-              clear
-            </button>
-          ) : null}
-        </label>
+        </div>
       </div>
     </header>
   );

--- a/packages/web/components/date-picker.tsx
+++ b/packages/web/components/date-picker.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Calendar, ChevronLeft, ChevronRight, X } from "lucide-react";
+import { ChipPopover } from "@/components/agents/pickers/chip-popover";
+import { cn } from "@/lib/utils";
+
+/**
+ * Date picker with a calendar popover. Native <input type="date"> works
+ * but its trigger is a tiny browser icon — users don't realise they can
+ * click it. This surfaces an explicit calendar button that opens a
+ * month grid, with an inline clear affordance.
+ *
+ * Value contract: YYYY-MM-DD strings. Empty string means "no date".
+ * `onClear` is rendered only when provided AND the value is non-empty.
+ */
+export function DatePicker({
+  value,
+  onChange,
+  onClear,
+  ariaLabel = "Pick a date",
+  align = "left",
+}: {
+  /** YYYY-MM-DD, or "" for unset. */
+  value: string;
+  onChange: (next: string) => void;
+  /** If provided, a small × button shows next to the picker when value !== "". */
+  onClear?: () => void;
+  ariaLabel?: string;
+  align?: "left" | "right";
+}) {
+  return (
+    <div className="inline-flex items-center gap-1">
+      <ChipPopover
+        ariaLabel={ariaLabel}
+        align={align}
+        chipClassName="px-2 py-1 text-xs"
+        chip={
+          <span className="inline-flex items-center gap-1.5">
+            <Calendar className="h-3.5 w-3.5" />
+            <span className="tabular-nums">
+              {value ? formatDisplay(value) : "Pick a date"}
+            </span>
+          </span>
+        }
+      >
+        {(close) => (
+          <CalendarGrid
+            value={value || toIsoDate(new Date())}
+            onPick={(next) => {
+              onChange(next);
+              close();
+            }}
+          />
+        )}
+      </ChipPopover>
+      {onClear && value ? (
+        <button
+          type="button"
+          onClick={onClear}
+          aria-label="Clear date"
+          className="inline-flex items-center justify-center h-6 w-6 rounded text-muted-foreground hover:text-foreground hover:bg-secondary/60 transition-colors"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Calendar grid (month view)
+// ─────────────────────────────────────────────────────────────────────────
+
+function CalendarGrid({
+  value,
+  onPick,
+}: {
+  value: string;
+  onPick: (iso: string) => void;
+}) {
+  const selected = useMemo(() => parseIso(value), [value]);
+  const [view, setView] = useState<Date>(
+    () => new Date(selected.getFullYear(), selected.getMonth(), 1),
+  );
+  const todayIso = toIsoDate(new Date());
+
+  const monthLabel = view.toLocaleString(undefined, {
+    month: "long",
+    year: "numeric",
+  });
+
+  const days = useMemo(() => monthGrid(view), [view]);
+
+  return (
+    <div className="px-3 pb-3 pt-2 w-64">
+      <div className="flex items-center justify-between mb-2">
+        <button
+          type="button"
+          aria-label="Previous month"
+          onClick={() => setView(addMonths(view, -1))}
+          className="inline-flex items-center justify-center h-7 w-7 rounded text-muted-foreground hover:text-foreground hover:bg-secondary/60 transition-colors"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </button>
+        <span className="text-xs font-medium tabular-nums">{monthLabel}</span>
+        <button
+          type="button"
+          aria-label="Next month"
+          onClick={() => setView(addMonths(view, 1))}
+          className="inline-flex items-center justify-center h-7 w-7 rounded text-muted-foreground hover:text-foreground hover:bg-secondary/60 transition-colors"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </button>
+      </div>
+      <div className="grid grid-cols-7 gap-0.5 text-[10px] text-muted-foreground mb-1">
+        {["S", "M", "T", "W", "T", "F", "S"].map((d, i) => (
+          <div key={i} className="text-center py-1">
+            {d}
+          </div>
+        ))}
+      </div>
+      <div className="grid grid-cols-7 gap-0.5">
+        {days.map((d, i) => {
+          const inMonth = d.getMonth() === view.getMonth();
+          const iso = toIsoDate(d);
+          const isSelected = iso === value;
+          const isToday = iso === todayIso;
+          return (
+            <button
+              key={i}
+              type="button"
+              onClick={() => onPick(iso)}
+              className={cn(
+                "h-7 text-xs tabular-nums rounded transition-colors",
+                !inMonth && "text-muted-foreground/40",
+                inMonth && !isSelected && "text-foreground hover:bg-secondary/60",
+                isSelected && "bg-primary text-primary-foreground font-medium",
+                isToday && !isSelected && "ring-1 ring-inset ring-border",
+              )}
+              aria-label={d.toDateString()}
+              aria-current={isSelected ? "date" : undefined}
+            >
+              {d.getDate()}
+            </button>
+          );
+        })}
+      </div>
+      <div className="mt-3 flex items-center justify-between">
+        <button
+          type="button"
+          onClick={() => onPick(todayIso)}
+          className="text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+        >
+          Today
+        </button>
+        <span className="text-[10px] text-muted-foreground tabular-nums">
+          {value || "—"}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Date helpers — local components, no UTC drift (matches localDate() in
+// packages/api/src/views/memory-activity.ts).
+// ─────────────────────────────────────────────────────────────────────────
+
+function toIsoDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function parseIso(s: string): Date {
+  // Local-midnight construction to match the rest of the system.
+  const [y, m, d] = s.split("-").map(Number);
+  return new Date(y ?? 1970, (m ?? 1) - 1, d ?? 1);
+}
+
+function addMonths(d: Date, n: number): Date {
+  return new Date(d.getFullYear(), d.getMonth() + n, 1);
+}
+
+function monthGrid(view: Date): Date[] {
+  // Always render a 6-week grid (42 cells). Start on Sunday so the
+  // weekday header row matches.
+  const firstOfMonth = new Date(view.getFullYear(), view.getMonth(), 1);
+  const startDow = firstOfMonth.getDay();
+  const start = new Date(view.getFullYear(), view.getMonth(), 1 - startDow);
+  return Array.from({ length: 42 }, (_, i) => {
+    return new Date(start.getFullYear(), start.getMonth(), start.getDate() + i);
+  });
+}
+
+function formatDisplay(iso: string): string {
+  const d = parseIso(iso);
+  return d.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/** Exported for callers that want "today" without re-deriving. */
+export function todayIso(): string {
+  return toIsoDate(new Date());
+}

--- a/packages/web/components/date-picker.tsx
+++ b/packages/web/components/date-picker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { Calendar, ChevronLeft, ChevronRight, X } from "lucide-react";
 import { ChipPopover } from "@/components/agents/pickers/chip-popover";
 import { cn } from "@/lib/utils";
@@ -34,6 +34,8 @@ export function DatePicker({
       <ChipPopover
         ariaLabel={ariaLabel}
         align={align}
+        // px-2 (vs ChipPopover's default px-2.5) keeps the chip flush with
+        // the weeks-selector beside it on the eval header.
         chipClassName="px-2 py-1 text-xs"
         chip={
           <span className="inline-flex items-center gap-1.5">
@@ -79,18 +81,19 @@ function CalendarGrid({
   value: string;
   onPick: (iso: string) => void;
 }) {
-  const selected = useMemo(() => parseIso(value), [value]);
-  const [view, setView] = useState<Date>(
-    () => new Date(selected.getFullYear(), selected.getMonth(), 1),
-  );
-  const todayIso = toIsoDate(new Date());
-
+  // Initial view = the month containing `value`. Subsequent prev/next
+  // navigation moves `view` independently; `value` only changes when the
+  // user picks a day.
+  const [view, setView] = useState<Date>(() => {
+    const d = parseIso(value);
+    return new Date(d.getFullYear(), d.getMonth(), 1);
+  });
+  const today = toIsoDate(new Date());
   const monthLabel = view.toLocaleString(undefined, {
     month: "long",
     year: "numeric",
   });
-
-  const days = useMemo(() => monthGrid(view), [view]);
+  const days = monthGrid(view);
 
   return (
     <div className="px-3 pb-3 pt-2 w-64">
@@ -125,7 +128,7 @@ function CalendarGrid({
           const inMonth = d.getMonth() === view.getMonth();
           const iso = toIsoDate(d);
           const isSelected = iso === value;
-          const isToday = iso === todayIso;
+          const isToday = iso === today;
           return (
             <button
               key={i}
@@ -149,7 +152,7 @@ function CalendarGrid({
       <div className="mt-3 flex items-center justify-between">
         <button
           type="button"
-          onClick={() => onPick(todayIso)}
+          onClick={() => onPick(today)}
           className="text-[11px] text-muted-foreground hover:text-foreground transition-colors"
         >
           Today
@@ -175,9 +178,11 @@ function toIsoDate(d: Date): string {
 }
 
 function parseIso(s: string): Date {
-  // Local-midnight construction to match the rest of the system.
+  // Local-midnight construction to match the rest of the system. Callers
+  // are expected to pass a validated YYYY-MM-DD string (the picker funnels
+  // empty input through `value || todayIso()` before this runs).
   const [y, m, d] = s.split("-").map(Number);
-  return new Date(y ?? 1970, (m ?? 1) - 1, d ?? 1);
+  return new Date(y!, m! - 1, d!);
 }
 
 function addMonths(d: Date, n: number): Date {


### PR DESCRIPTION
## Summary

Replaces the bare `<input type="date">` on `/memory/eval` with an explicit calendar popover trigger, and defaults the value to today so the before/after panel is discoverable on first load.

The native widget worked but its tiny browser icon was easy to miss — users were typing dates instead of seeing it as a calendar. Now the trigger is an obvious chip with a calendar icon + the formatted date.

## What changed

**New component** — `packages/web/components/date-picker.tsx`:
- `DatePicker` built on the existing `ChipPopover` primitive (also used by the agent runtime / model / review-policy chips). No new deps.
- Trigger reads as a clear chip: calendar icon + formatted date (`Jun 24, 2026`) or `"Pick a date"` if cleared.
- Popover content is a month-grid `Calendar` with:
  - `<` / `>` prev-next month navigation
  - Sunday-start weekday header (S M T W T F S)
  - 6-week stable grid (42 cells)
  - Selected day → primary fill, today → subtle inset ring, out-of-month → 40% opacity
  - A `"Today"` reset button bottom-left, current ISO bottom-right for verification
- Inline `×` clear button next to the trigger when a value is set.

**eval-client wiring** — `app/(authed)/memory/eval/eval-client.tsx`:
- Imports `DatePicker` + `todayIso`.
- `useState<string>(() => todayIso())` so the before/after panel shows on first load instead of having to discover it.
- Drops the inline `clear` text button — DatePicker owns that affordance now.

## Design notes

- **ISO contract preserved** — DatePicker takes/returns `"YYYY-MM-DD"`, same as the old input.
- **Local-midnight date construction** throughout (mirrors `localDate()` in `packages/api/src/views/memory-activity.ts`) so the day shown in the picker matches the day stored on the row regardless of the user's TZ.
- **No `date-fns` / `react-day-picker`** — our date math is thin enough (`addMonths`, `monthGrid`, ISO parse/format) that ~140 lines of inline helpers is simpler than pulling a library.
- Defaulting to today means today + 14 days is in the future (no post-window data). That's fine — the empty post side is informative ("nothing since today, which is now") and gives the user a familiar starting point to navigate from.

## Test plan

- [x] `pnpm --filter @beevibe/api build` clean
- [x] `pnpm --filter @beevibe/web typecheck` clean
- [x] `pnpm --filter @beevibe/web test` — 180/180 passing
- [ ] Visual: open `/memory/eval`, confirm the "compare around" chip shows today's formatted date and the before/after panel is visible
- [ ] Click the chip → calendar pops out, today is ring-highlighted
- [ ] Navigate prev/next months, pick a different date → panel updates
- [ ] Click `×` → date clears, panel hides, chip shows "Pick a date"
- [ ] Click chip again → calendar opens centered on today
- [ ] Press Escape → calendar closes (inherited from ChipPopover)
- [ ] Click outside → calendar closes (inherited from ChipPopover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)