### PR TITLE
refactor(core): unify duplicated CLI-runtime adapter helpers

### DIFF
--- a/packages/core/src/adapters/claude-code/runtime.ts
+++ b/packages/core/src/adapters/claude-code/runtime.ts
@@ -1,4 +1,3 @@
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type {
   AgentRuntime,
@@ -7,6 +6,7 @@ import type {
   RuntimeResult,
   Workspace,
 } from "../../ports/runtime.js";
+import { cliVersionHealthCheck } from "../runtime-common.js";
 import { runCliProcess } from "./spawn.js";
 import {
   extractStepEvents,
@@ -172,23 +172,7 @@ export class ClaudeCodeRuntime implements AgentRuntime {
   }
 
   async healthCheck(): Promise<RuntimeHealth> {
-    try {
-      // graceMs: 0 so a broken binary fails fast rather than waiting the
-      // default 20s after SIGTERM.
-      const result = await runCliProcess({
-        command: this.config.command ?? "claude",
-        args: ["--version"],
-        cwd: tmpdir(),
-        timeoutMs: 5_000,
-        graceMs: 0,
-      });
-      return { healthy: result.exitCode === 0 };
-    } catch {
-      return {
-        healthy: false,
-        error: `Command not found: ${this.config.command ?? "claude"}`,
-      };
-    }
+    return cliVersionHealthCheck(this.config.command ?? "claude");
   }
 
   async shutdown(): Promise<void> {

--- a/packages/core/src/adapters/claude-code/stream-json.ts
+++ b/packages/core/src/adapters/claude-code/stream-json.ts
@@ -1,4 +1,5 @@
 import type { RuntimeResult, RuntimeStep } from "../../ports/runtime.js";
+import { parseNdjsonLine } from "../runtime-common.js";
 
 /**
  * Parser for Claude Code's `--output-format stream-json` output. Each line
@@ -59,13 +60,7 @@ export interface StreamJsonMessage {
 }
 
 export function parseStreamJsonLine(line: string): StreamJsonMessage | null {
-  const trimmed = line.trim();
-  if (!trimmed || !trimmed.startsWith("{")) return null;
-  try {
-    return JSON.parse(trimmed) as StreamJsonMessage;
-  } catch {
-    return null;
-  }
+  return parseNdjsonLine<StreamJsonMessage>(line);
 }
 
 /**

--- a/packages/core/src/adapters/codex/runtime.ts
+++ b/packages/core/src/adapters/codex/runtime.ts
@@ -1,5 +1,4 @@
 import { existsSync, readFileSync, unlinkSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type {
   AgentRuntime,
@@ -11,6 +10,7 @@ import type {
 } from "../../ports/runtime.js";
 import { runCliProcess } from "../claude-code/spawn.js";
 import { MCP_TOOL_TIMEOUT_MS } from "../local-workspace/manager.js";
+import { cliVersionHealthCheck, composePrompt } from "../runtime-common.js";
 import {
   extractCodexStepEvents,
   parseCodexEventLine,
@@ -180,24 +180,9 @@ export class CodexRuntime implements AgentRuntime {
   }
 
   async healthCheck(): Promise<RuntimeHealth> {
-    try {
-      const result = await runCliProcess({
-        command: this.config.command ?? "codex",
-        args: ["--version"],
-        cwd: tmpdir(),
-        timeoutMs: 5_000,
-        graceMs: 0,
-      });
-      return {
-        healthy: result.exitCode === 0,
-        error: result.exitCode === 0 ? undefined : result.stderr.slice(-500),
-      };
-    } catch {
-      return {
-        healthy: false,
-        error: `Command not found: ${this.config.command ?? "codex"}`,
-      };
-    }
+    return cliVersionHealthCheck(this.config.command ?? "codex", {
+      includeStderrOnFailure: true,
+    });
   }
 
   async shutdown(): Promise<void> {
@@ -228,17 +213,6 @@ function buildGlobalArgs(context: RuntimeContext, config: CodexRuntimeConfig): s
   const model = context.model ?? config.model;
   if (model) args.push("--model", model);
   return args;
-}
-
-function composePrompt(context: RuntimeContext): string {
-  if (context.system_prompt_append.length === 0) return context.intent;
-  return [
-    "<beevibe_system_context>",
-    context.system_prompt_append,
-    "</beevibe_system_context>",
-    "",
-    context.intent,
-  ].join("\n");
 }
 
 function withBeevibeSession(mcpServerUrl: string, sid: string): string {

--- a/packages/core/src/adapters/codex/stream-json.ts
+++ b/packages/core/src/adapters/codex/stream-json.ts
@@ -1,5 +1,6 @@
 import type { RuntimeResult, RuntimeStep } from "../../ports/runtime.js";
 import { bareCliExitMessage } from "../claude-code/stream-json.js";
+import { describeToolInput, parseNdjsonLine } from "../runtime-common.js";
 
 /**
  * Parser for `codex exec --json` output.
@@ -89,13 +90,7 @@ export interface CodexEvent {
 }
 
 export function parseCodexEventLine(line: string): CodexEvent | null {
-  const trimmed = line.trim();
-  if (!trimmed || !trimmed.startsWith("{")) return null;
-  try {
-    return JSON.parse(trimmed) as CodexEvent;
-  } catch {
-    return null;
-  }
+  return parseNdjsonLine<CodexEvent>(line);
 }
 
 /**
@@ -131,7 +126,7 @@ export function extractCodexStepEvents(evt: CodexEvent): RuntimeStep[] {
       {
         kind: isCompletion ? "tool_result" : "tool_call",
         tool: item.tool ?? "unknown",
-        description: describeCodexInput(item.arguments),
+        description: describeToolInput(item.arguments),
         timestamp: now,
       },
     ];
@@ -175,29 +170,6 @@ export function extractCodexStepEvents(evt: CodexEvent): RuntimeStep[] {
   }
 
   return [];
-}
-
-/** Field-priority probe shared with claude's `describeToolInput` philosophy. */
-const PREFERRED_CODEX_FIELDS = [
-  "file_path",
-  "path",
-  "command",
-  "cmd",
-  "query",
-  "pattern",
-  "url",
-  "intent",
-] as const;
-
-function describeCodexInput(input: unknown): string {
-  if (typeof input === "string") return input.slice(0, 200);
-  if (!input || typeof input !== "object" || Array.isArray(input)) return "";
-  const obj = input as Record<string, unknown>;
-  for (const key of PREFERRED_CODEX_FIELDS) {
-    const v = obj[key];
-    if (typeof v === "string" && v.length > 0) return v.slice(0, 200);
-  }
-  return JSON.stringify(input).slice(0, 200);
 }
 
 /**

--- a/packages/core/src/adapters/opencode/runtime.ts
+++ b/packages/core/src/adapters/opencode/runtime.ts
@@ -1,5 +1,4 @@
 import { existsSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type {
   AgentRuntime,
@@ -10,6 +9,7 @@ import type {
   Workspace,
 } from "../../ports/runtime.js";
 import { runCliProcess } from "../claude-code/spawn.js";
+import { cliVersionHealthCheck, composePrompt } from "../runtime-common.js";
 import {
   extractOpenCodeStepEvents,
   parseOpenCodeEventLine,
@@ -133,21 +133,7 @@ export class OpenCodeRuntime implements AgentRuntime {
   }
 
   async healthCheck(): Promise<RuntimeHealth> {
-    try {
-      const result = await runCliProcess({
-        command: this.config.command ?? "opencode",
-        args: ["--version"],
-        cwd: tmpdir(),
-        timeoutMs: 5_000,
-        graceMs: 0,
-      });
-      return { healthy: result.exitCode === 0 };
-    } catch {
-      return {
-        healthy: false,
-        error: `Command not found: ${this.config.command ?? "opencode"}`,
-      };
-    }
+    return cliVersionHealthCheck(this.config.command ?? "opencode");
   }
 
   async shutdown(): Promise<void> {
@@ -165,17 +151,6 @@ export class OpenCodeRuntime implements AgentRuntime {
       mode: 0o600,
     });
   }
-}
-
-function composePrompt(context: RuntimeContext): string {
-  if (context.system_prompt_append.length === 0) return context.intent;
-  return [
-    "<beevibe_system_context>",
-    context.system_prompt_append,
-    "</beevibe_system_context>",
-    "",
-    context.intent,
-  ].join("\n");
 }
 
 export function buildOpenCodeConfig(apiKey: string, mcpServerUrl: string): string {

--- a/packages/core/src/adapters/opencode/stream-json.ts
+++ b/packages/core/src/adapters/opencode/stream-json.ts
@@ -1,6 +1,7 @@
 import type { SessionUsage } from "../../domain/session.js";
 import type { RuntimeResult, RuntimeStep } from "../../ports/runtime.js";
 import { bareCliExitMessage } from "../claude-code/stream-json.js";
+import { describeToolInput, parseNdjsonLine } from "../runtime-common.js";
 
 /**
  * Parser for `opencode run --format json` output.
@@ -79,13 +80,7 @@ export interface OpenCodeEvent {
 }
 
 export function parseOpenCodeEventLine(line: string): OpenCodeEvent | null {
-  const trimmed = line.trim();
-  if (!trimmed || !trimmed.startsWith("{")) return null;
-  try {
-    return JSON.parse(trimmed) as OpenCodeEvent;
-  } catch {
-    return null;
-  }
+  return parseNdjsonLine<OpenCodeEvent>(line);
 }
 
 /**
@@ -118,35 +113,13 @@ export function extractOpenCodeStepEvents(evt: OpenCodeEvent): RuntimeStep[] {
       {
         kind: isTerminal ? "tool_result" : "tool_call",
         tool: part.tool ?? "unknown",
-        description: describeOpenCodeInput(part.state?.input),
+        description: describeToolInput(part.state?.input),
         timestamp: now,
       },
     ];
   }
 
   return [];
-}
-
-const PREFERRED_OPENCODE_FIELDS = [
-  "file_path",
-  "path",
-  "command",
-  "cmd",
-  "query",
-  "pattern",
-  "url",
-  "intent",
-] as const;
-
-function describeOpenCodeInput(input: unknown): string {
-  if (typeof input === "string") return input.slice(0, 200);
-  if (!input || typeof input !== "object" || Array.isArray(input)) return "";
-  const obj = input as Record<string, unknown>;
-  for (const key of PREFERRED_OPENCODE_FIELDS) {
-    const v = obj[key];
-    if (typeof v === "string" && v.length > 0) return v.slice(0, 200);
-  }
-  return JSON.stringify(input).slice(0, 200);
 }
 
 /**

--- a/packages/core/src/adapters/runtime-common.ts
+++ b/packages/core/src/adapters/runtime-common.ts
@@ -1,0 +1,122 @@
+import { tmpdir } from "node:os";
+import type { RuntimeContext, RuntimeHealth } from "../ports/runtime.js";
+import { runCliProcess } from "./claude-code/spawn.js";
+
+/**
+ * Shared helpers for the CLI-subprocess runtimes (claude-code, codex,
+ * opencode). Each of those adapters spawns a `claude`/`codex`/`opencode`
+ * process, reads an NDJSON event stream off stdout, and maps the result to a
+ * `RuntimeResult`. The pieces that were byte-for-byte identical across the
+ * adapters live here so there is a single source of truth; the provider-
+ * specific event schemas and their `switch`-based parsers stay in each
+ * adapter's own `stream-json.ts` (they are genuinely different and must).
+ */
+
+/**
+ * Parse one line of an NDJSON event stream. Returns `null` for blank lines,
+ * non-object lines, or malformed JSON — the runtimes tolerate interleaved
+ * non-JSON log noise on stdout, so an unparseable line is skipped, not fatal.
+ *
+ * The `T` cast is unchecked: callers pass their provider-specific event type
+ * and the downstream `extract*StepEvents` / `parse*Events` functions do the
+ * real shape-narrowing.
+ */
+export function parseNdjsonLine<T>(line: string): T | null {
+  const trimmed = line.trim();
+  if (!trimmed || !trimmed.startsWith("{")) return null;
+  try {
+    return JSON.parse(trimmed) as T;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Field-priority probe used to turn a tool's structured input into a short
+ * human-readable label ("Read packages/foo.ts" not "{file_path: ...}") for
+ * the live transcript. Shared by the codex and opencode adapters, which see
+ * the same tool-input field names. (Claude Code's `describeToolInput` is a
+ * richer superset — extra `name`/`persona` and single-key branches — and
+ * intentionally keeps its own implementation.)
+ */
+export const PREFERRED_TOOL_INPUT_FIELDS = [
+  "file_path",
+  "path",
+  "command",
+  "cmd",
+  "query",
+  "pattern",
+  "url",
+  "intent",
+] as const;
+
+/**
+ * Pull the most informative string field out of a tool-call input payload,
+ * truncated to 200 chars. Falls back to the raw JSON when no preferred field
+ * is present. `fields` defaults to {@link PREFERRED_TOOL_INPUT_FIELDS}.
+ */
+export function describeToolInput(
+  input: unknown,
+  fields: readonly string[] = PREFERRED_TOOL_INPUT_FIELDS,
+): string {
+  if (typeof input === "string") return input.slice(0, 200);
+  if (!input || typeof input !== "object" || Array.isArray(input)) return "";
+  const obj = input as Record<string, unknown>;
+  for (const key of fields) {
+    const v = obj[key];
+    if (typeof v === "string" && v.length > 0) return v.slice(0, 200);
+  }
+  return JSON.stringify(input).slice(0, 200);
+}
+
+/**
+ * Compose the prompt passed to a CLI runtime on argv: the raw intent when
+ * there is no system-prompt append, otherwise the append wrapped in a
+ * `<beevibe_system_context>` block ahead of the intent. This wire format is a
+ * cross-provider contract (transcript summarizers key off the tags), so the
+ * codex and opencode adapters share this single definition rather than each
+ * carrying a copy that could silently drift. (Claude Code feeds the append
+ * via its `--append-system-prompt` flag and pipes the intent over stdin, so
+ * it does not use this.)
+ */
+export function composePrompt(context: RuntimeContext): string {
+  if (context.system_prompt_append.length === 0) return context.intent;
+  return [
+    "<beevibe_system_context>",
+    context.system_prompt_append,
+    "</beevibe_system_context>",
+    "",
+    context.intent,
+  ].join("\n");
+}
+
+/**
+ * Standard `<cli> --version` health check shared by every CLI runtime.
+ * `graceMs: 0` so a broken binary fails fast rather than waiting the default
+ * grace period after SIGTERM. A thrown spawn error (binary not on PATH) maps
+ * to `Command not found: <command>`.
+ *
+ * When `includeStderrOnFailure` is set, the stderr tail is surfaced on the
+ * unhealthy branch (codex opts into this for a more actionable error); the
+ * other runtimes leave `error` undefined on a clean non-zero exit.
+ */
+export async function cliVersionHealthCheck(
+  command: string,
+  opts: { includeStderrOnFailure?: boolean } = {},
+): Promise<RuntimeHealth> {
+  try {
+    const result = await runCliProcess({
+      command,
+      args: ["--version"],
+      cwd: tmpdir(),
+      timeoutMs: 5_000,
+      graceMs: 0,
+    });
+    if (result.exitCode === 0) return { healthy: true };
+    return opts.includeStderrOnFailure
+      ? { healthy: false, error: result.stderr.slice(-500) }
+      : { healthy: false };
+  } catch {
+    return { healthy: false, error: `Command not found: ${command}` };
+  }
+}


### PR DESCRIPTION
## Summary

The three CLI-subprocess runtimes — `claude-code`, `codex`, and `opencode` — carried **byte-for-byte copies** of several helpers that had drifted apart in name only. This PR extracts them into a single new module, `packages/core/src/adapters/runtime-common.ts`, so there is one source of truth.

Net effect: **~127 fewer lines** of duplicated logic across 6 files, behavior-preserving.

## What was unified

| Helper | Was duplicated in | Notes |
|--------|-------------------|-------|
| `parseNdjsonLine<T>` | `parseStreamJsonLine` (claude-code), `parseCodexEventLine`, `parseOpenCodeEventLine` — identical NDJSON line guard in all 3 | The three exported parsers now delegate to it; their public signatures are unchanged. |
| `describeToolInput` + `PREFERRED_TOOL_INPUT_FIELDS` | `describeCodexInput` / `describeOpenCodeInput` (+ their identical 8-field priority lists) | Claude Code's richer variant (extra `name`/`persona` and single-key branches) is intentionally left untouched. |
| `composePrompt` | codex & opencode runtimes | The `<beevibe_system_context>` wire format is a cross-provider contract; having two copies was a silent drift risk. Claude Code doesn't use this (it feeds the append via `--append-system-prompt`). |
| `cliVersionHealthCheck` | `healthCheck()` in all 3 runtimes | codex's `stderr`-on-failure behavior is preserved via an opt-in `includeStderrOnFailure` flag; the other two keep their exact output. |

## What was deliberately *not* merged

The provider-specific event schemas (`CodexEvent` / `OpenCodeEvent` / `StreamJsonMessage`) and their `switch`-based `extract*StepEvents` / `parse*Events` parsers stay in each adapter — they are genuinely different and correctly modeled as distinct. The `AnthropicLlmProvider` / `OpenAILlmProvider` pair is structurally parallel but each is a distinct SDK integration, so it is also left as-is.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm build` — clean
- All **116 adapter tests pass** (claude-code / codex / opencode runtime + stream-json suites); 2 smoke tests skipped as usual. Pre-existing failures elsewhere in the suite require live API keys / Postgres and are unrelated to this change.

## Follow-up candidates (not in this PR)

A broader scan surfaced further near-duplicates worth separate, higher-risk PRs:
- **`execute()` streaming/lifecycle boilerplate** shared across the 3 runtimes (line-buffering, truncation warning, stderr-tail) — the largest remaining win, but it touches process control flow, so it deserves its own review.
- **api ↔ web `format.ts`** (`deriveShortId`, `formatDurationLabel`, relative-time) — duplicated by design and drift-prone; candidate to hoist into `@beevibe/core`.
- **`core-memory.ts`** `applyUpdate` throwing plain `Error` where `setContent` throws typed `BlockNotFoundError`/`BlockCharLimitExceededError` — a correctness-adjacent inconsistency (the API maps the typed ones to 4xx).
- **api route/tool guard preambles** (`requireHuman` + id-guard + 404/500 fallback) and the trivial `deriveTaskShortId` duplicate of `deriveShortId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y6rUdekyZwiWVxsQdHqNgi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6rUdekyZwiWVxsQdHqNgi)_