### PR TITLE
fix(api): restore node-pg-migrate dep — unbreaks Railway deploy

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -39,6 +39,7 @@
     "@beevibe/core": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "express": "^5.2.1",
+    "node-pg-migrate": "^7.7.1",
     "pg": "^8.13.0",
     "ws": "^8.18.0",
     "zod": "^4.3.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      node-pg-migrate:
+        specifier: ^7.7.1
+        version: 7.9.1(@types/pg@8.20.0)(pg@8.20.0)
       pg:
         specifier: ^8.13.0
         version: 8.20.0

--- a/scripts/start-api.sh
+++ b/scripts/start-api.sh
@@ -10,6 +10,14 @@
 #
 # node-pg-migrate is now a direct dep of @beevibe/api, so its binary lives
 # at packages/api/node_modules/.bin/node-pg-migrate inside the image.
+#
+# DO NOT remove "node-pg-migrate" from packages/api/package.json. It is
+# never imported from api/src — it is invoked as a BINARY on the line
+# below, at container start. Import-based dead-code tools (knip, eslint,
+# depcheck) all report it as an unused dependency; it isn't. Dropping it
+# makes the api container exit here under `set -e`, before the process
+# ever launches, and the Railway healthcheck fails the deploy. Regressed
+# exactly this way in PR #256, reverted in #257.
 set -e
 
 cd /app


### PR DESCRIPTION
Fixes the failing api deploy on Railway. **Regression from #256 — my mistake.**

## What broke

I removed `node-pg-migrate` from `packages/api/package.json` because knip and eslint both reported it as an unused dependency, and I confirmed it was never imported anywhere in `api/src`. That confirmation was the wrong test: it isn't imported, it's **executed as a binary**.

`scripts/start-api.sh` is the Railway `startCommand` for the api service (`infra/railway/api.railway.json`) and applies pending migrations before launching the process:

```sh
packages/api/node_modules/.bin/node-pg-migrate --no-check-order up
```

`Dockerfile.api` installs with `pnpm install --frozen-lockfile --filter @beevibe/api...`. Under that filtered install the binary lands in the image **only** while `node-pg-migrate` is a direct dependency of `@beevibe/api` — a root devDep gets skipped. That is exactly why it was made a direct dep originally, and the reasoning was sitting in `start-api.sh`'s header comment the whole time. I grepped that file for a different symbol earlier in the sweep and never read the header.

The script runs under `set -e`, so the missing binary aborts it before `exec node packages/api/dist/main.js`. The container never binds a port, `/health` never answers, Railway fails the deploy.

## The fix

One line restored in `packages/api/package.json` (plus the lockfile entry), and a `DO NOT REMOVE` note in `start-api.sh` beside the invocation — every import-based tool will keep flagging this dependency as unused, so the guard belongs next to the usage.

## Verification

Reproduced the failure, then confirmed the fix against the real deploy path rather than just a plain install:

- **Before:** `packages/api/node_modules/.bin/node-pg-migrate` → `No such file or directory`
- **After** running the exact `Dockerfile.api` line, `pnpm install --frozen-lockfile --filter @beevibe/api...` → binary present, `--version` reports `7.9.1`
- Lockfile records it under the `packages/api` importer, so the image's `--frozen-lockfile` install still resolves (verified — it would otherwise fail the build with `ERR_PNPM_OUTDATED_LOCKFILE`)
- `sh -n scripts/start-api.sh` — syntax valid
- `typecheck`, `lint`, `build` clean across all non-web packages; lint warning count unchanged from baseline

Not verifiable in this sandbox: an actual `docker build` and a live Railway deploy (no Docker daemon available). The filtered-install simulation above is the closest proxy for the step that broke.

## Scope check on the rest of #256

I re-audited the other removals from that PR against deploy-time and script usage, not just imports:

- `@modelcontextprotocol/sdk`, `express`, `@types/express` removed from **root** devDeps — safe. `packages/api` declares all three itself, so the filtered install still provides them; `@types/express` is in api's own devDeps and the image's `tsc` build passes.
- The 10 deleted web components and the unused-import cleanups — no runtime or script references; web builds clean.
- `scheduler` and `web` services — neither start command touches `node-pg-migrate`; unaffected.

`node-pg-migrate` was the only deploy-time-binary dependency in that diff.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NfnxpUFpeu6qF1hU8fSy8Y)_