### PR TITLE
refactor: unify three clusters of near-duplicate abstractions

### DIFF
--- a/packages/api/src/mesh/server.ts
+++ b/packages/api/src/mesh/server.ts
@@ -40,6 +40,7 @@ import type {
   WorkspaceManager,
 } from "@beevibe/core";
 import {
+  escapeXmlAttr,
   negotiationId as makeNegId,
   negotiationRoundId as makeRoundId,
   sessionId as makeSessionId,
@@ -132,7 +133,7 @@ export class MeshServer {
     await this.checkMeshCapacity(toAgentId);
 
     const intent =
-      `<mesh-ask request_id="${escapeAttr(requestId)}" from="${escapeAttr(fromAgentId)}">\n` +
+      `<mesh-ask request_id="${escapeXmlAttr(requestId)}" from="${escapeXmlAttr(fromAgentId)}">\n` +
       `${question}\n` +
       `</mesh-ask>\n` +
       `<context type="ask_response">\n` +
@@ -243,7 +244,7 @@ export class MeshServer {
     await this.deps.negotiationRepo.update(neg.id, { rounds_completed: 1 });
 
     const intent =
-      `<mesh-negotiate negotiation_id="${escapeAttr(neg.id)}" from="${escapeAttr(fromAgentId)}" round="1">\n` +
+      `<mesh-negotiate negotiation_id="${escapeXmlAttr(neg.id)}" from="${escapeXmlAttr(fromAgentId)}" round="1">\n` +
       `${proposal}\n` +
       `</mesh-negotiate>\n` +
       `<context type="negotiation_round">\n` +
@@ -427,7 +428,7 @@ export class MeshServer {
     description: string,
   ): void {
     const intent =
-      `<mesh-blocker from="${escapeAttr(fromAgentId)}" task_id="${escapeAttr(taskId)}">\n` +
+      `<mesh-blocker from="${escapeXmlAttr(fromAgentId)}" task_id="${escapeXmlAttr(taskId)}">\n` +
       `${description}\n` +
       `</mesh-blocker>\n` +
       `<context type="blocker_report">\n` +
@@ -588,8 +589,4 @@ export class MeshServer {
   hasPendingCalleeSession(calleeSessionId: string): boolean {
     return this.pendingByCalleeSession.has(calleeSessionId);
   }
-}
-
-function escapeAttr(s: string): string {
-  return s.replace(/"/g, "&quot;").replace(/&/g, "&amp;");
 }

--- a/packages/api/src/routes/http-errors.ts
+++ b/packages/api/src/routes/http-errors.ts
@@ -1,0 +1,33 @@
+import type { Response } from "express";
+
+/**
+ * The 500 handler every route router grew its own copy of.
+ *
+ * `signin`, `signup`, `room` and `view` each defined a byte-identical (bar the
+ * log tag) `handleError`: log the error server-side, then return a 500 whose
+ * `message` is the error's own message. Four copies meant four places to
+ * change if the error envelope ever moves.
+ *
+ * `context` is optional so the two shapes in use both survive verbatim:
+ * routers with one handler for the whole file log `[room route]`, while `view`
+ * — which has 23 call sites across six resources — passes a per-call context
+ * and logs `[view route: task detail]`.
+ *
+ * NOTE: this reflects raw `err.message` back to the client, which is what all
+ * four routers already did. `routes/chat.ts` deliberately does NOT — it
+ * returns a generic message plus a `request_id` and keeps the detail in the
+ * logs. That is a real divergence in what we expose, not an accident of
+ * copy-paste, so chat keeps its own handler and this factory preserves the
+ * existing behavior of the other four rather than quietly changing it.
+ */
+export function makeErrorHandler(
+  tag: string,
+): (err: unknown, res: Response, context?: string) => void {
+  return (err, res, context) => {
+    console.error(context ? `[${tag}: ${context}]` : `[${tag}]`, err);
+    res.status(500).json({
+      error: "internal_error",
+      message: err instanceof Error ? err.message : String(err),
+    });
+  };
+}

--- a/packages/api/src/routes/room.ts
+++ b/packages/api/src/routes/room.ts
@@ -20,7 +20,7 @@
  * turn run sequentially.
  */
 
-import { Router, type RequestHandler, type Response } from "express";
+import { Router, type RequestHandler } from "express";
 import {
   AgentSession,
   type AgentSessionDeps,
@@ -42,6 +42,7 @@ import {
 } from "@beevibe/core";
 import type { MemoryAgent } from "@beevibe/core/services/memory";
 import { requireHuman } from "../auth/middleware.js";
+import { makeErrorHandler } from "./http-errors.js";
 import {
   processResponse,
   type OpenView,
@@ -179,13 +180,7 @@ function toMessageReply(m: RoomMessage): MessageReply {
   };
 }
 
-function handleError(err: unknown, res: Response): void {
-  console.error("[room route]", err);
-  res.status(500).json({
-    error: "internal_error",
-    message: err instanceof Error ? err.message : String(err),
-  });
-}
+const handleError = makeErrorHandler("room route");
 
 export function createRoomRouter(deps: RoomRoutesDeps): Router {
   const router = Router();

--- a/packages/api/src/routes/signin.ts
+++ b/packages/api/src/routes/signin.ts
@@ -26,9 +26,10 @@
  * the same config gates self-serve user surfaces.
  */
 
-import { Router, type Response } from "express";
+import { Router } from "express";
 import type { PersonRepository } from "@beevibe/core";
 import { SIGNIN_NO_PASSWORD_SET, verifyPassword } from "@beevibe/core/auth";
+import { makeErrorHandler } from "./http-errors.js";
 
 export interface SigninRoutesDeps {
   personRepo: PersonRepository;
@@ -38,13 +39,7 @@ export interface SigninRoutesDeps {
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-function handleError(err: unknown, res: Response): void {
-  console.error("[signin route]", err);
-  res.status(500).json({
-    error: "internal_error",
-    message: err instanceof Error ? err.message : String(err),
-  });
-}
+const handleError = makeErrorHandler("signin route");
 
 export function createSigninRouter(deps: SigninRoutesDeps): Router {
   const router = Router();

--- a/packages/api/src/routes/signup.ts
+++ b/packages/api/src/routes/signup.ts
@@ -15,7 +15,7 @@
  * route from the bootstrap mount) to disable this entirely.
  */
 
-import { Router, type Response } from "express";
+import { Router } from "express";
 import {
   agentId as makeAgentId,
   personId as makePersonId,
@@ -30,6 +30,7 @@ import {
   validatePasswordShape,
   verifyPassword,
 } from "@beevibe/core/auth";
+import { makeErrorHandler } from "./http-errors.js";
 
 export interface SignupRoutesDeps {
   agentRepo: AgentRepository;
@@ -42,13 +43,7 @@ export interface SignupRoutesDeps {
 const NAME_RE = /^[\p{L}\p{N} '\-_.]{1,80}$/u;
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-function handleError(err: unknown, res: Response): void {
-  console.error("[signup route]", err);
-  res.status(500).json({
-    error: "internal_error",
-    message: err instanceof Error ? err.message : String(err),
-  });
-}
+const handleError = makeErrorHandler("signup route");
 
 export function createSignupRouter(deps: SignupRoutesDeps): Router {
   const router = Router();

--- a/packages/api/src/routes/view.ts
+++ b/packages/api/src/routes/view.ts
@@ -60,6 +60,10 @@ import { listActivity } from "../views/activity.js";
 import { getWorkProduct } from "../views/work-product.js";
 import { listInbox } from "../views/inbox.js";
 import { getAgentNetwork } from "../views/agent-network.js";
+import { makeErrorHandler } from "./http-errors.js";
+
+/** Every handler below passes a per-call context, e.g. `[view route: task list]`. */
+const handleError = makeErrorHandler("view route");
 
 export interface ViewRoutesDeps {
   authMiddleware: RequestHandler;
@@ -693,12 +697,4 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
   });
 
   return router;
-}
-
-function handleError(err: unknown, res: import("express").Response, context: string): void {
-  console.error(`[view route: ${context}]`, err);
-  res.status(500).json({
-    error: "internal_error",
-    message: err instanceof Error ? err.message : String(err),
-  });
 }

--- a/packages/core/src/adapters/claude-code/runtime.ts
+++ b/packages/core/src/adapters/claude-code/runtime.ts
@@ -6,7 +6,13 @@ import type {
   RuntimeResult,
   Workspace,
 } from "../../ports/runtime.js";
-import { cliVersionHealthCheck } from "../runtime-common.js";
+import {
+  cancelledResult,
+  cliVersionHealthCheck,
+  createStdoutLineReader,
+  finalizeCliResult,
+  warnIfTruncated,
+} from "../runtime-common.js";
 import { runCliProcess } from "./spawn.js";
 import {
   extractStepEvents,
@@ -101,7 +107,6 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     // the entire stdout after close. A line buffer handles chunk boundaries
     // (a single JSON message can arrive split across multiple chunks).
     const messages: StreamJsonMessage[] = [];
-    let pending = "";
     const handleLine = (line: string): void => {
       const msg = parseStreamJsonLine(line);
       if (!msg) return;
@@ -112,6 +117,7 @@ export class ClaudeCodeRuntime implements AgentRuntime {
         }
       }
     };
+    const stdout = createStdoutLineReader(handleLine);
 
     const result = await runCliProcess({
       command: this.config.command ?? "claude",
@@ -123,52 +129,17 @@ export class ClaudeCodeRuntime implements AgentRuntime {
       onSpawn: ({ pid, process_group_id }) => {
         context.onSpawn?.({ process_pid: pid, process_group_id });
       },
-      onLog: (stream, chunk) => {
-        if (stream !== "stdout") return;
-        pending += chunk;
-        let nl: number;
-        while ((nl = pending.indexOf("\n")) !== -1) {
-          handleLine(pending.slice(0, nl));
-          pending = pending.slice(nl + 1);
-        }
-      },
+      onLog: stdout.onLog,
     });
 
     // Flush any final partial line (stream without trailing \n)
-    if (pending) handleLine(pending);
+    stdout.flush();
 
-    if (result.truncated) {
-      console.warn(
-        "[ClaudeCodeRuntime] stdout truncated at 4MB — result parsing may be incomplete",
-      );
-    }
+    warnIfTruncated("ClaudeCodeRuntime", result);
 
-    if (result.aborted) {
-      return {
-        status: "cancelled",
-        output: "Session cancelled.",
-        process_pid: result.pid ?? undefined,
-        process_group_id: result.process_group_id ?? undefined,
-      };
-    }
+    if (result.aborted) return cancelledResult(result);
 
-    const parsed = parseClaudeMessages(messages, result.exitCode);
-    // Surface the CLI's stderr tail on failure so operators / users get
-    // the actual diagnostic instead of just "CLI exited with code N".
-    // Capped at 4KB — most useful info is at the end (final error +
-    // stacktrace), so tail-slice rather than head.
-    const STDERR_TAIL_BYTES = 4096;
-    const stderrTail =
-      parsed.status === "failed" && result.stderr
-        ? result.stderr.slice(-STDERR_TAIL_BYTES)
-        : undefined;
-    return {
-      ...parsed,
-      process_pid: result.pid ?? undefined,
-      process_group_id: result.process_group_id ?? undefined,
-      exit_code: result.exitCode,
-      ...(stderrTail ? { stderr: stderrTail } : {}),
-    };
+    return finalizeCliResult(parseClaudeMessages(messages, result.exitCode), result);
   }
 
   async healthCheck(): Promise<RuntimeHealth> {

--- a/packages/core/src/adapters/codex/runtime.ts
+++ b/packages/core/src/adapters/codex/runtime.ts
@@ -10,7 +10,14 @@ import type {
 } from "../../ports/runtime.js";
 import { runCliProcess } from "../claude-code/spawn.js";
 import { MCP_TOOL_TIMEOUT_MS } from "../local-workspace/manager.js";
-import { cliVersionHealthCheck, composePrompt } from "../runtime-common.js";
+import {
+  cancelledResult,
+  cliVersionHealthCheck,
+  composePrompt,
+  createStdoutLineReader,
+  finalizeCliResult,
+  warnIfTruncated,
+} from "../runtime-common.js";
 import {
   extractCodexStepEvents,
   parseCodexEventLine,
@@ -114,7 +121,6 @@ export class CodexRuntime implements AgentRuntime {
     if (prepared) env.BEEVIBE_AGENT_API_KEY = prepared.agentApiKey;
 
     const events: CodexEvent[] = [];
-    let pending = "";
     const handleLine = (line: string): void => {
       const evt = parseCodexEventLine(line);
       if (!evt) return;
@@ -124,6 +130,7 @@ export class CodexRuntime implements AgentRuntime {
         context.onStep(step);
       }
     };
+    const stdout = createStdoutLineReader(handleLine);
 
     const result = await runCliProcess({
       command: this.config.command ?? "codex",
@@ -134,49 +141,23 @@ export class CodexRuntime implements AgentRuntime {
       onSpawn: ({ pid, process_group_id }) => {
         context.onSpawn?.({ process_pid: pid, process_group_id });
       },
-      onLog: (stream, chunk) => {
-        if (stream !== "stdout") return;
-        pending += chunk;
-        let nl: number;
-        while ((nl = pending.indexOf("\n")) !== -1) {
-          handleLine(pending.slice(0, nl));
-          pending = pending.slice(nl + 1);
-        }
-      },
+      onLog: stdout.onLog,
     });
-    if (pending) handleLine(pending);
+    stdout.flush();
 
-    if (result.truncated) {
-      console.warn(
-        "[CodexRuntime] stdout truncated at 4MB — result parsing may be incomplete",
-      );
-    }
+    warnIfTruncated("CodexRuntime", result);
 
     if (result.aborted) {
       removeIfExists(lastMessagePath);
-      return {
-        status: "cancelled",
-        output: "Session cancelled.",
-        process_pid: result.pid ?? undefined,
-        process_group_id: result.process_group_id ?? undefined,
-      };
+      return cancelledResult(result);
     }
 
     const lastMessage = readIfExists(lastMessagePath);
     removeIfExists(lastMessagePath);
-    const parsed = parseCodexEvents(events, result.exitCode, lastMessage);
-    const STDERR_TAIL_BYTES = 4096;
-    const stderrTail =
-      parsed.status === "failed" && result.stderr
-        ? result.stderr.slice(-STDERR_TAIL_BYTES)
-        : undefined;
-    return {
-      ...parsed,
-      process_pid: result.pid ?? undefined,
-      process_group_id: result.process_group_id ?? undefined,
-      exit_code: result.exitCode,
-      ...(stderrTail ? { stderr: stderrTail } : {}),
-    };
+    return finalizeCliResult(
+      parseCodexEvents(events, result.exitCode, lastMessage),
+      result,
+    );
   }
 
   async healthCheck(): Promise<RuntimeHealth> {

--- a/packages/core/src/adapters/opencode/runtime.ts
+++ b/packages/core/src/adapters/opencode/runtime.ts
@@ -9,7 +9,14 @@ import type {
   Workspace,
 } from "../../ports/runtime.js";
 import { runCliProcess } from "../claude-code/spawn.js";
-import { cliVersionHealthCheck, composePrompt } from "../runtime-common.js";
+import {
+  cancelledResult,
+  cliVersionHealthCheck,
+  composePrompt,
+  createStdoutLineReader,
+  finalizeCliResult,
+  warnIfTruncated,
+} from "../runtime-common.js";
 import {
   extractOpenCodeStepEvents,
   parseOpenCodeEventLine,
@@ -70,7 +77,6 @@ export class OpenCodeRuntime implements AgentRuntime {
     if (context.env) Object.assign(env, context.env);
 
     const events: OpenCodeEvent[] = [];
-    let pending = "";
     const handleLine = (line: string): void => {
       const evt = parseOpenCodeEventLine(line);
       if (!evt) return;
@@ -80,6 +86,7 @@ export class OpenCodeRuntime implements AgentRuntime {
         context.onStep(step);
       }
     };
+    const stdout = createStdoutLineReader(handleLine);
 
     const result = await runCliProcess({
       command: this.config.command ?? "opencode",
@@ -90,46 +97,15 @@ export class OpenCodeRuntime implements AgentRuntime {
       onSpawn: ({ pid, process_group_id }) => {
         context.onSpawn?.({ process_pid: pid, process_group_id });
       },
-      onLog: (stream, chunk) => {
-        if (stream !== "stdout") return;
-        pending += chunk;
-        let nl: number;
-        while ((nl = pending.indexOf("\n")) !== -1) {
-          handleLine(pending.slice(0, nl));
-          pending = pending.slice(nl + 1);
-        }
-      },
+      onLog: stdout.onLog,
     });
-    if (pending) handleLine(pending);
+    stdout.flush();
 
-    if (result.truncated) {
-      console.warn(
-        "[OpenCodeRuntime] stdout truncated at 4MB — result parsing may be incomplete",
-      );
-    }
+    warnIfTruncated("OpenCodeRuntime", result);
 
-    if (result.aborted) {
-      return {
-        status: "cancelled",
-        output: "Session cancelled.",
-        process_pid: result.pid ?? undefined,
-        process_group_id: result.process_group_id ?? undefined,
-      };
-    }
+    if (result.aborted) return cancelledResult(result);
 
-    const parsed = parseOpenCodeEvents(events, result.exitCode);
-    const STDERR_TAIL_BYTES = 4096;
-    const stderrTail =
-      parsed.status === "failed" && result.stderr
-        ? result.stderr.slice(-STDERR_TAIL_BYTES)
-        : undefined;
-    return {
-      ...parsed,
-      process_pid: result.pid ?? undefined,
-      process_group_id: result.process_group_id ?? undefined,
-      exit_code: result.exitCode,
-      ...(stderrTail ? { stderr: stderrTail } : {}),
-    };
+    return finalizeCliResult(parseOpenCodeEvents(events, result.exitCode), result);
   }
 
   async healthCheck(): Promise<RuntimeHealth> {

--- a/packages/core/src/adapters/runtime-common.test.ts
+++ b/packages/core/src/adapters/runtime-common.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CliProcessResult } from "./claude-code/spawn.js";
+import type { RuntimeResult } from "../ports/runtime.js";
+import {
+  cancelledResult,
+  createStdoutLineReader,
+  finalizeCliResult,
+  warnIfTruncated,
+} from "./runtime-common.js";
+
+function cliResult(overrides: Partial<CliProcessResult> = {}): CliProcessResult {
+  return {
+    stdout: "",
+    stderr: "",
+    exitCode: 0,
+    timedOut: false,
+    aborted: false,
+    pid: 4242,
+    process_group_id: 4242,
+    truncated: false,
+    ...overrides,
+  };
+}
+
+describe("createStdoutLineReader", () => {
+  it("emits one call per complete line", () => {
+    const lines: string[] = [];
+    const reader = createStdoutLineReader((l) => lines.push(l));
+    reader.onLog("stdout", "a\nb\nc\n");
+    expect(lines).toEqual(["a", "b", "c"]);
+  });
+
+  it("reassembles a line split across chunks", () => {
+    const lines: string[] = [];
+    const reader = createStdoutLineReader((l) => lines.push(l));
+    reader.onLog("stdout", '{"ty');
+    reader.onLog("stdout", 'pe":"x"}');
+    // Nothing emitted until the newline arrives.
+    expect(lines).toEqual([]);
+    reader.onLog("stdout", "\n");
+    expect(lines).toEqual(['{"type":"x"}']);
+  });
+
+  it("emits several lines arriving in a single chunk", () => {
+    const lines: string[] = [];
+    const reader = createStdoutLineReader((l) => lines.push(l));
+    reader.onLog("stdout", "one\ntwo\nthr");
+    expect(lines).toEqual(["one", "two"]);
+    reader.flush();
+    expect(lines).toEqual(["one", "two", "thr"]);
+  });
+
+  it("ignores stderr chunks", () => {
+    const lines: string[] = [];
+    const reader = createStdoutLineReader((l) => lines.push(l));
+    reader.onLog("stderr", "warning: noise\n");
+    reader.flush();
+    expect(lines).toEqual([]);
+  });
+
+  it("flush is a no-op when the stream ended on a newline", () => {
+    const lines: string[] = [];
+    const reader = createStdoutLineReader((l) => lines.push(l));
+    reader.onLog("stdout", "done\n");
+    reader.flush();
+    reader.flush();
+    expect(lines).toEqual(["done"]);
+  });
+
+  it("preserves empty lines between records", () => {
+    const lines: string[] = [];
+    const reader = createStdoutLineReader((l) => lines.push(l));
+    reader.onLog("stdout", "a\n\nb\n");
+    expect(lines).toEqual(["a", "", "b"]);
+  });
+});
+
+describe("warnIfTruncated", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("warns with the runtime tag when stdout was capped", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    warnIfTruncated("CodexRuntime", cliResult({ truncated: true }));
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]![0]).toContain("[CodexRuntime]");
+  });
+
+  it("stays quiet when the stream was complete", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    warnIfTruncated("CodexRuntime", cliResult({ truncated: false }));
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("cancelledResult", () => {
+  it("reports cancelled — distinct from a failure — with process metadata", () => {
+    expect(cancelledResult(cliResult({ aborted: true }))).toEqual({
+      status: "cancelled",
+      output: "Session cancelled.",
+      process_pid: 4242,
+      process_group_id: 4242,
+    });
+  });
+
+  it("maps a null pid (spawn failure) to undefined", () => {
+    const result = cancelledResult(cliResult({ pid: null, process_group_id: null }));
+    expect(result.process_pid).toBeUndefined();
+    expect(result.process_group_id).toBeUndefined();
+  });
+});
+
+describe("finalizeCliResult", () => {
+  const parsed: RuntimeResult = { status: "completed", output: "hi" };
+
+  it("merges process metadata onto the parsed result", () => {
+    expect(finalizeCliResult(parsed, cliResult({ exitCode: 0 }))).toEqual({
+      status: "completed",
+      output: "hi",
+      process_pid: 4242,
+      process_group_id: 4242,
+      exit_code: 0,
+    });
+  });
+
+  it("omits stderr when the run succeeded", () => {
+    const out = finalizeCliResult(parsed, cliResult({ stderr: "chatty but fine" }));
+    expect(out.stderr).toBeUndefined();
+  });
+
+  it("surfaces the stderr tail on failure", () => {
+    const failed: RuntimeResult = { status: "failed", output: "" };
+    const out = finalizeCliResult(failed, cliResult({ stderr: "boom", exitCode: 1 }));
+    expect(out.stderr).toBe("boom");
+    expect(out.exit_code).toBe(1);
+  });
+
+  it("tail-slices stderr to 4KB, keeping the end where the error is", () => {
+    const failed: RuntimeResult = { status: "failed", output: "" };
+    const stderr = "x".repeat(5000) + "FINAL_ERROR";
+    const out = finalizeCliResult(failed, cliResult({ stderr, exitCode: 1 }));
+    expect(out.stderr).toHaveLength(4096);
+    expect(out.stderr!.endsWith("FINAL_ERROR")).toBe(true);
+  });
+
+  it("omits stderr on failure when the CLI wrote nothing", () => {
+    const failed: RuntimeResult = { status: "failed", output: "" };
+    expect(finalizeCliResult(failed, cliResult({ stderr: "", exitCode: 1 })).stderr).toBeUndefined();
+  });
+});

--- a/packages/core/src/adapters/runtime-common.ts
+++ b/packages/core/src/adapters/runtime-common.ts
@@ -1,6 +1,6 @@
 import { tmpdir } from "node:os";
-import type { RuntimeContext, RuntimeHealth } from "../ports/runtime.js";
-import { runCliProcess } from "./claude-code/spawn.js";
+import type { RuntimeContext, RuntimeHealth, RuntimeResult } from "../ports/runtime.js";
+import { type CliProcessResult, runCliProcess } from "./claude-code/spawn.js";
 
 /**
  * Shared helpers for the CLI-subprocess runtimes (claude-code, codex,
@@ -119,4 +119,92 @@ export async function cliVersionHealthCheck(
   } catch {
     return { healthy: false, error: `Command not found: ${command}` };
   }
+}
+
+/**
+ * Build the `onLog` handler that turns raw stdout chunks into whole lines.
+ *
+ * Every CLI runtime reads an NDJSON stream off stdout, but chunk boundaries
+ * are arbitrary — a chunk can split a JSON object mid-line, or carry several
+ * lines at once. This buffers the remainder between chunks and invokes
+ * `handleLine` once per complete line. stderr is ignored (it is captured
+ * wholesale by `runCliProcess` and only read on failure).
+ *
+ * The returned `flush` emits any trailing partial line, for streams that end
+ * without a final newline. Callers must invoke it after the process settles.
+ */
+export function createStdoutLineReader(handleLine: (line: string) => void): {
+  onLog: (stream: "stdout" | "stderr", chunk: string) => void;
+  flush: () => void;
+} {
+  let pending = "";
+  return {
+    onLog: (stream, chunk) => {
+      if (stream !== "stdout") return;
+      pending += chunk;
+      let nl: number;
+      while ((nl = pending.indexOf("\n")) !== -1) {
+        handleLine(pending.slice(0, nl));
+        pending = pending.slice(nl + 1);
+      }
+    },
+    flush: () => {
+      if (pending) {
+        const last = pending;
+        pending = "";
+        handleLine(last);
+      }
+    },
+  };
+}
+
+/**
+ * Warn when the CLI's stdout hit the capture cap. Past that point the event
+ * stream is missing lines, so a parsed result may be incomplete — worth a log
+ * line, but not fatal: a truncated transcript still beats no result at all.
+ */
+export function warnIfTruncated(runtimeTag: string, result: CliProcessResult): void {
+  if (!result.truncated) return;
+  console.warn(`[${runtimeTag}] stdout truncated at 4MB — result parsing may be incomplete`);
+}
+
+/**
+ * The `RuntimeResult` for a session the caller aborted via `abort_signal`.
+ * Deliberately distinct from a failure so the executor marks the session
+ * `cancelled` rather than surfacing it as an error to the user.
+ */
+export function cancelledResult(result: CliProcessResult): RuntimeResult {
+  return {
+    status: "cancelled",
+    output: "Session cancelled.",
+    process_pid: result.pid ?? undefined,
+    process_group_id: result.process_group_id ?? undefined,
+  };
+}
+
+/**
+ * Merge the process-level metadata into a parsed `RuntimeResult`.
+ *
+ * Surfaces the CLI's stderr tail on failure so operators / users get the
+ * actual diagnostic instead of just "CLI exited with code N". Capped at 4KB —
+ * the most useful info (final error + stacktrace) is at the end, so this
+ * tail-slices rather than head-slices.
+ */
+const STDERR_TAIL_BYTES = 4096;
+
+export function finalizeCliResult(
+  parsed: RuntimeResult,
+  result: CliProcessResult,
+): RuntimeResult {
+  const stderrTail =
+    parsed.status === "failed" && result.stderr
+      ? result.stderr.slice(-STDERR_TAIL_BYTES)
+      : undefined;
+  return {
+    ...parsed,
+    process_pid: result.pid ?? undefined,
+    process_group_id: result.process_group_id ?? undefined,
+    exit_code: result.exitCode,
+    ...(stderrTail ? { stderr: stderrTail } : {}),
+  };
 }

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -14,3 +14,4 @@ export * from "./room.js";
 export * from "./repo-run.js";
 export * from "./task-watch.js";
 export * from "./session-search.js";
+export * from "./xml.js";

--- a/packages/core/src/domain/xml.test.ts
+++ b/packages/core/src/domain/xml.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { escapeXmlAttr, escapeXmlText } from "./xml.js";
+
+describe("escapeXmlAttr", () => {
+  it("escapes the ampersand exactly once", () => {
+    // The regression this guards: escaping `"` before `&` re-escapes the
+    // ampersand that `&quot;` just introduced, yielding `&amp;quot;`.
+    expect(escapeXmlAttr('say "hi"')).toBe("say &quot;hi&quot;");
+  });
+
+  it("escapes a bare ampersand", () => {
+    expect(escapeXmlAttr("R&D")).toBe("R&amp;D");
+  });
+
+  it("escapes ampersands and quotes together without double-escaping", () => {
+    expect(escapeXmlAttr('R&D "x"')).toBe("R&amp;D &quot;x&quot;");
+  });
+
+  it("escapes angle brackets so a value cannot open a tag", () => {
+    expect(escapeXmlAttr("<block>")).toBe("&lt;block&gt;");
+  });
+
+  it("leaves plain text untouched", () => {
+    expect(escapeXmlAttr("agent_01ABC")).toBe("agent_01ABC");
+  });
+
+  it("is stable on the empty string", () => {
+    expect(escapeXmlAttr("")).toBe("");
+  });
+});
+
+describe("escapeXmlText", () => {
+  it("escapes ampersand and angle brackets", () => {
+    expect(escapeXmlText("a & b <c>")).toBe("a &amp; b &lt;c&gt;");
+  });
+
+  it("leaves quotes alone — they are legal in element text", () => {
+    expect(escapeXmlText('say "hi"')).toBe('say "hi"');
+  });
+
+  it("does not double-escape an ampersand", () => {
+    expect(escapeXmlText("&lt;")).toBe("&amp;lt;");
+  });
+});

--- a/packages/core/src/domain/xml.ts
+++ b/packages/core/src/domain/xml.ts
@@ -1,0 +1,33 @@
+/**
+ * Escaping for the XML-ish blocks we hand to agents.
+ *
+ * Several surfaces render tagged text into an agent's prompt — core-memory
+ * `<block>` / `<fact>` elements in the memory briefing, `<mesh-ask>` /
+ * `<mesh-negotiate>` / `<mesh-blocker>` envelopes in the mesh server. They all
+ * need the same two escapes, and each had grown its own copy.
+ *
+ * Order matters: `&` MUST be replaced first, otherwise the ampersands
+ * introduced by the later replacements get escaped a second time and `"`
+ * renders as `&amp;quot;` instead of `&quot;`.
+ */
+
+/**
+ * Escape a value going inside a double-quoted attribute — `name="..."`.
+ * Covers `&`, `"`, `<` and `>`.
+ */
+export function escapeXmlAttr(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/**
+ * Escape a value going in element text — `<block>...</block>`. Quotes are
+ * legal in text content, so only `&`, `<` and `>` are escaped; leaving quotes
+ * alone keeps agent-authored prose readable in the prompt.
+ */
+export function escapeXmlText(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}

--- a/packages/core/src/services/memory/memory-agent.ts
+++ b/packages/core/src/services/memory/memory-agent.ts
@@ -3,6 +3,7 @@ import type { MemoryFact, MemoryScope } from "../../domain/memory.js";
 import type { SessionBriefingSnapshot } from "../../domain/session.js";
 import type { EmbeddingService } from "../../ports/embedding-service.js";
 import { promotionEventId } from "../../domain/ids.js";
+import { escapeXmlAttr, escapeXmlText } from "../../domain/xml.js";
 import type { MemoryPromotionEventRepository } from "../../ports/promotion-event-repo.js";
 import type { CoreMemory } from "./core-memory.js";
 import type { FactPromoter, PromotionResult } from "./fact-promoter.js";
@@ -212,10 +213,10 @@ function composeBriefing(
     // so the agent sees scope right next to the data it's about to
     // (potentially) edit. See packages/core/src/domain/core-memory.ts.
     const descAttr = b.description
-      ? ` description="${escapeAttr(b.description)}"`
+      ? ` description="${escapeXmlAttr(b.description)}"`
       : "";
     blockLines.push(
-      `  <block name="${escapeAttr(b.block_name)}"${descAttr}>${escapeText(b.content)}</block>`,
+      `  <block name="${escapeXmlAttr(b.block_name)}"${descAttr}>${escapeXmlText(b.content)}</block>`,
     );
     blockSnapshots.push({
       name: b.block_name,
@@ -271,7 +272,7 @@ function composeBriefing(
  */
 function renderFact(f: MemoryFact): string {
   const saved = f.created_at.toISOString().slice(0, 10);
-  return `  <fact type="${escapeAttr(f.fact_type)}" scope="${f.scope}" saved="${saved}">${escapeText(f.content)}</fact>`;
+  return `  <fact type="${escapeXmlAttr(f.fact_type)}" scope="${f.scope}" saved="${saved}">${escapeXmlText(f.content)}</fact>`;
 }
 
 /**
@@ -285,16 +286,4 @@ function renderArchivalEnvelope(facts: readonly MemoryFact[]): string {
   for (const f of facts) lines.push(renderFact(f));
   lines.push("</archival_memory>");
   return lines.join("\n");
-}
-
-function escapeAttr(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/"/g, "&quot;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
-
-function escapeText(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }

--- a/packages/sandbox/src/docker.ts
+++ b/packages/sandbox/src/docker.ts
@@ -406,7 +406,16 @@ function generateId(label: string): string {
   return `${safe}-${suffix}`;
 }
 
-function shellQuote(s: string): string {
+/**
+ * Single-quote a value for safe interpolation into a `sh -c` command line.
+ *
+ * Wraps in single quotes — inside which the shell expands nothing — and
+ * closes/re-opens around any embedded quote (`'` → `'\''`). Every path,
+ * filename and URL that reaches a container command must go through this;
+ * `orchestrator.ts` uses it for the same reason, so it lives here rather
+ * than being redefined there.
+ */
+export function shellQuote(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`;
 }
 

--- a/packages/sandbox/src/orchestrator.ts
+++ b/packages/sandbox/src/orchestrator.ts
@@ -28,6 +28,7 @@ import {
   destroySandbox,
   exec as sandboxExec,
   prepareBaseEnvironment,
+  shellQuote,
   type Sandbox,
 } from "./docker.js";
 
@@ -596,8 +597,4 @@ function defaultMcpServerCommand(): { command: string; args: string[] } {
   return isTsxRun
     ? { command: "npx", args: ["--no-install", "tsx", mcpServerPath] }
     : { command: "node", args: ["--enable-source-maps", mcpServerPath] };
-}
-
-function shellQuote(s: string): string {
-  return `'${s.replace(/'/g, `'\\''`)}'`;
 }

--- a/packages/sandbox/src/shell-quote.test.ts
+++ b/packages/sandbox/src/shell-quote.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Unit tests for `shellQuote` — the escaping every path, filename and URL
+ * passes through on its way into a `sh -c` command line inside a container.
+ * Pure string work, so unlike `docker.e2e.test.ts` these need no Docker.
+ */
+import { describe, expect, it } from "vitest";
+import { shellQuote } from "./docker.js";
+
+describe("shellQuote", () => {
+  it("wraps a plain value in single quotes", () => {
+    expect(shellQuote("/sandbox/out.txt")).toBe("'/sandbox/out.txt'");
+  });
+
+  it("neutralizes spaces so a path stays one argument", () => {
+    expect(shellQuote("my file.txt")).toBe("'my file.txt'");
+  });
+
+  it("closes and reopens around an embedded single quote", () => {
+    expect(shellQuote("it's")).toBe(`'it'\\''s'`);
+  });
+
+  it("keeps a command-substitution attempt inert", () => {
+    // Inside single quotes the shell expands nothing, so `$(...)` stays
+    // literal rather than running.
+    expect(shellQuote("$(rm -rf /)")).toBe("'$(rm -rf /)'");
+  });
+
+  it("keeps a quote-break-out attempt inert", () => {
+    // The `'` that would close our quoting is itself escaped, so the
+    // trailing `; rm -rf /` cannot become a second command.
+    const quoted = shellQuote(`'; rm -rf /; echo '`);
+    expect(quoted.startsWith("'")).toBe(true);
+    expect(quoted.endsWith("'")).toBe(true);
+    expect(quoted).toBe(`''\\''; rm -rf /; echo '\\'''`);
+  });
+
+  it("leaves other shell metacharacters literal", () => {
+    expect(shellQuote("a;b|c&d>e")).toBe("'a;b|c&d>e'");
+  });
+
+  it("handles the empty string", () => {
+    expect(shellQuote("")).toBe("''");
+  });
+});


### PR DESCRIPTION
A duplication sweep across the monorepo. Three clusters had enough copies —
and enough drift risk — to be worth collapsing. Each is a separate commit.

## 1. Finish the CLI-runtime adapter unification (#257 follow-up)

#257 pulled the byte-identical module-level helpers out of the three
CLI-subprocess runtimes into `adapters/runtime-common.ts`, but stopped there.
Four identical structures were still inlined in each `execute()`:

| Duplicated in all 3 | Now |
| --- | --- |
| stdout line-buffering `onLog` handler | `createStdoutLineReader(handleLine)` |
| `result.truncated` warning | `warnIfTruncated(tag, result)` |
| `result.aborted` early return | `cancelledResult(result)` |
| stderr-tail + exit-code merge, incl. `STDERR_TAIL_BYTES` | `finalizeCliResult(parsed, result)` |

The line buffer is the one that actually mattered: it is what keeps an NDJSON
event intact across an arbitrary chunk boundary, and three copies meant three
places to get a stream-framing fix right. Codex keeps its `removeIfExists`
cleanup before returning cancelled.

## 2. The 500-handler and the XML escapers

**`handleError` — 4 copies, 34 call sites.** `signin`, `signup` and `room`
were byte-identical bar the log tag; `view` differed only by taking a per-call
context. All four now come from `makeErrorHandler(tag)` in
`routes/http-errors.ts`, whose handler takes an optional `context` so both log
shapes survive verbatim.

`routes/chat.ts` keeps its own on purpose — it returns a generic message plus
a `request_id` and keeps the detail server-side, where the other four reflect
`err.message` straight back to the client. That is a deliberate difference in
what we expose, not copy-paste drift, so this PR preserves each existing
behavior rather than quietly changing it. Worth flagging that chat's is the
safer treatment and the other four are a reasonable follow-up.

**`escapeAttr` — 2 copies, one of them wrong.** The mesh server applied its
replacements in the wrong order:

```ts
s.replace(/"/g, "&quot;").replace(/&/g, "&amp;")
```

Escaping `"` first means the `&` that `&quot;` just introduced gets escaped
again — a quote renders as `&amp;quot;`, and `R&D "x"` becomes
`R&amp;D &amp;quot;x&amp;quot;`. The memory-agent copy had the correct
`&`-first order. Both now use `escapeXmlAttr` / `escapeXmlText` from
`domain/xml.ts`, which documents the ordering constraint. The mesh version
also picks up the `<`/`>` escaping it was missing.

Nothing is malformed today: the mesh call sites only ever escape generated ids
(`agent_…`, `req_…`), so this is a latent bug removed, not a live incident.

## 3. `shellQuote` in the sandbox

`docker.ts` and `orchestrator.ts` each had a private, byte-identical copy of
the POSIX single-quote escaper that guards every path, filename and URL going
into a `sh -c` line inside a container. `docker.ts` now exports it.

## Tests

31 new tests, all previously-uncovered shared code:

- `runtime-common.test.ts` (15) — chunk-split reassembly, multi-line chunks,
  stderr ignored, flush idempotence, the 4KB stderr tail-slice, null-pid
  mapping. Previously only exercised indirectly through each runtime.
- `domain/xml.test.ts` (9) — pins the escape ordering so the double-escape
  cannot come back.
- `shell-quote.test.ts` (7) — the first non-Docker-gated test in that package,
  so it actually runs in CI. Includes `$(...)` and `'; rm -rf /` break-out
  shapes staying inert.

## Verification

- `pnpm typecheck` — 9/9 clean
- `pnpm lint` — 0 errors (4 pre-existing `import/no-duplicates` warnings, none
  in touched files)
- `@beevibe/core` — 439 pass, only the 9 known provider-key failures
- `@beevibe/api` — 27 files pass / 9 DB-gated fail, 308 tests pass — exactly
  the baseline in CLAUDE.md
- 116 existing adapter tests pass unchanged

Behavior-preserving throughout, with the one intentional exception of the mesh
escaping fix. Net ~150 fewer lines of duplicated logic.

## Not done — noted for follow-up

- **`rowToAgentDisplay`** is ~90% duplicated between `views/agents.ts` and
  `views/agent-network.ts` (differ only in `owner_label` / `archived_at` and
  null-safety). The comment in one literally says "Match `agents.ts`", which
  is the drift risk stated out loud. Left alone because its only coverage is
  DB-gated and I could not verify a change to the payload here.
- **Test fixtures** — `makeAgent` / `makeSession` are redefined across 7-8
  test files. Real duplication, but a shared-fixtures move is its own PR.
- **`formatDurationLabel`** is duplicated between `packages/web/lib/format.ts`
  and `packages/api/src/views/format.ts`, identical bar web's date coercion.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VT2rcVHgsZZFf3kiimV2ZG)_