### PR TITLE
chore: remove dead frontend code found via static analysis

### DIFF
--- a/packages/web/components/detail/status-pill.tsx
+++ b/packages/web/components/detail/status-pill.tsx
@@ -92,11 +92,3 @@ export function EscalationStatusPill({ status, className }: { status: Escalation
 export function NegotiationStatusPill({ status, className }: { status: NegotiationStatus; className?: string }) {
   return <DotPill config={NEGOTIATION_PILL[status]} className={className} />;
 }
-
-export function PriorityPill({ priority }: { priority: string }) {
-  return (
-    <span className="inline-flex items-center h-6 px-2 rounded text-xs font-medium bg-secondary text-secondary-foreground">
-      {priority}
-    </span>
-  );
-}

--- a/packages/web/components/skeletons.tsx
+++ b/packages/web/components/skeletons.tsx
@@ -1,34 +1,5 @@
 import { Skeleton } from "./skeleton";
 
-export function TaskRowSkeleton() {
-  return (
-    <li className="flex items-start gap-3 px-6 py-3">
-      <Skeleton className="h-4 w-4 mt-0.5 shrink-0 rounded-full" />
-      <div className="flex-1 min-w-0 space-y-1.5">
-        <div className="flex items-baseline gap-2">
-          <Skeleton className="h-4 flex-1 max-w-md" />
-          <Skeleton className="h-3 w-12 shrink-0" />
-        </div>
-        <div className="flex items-center gap-1.5">
-          <Skeleton className="h-3 w-14" />
-          <Skeleton className="h-3 w-16" />
-          <Skeleton className="h-3 w-24" />
-        </div>
-      </div>
-    </li>
-  );
-}
-
-export function TaskListSkeleton({ rows = 8 }: { rows?: number }) {
-  return (
-    <ul>
-      {Array.from({ length: rows }).map((_, i) => (
-        <TaskRowSkeleton key={i} />
-      ))}
-    </ul>
-  );
-}
-
 export function FactRowSkeleton() {
   return (
     <tr>
@@ -53,29 +24,6 @@ export function FactRowSkeleton() {
       </td>
       <td />
     </tr>
-  );
-}
-
-export function FactTableSkeleton({ rows = 6 }: { rows?: number }) {
-  return (
-    <tbody>
-      {Array.from({ length: rows }).map((_, i) => (
-        <FactRowSkeleton key={i} />
-      ))}
-    </tbody>
-  );
-}
-
-export function TranscriptEntrySkeleton() {
-  return (
-    <div className="flex items-start gap-3 px-3 py-2 -mx-3">
-      <Skeleton className="h-4 w-4 rounded shrink-0 mt-0.5" />
-      <div className="flex-1 space-y-1">
-        <Skeleton className="h-3 w-20" />
-        <Skeleton className="h-3 w-full" />
-        <Skeleton className="h-3 w-4/5" />
-      </div>
-    </div>
   );
 }
 
@@ -115,16 +63,6 @@ export function PromotionEventSkeleton() {
         <Skeleton className="h-3 w-4/5" />
       </div>
       <Skeleton className="h-3 w-64" />
-    </div>
-  );
-}
-
-export function ChannelLinkSkeleton() {
-  return (
-    <div className="flex items-center gap-2 px-2 py-1.5 rounded">
-      <Skeleton className="h-3.5 w-3.5 shrink-0 rounded-full" />
-      <Skeleton className="h-3 flex-1 max-w-[180px]" />
-      <Skeleton className="h-2.5 w-6 shrink-0" />
     </div>
   );
 }

--- a/packages/web/components/team-orbit.tsx
+++ b/packages/web/components/team-orbit.tsx
@@ -5,7 +5,6 @@ import { useRef, useState } from "react";
 import { Bot } from "lucide-react";
 import { Avatar } from "@/components/avatar";
 import { Skeleton } from "@/components/skeleton";
-import { useAgents } from "@/lib/hooks/use-agents";
 import type { AgentDisplay } from "@/lib/types/agents";
 
 /**
@@ -101,8 +100,6 @@ export type AgentSelectHandler = (agentId: string) => void;
  * Render a single team's knowledge graph. Pass an explicit `agents`
  * array (typed as one team + its IC subordinates); the component picks
  * the top-level agent as the center and arranges the ICs around it.
- * For a self-rendering convenience that fetches the caller's own
- * agents, use <SelfTeamOrbit /> below.
  */
 export function TeamOrbit({
   agents,
@@ -145,15 +142,6 @@ export function TeamOrbit({
       ) : null}
     </div>
   );
-}
-
-/**
- * Self-rendering convenience — fetches the caller's own agents and
- * passes them to TeamOrbit. Used on the dashboard's compact summary.
- */
-export function SelfTeamOrbit({ size = "large" }: { size?: TeamOrbitSize }) {
-  const { data, isLoading } = useAgents();
-  return <TeamOrbit agents={data} size={size} loading={isLoading} />;
 }
 
 function Graph({

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -90,19 +90,6 @@ export interface MeResponse {
   needs_onboarding: boolean;
 }
 
-export interface HealthResponse {
-  ok: boolean;
-  /** `claude` CLI presence — chat agents spawn as CLI subprocesses. */
-  claude_cli: { ok: boolean; message?: string };
-  /**
-   * OpenAI embeddings — used by memory briefing's vector recall.
-   * `skipped: true` means no `OPENAI_API_KEY` was configured at boot;
-   * memory writes will return a friendly disabled message and recall
-   * returns blocks-only briefings. Chat works either way.
-   */
-  openai: { ok: boolean; skipped?: boolean; message?: string };
-}
-
 export interface ChatSendInput {
   message: string;
   /** Previous turn's session id — enables `--resume` continuity. */
@@ -697,18 +684,11 @@ export const api = {
     /** Identity + onboarding state for the welcome flow. */
     self: (opts: ReadOptions = {}) =>
       fetchJson<MeResponse>("/me", { signal: opts.signal }),
-    completeOnboarding: () =>
-      fetchJson<{ ok: true; onboarding_completed_at: string | null }>(
-        "/me/onboarding/complete",
-        { method: "POST" },
-      ),
     updatePreferences: (input: Partial<UserPreferences>) =>
       fetchJson<{ ok: true; preferences: UserPreferences }>(
         "/me/preferences",
         { method: "PATCH", body: input },
       ),
-    health: (opts: ReadOptions = {}) =>
-      fetchJson<HealthResponse>("/health/runtime", { signal: opts.signal }),
   },
   negotiations: {
     get: (id: string, opts: ReadOptions = {}) =>
@@ -750,14 +730,6 @@ export const api = {
       fetchJson<{ skill: LearnedSkill }>("/learned-skills", { method: "POST", body: input }),
     delete: (id: string) =>
       fetchJson<void>(`/learned-skills/${encodeURIComponent(id)}`, { method: "DELETE" }),
-    publish: (id: string) =>
-      fetchJson<{
-        ok: boolean;
-        pr_url?: string;
-        reason?: string;
-        skill_md?: string;
-        instructions?: string;
-      }>(`/learned-skills/${encodeURIComponent(id)}/publish`, { method: "POST" }),
   },
   findRepo: {
     /** Ranked search across all 4 find_repo tiers. Empty `goal` is a 400. */

--- a/packages/web/lib/hooks/keys.ts
+++ b/packages/web/lib/hooks/keys.ts
@@ -40,7 +40,6 @@ export const queryKeys = {
   me: {
     all: ["me"] as const,
     self: () => ["me", "self"] as const,
-    health: () => ["me", "health"] as const,
   },
   activity: {
     all: ["activity"] as const,

--- a/packages/web/lib/hooks/use-me.ts
+++ b/packages/web/lib/hooks/use-me.ts
@@ -1,7 +1,7 @@
 "use client";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { api, type HealthResponse, type MeResponse } from "@/lib/api/client";
+import { useQuery } from "@tanstack/react-query";
+import { api, type MeResponse } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
 import { queryKeys } from "./keys";
 
@@ -29,24 +29,4 @@ export function useIsOwner(ownerId: string | undefined): boolean | null {
   const me = useMe();
   if (!me.data) return null;
   return me.data.person.id === ownerId;
-}
-
-export function useLlmHealth(enabled = true) {
-  return useQuery<HealthResponse>({
-    queryKey: queryKeys.me.health(),
-    queryFn: ({ signal }) => api.me.health({ signal }),
-    enabled: isApiConfigured && enabled,
-    retry: false,
-    staleTime: 5_000,
-  });
-}
-
-export function useCompleteOnboarding() {
-  const client = useQueryClient();
-  return useMutation({
-    mutationFn: () => api.me.completeOnboarding(),
-    onSuccess: () => {
-      client.invalidateQueries({ queryKey: queryKeys.me.all });
-    },
-  });
 }


### PR DESCRIPTION
Follow-up sweep to #256. Ran eslint across all packages, `tsc`, knip in both default and `--production` mode, and a per-method scan of the web API client. Removed only what verified as unreferenced by **both** product code and tests — 133 lines, all in `packages/web`.

## What was removed

**Unused React components** — zero references anywhere in the package:

| Symbol | File |
| --- | --- |
| `TaskRowSkeleton`, `TaskListSkeleton`, `FactTableSkeleton`, `TranscriptEntrySkeleton`, `ChannelLinkSkeleton` | `components/skeletons.tsx` |
| `PriorityPill` | `components/detail/status-pill.tsx` |
| `SelfTeamOrbit` | `components/team-orbit.tsx` |

`FactRowSkeleton`, `KpiTileSkeleton`, `PromotionEventSkeleton` and `MeshAskSkeleton` stay — they're imported by live views. `SelfTeamOrbit`'s doc comment claimed dashboard usage that no longer exists; its now-orphaned `useAgents` import went with it.

**Unused hooks, and the API surface only they reached:**

- `useLlmHealth` and `useCompleteOnboarding` (`lib/hooks/use-me.ts`). Onboarding completion is flipped server-side by the chat route, so the client mutation had no caller.
- `api.me.health`, `api.me.completeOnboarding` and the `HealthResponse` interface (`lib/api/client.ts`) — unreachable once those hooks went.
- `queryKeys.me.health` (`lib/hooks/keys.ts`) — orphaned by the same removal.
- `api.learnedSkills.publish` — the only one of the client's 60 methods with no call site. **The `POST /learned-skills/:id/publish` endpoint itself is untouched** and still serves agents over MCP.

## What was deliberately left alone

- **17 knip "unused export" hits** (`resolveAddressees`, `STREAM_TYPE`, `DEFAULT_MAX_CONCURRENT`, `MODEL_PRESETS`, `toDate`, `splitWakeReason` and similar) — each is used inside its own module and merely over-exported, not dead. Same call as #256.
- **The 7 files knip lists as unused** are reachable dev/deploy tooling: `pre-deploy-fix-migration-names.cjs` runs from `start-api.sh`, `provision-demo.ts` from `dev.sh`, the sandbox scripts and `test-session-search.ts` document their own manual invocation, and the migration is executed by node-pg-migrate.
- **`node-pg-migrate` in `packages/api`** — knip still flags it, but it was re-added in 18c7fc9 because removing it broke the Railway deploy.
- **`prettier` at the root** — flagged as unused, but `.prettierrc.json` exists and it's used via editor integration / `npx prettier`.

## Flagged, not removed — one for the author

`useCreateTask` (`lib/hooks/use-task-mutations.ts`) has no product caller — only `use-task-mutations.test.tsx` and `client-mutations.test.ts` reach it and `api.tasks.create`. It's dead by the numbers, but the dedicated tests suggest intent, so it's left in place for you to decide.

## Verification

- `pnpm typecheck` — clean, 9/9 tasks
- `pnpm lint` — clean, 9/9 tasks (only pre-existing `import/no-duplicates` warnings)
- `pnpm --filter @beevibe/web exec next build` — succeeds
- `pnpm --filter @beevibe/web test` — 20 files, 180 tests, all passing

---
_Generated by [Claude Code](https://claude.ai/code/session_016aZMMLBudSnk1zNoVBS881)_