### PR TITLE
test: drop two implementation-detail tests, give the two assertion-free ones assertions

### DIFF
--- a/packages/core/src/adapters/anthropic/llm-provider.test.ts
+++ b/packages/core/src/adapters/anthropic/llm-provider.test.ts
@@ -61,9 +61,4 @@ describe("AnthropicLlmProvider", () => {
       process.env.ANTHROPIC_API_KEY = saved;
     }
   });
-
-  it("reports its identity via the type field", () => {
-    const llm = new AnthropicLlmProvider();
-    expect(llm.type).toBe("anthropic");
-  });
 });

--- a/packages/core/src/adapters/openai/llm-provider.test.ts
+++ b/packages/core/src/adapters/openai/llm-provider.test.ts
@@ -61,9 +61,4 @@ describe("OpenAILlmProvider", () => {
       process.env.OPENAI_API_KEY = saved;
     }
   });
-
-  it("reports its identity via the type field", () => {
-    const llm = new OpenAILlmProvider();
-    expect(llm.type).toBe("openai");
-  });
 });

--- a/packages/scheduler/src/cancel-listener.test.ts
+++ b/packages/scheduler/src/cancel-listener.test.ts
@@ -74,26 +74,44 @@ describe("CancelListener", () => {
     expect(cancelCalls).toEqual([]);
   });
 
-  it("start() is idempotent", async () => {
-    const { worker } = fakeWorker();
+  it("start() is idempotent — a second call does not double-subscribe", async () => {
+    const { worker, cancelCalls } = fakeWorker();
     listener = new CancelListener({
       connectionString: process.env.DATABASE_URL_TEST!,
       worker,
     });
     await listener.start();
     await listener.start(); // no-op
-    // shouldn't throw
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    await pool.query(`SELECT pg_notify('cancel_task', $1)`, ["task_once"]);
+
+    for (let i = 0; i < 20; i++) {
+      if (cancelCalls.length > 0) break;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    // A second LISTEN on a second connection would deliver the payload twice.
+    await new Promise((r) => setTimeout(r, 100));
+    expect(cancelCalls).toEqual(["task_once"]);
   });
 
-  it("stop() cleans up the connection", async () => {
-    const { worker } = fakeWorker();
+  it("stop() cleans up the connection — notifications stop being delivered", async () => {
+    const { worker, cancelCalls } = fakeWorker();
     listener = new CancelListener({
       connectionString: process.env.DATABASE_URL_TEST!,
       worker,
     });
     await listener.start();
+    await new Promise((r) => setTimeout(r, 50));
+
     await listener.stop();
     // stop is idempotent
     await listener.stop();
+
+    await pool.query(`SELECT pg_notify('cancel_task', $1)`, ["task_after_stop"]);
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(cancelCalls).toEqual([]);
   });
 });


### PR DESCRIPTION
A sweep of all 122 test files (~26k lines) looking for dead weight: skipped/xfail tests, tests for removed features, tests with no assertions, and tests that pin implementation details rather than behavior.

**The suite is in good shape.** Four items came out of the sweep — two removals and two tests that needed assertions. Everything else checked out.

## Removed — `reports its identity via the type field`

`packages/core/src/adapters/anthropic/llm-provider.test.ts`, `packages/core/src/adapters/openai/llm-provider.test.ts`

Each asserted `provider.type === "<name>"` on a field the `LlmProvider` port already declares as `readonly type: string` — so TypeScript pins it at compile time. Nothing branches on the value at runtime: `provider.type` has **zero consumers** outside these two tests. The assertion could therefore only ever fail if someone edited a string literal and its own test in opposite directions.

The second problem is cost. Each test constructed a live provider purely to read that constant, so CI had to spend a real `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` to assert a hardcoded string. The offline `throws when no API key is configured` case in both files is untouched.

## Strengthened — the only two assertion-free tests in the suite

`packages/scheduler/src/cancel-listener.test.ts`

Both passed as long as nothing threw, so neither actually checked the thing its name promised:

| Test | Was | Now |
| --- | --- | --- |
| `start() is idempotent` | Called `start()` twice, asserted nothing. Dropping the `started` guard would open a second connection and `LISTEN` twice, double-firing `cancelTask` — and this still passed. | Fires one `pg_notify`, asserts `cancelCalls` has exactly one entry. |
| `stop() cleans up the connection` | Never observed the connection at all. | Notifies after `stop()`, asserts nothing is delivered. |

Both are gated on `DATABASE_URL_TEST`, so they run in CI but not in a bare sandbox — the new assertions are derived from `cancel-listener.ts` (the `started` guard on `start()`, and `client.end()` + `client = undefined` on `stop()`) and will get their first real execution on this PR's CI run.

## Checked and found healthy — no action taken

- **No dormant skips.** No `.only`, no unconditional `.skip`, no `it.todo`, no xfail anywhere in the suite. Every skip is env- or platform-gated with a documented reason: `RUN_CLAUDE_SMOKE` (ci.yml carries a comment explaining why the smoke is excluded), `BEEVIBE_E2E_DOCKER`, `BEEVIBE_E2E_MULTI_INSTANCE`, `HAS_LIVE_API_KEYS` (which CI *does* set, via the `production` environment), and `process.platform === "win32"`.
- **No tests for removed features.** Nothing references a module deleted by the dead-code sweeps (#256, #260) or by the Crystal extraction (#238), and a clean typecheck across all 9 packages confirms no test imports a dangling symbol.
- **No redundancy from the recent unification refactors** (#257, #259). `runtime-common.test.ts` covers `createStdoutLineReader` / `warnIfTruncated` / `cancelledResult` / `finalizeCliResult`; the per-adapter `stream-json.test.ts` files remain the only coverage of `parseNdjsonLine` and of each CLI's own event shapes.
- **The view tests that inspect `pool._spy`** assert on bound parameters with `expect.any(String)` for the SQL text, so they test clamping and owner-scoping behavior rather than query strings.

## Verification

- `pnpm typecheck` — clean, 9/9 packages
- `pnpm lint` — clean, 9/9 packages
- `@beevibe/web` — 180/180 pass
- `@beevibe/core` — 439 pass (unchanged), failures 9 → 7. The two that disappear are exactly the removed live-key tests; the remaining 7 are the documented no-Postgres / no-provider-key sandbox baseline.
- `@beevibe/scheduler`, `@beevibe/sandbox` — unchanged from baseline
- Re-ran the assertion-free scan over the whole suite: zero remaining.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXRW1KN4Vk6VM3AEaaZkni)_