### PR TITLE
chore: dead-code sweep — one dead param, document false-positive traps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,40 @@ Diagnose Turbo's env filtering with
 `npx turbo run build --filter=@beevibe/web --dry-run=json` and check
 `envMode` / `passthrough`.
 
+## Dead-code analysis: known false positives
+
+`knip` and `depcheck` flag the same handful of things on every sweep. All
+of the below are **load-bearing — do not remove.** Verify against this
+table before deleting anything a tool reports as unused.
+
+| Reported as unused | Why it stays |
+| --- | --- |
+| `packages/api` dep `node-pg-migrate` | Runs migrations on deploy via `scripts/start-api.sh`. Removing it broke the Railway deploy once already (#258). |
+| `packages/api` dep `zod` | Required **peer dependency** of `@modelcontextprotocol/sdk` (`^3.25 \|\| ^4.0`). Nothing imports it directly. |
+| `packages/web` devDeps `postcss`, `autoprefixer` | Referenced by `packages/web/postcss.config.js`, which the tools don't parse. |
+| root devDep `prettier` | Formatting is editor/CLI-driven off `.prettierrc.json`; there's no `format` script to detect. |
+| `migrations/*.js` | Applied migration history. **Never** delete a migration file. |
+| `scripts/provision-demo.ts`, `pre-deploy-fix-migration-names.cjs` | Invoked from `scripts/dev.sh` and `scripts/start-api.sh` — shell call sites are invisible to knip. |
+| `scripts/seed-session-search-demo.ts`, `test-session-search.ts`, `packages/sandbox/src/scripts/*` | Documented manual dev/ops utilities, run by hand via `pnpm tsx …`. |
+| `OwnerLookup.singleOwnerSet` / `.meshOwners` | Called by the module-level `RESOLVERS` table, so they must stay public. Knip only checks cross-module use. |
+| `@beevibe/core/{domain,adapters/codex,adapters/opencode,services/skills,auth/constants}` subpath exports | Deliberate library surface. The codex/opencode runtimes are wired through `runtime-registry.ts`, which imports `./codex/runtime.js` directly rather than the barrel. |
+
+Most "unused export" hits are symbols used *within their own file* — the
+`export` is redundant, not dead. Leave them alone unless you're already
+editing the file.
+
+The checks that do find real dead code here:
+
+```bash
+npx tsc -p packages/<pkg>/tsconfig.json --noEmit --noUnusedLocals --noUnusedParameters
+npx tsc -p packages/<pkg>/tsconfig.json --noEmit --allowUnreachableCode false   # TS7027
+```
+
+Note `@typescript-eslint/no-unused-vars` defaults to `args: after-used`,
+so an unused parameter followed by a used one is **not** reported — only
+`--noUnusedParameters` catches it. Convention here is to prefix a
+deliberately-unused param with `_`.
+
 ## Deploying
 
 ```bash

--- a/packages/api/src/tools/hierarchy.ts
+++ b/packages/api/src/tools/hierarchy.ts
@@ -169,7 +169,7 @@ function asError(err: unknown): AgentToolResult {
 // ── Shared (IC + team) tools ─────────────────────────────────────────────
 
 function searchContextTool(
-  ctx: HierarchyToolContext,
+  _ctx: HierarchyToolContext,
   services: HierarchyToolServices,
 ): AgentTool {
   return {


### PR DESCRIPTION
## Summary

Full dead-code sweep of the monorepo. After #256, #259 and #260 the tree is **essentially clean** — the analysis surfaced exactly one genuine piece of dead code. The rest of this PR is a guard rail so the next sweep doesn't re-litigate the same false positives, or repeat the #258 outage.

## What was removed

**`searchContextTool`'s `ctx` parameter is never read** — `packages/api/src/tools/hierarchy.ts`. Renamed to `_ctx`, matching the convention its siblings already follow (`updateProgressTool`, `getAgentProfileTool`, `getTaskTool` all take `_ctx`).

Why CI never caught it: `@typescript-eslint/no-unused-vars` defaults to `args: after-used`, so an unused parameter *followed by a used one* is not reported. Only `tsc --noUnusedParameters` finds it.

## What was deliberately NOT removed

Every other tool hit was verified by hand as a false positive. Several are load-bearing — removing them breaks the build, the deploy, or the database:

| Reported as unused | Why it stays |
| --- | --- |
| `packages/api` dep `node-pg-migrate` | Runs migrations on deploy via `scripts/start-api.sh`. Removing it **already broke the Railway deploy once** (#258). |
| `packages/api` dep `zod` | Required **peer dependency** of `@modelcontextprotocol/sdk` (`^3.25 \|\| ^4.0`). Nothing imports it directly. |
| `packages/web` devDeps `postcss`, `autoprefixer` | Referenced by `packages/web/postcss.config.js`, which the tools don't parse. |
| root devDep `prettier` | Editor/CLI-driven off `.prettierrc.json`; no `format` script to detect. |
| `migrations/*.js` | Applied migration history — never deletable. |
| `scripts/provision-demo.ts`, `pre-deploy-fix-migration-names.cjs` | Invoked from `dev.sh` / `start-api.sh`. Shell call sites are invisible to knip. |
| `scripts/seed-session-search-demo.ts`, `test-session-search.ts`, `packages/sandbox/src/scripts/*` | Documented manual dev/ops utilities. |
| `OwnerLookup.singleOwnerSet` / `.meshOwners` | Called by the module-level `RESOLVERS` table, so they must stay public. Knip only checks cross-module use. |
| core `domain` / `codex` / `opencode` / `services/skills` / `auth/constants` subpath exports | Library surface. The runtimes are wired through `runtime-registry.ts`, which imports `./codex/runtime.js` directly rather than the barrel. |

The 13 reported "unused exports" are all used **within their own file** — the `export` keyword is redundant, not dead. Left alone.

Since this sweep runs on a schedule and will keep re-flagging these, the table is now recorded in `CLAUDE.md`.

## How it was analyzed

- `knip` — unused files, exports, types, class/enum members, duplicates
- `depcheck` — unused dependencies, per-package and root
- `eslint` — unused vars, unreachable code
- `tsc --noUnusedLocals --noUnusedParameters` — the one real hit
- `tsc --allowUnreachableCode false` — TS7027, clean across all packages
- A custom alias-aware orphan-file reachability pass (handles `@/*` and Next.js app-router conventional entrypoints, which knip's defaults get wrong). All remaining orphans are legitimate entrypoints: process `main.ts`s, package export barrels, documented CLI scripts.

## Testing

- `pnpm typecheck` — clean, 9/9 tasks
- `pnpm lint` — 0 errors (only pre-existing warnings)
- `packages/api` hierarchy tests — 25/25 pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01FAeJ7wD3KxJV3j73Pwd3hX)_