### PR TITLE
refactor: unify four more clusters of near-duplicate abstractions

### DIFF
--- a/packages/api/src/mesh/types.ts
+++ b/packages/api/src/mesh/types.ts
@@ -41,7 +41,23 @@ export interface EscalatedSentinel {
   negotiation_id: string;
 }
 
-export class MeshCapacityError extends Error {
+/**
+ * Base for mesh failures that carry a machine-readable `code` and
+ * structured `meta` alongside the human message.
+ *
+ * The mesh tool wrapper (`tools/mesh.ts`) projects every one of these
+ * into the same `{ error: code, ...meta, message }` envelope. Before
+ * this base existed that projection was written out once per subclass
+ * — three byte-identical `instanceof` branches — so adding a fourth
+ * coded error meant remembering to add a fourth branch or silently
+ * getting the generic `{ error: <message> }` envelope instead.
+ */
+export abstract class CodedMeshError extends Error {
+  abstract readonly code: string;
+  abstract readonly meta: Record<string, unknown>;
+}
+
+export class MeshCapacityError extends CodedMeshError {
   readonly code = "MESH_CAPACITY_EXCEEDED";
   constructor(
     message: string,
@@ -52,7 +68,7 @@ export class MeshCapacityError extends Error {
   }
 }
 
-export class MeshMaxRoundsError extends Error {
+export class MeshMaxRoundsError extends CodedMeshError {
   readonly code = "MAX_ROUNDS_EXCEEDED";
   constructor(
     public readonly meta: {
@@ -75,7 +91,7 @@ export class MeshMaxRoundsError extends Error {
  * negotiation against them would hang forever. Use `ask` (lateral one-shot)
  * or `create_task` (downward delegation) instead.
  */
-export class CannotNegotiateWithIcError extends Error {
+export class CannotNegotiateWithIcError extends CodedMeshError {
   readonly code = "CANNOT_NEGOTIATE_WITH_IC";
   constructor(public readonly meta: { agentId: string }) {
     super(

--- a/packages/api/src/tools/errors.test.ts
+++ b/packages/api/src/tools/errors.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  CannotNegotiateWithIcError,
+  MeshCapacityError,
+  MeshMaxRoundsError,
+} from "../mesh/types.js";
+import { toolError, toolErrorFromThrown } from "./errors.js";
+
+describe("toolError", () => {
+  it("puts the code in `error` and the human text in `message`", () => {
+    expect(toolError("watch_auth", "not your task")).toEqual({
+      content: { error: "watch_auth", message: "not your task" },
+      isError: true,
+    });
+  });
+
+  it("merges structured context alongside code and message", () => {
+    expect(toolError("watch_validation", "bad mode", { mode: "nope" })).toEqual({
+      content: { error: "watch_validation", message: "bad mode", mode: "nope" },
+      isError: true,
+    });
+  });
+});
+
+describe("toolErrorFromThrown", () => {
+  it("preserves the code and meta of every coded mesh error", () => {
+    const coded = [
+      new MeshCapacityError("at cap", { agentId: "agent_1", running: 3, cap: 3 }),
+      new MeshMaxRoundsError({
+        negotiationId: "neg_1",
+        rounds_completed: 5,
+        max_rounds: 5,
+      }),
+      new CannotNegotiateWithIcError({ agentId: "agent_2" }),
+    ];
+
+    for (const err of coded) {
+      const result = toolErrorFromThrown(err);
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({
+        error: err.code,
+        message: err.message,
+        ...err.meta,
+      });
+    }
+  });
+
+  it("reports an uncoded Error by its message, in the `error` field", () => {
+    expect(toolErrorFromThrown(new Error("boom"))).toEqual({
+      content: { error: "boom" },
+      isError: true,
+    });
+  });
+
+  it("stringifies a non-Error throw", () => {
+    expect(toolErrorFromThrown("just a string")).toEqual({
+      content: { error: "just a string" },
+      isError: true,
+    });
+  });
+
+  it("merges `extra` into the uncoded envelope", () => {
+    expect(toolErrorFromThrown(new Error("boom"), { agent_id: "agent_1" })).toEqual({
+      content: { error: "boom", agent_id: "agent_1" },
+      isError: true,
+    });
+  });
+
+  it("does not treat a plain object with a `code` as a coded error", () => {
+    // Guards the coded branch against duck-typing: pg and node fs errors
+    // carry a `code` too, and must not be reported as a mesh code.
+    const pgLike = Object.assign(new Error("duplicate key"), { code: "23505" });
+    expect(toolErrorFromThrown(pgLike).content).toEqual({ error: "duplicate key" });
+  });
+});

--- a/packages/api/src/tools/errors.ts
+++ b/packages/api/src/tools/errors.ts
@@ -1,0 +1,61 @@
+/**
+ * The MCP tool error envelope, in one place.
+ *
+ * Every agent tool reports failure as an `AgentToolResult` with
+ * `isError: true` and a `content` object. Two shapes were being
+ * hand-rolled across the tool modules:
+ *
+ *   - `{ error: <code>, message: <human text> }` — a known, named
+ *     failure the calling agent can branch on. `watch.ts` had this as a
+ *     private `errResult`; most other modules wrote the literal inline.
+ *   - `{ error: <message> }` — the catch-all for an unexpected throw.
+ *     `mesh.ts` and `hierarchy.ts` each had a private `asError` for it.
+ *
+ * Note the catch-all puts the human message in `error`, where the coded
+ * shape puts a stable code there. That is the existing wire contract on
+ * both paths, preserved here rather than harmonized — agents already
+ * branch on `error` for the coded tools.
+ */
+
+import { CodedMeshError } from "../mesh/types.js";
+import type { AgentToolResult } from "./types.js";
+
+/**
+ * A named failure: `code` is the stable identifier the agent branches
+ * on, `message` is for the human reading the transcript. `extra` merges
+ * in structured context (ids, limits) alongside them.
+ */
+export function toolError(
+  code: string,
+  message: string,
+  extra: Record<string, unknown> = {},
+): AgentToolResult {
+  return { content: { error: code, message, ...extra }, isError: true };
+}
+
+/**
+ * Envelope for something thrown out of a tool handler.
+ *
+ * A {@link CodedMeshError} keeps its code and meta — that's the whole
+ * point of raising one. Anything else degrades to the catch-all shape,
+ * with `extra` carrying whatever context the call site can add (which
+ * agent, which request) to an otherwise opaque failure.
+ */
+export function toolErrorFromThrown(
+  err: unknown,
+  extra: Record<string, unknown> = {},
+): AgentToolResult {
+  if (err instanceof CodedMeshError) {
+    return {
+      content: { error: err.code, ...err.meta, message: err.message },
+      isError: true,
+    };
+  }
+  return {
+    content: {
+      error: err instanceof Error ? err.message : String(err),
+      ...extra,
+    },
+    isError: true,
+  };
+}

--- a/packages/api/src/tools/hierarchy.ts
+++ b/packages/api/src/tools/hierarchy.ts
@@ -52,7 +52,8 @@ import {
   buildIntent,
   type ResumeReason,
 } from "@beevibe/core/services/agent-session";
-import type { AgentTool, AgentToolResult } from "./types.js";
+import { toolErrorFromThrown } from "./errors.js";
+import type { AgentTool } from "./types.js";
 
 // ── Agent-callable status subsets ─────────────────────────────────────────
 //
@@ -157,15 +158,6 @@ function projectTask(task: Task | undefined): Record<string, unknown> | null {
   };
 }
 
-function asError(err: unknown): AgentToolResult {
-  return {
-    content: {
-      error: err instanceof Error ? err.message : String(err),
-    },
-    isError: true,
-  };
-}
-
 // ── Shared (IC + team) tools ─────────────────────────────────────────────
 
 function searchContextTool(
@@ -202,7 +194,7 @@ function searchContextTool(
         const archival = await services.memoryAgent.searchArchival(query);
         return { content: { archival } };
       } catch (err) {
-        return asError(err);
+        return toolErrorFromThrown(err);
       }
     },
   };
@@ -264,7 +256,7 @@ function updateProgressTool(
           },
         };
       } catch (err) {
-        return asError(err);
+        return toolErrorFromThrown(err);
       }
     },
   };
@@ -286,7 +278,7 @@ function findUpTool(
         const parent = await services.agentRepo.findParent(ctx.agentId);
         return { content: { parent: projectAgent(parent) } };
       } catch (err) {
-        return asError(err);
+        return toolErrorFromThrown(err);
       }
     },
   };
@@ -316,7 +308,7 @@ function getAgentProfileTool(
         const agent = await services.agentRepo.findById(id);
         return { content: { agent: projectAgent(agent) } };
       } catch (err) {
-        return asError(err);
+        return toolErrorFromThrown(err);
       }
     },
   };
@@ -346,7 +338,7 @@ function getTaskTool(
         const task = await services.taskRepo.findById(id);
         return { content: { task: projectTask(task) } };
       } catch (err) {
-        return asError(err);
+        return toolErrorFromThrown(err);
       }
     },
   };
@@ -428,7 +420,7 @@ function createWorkProductTool(
           },
         };
       } catch (err) {
-        return asError(err);
+        return toolErrorFromThrown(err);
       }
     },
   };
@@ -473,7 +465,7 @@ function listWorkProductsTool(
           },
         };
       } catch (err) {
-        return asError(err);
+        return toolErrorFromThrown(err);
       }
     },
   };
@@ -525,7 +517,7 @@ function getWorkProductTool(
           },
         };
       } catch (err) {
-        return asError(err);
+        return toolErrorFromThrown(err);
       }
     },
   };
@@ -583,7 +575,7 @@ function updateWorkProductTool(
           },
         };
       } catch (err) {
-        return asError(err);
+        return toolErrorFromThrown(err);
       }
     },
   };
@@ -606,7 +598,7 @@ function findSubordinatesTool(
         const subs = await services.agentRepo.findSubordinates(ctx.agentId);
         return { content: { agents: subs.map(projectAgent) } };
       } catch (err) {
-        return asError(err);
+        return toolErrorFromThrown(err);
       }
     },
   };
@@ -627,7 +619,7 @@ function findPeersTool(
         const peers = await services.agentRepo.findPeers(ctx.agentId);
         return { content: { agents: peers.map(projectAgent) } };
       } catch (err) {
-        return asError(err);
+        return toolErrorFromThrown(err);
       }
     },
   };
@@ -761,7 +753,7 @@ function createTaskTool(
           },
         };
       } catch (err) {
-        return asError(err);
+        return toolErrorFromThrown(err);
       }
     },
   };
@@ -824,7 +816,7 @@ function checkWorkStatusTool(
           },
         };
       } catch (err) {
-        return asError(err);
+        return toolErrorFromThrown(err);
       }
     },
   };
@@ -931,7 +923,7 @@ function reviseTaskTool(
         if (err instanceof InvalidTaskTransitionError) {
           return { content: { error: "invalid_transition", message: err.message }, isError: true };
         }
-        return asError(err);
+        return toolErrorFromThrown(err);
       }
     },
   };
@@ -1016,7 +1008,7 @@ function addToEscalationTool(
           },
         };
       } catch (err) {
-        return asError(err);
+        return toolErrorFromThrown(err);
       }
     },
   };
@@ -1307,7 +1299,7 @@ function createSubordinateAgentTool(
           },
         };
       } catch (err) {
-        return asError(err);
+        return toolErrorFromThrown(err);
       }
     },
   };

--- a/packages/api/src/tools/mesh.ts
+++ b/packages/api/src/tools/mesh.ts
@@ -15,16 +15,14 @@ import type {
   CreateEscalationInput,
 } from "@beevibe/core/services/escalation-service";
 import type { Pool } from "@beevibe/core/adapters/postgres";
-import type { AgentTool, AgentToolResult } from "./types.js";
+import { toolErrorFromThrown } from "./errors.js";
+import type { AgentTool } from "./types.js";
 import type { McpCaller } from "./assemble.js";
 import type { MeshServer } from "../mesh/server.js";
-import {
-  CannotNegotiateWithIcError,
-  MeshCapacityError,
-  MeshMaxRoundsError,
-  type AskResponse,
-  type EscalatedSentinel,
-  type NegotiateResponse,
+import type {
+  AskResponse,
+  EscalatedSentinel,
+  NegotiateResponse,
 } from "../mesh/types.js";
 
 const NEGOTIATE_DECISIONS = ["counter", "accept", "reject"] as const;
@@ -43,34 +41,6 @@ export interface MeshToolContext {
   caller: McpCaller;
   /** Caller's beevibe session id (for ask/negotiate originator metadata). */
   beevibeSid: string;
-}
-
-function asError(err: unknown, extra: Record<string, unknown> = {}): AgentToolResult {
-  if (err instanceof MeshCapacityError) {
-    return {
-      content: { error: err.code, ...err.meta, message: err.message },
-      isError: true,
-    };
-  }
-  if (err instanceof MeshMaxRoundsError) {
-    return {
-      content: { error: err.code, ...err.meta, message: err.message },
-      isError: true,
-    };
-  }
-  if (err instanceof CannotNegotiateWithIcError) {
-    return {
-      content: { error: err.code, ...err.meta, message: err.message },
-      isError: true,
-    };
-  }
-  return {
-    content: {
-      error: err instanceof Error ? err.message : String(err),
-      ...extra,
-    },
-    isError: true,
-  };
 }
 
 function projectAskResponse(r: AskResponse): Record<string, unknown> {
@@ -139,7 +109,7 @@ function askTool(ctx: MeshToolContext, services: MeshToolServices): AgentTool {
         );
         return { content: projectAskResponse(response) };
       } catch (err) {
-        return asError(err);
+        return toolErrorFromThrown(err);
       }
     },
   };
@@ -175,7 +145,7 @@ function respondAskTool(ctx: MeshToolContext, services: MeshToolServices): Agent
         });
         return { content: { responded: true, request_id: requestId } };
       } catch (err) {
-        return asError(err);
+        return toolErrorFromThrown(err);
       }
     },
   };
@@ -224,7 +194,7 @@ function negotiateTool(ctx: MeshToolContext, services: MeshToolServices): AgentT
         );
         return { content: projectNegotiateResponse(response) };
       } catch (err) {
-        return asError(err);
+        return toolErrorFromThrown(err);
       }
     },
   };
@@ -300,7 +270,7 @@ function respondNegotiateTool(ctx: MeshToolContext, services: MeshToolServices):
         }
         return { content: projectNegotiateResponse(result) };
       } catch (err) {
-        return asError(err);
+        return toolErrorFromThrown(err);
       }
     },
   };
@@ -365,7 +335,7 @@ function reportBlockerTool(ctx: MeshToolContext, services: MeshToolServices): Ag
           },
         };
       } catch (err) {
-        return asError(err);
+        return toolErrorFromThrown(err);
       }
     },
   };
@@ -459,7 +429,7 @@ function escalateToHumansTool(
           },
         };
       } catch (err) {
-        return asError(err);
+        return toolErrorFromThrown(err);
       }
     },
   };

--- a/packages/api/src/tools/watch.ts
+++ b/packages/api/src/tools/watch.ts
@@ -17,6 +17,7 @@ import {
   WatchValidationError,
   type WatchService,
 } from "@beevibe/core/services/watch-service";
+import { toolError } from "./errors.js";
 import type { AgentTool, AgentToolResult } from "./types.js";
 
 export interface WatchToolContext {
@@ -37,20 +38,16 @@ function isMode(value: unknown): value is TaskWatchMode {
   );
 }
 
-function errResult(error: string, message: string): AgentToolResult {
-  return { content: { error, message }, isError: true };
-}
-
 function caughtError(err: unknown): AgentToolResult {
-  if (err instanceof WatchAuthError) return errResult("watch_auth", err.message);
+  if (err instanceof WatchAuthError) return toolError("watch_auth", err.message);
   if (err instanceof WatchValidationError) {
-    return errResult("watch_validation", err.message);
+    return toolError("watch_validation", err.message);
   }
   if (err instanceof WatchNotFoundError) {
-    return errResult("watch_not_found", err.message);
+    return toolError("watch_not_found", err.message);
   }
-  if (err instanceof Error) return errResult("watch_error", err.message);
-  return errResult("watch_error", String(err));
+  if (err instanceof Error) return toolError("watch_error", err.message);
+  return toolError("watch_error", String(err));
 }
 
 function buildWatchTasksTool(
@@ -104,7 +101,7 @@ function buildWatchTasksTool(
           ? input.task_ids.filter((x): x is string => typeof x === "string")
           : [];
         if (taskIds.length === 0) {
-          return errResult(
+          return toolError(
             "watch_validation",
             "task_ids must be a non-empty array of strings",
           );
@@ -115,7 +112,7 @@ function buildWatchTasksTool(
             ? input.reason.trim()
             : undefined;
         if (!ctx.sessionId) {
-          return errResult(
+          return toolError(
             "watch_validation",
             "watch_tasks must be called inside a session context",
           );
@@ -167,7 +164,7 @@ function buildUnwatchTool(
         const watchId =
           typeof input.watch_id === "string" ? input.watch_id : "";
         if (!watchId) {
-          return errResult(
+          return toolError(
             "watch_validation",
             "watch_id must be a non-empty string",
           );

--- a/packages/api/src/views/agent-display.test.ts
+++ b/packages/api/src/views/agent-display.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { toAgentDisplay, type AgentDisplayRow } from "./agent-display.js";
+
+const NOW = new Date("2026-01-01T00:00:00Z");
+
+function row(overrides: Partial<AgentDisplayRow> = {}): AgentDisplayRow {
+  return {
+    id: "agent_1",
+    name: "Atlas",
+    owner_id: "person_1",
+    parent_agent_id: null,
+    hierarchy_level: "ic",
+    review_policy: null,
+    runtime_config: { type: "claude", model: "opus" },
+    preferred_runtime_id: null,
+    created_at: NOW,
+    updated_at: NOW,
+    sessions_count: 3,
+    facts_learned: 7,
+    tag_line: null,
+    ...overrides,
+  };
+}
+
+describe("toAgentDisplay", () => {
+  it("splits runtime (CLI tool) from model (LLM alias)", () => {
+    const d = toAgentDisplay(row());
+    expect(d.runtime).toBe("claude");
+    expect(d.model).toBe("opus");
+  });
+
+  it("defaults runtime to claude for agents predating the runtime/model split", () => {
+    expect(toAgentDisplay(row({ runtime_config: {} })).runtime).toBe("claude");
+    expect(toAgentDisplay(row({ runtime_config: null })).runtime).toBe("claude");
+  });
+
+  it("leaves model undefined when the agent uses the CLI's own default", () => {
+    expect(toAgentDisplay(row({ runtime_config: { type: "codex" } })).model).toBeUndefined();
+  });
+
+  it("coerces counts whether the driver returns int or text", () => {
+    // The network view's SQL casts to ::int; the list view's COUNT(*)
+    // comes back as a string. Both must land as numbers.
+    expect(toAgentDisplay(row({ sessions_count: "12", facts_learned: "4" }))).toMatchObject({
+      sessions_count: 12,
+      facts_learned: 4,
+    });
+    expect(toAgentDisplay(row({ sessions_count: 12, facts_learned: 4 }))).toMatchObject({
+      sessions_count: 12,
+      facts_learned: 4,
+    });
+  });
+
+  it("derives specialization from the first non-empty tag_line line", () => {
+    expect(toAgentDisplay(row({ tag_line: "\n\n  Ships infra  \nmore prose" })).specialization).toBe(
+      "Ships infra",
+    );
+    expect(toAgentDisplay(row({ tag_line: "   \n  " })).specialization).toBeUndefined();
+    expect(toAgentDisplay(row({ tag_line: null })).specialization).toBeUndefined();
+  });
+
+  it("normalizes nullable columns to undefined so they drop out of JSON", () => {
+    const d = toAgentDisplay(row());
+    expect(d.parent_agent_id).toBeUndefined();
+    expect(d.review_policy).toBeUndefined();
+    expect(d.preferred_runtime_id).toBeUndefined();
+  });
+
+  it("mirrors name into display_name and hierarchy_level into hierarchy", () => {
+    const d = toAgentDisplay(row({ name: "Atlas", hierarchy_level: "team" }));
+    expect(d.display_name).toBe("Atlas");
+    expect(d.hierarchy).toBe("team");
+  });
+
+  it("emits neither owner_label nor archived_at — those are per-view additions", () => {
+    const d = toAgentDisplay(row());
+    expect(d.owner_label).toBeUndefined();
+    expect(d.archived_at).toBeUndefined();
+  });
+});

--- a/packages/api/src/views/agent-display.ts
+++ b/packages/api/src/views/agent-display.ts
@@ -1,0 +1,78 @@
+/**
+ * The `agent` row → `AgentDisplay` mapping, in one place.
+ *
+ * Three views project the same agent columns into the same display
+ * shape: the list (`agents.ts:listAgents`), the detail header
+ * (`agents.ts:getAgent`) and the network graph
+ * (`agent-network.ts:getAgentNetwork`, for both self and peer orbits).
+ * Each used to carry its own copy of the field-by-field mapping, which
+ * meant the derivation rules below had to be re-explained — and
+ * re-fixed — in each one.
+ *
+ * Callers with extra columns (`owner_label`, `archived_at`) spread the
+ * result and add them, so a view only opts into the fields its SQL
+ * actually selects.
+ */
+
+import type { HierarchyLevel } from "@beevibe/core";
+import { firstNonEmptyLine } from "./format.js";
+import type { AgentDisplay } from "./types.js";
+
+/**
+ * The columns every agent view selects. Widened where the callers
+ * disagree: counts come back as `int` (number) from the network's
+ * `COALESCE(...)::int` and as a string from `COUNT(*)` elsewhere, and
+ * `runtime_config` is read as loose JSON because it arrives straight
+ * from a jsonb column.
+ */
+export interface AgentDisplayRow {
+  id: string;
+  name: string;
+  owner_id: string;
+  parent_agent_id: string | null;
+  hierarchy_level: HierarchyLevel;
+  review_policy: string | null;
+  runtime_config: Record<string, unknown> | null;
+  preferred_runtime_id: string | null;
+  created_at: Date;
+  updated_at: Date;
+  sessions_count: string | number;
+  facts_learned: string | number;
+  tag_line: string | null;
+}
+
+export function toAgentDisplay(row: AgentDisplayRow): AgentDisplay {
+  // PR #96 split runtime (the CLI tool) from model (the LLM alias
+  // passed to it), so the UI shows "claude" under the Runtime label
+  // rather than "claude-opus-4-7". Agents predating the split have no
+  // `type`, hence the default.
+  const cfg = row.runtime_config ?? {};
+  const runtime = (cfg.type as string | undefined) ?? "claude";
+  const model = cfg.model as string | undefined;
+
+  // `specialization` is the first non-empty line of the `tag_line` core
+  // memory block (≤100 chars by template). Deliberately no fallback to
+  // `domain`: that block holds the agent's enduring expertise prose,
+  // not a UI headline, and mixing the two left agents with a set
+  // tag_line still showing their domain text on the card.
+  const specialization = firstNonEmptyLine(row.tag_line);
+
+  return {
+    id: row.id,
+    name: row.name,
+    owner_id: row.owner_id,
+    parent_agent_id: row.parent_agent_id ?? undefined,
+    hierarchy_level: row.hierarchy_level,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    display_name: row.name,
+    hierarchy: row.hierarchy_level,
+    sessions_count: Number(row.sessions_count),
+    facts_learned: Number(row.facts_learned),
+    runtime,
+    model,
+    specialization,
+    review_policy: row.review_policy ?? undefined,
+    preferred_runtime_id: row.preferred_runtime_id ?? undefined,
+  };
+}

--- a/packages/api/src/views/agent-network.ts
+++ b/packages/api/src/views/agent-network.ts
@@ -18,9 +18,8 @@
  */
 
 import type { Pool } from "@beevibe/core/adapters/postgres";
-import type { RuntimeConfig } from "@beevibe/core";
-import { firstNonEmptyLine } from "./format.js";
-import type { AgentDisplay, AgentNetwork, AgentPeerOwner } from "./types.js";
+import { toAgentDisplay, type AgentDisplayRow } from "./agent-display.js";
+import type { AgentNetwork, AgentPeerOwner } from "./types.js";
 
 // Defensive cap on the peer fetch. The agent graph is one orbit per
 // owner (~5 agents each); 500 rows covers roughly 100 owners' trees.
@@ -79,51 +78,14 @@ ORDER BY a.owner_id,
 LIMIT ${PEERS_LIMIT}
 `;
 
-interface AgentRow {
-  id: string;
-  name: string;
-  owner_id: string;
-  parent_agent_id: string | null;
-  hierarchy_level: "ic" | "team" | "org";
-  review_policy: string | null;
-  runtime_config: RuntimeConfig;
-  preferred_runtime_id: string | null;
-  created_at: Date;
-  updated_at: Date;
-  sessions_count: string | number;
-  facts_learned: string | number;
-  tag_line: string | null;
-}
+// Same columns as the agent list/detail views, so the row shape and the
+// mapping both come from agent-display.ts. `owner_label` rides on the
+// peer rows for the orbit grouping below, not on the AgentDisplay
+// itself — the UI reads it off the owner, not off each agent.
+type AgentRow = AgentDisplayRow;
 
 interface PeerRow extends AgentRow {
   owner_label: string;
-}
-
-function rowToAgentDisplay(row: AgentRow): AgentDisplay {
-  // PR #96 split runtime (CLI tool) from model (LLM alias). Match `agents.ts`
-  // so the network UI shows "claude" not "claude-opus-4-7" under the Runtime
-  // label.
-  const runtime = row.runtime_config.type ?? "claude";
-  const model = row.runtime_config.model;
-  const specialization = firstNonEmptyLine(row.tag_line);
-  return {
-    id: row.id,
-    name: row.name,
-    owner_id: row.owner_id,
-    parent_agent_id: row.parent_agent_id ?? undefined,
-    hierarchy_level: row.hierarchy_level,
-    created_at: row.created_at,
-    updated_at: row.updated_at,
-    display_name: row.name,
-    hierarchy: row.hierarchy_level,
-    sessions_count: Number(row.sessions_count),
-    facts_learned: Number(row.facts_learned),
-    runtime,
-    model,
-    specialization,
-    review_policy: (row.review_policy ?? undefined) as AgentDisplay["review_policy"],
-    preferred_runtime_id: row.preferred_runtime_id ?? undefined,
-  };
 }
 
 export async function getAgentNetwork(
@@ -137,7 +99,7 @@ export async function getAgentNetwork(
     pool.query<PeerRow>(PEERS_SQL, [personId]),
   ]);
 
-  const self = selfRes.rows.map(rowToAgentDisplay);
+  const self = selfRes.rows.map(toAgentDisplay);
 
   // Group peer rows by owner so the UI can render one orbit per peer.
   // Order preserved from the SQL (owner_id ASC, then hierarchy weight).
@@ -145,12 +107,12 @@ export async function getAgentNetwork(
   for (const row of peersRes.rows) {
     const existing = peersByOwner.get(row.owner_id);
     if (existing) {
-      existing.agents.push(rowToAgentDisplay(row));
+      existing.agents.push(toAgentDisplay(row));
     } else {
       peersByOwner.set(row.owner_id, {
         owner_id: row.owner_id,
         owner_label: row.owner_label,
-        agents: [rowToAgentDisplay(row)],
+        agents: [toAgentDisplay(row)],
       });
     }
   }

--- a/packages/api/src/views/agents.ts
+++ b/packages/api/src/views/agents.ts
@@ -7,7 +7,8 @@
 
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import type { HierarchyLevel, SessionStatus } from "@beevibe/core";
-import { deriveShortId, firstNonEmptyLine, formatRelativeShort } from "./format.js";
+import { toAgentDisplay } from "./agent-display.js";
+import { deriveShortId, formatRelativeShort } from "./format.js";
 import type {
   AgentDisplay,
   AgentDetail,
@@ -65,34 +66,11 @@ ORDER BY
   a.name ASC
 `;
 
+/** Shared mapping plus the two columns only this view selects. */
 function rowToAgentDisplay(row: AgentRow): AgentDisplay {
-  // `runtime` is the CLI tool name; `model` is the LLM alias passed to it.
-  // PR #96 split them. `specialization` is the first non-empty line of the
-  // `tag_line` core memory block (≤100 chars by template). No fallback to
-  // `domain` — that block is for the agent's enduring expertise prose, not
-  // a UI headline; mixing the two confused agents with set tag_lines whose
-  // cards still showed the domain text.
-  const runtime = (row.runtime_config?.type as string | undefined) ?? "claude";
-  const model = row.runtime_config?.model as string | undefined;
-  const specialization = firstNonEmptyLine(row.tag_line);
   return {
-    id: row.id,
-    name: row.name,
-    owner_id: row.owner_id,
+    ...toAgentDisplay(row),
     owner_label: row.owner_label ?? undefined,
-    parent_agent_id: row.parent_agent_id ?? undefined,
-    hierarchy_level: row.hierarchy_level,
-    created_at: row.created_at,
-    updated_at: row.updated_at,
-    display_name: row.name,
-    hierarchy: row.hierarchy_level,
-    sessions_count: Number(row.sessions_count),
-    facts_learned: Number(row.facts_learned),
-    runtime,
-    model,
-    specialization,
-    review_policy: row.review_policy ?? undefined,
-    preferred_runtime_id: row.preferred_runtime_id ?? undefined,
     archived_at: row.archived_at ? row.archived_at.toISOString() : undefined,
   };
 }

--- a/packages/api/src/views/format.ts
+++ b/packages/api/src/views/format.ts
@@ -1,35 +1,28 @@
 /**
- * Server-side formatters used by the views layer to produce display-ready
- * fields (`short_id`, `duration_label`, `elapsed`). Mirrors the logic in
- * `packages/web/lib/format.ts`. Defined here so the API can compute these
- * once and the web's format helpers stay in sync (drift will surface as a
- * mismatched `short_id` in the URL).
+ * Server-side formatters used by the views layer to produce
+ * display-ready fields (`short_id`, `duration_label`, `elapsed`).
+ *
+ * The shared ones now live in `@beevibe/core`'s domain layer, where the
+ * web app reads the same implementation — these used to be a parallel
+ * copy of `packages/web/lib/format.ts`, kept in sync by comment. The
+ * re-exports below keep this package's existing import sites working
+ * and keep the api's own naming (`formatRelativeShort` for the
+ * suffix-less form the wire uses).
  */
 
-/**
- * Strip the type prefix (`xxx_`) and take the first 6 chars. Matches
- * `packages/web/lib/format.ts:shortId`. Note: web prepends "#" for display
- * but the URL key is the raw 6-char string — that's what we return here.
- */
-export function deriveShortId(id: string): string {
-  const trimmed = id.replace(/^[a-z]+_/, "");
-  return trimmed.slice(0, 6);
-}
+import { formatRelative, type DateLike } from "@beevibe/core/domain/format";
+
+export {
+  deriveShortId,
+  firstNonEmptyLine,
+  formatDurationLabel,
+  toDate,
+  type DateLike,
+} from "@beevibe/core/domain/format";
 
 /** Relative-time label like "just now" / "2m" / "1h" / "3d". */
-export function formatRelativeShort(date: Date, now: Date = new Date()): string {
-  const diffMs = now.getTime() - date.getTime();
-  const diffSec = Math.floor(diffMs / 1000);
-  if (diffSec < 60) return "just now";
-  const diffMin = Math.floor(diffSec / 60);
-  if (diffMin < 60) return `${diffMin}m`;
-  const diffHr = Math.floor(diffMin / 60);
-  if (diffHr < 24) return `${diffHr}h`;
-  const diffDay = Math.floor(diffHr / 24);
-  if (diffDay < 30) return `${diffDay}d`;
-  const diffMonth = Math.floor(diffDay / 30);
-  if (diffMonth < 12) return `${diffMonth}mo`;
-  return `${Math.floor(diffMonth / 12)}y`;
+export function formatRelativeShort(date: DateLike, now: Date = new Date()): string {
+  return formatRelative(date, { now });
 }
 
 /**
@@ -47,42 +40,4 @@ export function computeCacheHitRatio(parts: {
 }): number {
   const total = parts.input + parts.cacheCreation + parts.cacheRead;
   return total > 0 ? parts.cacheRead / total : 0;
-}
-
-/**
- * Duration label between started_at and completed_at (or now if running).
- * Returns "—" if no start. Format: "2m", "1h 4m", "3d 2h", etc.
- */
-export function formatDurationLabel(
-  startedAt: Date | null | undefined,
-  completedAt: Date | null | undefined,
-  now: Date = new Date(),
-): string {
-  if (!startedAt) return "—";
-  const end = completedAt ?? now;
-  const diffSec = Math.max(0, Math.floor((end.getTime() - startedAt.getTime()) / 1000));
-  if (diffSec < 60) return `${diffSec}s`;
-  const min = Math.floor(diffSec / 60);
-  if (min < 60) return `${min}m`;
-  const hr = Math.floor(min / 60);
-  const mins = min % 60;
-  if (hr < 24) return mins ? `${hr}h ${mins}m` : `${hr}h`;
-  const days = Math.floor(hr / 24);
-  const hrs = hr % 24;
-  return hrs ? `${days}d ${hrs}h` : `${days}d`;
-}
-
-/**
- * First non-empty line of a multi-line block content. Used to derive a
- * one-liner UI headline (e.g. `specialization` from a core-memory
- * tag_line block) from text that might be empty / whitespace-only /
- * multi-line. Returns undefined when there is nothing renderable.
- */
-export function firstNonEmptyLine(content: string | null | undefined): string | undefined {
-  if (!content) return undefined;
-  for (const line of content.split("\n")) {
-    const trimmed = line.trim();
-    if (trimmed) return trimmed;
-  }
-  return undefined;
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,10 @@
       "types": "./dist/domain/index.d.ts",
       "default": "./dist/domain/index.js"
     },
+    "./domain/format": {
+      "types": "./dist/domain/format.d.ts",
+      "default": "./dist/domain/format.js"
+    },
     "./adapters/postgres": {
       "types": "./dist/adapters/postgres/index.d.ts",
       "default": "./dist/adapters/postgres/index.js"

--- a/packages/core/src/domain/format.test.ts
+++ b/packages/core/src/domain/format.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveShortId,
+  firstNonEmptyLine,
+  formatDurationLabel,
+  formatRelative,
+  toDate,
+} from "./format.js";
+
+const NOW = new Date("2026-01-10T12:00:00Z");
+const ago = (ms: number) => new Date(NOW.getTime() - ms);
+
+const SEC = 1000;
+const MIN = 60 * SEC;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+
+describe("toDate", () => {
+  it("passes a Date through and parses the JSON string form", () => {
+    expect(toDate(NOW)).toEqual(NOW);
+    expect(toDate(NOW.toISOString())).toEqual(NOW);
+    expect(toDate(NOW.getTime())).toEqual(NOW);
+  });
+
+  it("returns undefined for missing or unparseable input", () => {
+    expect(toDate(null)).toBeUndefined();
+    expect(toDate(undefined)).toBeUndefined();
+    // Would otherwise render as the literal text "Invalid Date".
+    expect(toDate("not a date")).toBeUndefined();
+  });
+});
+
+describe("deriveShortId", () => {
+  it("strips the typed-id prefix and takes 6 chars", () => {
+    expect(deriveShortId("agent_kBpTkqiCbsB3")).toBe("kBpTkq");
+    expect(deriveShortId("sess_abcdef123456")).toBe("abcdef");
+  });
+
+  it("leaves an unprefixed id alone", () => {
+    expect(deriveShortId("abcdefgh")).toBe("abcdef");
+  });
+
+  it("returns short ids whole rather than padding", () => {
+    expect(deriveShortId("sess_abc")).toBe("abc");
+  });
+});
+
+describe("formatRelative", () => {
+  it("walks every threshold in the ladder", () => {
+    const at = (ms: number) => formatRelative(ago(ms), { now: NOW });
+    expect(at(5 * SEC)).toBe("just now");
+    expect(at(59 * SEC)).toBe("just now");
+    expect(at(MIN)).toBe("1m");
+    expect(at(59 * MIN)).toBe("59m");
+    expect(at(HOUR)).toBe("1h");
+    expect(at(23 * HOUR)).toBe("23h");
+    expect(at(DAY)).toBe("1d");
+    expect(at(29 * DAY)).toBe("29d");
+    expect(at(30 * DAY)).toBe("1mo");
+    // Months are 30-day buckets, so the year rolls at 360 days, not 365.
+    expect(at(359 * DAY)).toBe("11mo");
+    expect(at(360 * DAY)).toBe("1y");
+  });
+
+  it("appends the suffix to every bucket except 'just now'", () => {
+    const at = (ms: number) => formatRelative(ago(ms), { now: NOW, suffix: " ago" });
+    expect(at(5 * SEC)).toBe("just now");
+    expect(at(2 * MIN)).toBe("2m ago");
+    expect(at(3 * HOUR)).toBe("3h ago");
+    expect(at(4 * DAY)).toBe("4d ago");
+    expect(at(60 * DAY)).toBe("2mo ago");
+    expect(at(800 * DAY)).toBe("2y ago");
+  });
+
+  it("renders a placeholder for an unparseable date", () => {
+    expect(formatRelative("nonsense", { now: NOW })).toBe("—");
+  });
+});
+
+describe("formatDurationLabel", () => {
+  it("formats each unit band", () => {
+    const from = (ms: number) => formatDurationLabel(ago(ms), NOW, NOW);
+    expect(from(30 * SEC)).toBe("30s");
+    expect(from(5 * MIN)).toBe("5m");
+    expect(from(HOUR)).toBe("1h");
+    expect(from(HOUR + 12 * MIN)).toBe("1h 12m");
+    expect(from(2 * DAY + 3 * HOUR)).toBe("2d 3h");
+    expect(from(2 * DAY)).toBe("2d");
+  });
+
+  it("measures against now while still running", () => {
+    expect(formatDurationLabel(ago(5 * MIN), null, NOW)).toBe("5m");
+  });
+
+  it("returns a placeholder without a start", () => {
+    expect(formatDurationLabel(null, NOW, NOW)).toBe("—");
+  });
+
+  it("clamps a completion that precedes the start to zero", () => {
+    expect(formatDurationLabel(NOW, ago(MIN), NOW)).toBe("0s");
+  });
+});
+
+describe("firstNonEmptyLine", () => {
+  it("skips leading blank and whitespace-only lines", () => {
+    expect(firstNonEmptyLine("\n \n  Ships infra  \nmore")).toBe("Ships infra");
+  });
+
+  it("returns undefined when there is nothing renderable", () => {
+    expect(firstNonEmptyLine("   \n\t\n ")).toBeUndefined();
+    expect(firstNonEmptyLine("")).toBeUndefined();
+    expect(firstNonEmptyLine(null)).toBeUndefined();
+  });
+});

--- a/packages/core/src/domain/format.ts
+++ b/packages/core/src/domain/format.ts
@@ -1,0 +1,122 @@
+/**
+ * Display formatters shared by the api's view layer and the web app.
+ *
+ * These four were maintained as parallel copies in
+ * `packages/api/src/views/format.ts` and `packages/web/lib/format.ts`,
+ * with a comment on each side pointing at the other and asking that
+ * they be kept in sync. That is a drift risk with teeth: `deriveShortId`
+ * decides both the `short_id` the api serializes and the 6-char
+ * fragment the web puts in a URL, so a change on one side alone
+ * produces links that 404.
+ *
+ * Everything here is pure and dependency-free — safe to pull into the
+ * browser bundle, which is why it lives in `domain/` rather than in a
+ * service.
+ *
+ * IMPORT THIS VIA `@beevibe/core/domain/format`, NOT the package root.
+ * The root barrel re-exports `./auth`, which reaches for `node:crypto`
+ * and `node:util`; a *value* import of the root from a client component
+ * drags those into webpack and fails `next build` with
+ * `UnhandledSchemeError: Reading from "node:crypto" is not handled by
+ * plugins`. Type-only root imports are fine — they erase — which is why
+ * the rest of the web app gets away with `import type { … } from
+ * "@beevibe/core"`. This module is the first runtime value the web
+ * pulls out of core, hence the dedicated export subpath.
+ */
+
+export type DateLike = Date | string | number;
+
+/**
+ * Coerce `Date | string | number` into a Date.
+ *
+ * JSON-bound api responses arrive as strings even when their TypeScript
+ * types claim `Date`, so callers pass values straight through without
+ * wrapping. Returns undefined for missing input (so callers can
+ * short-circuit) and for unparseable input (so a bad value renders as a
+ * placeholder rather than the literal text "Invalid Date").
+ */
+export function toDate(value: DateLike | null | undefined): Date | undefined {
+  if (value == null) return undefined;
+  const d = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(d.getTime()) ? undefined : d;
+}
+
+/**
+ * Strip the type prefix (`sess_`, `agent_`, …) and take the first 6
+ * chars. This is the id form that appears in routes and lookups on both
+ * sides, which is why it must be one function.
+ */
+export function deriveShortId(id: string): string {
+  return id.replace(/^[a-z]+_/, "").slice(0, 6);
+}
+
+/**
+ * Relative-time label: "just now", "2m", "1h", "3d", "5mo", "1y".
+ *
+ * The api serializes the bare form into `age` / `elapsed` fields; the
+ * web renders "2m ago" in prose. Same six thresholds either way, so
+ * `suffix` is the only thing that varies — previously the whole ladder
+ * was written out twice.
+ */
+export function formatRelative(
+  date: DateLike,
+  opts: { now?: Date; suffix?: string } = {},
+): string {
+  const { now = new Date(), suffix = "" } = opts;
+  const d = toDate(date);
+  if (!d) return "—";
+
+  const diffSec = Math.floor((now.getTime() - d.getTime()) / 1000);
+  if (diffSec < 60) return "just now";
+
+  const tail = (n: number, unit: string) => `${n}${unit}${suffix}`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return tail(diffMin, "m");
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return tail(diffHr, "h");
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 30) return tail(diffDay, "d");
+  const diffMonth = Math.floor(diffDay / 30);
+  if (diffMonth < 12) return tail(diffMonth, "mo");
+  return tail(Math.floor(diffMonth / 12), "y");
+}
+
+/**
+ * Duration between `startedAt` and `completedAt` (or `now` while still
+ * running): "30s", "5m", "1h 12m", "2d 3h". Returns "—" with no start.
+ */
+export function formatDurationLabel(
+  startedAt: DateLike | null | undefined,
+  completedAt: DateLike | null | undefined,
+  now: Date = new Date(),
+): string {
+  const start = toDate(startedAt);
+  if (!start) return "—";
+  const end = toDate(completedAt) ?? now;
+
+  const diffSec = Math.max(0, Math.floor((end.getTime() - start.getTime()) / 1000));
+  if (diffSec < 60) return `${diffSec}s`;
+  const min = Math.floor(diffSec / 60);
+  if (min < 60) return `${min}m`;
+  const hr = Math.floor(min / 60);
+  const mins = min % 60;
+  if (hr < 24) return mins ? `${hr}h ${mins}m` : `${hr}h`;
+  const days = Math.floor(hr / 24);
+  const hrs = hr % 24;
+  return hrs ? `${days}d ${hrs}h` : `${days}d`;
+}
+
+/**
+ * First non-empty line of a multi-line block, for deriving a one-line
+ * UI headline (an agent's `specialization` from its `tag_line` block)
+ * out of text that may be empty, whitespace-only, or multi-line.
+ * Undefined when there is nothing renderable.
+ */
+export function firstNonEmptyLine(content: string | null | undefined): string | undefined {
+  if (!content) return undefined;
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed) return trimmed;
+  }
+  return undefined;
+}

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -15,3 +15,4 @@ export * from "./repo-run.js";
 export * from "./task-watch.js";
 export * from "./session-search.js";
 export * from "./xml.js";
+export * from "./format.js";

--- a/packages/daemon/src/event-batcher.test.ts
+++ b/packages/daemon/src/event-batcher.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiClient } from "./api-client.js";
+import { createEventBatcher, type BatchedEvent } from "./event-batcher.js";
+
+function makeApi(post = vi.fn(async () => ({ status: 204, body: undefined }))) {
+  return { api: { post } as unknown as ApiClient, post };
+}
+
+/** The `events` array of the nth POST body. */
+function postedEvents(post: ReturnType<typeof vi.fn>, call = 0): BatchedEvent[] {
+  return (post.mock.calls[call]?.[1] as { events: BatchedEvent[] }).events;
+}
+
+describe("createEventBatcher", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("stamps session_id onto every event", async () => {
+    const { api, post } = makeApi();
+    const b = createEventBatcher({ api, sessionId: "sess_1", tag: "[t]" });
+
+    b.push({ kind: "agent", content: "hello" });
+    b.push({ kind: "tool_call", content: "Read(x)", tool_name: "Read" });
+    await b.close();
+
+    expect(post).toHaveBeenCalledOnce();
+    expect(post).toHaveBeenCalledWith("/runtime/events", expect.anything());
+    expect(postedEvents(post)).toEqual([
+      { session_id: "sess_1", kind: "agent", content: "hello" },
+      {
+        session_id: "sess_1",
+        kind: "tool_call",
+        content: "Read(x)",
+        tool_name: "Read",
+      },
+    ]);
+  });
+
+  it("holds events until the interval elapses, then posts them as one batch", async () => {
+    const { api, post } = makeApi();
+    const b = createEventBatcher({ api, sessionId: "sess_1", tag: "[t]" });
+
+    b.push({ kind: "agent", content: "a" });
+    b.push({ kind: "agent", content: "b" });
+    expect(post).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(250);
+    expect(post).toHaveBeenCalledOnce();
+    expect(postedEvents(post)).toHaveLength(2);
+  });
+
+  it("flushes immediately at the 16-event threshold without waiting", async () => {
+    const { api, post } = makeApi();
+    const b = createEventBatcher({ api, sessionId: "sess_1", tag: "[t]" });
+
+    for (let i = 0; i < 16; i++) b.push({ kind: "agent", content: `e${i}` });
+
+    // No timer advance — the threshold alone triggers the POST.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(post).toHaveBeenCalledOnce();
+    expect(postedEvents(post)).toHaveLength(16);
+  });
+
+  it("does not re-send events that were already flushed", async () => {
+    const { api, post } = makeApi();
+    const b = createEventBatcher({ api, sessionId: "sess_1", tag: "[t]" });
+
+    b.push({ kind: "agent", content: "first" });
+    await b.flush();
+    b.push({ kind: "agent", content: "second" });
+    await b.close();
+
+    expect(post).toHaveBeenCalledTimes(2);
+    expect(postedEvents(post, 0).map((e) => e.content)).toEqual(["first"]);
+    expect(postedEvents(post, 1).map((e) => e.content)).toEqual(["second"]);
+  });
+
+  it("skips the POST entirely when there is nothing buffered", async () => {
+    const { api, post } = makeApi();
+    const b = createEventBatcher({ api, sessionId: "sess_1", tag: "[t]" });
+
+    await b.close();
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("cancels the pending timer on flush so no empty POST follows", async () => {
+    const { api, post } = makeApi();
+    const b = createEventBatcher({ api, sessionId: "sess_1", tag: "[t]" });
+
+    b.push({ kind: "agent", content: "a" });
+    await b.flush();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(post).toHaveBeenCalledOnce();
+  });
+
+  it("swallows a failed POST — the run continues and events are dropped", async () => {
+    const post = vi.fn(async () => {
+      throw new Error("connection refused");
+    });
+    const b = createEventBatcher({
+      api: { post } as unknown as ApiClient,
+      sessionId: "sess_1",
+      tag: "[t]",
+    });
+
+    b.push({ kind: "agent", content: "a" });
+    await expect(b.close()).resolves.toBeUndefined();
+
+    // Dropped, not retried: the next flush carries only newer events.
+    b.push({ kind: "agent", content: "b" });
+    await b.close();
+    expect(post).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/daemon/src/event-batcher.ts
+++ b/packages/daemon/src/event-batcher.ts
@@ -1,0 +1,98 @@
+/**
+ * Batching writer for `/runtime/events`.
+ *
+ * Both dispatch paths — the CLI runtime in `spawner.ts` and the Docker
+ * sandbox in `repo-runs.ts` — stream fine-grained steps that would
+ * otherwise cost one POST per token. Each used to carry its own copy of
+ * the same buffer/timer/threshold trio; this is that logic in one place,
+ * so a change to the flush policy lands on both paths at once.
+ *
+ * Policy: flush when the buffer reaches BATCH_MAX, otherwise on a
+ * BATCH_INTERVAL_MS timer started by the first unflushed event. Callers
+ * must `close()` before POSTing `/runtime/done` so the persisted
+ * transcript is complete by the time the api-side resolver fires.
+ *
+ * A failed POST is warned about and the events are dropped: the
+ * transcript is a display surface, and blocking or retrying the run on
+ * it would be worse than a gap in it.
+ */
+
+import type { SessionEventKind } from "@beevibe/core";
+import type { ApiClient } from "./api-client.js";
+import { warn } from "./logger.js";
+
+/** Flush once this many events are buffered, without waiting for the timer. */
+const BATCH_MAX = 16;
+
+/** Time from the first unflushed event to an automatic flush. */
+const BATCH_INTERVAL_MS = 250;
+
+/** One row as the `/runtime/events` endpoint expects it. */
+export interface BatchedEvent {
+  session_id: string;
+  kind: SessionEventKind;
+  content: string;
+  tool_name?: string;
+}
+
+/** What a caller supplies — `session_id` is filled in by the batcher. */
+export type BatchedEventInput = Omit<BatchedEvent, "session_id">;
+
+export interface EventBatcher {
+  /** Queue an event, flushing immediately if the buffer is now full. */
+  push(event: BatchedEventInput): void;
+  /** Send everything buffered now, cancelling any pending timed flush. */
+  flush(): Promise<void>;
+  /** Final flush; no further timer fires afterwards. */
+  close(): Promise<void>;
+}
+
+export function createEventBatcher(opts: {
+  api: ApiClient;
+  sessionId: string;
+  /** Log prefix for the drop warning, e.g. `[daemon/spawner]`. */
+  tag: string;
+}): EventBatcher {
+  const buffer: BatchedEvent[] = [];
+  let flushTimer: NodeJS.Timeout | undefined;
+
+  const clearTimer = (): void => {
+    if (!flushTimer) return;
+    clearTimeout(flushTimer);
+    flushTimer = undefined;
+  };
+
+  const flush = async (): Promise<void> => {
+    clearTimer();
+    if (buffer.length === 0) return;
+    const events = buffer.splice(0);
+    try {
+      await opts.api.post("/runtime/events", { events });
+    } catch (err) {
+      warn(
+        `${opts.tag} /runtime/events POST failed; events dropped:`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  };
+
+  const scheduleFlush = (): void => {
+    if (flushTimer) return;
+    flushTimer = setTimeout(() => {
+      flushTimer = undefined;
+      void flush();
+    }, BATCH_INTERVAL_MS);
+  };
+
+  return {
+    push(event) {
+      buffer.push({ session_id: opts.sessionId, ...event });
+      if (buffer.length >= BATCH_MAX) void flush();
+      else scheduleFlush();
+    },
+    flush,
+    async close() {
+      await flush();
+    },
+  };
+}

--- a/packages/daemon/src/repo-runs.ts
+++ b/packages/daemon/src/repo-runs.ts
@@ -16,7 +16,8 @@
 import type { SessionEventKind, TerminalSessionStatus } from "@beevibe/core";
 import { runRepoAgent, type TranscriptEvent } from "@beevibe/sandbox/orchestrator";
 import type { ApiClient } from "./api-client.js";
-import { error, log, warn } from "./logger.js";
+import { createEventBatcher } from "./event-batcher.js";
+import { error, log } from "./logger.js";
 import type { DispatchPayload, RunRepoArtifact } from "./spawner.js";
 
 export interface RunRepoDeps {
@@ -46,36 +47,13 @@ export async function runRepoDispatch(
     `[daemon/repo-run] sess=${payload.session_id} repo_run=${rr.repo_run_id} repo=${rr.repo_url}`,
   );
 
-  // Same batching shape as spawner.ts so the live transcript renders
-  // smoothly without one POST per event.
-  const buffer: Array<{
-    session_id: string;
-    kind: SessionEventKind;
-    content: string;
-    tool_name?: string;
-  }> = [];
-  let flushTimer: NodeJS.Timeout | undefined;
-
-  const flush = async (): Promise<void> => {
-    if (buffer.length === 0) return;
-    const events = buffer.splice(0);
-    try {
-      await deps.api.post("/runtime/events", { events });
-    } catch (err) {
-      warn(
-        "[daemon/repo-run] /runtime/events POST failed:",
-        err instanceof Error ? err.message : String(err),
-      );
-    }
-  };
-
-  const scheduleFlush = (): void => {
-    if (flushTimer) return;
-    flushTimer = setTimeout(() => {
-      flushTimer = undefined;
-      void flush();
-    }, 250);
-  };
+  // Same batching as spawner.ts so the live transcript renders smoothly
+  // without one POST per event.
+  const events = createEventBatcher({
+    api: deps.api,
+    sessionId: payload.session_id,
+    tag: "[daemon/repo-run]",
+  });
 
   // Track the most recent transcript index we've already pushed so we
   // don't re-send earlier events every time on_state fires (the
@@ -85,15 +63,9 @@ export async function runRepoDispatch(
     for (let i = pushedUpTo; i < transcript.length; i++) {
       const ev = transcript[i];
       if (!ev) continue;
-      buffer.push({
-        session_id: payload.session_id,
-        kind: mapKind(ev.kind),
-        content: ev.text,
-      });
+      events.push({ kind: mapKind(ev.kind), content: ev.text });
     }
     pushedUpTo = transcript.length;
-    if (buffer.length >= 16) void flush();
-    else scheduleFlush();
   };
 
   // Capture install commands and the last invocation so we can report
@@ -134,21 +106,13 @@ export async function runRepoDispatch(
         // The orchestrator doesn't accept an abort signal yet; this is a
         // best-effort note in the transcript. Hard cancellation lands
         // when the child claude exit propagates.
-        buffer.push({
-          session_id: payload.session_id,
-          kind: "summary",
-          content: "[run cancelled by user]",
-        });
-        void flush();
+        events.push({ kind: "summary", content: "[run cancelled by user]" });
+        void events.flush();
       }
     },
   });
 
-  if (flushTimer) {
-    clearTimeout(flushTimer);
-    flushTimer = undefined;
-  }
-  await flush();
+  await events.close();
 
   const status: TerminalSessionStatus =
     result.status === "succeeded"

--- a/packages/daemon/src/spawner.ts
+++ b/packages/daemon/src/spawner.ts
@@ -23,7 +23,8 @@ import type {
 } from "@beevibe/core";
 import type { LocalWorkspaceManager } from "@beevibe/core/adapters/local-workspace";
 import type { ApiClient } from "./api-client.js";
-import { error, log, warn } from "./logger.js";
+import { createEventBatcher } from "./event-batcher.js";
+import { error, log } from "./logger.js";
 import { runRepoDispatch } from "./repo-runs.js";
 
 export interface DispatchPayload {
@@ -124,48 +125,21 @@ export async function runDispatch(
     throw new Error(runtimeMissingError(payload.runtime_type));
   }
 
-  // Buffer events so the daemon doesn't fire one POST per token. Flushed
-  // every BATCH_INTERVAL_MS or when the buffer hits BATCH_MAX. Final
+  // Buffer events so the daemon doesn't fire one POST per token. Final
   // flush happens before /runtime/done so the persisted transcript is
   // complete by the time chatResolver fires.
-  const buffer: Array<{
-    session_id: string;
-    kind: RuntimeStep["kind"];
-    content: string;
-    tool_name?: string;
-  }> = [];
-  let flushTimer: NodeJS.Timeout | undefined;
-
-  const flush = async (): Promise<void> => {
-    if (buffer.length === 0) return;
-    const events = buffer.splice(0);
-    try {
-      await deps.api.post("/runtime/events", { events });
-    } catch (err) {
-      warn(
-        "[daemon/spawner] /runtime/events POST failed; events dropped:",
-        err instanceof Error ? err.message : String(err),
-      );
-    }
-  };
-
-  const scheduleFlush = (): void => {
-    if (flushTimer) return;
-    flushTimer = setTimeout(() => {
-      flushTimer = undefined;
-      void flush();
-    }, 250);
-  };
+  const events = createEventBatcher({
+    api: deps.api,
+    sessionId: payload.session_id,
+    tag: "[daemon/spawner]",
+  });
 
   const onStep = (step: RuntimeStep): void => {
-    buffer.push({
-      session_id: payload.session_id,
+    events.push({
       kind: step.kind,
       content: step.description,
       tool_name: step.tool,
     });
-    if (buffer.length >= 16) void flush();
-    else scheduleFlush();
   };
 
   let result: RuntimeResult | undefined;
@@ -189,11 +163,7 @@ export async function runDispatch(
     runError = err instanceof Error ? err : new Error(String(err));
   }
 
-  if (flushTimer) {
-    clearTimeout(flushTimer);
-    flushTimer = undefined;
-  }
-  await flush();
+  await events.close();
 
   const status: TerminalSessionStatus = runError
     ? "failed"

--- a/packages/web/app/(authed)/rooms/[id]/room-detail-client.tsx
+++ b/packages/web/app/(authed)/rooms/[id]/room-detail-client.tsx
@@ -17,6 +17,8 @@ import { isApiConfigured } from "@/lib/api/config";
 import { api, type RoomDetail, type RoomMemberDetail, type RoomMessage } from "@/lib/api/client";
 import { ApiError, describeError } from "@/lib/api/http";
 import { queryKeys } from "@/lib/hooks/keys";
+import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
+import { ModalOverlay } from "@/components/modal-overlay";
 import { ChatMarkdown } from "@/components/chat/markdown";
 import { ToolStepList } from "@/components/chat/tool-step-list";
 import { useChatStream, type ChatStreamStep } from "@/lib/chat-stream";
@@ -273,7 +275,7 @@ function InviteDialog({ roomId, onClose }: { roomId: string; onClose: () => void
   const [error, setError] = useState<string | null>(null);
   /** When the invitee doesn't have an account yet, surface a share link they can use to sign up + auto-join. */
   const [shareLink, setShareLink] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopyToClipboard();
 
   const invite = useMutation({
     mutationFn: () => api.rooms.invite(roomId, { email: email.trim() }),
@@ -297,34 +299,19 @@ function InviteDialog({ roomId, onClose }: { roomId: string; onClose: () => void
     },
   });
 
-  const copyLink = async () => {
-    if (!shareLink) return;
-    try {
-      await navigator.clipboard.writeText(shareLink);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    } catch {
-      // clipboard API can fail in non-secure contexts; user can still
-      // long-press the input and copy manually.
-    }
-  };
-
   return (
-    <div
-      className="fixed inset-0 z-30 bg-background/60 backdrop-blur-sm flex items-center justify-center"
-      onClick={onClose}
+    <ModalOverlay
+      overlayClassName="z-30"
+      onClose={onClose}
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (!email.trim()) return;
+        setError(null);
+        setShareLink(null);
+        invite.mutate();
+      }}
     >
-      <form
-        onClick={(e) => e.stopPropagation()}
-        onSubmit={(e) => {
-          e.preventDefault();
-          if (!email.trim()) return;
-          setError(null);
-          setShareLink(null);
-          invite.mutate();
-        }}
-        className="bg-card border border-border rounded-lg p-5 w-full max-w-md shadow-md"
-      >
+      <>
         <h3 className="text-sm font-semibold mb-1">Invite to room</h3>
         <p className="text-xs text-muted-foreground mb-3">
           Enter the invitee&apos;s email. If they already have a beevibe account they&apos;re
@@ -360,7 +347,7 @@ function InviteDialog({ roomId, onClose }: { roomId: string; onClose: () => void
               />
               <button
                 type="button"
-                onClick={copyLink}
+                onClick={() => void copy(shareLink ?? "")}
                 className="h-7 px-2.5 rounded text-[11px] font-medium border border-border hover:bg-secondary transition-colors cursor-pointer shrink-0"
               >
                 {copied ? "Copied" : "Copy"}
@@ -386,8 +373,8 @@ function InviteDialog({ roomId, onClose }: { roomId: string; onClose: () => void
             </button>
           )}
         </div>
-      </form>
-    </div>
+      </>
+    </ModalOverlay>
   );
 }
 

--- a/packages/web/components/agents/agent-detail-panel.tsx
+++ b/packages/web/components/agents/agent-detail-panel.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import Link from "next/link";
-import { useEffect, useRef } from "react";
-import { AlertTriangle, Bot, ExternalLink, X } from "lucide-react";
+import { AlertTriangle, Bot } from "lucide-react";
 import { Avatar } from "@/components/avatar";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
+import { PanelFooterField, PeekPanel } from "@/components/detail/peek-panel";
 import { CoreBlockCard } from "@/components/agents/core-block-card";
 import { RecentSessionRow } from "@/components/agents/recent-session-row";
 import { RecentChatThreadRow } from "@/components/agents/recent-chat-thread-row";
@@ -30,75 +29,15 @@ export function AgentDetailPanel({
   agentId: string;
   onClose: () => void;
 }) {
-  const panelRef = useRef<HTMLElement>(null);
-
-  // Esc closes the panel — same pattern as Notion peek and most
-  // dialog/drawer components. Bound at window level so focus inside
-  // the panel doesn't have to be on a focusable element.
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onClose]);
-
-  // Click-outside closes. Listener attaches on mount, so the click
-  // that *opened* the panel (which fired before the panel rendered)
-  // doesn't race-trigger close.
-  useEffect(() => {
-    const onMouseDown = (e: MouseEvent) => {
-      const panel = panelRef.current;
-      if (!panel) return;
-      if (e.target instanceof Node && panel.contains(e.target)) return;
-      onClose();
-    };
-    document.addEventListener("mousedown", onMouseDown);
-    return () => document.removeEventListener("mousedown", onMouseDown);
-  }, [onClose]);
-
   return (
-    <aside
-      ref={panelRef}
-      role="dialog"
-      aria-label="Agent details"
-      data-pan="ignore"
-      className="absolute right-0 top-0 bottom-0 w-[520px] max-w-full bg-card border-l border-border shadow-xl flex flex-col"
+    <PeekPanel
+      ariaLabel="Agent details"
+      fullPageHref={`/agents/${agentId}`}
+      onClose={onClose}
+      ignorePan
     >
-      <PanelHeader agentId={agentId} onClose={onClose} />
-      <div className="flex-1 min-h-0 overflow-y-auto">
-        <PanelBody agentId={agentId} />
-      </div>
-    </aside>
-  );
-}
-
-function PanelHeader({
-  agentId,
-  onClose,
-}: {
-  agentId: string;
-  onClose: () => void;
-}) {
-  return (
-    <div className="flex items-center justify-between gap-2 px-4 h-11 border-b border-border/60 shrink-0">
-      <Link
-        href={`/agents/${agentId}`}
-        className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
-      >
-        <ExternalLink className="h-3 w-3" />
-        Open full page
-      </Link>
-      <button
-        type="button"
-        onClick={onClose}
-        aria-label="Close panel"
-        title="Close (Esc)"
-        className="h-7 w-7 inline-flex items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-secondary cursor-pointer transition-colors"
-      >
-        <X className="h-4 w-4" />
-      </button>
-    </div>
+      <PanelBody agentId={agentId} />
+    </PeekPanel>
   );
 }
 
@@ -301,19 +240,3 @@ function PanelMetric({ label, value }: { label: string; value: number }) {
   );
 }
 
-function PanelFooterField({
-  label,
-  children,
-}: {
-  label: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="min-w-0">
-      <div className="uppercase tracking-wider text-muted-foreground/70 mb-0.5 text-[10px]">
-        {label}
-      </div>
-      <div className="text-foreground/85 truncate">{children}</div>
-    </div>
-  );
-}

--- a/packages/web/components/agents/pickers/chip-popover.tsx
+++ b/packages/web/components/agents/pickers/chip-popover.tsx
@@ -1,13 +1,7 @@
 "use client";
 
-import {
-  type ReactNode,
-  useCallback,
-  useEffect,
-  useId,
-  useRef,
-  useState,
-} from "react";
+import { type ReactNode, useCallback, useId, useRef, useState } from "react";
+import { useDismissOnOutside } from "@/lib/hooks/use-dismiss";
 import { cn } from "@/lib/utils";
 
 /**
@@ -16,9 +10,8 @@ import { cn } from "@/lib/utils";
  *
  * Trigger is a `<button>` styled as a status chip; popover content is
  * authored by the caller. Manages open state, click-outside, and
- * Escape. The same click-outside pattern lives in `user-widget.tsx`;
- * this just packages it for reuse so three pickers don't each
- * re-derive it.
+ * Escape — all three via the shared `useDismissOnOutside` hook, which
+ * the peek panels and the user-widget menu use too.
  */
 export function ChipPopover({
   ariaLabel,
@@ -44,26 +37,15 @@ export function ChipPopover({
   const menuId = useId();
   const close = useCallback(() => setOpen(false), []);
 
-  useEffect(() => {
-    if (!open) return;
-    const onDown = (e: MouseEvent) => {
-      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        setOpen(false);
-        triggerRef.current?.focus();
-      }
-    };
-    document.addEventListener("mousedown", onDown);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("mousedown", onDown);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [open]);
+  // Escape also returns focus to the trigger, so the keyboard user
+  // isn't dropped at the top of the document when the popover closes.
+  useDismissOnOutside(rootRef, close, {
+    enabled: open,
+    onEscape: () => {
+      close();
+      triggerRef.current?.focus();
+    },
+  });
 
   return (
     <div ref={rootRef} className="relative inline-flex">

--- a/packages/web/components/cli-mcp-instructions.tsx
+++ b/packages/web/components/cli-mcp-instructions.tsx
@@ -3,17 +3,12 @@
 import { useState, type ReactNode } from "react";
 import { apiBaseUrl, getUserKey } from "@/lib/api/config";
 import { CommandBlock } from "@/components/command-block";
+import { SegmentedTabs, type SegmentedTabOption } from "@/components/segmented-tabs";
 import { cn } from "@/lib/utils";
 
 export type CliChannel = "claude" | "codex" | "opencode" | "manual";
 
-interface ChannelOption {
-  id: CliChannel;
-  label: string;
-  hint: string;
-}
-
-const CHANNEL_OPTIONS: readonly ChannelOption[] = [
+const CHANNEL_OPTIONS: readonly SegmentedTabOption<CliChannel>[] = [
   { id: "claude", label: "Claude Code", hint: "claude mcp add" },
   { id: "codex", label: "Codex", hint: "config.toml" },
   { id: "opencode", label: "opencode", hint: "opencode.json" },
@@ -143,24 +138,7 @@ export function CliMcpInstructions({ className }: { className?: string }) {
 
   return (
     <div className={cn("space-y-3", className)}>
-      <div className="flex gap-1 rounded-lg border border-border bg-card p-1">
-        {CHANNEL_OPTIONS.map((opt) => (
-          <button
-            key={opt.id}
-            type="button"
-            onClick={() => setChannel(opt.id)}
-            className={cn(
-              "flex-1 rounded px-3 py-1.5 text-xs font-medium transition-colors cursor-pointer",
-              channel === opt.id
-                ? "bg-primary text-primary-foreground"
-                : "text-muted-foreground hover:text-foreground",
-            )}
-          >
-            <div>{opt.label}</div>
-            <div className="text-[10px] font-normal opacity-80 mt-0.5">{opt.hint}</div>
-          </button>
-        ))}
-      </div>
+      <SegmentedTabs options={CHANNEL_OPTIONS} value={channel} onChange={setChannel} />
       <div className="space-y-2">
         {bundle.prelude}
         {bundle.steps.map((step, i) => (

--- a/packages/web/components/command-block.tsx
+++ b/packages/web/components/command-block.tsx
@@ -1,17 +1,13 @@
 "use client";
 
-import { useState } from "react";
 import { Check, Copy, Terminal } from "lucide-react";
+import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
 
 /**
  * Labeled shell command with an inline copy button. Used by the welcome
  * wizard's daemon-install step and the runtimes panel's empty state /
  * "set up another machine" disclosure — both want the same affordance:
  * "here's the command, click to copy."
- *
- * The clipboard write is a no-op when `navigator.clipboard` is missing
- * (older browsers / non-https origins) so the button still looks live
- * without throwing.
  */
 export function CommandBlock({
   label,
@@ -20,13 +16,7 @@ export function CommandBlock({
   label: string;
   command: string;
 }) {
-  const [copied, setCopied] = useState(false);
-  const copy = async () => {
-    if (typeof navigator === "undefined" || !navigator.clipboard) return;
-    await navigator.clipboard.writeText(command);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
-  };
+  const { copied, copy } = useCopyToClipboard();
   return (
     <div className="rounded-md border border-border bg-card overflow-hidden text-left">
       <div className="flex items-center gap-2 px-3 py-1.5 border-b border-border/60 bg-secondary/30">
@@ -36,7 +26,7 @@ export function CommandBlock({
         </span>
         <button
           type="button"
-          onClick={copy}
+          onClick={() => void copy(command)}
           className="ml-auto inline-flex items-center gap-1 h-5 px-1.5 rounded text-[10px] text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors cursor-pointer"
         >
           {copied ? (

--- a/packages/web/components/daemon-install.tsx
+++ b/packages/web/components/daemon-install.tsx
@@ -3,17 +3,12 @@
 import { useState, type ReactNode } from "react";
 import { apiBaseUrl, getUserKey } from "@/lib/api/config";
 import { CommandBlock } from "@/components/command-block";
+import { SegmentedTabs, type SegmentedTabOption } from "@/components/segmented-tabs";
 import { cn } from "@/lib/utils";
 
 export type InstallChannel = "brew" | "npx" | "direct";
 
-interface InstallOption {
-  id: InstallChannel;
-  label: string;
-  hint: string;
-}
-
-const INSTALL_OPTIONS: readonly InstallOption[] = [
+const INSTALL_OPTIONS: readonly SegmentedTabOption<InstallChannel>[] = [
   { id: "brew", label: "Homebrew", hint: "macOS" },
   { id: "npx", label: "npx", hint: "any platform with Node" },
   { id: "direct", label: "Direct download", hint: "advanced" },
@@ -102,24 +97,7 @@ export function DaemonInstallInstructions({ className }: { className?: string })
 
   return (
     <div className={cn("space-y-3", className)}>
-      <div className="flex gap-1 rounded-lg border border-border bg-card p-1">
-        {INSTALL_OPTIONS.map((opt) => (
-          <button
-            key={opt.id}
-            type="button"
-            onClick={() => setChannel(opt.id)}
-            className={cn(
-              "flex-1 rounded px-3 py-1.5 text-xs font-medium transition-colors cursor-pointer",
-              channel === opt.id
-                ? "bg-primary text-primary-foreground"
-                : "text-muted-foreground hover:text-foreground",
-            )}
-          >
-            <div>{opt.label}</div>
-            <div className="text-[10px] font-normal opacity-80 mt-0.5">{opt.hint}</div>
-          </button>
-        ))}
-      </div>
+      <SegmentedTabs options={INSTALL_OPTIONS} value={channel} onChange={setChannel} />
       <div className="space-y-2">
         {bundle.prelude}
         {bundle.steps.map((step, i) => (

--- a/packages/web/components/detail/click-to-copy-id.tsx
+++ b/packages/web/components/detail/click-to-copy-id.tsx
@@ -1,17 +1,13 @@
 "use client";
 
-import { useState } from "react";
 import { Check, Copy, Hash } from "lucide-react";
+import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
 
 export function ClickToCopyId({ id }: { id: string }) {
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopyToClipboard();
   return (
     <button
-      onClick={async () => {
-        await navigator.clipboard.writeText(id);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
-      }}
+      onClick={() => void copy(id)}
       className="inline-flex items-center gap-1.5 font-mono hover:text-foreground transition-colors cursor-pointer"
       title="Copy ID"
       aria-label={copied ? "ID copied" : `Copy ID ${id}`}

--- a/packages/web/components/detail/peek-panel.tsx
+++ b/packages/web/components/detail/peek-panel.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import Link from "next/link";
+import { useRef, type ReactNode } from "react";
+import { ExternalLink, X } from "lucide-react";
+import { useDismissOnOutside } from "@/lib/hooks/use-dismiss";
+import { cn } from "@/lib/utils";
+
+/**
+ * The Notion-style peek panel shell, shared by the agent peek (over the
+ * network canvas) and the task peek (over the kanban).
+ *
+ * Both are the same surface: a fixed-width `aside` pinned to the right
+ * of whatever it overlays, which stays visible and interactive
+ * underneath for comparison-by-click; a slim header with an "Open full
+ * page" link out to the deep-dive route and a close button; and a
+ * scrolling body. Both dismiss on Escape and on a click outside.
+ *
+ * Callers own the body — the heavier deep-dive (work-product bodies,
+ * session transcripts) is what "Open full page" is for, so keep the
+ * body single-column and summary-weight.
+ */
+export function PeekPanel({
+  ariaLabel,
+  fullPageHref,
+  onClose,
+  className,
+  ignorePan = false,
+  children,
+}: {
+  /** Names the dialog for screen readers, e.g. "Task details". */
+  ariaLabel: string;
+  /** Route behind "Open full page". */
+  fullPageHref: string;
+  onClose: () => void;
+  /** Extra classes on the aside — stacking context, mostly. */
+  className?: string;
+  /**
+   * Set over a pan-zoom canvas so a drag inside the panel doesn't pan
+   * what's underneath it.
+   */
+  ignorePan?: boolean;
+  children: ReactNode;
+}) {
+  const panelRef = useRef<HTMLElement>(null);
+  useDismissOnOutside(panelRef, onClose);
+
+  return (
+    <aside
+      ref={panelRef}
+      role="dialog"
+      aria-label={ariaLabel}
+      data-pan={ignorePan ? "ignore" : undefined}
+      className={cn(
+        "absolute right-0 top-0 bottom-0 w-[520px] max-w-full bg-card border-l border-border shadow-xl flex flex-col",
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between gap-2 px-4 h-11 border-b border-border/60 shrink-0">
+        <Link
+          href={fullPageHref}
+          className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ExternalLink className="h-3 w-3" />
+          Open full page
+        </Link>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close panel"
+          title="Close (Esc)"
+          className="h-7 w-7 inline-flex items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-secondary cursor-pointer transition-colors"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+      <div className="flex-1 min-h-0 overflow-y-auto">{children}</div>
+    </aside>
+  );
+}
+
+/**
+ * One label/value cell in a peek panel's footer grid. Both panels close
+ * with the same two-column metadata block (id, owner, timestamps), and
+ * both had a byte-identical copy of this.
+ */
+export function PanelFooterField({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="min-w-0">
+      <div className="uppercase tracking-wider text-muted-foreground/70 mb-0.5 text-[10px]">
+        {label}
+      </div>
+      <div className="text-foreground/85 truncate">{children}</div>
+    </div>
+  );
+}

--- a/packages/web/components/modal-overlay.tsx
+++ b/packages/web/components/modal-overlay.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import type { FormEvent, MouseEvent, ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+const CARD_CLASS = "bg-card border border-border rounded-lg p-5 w-full max-w-md shadow-md";
+
+/**
+ * Centered modal over a blurred backdrop, with click-the-backdrop to
+ * dismiss. Both invite dialogs — "invite a teammate" in the user widget
+ * and "invite to room" on the room page — were built from a
+ * byte-identical copy of this: the fixed backdrop with its `onClick`,
+ * and the card with the `stopPropagation` that keeps a click inside
+ * from bubbling out and closing the thing the user is typing into.
+ *
+ * Passing `onSubmit` renders the card as a `<form>`, which is what the
+ * room dialog needs so Enter submits the invite; without it the card is
+ * a plain `<div>`.
+ */
+export function ModalOverlay({
+  onClose,
+  className,
+  overlayClassName = "z-50",
+  onSubmit,
+  children,
+}: {
+  onClose: () => void;
+  /** Extra classes on the card. */
+  className?: string;
+  /**
+   * Stacking for the backdrop. The two callers sit at different depths
+   * today (z-50 in the user widget, z-30 on the room page); left as a
+   * knob rather than harmonized, since raising the room dialog is a
+   * visual change and not this refactor's business.
+   */
+  overlayClassName?: string;
+  /** Supply to render the card as a submitting form. */
+  onSubmit?: (e: FormEvent<HTMLFormElement>) => void;
+  children: ReactNode;
+}) {
+  const stop = (e: MouseEvent) => e.stopPropagation();
+  return (
+    <div
+      className={cn(
+        "fixed inset-0 bg-background/60 backdrop-blur-sm flex items-center justify-center",
+        overlayClassName,
+      )}
+      onClick={onClose}
+    >
+      {onSubmit ? (
+        <form onClick={stop} onSubmit={onSubmit} className={cn(CARD_CLASS, className)}>
+          {children}
+        </form>
+      ) : (
+        <div onClick={stop} className={cn(CARD_CLASS, className)}>
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/components/segmented-tabs.tsx
+++ b/packages/web/components/segmented-tabs.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+export interface SegmentedTabOption<T extends string> {
+  id: T;
+  label: string;
+  /** Small second line under the label — platform, caveat, audience. */
+  hint: string;
+}
+
+/**
+ * Segmented control with a two-line label, used to pick which set of
+ * setup commands to show: the daemon installer's brew/npx/direct
+ * channels and the MCP instructions' claude/codex/opencode/manual
+ * clients.
+ *
+ * Both were built from the same block of markup and the same
+ * `{id, label, hint}` option shape, down to the `text-[10px]` hint and
+ * the selected-state colors.
+ */
+export function SegmentedTabs<T extends string>({
+  options,
+  value,
+  onChange,
+  className,
+}: {
+  options: readonly SegmentedTabOption<T>[];
+  value: T;
+  onChange: (id: T) => void;
+  className?: string;
+}) {
+  return (
+    <div
+      role="tablist"
+      className={cn("flex gap-1 rounded-lg border border-border bg-card p-1", className)}
+    >
+      {options.map((opt) => (
+        <button
+          key={opt.id}
+          type="button"
+          role="tab"
+          aria-selected={value === opt.id}
+          onClick={() => onChange(opt.id)}
+          className={cn(
+            "flex-1 rounded px-3 py-1.5 text-xs font-medium transition-colors cursor-pointer",
+            value === opt.id
+              ? "bg-primary text-primary-foreground"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          <div>{opt.label}</div>
+          <div className="text-[10px] font-normal opacity-80 mt-0.5">{opt.hint}</div>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/packages/web/components/tasks/task-detail-panel.tsx
+++ b/packages/web/components/tasks/task-detail-panel.tsx
@@ -1,17 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useRef, useState } from "react";
-import {
-  AlertTriangle,
-  ExternalLink,
-  FileText,
-  ListChecks,
-  Terminal,
-  X,
-} from "lucide-react";
+import { useState } from "react";
+import { AlertTriangle, FileText, ListChecks, Terminal } from "lucide-react";
 import { ChatMarkdown } from "@/components/chat/markdown";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
+import { PanelFooterField, PeekPanel } from "@/components/detail/peek-panel";
 import { TaskStatusPill, SessionStatusPill } from "@/components/detail/status-pill";
 import { EmptyState } from "@/components/empty-state";
 import { HierChip } from "@/components/hier-chip";
@@ -47,74 +41,15 @@ export function TaskDetailPanel({
   taskId: string;
   onClose: () => void;
 }) {
-  const panelRef = useRef<HTMLElement>(null);
-
-  // Esc closes — same pattern as the agent peek and the rest of the
-  // dialog/drawer surfaces.
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onClose]);
-
-  // Click-outside closes. Listener attaches on mount, so the click that
-  // *opened* the panel (which fired before the panel rendered) doesn't
-  // race-trigger close. Any subsequent mousedown outside the aside
-  // fires onClose.
-  useEffect(() => {
-    const onMouseDown = (e: MouseEvent) => {
-      const panel = panelRef.current;
-      if (!panel) return;
-      if (e.target instanceof Node && panel.contains(e.target)) return;
-      onClose();
-    };
-    document.addEventListener("mousedown", onMouseDown);
-    return () => document.removeEventListener("mousedown", onMouseDown);
-  }, [onClose]);
-
   return (
-    <aside
-      ref={panelRef}
-      role="dialog"
-      aria-label="Task details"
-      className="absolute right-0 top-0 bottom-0 w-[520px] max-w-full bg-card border-l border-border shadow-xl flex flex-col z-20"
+    <PeekPanel
+      ariaLabel="Task details"
+      fullPageHref={`/tasks/${taskId}`}
+      onClose={onClose}
+      className="z-20"
     >
-      <PanelHeader taskId={taskId} onClose={onClose} />
-      <div className="flex-1 min-h-0 overflow-y-auto">
-        <PanelBody taskId={taskId} />
-      </div>
-    </aside>
-  );
-}
-
-function PanelHeader({
-  taskId,
-  onClose,
-}: {
-  taskId: string;
-  onClose: () => void;
-}) {
-  return (
-    <div className="flex items-center justify-between gap-2 px-4 h-11 border-b border-border/60 shrink-0">
-      <Link
-        href={`/tasks/${taskId}`}
-        className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
-      >
-        <ExternalLink className="h-3 w-3" />
-        Open full page
-      </Link>
-      <button
-        type="button"
-        onClick={onClose}
-        aria-label="Close panel"
-        title="Close (Esc)"
-        className="h-7 w-7 inline-flex items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-secondary cursor-pointer transition-colors"
-      >
-        <X className="h-4 w-4" />
-      </button>
-    </div>
+      <PanelBody taskId={taskId} />
+    </PeekPanel>
   );
 }
 
@@ -372,22 +307,6 @@ function Section({
   );
 }
 
-function PanelFooterField({
-  label,
-  children,
-}: {
-  label: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="min-w-0">
-      <div className="uppercase tracking-wider text-muted-foreground/70 mb-0.5 text-[10px]">
-        {label}
-      </div>
-      <div className="text-foreground/85 truncate">{children}</div>
-    </div>
-  );
-}
 
 function WorkProductRow({ wp }: { wp: WorkProduct }) {
   return (

--- a/packages/web/components/user-widget.tsx
+++ b/packages/web/components/user-widget.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import { type ReactNode, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import {
@@ -13,6 +13,9 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { useMe } from "@/lib/hooks/use-me";
+import { useDismissOnOutside } from "@/lib/hooks/use-dismiss";
+import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
+import { ModalOverlay } from "@/components/modal-overlay";
 import { clearUserKey } from "@/lib/api/config";
 import { cn } from "@/lib/utils";
 import { Avatar } from "@/components/avatar";
@@ -27,21 +30,7 @@ export function UserWidget() {
   const router = useRouter();
   const ref = useRef<HTMLDivElement | null>(null);
 
-  useEffect(() => {
-    if (view === "closed") return;
-    const onDown = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setView("closed");
-    };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setView("closed");
-    };
-    document.addEventListener("mousedown", onDown);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("mousedown", onDown);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [view]);
+  useDismissOnOutside(ref, () => setView("closed"), { enabled: view !== "closed" });
 
   const name = me?.person.name ?? "Signed in";
   const initial = name.charAt(0).toUpperCase() || "?";
@@ -159,7 +148,7 @@ function MenuItem({
 
 function InviteTeammateDialog({ onClose }: { onClose: () => void }) {
   const [email, setEmail] = useState("");
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopyToClipboard();
   const trimmed = email.trim().toLowerCase();
   const valid = EMAIL_RE.test(trimmed);
   const origin = typeof window !== "undefined" ? window.location.origin : "";
@@ -167,27 +156,9 @@ function InviteTeammateDialog({ onClose }: { onClose: () => void }) {
     ? `${origin}/sign-up?email=${encodeURIComponent(trimmed)}`
     : "";
 
-  const copyLink = async () => {
-    if (!shareLink) return;
-    try {
-      await navigator.clipboard.writeText(shareLink);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    } catch {
-      // Clipboard API can fail in non-secure contexts; the input is
-      // still selectable for manual copy.
-    }
-  };
-
   return (
-    <div
-      className="fixed inset-0 z-50 bg-background/60 backdrop-blur-sm flex items-center justify-center"
-      onClick={onClose}
-    >
-      <div
-        onClick={(e) => e.stopPropagation()}
-        className="bg-card border border-border rounded-lg p-5 w-full max-w-md shadow-md"
-      >
+    <ModalOverlay onClose={onClose}>
+      <>
         <h3 className="text-sm font-semibold mb-1">Invite a teammate</h3>
         <p className="text-xs text-muted-foreground mb-3">
           Share a sign-up link. When they sign up, they get their own team
@@ -215,7 +186,7 @@ function InviteTeammateDialog({ onClose }: { onClose: () => void }) {
               />
               <button
                 type="button"
-                onClick={copyLink}
+                onClick={() => void copy(shareLink)}
                 className="h-7 px-2.5 rounded text-[11px] font-medium border border-border hover:bg-secondary transition-colors cursor-pointer shrink-0"
               >
                 {copied ? "Copied" : "Copy"}
@@ -232,7 +203,7 @@ function InviteTeammateDialog({ onClose }: { onClose: () => void }) {
             Done
           </button>
         </div>
-      </div>
-    </div>
+      </>
+    </ModalOverlay>
   );
 }

--- a/packages/web/lib/format.ts
+++ b/packages/web/lib/format.ts
@@ -1,48 +1,28 @@
-export type DateLike = Date | string | number;
-
 /**
- * Coerce `Date | string | number | undefined` into a Date. JSON-bound
- * api responses arrive as strings even when their TypeScript types
- * claim `Date`; defensive callers pass them straight through helpers
- * like this one without manual `new Date(...)` wrapping. Returns
- * `undefined` for missing input (so callers can short-circuit) and
- * `undefined` for invalid input (so a bad value doesn't render as
- * "Invalid Date").
+ * Web-side display helpers.
+ *
+ * The ones the api also needs — `toDate`, `deriveShortId`, the
+ * relative-time ladder, `formatDurationLabel` — live in `@beevibe/core`
+ * and are re-exported here so existing `@/lib/format` imports keep
+ * working. They used to be a hand-kept parallel copy of
+ * `packages/api/src/views/format.ts`; `deriveShortId` in particular
+ * decides both the `short_id` the api serializes and the URL fragment
+ * the web navigates to, so the two drifting apart would produce dead
+ * links.
  */
-export function toDate(value: DateLike | null | undefined): Date | undefined {
-  if (value == null) return undefined;
-  const d = value instanceof Date ? value : new Date(value);
-  return Number.isNaN(d.getTime()) ? undefined : d;
-}
 
-export function formatRelativeTime(
-  date: DateLike,
-  now: Date = new Date(),
-): string {
-  const d = toDate(date);
-  if (!d) return "—";
-  const diffMs = now.getTime() - d.getTime();
-  const diffSec = Math.floor(diffMs / 1000);
-  if (diffSec < 60) return "just now";
-  const diffMin = Math.floor(diffSec / 60);
-  if (diffMin < 60) return `${diffMin}m ago`;
-  const diffHr = Math.floor(diffMin / 60);
-  if (diffHr < 24) return `${diffHr}h ago`;
-  const diffDay = Math.floor(diffHr / 24);
-  if (diffDay < 30) return `${diffDay}d ago`;
-  const diffMonth = Math.floor(diffDay / 30);
-  if (diffMonth < 12) return `${diffMonth}mo ago`;
-  return `${Math.floor(diffMonth / 12)}y ago`;
-}
+import { deriveShortId, formatRelative, type DateLike } from "@beevibe/core/domain/format";
 
-/**
- * The 6-char short id used in routes and lookups — strip the typed-id
- * prefix (`sess_`, `agent_`, …) and take the first 6 chars. Mirrors the
- * backend's `deriveShortId` (packages/api/src/views/format.ts) so the web
- * doesn't hard-code the prefix length in multiple places.
- */
-export function deriveShortId(id: string): string {
-  return id.replace(/^[a-z]+_/, "").slice(0, 6);
+export {
+  deriveShortId,
+  formatDurationLabel,
+  toDate,
+  type DateLike,
+} from "@beevibe/core/domain/format";
+
+/** Relative-time label in prose form: "just now" / "2m ago" / "3d ago". */
+export function formatRelativeTime(date: DateLike, now: Date = new Date()): string {
+  return formatRelative(date, { now, suffix: " ago" });
 }
 
 export function shortId(id: string): string {
@@ -89,30 +69,6 @@ export function sessionHref(sid: string, taskId?: string): string {
   const sessionShort = deriveShortId(sid);
   if (taskId) return `/tasks/${taskId}/sessions/${sessionShort}`;
   return `/sessions/${sessionShort}`;
-}
-
-/**
- * Duration between `startedAt` and `completedAt` (or `now` if running).
- * "30s" / "5m" / "1h 12m" / "2d 3h". Returns "—" if no start.
- */
-export function formatDurationLabel(
-  startedAt: DateLike | null | undefined,
-  completedAt: DateLike | null | undefined,
-  now: Date = new Date(),
-): string {
-  const start = toDate(startedAt);
-  if (!start) return "—";
-  const end = toDate(completedAt) ?? now;
-  const diffSec = Math.max(0, Math.floor((end.getTime() - start.getTime()) / 1000));
-  if (diffSec < 60) return `${diffSec}s`;
-  const min = Math.floor(diffSec / 60);
-  if (min < 60) return `${min}m`;
-  const hr = Math.floor(min / 60);
-  const mins = min % 60;
-  if (hr < 24) return mins ? `${hr}h ${mins}m` : `${hr}h`;
-  const days = Math.floor(hr / 24);
-  const hrs = hr % 24;
-  return hrs ? `${days}d ${hrs}h` : `${days}d`;
 }
 
 /**

--- a/packages/web/lib/hooks/use-copy-to-clipboard.test.tsx
+++ b/packages/web/lib/hooks/use-copy-to-clipboard.test.tsx
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useCopyToClipboard } from "./use-copy-to-clipboard";
+
+function stubClipboard(writeText: () => Promise<void>) {
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText: vi.fn(writeText) },
+    configurable: true,
+    writable: true,
+  });
+  return navigator.clipboard.writeText as ReturnType<typeof vi.fn>;
+}
+
+describe("useCopyToClipboard", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.useRealTimers();
+    Reflect.deleteProperty(navigator, "clipboard");
+  });
+
+  it("writes the text and raises the copied flag", async () => {
+    const writeText = stubClipboard(async () => {});
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      expect(await result.current.copy("hello")).toBe(true);
+    });
+
+    expect(writeText).toHaveBeenCalledWith("hello");
+    expect(result.current.copied).toBe(true);
+  });
+
+  it("lowers the flag again after the reset window", async () => {
+    stubClipboard(async () => {});
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      await result.current.copy("hello");
+    });
+    expect(result.current.copied).toBe(true);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+    expect(result.current.copied).toBe(false);
+  });
+
+  it("does nothing when the clipboard API is unavailable", async () => {
+    // Non-secure origins and older browsers have no navigator.clipboard.
+    // click-to-copy-id.tsx used to hit an unhandled rejection here.
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      expect(await result.current.copy("hello")).toBe(false);
+    });
+    expect(result.current.copied).toBe(false);
+  });
+
+  it("reports failure without throwing when the write is rejected", async () => {
+    stubClipboard(async () => {
+      throw new Error("permission denied");
+    });
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      expect(await result.current.copy("hello")).toBe(false);
+    });
+    expect(result.current.copied).toBe(false);
+  });
+
+  it("ignores an empty string rather than clearing the clipboard", async () => {
+    const writeText = stubClipboard(async () => {});
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      expect(await result.current.copy("")).toBe(false);
+    });
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it("clears the reset timer on unmount", async () => {
+    stubClipboard(async () => {});
+    const { result, unmount } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      await result.current.copy("hello");
+    });
+    unmount();
+
+    // The pending reset must not fire into an unmounted component.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/web/lib/hooks/use-copy-to-clipboard.ts
+++ b/packages/web/lib/hooks/use-copy-to-clipboard.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/** How long the "copied" confirmation stays up. */
+const RESET_MS = 1500;
+
+/**
+ * Copy-to-clipboard with a "copied" flash, for the four buttons that
+ * want exactly that: the id chip in the peek-panel footers, the shell
+ * command blocks, and the two invite dialogs' share links.
+ *
+ * Each had its own `setCopied(true); setTimeout(() => setCopied(false),
+ * 1500)`, and they disagreed on the parts that matter:
+ *
+ * - `navigator.clipboard` is undefined on non-secure origins and older
+ *   browsers. `command-block.tsx` checked for it; `click-to-copy-id.tsx`
+ *   did not, so a click there raised an unhandled rejection instead of
+ *   doing nothing. Guarded here for everyone.
+ * - The write can reject even when the API exists (permission denied).
+ *   Two of the four caught that; two didn't.
+ * - None of them cleared the timer on unmount, so closing the panel
+ *   inside the flash window set state on an unmounted component.
+ *
+ * `copy` resolves to whether the write actually landed, for callers
+ * that want to say something when it didn't. The text stays selectable
+ * either way, so a failed copy is a soft failure, not a dead end.
+ */
+export function useCopyToClipboard(): {
+  copied: boolean;
+  copy: (text: string) => Promise<boolean>;
+} {
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => () => clearTimeout(timer.current), []);
+
+  const copy = useCallback(async (text: string): Promise<boolean> => {
+    if (!text) return false;
+    if (typeof navigator === "undefined" || !navigator.clipboard) return false;
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      return false;
+    }
+    setCopied(true);
+    clearTimeout(timer.current);
+    timer.current = setTimeout(() => setCopied(false), RESET_MS);
+    return true;
+  }, []);
+
+  return { copied, copy };
+}

--- a/packages/web/lib/hooks/use-dismiss.test.tsx
+++ b/packages/web/lib/hooks/use-dismiss.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useRef } from "react";
+import { useDismissOnOutside } from "./use-dismiss";
+
+/**
+ * Mount a real element, point a ref at it, and bind the hook to it —
+ * the hook's whole job is the `contains` test against a live node.
+ */
+function setup(opts: { enabled?: boolean; onEscape?: () => void } = {}) {
+  const el = document.createElement("div");
+  const inside = document.createElement("button");
+  el.appendChild(inside);
+  document.body.appendChild(el);
+
+  const onDismiss = vi.fn();
+  const { unmount } = renderHook(() => {
+    const ref = useRef<HTMLDivElement | null>(el);
+    useDismissOnOutside(ref, onDismiss, opts);
+  });
+
+  return {
+    onDismiss,
+    inside,
+    unmount: () => {
+      unmount();
+      el.remove();
+    },
+  };
+}
+
+function mouseDownOn(target: EventTarget) {
+  target.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+}
+
+function pressKey(key: string) {
+  document.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+}
+
+describe("useDismissOnOutside", () => {
+  it("dismisses on a mousedown outside the element", () => {
+    const { onDismiss, unmount } = setup();
+    mouseDownOn(document.body);
+    expect(onDismiss).toHaveBeenCalledOnce();
+    unmount();
+  });
+
+  it("ignores a mousedown on a descendant", () => {
+    const { onDismiss, inside, unmount } = setup();
+    mouseDownOn(inside);
+    expect(onDismiss).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it("dismisses on Escape and ignores other keys", () => {
+    const { onDismiss, unmount } = setup();
+    pressKey("Enter");
+    expect(onDismiss).not.toHaveBeenCalled();
+    pressKey("Escape");
+    expect(onDismiss).toHaveBeenCalledOnce();
+    unmount();
+  });
+
+  it("routes Escape to onEscape when one is supplied", () => {
+    const onEscape = vi.fn();
+    const { onDismiss, unmount } = setup({ onEscape });
+
+    pressKey("Escape");
+    expect(onEscape).toHaveBeenCalledOnce();
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    // Click-outside still goes to onDismiss.
+    mouseDownOn(document.body);
+    expect(onDismiss).toHaveBeenCalledOnce();
+    unmount();
+  });
+
+  it("binds nothing while disabled", () => {
+    const { onDismiss, unmount } = setup({ enabled: false });
+    mouseDownOn(document.body);
+    pressKey("Escape");
+    expect(onDismiss).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it("unbinds on unmount", () => {
+    const { onDismiss, unmount } = setup();
+    unmount();
+    mouseDownOn(document.body);
+    pressKey("Escape");
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/lib/hooks/use-dismiss.ts
+++ b/packages/web/lib/hooks/use-dismiss.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useRef, type RefObject } from "react";
+
+/**
+ * Dismiss-on-Escape + dismiss-on-click-outside, for the overlay
+ * surfaces that all want exactly this: the agent and task peek panels,
+ * the user-widget menu, and the chip pickers on the agent list.
+ *
+ * Each of those had its own copy — same two listeners, same
+ * `ref.current.contains(e.target)` test, same document-level binding so
+ * focus doesn't have to be on a focusable element inside the surface.
+ *
+ * Two details worth keeping straight, both of which the copies got
+ * right and a fifth copy might not:
+ *
+ * - `mousedown`, not `click`. A click fires after the button that
+ *   opened the surface has already been released; mousedown lets the
+ *   surface close before the underlying element reacts.
+ * - The listener attaches when `enabled` flips true, so the very click
+ *   that opened the surface — which fired before this effect ran —
+ *   can't race-trigger a dismiss.
+ *
+ * Callbacks are read through a ref, so passing inline arrows doesn't
+ * re-bind the listeners on every render.
+ */
+export function useDismissOnOutside<T extends HTMLElement>(
+  ref: RefObject<T | null>,
+  onDismiss: () => void,
+  opts: {
+    /** False while the surface is closed. Defaults to true. */
+    enabled?: boolean;
+    /**
+     * Escape handler, when it needs to do more than dismiss — the chip
+     * pickers also return focus to their trigger. Defaults to
+     * `onDismiss`.
+     */
+    onEscape?: () => void;
+  } = {},
+): void {
+  const { enabled = true, onEscape } = opts;
+
+  const handlers = useRef({ onDismiss, onEscape });
+  handlers.current = { onDismiss, onEscape };
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const onMouseDown = (e: MouseEvent) => {
+      const el = ref.current;
+      if (!el) return;
+      if (e.target instanceof Node && el.contains(e.target)) return;
+      handlers.current.onDismiss();
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      const { onEscape: escape, onDismiss: dismiss } = handlers.current;
+      (escape ?? dismiss)();
+    };
+
+    document.addEventListener("mousedown", onMouseDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onMouseDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [enabled, ref]);
+}


### PR DESCRIPTION
Follow-up to #257 and #259, which covered the CLI-runtime adapters, the
route 500-handlers, the XML escapers and `shellQuote`. This sweep found
four more clusters — including the first pass over `packages/web`, which
had never had one — and two latent bugs the duplication was hiding.

One commit per cluster; each is independently reviewable.

## 1. `daemon`: one event batcher for both dispatch paths

`spawner.ts` (CLI runtime) and `repo-runs.ts` (Docker sandbox) each carried
their own copy of the `/runtime/events` batching logic: the buffer, the
`flushTimer`, `flush()`, `scheduleFlush()`, the 16-event threshold, the 250ms
interval, and the clearTimeout + final flush before `/runtime/done`. The
copies differed only in the log tag and in `repo-runs` omitting the
"; events dropped" half of the warning — the less accurate of the two, since
both drop.

Now `createEventBatcher({api, sessionId, tag})`. It stamps `session_id` onto
each event, so call sites push `{kind, content, tool_name}` and can't get the
id wrong on one path only. `BATCH_MAX` / `BATCH_INTERVAL_MS` are named
constants — spawner's comment already referred to them by name while both
files held the values inline as bare literals.

One behavior change, in the safe direction: `flush()` now cancels a pending
timer, so `repo-runs`' cancellation path no longer leaves a stray callback
that wakes to find an empty buffer.

## 2. `api`: the agent-row mapping and the tool error envelope

**`rowToAgentDisplay` — 2 copies, 3 call sites.** The agent list, the detail
header and the network graph all project the same `agent` columns into the
same `AgentDisplay`. The two copies had already drifted: one read
`row.runtime_config.type`, the other `row.runtime_config?.type`; one carried
a redundant cast. The "why" comments (the #96 runtime/model split, the
deliberate absence of a `domain` fallback) were written out twice in
different words.

`views/agent-display.ts` now owns the row type and the mapping. Counts are
coerced in one place, since they arrive as `int` from one query and as text
from another. The two view-specific columns (`owner_label`, `archived_at`)
stay opt-in, so the network payload keeps exactly the fields it has today
rather than silently gaining an `owner_label` per agent.

**The tool error envelope — 4 shapes across 3 files.** `mesh.ts` and
`hierarchy.ts` each had a private `asError`, and mesh's had three
`instanceof` branches byte-identical to each other, one per coded mesh
error. Adding a fourth coded error meant remembering to add a fourth branch
— or silently getting the generic `{error: "<human message>"}` envelope
instead of `{error: "<code>", ...meta}`, which would break any agent
branching on the code.

The three errors now share a `CodedMeshError` base, and `tools/errors.ts`
exports `toolError(code, message, extra?)` (replacing watch.ts's private
`errResult`, 9 call sites) and `toolErrorFromThrown(err, extra?)` (one
`instanceof` check covering all three, replacing both `asError` copies).
Matched on the base class rather than duck-typing a `code` property — pg and
node fs errors carry a `code` too, and there's a test pinning that they keep
reporting as generic failures.

## 3. `web`: five duplicated overlay/copy primitives 🐛

The web package had never had a duplication pass.

- **Dismiss-on-Escape + click-outside — 4 copies** (both peek panels, the
  user-widget menu, the chip pickers). `chip-popover.tsx`'s own doc comment
  admitted it: *"the same click-outside pattern lives in user-widget.tsx"*.
  Now `useDismissOnOutside`, which documents the two subtleties the copies
  happened to get right rather than leaving them to be rediscovered a fifth
  time: `mousedown` rather than `click`, and binding on open so the click
  that opened the surface can't race-trigger a dismiss.
- **The peek panel shell — 2 copies.** Identical `aside` element and
  `PanelHeader`, differing only in href, aria-label and stacking. Now
  `PeekPanel`, which also absorbs the byte-identical `PanelFooterField`.
  `Section` is left alone deliberately — the two versions differ in spacing,
  heading color and a `tone` variant, so folding them would be a visual
  change, not a refactor.
- **Copy-to-clipboard — 4 copies, and a latent bug.** All four wrote the same
  flash-then-reset and then disagreed on everything that matters.
  `navigator.clipboard` is undefined on non-secure origins:
  `command-block.tsx` checked for it, `click-to-copy-id.tsx` did not, so
  clicking the id chip over plain HTTP raised an unhandled rejection instead
  of doing nothing. Two of four caught a rejected write; two didn't. None
  cleared the timer on unmount, so dismissing a panel inside the 1.5s window
  set state on an unmounted component. `useCopyToClipboard` does all three.
  In practice the id chip is only reachable over https in deployment, so this
  is a latent bug removed, not a live incident.
- **The modal shell — 2 copies** (both invite dialogs). Now `ModalOverlay`.
  The z-index stays a prop: the two sit at z-50 and z-30 today, and raising
  the room dialog is a visual change this refactor shouldn't smuggle in.
- **The segmented tab bar — 2 copies.** Same `{id, label, hint}` shape and
  same markup down to the `text-[10px]` hint. Now `SegmentedTabs`, which
  also adds the `role="tablist"` / `aria-selected` neither copy had.

## 4. `core`/`api`/`web`: one implementation of the shared formatters 🐛

`api/src/views/format.ts` and `web/lib/format.ts` were parallel copies, each
carrying a comment pointing at the other and asking that they be kept in sync
by hand. The api file said it outright: *"Mirrors the logic in
packages/web/lib/format.ts … drift will surface as a mismatched short_id in
the URL."*

This is the sharpest version of the problem in the repo, because the drift is
silent and user-visible: `deriveShortId` decides both the `short_id` the api
serializes and the 6-char fragment the web puts in `/sessions/:short`.
Changing the regex or the slice length on one side fails no build and no
test — it produces links that 404.

Moved to `core`'s `domain/format.ts`, following the precedent `domain/xml.ts`
set in #259. Both format.ts files remain as thin re-export shims, so no call
site in either package changes.

The relative-time ladder was duplicated in a way that reads as different
code: `formatRelativeShort` returns "2m" for the wire, `formatRelativeTime`
returns "2m ago" for prose — same six thresholds, written out twice. Now one
`formatRelative(date, {suffix})`, each package keeping its exported name and
output. `formatDurationLabel` had genuinely diverged: web's coerced its args
through `toDate` (surviving the JSON string form of a `Date`), api's took
`Date` only. The shared one keeps the coercing version, which is strictly
more permissive.

**Imported via `@beevibe/core/domain/format`, not the package root.** The
root barrel re-exports `./auth`, which reaches for `node:crypto` and
`node:util`. The rest of the web app gets away with importing the root
because those are all `import type` and erase at compile time; this is the
first runtime *value* the web pulls out of core, and going through the root
fails `next build` with `UnhandledSchemeError: Reading from "node:crypto" is
not handled by plugins`. Hence the dedicated export subpath (4 lines in
core's `package.json`) and a note on the module saying why, so it doesn't get
"simplified" back to the root later.

## Tests

47 tests added, all against logic that was previously only exercised
indirectly through its call sites:

| File | Tests | Covers |
| --- | --- | --- |
| `daemon/event-batcher.test.ts` | 7 | threshold vs. interval flush, no re-send, timer cancellation, failed POST swallowed |
| `api/tools/errors.test.ts` | 7 | per-code envelope preservation, pg-style `code` not mistaken for a mesh code |
| `api/views/agent-display.test.ts` | 8 | runtime/model split + legacy default, count coercion from both column types |
| `web/lib/hooks/use-dismiss.test.tsx` | 6 | inside vs. outside mousedown, Escape/onEscape split, disabled and unmounted |
| `web/lib/hooks/use-copy-to-clipboard.test.tsx` | 6 | missing clipboard, rejected write, timer cleanup on unmount |
| `core/domain/format.test.ts` | 14 | every branch of both ladders, both suffix modes, invalid-date paths |

One of the format tests pins something worth knowing: months are 30-day
buckets, so the relative label rolls to "1y" at 360 days, not 365. That was
true of both copies before and is unchanged — now it's written down.

## Verification

CI green on all three checks — Sign-off, Build/Typecheck/Lint, and Unit +
Integration Tests. The CI test job runs against a real Postgres, so the
DB-gated suites that can't run in a bare sandbox are covered there.

Locally: `pnpm typecheck` 9/9 clean; `pnpm lint` 9/9 with 0 errors (only
pre-existing warnings); `next build` succeeds from a cleared `.next`; core
453 pass, web 22 files / 192 tests, daemon 29 pass — the remaining local
failures are the Docker/provider-key baseline documented in CLAUDE.md.

## Deliberately not done

Noted while surveying, left for a follow-up:

- **Test fixtures.** `makeAgent` / `makeSession` are re-declared ~7 times
  each across core, api and scheduler. Real duplication, but per-suite
  fixtures diverge on purpose often enough that collapsing them needs its own
  judgment call.
- **`Section` in the two peek panels** — visually divergent, see above.
- **The `{content: {error, message}, isError: true}` literal** is still
  written inline in ~5 other tool modules. `toolError` is now there for them;
  converting the rest is mechanical churn better done when those files are
  touched anyway.
- **`routes/chat.ts`'s error handler** still diverges from the other five, as
  #259 noted. Chat's treatment (generic message + `request_id`, detail kept
  server-side) remains the safer one.