### PR TITLE
Add comprehensive test coverage for core services and domain

### DIFF
--- a/packages/core/src/adapters/claude-code/spawn.test.ts
+++ b/packages/core/src/adapters/claude-code/spawn.test.ts
@@ -170,3 +170,126 @@ describe("runCliProcess", () => {
     },
   );
 });
+
+// The onLog fast path calls callbacks directly and only switches to a
+// serial Promise chain once one actually returns a thenable. Both modes
+// must swallow callback failures — a broken log consumer must never take
+// the session down — and the async mode must preserve chunk order.
+describe("runCliProcess — onLog delivery", () => {
+  const emit = (script: string) => ({
+    command: process.execPath,
+    args: ["-e", script],
+    cwd: process.cwd(),
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "delivers stdout and stderr chunks with their stream kind",
+    async () => {
+      const seen: Array<[string, string]> = [];
+      const result = await runCliProcess({
+        ...emit("process.stdout.write('out'); process.stderr.write('err');"),
+        onLog: (kind, text) => {
+          seen.push([kind, text]);
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(seen.some(([k, t]) => k === "stdout" && t.includes("out"))).toBe(true);
+      expect(seen.some(([k, t]) => k === "stderr" && t.includes("err"))).toBe(true);
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "survives a synchronous onLog that throws",
+    async () => {
+      let calls = 0;
+      const result = await runCliProcess({
+        ...emit(
+          "for (let i = 0; i < 3; i++) process.stdout.write('chunk' + i + '\\n');",
+        ),
+        onLog: () => {
+          calls++;
+          throw new Error("consumer exploded");
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(calls).toBeGreaterThan(0);
+      expect(result.stdout).toContain("chunk0");
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "switches to async mode on a thenable and preserves chunk order",
+    async () => {
+      const order: string[] = [];
+      const result = await runCliProcess({
+        ...emit(
+          // Space the writes out so they arrive as distinct 'data' events.
+          "let i = 0; const t = setInterval(() => { process.stdout.write('c' + i + '\\n'); if (++i === 4) clearInterval(t); }, 20);",
+        ),
+        onLog: async (_kind, text) => {
+          // Descending delay: if delivery weren't serialised, later chunks
+          // would resolve first and `order` would come out shuffled.
+          const n = Number(text.trim().replace("c", "")) || 0;
+          await new Promise((r) => setTimeout(r, (4 - n) * 5));
+          order.push(text.trim());
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      // The first chunk goes through the sync path (nothing to await yet);
+      // every chunk after it is serialised through the chain. Needs >1
+      // delivery for the ordering claim to mean anything.
+      expect(order.length).toBeGreaterThan(1);
+      expect(order).toEqual([...order].sort());
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "survives an onLog whose promise rejects",
+    async () => {
+      const result = await runCliProcess({
+        ...emit(
+          "let i = 0; const t = setInterval(() => { process.stdout.write('c' + i + '\\n'); if (++i === 3) clearInterval(t); }, 20);",
+        ),
+        onLog: async () => {
+          throw new Error("async consumer exploded");
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("c0");
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "survives an onLog that throws only after switching to async mode",
+    async () => {
+      let calls = 0;
+      const result = await runCliProcess({
+        ...emit(
+          "let i = 0; const t = setInterval(() => { process.stdout.write('c' + i + '\\n'); if (++i === 3) clearInterval(t); }, 20);",
+        ),
+        onLog: (_kind, text) => {
+          calls++;
+          // First call returns a thenable (flips asyncMode on); later calls
+          // throw synchronously from inside the chain.
+          if (calls === 1) return Promise.resolve();
+          throw new Error(`sync throw inside chain for ${text}`);
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(calls).toBeGreaterThan(1);
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "runs with no onLog configured at all",
+    async () => {
+      const result = await runCliProcess(emit("process.stdout.write('quiet');"));
+      expect(result.stdout).toContain("quiet");
+    },
+  );
+});

--- a/packages/core/src/adapters/claude-code/stream-json.test.ts
+++ b/packages/core/src/adapters/claude-code/stream-json.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  bareCliExitMessage,
   extractStepEvents,
+  isBareCliExitMessage,
   parseClaudeStreamJson,
   parseStreamJsonLine,
   type StreamJsonMessage,
@@ -100,6 +102,102 @@ describe("extractStepEvents", () => {
     });
     expect(step?.kind).toBe("tool_result");
     expect(step?.description).toBe("file contents line 1 line 2");
+  });
+
+  it("surfaces the new agent's name for the create_subordinate_agent shape", () => {
+    // `name` isn't in PREFERRED_INPUT_FIELDS, so this shape needs the
+    // name+persona special case to avoid rendering as raw JSON.
+    const step = firstStep({
+      type: "tool_use",
+      name: "create_subordinate_agent",
+      input: { name: "Backend IC", persona: "I write Go services.", hierarchy_level: "ic" },
+    });
+    expect(step?.description).toBe("Backend IC");
+  });
+
+  it("ignores the name+persona case when persona is absent", () => {
+    const step = firstStep({
+      type: "tool_use",
+      name: "SomeTool",
+      input: { name: "Backend IC", other: 1 },
+    });
+    expect(step?.description).toContain("Backend IC");
+    expect(step?.description).toContain("other");
+  });
+
+  it("emits one step per block for an assistant message with text + tool_use", () => {
+    const steps = extractStepEvents({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me look at that file." },
+          { type: "tool_use", id: "tu_1", name: "Read", input: { file_path: "/src/a.ts" } },
+        ],
+      },
+    });
+
+    expect(steps).toHaveLength(2);
+    expect(steps[0]).toMatchObject({
+      kind: "agent",
+      description: "Let me look at that file.",
+    });
+    expect(steps[1]).toMatchObject({
+      kind: "tool_call",
+      tool: "Read",
+      description: "/src/a.ts",
+    });
+  });
+
+  it("drops whitespace-only assistant text blocks", () => {
+    const steps = extractStepEvents({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "text", text: "   \n  " },
+          { type: "text", text: "real content" },
+        ],
+      },
+    });
+
+    expect(steps).toHaveLength(1);
+    expect(steps[0]?.description).toBe("real content");
+  });
+
+  it("skips thinking blocks in an assistant message", () => {
+    const steps = extractStepEvents({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "hmm", signature: "sig" }],
+      },
+    });
+
+    expect(steps).toEqual([]);
+  });
+
+  it("labels an assistant tool_use block with no name as 'unknown'", () => {
+    const steps = extractStepEvents({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "tu_1", input: { command: "ls" } }],
+      },
+    });
+
+    expect(steps[0]).toMatchObject({ kind: "tool_call", tool: "unknown", description: "ls" });
+  });
+
+  it("returns no steps for an assistant message whose content is a bare string", () => {
+    // The step feed only understands the block form; the string form is
+    // still picked up by parseClaudeStreamJson for the transcript.
+    expect(
+      extractStepEvents({
+        type: "assistant",
+        message: { role: "assistant", content: "plain" },
+      }),
+    ).toEqual([]);
   });
 
   it("tags tool_result with [error] prefix when is_error is true", () => {
@@ -234,5 +332,90 @@ describe("parseClaudeStreamJson", () => {
     const result = parseClaudeStreamJson(stream, 0);
     expect(result.transcript).toContain("[tool_result]");
     expect(result.transcript).not.toContain("from");
+  });
+
+  it("handles a string-valued assistant message content", () => {
+    // Older CLI builds emit `content` as a bare string rather than blocks.
+    const stream = JSON.stringify({
+      type: "assistant",
+      message: { role: "assistant", content: "plain string answer" },
+    });
+    const result = parseClaudeStreamJson(stream, 0);
+    expect(result.output).toBe("plain string answer");
+    expect(result.transcript).toContain("[assistant] plain string answer");
+  });
+
+  it("names the tool but omits the payload when a tool_result has no string content", () => {
+    // The tool_use_id → name map is built from assistant content blocks,
+    // so the tool_use has to arrive that way for the name to resolve.
+    const stream = [
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "tu_9", name: "Grep", input: { pattern: "x" } }],
+        },
+      }),
+      JSON.stringify({ type: "tool_result", tool_use_id: "tu_9", content: { rows: 3 } }),
+    ].join("\n");
+    const result = parseClaudeStreamJson(stream, 0);
+    expect(result.transcript).toContain("[tool_result from Grep]");
+    expect(result.transcript).not.toContain("rows");
+  });
+
+  it("records a top-level tool_use with no name as 'unknown'", () => {
+    const stream = JSON.stringify({ type: "tool_use", input: { file_path: "/a" } });
+    const result = parseClaudeStreamJson(stream, 0);
+    expect(result.transcript).toContain("[tool_call] unknown");
+  });
+
+  it("keeps thinking blocks out of the transcript", () => {
+    const stream = JSON.stringify({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "secret reasoning", signature: "sig" },
+          { type: "text", text: "visible answer" },
+        ],
+      },
+    });
+    const result = parseClaudeStreamJson(stream, 0);
+    expect(result.transcript).not.toContain("secret reasoning");
+    expect(result.output).toBe("visible answer");
+  });
+});
+
+describe("isBareCliExitMessage", () => {
+  it("matches the strings bareCliExitMessage produces", () => {
+    for (const code of [0, 1, 2, 137, -1, null]) {
+      expect(isBareCliExitMessage(bareCliExitMessage(code))).toBe(true);
+    }
+  });
+
+  it("rejects a real diagnostic that merely mentions an exit code", () => {
+    // The point of the predicate is to tell "we have nothing useful" apart
+    // from "we have a real error", so near-misses must not match.
+    expect(isBareCliExitMessage("CLI exited with code 1: OOM killed")).toBe(false);
+    expect(isBareCliExitMessage("claude: CLI exited with code 1")).toBe(false);
+    expect(isBareCliExitMessage("CLI exited with code")).toBe(false);
+    expect(isBareCliExitMessage("CLI exited with code abc")).toBe(false);
+    expect(isBareCliExitMessage("")).toBe(false);
+    expect(isBareCliExitMessage("Session completed.")).toBe(false);
+  });
+
+  it("flags the output parseClaudeStreamJson emits for an empty failed run", () => {
+    const result = parseClaudeStreamJson("", 2);
+    expect(isBareCliExitMessage(result.output)).toBe(true);
+  });
+
+  it("does not flag the output of a run that produced real text", () => {
+    const stream = JSON.stringify({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: "done" }] },
+    });
+    expect(isBareCliExitMessage(parseClaudeStreamJson(stream, 1).output)).toBe(
+      false,
+    );
   });
 });

--- a/packages/core/src/adapters/codex/stream-json.test.ts
+++ b/packages/core/src/adapters/codex/stream-json.test.ts
@@ -147,6 +147,110 @@ describe("extractCodexStepEvents", () => {
     });
     expect(steps[0]!.description).toBe("/repo/src/foo.ts");
   });
+
+  it("summarizes a file_change item as 'kind path' pairs", () => {
+    const steps = extractCodexStepEvents({
+      type: CODEX_EVENT_TYPE.ItemCompleted,
+      item: {
+        id: "item_6",
+        type: CODEX_ITEM_TYPE.FileChange,
+        changes: [
+          { kind: "add", path: "src/new.ts" },
+          { kind: "update", path: "src/old.ts" },
+        ],
+      },
+    });
+    expect(steps).toEqual([
+      expect.objectContaining({
+        kind: "tool_result",
+        tool: "file_change",
+        description: "add src/new.ts, update src/old.ts",
+      }),
+    ]);
+  });
+
+  it("emits a file_change tool_call while the edit is still in flight", () => {
+    const steps = extractCodexStepEvents({
+      type: CODEX_EVENT_TYPE.ItemStarted,
+      item: {
+        id: "item_6",
+        type: CODEX_ITEM_TYPE.FileChange,
+        changes: [{ kind: "delete", path: "src/gone.ts" }],
+      },
+    });
+    expect(steps[0]).toMatchObject({ kind: "tool_call", tool: "file_change" });
+  });
+
+  it("tolerates a file_change item with missing changes / partial entries", () => {
+    expect(
+      extractCodexStepEvents({
+        type: CODEX_EVENT_TYPE.ItemCompleted,
+        item: { id: "item_6", type: CODEX_ITEM_TYPE.FileChange },
+      })[0]!.description,
+    ).toBe("");
+
+    expect(
+      extractCodexStepEvents({
+        type: CODEX_EVENT_TYPE.ItemCompleted,
+        item: { id: "item_6", type: CODEX_ITEM_TYPE.FileChange, changes: [{}] },
+      })[0]!.description,
+    ).toBe("? ");
+  });
+
+  it("truncates a long file_change summary to 200 chars", () => {
+    const changes = Array.from({ length: 40 }, (_, i) => ({
+      kind: "update",
+      path: `src/some/long/path/file-${i}.ts`,
+    }));
+    const steps = extractCodexStepEvents({
+      type: CODEX_EVENT_TYPE.ItemCompleted,
+      item: { id: "item_6", type: CODEX_ITEM_TYPE.FileChange, changes },
+    });
+    expect(steps[0]!.description).toHaveLength(200);
+  });
+
+  it("emits a web_search step carrying the query", () => {
+    const started = extractCodexStepEvents({
+      type: CODEX_EVENT_TYPE.ItemStarted,
+      item: {
+        id: "item_7",
+        type: CODEX_ITEM_TYPE.WebSearch,
+        query: "vitest coverage v8",
+      },
+    });
+    expect(started).toEqual([
+      expect.objectContaining({
+        kind: "tool_call",
+        tool: "web_search",
+        description: "vitest coverage v8",
+      }),
+    ]);
+
+    const completed = extractCodexStepEvents({
+      type: CODEX_EVENT_TYPE.ItemCompleted,
+      item: { id: "item_7", type: CODEX_ITEM_TYPE.WebSearch, query: "q" },
+    });
+    expect(completed[0]).toMatchObject({ kind: "tool_result", tool: "web_search" });
+  });
+
+  it("tolerates a web_search item with no query", () => {
+    const steps = extractCodexStepEvents({
+      type: CODEX_EVENT_TYPE.ItemStarted,
+      item: { id: "item_7", type: CODEX_ITEM_TYPE.WebSearch },
+    });
+    expect(steps[0]!.description).toBe("");
+  });
+
+  it("skips item types with no step representation", () => {
+    for (const type of [CODEX_ITEM_TYPE.TodoList, CODEX_ITEM_TYPE.CollabToolCall]) {
+      expect(
+        extractCodexStepEvents({
+          type: CODEX_EVENT_TYPE.ItemCompleted,
+          item: { id: "item_8", type },
+        }),
+      ).toEqual([]);
+    }
+  });
 });
 
 describe("parseCodexEvents", () => {
@@ -220,5 +324,138 @@ describe("parseCodexEvents", () => {
     expect(result.transcript).toContain("[tool_call] create_task");
     expect(result.transcript).toContain("[tool_result from create_task] task_abc");
     expect(result.transcript).toContain("[assistant] Here is the fix.");
+  });
+
+  it("prefers an mcp_tool_call's error message over its result summary", () => {
+    const result = parseCodexEvents(
+      [
+        {
+          type: CODEX_EVENT_TYPE.ItemCompleted,
+          item: {
+            id: "item_t1",
+            type: CODEX_ITEM_TYPE.McpToolCall,
+            tool: "create_task",
+            result: { content: [{ type: "text", text: "ignored" }] },
+            error: { message: "assignee not found" },
+          },
+        },
+      ],
+      0,
+      "",
+    );
+    expect(result.transcript).toContain("[tool_result from create_task] assignee not found");
+    expect(result.transcript).not.toContain("ignored");
+  });
+
+  it("emits no tool_result line for an mcp_tool_call with neither result nor error", () => {
+    const result = parseCodexEvents(
+      [
+        {
+          type: CODEX_EVENT_TYPE.ItemCompleted,
+          item: { id: "item_t1", type: CODEX_ITEM_TYPE.McpToolCall, tool: "ping" },
+        },
+      ],
+      0,
+      "",
+    );
+    expect(result.transcript).toContain("[tool_call] ping");
+    expect(result.transcript).not.toContain("[tool_result");
+  });
+
+  it("falls back to a JSON snippet when the MCP result carries no text block", () => {
+    const result = parseCodexEvents(
+      [
+        {
+          type: CODEX_EVENT_TYPE.ItemCompleted,
+          item: {
+            id: "item_t1",
+            type: CODEX_ITEM_TYPE.McpToolCall,
+            tool: "screenshot",
+            result: { content: [{ type: "image", data: "base64blob" }] },
+          },
+        },
+      ],
+      0,
+      "",
+    );
+    expect(result.transcript).toContain("[tool_result from screenshot]");
+    expect(result.transcript).toContain('"type":"image"');
+  });
+
+  it("labels an mcp_tool_call with no tool name as 'unknown'", () => {
+    const result = parseCodexEvents(
+      [
+        {
+          type: CODEX_EVENT_TYPE.ItemCompleted,
+          item: { id: "item_t1", type: CODEX_ITEM_TYPE.McpToolCall },
+        },
+      ],
+      0,
+      "",
+    );
+    expect(result.transcript).toContain("[tool_call] unknown");
+  });
+
+  it("records a shell command and its aggregated output in the transcript", () => {
+    const result = parseCodexEvents(
+      [
+        {
+          type: CODEX_EVENT_TYPE.ItemCompleted,
+          item: {
+            id: "item_c1",
+            type: CODEX_ITEM_TYPE.CommandExecution,
+            command: "pnpm test",
+            aggregated_output: "line one\nline two",
+            exit_code: 0,
+          },
+        },
+      ],
+      0,
+      "",
+    );
+    expect(result.transcript).toContain("[tool_call] shell pnpm test");
+    // Newlines are flattened so one transcript line stays one line.
+    expect(result.transcript).toContain("[tool_result from shell] line one line two");
+  });
+
+  it("omits the shell tool_result line when the command produced no output", () => {
+    const result = parseCodexEvents(
+      [
+        {
+          type: CODEX_EVENT_TYPE.ItemCompleted,
+          item: {
+            id: "item_c1",
+            type: CODEX_ITEM_TYPE.CommandExecution,
+            command: "true",
+          },
+        },
+      ],
+      0,
+      "",
+    );
+    expect(result.transcript).toContain("[tool_call] shell true");
+    expect(result.transcript).not.toContain("[tool_result from shell]");
+  });
+
+  it("keeps item.started events out of the persisted transcript", () => {
+    // Only completions are persisted; a stream of nothing but item.started
+    // leaves no transcript at all rather than a half-written one.
+    const started = {
+      type: CODEX_EVENT_TYPE.ItemStarted,
+      item: {
+        id: "item_c1",
+        type: CODEX_ITEM_TYPE.CommandExecution,
+        command: "pnpm build",
+      },
+    };
+    expect(parseCodexEvents([started], 0, "").transcript).toBeUndefined();
+
+    const withCompletion = parseCodexEvents(
+      [started, { ...started, type: CODEX_EVENT_TYPE.ItemCompleted }],
+      0,
+      "",
+    );
+    // One entry, not two — the started event contributed nothing.
+    expect(withCompletion.transcript).toBe("[tool_call] shell pnpm build\n");
   });
 });

--- a/packages/core/src/domain/core-memory.test.ts
+++ b/packages/core/src/domain/core-memory.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { HIERARCHY_LEVELS } from "./agent.js";
+import {
+  DEFAULT_BLOCK_TEMPLATES,
+  ROUTING_BLOCKS,
+  TOTAL_BLOCK_CHAR_LIMIT,
+} from "./core-memory.js";
+
+/**
+ * `DEFAULT_BLOCK_TEMPLATES` is the source of truth for block descriptions:
+ * `coreMemoryRepo.initDefaults` seeds new agents from it, `pnpm
+ * sync-core-memory` back-fills existing ones, and the MCP tool definitions
+ * echo the same descriptions to the agent. Drift here is silent — nothing
+ * type-checks a block name against the templates — so these are consistency
+ * assertions, not restatements of the data.
+ */
+describe("DEFAULT_BLOCK_TEMPLATES", () => {
+  it("covers every hierarchy level", () => {
+    for (const level of HIERARCHY_LEVELS) {
+      expect(DEFAULT_BLOCK_TEMPLATES[level].length).toBeGreaterThan(0);
+    }
+    expect(Object.keys(DEFAULT_BLOCK_TEMPLATES).sort()).toEqual(
+      [...HIERARCHY_LEVELS].sort(),
+    );
+  });
+
+  it("has unique block names within each level", () => {
+    for (const level of HIERARCHY_LEVELS) {
+      const names = DEFAULT_BLOCK_TEMPLATES[level].map((t) => t.block_name);
+      expect(new Set(names).size).toBe(names.length);
+    }
+  });
+
+  it("gives every block a positive char_limit and a non-empty description", () => {
+    for (const level of HIERARCHY_LEVELS) {
+      for (const t of DEFAULT_BLOCK_TEMPLATES[level]) {
+        expect(t.block_name).not.toBe("");
+        expect(t.char_limit).toBeGreaterThan(0);
+        expect(t.description.trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("seeds initial_content that fits inside the block's own char_limit", () => {
+    // initDefaults writes initial_content straight through; a template that
+    // over-fills its own limit would break agent creation on the first write.
+    for (const level of HIERARCHY_LEVELS) {
+      for (const t of DEFAULT_BLOCK_TEMPLATES[level]) {
+        expect(t.initial_content.length).toBeLessThanOrEqual(t.char_limit);
+      }
+    }
+  });
+
+  it("keeps each level's total char budget under TOTAL_BLOCK_CHAR_LIMIT", () => {
+    for (const level of HIERARCHY_LEVELS) {
+      const total = DEFAULT_BLOCK_TEMPLATES[level].reduce(
+        (sum, t) => sum + t.char_limit,
+        0,
+      );
+      expect(total).toBeLessThanOrEqual(TOTAL_BLOCK_CHAR_LIMIT);
+    }
+  });
+
+  it("gives every level a tag_line and a persona block", () => {
+    // The agent cards in the web UI read tag_line; every briefing reads persona.
+    for (const level of HIERARCHY_LEVELS) {
+      const names = DEFAULT_BLOCK_TEMPLATES[level].map((t) => t.block_name);
+      expect(names).toContain("tag_line");
+      expect(names).toContain("persona");
+    }
+  });
+
+  it("caps tag_line at 100 chars on every level (the UI card width)", () => {
+    for (const level of HIERARCHY_LEVELS) {
+      const tagLine = DEFAULT_BLOCK_TEMPLATES[level].find(
+        (t) => t.block_name === "tag_line",
+      );
+      expect(tagLine?.char_limit).toBe(100);
+    }
+  });
+
+  it("marks every default block is_system", () => {
+    for (const level of HIERARCHY_LEVELS) {
+      for (const t of DEFAULT_BLOCK_TEMPLATES[level]) {
+        expect(t.is_system).toBe(true);
+      }
+    }
+  });
+});
+
+describe("ROUTING_BLOCKS", () => {
+  it("covers every hierarchy level", () => {
+    expect(Object.keys(ROUTING_BLOCKS).sort()).toEqual(
+      [...HIERARCHY_LEVELS].sort(),
+    );
+  });
+
+  it("only names blocks that the same level actually seeds", () => {
+    // Routing reads these by name; a typo or a renamed template would make
+    // the routing prompt silently consult nothing.
+    for (const level of HIERARCHY_LEVELS) {
+      const seeded = new Set(
+        DEFAULT_BLOCK_TEMPLATES[level].map((t) => t.block_name),
+      );
+      for (const name of ROUTING_BLOCKS[level]) {
+        expect(seeded.has(name)).toBe(true);
+      }
+    }
+  });
+
+  it("consults persona on every level and lists no duplicates", () => {
+    for (const level of HIERARCHY_LEVELS) {
+      const blocks = ROUTING_BLOCKS[level];
+      expect(blocks).toContain("persona");
+      expect(new Set(blocks).size).toBe(blocks.length);
+    }
+  });
+});

--- a/packages/core/src/domain/memory.test.ts
+++ b/packages/core/src/domain/memory.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { HIERARCHY_LEVELS, type HierarchyLevel } from "./agent.js";
+import {
+  FACT_TYPES,
+  FACT_TYPE_DESCRIPTIONS,
+  MEMORY_SCOPES,
+  hierarchyToScope,
+} from "./memory.js";
+
+describe("hierarchyToScope", () => {
+  it("maps every hierarchy level to a valid memory scope", () => {
+    for (const level of HIERARCHY_LEVELS) {
+      expect(MEMORY_SCOPES).toContain(hierarchyToScope(level));
+    }
+  });
+
+  it("is an identity mapping today", () => {
+    // The helper exists so the two nominal types can diverge later; until
+    // they do, the values must stay in lockstep or the cast is a lie.
+    expect([...MEMORY_SCOPES].sort()).toEqual([...HIERARCHY_LEVELS].sort());
+    for (const level of HIERARCHY_LEVELS) {
+      expect(hierarchyToScope(level)).toBe(level);
+    }
+  });
+
+  it("does not invent a scope for an unlisted level", () => {
+    // Guards the day someone adds a HierarchyLevel without extending
+    // MemoryScope: the cast would silently produce an unknown scope.
+    expect(MEMORY_SCOPES).toContain(hierarchyToScope("ic" as HierarchyLevel));
+  });
+});
+
+describe("FACT_TYPE_DESCRIPTIONS", () => {
+  it("describes every fact type exactly once", () => {
+    // The `save_memory` tool builds its `fact_type` enum from FACT_TYPES and
+    // its per-value guidance from this record — a missing key ships an enum
+    // value with no guidance, which is how #90's over-saving started.
+    expect(Object.keys(FACT_TYPE_DESCRIPTIONS).sort()).toEqual(
+      [...FACT_TYPES].sort(),
+    );
+  });
+
+  it("has no empty guidance", () => {
+    for (const type of FACT_TYPES) {
+      expect(FACT_TYPE_DESCRIPTIONS[type].trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("lists each fact type only once", () => {
+    expect(new Set(FACT_TYPES).size).toBe(FACT_TYPES.length);
+  });
+});

--- a/packages/core/src/domain/session-search.test.ts
+++ b/packages/core/src/domain/session-search.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  lineageKey,
+  parseUserMessageId,
+  userMessageId,
+} from "./session-search.js";
+
+describe("lineageKey", () => {
+  it("uses conversation_id when the session belongs to a chat thread", () => {
+    expect(lineageKey({ id: "sess_tail", conversation_id: "sess_head" })).toBe(
+      "sess_head",
+    );
+  });
+
+  it("falls back to the session id when conversation_id is null", () => {
+    expect(lineageKey({ id: "sess_task", conversation_id: null })).toBe(
+      "sess_task",
+    );
+  });
+
+  it("groups every turn of one chat thread under the same key", () => {
+    const head = { id: "sess_head", conversation_id: "sess_head" };
+    const tail = { id: "sess_tail", conversation_id: "sess_head" };
+    expect(lineageKey(head)).toBe(lineageKey(tail));
+  });
+});
+
+describe("userMessageId / parseUserMessageId", () => {
+  it("round-trips a session id through the intent: marker", () => {
+    const id = userMessageId("sess_abc");
+    expect(id).toBe("intent:sess_abc");
+    expect(parseUserMessageId(id)).toBe("sess_abc");
+  });
+
+  it("returns null for session_event row ids", () => {
+    expect(parseUserMessageId("evt_123")).toBeNull();
+  });
+
+  it("returns null when the marker is not at the start", () => {
+    expect(parseUserMessageId("evt_intent:sess_abc")).toBeNull();
+  });
+
+  it("returns an empty session id rather than null for a bare marker", () => {
+    // scroll() passes this straight to the repo, which finds no row — the
+    // parse step deliberately does not second-guess the caller.
+    expect(parseUserMessageId("intent:")).toBe("");
+  });
+});

--- a/packages/core/src/domain/session.test.ts
+++ b/packages/core/src/domain/session.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  IN_FLIGHT_SESSION_STATUSES,
+  SESSION_STATUSES,
+  SESSION_TYPES,
+  TERMINAL_SESSION_STATUSES,
+  isInFlightSessionStatus,
+  isTerminalSessionStatus,
+} from "./session.js";
+
+describe("isTerminalSessionStatus", () => {
+  it("accepts every terminal status", () => {
+    for (const s of TERMINAL_SESSION_STATUSES) {
+      expect(isTerminalSessionStatus(s)).toBe(true);
+    }
+  });
+
+  it("rejects pre-terminal statuses", () => {
+    expect(isTerminalSessionStatus("pending")).toBe(false);
+    expect(isTerminalSessionStatus("running")).toBe(false);
+  });
+
+  it("rejects non-status strings and non-strings", () => {
+    // `/runtime/done` validates untrusted request bodies through this guard,
+    // so the non-string cases are the ones that actually matter.
+    expect(isTerminalSessionStatus("succeeded ")).toBe(false);
+    expect(isTerminalSessionStatus("SUCCEEDED")).toBe(false);
+    expect(isTerminalSessionStatus("")).toBe(false);
+    expect(isTerminalSessionStatus(undefined)).toBe(false);
+    expect(isTerminalSessionStatus(null)).toBe(false);
+    expect(isTerminalSessionStatus(0)).toBe(false);
+    expect(isTerminalSessionStatus(["succeeded"])).toBe(false);
+    expect(isTerminalSessionStatus({ status: "succeeded" })).toBe(false);
+  });
+});
+
+describe("isInFlightSessionStatus", () => {
+  it("accepts every in-flight status", () => {
+    for (const s of IN_FLIGHT_SESSION_STATUSES) {
+      expect(isInFlightSessionStatus(s)).toBe(true);
+    }
+  });
+
+  it("rejects terminal statuses", () => {
+    for (const s of TERMINAL_SESSION_STATUSES) {
+      expect(isInFlightSessionStatus(s)).toBe(false);
+    }
+  });
+
+  it("rejects non-status strings and non-strings", () => {
+    expect(isInFlightSessionStatus("run")).toBe(false);
+    expect(isInFlightSessionStatus(null)).toBe(false);
+    expect(isInFlightSessionStatus(7)).toBe(false);
+  });
+});
+
+describe("session status constants", () => {
+  it("terminal + in-flight partition the full status set", () => {
+    const union = [
+      ...TERMINAL_SESSION_STATUSES,
+      ...IN_FLIGHT_SESSION_STATUSES,
+    ].sort();
+    expect(union).toEqual([...SESSION_STATUSES].sort());
+  });
+
+  it("terminal and in-flight sets are disjoint", () => {
+    const terminal = new Set<string>(TERMINAL_SESSION_STATUSES);
+    for (const s of IN_FLIGHT_SESSION_STATUSES) {
+      expect(terminal.has(s)).toBe(false);
+    }
+  });
+
+  it("exposes each session type exactly once", () => {
+    expect(new Set(SESSION_TYPES).size).toBe(SESSION_TYPES.length);
+    expect(SESSION_TYPES).toContain("task");
+    expect(SESSION_TYPES).toContain("chat");
+  });
+});

--- a/packages/core/src/services/agent-session.test.ts
+++ b/packages/core/src/services/agent-session.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Agent } from "../domain/agent.js";
 import type { Session } from "../domain/session.js";
 import type { AgentRepository } from "../ports/agent-repo.js";
@@ -541,6 +541,294 @@ describe("AgentSession.run", () => {
       "hook blew up",
     );
     errSpy.mockRestore();
+  });
+});
+
+// ── The post-Phase-4 claim path + the best-effort side channels ──────────
+
+describe("AgentSession.run — pre-inserted session row (daemon claim path)", () => {
+  beforeEach(() => {
+    vi.mocked(agentRepo.findById).mockResolvedValue(makeAgent());
+    vi.mocked(memoryAgent.prepareBriefing).mockResolvedValue({
+      systemPromptAppend: "",
+      userMessagePrefix: "",
+      snapshot: { block_count: 0, fact_count: 0, token_count: 0, blocks: [], facts: [] },
+    });
+    vi.mocked(runtime.execute).mockResolvedValue(makeRuntimeResult());
+    vi.mocked(sessionRepo.update).mockImplementation(async (id, patch) =>
+      makeSession(id, patch as Partial<Session>),
+    );
+  });
+
+  it("reuses an existing row and only stamps workspace_path", async () => {
+    // dispatchService already inserted the row at status='pending' and the
+    // worker promoted it to 'running'; re-INSERTing would violate the PK.
+    vi.mocked(sessionRepo.findById).mockResolvedValue(makeSession("sess_claimed"));
+
+    await service.run({
+      agentId: "agent_1",
+      intent: "x",
+      workspace: WORKSPACE,
+      sessionId: "sess_claimed",
+      taskId: "task_1",
+    });
+
+    expect(sessionRepo.create).not.toHaveBeenCalled();
+    expect(sessionRepo.update).toHaveBeenCalledWith("sess_claimed", {
+      workspace_path: "/tmp/ws",
+    });
+    expect(vi.mocked(runtime.execute).mock.calls[0]![0].env).toMatchObject({
+      BEEVIBE_SESSION_ID: "sess_claimed",
+    });
+  });
+
+  it("inserts under the caller's id when the row doesn't exist yet (mesh round 1)", async () => {
+    vi.mocked(sessionRepo.findById).mockResolvedValue(undefined);
+    vi.mocked(sessionRepo.create).mockImplementation(async (i) => makeSession(i.id));
+
+    await service.run({
+      agentId: "agent_1",
+      intent: "x",
+      workspace: WORKSPACE,
+      sessionId: "sess_preassigned",
+    });
+
+    expect(sessionRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "sess_preassigned", status: "running" }),
+    );
+  });
+
+  it("stamps room_id only when the session was kicked off inside a room", async () => {
+    vi.mocked(sessionRepo.findById).mockResolvedValue(undefined);
+    vi.mocked(sessionRepo.create).mockImplementation(async (i) => makeSession(i.id));
+
+    await service.run({
+      agentId: "agent_1",
+      intent: "x",
+      workspace: WORKSPACE,
+      roomId: "room_1",
+    });
+    expect(sessionRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ room_id: "room_1" }),
+    );
+
+    vi.mocked(sessionRepo.create).mockClear();
+    await service.run({ agentId: "agent_1", intent: "x", workspace: WORKSPACE });
+    expect(vi.mocked(sessionRepo.create).mock.calls[0]![0]).not.toHaveProperty("room_id");
+  });
+});
+
+describe("AgentSession.run — best-effort side channels never fail the session", () => {
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.mocked(agentRepo.findById).mockResolvedValue(makeAgent());
+    vi.mocked(sessionRepo.create).mockImplementation(async (i) => makeSession(i.id));
+    vi.mocked(memoryAgent.prepareBriefing).mockResolvedValue({
+      systemPromptAppend: "",
+      userMessagePrefix: "",
+      snapshot: { block_count: 1, fact_count: 2, token_count: 3, blocks: [], facts: [] },
+    });
+    vi.mocked(runtime.execute).mockResolvedValue(makeRuntimeResult());
+    vi.mocked(sessionRepo.update).mockImplementation(async (id, patch) =>
+      makeSession(id, patch as Partial<Session>),
+    );
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it("persists the briefing snapshot, and survives that write failing", async () => {
+    vi.mocked(sessionRepo.update).mockImplementation(async (id, patch) => {
+      if ((patch as { briefing?: unknown }).briefing) throw new Error("audit table gone");
+      return makeSession(id, patch as Partial<Session>);
+    });
+
+    await expect(
+      service.run({ agentId: "agent_1", intent: "x", workspace: WORKSPACE }),
+    ).resolves.toBeDefined();
+
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining("failed to persist briefing"),
+      "audit table gone",
+    );
+    expect(runtime.execute).toHaveBeenCalled();
+  });
+
+  it("logs and continues when a session_event append rejects", async () => {
+    vi.mocked(sessionEventRepo.append).mockRejectedValue(new Error("event table gone"));
+    vi.mocked(runtime.execute).mockImplementation(async (ctx) => {
+      ctx.onStep?.({ kind: "tool_call", tool: "Read", description: "/a.ts", timestamp: "t" });
+      return makeRuntimeResult();
+    });
+
+    await expect(
+      service.run({ agentId: "agent_1", intent: "x", workspace: WORKSPACE }),
+    ).resolves.toBeDefined();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("session_event tool_call dropped"),
+      "event table gone",
+    );
+  });
+
+  it("tees every step into session_event AND the caller's onStep", async () => {
+    const callerOnStep = vi.fn();
+    vi.mocked(runtime.execute).mockImplementation(async (ctx) => {
+      ctx.onStep?.({ kind: "agent", description: "thinking", timestamp: "t" });
+      ctx.onStep?.({ kind: "tool_call", tool: "Bash", description: "ls", timestamp: "t" });
+      return makeRuntimeResult({ output: "" });
+    });
+
+    await service.run({
+      agentId: "agent_1",
+      intent: "x",
+      workspace: WORKSPACE,
+      onStep: callerOnStep,
+    });
+
+    expect(callerOnStep).toHaveBeenCalledTimes(2);
+    expect(sessionEventRepo.append).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "tool_call", content: "ls", tool_name: "Bash" }),
+    );
+  });
+
+  it("appends a summary event only when the run produced output", async () => {
+    vi.mocked(runtime.execute).mockResolvedValue(makeRuntimeResult({ output: "" }));
+
+    await service.run({ agentId: "agent_1", intent: "x", workspace: WORKSPACE });
+
+    expect(
+      vi.mocked(sessionEventRepo.append).mock.calls.filter(
+        (c) => c[0].kind === "summary",
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("logs and continues when the onSpawn pid write rejects", async () => {
+    vi.mocked(sessionRepo.update).mockImplementation(async (id, patch) => {
+      if ((patch as { process_pid?: number }).process_pid !== undefined) {
+        throw new Error("pid write failed");
+      }
+      return makeSession(id, patch as Partial<Session>);
+    });
+    vi.mocked(runtime.execute).mockImplementation(async (ctx) => {
+      ctx.onSpawn?.({ process_pid: 42, process_group_id: 42 });
+      return makeRuntimeResult({ process_pid: undefined, process_group_id: undefined });
+    });
+
+    await expect(
+      service.run({ agentId: "agent_1", intent: "x", workspace: WORKSPACE }),
+    ).resolves.toBeDefined();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(errSpy).toHaveBeenCalledWith(
+      "[AgentSession] onSpawn persist failed:",
+      "pid write failed",
+    );
+  });
+
+  it("logs and continues when post-session memory work rejects", async () => {
+    vi.mocked(memoryAgent.onTaskComplete).mockRejectedValue(new Error("promoter down"));
+
+    await expect(
+      service.run({ agentId: "agent_1", intent: "x", workspace: WORKSPACE }),
+    ).resolves.toBeDefined();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(errSpy).toHaveBeenCalledWith(
+      "[AgentSession] onTaskComplete failed:",
+      "promoter down",
+    );
+  });
+
+  it("logs a hook failure on the runtime-threw path without swallowing the original error", async () => {
+    const onSessionComplete = vi
+      .fn<NonNullable<AgentSessionDeps["onSessionComplete"]>>()
+      .mockRejectedValue(new Error("hook blew up"));
+    const svc = new AgentSession({
+      agentRepo,
+      sessionRepo,
+      sessionEventRepo,
+      runtime,
+      memoryAgent,
+      onSessionComplete,
+    });
+    vi.mocked(runtime.execute).mockRejectedValue(new Error("spawn ENOENT"));
+
+    await expect(
+      svc.run({ agentId: "agent_1", intent: "x", workspace: WORKSPACE }),
+    ).rejects.toThrow("spawn ENOENT");
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(errSpy).toHaveBeenCalledWith(
+      "[AgentSession] onSessionComplete (catch path) failed:",
+      "hook blew up",
+    );
+  });
+
+  it("skips the catch-path hook when skipOnComplete is set", async () => {
+    const onSessionComplete = vi
+      .fn<NonNullable<AgentSessionDeps["onSessionComplete"]>>()
+      .mockResolvedValue();
+    const svc = new AgentSession({
+      agentRepo,
+      sessionRepo,
+      sessionEventRepo,
+      runtime,
+      memoryAgent,
+      onSessionComplete,
+    });
+    vi.mocked(runtime.execute).mockRejectedValue(new Error("spawn ENOENT"));
+
+    await expect(
+      svc.run({
+        agentId: "agent_1",
+        intent: "x",
+        workspace: WORKSPACE,
+        skipOnComplete: true,
+      }),
+    ).rejects.toThrow("spawn ENOENT");
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(onSessionComplete).not.toHaveBeenCalled();
+  });
+
+  it("maps a gracefully-failed runtime result to status 'failed' with exit_code 1", async () => {
+    vi.mocked(runtime.execute).mockResolvedValue(
+      makeRuntimeResult({ status: "failed", output: "CLI exited with code 1" }),
+    );
+
+    const out = await service.run({
+      agentId: "agent_1",
+      intent: "x",
+      workspace: WORKSPACE,
+    });
+
+    expect(out.status).toBe("failed");
+    const patch = vi
+      .mocked(sessionRepo.update)
+      .mock.calls.find((c) => (c[1] as { status?: string }).status === "failed")![1];
+    expect(patch.exit_code).toBe(1);
+  });
+
+  it("threads extraSystemPromptAppend into the system prompt", async () => {
+    await service.run({
+      agentId: "agent_1",
+      intent: "x",
+      workspace: WORKSPACE,
+      extraSystemPromptAppend: "<room_context>members: A, B</room_context>",
+    });
+
+    expect(
+      vi.mocked(runtime.execute).mock.calls[0]![0].system_prompt_append,
+    ).toContain("<room_context>members: A, B</room_context>");
   });
 });
 

--- a/packages/core/src/services/escalation-service.test.ts
+++ b/packages/core/src/services/escalation-service.test.ts
@@ -10,6 +10,7 @@ import type {
   NegotiationRoundRepository,
 } from "../ports/negotiation-repo.js";
 import type { TaskRepository } from "../ports/task-repo.js";
+import type { DispatchService } from "./dispatch-service.js";
 import {
   EscalationNotFoundError,
   EscalationService,
@@ -212,6 +213,50 @@ describe("EscalationService.create", () => {
       svc.create({ negotiationId: "neg_missing", callerAgentId: "agent_a", summary: "x" }),
     ).rejects.toBeInstanceOf(NegotiationNotFoundError);
   });
+
+  it("rejects a negotiation that never started round 1 (no counterparty session)", async () => {
+    // The escalation row requires both session ids; escalating before the
+    // counterparty ever ran would write a half-formed row.
+    vi.mocked(negotiationRepo.findById).mockResolvedValue(
+      makeNeg({ counterparty_session_id: undefined }),
+    );
+    vi.mocked(escalationRepo.findByNegotiation).mockResolvedValue(undefined);
+
+    await expect(
+      svc.create({ negotiationId: "neg_1", callerAgentId: "agent_a", summary: "x" }),
+    ).rejects.toThrow(/no counterparty_session_id/);
+    expect(escalationRepo.create).not.toHaveBeenCalled();
+    expect(negotiationRepo.update).not.toHaveBeenCalled();
+  });
+
+  it("skips the task block when the negotiation isn't task-bound", async () => {
+    vi.mocked(negotiationRepo.findById).mockResolvedValue(
+      makeNeg({ task_id: undefined }),
+    );
+    vi.mocked(escalationRepo.findByNegotiation).mockResolvedValue(undefined);
+    vi.mocked(escalationRepo.create).mockImplementation(async (input) => makeEsc(input));
+    vi.mocked(escalationRepo.findById).mockResolvedValue(makeEsc());
+
+    await svc.create({ negotiationId: "neg_1", callerAgentId: "agent_a", summary: "x" });
+
+    expect(negotiationRepo.update).toHaveBeenCalledWith("neg_1", { status: "escalated" });
+    expect(taskRepo.update).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the created row when the post-update re-fetch misses", async () => {
+    vi.mocked(negotiationRepo.findById).mockResolvedValue(makeNeg());
+    vi.mocked(escalationRepo.findByNegotiation).mockResolvedValue(undefined);
+    vi.mocked(escalationRepo.create).mockImplementation(async (input) => makeEsc(input));
+    vi.mocked(escalationRepo.findById).mockResolvedValue(undefined);
+
+    const result = await svc.create({
+      negotiationId: "neg_1",
+      callerAgentId: "agent_a",
+      summary: "x",
+    });
+
+    expect(result.negotiation_id).toBe("neg_1");
+  });
 });
 
 describe("EscalationService.addContribution", () => {
@@ -271,6 +316,66 @@ describe("EscalationService.addContribution", () => {
     await expect(
       svc.addContribution({ escalationId: "esc_1", callerAgentId: "agent_b" }),
     ).rejects.toBeInstanceOf(EscalationStateError);
+  });
+
+  it("populates the initiator slot when the counterparty escalated", async () => {
+    // Mirror of the first case — the role branch that picks initiator_* keys.
+    vi.mocked(escalationRepo.findById).mockResolvedValue(
+      makeEsc({
+        escalated_by_role: "counterparty",
+        counterparty_proposals: [{ title: "B", description: "b" }],
+        counterparty_submitted_at: new Date(),
+      }),
+    );
+    vi.mocked(negotiationRepo.findById).mockResolvedValue(makeNeg());
+    vi.mocked(escalationRepo.update).mockImplementation(async (id, patch) =>
+      makeEsc({ id, ...(patch as Partial<Escalation>) }),
+    );
+
+    const proposals: Proposal[] = [{ title: "A", description: "a" }];
+    await svc.addContribution({
+      escalationId: "esc_1",
+      callerAgentId: "agent_a",
+      proposals,
+    });
+
+    expect(escalationRepo.update).toHaveBeenCalledWith(
+      "esc_1",
+      expect.objectContaining({
+        initiator_proposals: proposals,
+        initiator_open_questions: [],
+        initiator_submitted_at: expect.any(Date),
+      }),
+    );
+  });
+
+  it("rejects contributions to an escalation that is no longer pending", async () => {
+    vi.mocked(escalationRepo.findById).mockResolvedValue(
+      makeEsc({ status: "resolved" }),
+    );
+
+    await expect(
+      svc.addContribution({ escalationId: "esc_1", callerAgentId: "agent_b" }),
+    ).rejects.toThrow(/not pending \(status='resolved'\)/);
+    // Bails before touching the negotiation.
+    expect(negotiationRepo.findById).not.toHaveBeenCalled();
+  });
+
+  it("throws EscalationNotFoundError for an unknown escalation id", async () => {
+    vi.mocked(escalationRepo.findById).mockResolvedValue(undefined);
+
+    await expect(
+      svc.addContribution({ escalationId: "esc_missing", callerAgentId: "agent_b" }),
+    ).rejects.toBeInstanceOf(EscalationNotFoundError);
+  });
+
+  it("throws NegotiationNotFoundError when the backing negotiation vanished", async () => {
+    vi.mocked(escalationRepo.findById).mockResolvedValue(makeEsc());
+    vi.mocked(negotiationRepo.findById).mockResolvedValue(undefined);
+
+    await expect(
+      svc.addContribution({ escalationId: "esc_1", callerAgentId: "agent_b" }),
+    ).rejects.toBeInstanceOf(NegotiationNotFoundError);
   });
 });
 
@@ -440,6 +545,104 @@ describe("EscalationService.resolve", () => {
         selector: { source: "counterparty", source_index: 0 },
       }),
     ).rejects.toBeInstanceOf(EscalationStateError);
+  });
+});
+
+describe("EscalationService.resolve — dispatch wiring", () => {
+  let dispatchService: DispatchService;
+
+  beforeEach(() => {
+    // Post-Phase-4 nobody polls for 'assigned' tasks, so resolve() must
+    // create the pending session rows itself. Without this the two sides
+    // sit assigned forever.
+    dispatchService = {
+      dispatchTask: vi.fn(async () => ({ session: {}, runtime_id: null })),
+    } as unknown as DispatchService;
+    svc = new EscalationService({
+      escalationRepo,
+      negotiationRepo,
+      negotiationRoundRepo,
+      taskRepo,
+      agentRepo,
+      dispatchService,
+    });
+
+    vi.mocked(escalationRepo.findById).mockResolvedValue(
+      makeEsc({
+        initiator_proposals: [{ title: "A0", description: "a0d" }],
+        counterparty_proposals: [{ title: "B0", description: "b0d" }],
+      }),
+    );
+    vi.mocked(negotiationRepo.findById).mockResolvedValue(makeNeg());
+    vi.mocked(escalationRepo.update).mockImplementation(async (id, patch) =>
+      makeEsc({ id, ...(patch as Partial<Escalation>) }),
+    );
+  });
+
+  it("dispatches both sides with post_escalation reasons pinned to their prior sessions", async () => {
+    await svc.resolve({
+      escalationId: "esc_1",
+      personId: "person_1",
+      selector: { source: "initiator", source_index: 0 },
+      notes: "go with A0",
+    });
+
+    expect(dispatchService.dispatchTask).toHaveBeenCalledTimes(2);
+    const calls = vi.mocked(dispatchService.dispatchTask).mock.calls.map((c) => c[0]);
+
+    const initiator = calls.find((c) => c.agentId === "agent_a");
+    expect(initiator).toBeDefined();
+    expect(initiator!.type).toBe("task");
+    expect(initiator!.reason).toMatchObject({
+      kind: "post_escalation",
+      role: "initiator",
+      prior_session_id: "sess_a",
+    });
+
+    const counterparty = calls.find((c) => c.agentId === "agent_b");
+    expect(counterparty).toBeDefined();
+    expect(counterparty!.reason).toMatchObject({
+      kind: "post_escalation",
+      role: "counterparty",
+      prior_session_id: "sess_b",
+    });
+  });
+
+  it("dispatches each side against its own task, with the resolution in the intent", async () => {
+    const result = await svc.resolve({
+      escalationId: "esc_1",
+      personId: "person_1",
+      selector: { source: "initiator", source_index: 0 },
+    });
+
+    const calls = vi.mocked(dispatchService.dispatchTask).mock.calls.map((c) => c[0]);
+    const initiator = calls.find((c) => c.agentId === "agent_a")!;
+    const counterparty = calls.find((c) => c.agentId === "agent_b")!;
+
+    expect(initiator.task.id).toBe(result.initiatorTaskId);
+    expect(counterparty.task.id).toBe(result.counterpartyTaskId);
+    expect(initiator.intent).toContain(result.initiatorTaskId);
+    expect(counterparty.intent).toContain(result.counterpartyTaskId);
+  });
+
+  it("still resolves when no dispatchService is configured", async () => {
+    svc = new EscalationService({
+      escalationRepo,
+      negotiationRepo,
+      negotiationRoundRepo,
+      taskRepo,
+      agentRepo,
+    });
+
+    const result = await svc.resolve({
+      escalationId: "esc_1",
+      personId: "person_1",
+      selector: { source: "initiator", source_index: 0 },
+    });
+
+    expect(dispatchService.dispatchTask).not.toHaveBeenCalled();
+    expect(result.initiatorTaskId).toBeTruthy();
+    expect(result.counterpartyTaskId).toBeTruthy();
   });
 });
 

--- a/packages/core/src/services/memory/core-memory.test.ts
+++ b/packages/core/src/services/memory/core-memory.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CoreMemoryBlock } from "../../domain/core-memory.js";
 import type { CoreMemoryBlockRepository } from "../../ports/core-memory-repo.js";
-import { CoreMemory } from "./core-memory.js";
+import {
+  BlockCharLimitExceededError,
+  BlockNotFoundError,
+  CoreMemory,
+} from "./core-memory.js";
 
 function makeBlock(overrides: Partial<CoreMemoryBlock> = {}): CoreMemoryBlock {
   return {
@@ -147,5 +151,83 @@ describe("CoreMemory plumbing", () => {
     vi.mocked(repo.initDefaults).mockResolvedValue([]);
     await service.initDefaults("agent_1", "team");
     expect(repo.initDefaults).toHaveBeenCalledWith("agent_1", "team");
+  });
+});
+
+describe("CoreMemory.setContent — owner-driven full-block overwrite", () => {
+  it("replaces the whole block, discarding the previous content", async () => {
+    vi.mocked(repo.findOne).mockResolvedValue(
+      makeBlock({ content: "Old persona." }),
+    );
+    vi.mocked(repo.updateContent).mockImplementation(async (_a, _b, c) =>
+      makeBlock({ content: c }),
+    );
+
+    const result = await service.setContent("agent_1", "persona", "Brand new.");
+
+    expect(repo.updateContent).toHaveBeenCalledWith(
+      "agent_1",
+      "persona",
+      "Brand new.",
+    );
+    expect(result.content).toBe("Brand new.");
+  });
+
+  it("allows clearing a block to the empty string", async () => {
+    vi.mocked(repo.findOne).mockResolvedValue(
+      makeBlock({ content: "Something." }),
+    );
+    vi.mocked(repo.updateContent).mockImplementation(async (_a, _b, c) =>
+      makeBlock({ content: c }),
+    );
+
+    await service.setContent("agent_1", "persona", "");
+
+    expect(repo.updateContent).toHaveBeenCalledWith("agent_1", "persona", "");
+  });
+
+  it("accepts content exactly at char_limit", async () => {
+    vi.mocked(repo.findOne).mockResolvedValue(makeBlock({ char_limit: 10 }));
+    vi.mocked(repo.updateContent).mockImplementation(async (_a, _b, c) =>
+      makeBlock({ content: c, char_limit: 10 }),
+    );
+
+    await service.setContent("agent_1", "persona", "0123456789");
+
+    expect(repo.updateContent).toHaveBeenCalled();
+  });
+
+  it("throws BlockNotFoundError when the block was never seeded", async () => {
+    vi.mocked(repo.findOne).mockResolvedValue(undefined);
+
+    await expect(
+      service.setContent("agent_1", "never_seeded", "x"),
+    ).rejects.toBeInstanceOf(BlockNotFoundError);
+    expect(repo.updateContent).not.toHaveBeenCalled();
+  });
+
+  it("throws BlockCharLimitExceededError when content overflows the limit", async () => {
+    vi.mocked(repo.findOne).mockResolvedValue(makeBlock({ char_limit: 10 }));
+
+    await expect(
+      service.setContent("agent_1", "persona", "01234567890"),
+    ).rejects.toBeInstanceOf(BlockCharLimitExceededError);
+    expect(repo.updateContent).not.toHaveBeenCalled();
+  });
+
+  it("names both errors so HTTP callers can map them to 4xx", async () => {
+    // The route layer branches on `instanceof`; `name` is what surfaces in
+    // the response body, so both need to survive subclassing.
+    const notFound = new BlockNotFoundError("agent_1", "persona");
+    expect(notFound.name).toBe("BlockNotFoundError");
+    expect(notFound).toBeInstanceOf(Error);
+    expect(notFound.message).toContain("persona");
+    expect(notFound.message).toContain("agent_1");
+
+    const overflow = new BlockCharLimitExceededError("persona", 100, 137);
+    expect(overflow.name).toBe("BlockCharLimitExceededError");
+    expect(overflow).toBeInstanceOf(Error);
+    expect(overflow.message).toContain("100");
+    expect(overflow.message).toContain("137");
   });
 });

--- a/packages/core/src/services/orphan-reaper.test.ts
+++ b/packages/core/src/services/orphan-reaper.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Session } from "../domain/session.js";
 import type { Task } from "../domain/task.js";
 import type { SessionRepository } from "../ports/session-repo.js";
@@ -195,5 +195,201 @@ describe("DaemonOrphanReaper.tick", () => {
       sessionStaleSeconds: 30,
       runtimeHeartbeatStaleSeconds: 10,
     });
+  });
+
+  it("defaults onError to console.error when none is configured", async () => {
+    vi.mocked(sessionRepo.listDaemonOrphaned).mockResolvedValue([fakeSession()]);
+    vi.mocked(sessionRepo.update).mockRejectedValue(new Error("db gone"));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    reaper = new DaemonOrphanReaper({ sessionRepo, taskRepo, dispatchService });
+
+    const result = await reaper.tick();
+
+    expect(result).toEqual({ reaped: 0, redispatched: 0 });
+    expect(errSpy).toHaveBeenCalledWith(
+      "[daemon-orphan-reaper]",
+      expect.any(Error),
+    );
+    errSpy.mockRestore();
+  });
+
+  it("wraps a non-Error throw before handing it to onError", async () => {
+    vi.mocked(sessionRepo.listDaemonOrphaned).mockResolvedValue([fakeSession()]);
+    vi.mocked(sessionRepo.update).mockRejectedValue("just a string");
+    const onError = vi.fn();
+    reaper = new DaemonOrphanReaper({
+      sessionRepo,
+      taskRepo,
+      dispatchService,
+      onError,
+    });
+
+    await reaper.tick();
+
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    expect(onError.mock.calls[0]![0].message).toBe("just a string");
+  });
+
+  it("keeps reaping the remaining orphans after one of them throws", async () => {
+    vi.mocked(sessionRepo.listDaemonOrphaned).mockResolvedValue([
+      fakeSession({ id: "sess_bad" }),
+      fakeSession({ id: "sess_good", task_id: undefined, type: "chat" }),
+    ]);
+    vi.mocked(sessionRepo.update).mockImplementation(async (id, patch) => {
+      if (id === "sess_bad") throw new Error("row locked");
+      return fakeSession({ id, ...(patch as Partial<Session>) });
+    });
+    const onError = vi.fn();
+    reaper = new DaemonOrphanReaper({
+      sessionRepo,
+      taskRepo,
+      dispatchService,
+      onError,
+    });
+
+    const result = await reaper.tick();
+
+    expect(result.reaped).toBe(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("DaemonOrphanReaper.start / stop", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reaps once immediately, then on every poll interval", async () => {
+    reaper = new DaemonOrphanReaper({
+      sessionRepo,
+      taskRepo,
+      dispatchService,
+      pollIntervalMs: 1_000,
+    });
+
+    await reaper.start();
+    expect(sessionRepo.listDaemonOrphaned).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(sessionRepo.listDaemonOrphaned).toHaveBeenCalledTimes(4);
+
+    await reaper.stop();
+  });
+
+  it("is idempotent — a second start does not add a second timer", async () => {
+    reaper = new DaemonOrphanReaper({
+      sessionRepo,
+      taskRepo,
+      dispatchService,
+      pollIntervalMs: 1_000,
+    });
+
+    await reaper.start();
+    await reaper.start();
+    vi.mocked(sessionRepo.listDaemonOrphaned).mockClear();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(sessionRepo.listDaemonOrphaned).toHaveBeenCalledTimes(1);
+
+    await reaper.stop();
+  });
+
+  it("stop halts the poll loop", async () => {
+    reaper = new DaemonOrphanReaper({
+      sessionRepo,
+      taskRepo,
+      dispatchService,
+      pollIntervalMs: 1_000,
+    });
+
+    await reaper.start();
+    await reaper.stop();
+    vi.mocked(sessionRepo.listDaemonOrphaned).mockClear();
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(sessionRepo.listDaemonOrphaned).not.toHaveBeenCalled();
+  });
+
+  it("stop before start is a no-op", async () => {
+    reaper = new DaemonOrphanReaper({ sessionRepo, taskRepo, dispatchService });
+    await expect(reaper.stop()).resolves.toBeUndefined();
+  });
+
+  it("routes a rejecting interval tick to onError and keeps polling", async () => {
+    const onError = vi.fn();
+    reaper = new DaemonOrphanReaper({
+      sessionRepo,
+      taskRepo,
+      dispatchService,
+      pollIntervalMs: 1_000,
+      onError,
+    });
+
+    await reaper.start();
+    vi.mocked(sessionRepo.listDaemonOrphaned).mockRejectedValue(
+      new Error("db gone"),
+    );
+
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(onError).toHaveBeenCalledTimes(2);
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    await reaper.stop();
+  });
+
+  it("a first tick that rejects wedges the reaper: no timer, and restart is a no-op", async () => {
+    // Documents current behaviour, not desired behaviour. start() flips
+    // `running` before awaiting the immediate tick, so a rejection there
+    // escapes past the setInterval call: no poll loop is ever installed,
+    // and the `if (this.running) return` guard makes every later start()
+    // a silent no-op. A caller that logs-and-continues on start() gets a
+    // reaper that never reaps again.
+    vi.mocked(sessionRepo.listDaemonOrphaned).mockRejectedValue(
+      new Error("db gone"),
+    );
+    reaper = new DaemonOrphanReaper({
+      sessionRepo,
+      taskRepo,
+      dispatchService,
+      pollIntervalMs: 1_000,
+      onError: vi.fn(),
+    });
+
+    await expect(reaper.start()).rejects.toThrow("db gone");
+
+    vi.mocked(sessionRepo.listDaemonOrphaned).mockResolvedValue([]);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(sessionRepo.listDaemonOrphaned).toHaveBeenCalledTimes(1);
+
+    await reaper.start();
+    expect(sessionRepo.listDaemonOrphaned).toHaveBeenCalledTimes(1);
+
+    // Only an explicit stop() clears `running` and lets a restart take.
+    await reaper.stop();
+    await reaper.start();
+    expect(sessionRepo.listDaemonOrphaned).toHaveBeenCalledTimes(2);
+    await reaper.stop();
+  });
+
+  it("start after stop resumes polling", async () => {
+    reaper = new DaemonOrphanReaper({
+      sessionRepo,
+      taskRepo,
+      dispatchService,
+      pollIntervalMs: 1_000,
+    });
+
+    await reaper.start();
+    await reaper.stop();
+    vi.mocked(sessionRepo.listDaemonOrphaned).mockClear();
+
+    await reaper.start();
+    expect(sessionRepo.listDaemonOrphaned).toHaveBeenCalledTimes(1);
+
+    await reaper.stop();
   });
 });

--- a/packages/core/src/services/post-dispatch.test.ts
+++ b/packages/core/src/services/post-dispatch.test.ts
@@ -1,12 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Agent } from "../domain/agent.js";
 import type { Session } from "../domain/session.js";
 import type { Task } from "../domain/task.js";
+import type { AgentRepository } from "../ports/agent-repo.js";
 import type { SessionRepository } from "../ports/session-repo.js";
 import type { TaskRepository } from "../ports/task-repo.js";
 import type { DispatchService } from "./dispatch-service.js";
 import type { TaskService } from "./task-service.js";
 import {
   NUDGE_COMPLETION_MARKER,
+  buildPostDispatchHook,
   postDispatchCheck,
 } from "./post-dispatch.js";
 
@@ -37,10 +40,24 @@ function makeSession(overrides: Partial<Session> = {}): Session {
   } as Session;
 }
 
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: "agent_a",
+    name: "Ada",
+    owner_id: "person_owner",
+    hierarchy_level: "ic",
+    runtime_config: { type: "claude" },
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
 let taskRepo: TaskRepository;
 let taskService: TaskService;
 let dispatchService: DispatchService;
 let sessionRepo: SessionRepository;
+let agentRepo: AgentRepository;
 
 beforeEach(() => {
   vi.useFakeTimers();
@@ -82,6 +99,9 @@ beforeEach(() => {
   vi.mocked(sessionRepo.findLatestForTask).mockResolvedValue({
     id: "sess_orig",
   } as unknown as Session);
+  agentRepo = {
+    findById: vi.fn(async () => makeAgent()),
+  } as unknown as AgentRepository;
 });
 
 afterEach(() => {
@@ -275,5 +295,91 @@ describe("postDispatchCheck (Phase 4 — dispatchService retry)", () => {
     await p;
 
     expect(dispatchService.dispatchTask).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("buildPostDispatchHook", () => {
+  function hook() {
+    return buildPostDispatchHook({
+      taskRepo,
+      taskService,
+      agentRepo,
+      sessionRepo,
+      dispatchService,
+    });
+  }
+
+  it("ignores non-task sessions", async () => {
+    await hook()(makeSession({ type: "chat", task_id: undefined }));
+
+    expect(agentRepo.findById).not.toHaveBeenCalled();
+    expect(taskRepo.findById).not.toHaveBeenCalled();
+  });
+
+  it("ignores a task-typed session with no task_id", async () => {
+    // Shouldn't happen, but the hook is wired to every terminal session
+    // write — a malformed row must not take the worker down.
+    await hook()(makeSession({ type: "task", task_id: undefined }));
+
+    expect(agentRepo.findById).not.toHaveBeenCalled();
+    expect(taskRepo.findById).not.toHaveBeenCalled();
+  });
+
+  it("ignores mesh sessions", async () => {
+    await hook()(makeSession({ type: "mesh_ask", task_id: undefined }));
+
+    expect(taskRepo.findById).not.toHaveBeenCalled();
+  });
+
+  it("bails when the session's agent no longer exists", async () => {
+    vi.mocked(agentRepo.findById).mockResolvedValue(undefined);
+
+    await hook()(makeSession());
+
+    expect(agentRepo.findById).toHaveBeenCalledWith("agent_a");
+    expect(taskRepo.findById).not.toHaveBeenCalled();
+  });
+
+  it("runs the post-dispatch check for a terminal task session", async () => {
+    vi.mocked(taskRepo.findById).mockResolvedValue(makeTask({ status: "done" }));
+
+    const p = hook()(makeSession({ task_id: "task_t", agent_id: "agent_a" }));
+    await advanceGrace();
+    await p;
+
+    expect(taskRepo.findById).toHaveBeenCalledWith("task_t");
+    expect(taskService.checkAndCompleteParent).toHaveBeenCalledWith("task_t");
+  });
+
+  it("threads the session through, so the stale-dispatch guard sees its id", async () => {
+    vi.mocked(taskRepo.findById).mockResolvedValue(
+      makeTask({ status: "in_progress" }),
+    );
+    vi.mocked(sessionRepo.findLatestForTask).mockResolvedValue({
+      id: "sess_newer",
+    } as unknown as Session);
+
+    const p = hook()(makeSession({ id: "sess_orig" }));
+    await advanceGrace();
+    await p;
+
+    expect(dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("dispatches the nudge retry for a leaf task the agent left running", async () => {
+    vi.mocked(taskRepo.findById)
+      .mockResolvedValueOnce(makeTask({ status: "in_progress" }))
+      .mockResolvedValueOnce(makeTask({ status: "done" }));
+    vi.mocked(taskRepo.countChildrenNotComplete).mockResolvedValue(0);
+    vi.mocked(taskRepo.countChildren).mockResolvedValue(0);
+
+    const p = hook()(makeSession({ id: "sess_orig", agent_id: "agent_a" }));
+    await advanceGrace();
+    await advanceRetryWait();
+    await p;
+
+    const arg = vi.mocked(dispatchService.dispatchTask).mock.calls[0]![0];
+    expect(arg.agentId).toBe("agent_a");
+    expect(arg.intent).toContain(NUDGE_COMPLETION_MARKER);
   });
 });

--- a/packages/core/src/services/session-search.test.ts
+++ b/packages/core/src/services/session-search.test.ts
@@ -257,4 +257,77 @@ describe("SessionSearchService", () => {
       ),
     ).rejects.toThrow(SessionSearchError);
   });
+
+  it("scroll rejects a missing session_id too", async () => {
+    const { service } = makeService({
+      sessions: { sess_a: makeSession({ id: "sess_a", agent_id: "agent_a" }) },
+    });
+    await expect(
+      service.search(
+        { kind: "scroll", session_id: "", around_message_id: "evt_1" },
+        { callerAgentId: "agent_a", hierarchyLevel: "ic", currentSessionId: "sess_a" },
+      ),
+    ).rejects.toThrow(/scroll requires both/);
+  });
+
+  it("read requires a session_id", async () => {
+    const { service } = makeService({
+      sessions: { sess_a: makeSession({ id: "sess_a", agent_id: "agent_a" }) },
+    });
+    await expect(
+      service.search(
+        { kind: "read", session_id: "" },
+        { callerAgentId: "agent_a", hierarchyLevel: "ic", currentSessionId: "sess_a" },
+      ),
+    ).rejects.toThrow(/read requires session_id/);
+  });
+
+  it("routes each request kind to its matching repo method, with scope attached", async () => {
+    const ctx = {
+      callerAgentId: "agent_a",
+      hierarchyLevel: "ic" as const,
+      currentSessionId: "sess_a",
+    };
+    const sessions = { sess_a: makeSession({ id: "sess_a", agent_id: "agent_a" }) };
+
+    const scroll = makeService({ sessions });
+    await scroll.service.search(
+      { kind: "scroll", session_id: "sess_x", around_message_id: "evt_1" },
+      ctx,
+    );
+    expect(scroll.repo.lastScope?.agent_ids).toEqual(["agent_a"]);
+
+    const read = makeService({ sessions });
+    await read.service.search({ kind: "read", session_id: "sess_x" }, ctx);
+    expect(read.repo.lastScope?.agent_ids).toEqual(["agent_a"]);
+
+    const browse = makeService({ sessions });
+    const result = await browse.service.search({ kind: "browse" }, ctx);
+    expect(result).toMatchObject({ kind: "browse" });
+    expect(browse.repo.lastScope?.agent_ids).toEqual(["agent_a"]);
+  });
+
+  it("browse needs no query or session_id", async () => {
+    const { service } = makeService({
+      sessions: { sess_a: makeSession({ id: "sess_a", agent_id: "agent_a" }) },
+    });
+    await expect(
+      service.search(
+        { kind: "browse", limit: 5 },
+        { callerAgentId: "agent_a", hierarchyLevel: "ic", currentSessionId: "sess_a" },
+      ),
+    ).resolves.toMatchObject({ kind: "browse" });
+  });
+
+  it("rejects a whitespace-only discover query", async () => {
+    const { service } = makeService({
+      sessions: { sess_a: makeSession({ id: "sess_a", agent_id: "agent_a" }) },
+    });
+    await expect(
+      service.search(
+        { kind: "discover", query: "   " },
+        { callerAgentId: "agent_a", hierarchyLevel: "ic", currentSessionId: "sess_a" },
+      ),
+    ).rejects.toThrow(/query is required/);
+  });
 });

--- a/packages/core/src/services/task-service.test.ts
+++ b/packages/core/src/services/task-service.test.ts
@@ -155,6 +155,44 @@ describe("TaskService.updateProgress", () => {
     ).rejects.toBeInstanceOf(TaskNotFoundError);
   });
 
+  it("refuses a late update on a task a human already cancelled", async () => {
+    // Without this guard an agent that finishes after the cancel silently
+    // overwrites the human's intervention and loses the "(cancelled by …)"
+    // summary.
+    vi.mocked(taskRepo.findById).mockResolvedValue(
+      makeTask({ status: "cancelled", result_summary: "(cancelled by owner)" }),
+    );
+
+    await expect(
+      service.updateProgress("task_1", "done", "all finished!"),
+    ).rejects.toBeInstanceOf(InvalidTaskTransitionError);
+    expect(taskRepo.updateProgress).not.toHaveBeenCalled();
+  });
+
+  it("refuses a late update on an already-done task", async () => {
+    vi.mocked(taskRepo.findById).mockResolvedValue(makeTask({ status: "done" }));
+
+    await expect(
+      service.updateProgress("task_1", "failed", "actually it broke"),
+    ).rejects.toThrow(/already in terminal status 'done'/);
+    expect(taskRepo.updateProgress).not.toHaveBeenCalled();
+  });
+
+  it("still accepts updates on non-terminal statuses", async () => {
+    // 'failed' and 'blocked' are not "I'm finished" claims — an agent can
+    // still move off them.
+    for (const status of ["failed", "blocked", "review"] as const) {
+      vi.mocked(taskRepo.updateProgress).mockClear();
+      vi.mocked(taskRepo.findById).mockResolvedValue(makeTask({ status }));
+      vi.mocked(taskRepo.updateProgress).mockImplementation(
+        async (id, s, summary) => makeTask({ id, status: s, result_summary: summary }),
+      );
+
+      await service.updateProgress("task_1", "in_progress", "picking it back up");
+      expect(taskRepo.updateProgress).toHaveBeenCalled();
+    }
+  });
+
   describe("review_policy gating", () => {
     it("agent.review_policy='require_human' + status='done' → transitions to 'review'", async () => {
       vi.mocked(taskRepo.findById).mockResolvedValue(
@@ -572,6 +610,44 @@ describe("TaskService.createWorkProduct + listWorkProducts", () => {
     const out = await service.listWorkProducts("task_1");
     expect(out).toHaveLength(1);
     expect(workProductRepo.listByTask).toHaveBeenCalledWith("task_1");
+  });
+
+  it("getWorkProduct delegates to the repo", async () => {
+    vi.mocked(workProductRepo.findById).mockResolvedValue(makeWorkProduct());
+    const out = await service.getWorkProduct("wp_1");
+    expect(workProductRepo.findById).toHaveBeenCalledWith("wp_1");
+    expect(out?.id).toBe("wp_1");
+  });
+
+  it("getWorkProduct passes an unknown id straight through as undefined", async () => {
+    vi.mocked(workProductRepo.findById).mockResolvedValue(undefined);
+    await expect(service.getWorkProduct("wp_missing")).resolves.toBeUndefined();
+  });
+
+  it("updateWorkProduct forwards the mutable patch to the repo", async () => {
+    vi.mocked(workProductRepo.update).mockImplementation(async (id, patch) =>
+      makeWorkProduct({ id, ...patch }),
+    );
+
+    const out = await service.updateWorkProduct("wp_1", {
+      summary: "now merged",
+      url: "https://example.test/pr/42",
+    });
+
+    expect(workProductRepo.update).toHaveBeenCalledWith("wp_1", {
+      summary: "now merged",
+      url: "https://example.test/pr/42",
+    });
+    expect(out.summary).toBe("now merged");
+  });
+
+  it("updateWorkProduct surfaces the repo's not-found error", async () => {
+    vi.mocked(workProductRepo.update).mockRejectedValue(
+      new Error("work_product wp_missing not found"),
+    );
+    await expect(
+      service.updateWorkProduct("wp_missing", { summary: "x" }),
+    ).rejects.toThrow(/work_product wp_missing not found/);
   });
 });
 


### PR DESCRIPTION
## Summary

Ran v8 line coverage over `@beevibe/core` and wrote tests for the files that came back weakest, prioritising the ones on the task-completion and session-orchestration paths.

**126 new tests** across 14 files (4 of them new), +1,866/−3 lines. No production code changed.

| | before | after |
|---|---|---|
| lines | 48.37% | 55.46% |
| functions | 82.41% | 86.85% |
| branches | 85.47% | 90.22% |

Both measurements exclude the suites that can't run without Docker and provider keys (the Postgres adapters, OpenAI/Anthropic providers, `auth.integration`, `watch-service`), so the delta is apples-to-apples. Those files are the bulk of what still sits under 90% — their tests are gated, not missing.

## What was untested and now isn't

**`buildPostDispatchHook`** (`post-dispatch.test.ts`) — the whole function had no coverage. It's the guard that decides whether a terminal session gets a parent rollup or a nudge retry: non-task sessions, mesh sessions, a task-typed session with no `task_id`, a vanished agent, and the leaf-retry dispatch.

**`AgentSession.run`** (`agent-session.test.ts`) — the pre-inserted-row path (the post-Phase-4 daemon claim, where re-INSERTing would hit the PK), plus every best-effort side channel: briefing persist, `session_event` append, `onSpawn` pid write, `onTaskComplete`, and the catch-path completion hook. Each is asserted to log and continue rather than fail the session. Also the `onStep` tee and the gracefully-failed (not thrown) runtime result.

**`CoreMemory.setContent`** (`memory/core-memory.test.ts`) — the owner-driven full-block overwrite behind the agent detail page's Edit affordance, plus `BlockNotFoundError` / `BlockCharLimitExceededError`, which the route layer branches on via `instanceof`.

**`DaemonOrphanReaper`** (`orphan-reaper.test.ts`) — `start`/`stop` lifecycle under fake timers, the default `onError`, non-`Error` throw wrapping, and continuing to reap after one orphan throws.

**`EscalationService`** (`escalation-service.test.ts`) — the no-counterparty-session guard, the initiator slot in `addContribution`, non-task-bound negotiations, the re-fetch fallback, and the resolve-time dispatch of both sides (without it the two sides sit `assigned` forever, since nothing polls tasks post-Phase-4).

**Both stream-json parsers** — the assistant-block step path and `create_subordinate_agent` shape for Claude Code; `file_change` / `web_search` items, MCP result summarisation, and shell transcript entries for codex; plus `isBareCliExitMessage`.

**`runCliProcess`'s `onLog` fallback** (`spawn.test.ts`) — both sync and async modes swallowing a throwing consumer, and async mode preserving chunk order.

**`TaskService`** (`task-service.test.ts`) — the terminal-status guard on `updateProgress` (the one that stops a late agent write from undoing a human cancel) and the work-product accessors.

**Drift assertions** (`domain/core-memory.test.ts`, `domain/memory.test.ts`) — `DEFAULT_BLOCK_TEMPLATES` ↔ `ROUTING_BLOCKS` and `FACT_TYPES` ↔ `FACT_TYPE_DESCRIPTIONS`. Nothing type-checks a block name against its template, so those pairs can diverge silently.

## One test documents a bug rather than asserting correct behaviour

`DaemonOrphanReaper.start` sets `running = true` before awaiting the first tick, so if that tick throws, the rejection escapes past the `setInterval` call — no poll loop is installed, and the `if (this.running) return` guard makes every later `start()` a silent no-op. A caller that logs-and-continues on `start()` ends up with a reaper that never reaps again.

Left as-is and named in the test, since the fix is a behaviour change that deserves its own PR.

## Testing notes

Most new tests are hermetic and use mocked dependencies. The exception is the `spawn.test.ts` additions, which spawn real subprocesses on purpose — consistent with the note already at the top of that file that process-lifecycle semantics can't be verified against a mock.

Deliberately skipped: the 0%-coverage domain modules that are only status-string unions (`repo-run`, `work-product`, `runtime`, `task-watch`). Tests there would restate the constants without catching anything.

https://claude.ai/code/session_01VsSg9Z57c4LE5RM3Acmn4H
