### PR TITLE
test: drop a tautological test, make the mesh-window test actually test the window

### DIFF
--- a/packages/api/src/views/mesh.test.ts
+++ b/packages/api/src/views/mesh.test.ts
@@ -278,10 +278,46 @@ describe("getMeshOverview — nodes + edges + summary", () => {
     expect(summary).toEqual({ asks_24h: 12, in_flight: 3, edge_count: 7 });
   });
 
-  it("accepts an explicit window parameter without crashing", async () => {
+  // The window predicates are the only ones that qualify their column with
+  // `n.` / `s.`. Summary's `asks_24h` counter is a deliberately fixed 24h
+  // bucket on the already-windowed CTE, so it matches neither pattern.
+  const windowPredicates = (pool: ReturnType<typeof makeMockPool>): string[][] =>
+    pool._spy.mock.calls.map(([text]) =>
+      String(text).match(/[ns]\.(?:created_at|started_at) >= NOW\(\) - INTERVAL '[^']+'/g) ?? [],
+    );
+
+  it("threads the window into every query that filters on time", async () => {
     const pool = makeMockPool([[], [], [], [], []]);
-    await expect(getMeshOverview(pool, "7d")).resolves.toBeDefined();
-    await expect(getMeshOverview(pool, "all")).resolves.toBeDefined();
+    await getMeshOverview(pool, "7d");
+
+    // All five queries are built from the same fragment pair, so a regression
+    // that dropped the parameter on any one of them shows up here.
+    const perQuery = windowPredicates(pool);
+    expect(perQuery).toHaveLength(5);
+    for (const predicates of perQuery) {
+      expect(predicates.length).toBeGreaterThan(0);
+      for (const p of predicates) expect(p).toContain("INTERVAL '7 days'");
+    }
+  });
+
+  it("defaults to the 24h window", async () => {
+    const pool = makeMockPool([[], [], [], [], []]);
+    await getMeshOverview(pool);
+
+    for (const predicates of windowPredicates(pool)) {
+      for (const p of predicates) expect(p).toContain("INTERVAL '24 hours'");
+    }
+  });
+
+  it("drops the time predicate entirely for the 'all' window", async () => {
+    const pool = makeMockPool([[], [], [], [], []]);
+    await getMeshOverview(pool, "all");
+
+    expect(windowPredicates(pool).flat()).toEqual([]);
+    // "all" only widens history — the session type filter must survive, or the
+    // graph would pull in every session on the instance.
+    const sql = pool._spy.mock.calls.map(([text]) => String(text));
+    expect(sql.some((t) => t.includes("s.type IN ('mesh_ask', 'blocker')"))).toBe(true);
   });
 });
 

--- a/packages/sandbox/src/docker.e2e.test.ts
+++ b/packages/sandbox/src/docker.e2e.test.ts
@@ -64,13 +64,4 @@ describeOrSkip("sandbox primitives (e2e — Docker required)", () => {
       if (sandbox) await destroySandbox(sandbox);
     }
   }, 240_000); // 4 min — apt-get pulls take ~30–60s on a cold base image.
-
-  it("surfaces a friendly error when the docker daemon is unreachable", async () => {
-    // Sanity check that the existing path will error rather than hang
-    // when docker is unavailable. We can't easily simulate "daemon
-    // down" without stopping docker, so this test just ensures the
-    // public surface is callable; the friendly-message path is
-    // exercised in classifyStartupError at the orchestrator layer.
-    expect(typeof createSandbox).toBe("function");
-  });
 });


### PR DESCRIPTION
A second sweep of all 122 test files for dead weight — skipped/disabled tests, tests for removed features, tests with no assertions, and tests that pin implementation details rather than behavior. The suite remains in good shape; two items came out of it, both in the same class: **assertions that could not fail.**

## Removed — `surfaces a friendly error when the docker daemon is unreachable`

`packages/sandbox/src/docker.e2e.test.ts`

Its entire body was:

```ts
expect(typeof createSandbox).toBe("function");
```

A tautology — the import and the TS signature already guarantee it. The test never tested its own name, and its comment said so outright, deferring the real behavior to *"classifyStartupError at the orchestrator layer."* That deferral doesn't hold up: `classifyStartupError` is a private function in `orchestrator.ts` with **zero** test coverage, so the comment pointed at nothing. The test also sat inside a `describe.skip` suite gated on `BEEVIBE_E2E_DOCKER=1`, so it never ran in CI either. Nothing is lost by deleting it.

> Worth a follow-up: exporting and testing `classifyStartupError` would give the friendly-error path its first real coverage. Out of scope for a cleanup pass.

## Strengthened — `accepts an explicit window parameter without crashing`

`packages/api/src/views/mesh.test.ts`

It called `getMeshOverview(pool, "7d")` and `(pool, "all")` against a mock pool and asserted only `resolves.toBeDefined()`. Since the function always returns an object, it passed for *any* window handling whatsoever — including none at all. Meanwhile `getMeshOverview` threads the window through `buildWindowFragments` into all five queries, and that mapping had no coverage.

Replaced with three tests that read the SQL back off the existing `_spy`:

| Test | Asserts |
| --- | --- |
| `threads the window into every query that filters on time` | `7d` puts `INTERVAL '7 days'` in all five queries |
| `defaults to the 24h window` | the default is `24h` |
| `drops the time predicate entirely for the 'all' window` | no time predicate, but `s.type IN ('mesh_ask', 'blocker')` survives — without it the graph would pull in every session on the instance |

**Verified by mutation.** Hardcoding the interval to 24h and disabling the `"all"` branch fails two of the three. The old test passed both mutants.

The assertions key on the `n.`/`s.`-qualified predicates rather than a bare `INTERVAL` match, because `summarySql`'s `asks_24h` counter is a deliberately fixed 24-hour bucket over the already-windowed CTE and must not be swept up. (Writing this the naive way is how the fixed bucket got noticed.)

## Considered and deliberately kept

- **The four env-gated suites** (`smoke.test.ts`, `docker.e2e.test.ts`, `multi-instance.e2e.test.ts`, `mcp.test.ts`). Each documents a clear reason for being opt-in — a real `claude` binary, Docker, live API keys. Since test files are excluded from every `tsconfig` *and* these never run in CI, they can rot silently, so all four were checked import-by-import against current sources: every symbol still resolves, and `smoke.test.ts` still matches the current `RuntimeContext` / `Workspace` / `RuntimeResult` shapes.
- **`it.skipIf(process.platform === "win32")`** in `spawn.test.ts` and `manager.test.ts` — a live platform gate, not an abandoned skip.
- **The two `not.toThrow()` no-op tests** in `hub.test.ts` and `mesh/server.test.ts`. Both guard a real undefined-deref on an unknown-key lookup, and both paths are reachable in production (`cancel` for an offline daemon, `failResolverForCalleeSession` on the daemon-death path). Weak in form, but they can fail.

No assertion-free tests remain — a scan of all 1,380 test blocks found none.

## Testing

- `packages/api` and `packages/sandbox` typecheck and lint clean
- sandbox suite green (7 passed, 1 skipped)
- full api suite matches the documented no-Postgres baseline: the same 9 DB-gated files fail on `DATABASE_URL_TEST`, with 325 tests passing

---
_Generated by [Claude Code](https://claude.ai/code/session_01QaDF4Fwd72bMy6FuMC4y2h)_