### PR TITLE
refactor: unify four more clusters of near-duplicate abstractions

### DIFF
--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -1,39 +1,25 @@
 #!/usr/bin/env node
 import { config as loadEnv } from "dotenv";
-import { readPositiveInt, resolveMcpServerUrl } from "@beevibe/core";
+import {
+  installShutdownHandlers,
+  readPositiveInt,
+  resolveRuntimeEnv,
+  runEntrypoint,
+} from "@beevibe/core";
 import { bootstrap } from "./bootstrap.js";
 import { parseAllowedOrigins } from "./cors.js";
-
-const REQUIRED_ENV = [
-  "DATABASE_URL",
-  "OPENAI_API_KEY",
-  "ANTHROPIC_API_KEY",
-] as const;
 
 async function main(): Promise<void> {
   loadEnv();
 
-  const mcpServerUrl = resolveMcpServerUrl(process.env);
-
-  const missing: string[] = REQUIRED_ENV.filter((k) => !process.env[k]);
-  if (!mcpServerUrl) missing.push("BEEVIBE_MCP_SERVER_URL");
-  if (missing.length > 0) {
-    throw new Error(
-      `Missing required env vars: ${missing.join(", ")}. See .env.example for the full set.`,
-    );
-  }
+  const env = resolveRuntimeEnv(process.env);
 
   // Railway / Heroku-style PaaS injects PORT; honor it before falling back
   // to BEEVIBE_API_PORT (local dev) and then to 3000.
   const port = readPositiveInt(process.env.PORT ?? process.env.BEEVIBE_API_PORT, 3000);
   const corsAllowedOrigins = parseAllowedOrigins(process.env.BEEVIBE_CORS_ORIGINS);
   const { server, shutdown } = await bootstrap({
-    databaseUrl: process.env.DATABASE_URL!,
-    mcpServerUrl: mcpServerUrl!,
-    openaiApiKey: process.env.OPENAI_API_KEY!,
-    anthropicApiKey: process.env.ANTHROPIC_API_KEY!,
-    workspaceRoot: process.env.WORKSPACE_ROOT,
-    skillsSourceDir: process.env.BEEVIBE_SKILLS_DIR,
+    ...env,
     corsAllowedOrigins,
     port,
   });
@@ -41,25 +27,7 @@ async function main(): Promise<void> {
   await server.start();
   console.error(`[api] ready on port ${port}`);
 
-  const stop = async (signal: string): Promise<void> => {
-    console.error(`[api] ${signal} received, shutting down`);
-    try {
-      await shutdown();
-    } catch (err) {
-      console.error("[api] shutdown error:", err);
-    }
-    process.exit(0);
-  };
-
-  process.on("SIGINT", () => {
-    void stop("SIGINT");
-  });
-  process.on("SIGTERM", () => {
-    void stop("SIGTERM");
-  });
+  installShutdownHandlers("api", shutdown);
 }
 
-main().catch((err: unknown) => {
-  console.error("[api] fatal:", err);
-  process.exit(1);
-});
+runEntrypoint("api", main);

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -43,6 +43,9 @@ import type { ChatResolver } from "../runtime/chat-resolver.js";
 import type { DaemonHub } from "../runtime/hub.js";
 import { ChatRateLimiter } from "./chat-rate-limit.js";
 import { processResponse, type RepoCard, type SuggestedAction } from "./directives.js";
+import { requireParam } from "./http-errors.js";
+import { truncate } from "../views/format.js";
+import { CHAT_THREAD_TITLE_MAX } from "../views/types.js";
 
 export interface ChatRoutesDeps {
   authMiddleware: RequestHandler;
@@ -469,8 +472,7 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
       const last = chain.sessions[chain.sessions.length - 1]!;
       return {
         head_id: chain.head_id,
-        title:
-          head.intent.length <= 80 ? head.intent : head.intent.slice(0, 79) + "…",
+        title: truncate(head.intent, CHAT_THREAD_TITLE_MAX),
         turn_count: chain.sessions.length,
         last_at: last.created_at.toISOString(),
         last_preview: previewOf(last),
@@ -486,11 +488,8 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
   // Idempotent: re-deleting an already-deleted chain returns 200.
   router.delete("/conversations/:headId", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const headId = req.params.headId;
-    if (!headId) {
-      res.status(400).json({ error: "missing_head_id" });
-      return;
-    }
+    const headId = requireParam(req, res, "headId", "missing_head_id");
+    if (!headId) return;
     try {
       const agent = await deps.agentRepo.findTopLevelForOwner(req.caller.personId);
       if (!agent) {

--- a/packages/api/src/routes/escalation.ts
+++ b/packages/api/src/routes/escalation.ts
@@ -27,6 +27,7 @@ import {
 } from "@beevibe/core/services/escalation-service";
 import { NegotiationNotFoundError } from "@beevibe/core/services/negotiation-service";
 import { requireHuman } from "../auth/middleware.js";
+import { requireParam } from "./http-errors.js";
 
 export interface EscalationRoutesDeps {
   authMiddleware: RequestHandler;
@@ -113,11 +114,8 @@ export function createEscalationRouter(deps: EscalationRoutesDeps): Router {
 
   router.get("/:id", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const id = req.params.id;
-    if (!id) {
-      res.status(400).json({ error: "missing_escalation_id" });
-      return;
-    }
+    const id = requireParam(req, res, "id", "missing_escalation_id");
+    if (!id) return;
     try {
       const escalation = await deps.escalationService.getReview(id);
       res.json({ ok: true, escalation });
@@ -128,11 +126,8 @@ export function createEscalationRouter(deps: EscalationRoutesDeps): Router {
 
   router.post("/:id/resolve", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const id = req.params.id;
-    if (!id) {
-      res.status(400).json({ error: "missing_escalation_id" });
-      return;
-    }
+    const id = requireParam(req, res, "id", "missing_escalation_id");
+    if (!id) return;
 
     const selectorResult = buildSelector(req.body);
     if (!selectorResult.ok) {

--- a/packages/api/src/routes/http-errors.test.ts
+++ b/packages/api/src/routes/http-errors.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Request, Response } from "express";
+import { loadOwned, requireParam } from "./http-errors.js";
+
+function fakeRes(): Response & { statusCode?: number; body?: unknown } {
+  const res = {
+    statusCode: undefined as number | undefined,
+    body: undefined as unknown,
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    json(payload: unknown) {
+      res.body = payload;
+      return res;
+    },
+  };
+  return res as unknown as Response & { statusCode?: number; body?: unknown };
+}
+
+function fakeReq(params: Record<string, unknown>): Request {
+  return { params } as unknown as Request;
+}
+
+describe("requireParam", () => {
+  it("returns the param and answers nothing when present", () => {
+    const res = fakeRes();
+    expect(requireParam(fakeReq({ id: "agent_123" }), res, "id", "missing_agent_id")).toBe(
+      "agent_123",
+    );
+    expect(res.statusCode).toBeUndefined();
+  });
+
+  it("400s with the caller's own error code, not a generic one", () => {
+    // The codes are already in the wire contract and clients may branch
+    // on them, so the helper factors out the shape but never the code.
+    const res = fakeRes();
+    expect(requireParam(fakeReq({}), res, "id", "missing_task_id")).toBeUndefined();
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: "missing_task_id" });
+  });
+
+  it("treats an empty segment as missing", () => {
+    const res = fakeRes();
+    expect(requireParam(fakeReq({ id: "" }), res, "id", "missing_id")).toBeUndefined();
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects an array-valued param rather than handing back an array", () => {
+    // Express 5 types params as `string | string[]`; a repeated segment
+    // must not reach a handler that expects a string.
+    const res = fakeRes();
+    expect(requireParam(fakeReq({ id: ["a", "b"] }), res, "id", "missing_id")).toBeUndefined();
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe("loadOwned", () => {
+  const agent = { id: "agent_1", owner_id: "person_1" };
+
+  it("returns the entity when the caller owns it", async () => {
+    const res = fakeRes();
+    const got = await loadOwned(
+      res,
+      "person_1",
+      () => Promise.resolve(agent),
+      (a) => a.owner_id,
+      "agent_not_found",
+    );
+    expect(got).toBe(agent);
+    expect(res.statusCode).toBeUndefined();
+  });
+
+  it("404s with the caller's code when the row is missing", async () => {
+    const res = fakeRes();
+    const got = await loadOwned(
+      res,
+      "person_1",
+      () => Promise.resolve(undefined),
+      (a: typeof agent) => a.owner_id,
+      "agent_not_found",
+    );
+    expect(got).toBeUndefined();
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({ error: "agent_not_found" });
+  });
+
+  it("403s when the row belongs to somebody else", async () => {
+    // The half that's easy to forget when this is written out by hand —
+    // forgetting it is a cross-tenant read.
+    const res = fakeRes();
+    const got = await loadOwned(
+      res,
+      "person_OTHER",
+      () => Promise.resolve(agent),
+      (a) => a.owner_id,
+      "agent_not_found",
+    );
+    expect(got).toBeUndefined();
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({ error: "not_owner" });
+  });
+
+  it("can answer non-owners with the not-found shape instead", async () => {
+    // What `runtimes` does: don't confirm that a daemon id exists.
+    const res = fakeRes();
+    const got = await loadOwned(
+      res,
+      "person_OTHER",
+      () => Promise.resolve({ id: "rt_1", owner_person_id: "person_1" }),
+      (d) => d.owner_person_id,
+      "daemon_not_found",
+      { status: 404, error: "daemon_not_found" },
+    );
+    expect(got).toBeUndefined();
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({ error: "daemon_not_found" });
+  });
+
+  it("treats a null owner column as not-owned", async () => {
+    const res = fakeRes();
+    const got = await loadOwned(
+      res,
+      "person_1",
+      () => Promise.resolve({ id: "x", owner_id: null }),
+      (e) => e.owner_id,
+      "not_found",
+    );
+    expect(got).toBeUndefined();
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("does not call the loader more than once", async () => {
+    const load = vi.fn().mockResolvedValue(agent);
+    await loadOwned(fakeRes(), "person_1", load, (a: typeof agent) => a.owner_id, "nf");
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/api/src/routes/http-errors.ts
+++ b/packages/api/src/routes/http-errors.ts
@@ -1,4 +1,80 @@
-import type { Response } from "express";
+import type { Request, Response } from "express";
+
+/**
+ * Read a required route param, 400-ing when Express hands back an empty
+ * string.
+ *
+ * A `:id` segment can't normally be absent — the route wouldn't have
+ * matched — but `req.params.id` is typed `string | undefined` under
+ * `noUncheckedIndexedAccess`, so all 26 handlers that take a param grew
+ * the same five-line preamble to narrow it. The `errorCode` stays
+ * per-call-site because the codes already in the wire contract are not
+ * uniform (`missing_id`, `missing_task_id`, `missing_agent_id`, …) and
+ * clients may branch on them; this factors out the shape, not the codes.
+ *
+ * Returns `undefined` after responding, so the caller's next line is
+ * `if (!id) return;` — the same guard convention as `requireHuman`.
+ */
+export function requireParam(
+  req: Request,
+  res: Response,
+  name: string,
+  errorCode: string,
+): string | undefined {
+  // Express 5 types a params value as `string | string[]`. A single
+  // `:name` segment is always a string at runtime; narrow rather than
+  // cast so a future repeated-segment route can't slip an array past
+  // handlers that expect a string.
+  const value = req.params[name];
+  if (typeof value !== "string" || !value) {
+    res.status(400).json({ error: errorCode });
+    return undefined;
+  }
+  return value;
+}
+
+/**
+ * Load an entity and gate it on the caller owning it: 404 when it
+ * doesn't exist, 403 when it belongs to somebody else.
+ *
+ * Eight handlers across `view`, `learned-skills` and `runtimes` spelled
+ * this out inline — fetch, `if (!row) 404`, `if (row.owner !== caller)
+ * 403` — which is eight chances to forget the second half. Forgetting it
+ * is a cross-tenant read, so it's worth having one implementation that
+ * can't be half-written.
+ *
+ * `ownerOf` is a projector rather than a fixed field name because the
+ * column isn't uniform: agents and learned skills use `owner_id`,
+ * daemons use `owner_person_id`.
+ *
+ * `notOwner` defaults to the usual 403 `not_owner`. `runtimes` overrides
+ * it with its own 404 — that endpoint deliberately answers non-owners
+ * with the not-found shape so it doesn't confirm that a daemon id
+ * exists. Spelling the status out keeps that an explicit choice at the
+ * call site rather than something inferred from the error code.
+ *
+ * Returns `undefined` after responding, so the caller's next line is
+ * `if (!row) return;`.
+ */
+export async function loadOwned<T>(
+  res: Response,
+  personId: string,
+  load: () => Promise<T | null | undefined>,
+  ownerOf: (entity: T) => string | null | undefined,
+  notFoundError: string,
+  notOwner: { status: number; error: string } = { status: 403, error: "not_owner" },
+): Promise<T | undefined> {
+  const entity = await load();
+  if (!entity) {
+    res.status(404).json({ error: notFoundError });
+    return undefined;
+  }
+  if (ownerOf(entity) !== personId) {
+    res.status(notOwner.status).json({ error: notOwner.error });
+    return undefined;
+  }
+  return entity;
+}
 
 /**
  * The 500 handler every route router grew its own copy of.

--- a/packages/api/src/routes/learned-skills.ts
+++ b/packages/api/src/routes/learned-skills.ts
@@ -19,6 +19,7 @@ import {
 } from "@beevibe/core";
 import { requireHuman } from "../auth/middleware.js";
 import { readArtifactBody } from "../views/work-product.js";
+import { loadOwned, requireParam } from "./http-errors.js";
 
 export interface LearnedSkillsRouterDeps {
   authMiddleware: RequestHandler;
@@ -135,21 +136,17 @@ export function createLearnedSkillsRouter(deps: LearnedSkillsRouterDeps): Router
   // DELETE /learned-skills/:id
   router.delete("/:id", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const { id } = req.params;
-    if (!id) {
-      res.status(400).json({ error: "missing_id" });
-      return;
-    }
+    const id = requireParam(req, res, "id", "missing_id");
+    if (!id) return;
     try {
-      const skill = await deps.learnedSkillRepo.findById(id);
-      if (!skill) {
-        res.status(404).json({ error: "not_found" });
-        return;
-      }
-      if (skill.owner_id !== req.caller!.personId) {
-        res.status(403).json({ error: "not_owner" });
-        return;
-      }
+      const skill = await loadOwned(
+        res,
+        req.caller!.personId,
+        () => deps.learnedSkillRepo.findById(id),
+        (s) => s.owner_id,
+        "not_found",
+      );
+      if (!skill) return;
       await deps.learnedSkillRepo.delete(id);
       res.status(204).send();
     } catch (err) {
@@ -164,21 +161,17 @@ export function createLearnedSkillsRouter(deps: LearnedSkillsRouterDeps): Router
   // returns a tarball-style instructions response so the user can PR manually.
   router.post("/:id/publish", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const { id } = req.params;
-    if (!id) {
-      res.status(400).json({ error: "missing_id" });
-      return;
-    }
+    const id = requireParam(req, res, "id", "missing_id");
+    if (!id) return;
     try {
-      const skill = await deps.learnedSkillRepo.findById(id);
-      if (!skill) {
-        res.status(404).json({ error: "not_found" });
-        return;
-      }
-      if (skill.owner_id !== req.caller!.personId) {
-        res.status(403).json({ error: "not_owner" });
-        return;
-      }
+      const skill = await loadOwned(
+        res,
+        req.caller!.personId,
+        () => deps.learnedSkillRepo.findById(id),
+        (s) => s.owner_id,
+        "not_found",
+      );
+      if (!skill) return;
 
       const token = process.env.BEEVIBE_REGISTRY_TOKEN;
       const md = generateSkillMd(

--- a/packages/api/src/routes/negotiation.ts
+++ b/packages/api/src/routes/negotiation.ts
@@ -14,6 +14,7 @@ import {
   NegotiationNotFoundError,
 } from "@beevibe/core/services/negotiation-service";
 import { requireHuman } from "../auth/middleware.js";
+import { requireParam } from "./http-errors.js";
 
 export interface NegotiationRoutesDeps {
   authMiddleware: RequestHandler;
@@ -26,11 +27,8 @@ export function createNegotiationRouter(deps: NegotiationRoutesDeps): Router {
 
   router.get("/:id", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const id = req.params.id;
-    if (!id) {
-      res.status(400).json({ error: "missing_negotiation_id" });
-      return;
-    }
+    const id = requireParam(req, res, "id", "missing_negotiation_id");
+    if (!id) return;
     try {
       const negotiation = await deps.negotiationService.getReview(id);
       res.json({ ok: true, negotiation });

--- a/packages/api/src/routes/repo-runs.ts
+++ b/packages/api/src/routes/repo-runs.ts
@@ -19,6 +19,7 @@ import type {
   SessionEventRepository,
 } from "@beevibe/core";
 import { requireHuman } from "../auth/middleware.js";
+import { requireParam } from "./http-errors.js";
 
 export interface RepoRunsRouterDeps {
   authMiddleware: RequestHandler;
@@ -74,11 +75,8 @@ export function createRepoRunsRouter(deps: RepoRunsRouterDeps): Router {
   // GET /repo-runs/:id — full run detail including transcript.
   router.get("/:id", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const { id } = req.params;
-    if (!id) {
-      res.status(400).json({ error: "missing_id" });
-      return;
-    }
+    const id = requireParam(req, res, "id", "missing_id");
+    if (!id) return;
     try {
       const run = await deps.repoRunRepo.findById(id);
       if (!run) {
@@ -114,11 +112,8 @@ export function createRepoRunsRouter(deps: RepoRunsRouterDeps): Router {
   // the daemon hub sends a cancel WS message (separate flow).
   router.post("/:id/cancel", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const { id } = req.params;
-    if (!id) {
-      res.status(400).json({ error: "missing_id" });
-      return;
-    }
+    const id = requireParam(req, res, "id", "missing_id");
+    if (!id) return;
     try {
       const run = await deps.repoRunRepo.findById(id);
       if (!run) {
@@ -152,11 +147,10 @@ export function createRepoRunsRouter(deps: RepoRunsRouterDeps): Router {
   // join — for MVP we trust the host_path from repo_run).
   router.get("/:id/artifacts/:file", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const { id, file } = req.params;
-    if (!id || !file) {
-      res.status(400).json({ error: "missing_params" });
-      return;
-    }
+    const id = requireParam(req, res, "id", "missing_params");
+    if (!id) return;
+    const file = requireParam(req, res, "file", "missing_params");
+    if (!file) return;
     try {
       const run = await deps.repoRunRepo.findById(id);
       if (!run) {

--- a/packages/api/src/routes/runtimes.ts
+++ b/packages/api/src/routes/runtimes.ts
@@ -24,6 +24,7 @@ import type {
 } from "@beevibe/core";
 import { requireHuman } from "../auth/middleware.js";
 import type { DaemonHub } from "../runtime/hub.js";
+import { loadOwned, requireParam } from "./http-errors.js";
 
 export interface RuntimesRoutesDeps {
   authMiddleware: RequestHandler;
@@ -101,21 +102,19 @@ export function createRuntimesRouter(deps: RuntimesRoutesDeps): Router {
 
   router.post("/:id/revoke", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const id = req.params.id;
-    if (!id) {
-      res.status(400).json({ error: "missing_daemon_id" });
-      return;
-    }
-    const daemon = await deps.daemonRepo.findById(id);
-    if (!daemon) {
-      res.status(404).json({ error: "daemon_not_found" });
-      return;
-    }
-    if (daemon.owner_person_id !== req.caller.personId) {
-      // Don't leak existence to non-owners — same shape as 404.
-      res.status(404).json({ error: "daemon_not_found" });
-      return;
-    }
+    const id = requireParam(req, res, "id", "missing_daemon_id");
+    if (!id) return;
+    // Non-owners get the 404 shape too — this endpoint deliberately
+    // doesn't confirm that a daemon id exists.
+    const daemon = await loadOwned(
+      res,
+      req.caller.personId,
+      () => deps.daemonRepo.findById(id),
+      (d) => d.owner_person_id,
+      "daemon_not_found",
+      { status: 404, error: "daemon_not_found" },
+    );
+    if (!daemon) return;
     if (daemon.revoked_at) {
       // Idempotent: already revoked is success, not error.
       res.json({ ok: true, daemon_id: id, already_revoked: true });

--- a/packages/api/src/routes/task.ts
+++ b/packages/api/src/routes/task.ts
@@ -42,6 +42,7 @@ import { buildIntent, type ResumeReason } from "@beevibe/core/services/agent-ses
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
 import { requireHuman } from "../auth/middleware.js";
 import type { DaemonHub } from "../runtime/hub.js";
+import { requireParam } from "./http-errors.js";
 
 /** Statuses from which /cancel is legal. Anything non-terminal. */
 const CANCELLABLE_FROM: readonly TaskStatus[] = [
@@ -187,11 +188,8 @@ export function createTaskRouter(deps: TaskRoutesDeps): Router {
   // POST /task/:id/approve
   router.post("/:id/approve", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const id = req.params.id;
-    if (!id) {
-      res.status(400).json({ error: "missing_task_id" });
-      return;
-    }
+    const id = requireParam(req, res, "id", "missing_task_id");
+    if (!id) return;
     try {
       const summary =
         typeof req.body?.result_summary === "string"
@@ -208,11 +206,8 @@ export function createTaskRouter(deps: TaskRoutesDeps): Router {
   // POST /task/:id/reject
   router.post("/:id/reject", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const id = req.params.id;
-    if (!id) {
-      res.status(400).json({ error: "missing_task_id" });
-      return;
-    }
+    const id = requireParam(req, res, "id", "missing_task_id");
+    if (!id) return;
     try {
       const summary =
         typeof req.body?.result_summary === "string"
@@ -229,11 +224,8 @@ export function createTaskRouter(deps: TaskRoutesDeps): Router {
   // POST /task/:id/revise
   router.post("/:id/revise", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const id = req.params.id;
-    if (!id) {
-      res.status(400).json({ error: "missing_task_id" });
-      return;
-    }
+    const id = requireParam(req, res, "id", "missing_task_id");
+    if (!id) return;
     const feedback = typeof req.body?.feedback === "string" ? req.body.feedback : "";
     if (!feedback) {
       res.status(400).json({
@@ -289,11 +281,8 @@ export function createTaskRouter(deps: TaskRoutesDeps): Router {
   // POST /task/:id/retry
   router.post("/:id/retry", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const id = req.params.id;
-    if (!id) {
-      res.status(400).json({ error: "missing_task_id" });
-      return;
-    }
+    const id = requireParam(req, res, "id", "missing_task_id");
+    if (!id) return;
     try {
       const { task, assigneeId, priorSessionId } =
         await deps.taskService.prepareRetry(id);
@@ -320,11 +309,8 @@ export function createTaskRouter(deps: TaskRoutesDeps): Router {
   // POST /task/:id/cancel
   router.post("/:id/cancel", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const id = req.params.id;
-    if (!id) {
-      res.status(400).json({ error: "missing_task_id" });
-      return;
-    }
+    const id = requireParam(req, res, "id", "missing_task_id");
+    if (!id) return;
     try {
       const task = await deps.taskRepo.findById(id);
       if (!task) {

--- a/packages/api/src/routes/view.ts
+++ b/packages/api/src/routes/view.ts
@@ -60,7 +60,7 @@ import { listActivity } from "../views/activity.js";
 import { getWorkProduct } from "../views/work-product.js";
 import { listInbox } from "../views/inbox.js";
 import { getAgentNetwork } from "../views/agent-network.js";
-import { makeErrorHandler } from "./http-errors.js";
+import { loadOwned, makeErrorHandler, requireParam } from "./http-errors.js";
 
 /** Every handler below passes a per-call context, e.g. `[view route: task list]`. */
 const handleError = makeErrorHandler("view route");
@@ -135,11 +135,8 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
 
   router.get("/task/:id", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const id = req.params.id;
-    if (!id) {
-      res.status(400).json({ error: "missing_task_id" });
-      return;
-    }
+    const id = requireParam(req, res, "id", "missing_task_id");
+    if (!id) return;
     try {
       const task = await getTask(deps.pool, id);
       if (!task) {
@@ -185,11 +182,8 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
 
   router.get("/agent/:id", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const id = req.params.id;
-    if (!id) {
-      res.status(400).json({ error: "missing_agent_id" });
-      return;
-    }
+    const id = requireParam(req, res, "id", "missing_agent_id");
+    if (!id) return;
     try {
       const agent = await getAgent(deps.pool, id);
       if (!agent) {
@@ -204,11 +198,8 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
 
   router.post("/agent/:id/runtime", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const id = req.params.id;
-    if (!id) {
-      res.status(400).json({ error: "missing_agent_id" });
-      return;
-    }
+    const id = requireParam(req, res, "id", "missing_agent_id");
+    if (!id) return;
     const body = req.body as { runtime_id?: string | null } | undefined;
     // Allow explicit null to unbind, or a non-empty string to bind.
     const runtimeId =
@@ -225,15 +216,14 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
       return;
     }
     try {
-      const existing = await deps.agentRepo.findById(id);
-      if (!existing) {
-        res.status(404).json({ error: "agent_not_found" });
-        return;
-      }
-      if (existing.owner_id !== req.caller.personId) {
-        res.status(403).json({ error: "not_owner" });
-        return;
-      }
+      const existing = await loadOwned(
+        res,
+        req.caller.personId,
+        () => deps.agentRepo.findById(id),
+        (a) => a.owner_id,
+        "agent_not_found",
+      );
+      if (!existing) return;
       // Validate the runtime belongs to a daemon owned by the caller.
       // Otherwise a user could re-target their agent at someone else's
       // daemon (cross-tenant escalation).
@@ -284,11 +274,8 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
 
   router.post("/agent/:id/model", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const id = req.params.id;
-    if (!id) {
-      res.status(400).json({ error: "missing_agent_id" });
-      return;
-    }
+    const id = requireParam(req, res, "id", "missing_agent_id");
+    if (!id) return;
     const body = req.body as { model?: string | null } | undefined;
     // null clears (agent uses CLI default), non-empty string sets.
     const model =
@@ -305,15 +292,14 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
       return;
     }
     try {
-      const existing = await deps.agentRepo.findById(id);
-      if (!existing) {
-        res.status(404).json({ error: "agent_not_found" });
-        return;
-      }
-      if (existing.owner_id !== req.caller.personId) {
-        res.status(403).json({ error: "not_owner" });
-        return;
-      }
+      const existing = await loadOwned(
+        res,
+        req.caller.personId,
+        () => deps.agentRepo.findById(id),
+        (a) => a.owner_id,
+        "agent_not_found",
+      );
+      if (!existing) return;
       // Build the next runtime_config: keep the existing fields, override
       // (or remove) just the `model` key. Don't replace the whole config
       // wholesale — type / max_turns / etc. should survive.
@@ -337,11 +323,8 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
 
   router.post("/agent/:id/review-policy", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const id = req.params.id;
-    if (!id) {
-      res.status(400).json({ error: "missing_agent_id" });
-      return;
-    }
+    const id = requireParam(req, res, "id", "missing_agent_id");
+    if (!id) return;
     const body = req.body as { review_policy?: unknown } | undefined;
     const policy = body?.review_policy;
     if (!isReviewPolicy(policy)) {
@@ -352,15 +335,14 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
       return;
     }
     try {
-      const existing = await deps.agentRepo.findById(id);
-      if (!existing) {
-        res.status(404).json({ error: "agent_not_found" });
-        return;
-      }
-      if (existing.owner_id !== req.caller.personId) {
-        res.status(403).json({ error: "not_owner" });
-        return;
-      }
+      const existing = await loadOwned(
+        res,
+        req.caller.personId,
+        () => deps.agentRepo.findById(id),
+        (a) => a.owner_id,
+        "agent_not_found",
+      );
+      if (!existing) return;
       const updated = await deps.agentRepo.update(id, { review_policy: policy });
       res.json({ ok: true, review_policy: updated.review_policy });
     } catch (err) {
@@ -370,12 +352,10 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
 
   router.post("/agent/:id/core-memory/:blockName", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const id = req.params.id;
-    const blockName = req.params.blockName;
-    if (!id || !blockName) {
-      res.status(400).json({ error: "missing_param" });
-      return;
-    }
+    const id = requireParam(req, res, "id", "missing_param");
+    if (!id) return;
+    const blockName = requireParam(req, res, "blockName", "missing_param");
+    if (!blockName) return;
     const body = req.body as { content?: unknown } | undefined;
     if (typeof body?.content !== "string") {
       res.status(400).json({
@@ -385,15 +365,14 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
       return;
     }
     try {
-      const existing = await deps.agentRepo.findById(id);
-      if (!existing) {
-        res.status(404).json({ error: "agent_not_found" });
-        return;
-      }
-      if (existing.owner_id !== req.caller.personId) {
-        res.status(403).json({ error: "not_owner" });
-        return;
-      }
+      const existing = await loadOwned(
+        res,
+        req.caller.personId,
+        () => deps.agentRepo.findById(id),
+        (a) => a.owner_id,
+        "agent_not_found",
+      );
+      if (!existing) return;
       await deps.coreMemory.setContent(id, blockName, body.content);
       res.json({ ok: true });
     } catch (err) {
@@ -411,21 +390,17 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
 
   router.post("/agent/:id/archive", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const id = req.params.id;
-    if (!id) {
-      res.status(400).json({ error: "missing_agent_id" });
-      return;
-    }
+    const id = requireParam(req, res, "id", "missing_agent_id");
+    if (!id) return;
     try {
-      const existing = await deps.agentRepo.findById(id);
-      if (!existing) {
-        res.status(404).json({ error: "agent_not_found" });
-        return;
-      }
-      if (existing.owner_id !== req.caller.personId) {
-        res.status(403).json({ error: "not_owner" });
-        return;
-      }
+      const existing = await loadOwned(
+        res,
+        req.caller.personId,
+        () => deps.agentRepo.findById(id),
+        (a) => a.owner_id,
+        "agent_not_found",
+      );
+      if (!existing) return;
       if (existing.archived_at) {
         res.json({ ok: true, archived_at: existing.archived_at.toISOString() });
         return;
@@ -620,11 +595,8 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
 
   router.delete("/memory/fact/:id", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const id = req.params.id;
-    if (!id) {
-      res.status(400).json({ error: "missing_fact_id" });
-      return;
-    }
+    const id = requireParam(req, res, "id", "missing_fact_id");
+    if (!id) return;
     try {
       const fact = await deps.memoryFactRepo.findById(id);
       if (!fact) {
@@ -651,11 +623,8 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
 
   router.get("/work-product/:id", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const id = req.params.id;
-    if (!id) {
-      res.status(400).json({ error: "missing_work_product_id" });
-      return;
-    }
+    const id = requireParam(req, res, "id", "missing_work_product_id");
+    if (!id) return;
     try {
       const wp = await getWorkProduct(deps.pool, id);
       if (!wp) {

--- a/packages/api/src/views/agents.ts
+++ b/packages/api/src/views/agents.ts
@@ -8,7 +8,8 @@
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import type { HierarchyLevel, SessionStatus } from "@beevibe/core";
 import { toAgentDisplay } from "./agent-display.js";
-import { deriveShortId, formatRelativeShort } from "./format.js";
+import { deriveShortId, formatRelativeShort, truncate } from "./format.js";
+import { CHAT_THREAD_TITLE_MAX } from "./types.js";
 import type {
   AgentDisplay,
   AgentDetail,
@@ -293,10 +294,7 @@ export async function getAgent(
   const recent_chat_threads: RecentChatThread[] = chatThreadResult.rows.map((t) => ({
     conversation_id: t.conversation_id,
     short_id: deriveShortId(t.conversation_id),
-    title:
-      t.intent_first.length <= 80
-        ? t.intent_first
-        : t.intent_first.slice(0, 79) + "…",
+    title: truncate(t.intent_first, CHAT_THREAD_TITLE_MAX),
     turn_count: Number(t.turn_count),
     age: formatRelativeShort(t.last_at),
     last_status: recentSessionStatus(t.last_status),

--- a/packages/api/src/views/format.ts
+++ b/packages/api/src/views/format.ts
@@ -17,6 +17,7 @@ export {
   firstNonEmptyLine,
   formatDurationLabel,
   toDate,
+  truncate,
   type DateLike,
 } from "@beevibe/core/domain/format";
 

--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -124,6 +124,15 @@ export interface RecentSession {
 }
 
 /**
+ * Cap for `RecentChatThread.title` and the identical `title` on the
+ * chat-conversation list (`routes/chat.ts`). Both endpoints derive that
+ * title from the head turn's intent, so the cap has to be one constant —
+ * two values would render the same thread under two different titles
+ * depending on which page you opened.
+ */
+export const CHAT_THREAD_TITLE_MAX = 80;
+
+/**
  * Recent chat conversation surfaced on the agent detail page as one
  * collapsed card per thread. Each thread groups N chat-turn sessions
  * sharing the same `conversation_id` (the head turn's session id —

--- a/packages/api/src/views/work-product.ts
+++ b/packages/api/src/views/work-product.ts
@@ -11,6 +11,7 @@ import { readFile, stat } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import type { WorkProductType } from "@beevibe/core";
+import { deriveShortId } from "./format.js";
 
 export interface WorkProductDetail {
   id: string;
@@ -68,10 +69,6 @@ interface Row {
 }
 
 const MAX_BODY_BYTES = 256 * 1024;
-
-function deriveTaskShortId(id: string): string {
-  return id.replace(/^[a-z]+_/, "").slice(0, 6);
-}
 
 function truncateToMax(body: string | null | undefined): string | undefined {
   if (!body) return undefined;
@@ -152,7 +149,7 @@ export async function getWorkProduct(
   return {
     id: row.id,
     task_id: row.task_id,
-    task_short_id: deriveTaskShortId(row.task_id),
+    task_short_id: deriveShortId(row.task_id),
     task_title: row.task_title,
     agent_id: row.agent_id,
     agent_label: row.agent_label,

--- a/packages/core/src/domain/format.test.ts
+++ b/packages/core/src/domain/format.test.ts
@@ -5,6 +5,7 @@ import {
   formatDurationLabel,
   formatRelative,
   toDate,
+  truncate,
 } from "./format.js";
 
 const NOW = new Date("2026-01-10T12:00:00Z");
@@ -42,6 +43,28 @@ describe("deriveShortId", () => {
 
   it("returns short ids whole rather than padding", () => {
     expect(deriveShortId("sess_abc")).toBe("abc");
+  });
+});
+
+describe("truncate", () => {
+  it("leaves a string at or under the cap untouched", () => {
+    expect(truncate("short", 80)).toBe("short");
+    expect(truncate("x".repeat(80), 80)).toBe("x".repeat(80));
+  });
+
+  it("caps at n characters INCLUDING the ellipsis", () => {
+    // The contract that matters: the result is never longer than `n`,
+    // so a column sized for 80 chars can't overflow by one.
+    expect(truncate("x".repeat(81), 80)).toHaveLength(80);
+    expect(truncate("x".repeat(200), 80).endsWith("…")).toBe(true);
+  });
+
+  it("keeps the leading n-1 characters", () => {
+    expect(truncate("abcdef", 4)).toBe("abc…");
+  });
+
+  it("is stable on the empty string", () => {
+    expect(truncate("", 80)).toBe("");
   });
 });
 

--- a/packages/core/src/domain/format.ts
+++ b/packages/core/src/domain/format.ts
@@ -51,6 +51,27 @@ export function deriveShortId(id: string): string {
 }
 
 /**
+ * Cap a string at `n` characters, ellipsis included — `truncate(s, 80)`
+ * never returns more than 80 chars.
+ *
+ * The web had this as `truncate` in `lib/format.ts`; the api wrote the
+ * same expression out longhand in two places that build the *same*
+ * field — the chat-thread `title`, once in `views/agents.ts` for the
+ * agent detail page and once in `routes/chat.ts` for the conversation
+ * list. Those two disagreeing would show one thread under two different
+ * titles depending on which page you were looking at, which is exactly
+ * the drift the rest of this module exists to prevent.
+ *
+ * Note this is not the only truncation idiom in the tree: several call
+ * sites use `s.length > n ? s.slice(0, n - 3) + "…"`, which caps at
+ * `n - 2`. That is a different (probably accidental) contract, so those
+ * sites are deliberately left alone rather than silently re-lengthened.
+ */
+export function truncate(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n - 1) + "…" : s;
+}
+
+/**
  * Relative-time label: "just now", "2m", "1h", "3d", "5mo", "1y".
  *
  * The api serializes the bare form into `age` / `elapsed` fields; the

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,3 +5,4 @@ export * from "./domain/index.js";
 export * from "./ports/index.js";
 export * from "./auth/index.js";
 export * from "./env.js";
+export * from "./process-lifecycle.js";

--- a/packages/core/src/process-lifecycle.test.ts
+++ b/packages/core/src/process-lifecycle.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { installShutdownHandlers, resolveRuntimeEnv, runEntrypoint } from "./process-lifecycle.js";
+
+const FULL_ENV = {
+  DATABASE_URL: "postgres://localhost/beevibe",
+  OPENAI_API_KEY: "sk-openai",
+  ANTHROPIC_API_KEY: "sk-anthropic",
+  BEEVIBE_MCP_SERVER_URL: "https://api.example.com/mcp",
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.removeAllListeners("SIGINT");
+  process.removeAllListeners("SIGTERM");
+});
+
+describe("resolveRuntimeEnv", () => {
+  it("returns the four required values", () => {
+    expect(resolveRuntimeEnv(FULL_ENV)).toEqual({
+      databaseUrl: "postgres://localhost/beevibe",
+      openaiApiKey: "sk-openai",
+      anthropicApiKey: "sk-anthropic",
+      mcpServerUrl: "https://api.example.com/mcp",
+      workspaceRoot: undefined,
+      skillsSourceDir: undefined,
+    });
+  });
+
+  it("passes through the optional workspace + skills overrides", () => {
+    const env = resolveRuntimeEnv({
+      ...FULL_ENV,
+      WORKSPACE_ROOT: "/srv/workspaces",
+      BEEVIBE_SKILLS_DIR: "/srv/skills",
+    });
+    expect(env.workspaceRoot).toBe("/srv/workspaces");
+    expect(env.skillsSourceDir).toBe("/srv/skills");
+  });
+
+  it("reports EVERY missing var in one throw, not just the first", () => {
+    // The point of collecting rather than short-circuiting: an operator
+    // bringing up a fresh deploy fixes one round of config instead of
+    // one variable per restart.
+    expect(() => resolveRuntimeEnv({})).toThrowError(
+      /DATABASE_URL, OPENAI_API_KEY, ANTHROPIC_API_KEY, BEEVIBE_MCP_SERVER_URL/,
+    );
+  });
+
+  it("treats an empty string as missing", () => {
+    expect(() => resolveRuntimeEnv({ ...FULL_ENV, DATABASE_URL: "" })).toThrowError(
+      /DATABASE_URL/,
+    );
+  });
+
+  it("accepts the Railway fallback in place of an explicit MCP url", () => {
+    const { BEEVIBE_MCP_SERVER_URL: _omitted, ...noMcp } = FULL_ENV;
+    expect(resolveRuntimeEnv({ ...noMcp, RAILWAY_PUBLIC_DOMAIN: "beevibe.up.railway.app" }))
+      .toMatchObject({ mcpServerUrl: "https://beevibe.up.railway.app/mcp" });
+  });
+
+  it("names BEEVIBE_MCP_SERVER_URL when neither it nor the Railway domain is set", () => {
+    const { BEEVIBE_MCP_SERVER_URL: _omitted, ...noMcp } = FULL_ENV;
+    expect(() => resolveRuntimeEnv(noMcp)).toThrowError(/BEEVIBE_MCP_SERVER_URL/);
+  });
+});
+
+describe("installShutdownHandlers", () => {
+  it("drains and exits 0 on SIGTERM", async () => {
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const shutdown = vi.fn().mockResolvedValue(undefined);
+
+    installShutdownHandlers("api", shutdown);
+    process.emit("SIGTERM");
+    await vi.waitFor(() => expect(exit).toHaveBeenCalled());
+
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it("still exits 0 when shutdown throws", async () => {
+    // A failed drain must not look like a crash: the handles are already
+    // unusable, and a non-zero exit would make an orchestrator treat an
+    // ordinary redeploy as a crash loop.
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    const logged = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const shutdown = vi.fn().mockRejectedValue(new Error("pool already closed"));
+
+    installShutdownHandlers("scheduler", shutdown);
+    process.emit("SIGINT");
+    await vi.waitFor(() => expect(exit).toHaveBeenCalled());
+
+    expect(exit).toHaveBeenCalledWith(0);
+    expect(logged).toHaveBeenCalledWith("[scheduler] shutdown error:", expect.any(Error));
+  });
+
+  it("handles SIGINT and SIGTERM alike", async () => {
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const shutdown = vi.fn().mockResolvedValue(undefined);
+
+    installShutdownHandlers("api", shutdown);
+    process.emit("SIGINT");
+    process.emit("SIGTERM");
+    await vi.waitFor(() => expect(shutdown).toHaveBeenCalledTimes(2));
+  });
+});
+
+describe("runEntrypoint", () => {
+  it("exits 1 when main rejects", async () => {
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    const logged = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    runEntrypoint("api", () => Promise.reject(new Error("Missing required env vars: X")));
+    await vi.waitFor(() => expect(exit).toHaveBeenCalled());
+
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(logged).toHaveBeenCalledWith("[api] fatal:", expect.any(Error));
+  });
+
+  it("does not exit when main resolves", async () => {
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    const main = vi.fn().mockResolvedValue(undefined);
+
+    runEntrypoint("api", main);
+    await vi.waitFor(() => expect(main).toHaveBeenCalled());
+
+    expect(exit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/process-lifecycle.ts
+++ b/packages/core/src/process-lifecycle.ts
@@ -1,0 +1,122 @@
+/**
+ * Process-entrypoint scaffolding shared by the `api` and `scheduler`
+ * binaries.
+ *
+ * `packages/api/src/main.ts` and `packages/scheduler/src/main.ts` were
+ * the same 60-line file twice over, differing only in the log tag and in
+ * which handles the bootstrap returns: the same `REQUIRED_ENV` list, the
+ * same "collect every missing var then throw one message" loop, the same
+ * `resolveMcpServerUrl` fallback, the same `stop(signal)` closure wired
+ * to SIGINT + SIGTERM, and the same `main().catch` fatal handler.
+ *
+ * Splitting it this way keeps each binary's *own* wiring — its ports,
+ * its start order, its extra config — in its own main.ts, and moves only
+ * the parts that were textually identical here.
+ *
+ * `resolveRuntimeEnv` also tightens a footgun the copies shared: each
+ * validated `process.env` and then separately re-read it with non-null
+ * assertions (`process.env.DATABASE_URL!`) when building the bootstrap
+ * config, so the check and the read were two statements in two files
+ * that could drift apart. Validating and reading in one function leaves
+ * a single place where those assertions are made, next to the check
+ * that justifies them, and adding a required var is now one edit
+ * instead of three.
+ */
+
+import { resolveMcpServerUrl, type EnvSnapshot } from "./env.js";
+
+/**
+ * The env every composition root needs, validated and read in one step.
+ * Field names match the `BootstrapConfig` both binaries accept, so call
+ * sites can spread this straight into `bootstrap({ ...env, … })`.
+ */
+export interface RuntimeEnv {
+  databaseUrl: string;
+  openaiApiKey: string;
+  anthropicApiKey: string;
+  mcpServerUrl: string;
+  /** Optional — bootstrap defaults to `~/.beevibe/workspaces`. */
+  workspaceRoot?: string;
+  /** Optional — bootstrap defaults to `<cwd>/skills`. */
+  skillsSourceDir?: string;
+}
+
+/** Vars with no fallback; absence is fatal. */
+const REQUIRED_ENV = ["DATABASE_URL", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"] as const;
+
+/**
+ * Validate and read the composition-root env.
+ *
+ * Reports *every* missing var in one throw rather than failing on the
+ * first — an operator bringing up a fresh deploy fixes one round of
+ * config instead of one var per restart. `BEEVIBE_MCP_SERVER_URL` is
+ * checked through {@link resolveMcpServerUrl}, so a Railway deploy that
+ * only sets `RAILWAY_PUBLIC_DOMAIN` still passes.
+ */
+export function resolveRuntimeEnv(env: EnvSnapshot): RuntimeEnv {
+  const mcpServerUrl = resolveMcpServerUrl(env);
+
+  const missing: string[] = REQUIRED_ENV.filter((k) => !env[k]);
+  if (!mcpServerUrl) missing.push("BEEVIBE_MCP_SERVER_URL");
+  // The `!mcpServerUrl` half is redundant at runtime — it's already in
+  // `missing` — but it's what narrows the type for the return below.
+  if (missing.length > 0 || !mcpServerUrl) {
+    throw new Error(
+      `Missing required env vars: ${missing.join(", ")}. See .env.example for the full set.`,
+    );
+  }
+
+  return {
+    // Safe past the throw above: `missing` is empty, so each of these
+    // is a present, non-empty string.
+    databaseUrl: env.DATABASE_URL!,
+    openaiApiKey: env.OPENAI_API_KEY!,
+    anthropicApiKey: env.ANTHROPIC_API_KEY!,
+    mcpServerUrl,
+    workspaceRoot: env.WORKSPACE_ROOT,
+    skillsSourceDir: env.BEEVIBE_SKILLS_DIR,
+  };
+}
+
+/**
+ * Drain on SIGINT / SIGTERM, then exit 0.
+ *
+ * A shutdown that throws is logged and still exits 0: the handles are
+ * already unusable by then, and a non-zero exit would make an
+ * orchestrator treat an ordinary redeploy as a crash loop.
+ */
+export function installShutdownHandlers(
+  tag: string,
+  shutdown: () => Promise<void>,
+): void {
+  const stop = async (signal: string): Promise<void> => {
+    console.error(`[${tag}] ${signal} received, shutting down`);
+    try {
+      await shutdown();
+    } catch (err) {
+      console.error(`[${tag}] shutdown error:`, err);
+    }
+    process.exit(0);
+  };
+
+  process.on("SIGINT", () => {
+    void stop("SIGINT");
+  });
+  process.on("SIGTERM", () => {
+    void stop("SIGTERM");
+  });
+}
+
+/**
+ * Run a binary's `main`, exiting 1 on an unhandled rejection.
+ *
+ * Without this an env-validation throw would surface as node's default
+ * `UnhandledPromiseRejection` trace and — depending on node version and
+ * flags — an exit code an orchestrator may not treat as a failure.
+ */
+export function runEntrypoint(tag: string, main: () => Promise<void>): void {
+  main().catch((err: unknown) => {
+    console.error(`[${tag}] fatal:`, err);
+    process.exit(1);
+  });
+}

--- a/packages/scheduler/src/main.ts
+++ b/packages/scheduler/src/main.ts
@@ -1,36 +1,22 @@
 #!/usr/bin/env node
 import { config as loadEnv } from "dotenv";
-import { readPositiveInt, resolveMcpServerUrl } from "@beevibe/core";
+import {
+  installShutdownHandlers,
+  readPositiveInt,
+  resolveRuntimeEnv,
+  runEntrypoint,
+} from "@beevibe/core";
 import { bootstrap } from "./bootstrap.js";
-
-const REQUIRED_ENV = [
-  "DATABASE_URL",
-  "OPENAI_API_KEY",
-  "ANTHROPIC_API_KEY",
-] as const;
 
 async function main(): Promise<void> {
   // Load .env from CWD (production: env provided by orchestrator;
   // local dev: repo-root .env).
   loadEnv();
 
-  const mcpServerUrl = resolveMcpServerUrl(process.env);
-
-  const missing: string[] = REQUIRED_ENV.filter((k) => !process.env[k]);
-  if (!mcpServerUrl) missing.push("BEEVIBE_MCP_SERVER_URL");
-  if (missing.length > 0) {
-    throw new Error(
-      `Missing required env vars: ${missing.join(", ")}. See .env.example for the full set.`,
-    );
-  }
+  const env = resolveRuntimeEnv(process.env);
 
   const { worker, cancelListener, healthServer, shutdown } = await bootstrap({
-    databaseUrl: process.env.DATABASE_URL!,
-    mcpServerUrl: mcpServerUrl!,
-    openaiApiKey: process.env.OPENAI_API_KEY!,
-    anthropicApiKey: process.env.ANTHROPIC_API_KEY!,
-    workspaceRoot: process.env.WORKSPACE_ROOT,
-    skillsSourceDir: process.env.BEEVIBE_SKILLS_DIR,
+    ...env,
     pollIntervalMs: readPositiveInt(process.env.POLL_INTERVAL_MS, 0) || undefined,
     healthPort: readPositiveInt(process.env.BEEVIBE_SCHEDULER_HEALTH_PORT, 0) || undefined,
   });
@@ -40,25 +26,7 @@ async function main(): Promise<void> {
   await healthServer.start();
   console.error("[scheduler] ready");
 
-  const stop = async (signal: string): Promise<void> => {
-    console.error(`[scheduler] ${signal} received, shutting down`);
-    try {
-      await shutdown();
-    } catch (err) {
-      console.error("[scheduler] shutdown error:", err);
-    }
-    process.exit(0);
-  };
-
-  process.on("SIGINT", () => {
-    void stop("SIGINT");
-  });
-  process.on("SIGTERM", () => {
-    void stop("SIGTERM");
-  });
+  installShutdownHandlers("scheduler", shutdown);
 }
 
-main().catch((err: unknown) => {
-  console.error("[scheduler] fatal:", err);
-  process.exit(1);
-});
+runEntrypoint("scheduler", main);

--- a/packages/web/components/chip.tsx
+++ b/packages/web/components/chip.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * The inline label chip the app uses for short enum-ish values.
+ *
+ * `HierChip`, `ScopeChip` and `FactTypeTag` were the same component
+ * three times: a `<span>` with `inline-flex items-center rounded
+ * font-medium`, a `Record<Enum, string>` of colour classes indexed by
+ * the value, and a `className` passthrough merged last so call sites can
+ * resize. Only the colour map and two size values differed — and
+ * `ScopeChip` and `HierChip` didn't even differ in size, they were
+ * byte-identical apart from the map.
+ *
+ * The colour maps stay with their own components: each is a statement
+ * about a specific domain enum (which hierarchy tier is outline-only,
+ * which fact type is amber) and belongs next to the type it keys on.
+ * What's shared is the shape, which is what lives here.
+ */
+
+export type ChipSize = "sm" | "md";
+
+const SIZE_CLASS: Record<ChipSize, string> = {
+  /** Inline-with-text chips (hierarchy, memory scope). */
+  sm: "h-3.5 px-1 text-[10px]",
+  /** Standalone tags that carry their own line (fact type). */
+  md: "h-5 px-2 text-[11px] tracking-[0.01em] whitespace-nowrap",
+};
+
+export function Chip({
+  size = "sm",
+  tone,
+  className,
+  children,
+}: {
+  size?: ChipSize;
+  /** Colour classes for this value, e.g. `bg-hier-ic/15 text-hier-ic`. */
+  tone: string;
+  /**
+   * Per-call-site overrides. Merged last, so `cn`'s tailwind-merge lets
+   * a caller pass `h-5 px-1.5` to resize a chip without the base size
+   * fighting it — which is how `promotions/event-row` and
+   * `sessions/briefing-composer` already used `ScopeChip`.
+   */
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded font-medium",
+        SIZE_CLASS[size],
+        tone,
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/packages/web/components/fact-type-tag.tsx
+++ b/packages/web/components/fact-type-tag.tsx
@@ -1,5 +1,5 @@
 import type { FactType } from "@beevibe/core";
-import { cn } from "@/lib/utils";
+import { Chip } from "@/components/chip";
 
 const FACT_TYPE_CLASS: Record<FactType, string> = {
   belief: "bg-type-belief-bg text-type-belief-fg",
@@ -17,14 +17,8 @@ export function FactTypeTag({
   className?: string;
 }) {
   return (
-    <span
-      className={cn(
-        "inline-flex items-center h-5 px-2 rounded text-[11px] font-medium tracking-[0.01em] whitespace-nowrap",
-        FACT_TYPE_CLASS[type],
-        className,
-      )}
-    >
+    <Chip size="md" tone={FACT_TYPE_CLASS[type]} className={className}>
       {type}
-    </span>
+    </Chip>
   );
 }

--- a/packages/web/components/hier-chip.tsx
+++ b/packages/web/components/hier-chip.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils";
+import { Chip } from "@/components/chip";
 
 export type Hierarchy = "ic" | "team" | "org";
 
@@ -17,14 +17,8 @@ export function HierChip({
   className?: string;
 }) {
   return (
-    <span
-      className={cn(
-        "inline-flex items-center h-3.5 px-1 rounded text-[10px] font-medium",
-        HIER_CLASS[hier],
-        className,
-      )}
-    >
+    <Chip tone={HIER_CLASS[hier]} className={className}>
       {hier}
-    </span>
+    </Chip>
   );
 }

--- a/packages/web/components/scope-chip.tsx
+++ b/packages/web/components/scope-chip.tsx
@@ -1,5 +1,5 @@
 import type { MemoryScope } from "@beevibe/core";
-import { cn } from "@/lib/utils";
+import { Chip } from "@/components/chip";
 
 const SCOPE_CLASS: Record<MemoryScope, string> = {
   ic: "bg-hier-ic/15 text-hier-ic",
@@ -16,14 +16,8 @@ export function ScopeChip({
   className?: string;
 }) {
   return (
-    <span
-      className={cn(
-        "inline-flex items-center h-3.5 px-1 rounded text-[10px] font-medium",
-        SCOPE_CLASS[scope],
-        className,
-      )}
-    >
+    <Chip tone={SCOPE_CLASS[scope]} className={className}>
       {scope}
-    </span>
+    </Chip>
   );
 }

--- a/packages/web/lib/format.ts
+++ b/packages/web/lib/format.ts
@@ -17,6 +17,7 @@ export {
   deriveShortId,
   formatDurationLabel,
   toDate,
+  truncate,
   type DateLike,
 } from "@beevibe/core/domain/format";
 
@@ -27,11 +28,6 @@ export function formatRelativeTime(date: DateLike, now: Date = new Date()): stri
 
 export function shortId(id: string): string {
   return `#${deriveShortId(id)}`;
-}
-
-/** Cap a string at `n` chars, adding an ellipsis suffix when truncated. */
-export function truncate(s: string, n: number): string {
-  return s.length > n ? s.slice(0, n - 1) + "…" : s;
 }
 
 /**


### PR DESCRIPTION
Fourth sweep for near-duplicate abstractions, picking up where #257, #259 and #263 left off. Four clusters, ~324 lines removed against ~297 added (the added side is mostly tests and the doc comments explaining why each merge is safe).

Net production code is meaningfully smaller: **-127 lines** excluding the 25 new tests.

## 1. One process entrypoint, two binaries

`packages/api/src/main.ts` and `packages/scheduler/src/main.ts` were the same 60-line file twice over, differing only in the log tag and in which handles their bootstrap returns — same `REQUIRED_ENV` list, same collect-then-throw loop, same `resolveMcpServerUrl` fallback, same `stop(signal)` closure on SIGINT + SIGTERM, same `main().catch` fatal handler. `jscpd` flagged two separate clone regions between the pair.

Extracted to `core/src/process-lifecycle.ts` as `resolveRuntimeEnv`, `installShutdownHandlers`, `runEntrypoint`. Each `main.ts` keeps its own wiring — its ports, its start order, its extra config — and loses only what was textually identical.

`resolveRuntimeEnv` also tightens a footgun both copies shared: each validated `process.env` and then *separately* re-read it with non-null assertions when building the bootstrap config, so the check and the read were two statements in two files that could drift. Validating and reading in one function leaves a single place where those assertions live, next to the check that justifies them; adding a required var is now one edit instead of three. It returns the field names `BootstrapConfig` already takes, so both call sites just spread it.

| | before | after |
| --- | --- | --- |
| `api/src/main.ts` | 65 lines | 33 |
| `scheduler/src/main.ts` | 64 lines | 32 |

## 2. Two API route guards that were written out 34 times

**`requireParam`** — replaces the five-line `const id = req.params.id; if (!id) { 400; return; }` preamble at **24 handlers** across 8 route files. A `:id` segment can't actually be absent (the route wouldn't have matched), but the param is typed `string | undefined` under `noUncheckedIndexedAccess`, so every handler narrowed it by hand.

The error code stays per-call-site deliberately: the codes already in the wire contract are not uniform (`missing_id`, `missing_task_id`, `missing_agent_id`, `missing_head_id`, …) and clients may branch on them. This factors out the shape, not the codes — every response stays byte-identical. It also *narrows* Express 5's `string | string[]` rather than casting, which is what the one handler that had noticed that was already doing longhand.

**`loadOwned`** — replaces the fetch → `if (!row) 404` → `if (row.owner !== caller) 403` block at **8 handlers** in `view`, `learned-skills` and `runtimes`. Eight hand-written copies is eight chances to forget the second half, and forgetting it is a cross-tenant read; worth having one implementation that can't be half-written.

`ownerOf` is a projector rather than a field name because the column isn't uniform (`owner_id` on agents and learned skills, `owner_person_id` on daemons). The non-owner response is an explicit `{status, error}` rather than something inferred, so `runtimes` keeps answering **404** — that endpoint deliberately doesn't confirm a daemon id exists, and making that a visible argument keeps it an explicit choice.

Two ownership guards are **left inline on purpose**: `view`'s memory-fact delete and `capabilities` both collapse not-found into the 403 (the row is guaranteed to exist by an `ON DELETE CASCADE` FK). Routing those through `loadOwned` would turn a documented-impossible missing row into a 404 — a behavior change on an unreachable path, for no gain on a 2-line guard.

## 3. Finishing the `format.ts` consolidation from #263

- `views/work-product.ts` still carried a private `deriveTaskShortId` **byte-identical** to core's `deriveShortId`. The last sweep missed it because the name differed.
- `truncate` moves from `web/lib/format.ts` into `core/domain/format.ts` alongside the other shared formatters. The api had written the same expression out longhand in **two places that build the same field** — the chat-thread `title`, once in `views/agents.ts` (agent detail page) and once in `routes/chat.ts` (conversation list). Those two disagreeing would render one thread under two different titles depending on which page you opened, which is exactly the drift the rest of that module exists to prevent. The cap is now a single `CHAT_THREAD_TITLE_MAX` sitting next to the DTO that documents it.

**Deliberately not folded in:** several call sites (`tools/use-repo.ts`, `capabilities/runs/[id]`, `lib/capabilities.ts`) use `s.length > n ? s.slice(0, n - 3) + "…"`, which caps at `n - 2` rather than `n`. That's a different — probably accidental — contract, and folding it in would silently re-lengthen those strings. Flagging it rather than changing it.

## 4. One chip primitive under three chips

`HierChip`, `ScopeChip` and `FactTypeTag` were the same component three times: a `<span>` with `inline-flex items-center rounded font-medium`, a `Record<Enum, string>` of colour classes indexed by the value, and a `className` merged last so call sites can resize. `ScopeChip` and `HierChip` didn't even differ in size — byte-identical apart from the map.

The colour maps **stay with their own components**: each is a statement about a specific domain enum (which hierarchy tier is outline-only, which fact type is amber) and belongs next to the type it keys on. Only the shape moved, to `components/chip.tsx`. Class sets are unchanged, so tailwind-merge still lets `promotions/event-row` and `sessions/briefing-composer` resize a chip from the call site as they already do.

## Tests

25 new tests over code that had none directly:

- `process-lifecycle.test.ts` (11) — all-missing-vars-reported-at-once, empty string treated as missing, the Railway MCP fallback, exit 0 on signal, **exit 0 when the drain itself throws** (a failed drain must not read as a crash loop to an orchestrator), exit 1 on a rejected `main`.
- `http-errors.test.ts` (10) — both guards, including array-param rejection and the existence-hiding 404 variant.
- 4 `truncate` cases pinning the cap-includes-the-ellipsis contract.

## Verification

- `pnpm typecheck` — 9/9 tasks clean
- `pnpm lint` — 0 errors (4 pre-existing `import/no-duplicates` warnings in untouched test files)
- `@beevibe/web` — 192/192 pass
- `@beevibe/core`, `@beevibe/api`, `@beevibe/scheduler` — match the bare-sandbox baseline in CLAUDE.md; every failure is a no-Postgres or no-provider-key one. API is actually ahead of the documented baseline (333 passing vs 308) with **zero** failing test cases — only file-level collection failures from the missing DB.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpZi5GFaWAqNbEvZu29jEn)_