### PR TITLE
test(daemon): cover the six untested daemon modules (30% → 80% lines)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,27 @@ pnpm test
 `.github/workflows/ci.yml` is the source of truth; CONTRIBUTING.md has
 the long form. Narrower loop: `pnpm --filter @beevibe/core test`.
 
+### Measuring coverage
+
+No coverage provider is tracked as a dependency — install one for the
+sweep and don't commit it:
+
+```bash
+pnpm add -Dw @vitest/coverage-v8@2.1.9
+cd packages/daemon && npx vitest run --coverage --coverage.provider=v8 \
+  --coverage.all --coverage.include='src/**/*.ts' \
+  --coverage.exclude='src/**/*.test.ts' --exclude '**/*.e2e.test.ts'
+```
+
+Two traps:
+
+- `--coverage.all` is required, or files with no test file at all are
+  simply absent from the report and read as "covered".
+- An **unhandled** error in a test file (the DB-gated suites throw one
+  from `afterAll`) aborts report generation entirely — the run prints
+  results but writes no `coverage-summary.json`. Exclude the DB- and
+  key-gated suites when measuring without Postgres.
+
 ### Recognizing environmental failures vs. real ones
 
 In a sandbox with no Docker and no provider keys, these failures are

--- a/packages/daemon/src/api-client.test.ts
+++ b/packages/daemon/src/api-client.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiClient } from "./api-client.js";
+
+const { wsCalls } = vi.hoisted(() => ({
+  wsCalls: [] as Array<{ url: string; options: { headers: Record<string, string> } }>,
+}));
+
+vi.mock("ws", () => ({
+  default: class FakeWebSocket {
+    constructor(url: string, options: { headers: Record<string, string> }) {
+      wsCalls.push({ url, options });
+    }
+  },
+}));
+
+/** Minimal stand-in for the parts of `Response` ApiClient touches. */
+function response(init: { status: number; json?: unknown; text?: string }) {
+  return {
+    status: init.status,
+    json: async () => init.json,
+    text: async () =>
+      init.text ?? (init.json === undefined ? "" : JSON.stringify(init.json)),
+  };
+}
+
+function client(): { api: ApiClient; fetchMock: ReturnType<typeof vi.fn> } {
+  const fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+  return {
+    api: new ApiClient({ apiUrl: "http://api.test", daemonToken: "bv_d_secret" }),
+    fetchMock,
+  };
+}
+
+/** The `init` object handed to the Nth fetch call. */
+function initOf(fetchMock: ReturnType<typeof vi.fn>, n = 0): RequestInit {
+  return fetchMock.mock.calls[n]?.[1] as RequestInit;
+}
+
+beforeEach(() => {
+  wsCalls.length = 0;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("ApiClient.get", () => {
+  it("returns the parsed body and sends bearer auth against the configured base URL", async () => {
+    const { api, fetchMock } = client();
+    fetchMock.mockResolvedValue(response({ status: 200, json: { ok: true } }));
+
+    await expect(api.get("/runtime/skills")).resolves.toEqual({ ok: true });
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://api.test/runtime/skills");
+    expect(initOf(fetchMock).headers).toEqual({
+      authorization: "Bearer bv_d_secret",
+    });
+  });
+
+  it.each([
+    { status: 204, label: "204 no-content" },
+    { status: 401, label: "401 unauthorized" },
+    { status: 404, label: "404 not found" },
+    { status: 500, label: "500 server error" },
+  ])("returns undefined on $label without parsing a body", async ({ status }) => {
+    const { api, fetchMock } = client();
+    const json = vi.fn();
+    fetchMock.mockResolvedValue({ status, json });
+
+    await expect(api.get("/runtime/skills")).resolves.toBeUndefined();
+    expect(json).not.toHaveBeenCalled();
+  });
+});
+
+describe("ApiClient.post", () => {
+  it("sends a JSON body with content-type and bearer auth", async () => {
+    const { api, fetchMock } = client();
+    fetchMock.mockResolvedValue(response({ status: 200, json: { id: "x" } }));
+
+    await api.post("/runtime/events", { events: [{ kind: "agent" }] });
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://api.test/runtime/events");
+    const init = initOf(fetchMock);
+    expect(init.method).toBe("POST");
+    expect(init.headers).toEqual({
+      "content-type": "application/json",
+      authorization: "Bearer bv_d_secret",
+    });
+    expect(init.body).toBe(JSON.stringify({ events: [{ kind: "agent" }] }));
+  });
+
+  it("returns status + parsed body on a 200", async () => {
+    const { api, fetchMock } = client();
+    fetchMock.mockResolvedValue(response({ status: 200, json: { runtimes: [] } }));
+
+    await expect(api.post("/runtime/sync", {})).resolves.toEqual({
+      status: 200,
+      body: { runtimes: [] },
+    });
+  });
+
+  it("short-circuits a 204 without reading the body", async () => {
+    const { api, fetchMock } = client();
+    const text = vi.fn();
+    fetchMock.mockResolvedValue({ status: 204, text });
+
+    await expect(api.post("/runtime/done", {})).resolves.toEqual({
+      status: 204,
+      body: undefined,
+    });
+    expect(text).not.toHaveBeenCalled();
+  });
+
+  it("treats an empty response body as no body, keeping the status", async () => {
+    const { api, fetchMock } = client();
+    fetchMock.mockResolvedValue(response({ status: 202, text: "" }));
+
+    await expect(api.post("/runtime/done", {})).resolves.toEqual({
+      status: 202,
+      body: undefined,
+    });
+  });
+
+  it("swallows unparseable bodies but still reports the status", async () => {
+    const { api, fetchMock } = client();
+    fetchMock.mockResolvedValue(
+      response({ status: 502, text: "<html>bad gateway</html>" }),
+    );
+
+    await expect(api.post("/runtime/done", {})).resolves.toEqual({
+      status: 502,
+      body: undefined,
+    });
+  });
+
+  it("parses error bodies on 4xx so callers can read the reason", async () => {
+    const { api, fetchMock } = client();
+    fetchMock.mockResolvedValue(
+      response({ status: 409, json: { error: "already claimed" } }),
+    );
+
+    await expect(api.post("/runtime/claim", {})).resolves.toEqual({
+      status: 409,
+      body: { error: "already claimed" },
+    });
+  });
+});
+
+describe("ApiClient.claim", () => {
+  it("POSTs /runtime/claim with the runtime id url-encoded into the query", async () => {
+    const { api, fetchMock } = client();
+    fetchMock.mockResolvedValue(response({ status: 200, json: { session_id: "s1" } }));
+
+    await expect(api.claim("rt/with space")).resolves.toEqual({ session_id: "s1" });
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "http://api.test/runtime/claim?runtime_id=rt%2Fwith%20space",
+    );
+    const init = initOf(fetchMock);
+    expect(init.method).toBe("POST");
+    expect(init.headers).toEqual({ authorization: "Bearer bv_d_secret" });
+  });
+
+  it.each([
+    { status: 204, label: "nothing pending (204)" },
+    { status: 409, label: "already-claimed race (409)" },
+    { status: 404, label: "unknown runtime (404)" },
+  ])("returns undefined for $label", async ({ status }) => {
+    const { api, fetchMock } = client();
+    fetchMock.mockResolvedValue({ status, json: vi.fn() });
+
+    await expect(api.claim("rt_1")).resolves.toBeUndefined();
+  });
+});
+
+describe("ApiClient.openWebSocket", () => {
+  it("swaps http for ws and passes the runtime ids comma-joined", () => {
+    const { api } = client();
+
+    api.openWebSocket(["rt_1", "rt_2"]);
+
+    expect(wsCalls).toHaveLength(1);
+    expect(wsCalls[0]?.url).toBe(
+      "ws://api.test/runtime/ws?runtime_ids=rt_1,rt_2",
+    );
+    expect(wsCalls[0]?.options.headers).toEqual({
+      authorization: "Bearer bv_d_secret",
+    });
+  });
+
+  it("swaps https for wss", () => {
+    vi.stubGlobal("fetch", vi.fn());
+    const api = new ApiClient({
+      apiUrl: "https://api.beevibe.test",
+      daemonToken: "bv_d_secret",
+    });
+
+    api.openWebSocket(["rt_1"]);
+
+    expect(wsCalls[0]?.url).toBe(
+      "wss://api.beevibe.test/runtime/ws?runtime_ids=rt_1",
+    );
+  });
+
+  it("url-encodes each runtime id individually, not the joined string", () => {
+    const { api } = client();
+
+    api.openWebSocket(["rt a", "rt+b"]);
+
+    expect(wsCalls[0]?.url).toBe(
+      "ws://api.test/runtime/ws?runtime_ids=rt%20a,rt%2Bb",
+    );
+  });
+});

--- a/packages/daemon/src/claimer.test.ts
+++ b/packages/daemon/src/claimer.test.ts
@@ -1,9 +1,15 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { LocalWorkspaceManager } from "@beevibe/core/adapters/local-workspace";
 import type WebSocket from "ws";
 import type { ApiClient } from "./api-client.js";
 import { Claimer } from "./claimer.js";
 import { Supervisor } from "./supervisor.js";
+import type { DispatchPayload } from "./spawner.js";
+
+const { runDispatchMock } = vi.hoisted(() => ({ runDispatchMock: vi.fn() }));
+
+vi.mock("./spawner.js", () => ({ runDispatch: runDispatchMock }));
+vi.mock("./logger.js", () => ({ log: vi.fn(), warn: vi.fn(), error: vi.fn() }));
 
 interface FakeWs {
   on(event: string, cb: (...args: unknown[]) => void): FakeWs;
@@ -167,5 +173,298 @@ describe("Claimer.pollRuntime resilience", () => {
       process.off("unhandledRejection", unhandled);
       await claimer.stop();
     }
+  });
+});
+
+function dispatch(overrides: Partial<DispatchPayload> = {}): DispatchPayload {
+  return {
+    session_id: "sess_1",
+    agent_id: "agent_1",
+    agent_api_key: "bv_a_test",
+    agent_hierarchy_level: "ic",
+    runtime_type: "claude",
+    intent: "work",
+    system_prompt_append: "",
+    env: {},
+    type: "task",
+    mcp_server_url: "http://api.test/mcp",
+    ...overrides,
+  };
+}
+
+/** A Claimer with quiet timers: only explicit triggers drive it. */
+function makeClaimer(
+  api: ApiClient,
+  supervisor = new Supervisor(2),
+  runtimeIds = ["rt_1", "rt_2"],
+): { claimer: Claimer; supervisor: Supervisor } {
+  return {
+    claimer: new Claimer({
+      api,
+      supervisor,
+      workspaceManager: {} as LocalWorkspaceManager,
+      runtimeRegistry: {},
+      runtimeIds,
+      pollIntervalMs: 600_000,
+      heartbeatIntervalMs: 600_000,
+      wsPingIntervalMs: 600_000,
+    }),
+    supervisor,
+  };
+}
+
+/** Let queued microtasks and the poll loop settle. */
+const settle = async (): Promise<void> => {
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+};
+
+beforeEach(() => {
+  runDispatchMock.mockReset();
+  runDispatchMock.mockResolvedValue(undefined);
+});
+
+describe("Claimer heartbeat", () => {
+  it("posts every registered runtime id on start", async () => {
+    const post = vi.fn(async () => ({ status: 204, body: undefined }));
+    const { claimer } = makeClaimer(makeApi({ post } as Partial<ApiClient>));
+
+    claimer.start();
+    await settle();
+    await claimer.stop();
+
+    expect(post).toHaveBeenCalledWith("/runtime/heartbeat", {
+      runtime_ids: ["rt_1", "rt_2"],
+    });
+  });
+
+  it("survives a heartbeat POST failure", async () => {
+    const post = vi.fn(async () => {
+      throw new TypeError("fetch failed");
+    });
+    const { claimer } = makeClaimer(makeApi({ post } as Partial<ApiClient>));
+
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+    try {
+      claimer.start();
+      await settle();
+      expect(post).toHaveBeenCalled();
+      expect(unhandled).not.toHaveBeenCalled();
+    } finally {
+      process.off("unhandledRejection", unhandled);
+      await claimer.stop();
+    }
+  });
+
+  it("stops heartbeating once stopped", async () => {
+    const post = vi.fn(async () => ({ status: 204, body: undefined }));
+    const { claimer } = makeClaimer(makeApi({ post } as Partial<ApiClient>));
+
+    claimer.start();
+    await settle();
+    await claimer.stop();
+    const afterStop = post.mock.calls.length;
+    await settle();
+
+    expect(post).toHaveBeenCalledTimes(afterStop);
+  });
+});
+
+describe("Claimer claim handoff", () => {
+  it("drains a runtime's queue until /runtime/claim returns nothing", async () => {
+    const claim = vi
+      .fn()
+      .mockResolvedValueOnce(dispatch({ session_id: "sess_1" }))
+      .mockResolvedValueOnce(dispatch({ session_id: "sess_2" }))
+      .mockResolvedValue(undefined);
+    const { claimer } = makeClaimer(
+      makeApi({ claim } as Partial<ApiClient>),
+      new Supervisor(2),
+      ["rt_1"],
+    );
+
+    claimer.start();
+    await settle();
+    await claimer.stop();
+
+    expect(runDispatchMock.mock.calls.map((c: unknown[]) => (c[1] as DispatchPayload).session_id))
+      .toEqual(["sess_1", "sess_2"]);
+  });
+
+  it("aborts an in-flight dispatch when the claimer stops", async () => {
+    // Never resolves: the session stays in-flight so stop() has something
+    // to cancel.
+    runDispatchMock.mockImplementation(() => new Promise(() => {}));
+    const claim = vi.fn().mockResolvedValueOnce(dispatch()).mockResolvedValue(undefined);
+    const { claimer } = makeClaimer(
+      makeApi({ claim } as Partial<ApiClient>),
+      new Supervisor(2),
+      ["rt_1"],
+    );
+
+    claimer.start();
+    await settle();
+
+    const signal = runDispatchMock.mock.calls[0]?.[2] as AbortSignal;
+    expect(signal.aborted).toBe(false);
+    await claimer.stop();
+    expect(signal.aborted).toBe(true);
+  });
+
+  it("releases the supervisor slot when a dispatch throws", async () => {
+    const claim = vi.fn().mockResolvedValueOnce(dispatch()).mockResolvedValue(undefined);
+    const supervisor = new Supervisor(2);
+    runDispatchMock.mockRejectedValue(new Error("spawn failed"));
+    const { claimer } = makeClaimer(
+      makeApi({ claim } as Partial<ApiClient>),
+      supervisor,
+      ["rt_1"],
+    );
+
+    claimer.start();
+    await settle();
+    await settle();
+
+    expect(supervisor.hasCapacity()).toBe(true);
+    await claimer.stop();
+  });
+
+  it("stops claiming once the supervisor is at capacity", async () => {
+    // Never resolves: the slot stays held for the whole test.
+    runDispatchMock.mockImplementation(() => new Promise(() => {}));
+    const claim = vi.fn(async () => dispatch({ session_id: `sess_${claim.mock.calls.length}` }));
+    const { claimer } = makeClaimer(
+      makeApi({ claim } as Partial<ApiClient>),
+      new Supervisor(1),
+      ["rt_1"],
+    );
+
+    claimer.start();
+    await settle();
+    await claimer.stop();
+
+    expect(runDispatchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Claimer ws push handling", () => {
+  function connected(api: ApiClient): {
+    claimer: Claimer;
+    socket: WebSocket & FakeWs;
+  } {
+    let socket: (WebSocket & FakeWs) | undefined;
+    const withWs = makeApi({
+      ...api,
+      openWebSocket: vi.fn(() => {
+        socket = fakeWs();
+        return socket;
+      }) as unknown as ApiClient["openWebSocket"],
+    } as Partial<ApiClient>);
+    const { claimer } = makeClaimer(withWs);
+    claimer.start();
+    return { claimer, socket: socket! };
+  }
+
+  it("claims the named runtime on a task_available push", async () => {
+    const claim = vi.fn(async () => undefined);
+    const { claimer, socket } = connected(makeApi({ claim } as Partial<ApiClient>));
+    await settle();
+    claim.mockClear();
+
+    socket.fire("message", Buffer.from(JSON.stringify({
+      type: "task_available",
+      runtime_id: "rt_2",
+    })));
+    await settle();
+
+    expect(claim).toHaveBeenCalledWith("rt_2");
+    await claimer.stop();
+  });
+
+  it("cancels the named session on a cancel push", async () => {
+    const supervisor = new Supervisor(2);
+    const cancel = vi.spyOn(supervisor, "cancel");
+    let socket: (WebSocket & FakeWs) | undefined;
+    const api = makeApi({
+      openWebSocket: vi.fn(() => {
+        socket = fakeWs();
+        return socket;
+      }) as unknown as ApiClient["openWebSocket"],
+    });
+    const { claimer } = makeClaimer(api, supervisor);
+    claimer.start();
+
+    socket!.fire("message", Buffer.from(JSON.stringify({
+      type: "cancel",
+      session_id: "sess_9",
+    })));
+
+    expect(cancel).toHaveBeenCalledWith("sess_9");
+    await claimer.stop();
+  });
+
+  it.each([
+    { raw: "not json", label: "unparseable frames" },
+    { raw: '{"type":"task_available"}', label: "a task_available with no runtime_id" },
+    { raw: '{"type":"cancel"}', label: "a cancel with no session_id" },
+    { raw: '{"type":"something_else","runtime_id":"rt_1"}', label: "unknown push types" },
+  ])("ignores $label", async ({ raw }) => {
+    const claim = vi.fn(async () => undefined);
+    const { claimer, socket } = connected(makeApi({ claim } as Partial<ApiClient>));
+    await settle();
+    claim.mockClear();
+
+    expect(() => socket.fire("message", Buffer.from(raw))).not.toThrow();
+    await settle();
+
+    expect(claim).not.toHaveBeenCalled();
+    await claimer.stop();
+  });
+
+  it("logs a ws error without reconnecting — close drives that", async () => {
+    const { claimer, socket } = connected(makeApi());
+
+    expect(() => socket.fire("error", new Error("ECONNRESET"))).not.toThrow();
+
+    await claimer.stop();
+  });
+
+  it("does not reconnect after stop()", async () => {
+    const sockets: Array<WebSocket & FakeWs> = [];
+    const api = makeApi({
+      openWebSocket: vi.fn(() => {
+        const ws = fakeWs();
+        sockets.push(ws);
+        return ws;
+      }) as unknown as ApiClient["openWebSocket"],
+    });
+    const { claimer } = makeClaimer(api);
+
+    claimer.start();
+    await claimer.stop();
+    sockets[0]!.fire("close");
+    await settle();
+
+    expect(sockets).toHaveLength(1);
+  });
+
+  it("is idempotent — a second start() does not open a second socket", async () => {
+    const sockets: Array<WebSocket & FakeWs> = [];
+    const api = makeApi({
+      openWebSocket: vi.fn(() => {
+        const ws = fakeWs();
+        sockets.push(ws);
+        return ws;
+      }) as unknown as ApiClient["openWebSocket"],
+    });
+    const { claimer } = makeClaimer(api);
+
+    claimer.start();
+    claimer.start();
+    await settle();
+
+    expect(sockets).toHaveLength(1);
+    await claimer.stop();
   });
 });

--- a/packages/daemon/src/detect-clis.test.ts
+++ b/packages/daemon/src/detect-clis.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { KNOWN_CLIS } from "@beevibe/core";
+import { detectClis } from "./detect-clis.js";
+
+const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }));
+
+vi.mock("node:child_process", () => ({ execFile: execFileMock }));
+
+type ExecCallback = (err: Error | null, out?: { stdout: string; stderr: string }) => void;
+
+/**
+ * Drive the promisified `execFile` from a table of
+ * `"<cmd> <args…>" -> stdout | Error`. Anything not in the table fails,
+ * which models "not on PATH" for `which` probes.
+ */
+function program(table: Record<string, string | Error>): void {
+  execFileMock.mockImplementation(
+    (cmd: string, args: string[], cb: ExecCallback) => {
+      const key = [cmd, ...args].join(" ");
+      const outcome = table[key];
+      if (outcome === undefined) {
+        cb(new Error(`command failed: ${key}`));
+        return;
+      }
+      if (outcome instanceof Error) {
+        cb(outcome);
+        return;
+      }
+      cb(null, { stdout: outcome, stderr: "" });
+    },
+  );
+}
+
+/** Every CLI on PATH, each reporting `<cli> 1.0.0`. */
+function allPresent(): Record<string, string | Error> {
+  return Object.fromEntries(
+    KNOWN_CLIS.flatMap((cli) => [
+      [`which ${cli}`, `/usr/local/bin/${cli}\n`],
+      [`${cli} --version`, `${cli} 1.0.0\n`],
+    ]),
+  );
+}
+
+beforeEach(() => {
+  execFileMock.mockReset();
+});
+
+describe("detectClis", () => {
+  it("reports every known CLI on PATH with its version", async () => {
+    program(allPresent());
+
+    await expect(detectClis()).resolves.toEqual(
+      KNOWN_CLIS.map((cli) => ({ cli, cli_version: `${cli} 1.0.0` })),
+    );
+  });
+
+  it("returns an empty list when nothing is on PATH", async () => {
+    program({});
+
+    await expect(detectClis()).resolves.toEqual([]);
+    // Still probed once per known CLI — no early bail-out.
+    expect(execFileMock).toHaveBeenCalledTimes(KNOWN_CLIS.length);
+  });
+
+  it("omits CLIs whose `which` lookup fails and never asks them for a version", async () => {
+    const table = allPresent();
+    delete table[`which ${KNOWN_CLIS[1]}`];
+    program(table);
+
+    const detected = await detectClis();
+
+    expect(detected.map((d) => d.cli)).toEqual(
+      KNOWN_CLIS.filter((c) => c !== KNOWN_CLIS[1]),
+    );
+    const invoked = execFileMock.mock.calls.map(
+      (c: unknown[]) => [c[0], ...(c[1] as string[])].join(" "),
+    );
+    expect(invoked).not.toContain(`${KNOWN_CLIS[1]} --version`);
+  });
+
+  it("keeps a CLI whose --version errors, with no version attached", async () => {
+    const table = allPresent();
+    table[`${KNOWN_CLIS[0]} --version`] = new Error("exit 1");
+    program(table);
+
+    const detected = await detectClis();
+
+    expect(detected[0]).toEqual({ cli: KNOWN_CLIS[0], cli_version: undefined });
+    expect(detected).toHaveLength(KNOWN_CLIS.length);
+  });
+
+  it("keeps only the first line of a multi-line version banner", async () => {
+    const table = allPresent();
+    table[`${KNOWN_CLIS[0]} --version`] =
+      "1.2.3 (Claude Code)\nnode v22.0.0\nplatform darwin\n";
+    program(table);
+
+    const [first] = await detectClis();
+
+    expect(first?.cli_version).toBe("1.2.3 (Claude Code)");
+  });
+
+  it("preserves KNOWN_CLIS order regardless of which probe settles first", async () => {
+    const table = allPresent();
+    const rank = (cmd: string, args: string[]): number =>
+      KNOWN_CLIS.indexOf((cmd === "which" ? args[0] : cmd) as never);
+    execFileMock.mockImplementation(
+      (cmd: string, args: string[], cb: ExecCallback) => {
+        const outcome = table[[cmd, ...args].join(" ")] as string;
+        // Reverse declaration order: the last known CLI answers first.
+        const delay = (KNOWN_CLIS.length - rank(cmd, args)) * 2;
+        setTimeout(() => cb(null, { stdout: outcome, stderr: "" }), delay);
+      },
+    );
+
+    const detected = await detectClis();
+
+    expect(detected.map((d) => d.cli)).toEqual([...KNOWN_CLIS]);
+  });
+});

--- a/packages/daemon/src/repo-runs.test.ts
+++ b/packages/daemon/src/repo-runs.test.ts
@@ -1,0 +1,347 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RunState, TranscriptEvent } from "@beevibe/sandbox/orchestrator";
+import type { ApiClient } from "./api-client.js";
+import { runRepoDispatch } from "./repo-runs.js";
+import type { DispatchPayload } from "./spawner.js";
+
+const { runRepoAgentMock } = vi.hoisted(() => ({ runRepoAgentMock: vi.fn() }));
+
+vi.mock("@beevibe/sandbox/orchestrator", () => ({ runRepoAgent: runRepoAgentMock }));
+vi.mock("./logger.js", () => ({ log: vi.fn(), warn: vi.fn(), error: vi.fn() }));
+
+function payload(overrides: Partial<DispatchPayload> = {}): DispatchPayload {
+  return {
+    session_id: "sess_1",
+    agent_id: "agent_1",
+    agent_api_key: "bv_a_test",
+    agent_hierarchy_level: "ic",
+    runtime_type: "claude",
+    intent: "borrow a repo",
+    system_prompt_append: "",
+    env: {},
+    type: "run_repo",
+    mcp_server_url: "http://api.test/mcp",
+    run_repo: {
+      repo_run_id: "rr_1",
+      repo_url: "https://github.com/acme/tool",
+      goal: "convert the PDF",
+    },
+    ...overrides,
+  };
+}
+
+function event(kind: TranscriptEvent["kind"], text: string): TranscriptEvent {
+  return { at: "2026-01-01T00:00:00.000Z", kind, text };
+}
+
+function runState(overrides: Partial<RunState> = {}): RunState {
+  return {
+    run_id: "rr_1",
+    status: "succeeded",
+    repo_url: "https://github.com/acme/tool",
+    goal: "convert the PDF",
+    started_at: "2026-01-01T00:00:00.000Z",
+    transcript: [],
+    artifacts: [],
+    ...overrides,
+  };
+}
+
+interface Post {
+  path: string;
+  body: Record<string, unknown>;
+}
+
+function fakeApi(): { api: ApiClient; posts: Post[] } {
+  const posts: Post[] = [];
+  const post = vi.fn(async (path: string, body: unknown) => {
+    posts.push({ path, body: body as Record<string, unknown> });
+    return { status: 200, body: undefined };
+  });
+  return { api: { post } as unknown as ApiClient, posts };
+}
+
+/** Every event the batcher pushed to /runtime/events, in order. */
+function eventsFrom(posts: Post[]): Array<{ kind: string; content: string }> {
+  return posts
+    .filter((p) => p.path === "/runtime/events")
+    .flatMap((p) => p.body.events as Array<{ kind: string; content: string }>);
+}
+
+function doneFrom(posts: Post[]): Record<string, unknown> {
+  const done = posts.find((p) => p.path === "/runtime/done");
+  if (!done) throw new Error("no /runtime/done POST was made");
+  return done.body;
+}
+
+/** Make the mocked orchestrator replay `transcript` through on_state in slices. */
+function replay(transcript: TranscriptEvent[], slices: number[], result: RunState) {
+  runRepoAgentMock.mockImplementation(
+    async (opts: { on_state?: (s: RunState) => void }) => {
+      for (const upTo of slices) {
+        opts.on_state?.(runState({ transcript: transcript.slice(0, upTo) }));
+      }
+      return result;
+    },
+  );
+}
+
+beforeEach(() => {
+  runRepoAgentMock.mockReset();
+  runRepoAgentMock.mockResolvedValue(runState());
+});
+
+describe("runRepoDispatch", () => {
+  it("rejects a dispatch that is missing its run_repo block", async () => {
+    const { api } = fakeApi();
+
+    await expect(
+      runRepoDispatch({ api }, payload({ run_repo: undefined })),
+    ).rejects.toThrow(/missing payload\.run_repo/);
+    expect(runRepoAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("hands the run_repo block to the orchestrator, defaulting the wall clock to 20 minutes", async () => {
+    const { api } = fakeApi();
+
+    await runRepoDispatch({ api }, payload());
+
+    expect(runRepoAgentMock.mock.calls[0]?.[0]).toMatchObject({
+      run_id: "rr_1",
+      repo_url: "https://github.com/acme/tool",
+      goal: "convert the PDF",
+      max_runtime_seconds: 20 * 60,
+    });
+  });
+
+  it("converts the wall-clock limit from minutes to seconds", async () => {
+    const { api } = fakeApi();
+
+    await runRepoDispatch(
+      { api },
+      payload({
+        run_repo: {
+          repo_run_id: "rr_1",
+          repo_url: "https://github.com/acme/tool",
+          goal: "convert the PDF",
+          limits: { wall_clock_minutes: 5 },
+        },
+      }),
+    );
+
+    expect(runRepoAgentMock.mock.calls[0]?.[0]).toMatchObject({
+      max_runtime_seconds: 300,
+    });
+  });
+
+  it("maps orchestrator transcript kinds onto session event kinds", async () => {
+    const { api, posts } = fakeApi();
+    replay(
+      [
+        event("agent", "thinking"),
+        event("tool_call", "sandbox_exec({\"cmd\":\"ls\"})"),
+        event("log", "container ready"),
+        event("error", "exit 1"),
+      ],
+      [4],
+      runState(),
+    );
+
+    await runRepoDispatch({ api }, payload());
+
+    expect(eventsFrom(posts)).toEqual([
+      { session_id: "sess_1", kind: "agent", content: "thinking" },
+      {
+        session_id: "sess_1",
+        kind: "tool_call",
+        content: "sandbox_exec({\"cmd\":\"ls\"})",
+      },
+      { session_id: "sess_1", kind: "summary", content: "container ready" },
+      { session_id: "sess_1", kind: "tool_result", content: "exit 1" },
+    ]);
+  });
+
+  it("sends each transcript entry once even though on_state replays the whole transcript", async () => {
+    const { api, posts } = fakeApi();
+    replay(
+      [event("agent", "one"), event("agent", "two"), event("agent", "three")],
+      [1, 2, 3],
+      runState(),
+    );
+
+    await runRepoDispatch({ api }, payload());
+
+    expect(eventsFrom(posts).map((e) => e.content)).toEqual(["one", "two", "three"]);
+  });
+
+  it("captures install commands and the last non-install exec as the invocation", async () => {
+    const { api, posts } = fakeApi();
+    replay(
+      [
+        event("tool_call", 'sandbox_exec({"cmd":"pip install pdfplumber"})'),
+        event("tool_call", 'sandbox_exec({"cmd":"git clone https://x/y"})'),
+        event("tool_call", 'sandbox_exec({"cmd":"python convert.py in.pdf"})'),
+      ],
+      [1, 3],
+      runState(),
+    );
+
+    await runRepoDispatch({ api }, payload());
+
+    expect(doneFrom(posts).run_repo).toMatchObject({
+      install_log: "pip install pdfplumber\ngit clone https://x/y",
+      invocation: "python convert.py in.pdf",
+    });
+  });
+
+  it("leaves install_log and invocation unset when no exec tool calls happened", async () => {
+    const { api, posts } = fakeApi();
+    replay([event("agent", "nothing to run")], [1], runState());
+
+    await runRepoDispatch({ api }, payload());
+
+    const runRepo = doneFrom(posts).run_repo as Record<string, unknown>;
+    expect(runRepo.install_log).toBeUndefined();
+    expect(runRepo.invocation).toBeUndefined();
+  });
+
+  it("ignores tool calls that are not sandbox_exec", async () => {
+    const { api, posts } = fakeApi();
+    replay(
+      [event("tool_call", 'sandbox_export_artifact({"sandbox_path":"/out.csv"})')],
+      [1],
+      runState(),
+    );
+
+    await runRepoDispatch({ api }, payload());
+
+    const runRepo = doneFrom(posts).run_repo as Record<string, unknown>;
+    expect(runRepo.install_log).toBeUndefined();
+    expect(runRepo.invocation).toBeUndefined();
+  });
+
+  it.each([
+    { status: "succeeded", expected: "succeeded" },
+    { status: "blocked", expected: "failed" },
+    { status: "failed", expected: "failed" },
+    { status: "running", expected: "failed" },
+  ] as const)(
+    "reports orchestrator status '$status' as session status '$expected'",
+    async ({ status, expected }) => {
+      const { api, posts } = fakeApi();
+      runRepoAgentMock.mockResolvedValue(
+        runState({ status, error: status === "succeeded" ? undefined : "boom" }),
+      );
+
+      await runRepoDispatch({ api }, payload());
+
+      expect(doneFrom(posts).status).toBe(expected);
+    },
+  );
+
+  it("summarizes a successful run by artifact count and forwards the artifacts", async () => {
+    const { api, posts } = fakeApi();
+    runRepoAgentMock.mockResolvedValue(
+      runState({
+        artifacts: [
+          {
+            filename: "out.csv",
+            title: "Extracted table",
+            size_bytes: 42,
+            host_path: "/host/out.csv",
+            sandbox_path: "/sandbox/artifacts/out.csv",
+          },
+        ],
+      }),
+    );
+
+    await runRepoDispatch({ api }, payload());
+
+    const done = doneFrom(posts);
+    expect(done.result_summary).toBe("Exported 1 artifact.");
+    expect((done.run_repo as { artifacts: unknown[] }).artifacts).toEqual([
+      {
+        filename: "out.csv",
+        title: "Extracted table",
+        size_bytes: 42,
+        host_path: "/host/out.csv",
+        sandbox_path: "/sandbox/artifacts/out.csv",
+      },
+    ]);
+  });
+
+  it("pluralizes the artifact summary", async () => {
+    const { api, posts } = fakeApi();
+    runRepoAgentMock.mockResolvedValue(
+      runState({
+        artifacts: [
+          { filename: "a.csv", title: "A", size_bytes: 1, host_path: "/h/a.csv" },
+          { filename: "b.csv", title: "B", size_bytes: 2, host_path: "/h/b.csv" },
+        ],
+      }),
+    );
+
+    await runRepoDispatch({ api }, payload());
+
+    expect(doneFrom(posts).result_summary).toBe("Exported 2 artifacts.");
+  });
+
+  it("uses the orchestrator error as the summary when the run did not succeed", async () => {
+    const { api, posts } = fakeApi();
+    runRepoAgentMock.mockResolvedValue(
+      runState({ status: "blocked", error: "could not install pdfplumber" }),
+    );
+
+    await runRepoDispatch({ api }, payload());
+
+    expect(doneFrom(posts)).toMatchObject({
+      status: "failed",
+      result_summary: "could not install pdfplumber",
+      error: "could not install pdfplumber",
+    });
+  });
+
+  it("falls back to a generic summary when a failed run reports no error", async () => {
+    const { api, posts } = fakeApi();
+    runRepoAgentMock.mockResolvedValue(runState({ status: "failed" }));
+
+    await runRepoDispatch({ api }, payload());
+
+    expect(doneFrom(posts).result_summary).toBe("Run did not produce an artifact.");
+  });
+
+  it("notes cancellation in the transcript when the abort signal has fired", async () => {
+    const { api, posts } = fakeApi();
+    const controller = new AbortController();
+    controller.abort();
+    replay([event("agent", "working")], [1], runState());
+
+    await runRepoDispatch({ api }, payload(), controller.signal);
+
+    expect(eventsFrom(posts)).toContainEqual({
+      session_id: "sess_1",
+      kind: "summary",
+      content: "[run cancelled by user]",
+    });
+  });
+
+  it("flushes the transcript before reporting done", async () => {
+    const { api, posts } = fakeApi();
+    replay([event("agent", "working")], [1], runState());
+
+    await runRepoDispatch({ api }, payload());
+
+    expect(posts.map((p) => p.path)).toEqual(["/runtime/events", "/runtime/done"]);
+  });
+
+  it("does not throw when the /runtime/done POST fails — the run is already over", async () => {
+    const post = vi.fn(async (path: string) => {
+      if (path === "/runtime/done") throw new Error("connection reset");
+      return { status: 200, body: undefined };
+    });
+    const api = { post } as unknown as ApiClient;
+
+    await expect(runRepoDispatch({ api }, payload())).resolves.toBeUndefined();
+    expect(post).toHaveBeenCalledWith("/runtime/done", expect.anything());
+  });
+});

--- a/packages/daemon/src/repo-runs.ts
+++ b/packages/daemon/src/repo-runs.ts
@@ -95,10 +95,13 @@ export async function runRepoDispatch(
     claude_bin: CLAUDE_BIN,
     max_runtime_seconds: (rr.limits?.wall_clock_minutes ?? 20) * 60,
     on_state: (s) => {
+      // Read the watermark before pushNew moves it — the tool-call scan
+      // below must cover exactly the entries this callback added, or
+      // every install command is re-recorded on each subsequent state.
+      const scanFrom = pushedUpTo;
       pushNew(s.transcript);
       // Walk new tool-call events to capture install/invocation hints.
-      for (let i = pushedUpTo - (s.transcript.length - 0); i < s.transcript.length; i++) {
-        if (i < 0) continue;
+      for (let i = scanFrom; i < s.transcript.length; i++) {
         const ev = s.transcript[i];
         if (ev?.kind === "tool_call") noteCommandFromToolCall(ev.text);
       }

--- a/packages/daemon/src/setup.test.ts
+++ b/packages/daemon/src/setup.test.ts
@@ -1,0 +1,164 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { hostname, tmpdir, userInfo } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { KNOWN_CLIS } from "@beevibe/core";
+import { loadConfig } from "./config.js";
+import { runSetup, type SetupOptions } from "./setup.js";
+
+const { detectClisMock } = vi.hoisted(() => ({ detectClisMock: vi.fn() }));
+
+vi.mock("./detect-clis.js", () => ({ detectClis: detectClisMock }));
+
+const REGISTERED = {
+  daemon_id: "dmn_1",
+  daemon_token: "bv_d_secret",
+  runtimes: [{ id: "rt_claude", cli: "claude" }],
+};
+
+function stubFetch(
+  init: { status: number; body?: unknown; text?: string } = { status: 200, body: REGISTERED },
+): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(async () => ({
+    status: init.status,
+    json: async () => init.body,
+    text: async () => init.text ?? JSON.stringify(init.body ?? {}),
+  }));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+let root: string;
+
+function options(overrides: Partial<SetupOptions> = {}): SetupOptions {
+  return {
+    apiUrl: "http://api.test",
+    userToken: "bv_u_human",
+    detectedClis: [{ cli: "claude", cli_version: "1.0.0" }],
+    configRoot: root,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "beevibe-setup-test-"));
+  detectClisMock.mockReset();
+  detectClisMock.mockResolvedValue([{ cli: "claude", cli_version: "1.0.0" }]);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("runSetup validation", () => {
+  it.each(["api.test", "ftp://api.test", ""])(
+    "rejects %j as an --api value before touching the network",
+    async (apiUrl) => {
+      const fetchMock = stubFetch();
+
+      await expect(runSetup(options({ apiUrl }))).rejects.toThrow(
+        /--api must be an http\(s\) URL/,
+      );
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects a token that is not a bv_u_ user token", async () => {
+    stubFetch();
+
+    await expect(runSetup(options({ userToken: "bv_d_daemon" }))).rejects.toThrow(
+      /--user-token must start with bv_u_/,
+    );
+  });
+
+  it("refuses to register a machine with no supported CLI, listing what it looks for", async () => {
+    stubFetch();
+
+    await expect(runSetup(options({ detectedClis: [] }))).rejects.toThrow(
+      new RegExp(KNOWN_CLIS.join(", ")),
+    );
+  });
+
+  it("probes PATH when no CLIs were injected", async () => {
+    stubFetch();
+
+    await runSetup(options({ detectedClis: undefined }));
+
+    expect(detectClisMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("runSetup registration", () => {
+  it("POSTs /runtime/register with the user token and the detected CLIs", async () => {
+    const fetchMock = stubFetch();
+
+    await runSetup(
+      options({
+        detectedClis: [
+          { cli: "claude", cli_version: "1.0.0" },
+          { cli: "codex" },
+        ],
+      }),
+    );
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://api.test/runtime/register");
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect(init.headers).toEqual({
+      "content-type": "application/json",
+      authorization: "Bearer bv_u_human",
+    });
+    expect(JSON.parse(init.body as string)).toEqual({
+      external_id: hostname(),
+      device_name: `${userInfo().username}@${hostname()}`,
+      runtimes: [{ cli: "claude", cli_version: "1.0.0" }, { cli: "codex" }],
+    });
+  });
+
+  it("honours explicit external_id and device_name overrides", async () => {
+    const fetchMock = stubFetch();
+
+    await runSetup(
+      options({ externalId: "ci-runner-7", deviceName: "CI runner #7" }),
+    );
+
+    const body = JSON.parse(
+      (fetchMock.mock.calls[0]?.[1] as RequestInit).body as string,
+    );
+    expect(body).toMatchObject({
+      external_id: "ci-runner-7",
+      device_name: "CI runner #7",
+    });
+  });
+
+  it("persists the server-issued identity under the given config root", async () => {
+    stubFetch();
+
+    const config = await runSetup(options({ externalId: "host.test" }));
+
+    expect(config).toEqual({
+      api_url: "http://api.test",
+      external_id: "host.test",
+      daemon_id: "dmn_1",
+      daemon_token: "bv_d_secret",
+      runtimes: [{ id: "rt_claude", cli: "claude" }],
+    });
+    expect(loadConfig(root)).toEqual(config);
+  });
+
+  it.each([200, 201])("accepts a %i from /runtime/register", async (status) => {
+    stubFetch({ status, body: REGISTERED });
+
+    await expect(runSetup(options())).resolves.toMatchObject({ daemon_id: "dmn_1" });
+  });
+
+  it("surfaces the status and body when registration is rejected, writing no config", async () => {
+    stubFetch({ status: 401, text: "invalid user token" });
+
+    await expect(runSetup(options())).rejects.toThrow(
+      "/runtime/register failed: 401 invalid user token",
+    );
+    expect(loadConfig(root)).toBeUndefined();
+  });
+});

--- a/packages/daemon/src/skills-cache.test.ts
+++ b/packages/daemon/src/skills-cache.test.ts
@@ -1,0 +1,178 @@
+import { mkdirSync, mkdtempSync, promises as fs, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiClient } from "./api-client.js";
+import { readCachedVersion, skillsCacheDir, syncSkillsCache } from "./skills-cache.js";
+
+interface SkillsBundle {
+  version: string;
+  skills: Array<{ name: string; files: Array<{ path: string; content: string }> }>;
+}
+
+function bundle(version: string, ...names: string[]): SkillsBundle {
+  return {
+    version,
+    skills: names.map((name) => ({
+      name,
+      files: [{ path: "SKILL.md", content: `# ${name} @ ${version}` }],
+    })),
+  };
+}
+
+/** ApiClient stand-in that serves one queued `/runtime/skills` body per call. */
+function fakeApi(...bodies: Array<SkillsBundle | undefined>) {
+  const get = vi.fn(async (path: string) => {
+    expect(path).toBe("/runtime/skills");
+    return bodies.shift();
+  });
+  return { api: { get } as unknown as ApiClient, get };
+}
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "beevibe-skills-cache-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("skillsCacheDir", () => {
+  it("is <configRoot>/skills", () => {
+    expect(skillsCacheDir("/tmp/x/.beevibe")).toBe("/tmp/x/.beevibe/skills");
+  });
+});
+
+describe("readCachedVersion", () => {
+  it("returns undefined when the cache has never been written", async () => {
+    await expect(readCachedVersion(root)).resolves.toBeUndefined();
+  });
+
+  it("returns the version written by a prior sync, trimmed", async () => {
+    const cache = skillsCacheDir(root);
+    mkdirSync(cache, { recursive: true });
+    await fs.writeFile(join(cache, ".version"), "sha-abc\n");
+
+    await expect(readCachedVersion(root)).resolves.toBe("sha-abc");
+  });
+});
+
+describe("syncSkillsCache", () => {
+  it("materializes the bundle and records its version", async () => {
+    const { api } = fakeApi(bundle("v1", "beevibe-core", "beevibe-mesh"));
+
+    const cache = await syncSkillsCache(api, root);
+
+    expect(cache).toBe(skillsCacheDir(root));
+    await expect(
+      fs.readFile(join(cache, "beevibe-core", "SKILL.md"), "utf8"),
+    ).resolves.toBe("# beevibe-core @ v1");
+    await expect(
+      fs.readFile(join(cache, "beevibe-mesh", "SKILL.md"), "utf8"),
+    ).resolves.toBe("# beevibe-mesh @ v1");
+    await expect(readCachedVersion(root)).resolves.toBe("v1");
+  });
+
+  it("creates parent directories for nested file paths", async () => {
+    const { api } = fakeApi({
+      version: "v1",
+      skills: [
+        {
+          name: "beevibe-core",
+          files: [
+            { path: "SKILL.md", content: "top" },
+            { path: "references/palette.md", content: "nested" },
+          ],
+        },
+      ],
+    });
+
+    const cache = await syncSkillsCache(api, root);
+
+    await expect(
+      fs.readFile(join(cache, "beevibe-core", "references", "palette.md"), "utf8"),
+    ).resolves.toBe("nested");
+  });
+
+  it("short-circuits when the server version matches the cache", async () => {
+    const { api, get } = fakeApi(bundle("v1", "beevibe-core"), bundle("v1", "beevibe-core"));
+    const cache = await syncSkillsCache(api, root);
+
+    // Local edit stands in for "the files were not rewritten".
+    await fs.writeFile(join(cache, "beevibe-core", "SKILL.md"), "untouched");
+    await syncSkillsCache(api, root);
+
+    expect(get).toHaveBeenCalledTimes(2);
+    await expect(
+      fs.readFile(join(cache, "beevibe-core", "SKILL.md"), "utf8"),
+    ).resolves.toBe("untouched");
+  });
+
+  it("re-materializes when the server version moves on", async () => {
+    const { api } = fakeApi(bundle("v1", "beevibe-core"), bundle("v2", "beevibe-core"));
+    const cache = await syncSkillsCache(api, root);
+
+    await syncSkillsCache(api, root);
+
+    await expect(
+      fs.readFile(join(cache, "beevibe-core", "SKILL.md"), "utf8"),
+    ).resolves.toBe("# beevibe-core @ v2");
+    await expect(readCachedVersion(root)).resolves.toBe("v2");
+  });
+
+  it("wipes stale beevibe skills on a version bump but leaves foreign dirs alone", async () => {
+    const { api } = fakeApi(
+      bundle("v1", "beevibe-core", "beevibe-retired"),
+      bundle("v2", "beevibe-core"),
+    );
+    const cache = await syncSkillsCache(api, root);
+    // A directory the daemon did not put there — defensive case in the
+    // source: only the beevibe namespace is ever removed.
+    await fs.mkdir(join(cache, "someone-elses-skill"), { recursive: true });
+    await fs.writeFile(join(cache, "someone-elses-skill", "SKILL.md"), "mine");
+
+    await syncSkillsCache(api, root);
+
+    await expect(fs.readdir(join(cache, "beevibe-retired"))).rejects.toThrow(/ENOENT/);
+    await expect(
+      fs.readFile(join(cache, "someone-elses-skill", "SKILL.md"), "utf8"),
+    ).resolves.toBe("mine");
+    await expect(
+      fs.readFile(join(cache, "beevibe-core", "SKILL.md"), "utf8"),
+    ).resolves.toBe("# beevibe-core @ v2");
+  });
+
+  it("keeps the existing cache when the server returns no body", async () => {
+    const { api } = fakeApi(bundle("v1", "beevibe-core"), undefined);
+    const cache = await syncSkillsCache(api, root);
+
+    await expect(syncSkillsCache(api, root)).resolves.toBe(cache);
+
+    await expect(
+      fs.readFile(join(cache, "beevibe-core", "SKILL.md"), "utf8"),
+    ).resolves.toBe("# beevibe-core @ v1");
+    await expect(readCachedVersion(root)).resolves.toBe("v1");
+  });
+
+  it("throws when the server returns no body and there is nothing cached", async () => {
+    const { api } = fakeApi(undefined);
+
+    await expect(syncSkillsCache(api, root)).rejects.toThrow(
+      /no body and no local cache/,
+    );
+  });
+
+  it("writes the cache dir 0700 and skill files 0600 — it holds no secrets but is agent-owned", async () => {
+    const { api } = fakeApi(bundle("v1", "beevibe-core"));
+
+    const cache = await syncSkillsCache(api, root);
+
+    expect((statSync(cache).mode & 0o777).toString(8)).toBe("700");
+    expect(
+      (statSync(join(cache, "beevibe-core", "SKILL.md")).mode & 0o777).toString(8),
+    ).toBe("600");
+    expect((statSync(join(cache, ".version")).mode & 0o777).toString(8)).toBe("600");
+  });
+});

--- a/packages/daemon/src/spawner.test.ts
+++ b/packages/daemon/src/spawner.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 import type { AgentRuntime, RuntimeContext, RuntimeResult, RuntimeRegistry, Workspace } from "@beevibe/core";
 import { runDispatch, type DispatchPayload } from "./spawner.js";
 
+const { runRepoDispatchMock } = vi.hoisted(() => ({ runRepoDispatchMock: vi.fn() }));
+
+vi.mock("./repo-runs.js", () => ({ runRepoDispatch: runRepoDispatchMock }));
+vi.mock("./logger.js", () => ({ log: vi.fn(), warn: vi.fn(), error: vi.fn() }));
+
 function payload(overrides: Partial<DispatchPayload> = {}): DispatchPayload {
   return {
     session_id: "sess_123",
@@ -77,5 +82,206 @@ describe("runDispatch", () => {
     };
     expect(done.status).toBe("succeeded");
     expect(done.cli_session_id).toBe("opencode_sess_1");
+  });
+});
+
+interface Post {
+  path: string;
+  body: Record<string, unknown>;
+}
+
+/** A runtime that resolves with `result`, or throws `result` if it is an Error. */
+function fakeRuntime(result: Partial<RuntimeResult> | Error): AgentRuntime {
+  return {
+    type: "opencode",
+    execute: vi.fn(async () => {
+      if (result instanceof Error) throw result;
+      return result as RuntimeResult;
+    }),
+    healthCheck: vi.fn(),
+    shutdown: vi.fn(),
+    skillsDir: (workspace: Workspace) => `${workspace.path}/.opencode/skills`,
+  };
+}
+
+function harness(
+  runtime?: AgentRuntime,
+  postImpl?: (path: string) => Promise<unknown>,
+): { deps: Parameters<typeof runDispatch>[0]; posts: Post[] } {
+  const posts: Post[] = [];
+  const api = {
+    post: vi.fn(async (path: string, body: unknown) => {
+      posts.push({ path, body: body as Record<string, unknown> });
+      return postImpl ? await postImpl(path) : undefined;
+    }),
+  };
+  const workspaceManager = {
+    ensureWorkspace: vi.fn(async () => ({ path: "/tmp/ws-opencode" })),
+  };
+  return {
+    deps: {
+      api: api as never,
+      workspaceManager: workspaceManager as never,
+      runtimeRegistry: (runtime ? { opencode: runtime } : {}) as RuntimeRegistry,
+    },
+    posts,
+  };
+}
+
+function doneOf(posts: Post[]): Record<string, unknown> {
+  const done = posts.find((p) => p.path === "/runtime/done");
+  if (!done) throw new Error("no /runtime/done POST was made");
+  return done.body;
+}
+
+describe("runDispatch terminal reporting", () => {
+  it("hands a run_repo dispatch to the sandbox orchestrator without provisioning a workspace", async () => {
+    runRepoDispatchMock.mockReset();
+    const runtime = fakeRuntime({ status: "completed" });
+    const { deps } = harness(runtime);
+    const signal = new AbortController().signal;
+    const p = payload({ type: "run_repo" });
+
+    await runDispatch(deps, p, signal);
+
+    expect(runRepoDispatchMock).toHaveBeenCalledWith(
+      { api: expect.anything() },
+      p,
+      signal,
+    );
+    expect(deps.workspaceManager.ensureWorkspace).not.toHaveBeenCalled();
+    expect(runtime.execute).not.toHaveBeenCalled();
+  });
+
+  it("throws a named error when the payload asks for a runtime the daemon has no adapter for", async () => {
+    const { deps, posts } = harness();
+
+    await expect(runDispatch(deps, payload())).rejects.toThrow(/opencode/);
+    expect(posts).toEqual([]);
+  });
+
+  it.each([
+    { status: "completed", expected: "succeeded" },
+    { status: "cancelled", expected: "cancelled" },
+    { status: "failed", expected: "failed" },
+    { status: "timed_out", expected: "failed" },
+  ] as const)(
+    "reports runtime status '$status' as session status '$expected'",
+    async ({ status, expected }) => {
+      const { deps, posts } = harness(
+        fakeRuntime({ status: status as RuntimeResult["status"], output: "" }),
+      );
+
+      await runDispatch(deps, payload());
+
+      expect(doneOf(posts).status).toBe(expected);
+    },
+  );
+
+  it("reports a spawn-time throw as failed with a null exit code, so the api can tell it never ran", async () => {
+    const { deps, posts } = harness(
+      fakeRuntime(new Error("spawn claude ENOENT")),
+    );
+
+    await runDispatch(deps, payload());
+
+    expect(doneOf(posts)).toMatchObject({
+      status: "failed",
+      exit_code: null,
+      error: "spawn claude ENOENT",
+      result_summary: "",
+    });
+  });
+
+  it("wraps a non-Error throw so the failure still carries a message", async () => {
+    const runtime = fakeRuntime({ status: "completed" });
+    runtime.execute = vi.fn(async () => {
+      throw "just a string";
+    });
+    const { deps, posts } = harness(runtime);
+
+    await runDispatch(deps, payload());
+
+    expect(doneOf(posts)).toMatchObject({ status: "failed", error: "just a string" });
+  });
+
+  it("prefers the CLI's stderr tail as the error when the runtime ran but failed", async () => {
+    const { deps, posts } = harness(
+      fakeRuntime({
+        status: "failed",
+        output: "",
+        exit_code: 1,
+        stderr: "Error: model not found",
+      }),
+    );
+
+    await runDispatch(deps, payload());
+
+    expect(doneOf(posts)).toMatchObject({
+      status: "failed",
+      exit_code: 1,
+      error: "Error: model not found",
+    });
+  });
+
+  it("forwards usage and cli_session_id from a successful run", async () => {
+    const { deps, posts } = harness(
+      fakeRuntime({
+        status: "completed",
+        output: "all done",
+        exit_code: 0,
+        cli_session_id: "opencode_sess_9",
+        usage: { input_tokens: 10, output_tokens: 20 },
+      }),
+    );
+
+    await runDispatch(deps, payload());
+
+    expect(doneOf(posts)).toMatchObject({
+      session_id: "sess_123",
+      status: "succeeded",
+      exit_code: 0,
+      cli_session_id: "opencode_sess_9",
+      result_summary: "all done",
+      usage: { input_tokens: 10, output_tokens: 20 },
+    });
+  });
+
+  it("flushes buffered events before reporting done", async () => {
+    const runtime = fakeRuntime({ status: "completed", output: "" });
+    runtime.execute = vi.fn(async (ctx: RuntimeContext) => {
+      ctx.onStep?.({
+        kind: "tool_call",
+        tool: "read",
+        description: "README.md",
+        timestamp: new Date().toISOString(),
+      });
+      return { status: "completed", output: "" } as RuntimeResult;
+    });
+    const { deps, posts } = harness(runtime);
+
+    await runDispatch(deps, payload());
+
+    expect(posts.map((p) => p.path)).toEqual(["/runtime/events", "/runtime/done"]);
+    expect(posts[0]?.body.events).toEqual([
+      {
+        session_id: "sess_123",
+        kind: "tool_call",
+        content: "README.md",
+        tool_name: "read",
+      },
+    ]);
+  });
+
+  it("does not throw when the /runtime/done POST fails — the session is already over", async () => {
+    const { deps } = harness(
+      fakeRuntime({ status: "completed", output: "" }),
+      async (path) => {
+        if (path === "/runtime/done") throw new Error("connection reset");
+        return undefined;
+      },
+    );
+
+    await expect(runDispatch(deps, payload())).resolves.toBeUndefined();
   });
 });

--- a/packages/daemon/src/sync.test.ts
+++ b/packages/daemon/src/sync.test.ts
@@ -1,0 +1,146 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { KNOWN_CLIS } from "@beevibe/core";
+import { loadConfig, saveConfig, type DaemonConfig } from "./config.js";
+import { runSync } from "./sync.js";
+
+const { detectClisMock } = vi.hoisted(() => ({ detectClisMock: vi.fn() }));
+
+vi.mock("./detect-clis.js", () => ({ detectClis: detectClisMock }));
+
+function seedConfig(root: string, overrides: Partial<DaemonConfig> = {}): DaemonConfig {
+  const config: DaemonConfig = {
+    api_url: "http://api.test",
+    external_id: "host.test",
+    daemon_id: "dmn_1",
+    daemon_token: "bv_d_secret",
+    runtimes: [{ id: "rt_claude", cli: "claude" }],
+    ...overrides,
+  };
+  saveConfig(config, root);
+  return config;
+}
+
+function stubFetch(init: { status: number; body?: unknown }): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(async () => ({
+    status: init.status,
+    text: async () => (init.body === undefined ? "" : JSON.stringify(init.body)),
+  }));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "beevibe-sync-test-"));
+  detectClisMock.mockReset();
+  detectClisMock.mockResolvedValue([{ cli: "claude", cli_version: "1.0.0" }]);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("runSync", () => {
+  it("refuses to run before setup, naming the config path", async () => {
+    await expect(runSync({ configRoot: root })).rejects.toThrow(
+      /No daemon config at .*config\.json.*beevibe-daemon setup/s,
+    );
+  });
+
+  it("refuses when no supported CLI is on PATH, listing the ones it looks for", async () => {
+    seedConfig(root);
+    detectClisMock.mockResolvedValue([]);
+
+    await expect(runSync({ configRoot: root })).rejects.toThrow(
+      new RegExp(KNOWN_CLIS.join(", ")),
+    );
+  });
+
+  it("POSTs the detected CLIs to /runtime/sync with the daemon's bv_d_ token", async () => {
+    seedConfig(root);
+    detectClisMock.mockResolvedValue([
+      { cli: "claude", cli_version: "1.0.0" },
+      { cli: "codex", cli_version: "0.9.0" },
+    ]);
+    const fetchMock = stubFetch({
+      status: 200,
+      body: {
+        runtimes: [
+          { id: "rt_claude", cli: "claude" },
+          { id: "rt_codex", cli: "codex" },
+        ],
+      },
+    });
+
+    await runSync({ configRoot: root });
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://api.test/runtime/sync");
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>).authorization).toBe(
+      "Bearer bv_d_secret",
+    );
+    expect(JSON.parse(init.body as string)).toEqual({
+      runtimes: [
+        { cli: "claude", cli_version: "1.0.0" },
+        { cli: "codex", cli_version: "0.9.0" },
+      ],
+    });
+  });
+
+  it("reports only the newly-registered CLIs as added and persists the full list", async () => {
+    seedConfig(root);
+    const runtimes = [
+      { id: "rt_claude", cli: "claude" },
+      { id: "rt_codex", cli: "codex" },
+    ];
+    stubFetch({ status: 200, body: { runtimes } });
+
+    const result = await runSync({ configRoot: root });
+
+    expect(result.added).toEqual([{ id: "rt_codex", cli: "codex" }]);
+    expect(result.runtimes).toEqual(runtimes);
+    expect(loadConfig(root)?.runtimes).toEqual(runtimes);
+  });
+
+  it("reports nothing added when the server returns the CLIs already on file", async () => {
+    seedConfig(root);
+    stubFetch({ status: 200, body: { runtimes: [{ id: "rt_claude", cli: "claude" }] } });
+
+    await expect(runSync({ configRoot: root })).resolves.toMatchObject({ added: [] });
+  });
+
+  it("keeps identity fields untouched — sync re-registers CLIs, it does not rotate credentials", async () => {
+    const before = seedConfig(root);
+    stubFetch({ status: 200, body: { runtimes: [{ id: "rt_new", cli: "claude" }] } });
+
+    await runSync({ configRoot: root });
+
+    const after = loadConfig(root);
+    expect(after).toMatchObject({
+      api_url: before.api_url,
+      external_id: before.external_id,
+      daemon_id: before.daemon_id,
+      daemon_token: before.daemon_token,
+    });
+  });
+
+  it.each([
+    { status: 401, body: { error: "bad token" }, label: "an auth rejection" },
+    { status: 500, body: undefined, label: "a server error with no body" },
+    { status: 200, body: undefined, label: "a 200 with an empty body" },
+  ])("throws on $label and leaves the stored config alone", async ({ status, body }) => {
+    const before = seedConfig(root);
+    stubFetch({ status, body });
+
+    await expect(runSync({ configRoot: root })).rejects.toThrow(
+      `/runtime/sync failed: ${status}`,
+    );
+    expect(loadConfig(root)).toEqual(before);
+  });
+});

--- a/packages/daemon/src/update.test.ts
+++ b/packages/daemon/src/update.test.ts
@@ -1,0 +1,293 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runUpdate } from "./update.js";
+
+const { renameSyncMock, chmodSyncMock, logMock, errorMock, questionMock } = vi.hoisted(
+  () => ({
+    renameSyncMock: vi.fn(),
+    chmodSyncMock: vi.fn(),
+    logMock: vi.fn(),
+    errorMock: vi.fn(),
+    questionMock: vi.fn(),
+  }),
+);
+
+// Only the two mutating calls are faked: staging still happens in a real
+// temp dir so the streamed download + hash path is exercised for real.
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, renameSync: renameSyncMock, chmodSync: chmodSyncMock };
+});
+vi.mock("./logger.js", () => ({ log: logMock, warn: vi.fn(), error: errorMock }));
+vi.mock("node:readline/promises", () => ({
+  createInterface: () => ({ question: questionMock, close: vi.fn() }),
+}));
+
+const RELEASES_API_URL =
+  "https://api.github.com/repos/beevibe-ai/beevibe/releases/latest";
+const ASSET = "beevibe-daemon-linux-x64";
+const BINARY = "#!/fake compiled daemon binary\n";
+const BINARY_SHA = createHash("sha256").update(BINARY).digest("hex");
+
+class ProcessExit extends Error {
+  constructor(readonly code: number | undefined) {
+    super(`process.exit(${code})`);
+  }
+}
+
+/** Serve the release manifest, the asset stream and its .sha256 companion. */
+function stubGithub(opts: {
+  release?: { status?: number; tag?: string } | null;
+  binary?: string;
+  checksum?: string;
+}): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(async (url: string) => {
+    if (url === RELEASES_API_URL) {
+      const status = opts.release?.status ?? 200;
+      if (status !== 200) {
+        return { status, ok: false, text: async () => "boom" };
+      }
+      return {
+        status,
+        ok: true,
+        json: async () => ({ tag_name: opts.release?.tag ?? "v9.9.9", assets: [] }),
+      };
+    }
+    if (url.endsWith(".sha256")) {
+      return {
+        status: 200,
+        ok: true,
+        text: async () => `${opts.checksum ?? BINARY_SHA}  ${ASSET}`,
+      };
+    }
+    return { status: 200, ok: true, body: new Response(opts.binary ?? BINARY).body };
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+/** Present the process as a Bun-compiled standalone binary. */
+function asCompiledBinary(): void {
+  (process.versions as { bun?: string }).bun = "1.1.0";
+  Object.defineProperty(process, "execPath", {
+    value: "/usr/local/bin/beevibe-daemon",
+    configurable: true,
+    writable: true,
+  });
+}
+
+const g = globalThis as Record<string, unknown>;
+let realExecPath: string;
+
+beforeEach(() => {
+  realExecPath = process.execPath;
+  g.BEEVIBE_DAEMON_VERSION = "1.0.0";
+  vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new ProcessExit(code);
+  }) as never);
+});
+
+afterEach(() => {
+  delete g.BEEVIBE_DAEMON_VERSION;
+  delete (process.versions as { bun?: string }).bun;
+  Object.defineProperty(process, "execPath", {
+    value: realExecPath,
+    configurable: true,
+    writable: true,
+  });
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  renameSyncMock.mockReset();
+  chmodSyncMock.mockReset();
+  logMock.mockReset();
+  errorMock.mockReset();
+  questionMock.mockReset();
+});
+
+/** Everything passed to the mocked logger, flattened for substring matching. */
+function logged(mock: typeof logMock): string {
+  return mock.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+}
+
+describe("runUpdate install-method guards", () => {
+  it("exits 2 with per-install-method hints when the version was never baked in", async () => {
+    delete g.BEEVIBE_DAEMON_VERSION;
+    const fetchMock = stubGithub({});
+
+    await expect(runUpdate({ skipPrompt: true })).rejects.toBeInstanceOf(ProcessExit);
+    expect(logged(logMock)).toMatch(/npm update -g @beevibe\/daemon/);
+    expect(logged(logMock)).toMatch(/git pull/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("bails with hints, not an error, when not running as a compiled binary", async () => {
+    const fetchMock = stubGithub({});
+
+    await expect(runUpdate({ skipPrompt: true })).resolves.toBeUndefined();
+
+    expect(logged(logMock)).toMatch(/not produced by the standalone build path/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("treats `bun src/main.ts` as a source run, not a compiled binary", async () => {
+    (process.versions as { bun?: string }).bun = "1.1.0";
+    Object.defineProperty(process, "execPath", {
+      value: "/home/dev/.bun/bin/bun",
+      configurable: true,
+      writable: true,
+    });
+    const fetchMock = stubGithub({});
+
+    await runUpdate({ skipPrompt: true });
+
+    expect(logged(logMock)).toMatch(/not produced by the standalone build path/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("exits 2 on a platform with no published binary", async () => {
+    asCompiledBinary();
+    Object.defineProperty(process, "platform", { value: "sunos", configurable: true });
+    stubGithub({});
+
+    try {
+      await expect(runUpdate({ skipPrompt: true })).rejects.toBeInstanceOf(ProcessExit);
+      expect(errorMock.mock.calls.flat().join("\n")).toMatch(/Unsupported platform/);
+    } finally {
+      Object.defineProperty(process, "platform", {
+        value: "linux",
+        configurable: true,
+      });
+    }
+  });
+});
+
+describe("runUpdate version comparison", () => {
+  beforeEach(asCompiledBinary);
+
+  it("stops when GitHub has no releases yet", async () => {
+    stubGithub({ release: { status: 404 } });
+
+    await expect(runUpdate({ skipPrompt: true })).resolves.toBeUndefined();
+    expect(logged(logMock)).toMatch(/No releases published yet/);
+    expect(renameSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a non-404 GitHub API failure", async () => {
+    stubGithub({ release: { status: 503 } });
+
+    await expect(runUpdate({ skipPrompt: true })).rejects.toThrow(
+      /GitHub API returned 503/,
+    );
+  });
+
+  it.each([
+    { latest: "v1.0.0", why: "identical" },
+    { latest: "v0.9.9", why: "older patch" },
+    { latest: "v0.11.0", why: "older minor despite the higher digit" },
+  ])("stays put when the latest release is $why ($latest)", async ({ latest }) => {
+    stubGithub({ release: { tag: latest } });
+
+    await runUpdate({ skipPrompt: true });
+
+    expect(logged(logMock)).toMatch(/Already on the latest version/);
+    expect(renameSyncMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["v1.0.1", "v1.1.0", "v2.0.0"])(
+    "updates when the latest release is %s",
+    async (latest) => {
+      stubGithub({ release: { tag: latest } });
+
+      await runUpdate({ skipPrompt: true });
+
+      expect(renameSyncMock).toHaveBeenCalledTimes(1);
+      expect(logged(logMock)).toMatch(new RegExp(`Updated to ${latest}`));
+    },
+  );
+});
+
+describe("runUpdate install", () => {
+  beforeEach(asCompiledBinary);
+
+  it("verifies the checksum, chmods 0755 and renames over the running binary", async () => {
+    stubGithub({ release: { tag: "v2.0.0" } });
+    // The staging dir is removed in a finally block, so read it while
+    // the install is still in flight.
+    let staged: { path: string; mode: number; content: string } | undefined;
+    chmodSyncMock.mockImplementation((path: string, mode: number) => {
+      staged = { path, mode, content: readFileSync(path, "utf8") };
+    });
+
+    await runUpdate({ skipPrompt: true });
+
+    expect(staged?.mode).toBe(0o755);
+    expect(staged?.content).toBe(BINARY);
+    expect(renameSyncMock).toHaveBeenCalledWith(
+      staged?.path,
+      "/usr/local/bin/beevibe-daemon",
+    );
+  });
+
+  it("exits 3 without installing when the downloaded bytes do not match the checksum", async () => {
+    stubGithub({ release: { tag: "v2.0.0" }, checksum: "a".repeat(64) });
+
+    await expect(runUpdate({ skipPrompt: true })).rejects.toBeInstanceOf(ProcessExit);
+
+    expect(renameSyncMock).not.toHaveBeenCalled();
+    expect(errorMock.mock.calls.flat().join("\n")).toMatch(/Checksum mismatch/);
+  });
+
+  it("rejects a checksum file that is not 64 hex characters", async () => {
+    stubGithub({ release: { tag: "v2.0.0" }, checksum: "not-a-sha" });
+
+    await expect(runUpdate({ skipPrompt: true })).rejects.toThrow(
+      /bad checksum format/,
+    );
+    expect(renameSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("leaves the staged binary in place and returns when the rename fails", async () => {
+    stubGithub({ release: { tag: "v2.0.0" } });
+    renameSyncMock.mockImplementation(() => {
+      throw new Error("EACCES: permission denied");
+    });
+
+    await expect(runUpdate({ skipPrompt: true })).resolves.toBeUndefined();
+
+    const errors = errorMock.mock.calls.flat().join("\n");
+    expect(errors).toMatch(/EACCES: permission denied/);
+    expect(errors).toMatch(/install manually if needed/);
+  });
+
+  it("asks before installing and honours a refusal", async () => {
+    stubGithub({ release: { tag: "v2.0.0" } });
+    questionMock.mockResolvedValue("n");
+
+    await runUpdate();
+
+    expect(questionMock).toHaveBeenCalledWith(
+      expect.stringContaining("Install this update now?"),
+    );
+    expect(renameSyncMock).not.toHaveBeenCalled();
+    expect(logged(logMock)).toMatch(/Update cancelled/);
+  });
+
+  it.each(["y", "Y", "yes", " yes "])("installs on a %j answer", async (answer) => {
+    stubGithub({ release: { tag: "v2.0.0" } });
+    questionMock.mockResolvedValue(answer);
+
+    await runUpdate();
+
+    expect(renameSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["", "no", "later"])("does not install on a %j answer", async (answer) => {
+    stubGithub({ release: { tag: "v2.0.0" } });
+    questionMock.mockResolvedValue(answer);
+
+    await runUpdate();
+
+    expect(renameSyncMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Why

A coverage sweep across the monorepo put `@beevibe/daemon` far below everything else — **30.6% line coverage**, with six modules at **0%**. Those six are exactly the ones that talk to the API, touch the user's disk, or replace the running binary, and the daemon is the only component that runs on end users' machines.

| Package | Lines before | Lines after |
| --- | --- | --- |
| `@beevibe/daemon` | 30.6% | **80.4%** (fn 92%, br 91%) |

## What

Six new suites for the modules that had none:

| Module | Was | Now | What the tests pin down |
| --- | --- | --- | --- |
| `api-client.ts` | 0% | 100% | Every `/runtime/*` verb — `204` / `4xx` / empty / unparseable body handling, bearer auth, query encoding, `http→ws` and `https→wss` upgrade |
| `detect-clis.ts` | 0% | 100% | PATH probing: CLI absent, `--version` failing while the CLI still counts, multi-line version banners, `KNOWN_CLIS` order preserved when probes settle out of order |
| `skills-cache.ts` | 0% | 100% | Version short-circuit, stale `beevibe-*` wipe that leaves foreign dirs alone, flaky-server fallback to the local cache, nested file paths, `0700`/`0600` modes |
| `sync.ts` | 0% | 100% | Pre-setup and no-CLI refusals, added-runtime diffing, config persistence, and that identity fields are not rotated by a sync |
| `setup.ts` | 0% | 100% | `--api` / `--user-token` validation *before* any network call, register payload shape, `200`/`201` acceptance, no config written on failure |
| `update.ts` | 0% | 100% | Install-method guards, semver comparison, checksum verification incl. the mismatch → `exit 3` path, the `chmod`+`rename` install, and the y/N prompt |

Two existing suites extended over their uncovered failure paths:

- **`spawner.ts`** (76% → 100%): `run_repo` hand-off skipping workspace provisioning, missing runtime adapter, spawn-time throw reported as `exit_code: null`, stderr-as-error preference, `/runtime/done` POST failure swallowed.
- **`claimer.ts`** (76% → 97%): heartbeat POST and its failure path, claim → supervisor → dispatch hand-off, abort-on-stop, slot release when a dispatch throws, and WS push handling (`task_available`, `cancel`, malformed frames).

## One fix, found by the new tests

`repo-runs.ts` read the transcript watermark **after** `pushNew()` had already advanced it, so the tool-call scan restarted at index `0` on every `on_state` callback and re-recorded every install command once per state update. A run that reported two states shipped a duplicated `install_log` to `/runtime/done`. The test failed on exactly that (`pip install pdfplumber` twice); the fix reads the watermark first, matching the "walk **new** tool-call events" comment already in the source.

## Noted, not fixed

`Claimer.pollAll` fans out over `runtimeIds` with `Promise.all`, and `pollRuntime` has an `await claim()` between its `hasCapacity()` check and `supervisor.start()`. With two or more registered CLIs at the concurrency cap, both pollers can pass the check and the second `start()` throws `supervisor at capacity` — an unhandled rejection out of the `void this.pollAll()` call site, same failure class as the `claim()` ECONNREFUSED case already handled. Dropping the claimed payload would strand the session, so the right fix is a design call rather than a `catch`; the new capacity test uses a single runtime id so it exercises the intended loop exit without depending on the race.

## Not covered

`main.ts` and `start.ts` stay at 0%. `main.ts` self-invokes on import and exports nothing; both are process-lifetime wiring over functions this PR now covers, so testing them means refactoring the entry point — out of scope here.

## Verification

```
pnpm --filter @beevibe/daemon test       # 156 passed, 2 skipped (Docker-gated e2e)
pnpm --filter @beevibe/daemon typecheck  # clean
pnpm --filter @beevibe/daemon lint       # clean (3 pre-existing ws warnings)
pnpm --filter @beevibe/daemon build      # clean
```

No coverage provider is added as a dependency — `CLAUDE.md` gains a short section with the exact incantation to reproduce the numbers, plus the two traps that cost time here (`--coverage.all` is required or untested files vanish from the report entirely, and an unhandled error in any test file silently suppresses report generation).

---
_Generated by [Claude Code](https://claude.ai/code/session_01A35L1fZXox1bAgZ8a8niUT)_