### PR TITLE
fix(core): don't let a failed first tick kill the orphan reaper

### DIFF
--- a/packages/core/src/services/orphan-reaper.test.ts
+++ b/packages/core/src/services/orphan-reaper.test.ts
@@ -341,13 +341,34 @@ describe("DaemonOrphanReaper.start / stop", () => {
     await reaper.stop();
   });
 
-  it("a first tick that rejects wedges the reaper: no timer, and restart is a no-op", async () => {
-    // Documents current behaviour, not desired behaviour. start() flips
-    // `running` before awaiting the immediate tick, so a rejection there
-    // escapes past the setInterval call: no poll loop is ever installed,
-    // and the `if (this.running) return` guard makes every later start()
-    // a silent no-op. A caller that logs-and-continues on start() gets a
-    // reaper that never reaps again.
+  it("a first tick that rejects goes to onError instead of escaping", async () => {
+    // `running` is set before the immediate tick is awaited, so an escaping
+    // rejection would leave the reaper flagged running with no timer — dead,
+    // and immune to restart via the `if (this.running) return` guard. The
+    // API calls this as `void reaper.start()`, so it would also be an
+    // unhandled rejection and take the process down.
+    vi.mocked(sessionRepo.listDaemonOrphaned).mockRejectedValue(
+      new Error("db gone"),
+    );
+    const onError = vi.fn();
+    reaper = new DaemonOrphanReaper({
+      sessionRepo,
+      taskRepo,
+      dispatchService,
+      pollIntervalMs: 1_000,
+      onError,
+    });
+
+    await expect(reaper.start()).resolves.toBeUndefined();
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    expect(onError.mock.calls[0]![0].message).toBe("db gone");
+
+    await reaper.stop();
+  });
+
+  it("still installs the poll loop after a failed first tick, and recovers", async () => {
+    // The reap pass is lost, not the reaper: once the DB comes back the
+    // next interval tick succeeds without anyone restarting anything.
     vi.mocked(sessionRepo.listDaemonOrphaned).mockRejectedValue(
       new Error("db gone"),
     );
@@ -359,20 +380,39 @@ describe("DaemonOrphanReaper.start / stop", () => {
       onError: vi.fn(),
     });
 
-    await expect(reaper.start()).rejects.toThrow("db gone");
-
-    vi.mocked(sessionRepo.listDaemonOrphaned).mockResolvedValue([]);
-    await vi.advanceTimersByTimeAsync(5_000);
-    expect(sessionRepo.listDaemonOrphaned).toHaveBeenCalledTimes(1);
-
     await reaper.start();
     expect(sessionRepo.listDaemonOrphaned).toHaveBeenCalledTimes(1);
 
-    // Only an explicit stop() clears `running` and lets a restart take.
-    await reaper.stop();
-    await reaper.start();
+    vi.mocked(sessionRepo.listDaemonOrphaned).mockResolvedValue([fakeSession()]);
+    await vi.advanceTimersByTimeAsync(1_000);
+
     expect(sessionRepo.listDaemonOrphaned).toHaveBeenCalledTimes(2);
+    expect(sessionRepo.update).toHaveBeenCalledWith(
+      "sess_orphan",
+      expect.objectContaining({ status: "failed", error: "daemon_orphaned" }),
+    );
+
     await reaper.stop();
+  });
+
+  it("stop() still halts a reaper whose first tick failed", async () => {
+    vi.mocked(sessionRepo.listDaemonOrphaned).mockRejectedValue(
+      new Error("db gone"),
+    );
+    reaper = new DaemonOrphanReaper({
+      sessionRepo,
+      taskRepo,
+      dispatchService,
+      pollIntervalMs: 1_000,
+      onError: vi.fn(),
+    });
+
+    await reaper.start();
+    await reaper.stop();
+    vi.mocked(sessionRepo.listDaemonOrphaned).mockClear();
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(sessionRepo.listDaemonOrphaned).not.toHaveBeenCalled();
   });
 
   it("start after stop resumes polling", async () => {

--- a/packages/core/src/services/orphan-reaper.ts
+++ b/packages/core/src/services/orphan-reaper.ts
@@ -86,10 +86,30 @@ export class DaemonOrphanReaper {
       ((err) => console.error("[daemon-orphan-reaper]", err));
   }
 
+  /**
+   * Run one reap pass immediately, then poll on an interval.
+   *
+   * The first tick is treated exactly like every later one: a failure goes
+   * to `onError` and the poll loop starts anyway. It must not escape.
+   * `running` is set before the await (to close the re-entry window), so a
+   * rejection propagating out of here would leave the reaper flagged as
+   * running with no timer installed — permanently dead, and immune to
+   * restart via the `if (this.running) return` guard above. The API's
+   * composition root calls this as `void reaper.start()`, so an escaping
+   * rejection is also an unhandled rejection, which Node terminates the
+   * process for.
+   *
+   * A transient DB error at boot is the realistic trigger, and it should
+   * cost one reap pass, not the reaper or the process.
+   */
   async start(): Promise<void> {
     if (this.running) return;
     this.running = true;
-    await this.tick();
+    try {
+      await this.tick();
+    } catch (err) {
+      this.onError(asError(err));
+    }
     this.pollTimer = setInterval(() => {
       void this.tick().catch(this.onError);
     }, this.pollIntervalMs);


### PR DESCRIPTION
Follow-up to #264, which surfaced this while adding coverage for `DaemonOrphanReaper` and documented it in a test rather than changing behaviour.

**Based on `claude/loving-cori-y1mubu` (#264), not `main`** — see the note at the bottom.

## The bug

`DaemonOrphanReaper.start` sets `running = true` before awaiting the immediate first tick, but installs the poll timer *after* it:

```ts
if (this.running) return;   // re-entry guard
this.running = true;        // flag set BEFORE the risky await
await this.tick();          // can reject
this.pollTimer = setInterval(...);  // skipped entirely if the await threw
```

A rejection from that tick escapes between the two statements. What's left is a reaper flagged as running with no timer installed — permanently dead, and immune to restart, because the `if (this.running) return` guard makes every later `start()` a silent no-op that *resolves*. Only an explicit `stop()` first would let a restart take.

`tick()` already catches around its per-session work, so the only way it rejects is `listDaemonOrphaned` itself failing — a DB-level error. Postgres not being ready yet at boot is the realistic trigger.

## Why it's worse than a dead reaper today

The API's composition root calls this as `void daemonOrphanReaper.start()` (`packages/api/src/bootstrap.ts:605`), which attaches no rejection handler. There is no `unhandledRejection` handler anywhere in `packages/api/src`, and no `--unhandled-rejections` flag in `scripts/start-api.sh` or the `start` script — so Node 20's default (`throw`) applies.

An escaping rejection therefore **terminates the API process at boot**, with a stack pointing at the reaper rather than at the DB error behind it. Two failure modes, one root cause:

| Caller shape | Outcome before this PR |
|---|---|
| `void start()` — today's caller | unhandled rejection → API process dies at boot |
| `start().catch(log)` | reaper silently dead for the process lifetime; every restart a no-op |

## The fix

Treat the first tick like every later one — route the failure to `onError` and start the poll loop regardless:

```ts
this.running = true;
try {
  await this.tick();
} catch (err) {
  this.onError(asError(err));
}
this.pollTimer = setInterval(...);
```

This is what the existing `.catch(this.onError)` on the interval tick already implies was intended, and what `void start()` at the call site signals the caller wants. A transient DB error at boot now costs one reap pass instead of the reaper or the process, and the reaper recovers on its own — the loop survives and the next tick succeeds once the DB is back.

## Behaviour change to be aware of

`start()` no longer rejects. A caller relying on that to abort boot would silently lose it. Nothing does today — the only call site discards the promise — but it's the reason #264 left this alone instead of fixing it inline.

## Tests

Replaces the test that documented this as a known wart with three that pin the fixed behaviour:

- first-tick failure routed to `onError`, `start()` resolving
- poll loop still installed after a failed first tick, and recovering once the DB returns
- `stop()` still halting a reaper whose first tick failed

All three were verified to fail against the old `start()` (source fix reverted, watched them go red, restored) — a regression test that passes either way isn't one.

Full core suite: 581 passing, with the same 7 pre-existing failures that need Docker and provider keys. `typecheck` and `lint` clean.

## Base branch

The fix has to replace the test asserting the buggy behaviour, and that test exists only on #264's branch — `main` doesn't have it. Branching from `main` would mean that whenever #264 merged, it would reintroduce a test asserting the old behaviour against fixed code and turn `main` red regardless of merge order.

So this stacks: one commit on top of #264. **Merge #264 first**; GitHub will retarget this to `main` automatically. If you'd rather the two be independent, I can rebase this onto `main` and amend #264's test instead — but then they'd have to merge together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsSg9Z57c4LE5RM3Acmn4H


---
_Generated by [Claude Code](https://claude.ai/code/session_01VsSg9Z57c4LE5RM3Acmn4H)_