### PR TITLE
test: drop eight zero-signal tests, make tier gating assert names not counts

### DIFF
--- a/packages/api/src/tools/hierarchy.test.ts
+++ b/packages/api/src/tools/hierarchy.test.ts
@@ -1,9 +1,9 @@
 /**
  * Hierarchy / work-product tools — unit tests with vitest fakes (no DB).
  *
- * Covers all 12 tools (8 IC-shared + 4 team-only) plus the IC vs team set
- * gating in `buildHierarchyTools`. Each tool's handler is a thin closure
- * over (ctx, services); the fakes here exercise auth + delegation.
+ * Covers the IC-shared and team-only tools plus the IC vs team set gating
+ * in `buildHierarchyTools`. Each tool's handler is a thin closure over
+ * (ctx, services); the fakes here exercise auth + delegation.
  */
 import { describe, expect, it, vi } from "vitest";
 import type {
@@ -11,6 +11,7 @@ import type {
   AgentProvisionEventRepository,
   AgentRepository,
   CoreMemoryBlockRepository,
+  HierarchyLevel,
   Session,
   Task,
   TaskRepository,
@@ -192,48 +193,47 @@ async function callTool(
 
 // ── Tier gating ──────────────────────────────────────────────────────────
 
+/** Every tier gets these; the IC tier gets nothing else. */
+const SHARED_TOOLS = [
+  "create_work_product",
+  "find_up",
+  "get_agent_profile",
+  "get_task",
+  "get_work_product",
+  "list_work_products",
+  "search_context",
+  "update_progress",
+  "update_work_product",
+];
+
+/** Delegation surface — only tiers that can have subordinates get these. */
+const TEAM_ONLY_TOOLS = [
+  "add_to_escalation",
+  "check_work_status",
+  "create_subordinate_agent",
+  "create_task",
+  "find_peers",
+  "find_subordinates",
+  "revise_task",
+];
+
+function toolNames(level: HierarchyLevel): string[] {
+  return buildHierarchyTools({ agentId: `agent_${level}`, hierarchyLevel: level }, buildServices())
+    .map((t) => t.name)
+    .sort();
+}
+
 describe("buildHierarchyTools — IC vs team gating", () => {
-  it("IC tier exposes 9 shared tools (no find_subordinates / find_peers / create_task / check_work_status)", () => {
-    const tools = buildHierarchyTools(
-      { agentId: "agent_ic", hierarchyLevel: "ic" },
-      buildServices(),
-    );
-    const names = tools.map((t) => t.name).sort();
-    expect(names).toEqual([
-      "create_work_product",
-      "find_up",
-      "get_agent_profile",
-      "get_task",
-      "get_work_product",
-      "list_work_products",
-      "search_context",
-      "update_progress",
-      "update_work_product",
-    ]);
+  it("IC tier gets the shared tools and nothing that implies subordinates", () => {
+    expect(toolNames("ic")).toEqual([...SHARED_TOOLS].sort());
   });
 
-  it("team tier exposes 16 tools (9 shared + 6 team-only + create_subordinate_agent)", () => {
-    const tools = buildHierarchyTools(
-      { agentId: "agent_t", hierarchyLevel: "team" },
-      buildServices(),
-    );
-    const names = tools.map((t) => t.name);
-    expect(names.length).toBe(16);
-    expect(names).toContain("find_subordinates");
-    expect(names).toContain("find_peers");
-    expect(names).toContain("create_task");
-    expect(names).toContain("check_work_status");
-    expect(names).toContain("revise_task");
-    expect(names).toContain("add_to_escalation");
-    expect(names).toContain("create_subordinate_agent");
+  it("team tier gets the shared tools plus the delegation surface", () => {
+    expect(toolNames("team")).toEqual([...SHARED_TOOLS, ...TEAM_ONLY_TOOLS].sort());
   });
 
-  it("org tier also gets all 16 (parents have subordinates too)", () => {
-    const tools = buildHierarchyTools(
-      { agentId: "agent_o", hierarchyLevel: "org" },
-      buildServices(),
-    );
-    expect(tools.length).toBe(16);
+  it("org tier gets exactly the team set (parents have subordinates too)", () => {
+    expect(toolNames("org")).toEqual(toolNames("team"));
   });
 });
 

--- a/packages/api/src/tools/hierarchy.ts
+++ b/packages/api/src/tools/hierarchy.ts
@@ -1310,13 +1310,12 @@ function createSubordinateAgentTool(
  * Picks IC vs team set based on `ctx.hierarchyLevel`. Team and org both
  * get the team set (org-tier agents have subordinates too).
  *
- * M6.4 totals:
- *   IC tier:   8 shared tools.
- *   Team/org: 15 tools (8 shared + 6 team-only — find_subordinates,
- *                       find_peers, create_task, check_work_status,
- *                       revise_task [parent unblock subordinate],
- *                       add_to_escalation [populate peer slot] —
- *                       plus create_subordinate_agent (Phase 9)).
+ * IC tier gets the shared tools only. Team/org additionally get the
+ * delegation surface: find_subordinates, find_peers, create_task,
+ * check_work_status, revise_task (parent unblocks a subordinate),
+ * add_to_escalation (populate peer slot), and create_subordinate_agent.
+ * `hierarchy.test.ts` pins the exact name sets — see the tier-gating block
+ * there rather than trusting a count in this comment.
  */
 export function buildHierarchyTools(
   ctx: HierarchyToolContext,

--- a/packages/core/src/domain/memory.test.ts
+++ b/packages/core/src/domain/memory.test.ts
@@ -25,12 +25,6 @@ describe("hierarchyToScope", () => {
       expect(hierarchyToScope(level)).toBe(level);
     }
   });
-
-  it("does not invent a scope for an unlisted level", () => {
-    // Guards the day someone adds a HierarchyLevel without extending
-    // MemoryScope: the cast would silently produce an unknown scope.
-    expect(MEMORY_SCOPES).toContain(hierarchyToScope("ic" as HierarchyLevel));
-  });
 });
 
 describe("FACT_TYPE_DESCRIPTIONS", () => {

--- a/packages/core/src/services/memory/core-memory.test.ts
+++ b/packages/core/src/services/memory/core-memory.test.ts
@@ -139,19 +139,6 @@ describe("CoreMemory plumbing", () => {
       service.applyUpdate("agent_1", "never_seeded", "append", "x"),
     ).rejects.toThrow(/not found/);
   });
-
-  it("read delegates to repo.findByAgent", async () => {
-    vi.mocked(repo.findByAgent).mockResolvedValue([makeBlock()]);
-    const blocks = await service.read("agent_1");
-    expect(repo.findByAgent).toHaveBeenCalledWith("agent_1");
-    expect(blocks).toHaveLength(1);
-  });
-
-  it("initDefaults delegates to repo.initDefaults with the given level", async () => {
-    vi.mocked(repo.initDefaults).mockResolvedValue([]);
-    await service.initDefaults("agent_1", "team");
-    expect(repo.initDefaults).toHaveBeenCalledWith("agent_1", "team");
-  });
 });
 
 describe("CoreMemory.setContent — owner-driven full-block overwrite", () => {

--- a/packages/core/src/services/memory/fact-store.test.ts
+++ b/packages/core/src/services/memory/fact-store.test.ts
@@ -192,20 +192,4 @@ describe("FactStore thin delegations", () => {
     expect(repo.update).toHaveBeenCalledWith("fact_x", { scope: "team" });
   });
 
-  it("search delegates to repo.searchByVector", async () => {
-    vi.mocked(repo.searchByVector).mockResolvedValue([]);
-    await store.search({
-      agent_id: "agent_1",
-      scope: "ic",
-      embedding: [],
-      limit: 5,
-    });
-    expect(repo.searchByVector).toHaveBeenCalled();
-  });
-
-  it("listBySessionId delegates to repo.listBySessionId", async () => {
-    vi.mocked(repo.listBySessionId).mockResolvedValue([]);
-    await store.listBySessionId("sess_abc");
-    expect(repo.listBySessionId).toHaveBeenCalledWith("sess_abc");
-  });
 });

--- a/packages/core/src/services/task-service.test.ts
+++ b/packages/core/src/services/task-service.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Agent, ReviewPolicy } from "../domain/agent.js";
 import type { Task } from "../domain/task.js";
-import type { WorkProduct, WorkProductListItem } from "../domain/work-product.js";
+import type { WorkProduct } from "../domain/work-product.js";
 import type { Session } from "../domain/session.js";
 import type { AgentRepository } from "../ports/agent-repo.js";
 import type { SessionRepository } from "../ports/session-repo.js";
@@ -38,13 +38,6 @@ function makeWorkProduct(overrides: Partial<WorkProduct> = {}): WorkProduct {
     updated_at: new Date(),
     ...overrides,
   };
-}
-
-function makeWorkProductListItem(
-  overrides: Partial<WorkProductListItem> = {},
-): WorkProductListItem {
-  const { body: _body, ...rest } = makeWorkProduct();
-  return { ...rest, body_bytes: 0, ...overrides };
 }
 
 function makeSession(overrides: Partial<Session> = {}): Session {
@@ -603,26 +596,6 @@ describe("TaskService.createWorkProduct + listWorkProducts", () => {
     expect(workProductRepo.create).not.toHaveBeenCalled();
   });
 
-  it("listWorkProducts delegates to the repo", async () => {
-    vi.mocked(workProductRepo.listByTask).mockResolvedValue([
-      makeWorkProductListItem(),
-    ]);
-    const out = await service.listWorkProducts("task_1");
-    expect(out).toHaveLength(1);
-    expect(workProductRepo.listByTask).toHaveBeenCalledWith("task_1");
-  });
-
-  it("getWorkProduct delegates to the repo", async () => {
-    vi.mocked(workProductRepo.findById).mockResolvedValue(makeWorkProduct());
-    const out = await service.getWorkProduct("wp_1");
-    expect(workProductRepo.findById).toHaveBeenCalledWith("wp_1");
-    expect(out?.id).toBe("wp_1");
-  });
-
-  it("getWorkProduct passes an unknown id straight through as undefined", async () => {
-    vi.mocked(workProductRepo.findById).mockResolvedValue(undefined);
-    await expect(service.getWorkProduct("wp_missing")).resolves.toBeUndefined();
-  });
 
   it("updateWorkProduct forwards the mutable patch to the repo", async () => {
     vi.mocked(workProductRepo.update).mockImplementation(async (id, patch) =>


### PR DESCRIPTION
Sweep of the test suite for tests that no longer earn their place.

## What the sweep ruled out

- **Skipped / disabled / xfail suites** — every `.skip` in the tree is a live environment gate with a real condition behind it, not an abandoned test: `docker.e2e.test.ts` and `multi-instance.e2e.test.ts` (`ENABLED` flag), `mcp.test.ts` (`HAS_LIVE_API_KEYS`), `smoke.test.ts` (`RUN_CLAUDE_SMOKE`), and the `skipIf(process.platform === "win32")` guards in `spawn.test.ts` / `manager.test.ts`. The win32 guards look dead on an ubuntu-only CI, but `spawn.ts:67` really does branch on `process.platform === "win32"`, so they stay.
- **Tests for removed features** — `pnpm typecheck` is clean across all nine projects, so no test references an API that no longer exists.
- **Tests with no assertions** — none. #261 already gave the last two assertion-free tests assertions.

## What it found

### Pure pass-through delegation (7 tests removed)

Each covers a method whose entire body is `return this.deps.repo.x(...)`, and asserts only that the mock was called with the arguments the test just handed it. A wrong repo method would fail typecheck first, so these can only fail when the test itself is edited.

| File | Test |
| --- | --- |
| `core/src/services/memory/core-memory.test.ts` | `read delegates to repo.findByAgent` |
| `core/src/services/memory/core-memory.test.ts` | `initDefaults delegates to repo.initDefaults with the given level` |
| `core/src/services/memory/fact-store.test.ts` | `search delegates to repo.searchByVector` — asserted only `toHaveBeenCalled()`, not even the args |
| `core/src/services/memory/fact-store.test.ts` | `listBySessionId delegates to repo.listBySessionId` |
| `core/src/services/task-service.test.ts` | `listWorkProducts delegates to the repo` |
| `core/src/services/task-service.test.ts` | `getWorkProduct delegates to the repo` |
| `core/src/services/task-service.test.ts` | `getWorkProduct passes an unknown id straight through as undefined` |

`makeWorkProductListItem` was left with no callers, so it and its now-unused `WorkProductListItem` import go too.

### Tautology (1 test removed)

`core/src/domain/memory.test.ts` — `does not invent a scope for an unlisted level`. Its comment claims it guards the day someone adds a `HierarchyLevel` without extending `MemoryScope`, but it hardcodes `"ic" as HierarchyLevel` — a no-op cast on a value that already *is* a `HierarchyLevel`. It is one iteration of the loop two tests above it. The real guard is `is an identity mapping today`, which compares `MEMORY_SCOPES` against `HIERARCHY_LEVELS` wholesale; that one stays.

### Implementation-detail assertion, fixed rather than deleted

`buildHierarchyTools`' tier gating asserted `length === 16` in two places, and for the org tier asserted *only* the count — so "org also gets all 16" never checked that org gets the same **tools** as team, just the same **number**. All three tiers now assert full sorted name sets (matching how the IC tier was already written), and org is pinned to equal team directly.

The same magic numbers had already rotted in the `M6.4 totals` doc comment above `buildHierarchyTools` — it said 8 IC / 15 team when the real counts are 9 and 16. Replaced with a prose description that points at the test as the source of truth.

## Considered and kept

`assemble.test.ts` also asserts `tools.length` (29 team / 16 IC), but pairs each count with substantive per-name assertions, and the total assembled surface is a broader contract worth pinning. Left alone.

## Verification

- `packages/core`: 590 → 582 passing, failure count unchanged at 7 — exactly the eight removed tests and nothing else. All 7 failures are the documented environmental ones (no Postgres, no provider keys), confirmed identical by stashing the diff and re-running.
- `packages/api`: `hierarchy.test.ts` + `assemble.test.ts` — 31 passed.
- `pnpm typecheck` and `pnpm lint` clean (4 pre-existing `import/no-duplicates` warnings in `negotiation.test.ts` / `ws-server.test.ts`, untouched here).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AG1iVSKpLVx5qVxSKarcET)_