### PR TITLE
refactor: unify four clusters of near-duplicate abstractions

### DIFF
--- a/packages/api/src/routes/directives.ts
+++ b/packages/api/src/routes/directives.ts
@@ -21,6 +21,8 @@
  *     Hydrated as reference cards by the UI; collected as `view_refs`.
  */
 
+import { extractGitHubRepoRefs } from "@beevibe/core";
+
 const ENTITY_ID_RE = /\b((?:task|agent|sess)_[A-Za-z0-9]{12})\b/g;
 const OPEN_VIEW_RE =
   /<open_view\s+path="([^"]+)"(?:\s+label="([^"]+)")?\s*\/?>(?:\s*<\/open_view>)?/i;
@@ -35,24 +37,6 @@ const ATTR_LANGUAGE_RE = /\blanguage\s*=\s*"([^"]*)"/i;
 const ATTR_SOURCE_RE = /\bsource\s*=\s*"([^"]*)"/i;
 const ATTR_DESCRIPTION_RE = /\bdescription\s*=\s*"([^"]*)"/i;
 const VALID_REPO_SOURCES = new Set(["learned", "trending", "community", "github"]);
-
-/**
- * Bare GitHub URL pattern. We auto-promote any GitHub repo URL in the
- * agent's visible text into a repo_card, so the user gets a Try button
- * even when the agent emits markdown links instead of <repo_card> tags.
- * Stops at the second path segment so `/owner/repo/blob/...` collapses
- * to the repo root.
- */
-const BARE_GITHUB_URL_RE =
-  /https:\/\/github\.com\/([A-Za-z0-9][A-Za-z0-9._-]*)\/([A-Za-z0-9][A-Za-z0-9._-]*)(?=[/\s)"',<>]|$)/g;
-
-/** github.com paths that aren't repos. */
-const NON_REPO_OWNERS = new Set([
-  "orgs", "settings", "marketplace", "topics", "trending", "features",
-  "pricing", "search", "notifications", "issues", "pulls", "explore",
-  "about", "contact", "site", "security", "login", "signup", "logout",
-  "new",
-]);
 
 /**
  * Paths the chat UI knows how to navigate to. The system prompt names
@@ -192,23 +176,13 @@ export function processResponse(raw: string): ProcessedResponse {
 
   // Auto-promote bare github URLs so Try works when agents skip
   // <repo_card>. URLs stay in `visible` for the markdown renderer.
-  BARE_GITHUB_URL_RE.lastIndex = 0;
-  let urlMatch: RegExpExecArray | null;
-  while ((urlMatch = BARE_GITHUB_URL_RE.exec(visible)) !== null) {
-    const owner = urlMatch[1];
-    const nameRaw = urlMatch[2];
-    if (!owner || !nameRaw) continue;
-    if (NON_REPO_OWNERS.has(owner.toLowerCase())) continue;
-    // Strip trailing periods so sentence punctuation doesn't leak in.
-    const name = nameRaw.replace(/\.git$/i, "").replace(/\.+$/, "");
-    if (!name) continue;
-    const canonical = `https://github.com/${owner}/${name}`;
-    if (seenRepoUrls.has(canonical)) continue;
-    seenRepoUrls.add(canonical);
+  for (const ref of extractGitHubRepoRefs(visible)) {
+    if (seenRepoUrls.has(ref.url)) continue;
+    seenRepoUrls.add(ref.url);
     repoCards.push({
-      repo_url: canonical,
-      owner,
-      name,
+      repo_url: ref.url,
+      owner: ref.owner,
+      name: ref.name,
     });
   }
 

--- a/packages/api/src/routes/http-errors.test.ts
+++ b/packages/api/src/routes/http-errors.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Request, Response } from "express";
-import { loadOwned, requireParam } from "./http-errors.js";
+import {
+  invalidBody,
+  loadOwned,
+  requireNullableString,
+  requireParam,
+} from "./http-errors.js";
 
 function fakeRes(): Response & { statusCode?: number; body?: unknown } {
   const res = {
@@ -20,6 +25,10 @@ function fakeRes(): Response & { statusCode?: number; body?: unknown } {
 
 function fakeReq(params: Record<string, unknown>): Request {
   return { params } as unknown as Request;
+}
+
+function fakeBodyReq(body: unknown): Request {
+  return { body } as unknown as Request;
 }
 
 describe("requireParam", () => {
@@ -134,5 +143,79 @@ describe("loadOwned", () => {
     const load = vi.fn().mockResolvedValue(agent);
     await loadOwned(fakeRes(), "person_1", load, (a: typeof agent) => a.owner_id, "nf");
     expect(load).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("invalidBody", () => {
+  it("400s with the invalid_body envelope and the caller's message", () => {
+    const res = fakeRes();
+    invalidBody(res, "expected { content: string }");
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      error: "invalid_body",
+      message: "expected { content: string }",
+    });
+  });
+
+  // The wording is the only part a client sees and it is not uniform
+  // across routers, so the helper factors out the envelope, not the prose.
+  it("passes the message through verbatim", () => {
+    const res = fakeRes();
+    invalidBody(res, "name, goal_pattern, repo_run_id required");
+    expect(res.body).toMatchObject({
+      message: "name, goal_pattern, repo_run_id required",
+    });
+  });
+});
+
+describe("requireNullableString", () => {
+  it("returns a non-empty string and answers nothing", () => {
+    const res = fakeRes();
+    expect(requireNullableString(fakeBodyReq({ model: "opus" }), res, "model")).toBe("opus");
+    expect(res.statusCode).toBeUndefined();
+  });
+
+  // null is a VALID value here — it clears the column — so it must come
+  // back as null rather than being lumped in with the reject case.
+  it("returns null for an explicit null without responding", () => {
+    const res = fakeRes();
+    expect(requireNullableString(fakeBodyReq({ model: null }), res, "model")).toBeNull();
+    expect(res.statusCode).toBeUndefined();
+  });
+
+  it("400s when the field is absent", () => {
+    const res = fakeRes();
+    expect(requireNullableString(fakeBodyReq({}), res, "model")).toBeUndefined();
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      error: "invalid_body",
+      message: "expected { model: string | null }",
+    });
+  });
+
+  it("400s on an empty string rather than binding it", () => {
+    const res = fakeRes();
+    expect(requireNullableString(fakeBodyReq({ runtime_id: "" }), res, "runtime_id")).toBeUndefined();
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("400s on a non-string, non-null type", () => {
+    const res = fakeRes();
+    expect(requireNullableString(fakeBodyReq({ model: 7 }), res, "model")).toBeUndefined();
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("400s when there is no body at all", () => {
+    const res = fakeRes();
+    expect(requireNullableString(fakeBodyReq(undefined), res, "model")).toBeUndefined();
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("names the field it was asked for in the message", () => {
+    const res = fakeRes();
+    requireNullableString(fakeBodyReq({}), res, "runtime_id");
+    expect(res.body).toMatchObject({
+      message: "expected { runtime_id: string | null }",
+    });
   });
 });

--- a/packages/api/src/routes/http-errors.ts
+++ b/packages/api/src/routes/http-errors.ts
@@ -34,6 +34,49 @@ export function requireParam(
 }
 
 /**
+ * The 400 a handler returns when the request body doesn't typecheck.
+ *
+ * Six handlers across `view`, `learned-skills` and `me` wrote out the
+ * same `res.status(400).json({ error: "invalid_body", message })`. The
+ * `message` stays a parameter rather than being derived: the wording is
+ * not uniform (`view` describes the expected shape, `learned-skills`
+ * lists the missing fields) and it is the only part a client sees, so
+ * this factors out the envelope, not the prose.
+ */
+export function invalidBody(res: Response, message: string): void {
+  res.status(400).json({ error: "invalid_body", message });
+}
+
+/**
+ * Read a body field that accepts either an explicit `null` (clear the
+ * value) or a non-empty string (set it), 400-ing on anything else —
+ * absent, empty string, wrong type.
+ *
+ * `view`'s `/agent/:id/runtime` and `/agent/:id/model` are the same
+ * nullable-string patch endpoint over different columns, and each had
+ * spelled the three-way ternary out by hand. The distinction that makes
+ * it fiddly is that `null` is a *valid* value here while `undefined`
+ * means "reject" — inverted from the usual falsy check, and easy to get
+ * subtly wrong when written twice.
+ *
+ * Returns `undefined` after responding, so the caller's next line is
+ * `if (value === undefined) return;` — note the explicit compare, since
+ * a returned `null` is success.
+ */
+export function requireNullableString(
+  req: Request,
+  res: Response,
+  field: string,
+): string | null | undefined {
+  const body = req.body as Record<string, unknown> | undefined;
+  const raw = body?.[field];
+  if (raw === null) return null;
+  if (typeof raw === "string" && raw) return raw;
+  invalidBody(res, `expected { ${field}: string | null }`);
+  return undefined;
+}
+
+/**
  * Load an entity and gate it on the caller owning it: 404 when it
  * doesn't exist, 403 when it belongs to somebody else.
  *

--- a/packages/api/src/routes/learned-skills.ts
+++ b/packages/api/src/routes/learned-skills.ts
@@ -19,7 +19,7 @@ import {
 } from "@beevibe/core";
 import { requireHuman } from "../auth/middleware.js";
 import { readArtifactBody } from "../views/work-product.js";
-import { loadOwned, requireParam } from "./http-errors.js";
+import { invalidBody, loadOwned, requireParam } from "./http-errors.js";
 
 export interface LearnedSkillsRouterDeps {
   authMiddleware: RequestHandler;
@@ -65,7 +65,7 @@ export function createLearnedSkillsRouter(deps: LearnedSkillsRouterDeps): Router
       repo_run_id: string;
     }>;
     if (!body.name || !body.goal_pattern || !body.repo_run_id) {
-      res.status(400).json({ error: "invalid_body", message: "name, goal_pattern, repo_run_id required" });
+      invalidBody(res, "name, goal_pattern, repo_run_id required");
       return;
     }
     // Validate slug — lowercase alphanum + hyphens only.

--- a/packages/api/src/routes/me.ts
+++ b/packages/api/src/routes/me.ts
@@ -27,6 +27,7 @@ import type {
   RuntimeRegistry,
 } from "@beevibe/core";
 import { requireHuman } from "../auth/middleware.js";
+import { invalidBody } from "./http-errors.js";
 
 export interface MeRoutesDeps {
   authMiddleware: RequestHandler;
@@ -84,7 +85,7 @@ export function createMeRouter(deps: MeRoutesDeps): Router {
     if (!requireHuman(req, res)) return;
     const body = req.body as { capability_network_enabled?: unknown } | undefined;
     if (!body || typeof body.capability_network_enabled !== "boolean") {
-      res.status(400).json({ error: "invalid_body", message: "capability_network_enabled (boolean) required" });
+      invalidBody(res, "capability_network_enabled (boolean) required");
       return;
     }
     const updated = await deps.personRepo.update(req.caller.personId, {

--- a/packages/api/src/routes/view.ts
+++ b/packages/api/src/routes/view.ts
@@ -18,7 +18,7 @@
  * guess); it matches M6's singular-noun, no-prefix style (`/task/:id/...`).
  */
 
-import { Router, type RequestHandler } from "express";
+import { Router, type RequestHandler, type Response } from "express";
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import {
   MEMORY_SCOPES,
@@ -60,7 +60,13 @@ import { listActivity } from "../views/activity.js";
 import { getWorkProduct } from "../views/work-product.js";
 import { listInbox } from "../views/inbox.js";
 import { getAgentNetwork } from "../views/agent-network.js";
-import { loadOwned, makeErrorHandler, requireParam } from "./http-errors.js";
+import {
+  invalidBody,
+  loadOwned,
+  makeErrorHandler,
+  requireNullableString,
+  requireParam,
+} from "./http-errors.js";
 
 /** Every handler below passes a per-call context, e.g. `[view route: task list]`. */
 const handleError = makeErrorHandler("view route");
@@ -92,6 +98,20 @@ function isReviewPolicy(v: unknown): v is ReviewPolicy {
 export function createViewRouter(deps: ViewRoutesDeps): Router {
   const router = Router();
   router.use(deps.authMiddleware);
+
+  /**
+   * `loadOwned` bound to the agent table — the five `/agent/:id/*` mutation
+   * handlers below all gate on the caller owning the agent, and all five
+   * passed the identical projector and error code to do it.
+   */
+  const loadOwnedAgent = (res: Response, personId: string, id: string) =>
+    loadOwned(
+      res,
+      personId,
+      () => deps.agentRepo.findById(id),
+      (a) => a.owner_id,
+      "agent_not_found",
+    );
 
   router.get("/task", async (req, res) => {
     if (!requireHuman(req, res)) return;
@@ -200,29 +220,11 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
     if (!requireHuman(req, res)) return;
     const id = requireParam(req, res, "id", "missing_agent_id");
     if (!id) return;
-    const body = req.body as { runtime_id?: string | null } | undefined;
     // Allow explicit null to unbind, or a non-empty string to bind.
-    const runtimeId =
-      body?.runtime_id === null
-        ? null
-        : typeof body?.runtime_id === "string" && body.runtime_id
-          ? body.runtime_id
-          : undefined;
-    if (runtimeId === undefined) {
-      res.status(400).json({
-        error: "invalid_body",
-        message: "expected { runtime_id: string | null }",
-      });
-      return;
-    }
+    const runtimeId = requireNullableString(req, res, "runtime_id");
+    if (runtimeId === undefined) return;
     try {
-      const existing = await loadOwned(
-        res,
-        req.caller.personId,
-        () => deps.agentRepo.findById(id),
-        (a) => a.owner_id,
-        "agent_not_found",
-      );
+      const existing = await loadOwnedAgent(res, req.caller.personId, id);
       if (!existing) return;
       // Validate the runtime belongs to a daemon owned by the caller.
       // Otherwise a user could re-target their agent at someone else's
@@ -276,29 +278,11 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
     if (!requireHuman(req, res)) return;
     const id = requireParam(req, res, "id", "missing_agent_id");
     if (!id) return;
-    const body = req.body as { model?: string | null } | undefined;
     // null clears (agent uses CLI default), non-empty string sets.
-    const model =
-      body?.model === null
-        ? null
-        : typeof body?.model === "string" && body.model
-          ? body.model
-          : undefined;
-    if (model === undefined) {
-      res.status(400).json({
-        error: "invalid_body",
-        message: "expected { model: string | null }",
-      });
-      return;
-    }
+    const model = requireNullableString(req, res, "model");
+    if (model === undefined) return;
     try {
-      const existing = await loadOwned(
-        res,
-        req.caller.personId,
-        () => deps.agentRepo.findById(id),
-        (a) => a.owner_id,
-        "agent_not_found",
-      );
+      const existing = await loadOwnedAgent(res, req.caller.personId, id);
       if (!existing) return;
       // Build the next runtime_config: keep the existing fields, override
       // (or remove) just the `model` key. Don't replace the whole config
@@ -328,20 +312,14 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
     const body = req.body as { review_policy?: unknown } | undefined;
     const policy = body?.review_policy;
     if (!isReviewPolicy(policy)) {
-      res.status(400).json({
-        error: "invalid_body",
-        message: `expected { review_policy: ${REVIEW_POLICIES.map((p) => `"${p}"`).join(" | ")} }`,
-      });
+      invalidBody(
+        res,
+        `expected { review_policy: ${REVIEW_POLICIES.map((p) => `"${p}"`).join(" | ")} }`,
+      );
       return;
     }
     try {
-      const existing = await loadOwned(
-        res,
-        req.caller.personId,
-        () => deps.agentRepo.findById(id),
-        (a) => a.owner_id,
-        "agent_not_found",
-      );
+      const existing = await loadOwnedAgent(res, req.caller.personId, id);
       if (!existing) return;
       const updated = await deps.agentRepo.update(id, { review_policy: policy });
       res.json({ ok: true, review_policy: updated.review_policy });
@@ -358,20 +336,11 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
     if (!blockName) return;
     const body = req.body as { content?: unknown } | undefined;
     if (typeof body?.content !== "string") {
-      res.status(400).json({
-        error: "invalid_body",
-        message: "expected { content: string }",
-      });
+      invalidBody(res, "expected { content: string }");
       return;
     }
     try {
-      const existing = await loadOwned(
-        res,
-        req.caller.personId,
-        () => deps.agentRepo.findById(id),
-        (a) => a.owner_id,
-        "agent_not_found",
-      );
+      const existing = await loadOwnedAgent(res, req.caller.personId, id);
       if (!existing) return;
       await deps.coreMemory.setContent(id, blockName, body.content);
       res.json({ ok: true });
@@ -393,13 +362,7 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
     const id = requireParam(req, res, "id", "missing_agent_id");
     if (!id) return;
     try {
-      const existing = await loadOwned(
-        res,
-        req.caller.personId,
-        () => deps.agentRepo.findById(id),
-        (a) => a.owner_id,
-        "agent_not_found",
-      );
+      const existing = await loadOwnedAgent(res, req.caller.personId, id);
       if (!existing) return;
       if (existing.archived_at) {
         res.json({ ok: true, archived_at: existing.archived_at.toISOString() });

--- a/packages/api/src/tools/find-repo.ts
+++ b/packages/api/src/tools/find-repo.ts
@@ -576,25 +576,48 @@ function trendingHaystack(e: TrendingRepoEntry): string {
   return [e.owner, e.name, e.description ?? ""].filter(Boolean).join(" ");
 }
 
-async function ensureTrendingEmbeddings(
-  entries: TrendingRepoEntry[],
+/**
+ * Resolve one vector per distinct entry, cheapest source first: the
+ * entry's own precomputed `embedding`, then the process-level cache,
+ * then a single batched embed call for whatever is left. Newly embedded
+ * vectors are written back to `cache`.
+ *
+ * The trending and community tiers differ only in which cache they use
+ * and in how an entry projects to its cache key and its embeddable text
+ * — the resolution order, the dedup, the batch call and the write-back
+ * are the same work, so they share one implementation. `key` and `text`
+ * diverge for trending (keyed on the normalized URL, embedded on
+ * owner/name/description) and coincide for community (both are
+ * `goal_pattern`).
+ *
+ * Entries whose `text` is empty are skipped rather than embedded — there
+ * is no signal in a zero-length haystack, and it would still cost a slot
+ * in the batch.
+ */
+async function ensureEmbeddings<T extends { embedding?: number[] }>(
+  entries: readonly T[],
   embeddings: EmbeddingService,
+  spec: {
+    cache: Map<string, number[]>;
+    key: (entry: T) => string;
+    text: (entry: T) => string;
+  },
 ): Promise<Map<string, number[]>> {
   const out = new Map<string, number[]>();
   const toEmbed: { key: string; text: string }[] = [];
   for (const e of entries) {
-    const key = normalizeUrl(e.repo_url);
-    if (out.has(key)) continue; // dedup across daily/weekly
+    const key = spec.key(e);
+    if (out.has(key)) continue; // dedup (e.g. a repo in both daily and weekly)
     if (Array.isArray(e.embedding) && e.embedding.length > 0) {
       out.set(key, e.embedding);
       continue;
     }
-    const cached = trendingEmbeddingCache.get(key);
+    const cached = spec.cache.get(key);
     if (cached) {
       out.set(key, cached);
       continue;
     }
-    const text = trendingHaystack(e);
+    const text = spec.text(e);
     if (!text) continue;
     toEmbed.push({ key, text });
   }
@@ -604,41 +627,32 @@ async function ensureTrendingEmbeddings(
     const key = toEmbed[i]!.key;
     const vec = vecs[i];
     if (!vec) continue;
-    trendingEmbeddingCache.set(key, vec);
+    spec.cache.set(key, vec);
     out.set(key, vec);
   }
   return out;
 }
 
-async function ensureRegistryEmbeddings(
+function ensureTrendingEmbeddings(
+  entries: TrendingRepoEntry[],
+  embeddings: EmbeddingService,
+): Promise<Map<string, number[]>> {
+  return ensureEmbeddings(entries, embeddings, {
+    cache: trendingEmbeddingCache,
+    key: (e) => normalizeUrl(e.repo_url),
+    text: trendingHaystack,
+  });
+}
+
+function ensureRegistryEmbeddings(
   entries: CommunityRegistryEntry[],
   embeddings: EmbeddingService,
 ): Promise<Map<string, number[]>> {
-  const out = new Map<string, number[]>();
-  const toEmbed: { key: string; text: string }[] = [];
-  for (const e of entries) {
-    if (out.has(e.goal_pattern)) continue;
-    if (Array.isArray(e.embedding) && e.embedding.length > 0) {
-      out.set(e.goal_pattern, e.embedding);
-      continue;
-    }
-    const cached = communityEmbeddingCache.get(e.goal_pattern);
-    if (cached) {
-      out.set(e.goal_pattern, cached);
-      continue;
-    }
-    toEmbed.push({ key: e.goal_pattern, text: e.goal_pattern });
-  }
-  if (toEmbed.length === 0) return out;
-  const vecs = await embeddings.embedBatch(toEmbed.map((t) => t.text));
-  for (let i = 0; i < toEmbed.length; i++) {
-    const key = toEmbed[i]!.key;
-    const vec = vecs[i];
-    if (!vec) continue;
-    communityEmbeddingCache.set(key, vec);
-    out.set(key, vec);
-  }
-  return out;
+  return ensureEmbeddings(entries, embeddings, {
+    cache: communityEmbeddingCache,
+    key: (e) => e.goal_pattern,
+    text: (e) => e.goal_pattern,
+  });
 }
 
 function popularityScore(stars: number): number {

--- a/packages/core/src/domain/github-url.test.ts
+++ b/packages/core/src/domain/github-url.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { extractGitHubRepoRefs, NON_REPO_OWNERS } from "./github-url.js";
+
+describe("extractGitHubRepoRefs", () => {
+  it("pulls owner, name and canonical root out of a bare URL", () => {
+    expect(extractGitHubRepoRefs("see https://github.com/beevibe-ai/beevibe now")).toEqual([
+      {
+        owner: "beevibe-ai",
+        name: "beevibe",
+        url: "https://github.com/beevibe-ai/beevibe",
+      },
+    ]);
+  });
+
+  it("collapses a deep path to the repo root", () => {
+    const [ref] = extractGitHubRepoRefs(
+      "https://github.com/owner/repo/blob/main/CLAUDE.md",
+    );
+    expect(ref?.url).toBe("https://github.com/owner/repo");
+  });
+
+  it("returns nothing for empty text", () => {
+    expect(extractGitHubRepoRefs("")).toEqual([]);
+  });
+
+  it("skips github.com paths that aren't owners", () => {
+    const text = [...NON_REPO_OWNERS]
+      .map((o) => `https://github.com/${o}/something`)
+      .join("\n");
+    expect(extractGitHubRepoRefs(text)).toEqual([]);
+  });
+
+  it("matches the non-repo owner list case-insensitively", () => {
+    expect(extractGitHubRepoRefs("https://github.com/ORGS/anthropic")).toEqual([]);
+  });
+
+  it("strips a .git clone suffix", () => {
+    const [ref] = extractGitHubRepoRefs("git clone https://github.com/owner/repo.git");
+    expect(ref).toMatchObject({ name: "repo", url: "https://github.com/owner/repo" });
+  });
+
+  // `.` is a legal name character, so the regex takes the full stop with it.
+  // Left unstripped this yields `repo.` — a URL that 404s and never matches a
+  // repo already stored in the learned-skill registry.
+  it("strips a trailing period from a URL that ends a sentence", () => {
+    const [ref] = extractGitHubRepoRefs("I used https://github.com/owner/repo.");
+    expect(ref).toMatchObject({ name: "repo", url: "https://github.com/owner/repo" });
+  });
+
+  it("keeps interior dots in the repo name", () => {
+    const [ref] = extractGitHubRepoRefs("https://github.com/owner/my.cool.repo ");
+    expect(ref?.name).toBe("my.cool.repo");
+  });
+
+  it("stops at closing punctuation around a markdown link", () => {
+    const [ref] = extractGitHubRepoRefs("[repo](https://github.com/owner/repo)");
+    expect(ref?.url).toBe("https://github.com/owner/repo");
+  });
+
+  it("finds every mention in order, without deduping", () => {
+    const refs = extractGitHubRepoRefs(
+      "https://github.com/a/one and https://github.com/b/two and https://github.com/a/one",
+    );
+    expect(refs.map((r) => r.url)).toEqual([
+      "https://github.com/a/one",
+      "https://github.com/b/two",
+      "https://github.com/a/one",
+    ]);
+  });
+
+  // The module-level regex is global; a stale lastIndex would make the second
+  // call start mid-string and miss the match.
+  it("is not order-dependent across calls", () => {
+    const text = "https://github.com/owner/repo";
+    expect(extractGitHubRepoRefs(text)).toEqual(extractGitHubRepoRefs(text));
+  });
+});

--- a/packages/core/src/domain/github-url.ts
+++ b/packages/core/src/domain/github-url.ts
@@ -1,0 +1,107 @@
+/**
+ * Recognizing GitHub repo URLs in free text, in one place.
+ *
+ * Two callers sweep model-authored prose for repo links and they must agree,
+ * because the URL one produces is matched against the URL the other stored:
+ *
+ *   - `api/routes/directives.ts` auto-promotes a bare URL in an agent's
+ *     visible text into a `<repo_card>`, so the user gets a Try button even
+ *     when the model emitted a plain markdown link.
+ *   - `core/services/referenced-repos.ts` mines a closed task's transcript
+ *     for the repos the agent actually used, and looks each one up against
+ *     the learned-skill registry to mark it `already_saved`.
+ *
+ * Both carried a byte-identical copy of the regex and of the 20-entry
+ * `NON_REPO_OWNERS` set. Adding a new non-repo path (GitHub ships them —
+ * `sponsors`, `codespaces`) to one copy and not the other would leave the
+ * two disagreeing about what counts as a repo, and the disagreement would
+ * surface as a card that never matches a saved skill rather than as an
+ * error.
+ */
+
+/**
+ * Repo root only. `owner` and `name` follow GitHub's schema (alphanumeric
+ * plus dot/hyphen/underscore, first char alphanumeric). We deliberately STOP
+ * at the second path segment, so `/owner/repo/blob/main/CLAUDE.md` collapses
+ * to the repo root. The trailing boundary class keeps closing punctuation
+ * out of `name`.
+ *
+ * Global — callers using `.exec()` in a loop must reset `lastIndex` first,
+ * which is why {@link extractGitHubRepoRefs} exists rather than each site
+ * driving the regex by hand.
+ */
+export const GITHUB_REPO_URL_RE =
+  /https:\/\/github\.com\/([A-Za-z0-9][A-Za-z0-9._-]*)\/([A-Za-z0-9][A-Za-z0-9._-]*)(?=[/\s)"',<>]|$)/g;
+
+/**
+ * First-segment paths under github.com that aren't owners —
+ * `github.com/orgs/foo`, `/settings`, `/marketplace`, etc. Filtered at the
+ * owner segment rather than against the whole URL.
+ */
+export const NON_REPO_OWNERS: ReadonlySet<string> = new Set([
+  "orgs",
+  "settings",
+  "marketplace",
+  "topics",
+  "trending",
+  "features",
+  "pricing",
+  "search",
+  "notifications",
+  "issues",
+  "pulls",
+  "explore",
+  "about",
+  "contact",
+  "site",
+  "security",
+  "login",
+  "signup",
+  "logout",
+  "new",
+]);
+
+/** A repo reference found in free text, with its canonical root URL. */
+export interface GitHubRepoRef {
+  owner: string;
+  name: string;
+  /** `https://github.com/<owner>/<name>` — always the repo root. */
+  url: string;
+}
+
+/**
+ * Strip the suffixes that ride along when a regex sweeps prose rather than
+ * structured metadata:
+ *
+ *   - `.git`, from clone URLs (`github.com/owner/repo.git`).
+ *   - trailing periods, from a URL that ends a sentence. `.` is a legal
+ *     `name` character, so the regex happily takes the full stop with it and
+ *     yields `repo.` — a URL that 404s and never matches a stored repo.
+ */
+function normalizeName(raw: string): string {
+  return raw.replace(/\.git$/i, "").replace(/\.+$/, "");
+}
+
+/**
+ * Every GitHub repo root cited in `text`, in the order it appears.
+ *
+ * Duplicates are NOT collapsed — callers want different things from a repeat
+ * mention (directives dedups to one card; referenced-repos counts occurrences
+ * to rank), so deduping is left to them.
+ */
+export function extractGitHubRepoRefs(text: string): GitHubRepoRef[] {
+  const out: GitHubRepoRef[] = [];
+  if (!text) return out;
+  GITHUB_REPO_URL_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = GITHUB_REPO_URL_RE.exec(text)) !== null) {
+    const owner = match[1];
+    const nameRaw = match[2];
+    if (!owner || !nameRaw) continue;
+    if (NON_REPO_OWNERS.has(owner.toLowerCase())) continue;
+    const name = normalizeName(nameRaw);
+    if (!name) continue;
+    out.push({ owner, name, url: `https://github.com/${owner}/${name}` });
+  }
+  return out;
+}

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -16,3 +16,4 @@ export * from "./task-watch.js";
 export * from "./session-search.js";
 export * from "./xml.js";
 export * from "./format.js";
+export * from "./github-url.js";

--- a/packages/core/src/services/escalation-service.ts
+++ b/packages/core/src/services/escalation-service.ts
@@ -5,6 +5,7 @@ import type {
   RecoveredPosition,
   ResolutionProposal,
 } from "../domain/escalation.js";
+import type { Negotiation } from "../domain/negotiation.js";
 import type { NextDispatchContext } from "../domain/task.js";
 import { escalationId as makeEscalationId, taskId as makeTaskId } from "../domain/ids.js";
 import type { AgentRepository } from "../ports/agent-repo.js";
@@ -191,16 +192,9 @@ export class EscalationService {
    * must be the party who DIDN'T escalate.
    */
   async addContribution(input: AddToEscalationInput): Promise<Escalation> {
-    const esc = await this.deps.escalationRepo.findById(input.escalationId);
-    if (!esc) throw new EscalationNotFoundError(input.escalationId);
-    if (esc.status !== "pending") {
-      throw new EscalationStateError(
-        `escalation ${esc.id} is not pending (status='${esc.status}')`,
-      );
-    }
-
-    const neg = await this.deps.negotiationRepo.findById(esc.negotiation_id);
-    if (!neg) throw new NegotiationNotFoundError(esc.negotiation_id);
+    const { esc, neg } = await this.loadEscalationContext(input.escalationId, {
+      requirePending: true,
+    });
 
     const role = this.callerRole(neg, input.callerAgentId);
     if (role === esc.escalated_by_role) {
@@ -246,11 +240,9 @@ export class EscalationService {
    * only — the escalation row is never mutated.
    */
   async getReview(escalationId: string): Promise<EscalationReview> {
-    const esc = await this.deps.escalationRepo.findById(escalationId);
-    if (!esc) throw new EscalationNotFoundError(escalationId);
-
-    const neg = await this.deps.negotiationRepo.findById(esc.negotiation_id);
-    if (!neg) throw new NegotiationNotFoundError(esc.negotiation_id);
+    const { esc, neg } = await this.loadEscalationContext(escalationId, {
+      requirePending: false,
+    });
 
     const [initiatorAgent, counterpartyAgent] = await Promise.all([
       this.deps.agentRepo.findById(neg.initiator_agent_id),
@@ -303,16 +295,9 @@ export class EscalationService {
    * picks them up within ≤30s. NO spawning happens here.
    */
   async resolve(input: ResolveInput): Promise<ResolveResult> {
-    const esc = await this.deps.escalationRepo.findById(input.escalationId);
-    if (!esc) throw new EscalationNotFoundError(input.escalationId);
-    if (esc.status !== "pending") {
-      throw new EscalationStateError(
-        `escalation ${esc.id} is not pending (status='${esc.status}')`,
-      );
-    }
-
-    const neg = await this.deps.negotiationRepo.findById(esc.negotiation_id);
-    if (!neg) throw new NegotiationNotFoundError(esc.negotiation_id);
+    const { esc, neg } = await this.loadEscalationContext(input.escalationId, {
+      requirePending: true,
+    });
 
     const chosenProposal = this.buildResolutionProposal(esc, input.selector);
 
@@ -420,6 +405,39 @@ export class EscalationService {
   }
 
   // ── helpers ────────────────────────────────────────────────────────────
+
+  /**
+   * Load an escalation together with the negotiation it hangs off, raising
+   * the not-found error appropriate to whichever is missing.
+   *
+   * Every entry point that takes an `escalationId` opens this way, and the
+   * two that mutate (`addContribution`, `resolve`) additionally require the
+   * row still be pending — a resolved escalation must not take another
+   * contribution or be resolved twice. `getReview` is read-only and passes
+   * `requirePending: false` so a human can still open a resolved escalation.
+   *
+   * The pending check lives here rather than at each call site because it is
+   * the guard whose absence is silent: forgetting a not-found check throws on
+   * the next line anyway, where forgetting the status check writes to a row
+   * that has already been decided.
+   */
+  private async loadEscalationContext(
+    escalationId: string,
+    opts: { requirePending: boolean },
+  ): Promise<{ esc: Escalation; neg: Negotiation }> {
+    const esc = await this.deps.escalationRepo.findById(escalationId);
+    if (!esc) throw new EscalationNotFoundError(escalationId);
+    if (opts.requirePending && esc.status !== "pending") {
+      throw new EscalationStateError(
+        `escalation ${esc.id} is not pending (status='${esc.status}')`,
+      );
+    }
+
+    const neg = await this.deps.negotiationRepo.findById(esc.negotiation_id);
+    if (!neg) throw new NegotiationNotFoundError(esc.negotiation_id);
+
+    return { esc, neg };
+  }
 
   private callerRole(
     neg: { initiator_agent_id: string; counterparty_agent_id: string },

--- a/packages/core/src/services/referenced-repos.ts
+++ b/packages/core/src/services/referenced-repos.ts
@@ -12,6 +12,7 @@
  *   forgets.
  */
 
+import { extractGitHubRepoRefs } from "../domain/github-url.js";
 import type { SessionRepository } from "../ports/session-repo.js";
 import type { SessionEventRepository } from "../ports/session-event-repo.js";
 import type { WorkProductRepository } from "../ports/work-product-repo.js";
@@ -33,66 +34,6 @@ export interface ReferencedReposDeps {
   sessionEventRepo: SessionEventRepository;
   workProductRepo: WorkProductRepository;
   learnedSkillRepo: LearnedSkillRepository;
-}
-
-// Repo root only — owner/name are alphanumeric + dot/hyphen/underscore in
-// GitHub's schema. We deliberately STOP at the second path segment, so
-// `/owner/repo/blob/main/CLAUDE.md` collapses to the repo root. The
-// boundary class (`[\s)"',<>]|$`) keeps trailing punctuation out.
-const GITHUB_URL_RE =
-  /https:\/\/github\.com\/([A-Za-z0-9][A-Za-z0-9._-]*)\/([A-Za-z0-9][A-Za-z0-9._-]*)(?=[/\s)"',<>]|$)/g;
-
-// Paths under github.com that aren't repos. github.com/orgs/foo, settings,
-// marketplace, etc. — filter at the owner segment, not the URL.
-const NON_REPO_OWNERS = new Set([
-  "orgs",
-  "settings",
-  "marketplace",
-  "topics",
-  "trending",
-  "features",
-  "pricing",
-  "search",
-  "notifications",
-  "issues",
-  "pulls",
-  "explore",
-  "about",
-  "contact",
-  "site",
-  "security",
-  "login",
-  "signup",
-  "logout",
-  "new",
-]);
-
-// Common false-positive `name` values that show up when a regex sweeps
-// commit metadata or download URLs (`github.com/owner/repo.git`, raw
-// fragments, etc.). `.git` is the only common one — strip it.
-function normalizeName(raw: string): string {
-  return raw.replace(/\.git$/i, "");
-}
-
-function extractFromString(text: string): Array<{ owner: string; name: string; url: string }> {
-  const out: Array<{ owner: string; name: string; url: string }> = [];
-  if (!text) return out;
-  GITHUB_URL_RE.lastIndex = 0;
-  let match: RegExpExecArray | null;
-  while ((match = GITHUB_URL_RE.exec(text)) !== null) {
-    const owner = match[1];
-    const nameRaw = match[2];
-    if (!owner || !nameRaw) continue;
-    if (NON_REPO_OWNERS.has(owner.toLowerCase())) continue;
-    const name = normalizeName(nameRaw);
-    if (!name) continue;
-    out.push({
-      owner,
-      name,
-      url: `https://github.com/${owner}/${name}`,
-    });
-  }
-  return out;
 }
 
 /**
@@ -141,7 +82,7 @@ export async function getReferencedRepos(
   // Aggregate by canonical URL.
   const tally = new Map<string, { owner: string; name: string; url: string; count: number }>();
   for (const src of sources) {
-    for (const hit of extractFromString(src)) {
+    for (const hit of extractGitHubRepoRefs(src)) {
       const prior = tally.get(hit.url);
       if (prior) {
         prior.count += 1;


### PR DESCRIPTION
Another dedup sweep. Structural clone detection (`jscpd`) now reports 0.72% duplication repo-wide, so the remaining clusters are mostly *semantic* — same logic, different identifiers — which token-level detection misses. Three of the four below were found by reading; only one was flagged by the tool.

## 1. GitHub repo-URL recognition — two copies, in two packages

`api/routes/directives.ts` (auto-promoting a bare URL in an agent's visible text into a `<repo_card>`) and `core/services/referenced-repos.ts` (mining a closed task's transcript for repos the agent used) each carried a **byte-identical** match regex and the same 20-entry `NON_REPO_OWNERS` set, plus a near-identical exec loop.

These two have to agree — the URL directives emits is matched against the URL referenced-repos stored. Adding a non-repo path GitHub ships later (`sponsors`, `codespaces`) to one copy and not the other wouldn't error; it would surface as a card that silently never matches a saved skill.

Now `core/domain/github-url.ts` → `extractGitHubRepoRefs`.

**The copies had already drifted, which is the argument for the merge.** directives stripped a trailing period; referenced-repos didn't. `.` is a legal name character and the boundary class admits it, so a URL ending a sentence —

```
I used https://github.com/owner/repo.
```

— parsed as name `repo.` and a URL that 404s and matches nothing in the registry. Unifying on the stricter of the two fixes it. **This is the one intended behavior change in the PR**, and it has a test.

## 2. `find-repo.ts` — the same embedding cache written twice

`ensureTrendingEmbeddings` and `ensureRegistryEmbeddings` were the same 35 lines: resolve each entry cheapest-source-first (its own precomputed `embedding` → the process cache → one batched embed call for the remainder), dedup, write back. They differed only in *which cache Map* and in *how an entry projects to its key and its embeddable text*.

`jscpd` never flagged this pair — every identifier differs.

Now one `ensureEmbeddings(entries, embeddings, {cache, key, text})` with two thin call sites. `key` and `text` diverge for trending (keyed on normalized URL, embedded on owner/name/description) and coincide for community (both `goal_pattern`) — exactly what the parameters are for.

## 3. `escalation-service.ts` — the same guard preamble at three entries

`addContribution`, `getReview` and `resolve` all opened by loading the escalation → 404, loading its negotiation → 404; two of the three also required the row still be pending. Now `loadEscalationContext(id, {requirePending})`.

The pending check is the one worth centralizing: forgetting a not-found check throws on the next line anyway, where **forgetting the status check writes to an escalation that has already been decided**. `getReview` passes `requirePending: false` — it's read-only, and a human must still be able to open a resolved escalation.

## 4. `routes/view.ts` — three shapes written out 11 times

| Shape | Sites | Extracted to |
| --- | --- | --- |
| `loadOwned` against the agent table, identical projector + error code | 5 | `loadOwnedAgent` (bound at the router) |
| the `invalid_body` 400 envelope | 6, across `view`/`learned-skills`/`me` | `invalidBody` |
| nullable-string body patch (`runtime_id`, `model`) | 2 | `requireNullableString` |

The last is the fiddly one and the reason it earns a helper: `null` is a **valid** value there — it clears the column — while `undefined` means reject, inverting the usual falsy check.

The `invalid_body` *message* stays a parameter: the wording isn't uniform across routers and it's the only part a client sees, so this factors out the envelope, not the prose.

## Testing

Adds `github-url.test.ts` (11 tests, including the trailing-period case) and 9 tests for the two new route helpers.

Behavior-preserving otherwise:

- `typecheck` clean across all packages
- `lint` warning counts unchanged vs. base (verified by stash-and-compare); the one `web` lint error is pre-existing on `main`
- every suite that runs without Postgres or provider keys passes — **api 344, daemon 156, core 601**; all remaining failures are the documented `DATABASE_URL_TEST` / missing-API-key gates from CLAUDE.md

## Considered and rejected

- **The three append-only event repos** (`session-event`, `promotion-event`, `agent-provision-event`) share a name and a shape but genuinely different columns and SQL (a CTE that bumps `last_event_at`, a JOIN for owner scoping, a count-since window). A generic column-mapper would cost more than the copies.
- **`anthropic` / `openai` llm-provider** — only the ~8-line constructor is parallel; the SDK request/response shapes differ enough that unifying adds indirection without removing logic.
- **`describeToolInput`** appears in both `runtime-common.ts` and `claude-code/stream-json.ts`, but the divergence is deliberate and documented in the shared copy — left alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1rwLmh5dm2pp9wtHMM7Lt)_