### PR TITLE
test(api): cover six untested api modules (0% → 100% lines)

### DIFF
--- a/packages/api/src/routes/capabilities.test.ts
+++ b/packages/api/src/routes/capabilities.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Tests for the /capabilities router.
+ *
+ * Every collaborator is injected, so the router mounts against a bare
+ * Express app with stub repos — no database. The interesting surface is
+ * the authorization ladder on `referenced-repos` (human-only, task must
+ * exist, caller must own it directly or via the creating agent) and the
+ * validation + error mapping on `POST /use`.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import express, { json, type RequestHandler } from "express";
+import request from "supertest";
+import { createCapabilitiesRouter } from "./capabilities.js";
+
+const { getReferencedRepos, useRepoHandler, createUseRepoTool } = vi.hoisted(() => {
+  const useRepoHandler = vi.fn();
+  return {
+    getReferencedRepos: vi.fn(),
+    useRepoHandler,
+    createUseRepoTool: vi.fn(() => ({ handler: useRepoHandler })),
+  };
+});
+
+vi.mock("@beevibe/core/services/referenced-repos", () => ({ getReferencedRepos }));
+vi.mock("../tools/use-repo.js", () => ({ createUseRepoTool }));
+
+const PERSON = "per_alice";
+
+/**
+ * Auth middleware stand-in — attaches whatever caller the test wants.
+ * `null` leaves `req.caller` unset, standing in for an unauthenticated
+ * request that somehow reached the router.
+ */
+function callerAs(caller: unknown): RequestHandler {
+  return (req, _res, next) => {
+    if (caller !== null) (req as { caller?: unknown }).caller = caller;
+    next();
+  };
+}
+
+const humanCaller = { source: "human", personId: PERSON };
+const agentCaller = { source: "agent", personId: PERSON, agentId: "agt_1" };
+
+interface Stubs {
+  taskFindById: ReturnType<typeof vi.fn>;
+  agentFindById: ReturnType<typeof vi.fn>;
+  agentFindTopLevel: ReturnType<typeof vi.fn>;
+}
+
+function makeApp(caller: unknown = humanCaller): { app: express.Express } & Stubs {
+  const taskFindById = vi.fn();
+  const agentFindById = vi.fn();
+  const agentFindTopLevel = vi.fn();
+
+  const router = createCapabilitiesRouter({
+    authMiddleware: callerAs(caller),
+    agentRepo: {
+      findById: agentFindById,
+      findTopLevelForOwner: agentFindTopLevel,
+    } as never,
+    taskRepo: { findById: taskFindById } as never,
+    sessionRepo: {} as never,
+    sessionEventRepo: {} as never,
+    workProductRepo: {} as never,
+    repoRunRepo: {} as never,
+    learnedSkillRepo: {} as never,
+    dispatchService: {} as never,
+  });
+
+  const app = express();
+  app.use(json());
+  app.use("/capabilities", router);
+  return { app, taskFindById, agentFindById, agentFindTopLevel };
+}
+
+/** Task created directly by the calling human. */
+const ownTask = {
+  id: "tsk_1",
+  creator_id: PERSON,
+  creator_type: "human",
+};
+
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  createUseRepoTool.mockReturnValue({ handler: useRepoHandler });
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  errorSpy.mockRestore();
+});
+
+describe("GET /capabilities/referenced-repos — auth", () => {
+  it("rejects a non-human caller with 403", async () => {
+    const { app, taskFindById } = makeApp(agentCaller);
+    const res = await request(app)
+      .get("/capabilities/referenced-repos")
+      .query({ task_id: "tsk_1" });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("human_required");
+    expect(taskFindById).not.toHaveBeenCalled();
+  });
+
+  it("rejects a request with no caller at all", async () => {
+    const { app } = makeApp(null);
+    const res = await request(app)
+      .get("/capabilities/referenced-repos")
+      .query({ task_id: "tsk_1" });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("GET /capabilities/referenced-repos — validation", () => {
+  it.each([
+    ["omitted", undefined],
+    ["empty", ""],
+    ["whitespace only", "   "],
+  ])("400s when task_id is %s", async (_label, taskId) => {
+    const { app, taskFindById } = makeApp();
+    const req = request(app).get("/capabilities/referenced-repos");
+    const res = await (taskId === undefined ? req : req.query({ task_id: taskId }));
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("missing_task_id");
+    expect(taskFindById).not.toHaveBeenCalled();
+  });
+
+  it("trims the task_id before looking it up", async () => {
+    const { app, taskFindById } = makeApp();
+    taskFindById.mockResolvedValue(ownTask);
+    getReferencedRepos.mockResolvedValue([]);
+    await request(app)
+      .get("/capabilities/referenced-repos")
+      .query({ task_id: "  tsk_1  " });
+    expect(taskFindById).toHaveBeenCalledWith("tsk_1");
+  });
+
+  it("404s when the task does not exist", async () => {
+    const { app, taskFindById } = makeApp();
+    taskFindById.mockResolvedValue(null);
+    const res = await request(app)
+      .get("/capabilities/referenced-repos")
+      .query({ task_id: "tsk_gone" });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("task_not_found");
+  });
+});
+
+describe("GET /capabilities/referenced-repos — ownership", () => {
+  it("allows a task the caller created directly", async () => {
+    const { app, taskFindById, agentFindById } = makeApp();
+    taskFindById.mockResolvedValue(ownTask);
+    getReferencedRepos.mockResolvedValue([{ url: "https://github.com/a/b" }]);
+
+    const res = await request(app)
+      .get("/capabilities/referenced-repos")
+      .query({ task_id: "tsk_1" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ repos: [{ url: "https://github.com/a/b" }] });
+    // Direct ownership short-circuits the agent lookup.
+    expect(agentFindById).not.toHaveBeenCalled();
+  });
+
+  it("allows any agent-created task without an ownership lookup", async () => {
+    const { app, taskFindById, agentFindById } = makeApp();
+    taskFindById.mockResolvedValue({
+      id: "tsk_2",
+      creator_id: "agt_other",
+      creator_type: "agent",
+    });
+    getReferencedRepos.mockResolvedValue([]);
+
+    const res = await request(app)
+      .get("/capabilities/referenced-repos")
+      .query({ task_id: "tsk_2" });
+
+    expect(res.status).toBe(200);
+    expect(agentFindById).not.toHaveBeenCalled();
+  });
+
+  it("403s when another human created the task and no agent backs the id", async () => {
+    const { app, taskFindById, agentFindById } = makeApp();
+    taskFindById.mockResolvedValue({
+      id: "tsk_3",
+      creator_id: "per_bob",
+      creator_type: "human",
+    });
+    agentFindById.mockResolvedValue(null);
+
+    const res = await request(app)
+      .get("/capabilities/referenced-repos")
+      .query({ task_id: "tsk_3" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("not_owner");
+    expect(getReferencedRepos).not.toHaveBeenCalled();
+  });
+
+  it("403s when the creating agent belongs to a different owner", async () => {
+    const { app, taskFindById, agentFindById } = makeApp();
+    taskFindById.mockResolvedValue({
+      id: "tsk_4",
+      creator_id: "agt_bob",
+      creator_type: "system",
+    });
+    agentFindById.mockResolvedValue({ id: "agt_bob", owner_id: "per_bob" });
+
+    const res = await request(app)
+      .get("/capabilities/referenced-repos")
+      .query({ task_id: "tsk_4" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("not_owner");
+  });
+
+  it("allows a task whose creating agent the caller owns", async () => {
+    const { app, taskFindById, agentFindById } = makeApp();
+    taskFindById.mockResolvedValue({
+      id: "tsk_5",
+      creator_id: "agt_mine",
+      creator_type: "system",
+    });
+    agentFindById.mockResolvedValue({ id: "agt_mine", owner_id: PERSON });
+    getReferencedRepos.mockResolvedValue([]);
+
+    const res = await request(app)
+      .get("/capabilities/referenced-repos")
+      .query({ task_id: "tsk_5" });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("scopes the repo scan to the task and the calling person", async () => {
+    const { app, taskFindById } = makeApp();
+    taskFindById.mockResolvedValue(ownTask);
+    getReferencedRepos.mockResolvedValue([]);
+
+    await request(app)
+      .get("/capabilities/referenced-repos")
+      .query({ task_id: "tsk_1" });
+
+    expect(getReferencedRepos).toHaveBeenCalledWith(
+      "tsk_1",
+      PERSON,
+      expect.objectContaining({
+        sessionRepo: expect.anything(),
+        sessionEventRepo: expect.anything(),
+        workProductRepo: expect.anything(),
+        learnedSkillRepo: expect.anything(),
+      }),
+    );
+  });
+
+  it("500s with scan_failed when the scan throws", async () => {
+    const { app, taskFindById } = makeApp();
+    taskFindById.mockResolvedValue(ownTask);
+    getReferencedRepos.mockRejectedValue(new Error("transcript unavailable"));
+
+    const res = await request(app)
+      .get("/capabilities/referenced-repos")
+      .query({ task_id: "tsk_1" });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("scan_failed");
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});
+
+describe("POST /capabilities/use", () => {
+  const body = { repo_url: "https://github.com/a/b", goal: "add tests" };
+
+  it("rejects a non-human caller with 403", async () => {
+    const { app, agentFindTopLevel } = makeApp(agentCaller);
+    const res = await request(app).post("/capabilities/use").send(body);
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("human_required");
+    expect(agentFindTopLevel).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["repo_url is missing", { goal: "add tests" }, "missing_repo_url"],
+    ["repo_url is blank", { repo_url: "  ", goal: "add tests" }, "missing_repo_url"],
+    ["repo_url is not a string", { repo_url: 42, goal: "g" }, "missing_repo_url"],
+    ["goal is missing", { repo_url: "https://github.com/a/b" }, "missing_goal"],
+    ["goal is blank", { repo_url: "https://github.com/a/b", goal: " " }, "missing_goal"],
+  ])("400s when %s", async (_label, payload, error) => {
+    const { app, agentFindTopLevel } = makeApp();
+    const res = await request(app).post("/capabilities/use").send(payload);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe(error);
+    expect(agentFindTopLevel).not.toHaveBeenCalled();
+  });
+
+  it("404s when the caller has no primary agent", async () => {
+    const { app, agentFindTopLevel } = makeApp();
+    agentFindTopLevel.mockResolvedValue(null);
+    const res = await request(app).post("/capabilities/use").send(body);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("no_agent");
+    expect(agentFindTopLevel).toHaveBeenCalledWith(PERSON);
+  });
+
+  it("202s with the tool's payload and runs under the primary agent", async () => {
+    const { app, agentFindTopLevel } = makeApp();
+    agentFindTopLevel.mockResolvedValue({ id: "agt_top" });
+    useRepoHandler.mockResolvedValue({
+      isError: false,
+      content: { repo_run_id: "rr_1", watch_url: "/runs/rr_1" },
+    });
+
+    const res = await request(app).post("/capabilities/use").send(body);
+
+    expect(res.status).toBe(202);
+    expect(res.body).toEqual({ repo_run_id: "rr_1", watch_url: "/runs/rr_1" });
+    expect(createUseRepoTool).toHaveBeenCalledWith(
+      { agentId: "agt_top" },
+      expect.objectContaining({ agentRepo: expect.anything() }),
+    );
+    expect(useRepoHandler).toHaveBeenCalledWith({
+      goal: "add tests",
+      repo_url: "https://github.com/a/b",
+    });
+  });
+
+  it("trims repo_url and goal before handing them to the tool", async () => {
+    const { app, agentFindTopLevel } = makeApp();
+    agentFindTopLevel.mockResolvedValue({ id: "agt_top" });
+    useRepoHandler.mockResolvedValue({ isError: false, content: {} });
+
+    await request(app)
+      .post("/capabilities/use")
+      .send({ repo_url: "  https://github.com/a/b  ", goal: "  add tests  " });
+
+    expect(useRepoHandler).toHaveBeenCalledWith({
+      goal: "add tests",
+      repo_url: "https://github.com/a/b",
+    });
+  });
+
+  it("maps a tool-level error to 400 and forwards its content", async () => {
+    const { app, agentFindTopLevel } = makeApp();
+    agentFindTopLevel.mockResolvedValue({ id: "agt_top" });
+    useRepoHandler.mockResolvedValue({
+      isError: true,
+      content: { error: "repo_unreachable" },
+    });
+
+    const res = await request(app).post("/capabilities/use").send(body);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "repo_unreachable" });
+  });
+
+  it("500s with use_failed when the tool throws", async () => {
+    const { app, agentFindTopLevel } = makeApp();
+    agentFindTopLevel.mockResolvedValue({ id: "agt_top" });
+    useRepoHandler.mockRejectedValue(new Error("dispatch down"));
+
+    const res = await request(app).post("/capabilities/use").send(body);
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("use_failed");
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/routes/find-repo.test.ts
+++ b/packages/api/src/routes/find-repo.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for the /find-repo router — the HTTP wrapper around the
+ * `find_repo` ranker. Pure DI, so it mounts on a bare Express app with
+ * a stubbed agent repo and a mocked tool factory.
+ *
+ * The logic worth pinning down is the `limit` coercion (string query
+ * param → clamped integer, with a default when absent or unparseable)
+ * and the error mapping around the tool call.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import express, { type RequestHandler } from "express";
+import request from "supertest";
+import { createFindRepoRouter } from "./find-repo.js";
+
+const { findRepoHandler, createFindRepoTool } = vi.hoisted(() => {
+  const findRepoHandler = vi.fn();
+  return {
+    findRepoHandler,
+    createFindRepoTool: vi.fn(() => ({ handler: findRepoHandler })),
+  };
+});
+
+vi.mock("../tools/find-repo.js", () => ({ createFindRepoTool }));
+
+const PERSON = "per_alice";
+const humanCaller = { source: "human", personId: PERSON };
+
+function callerAs(caller: unknown): RequestHandler {
+  return (req, _res, next) => {
+    if (caller !== null) (req as { caller?: unknown }).caller = caller;
+    next();
+  };
+}
+
+function makeApp(caller: unknown = humanCaller) {
+  const agentFindTopLevel = vi.fn();
+  const router = createFindRepoRouter({
+    authMiddleware: callerAs(caller),
+    agentRepo: { findTopLevelForOwner: agentFindTopLevel } as never,
+    learnedSkillRepo: {} as never,
+    embeddings: {} as never,
+  });
+  const app = express();
+  app.use("/find-repo", router);
+  return { app, agentFindTopLevel };
+}
+
+/** App with a resolved primary agent and a successful ranker. */
+function makeReadyApp() {
+  const ctx = makeApp();
+  ctx.agentFindTopLevel.mockResolvedValue({ id: "agt_top" });
+  findRepoHandler.mockResolvedValue({ isError: false, content: { repos: [] } });
+  return ctx;
+}
+
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  createFindRepoTool.mockReturnValue({ handler: findRepoHandler });
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  errorSpy.mockRestore();
+});
+
+describe("GET /find-repo — auth and validation", () => {
+  it("rejects a non-human caller with 403", async () => {
+    const { app, agentFindTopLevel } = makeApp({
+      source: "agent",
+      personId: PERSON,
+    });
+    const res = await request(app).get("/find-repo").query({ goal: "add tests" });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("human_required");
+    expect(agentFindTopLevel).not.toHaveBeenCalled();
+  });
+
+  it("rejects a request with no caller", async () => {
+    const { app } = makeApp(null);
+    const res = await request(app).get("/find-repo").query({ goal: "add tests" });
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    ["omitted", undefined],
+    ["empty", ""],
+    ["whitespace only", "   "],
+  ])("400s when goal is %s", async (_label, goal) => {
+    const { app, agentFindTopLevel } = makeApp();
+    const req = request(app).get("/find-repo");
+    const res = await (goal === undefined ? req : req.query({ goal }));
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("missing_goal");
+    expect(agentFindTopLevel).not.toHaveBeenCalled();
+  });
+
+  it("404s when the caller has no primary agent", async () => {
+    const { app, agentFindTopLevel } = makeApp();
+    agentFindTopLevel.mockResolvedValue(null);
+    const res = await request(app).get("/find-repo").query({ goal: "add tests" });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("no_agent");
+    expect(agentFindTopLevel).toHaveBeenCalledWith(PERSON);
+  });
+});
+
+describe("GET /find-repo — limit coercion", () => {
+  it.each([
+    ["defaults to 5 when absent", undefined, 5],
+    ["passes a valid limit through", "3", 3],
+    ["clamps above the max", "999", 10],
+    ["clamps below the min", "0", 1],
+    ["clamps a negative", "-4", 1],
+    ["floors a fractional limit", "3.9", 3],
+    ["falls back to 5 when unparseable", "abc", 5],
+  ])("%s", async (_label, limit, expected) => {
+    const { app } = makeReadyApp();
+    const req = request(app).get("/find-repo");
+    await (limit === undefined
+      ? req.query({ goal: "add tests" })
+      : req.query({ goal: "add tests", limit }));
+    expect(findRepoHandler).toHaveBeenCalledWith({ goal: "add tests", limit: expected });
+  });
+});
+
+describe("GET /find-repo — ranker call", () => {
+  it("200s with the ranker payload and runs under the primary agent", async () => {
+    const { app } = makeReadyApp();
+    findRepoHandler.mockResolvedValue({
+      isError: false,
+      content: { repos: [{ url: "https://github.com/a/b", score: 0.9 }] },
+    });
+
+    const res = await request(app).get("/find-repo").query({ goal: "add tests" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ repos: [{ url: "https://github.com/a/b", score: 0.9 }] });
+    expect(createFindRepoTool).toHaveBeenCalledWith(
+      { agentId: "agt_top" },
+      expect.objectContaining({ embeddings: expect.anything() }),
+    );
+  });
+
+  it("trims the goal before handing it to the ranker", async () => {
+    const { app } = makeReadyApp();
+    await request(app).get("/find-repo").query({ goal: "  add tests  " });
+    expect(findRepoHandler).toHaveBeenCalledWith({ goal: "add tests", limit: 5 });
+  });
+
+  it("maps a tool-level error to 400 and forwards its content", async () => {
+    const { app } = makeReadyApp();
+    findRepoHandler.mockResolvedValue({
+      isError: true,
+      content: { error: "embeddings_unavailable" },
+    });
+    const res = await request(app).get("/find-repo").query({ goal: "add tests" });
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "embeddings_unavailable" });
+  });
+
+  it("500s with search_failed when the ranker throws", async () => {
+    const { app } = makeReadyApp();
+    findRepoHandler.mockRejectedValue(new Error("index down"));
+    const res = await request(app).get("/find-repo").query({ goal: "add tests" });
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("search_failed");
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/sse/listener.test.ts
+++ b/packages/api/src/sse/listener.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Tests for SseListener — the pg LISTEN client that feeds `bv_event`
+ * notifications into SseManager.
+ *
+ * `pg.Client` is mocked with an EventEmitter stand-in so we can drive
+ * `notification` / `end` / `error` by hand. That covers the three things
+ * worth pinning down: the payload parser's accept/reject rules, the
+ * onEvent side-channel's error isolation, and the reconnect loop's
+ * lifecycle (reconnect on drop, no reconnect after stop()).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "node:events";
+import type { BvEvent } from "./manager.js";
+
+class FakeClient extends EventEmitter {
+  static instances: FakeClient[] = [];
+  static connectImpl: (() => Promise<void>) | undefined;
+
+  readonly queries: string[] = [];
+  readonly options: { connectionString?: string };
+  connectCalls = 0;
+  endCalls = 0;
+  endImpl: (() => Promise<void>) | undefined;
+
+  constructor(options: { connectionString?: string }) {
+    super();
+    this.options = options;
+    FakeClient.instances.push(this);
+  }
+
+  async connect(): Promise<void> {
+    this.connectCalls++;
+    if (FakeClient.connectImpl) await FakeClient.connectImpl();
+  }
+
+  async query(sql: string): Promise<{ rows: never[] }> {
+    this.queries.push(sql);
+    return { rows: [] };
+  }
+
+  async end(): Promise<void> {
+    this.endCalls++;
+    if (this.endImpl) await this.endImpl();
+    this.emit("end");
+  }
+}
+
+vi.mock("pg", () => ({ Client: FakeClient }));
+
+// Imported after vi.mock so the listener picks up FakeClient.
+const { SseListener } = await import("./listener.js");
+
+/** Yield to the microtask queue so the listener's awaits settle. */
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+/**
+ * Poll until `predicate` holds. Reconnects go through a real
+ * `setTimeout(reconnectDelayMs)`, which `setImmediate` outruns — so
+ * anything asserting on a *subsequent* connection has to wait on the
+ * clock rather than the microtask queue.
+ */
+async function until(predicate: () => boolean, label: string): Promise<void> {
+  for (let i = 0; i < 200; i++) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(`timed out waiting for: ${label}`);
+}
+
+const reconnected = () =>
+  until(() => FakeClient.instances.length > 1, "a second connection attempt");
+
+function makeDeps() {
+  const published: Array<{ event: BvEvent; owners: ReadonlySet<string> }> = [];
+  const manager = {
+    publish: vi.fn((event: BvEvent, owners: ReadonlySet<string>) => {
+      published.push({ event, owners });
+    }),
+  };
+  const ownerLookup = {
+    ownersOf: vi.fn(async () => new Set(["per_1"]) as ReadonlySet<string>),
+  };
+  return { manager, ownerLookup, published };
+}
+
+/**
+ * Start a listener and wait until its first client is connected and
+ * LISTENing. Returns the listener plus that client.
+ */
+async function startListener(
+  overrides: Record<string, unknown> = {},
+): Promise<{
+  listener: InstanceType<typeof SseListener>;
+  client: FakeClient;
+  deps: ReturnType<typeof makeDeps>;
+}> {
+  const deps = makeDeps();
+  const listener = new SseListener({
+    databaseUrl: "postgres://test/db",
+    manager: deps.manager as never,
+    ownerLookup: deps.ownerLookup as never,
+    reconnectDelayMs: 1,
+    ...overrides,
+  });
+  listener.start();
+  await tick();
+  return { listener, client: FakeClient.instances[0]!, deps };
+}
+
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  FakeClient.instances = [];
+  FakeClient.connectImpl = undefined;
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  errorSpy.mockRestore();
+});
+
+describe("SseListener — connection lifecycle", () => {
+  it("connects with the configured url and issues LISTEN bv_event", async () => {
+    const { listener, client } = await startListener();
+    expect(client.options.connectionString).toBe("postgres://test/db");
+    expect(client.connectCalls).toBe(1);
+    expect(client.queries).toEqual(["LISTEN bv_event"]);
+    await listener.stop();
+  });
+
+  it("reconnects with a fresh client after the connection ends", async () => {
+    const { listener, client } = await startListener();
+    client.emit("end");
+    await reconnected();
+    expect(FakeClient.instances[1]!.queries).toEqual(["LISTEN bv_event"]);
+    await listener.stop();
+  });
+
+  it("logs and reconnects after a socket-level client error", async () => {
+    const { listener, client } = await startListener();
+    client.emit("error", new Error("ECONNRESET"));
+    await reconnected();
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[SseListener] client error:",
+      "ECONNRESET",
+    );
+    await listener.stop();
+  });
+
+  it("logs a failed connect and retries rather than throwing", async () => {
+    FakeClient.connectImpl = vi.fn(async () => {
+      throw new Error("connection refused");
+    });
+    const { listener } = await startListener();
+    await reconnected();
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[SseListener] connect failed:",
+      "connection refused",
+    );
+    await listener.stop();
+  });
+
+  it("stop() ends the live client and halts the reconnect loop", async () => {
+    const { listener, client } = await startListener();
+    await listener.stop();
+    expect(client.endCalls).toBe(1);
+
+    // Wait well past the 1ms reconnect delay — nothing should reconnect.
+    const countAfterStop = FakeClient.instances.length;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(FakeClient.instances.length).toBe(countAfterStop);
+  });
+
+  it("stop() swallows an end() that rejects because the socket is already gone", async () => {
+    const { listener, client } = await startListener();
+    client.endImpl = async () => {
+      throw new Error("already disconnected");
+    };
+    await expect(listener.stop()).resolves.toBeUndefined();
+  });
+
+  it("stop() is idempotent", async () => {
+    const { listener, client } = await startListener();
+    await listener.stop();
+    await listener.stop();
+    expect(client.endCalls).toBe(1);
+  });
+
+  it("refuses to start a listener that has been stopped", async () => {
+    const { listener } = await startListener();
+    await listener.stop();
+    expect(() => listener.start()).toThrow(/cannot start a stopped listener/);
+  });
+});
+
+describe("SseListener — notification routing", () => {
+  it("publishes a parsed event to the owners resolved by OwnerLookup", async () => {
+    const { listener, client, deps } = await startListener();
+    client.emit("notification", {
+      channel: "bv_event",
+      payload: JSON.stringify({ event: "task.updated", id: "tsk_1" }),
+    });
+    await tick();
+    expect(deps.ownerLookup.ownersOf).toHaveBeenCalledWith({
+      event: "task.updated",
+      id: "tsk_1",
+    });
+    expect(deps.manager.publish).toHaveBeenCalledWith(
+      { event: "task.updated", id: "tsk_1" },
+      new Set(["per_1"]),
+    );
+    await listener.stop();
+  });
+
+  it("forwards an inline data payload when the event carries one", async () => {
+    const { listener, client, deps } = await startListener();
+    client.emit("notification", {
+      channel: "bv_event",
+      payload: JSON.stringify({
+        event: "session.step",
+        id: "sess_1",
+        data: { kind: "tool_use", tool_name: "Read" },
+      }),
+    });
+    await tick();
+    expect(deps.published[0]!.event).toEqual({
+      event: "session.step",
+      id: "sess_1",
+      data: { kind: "tool_use", tool_name: "Read" },
+    });
+    await listener.stop();
+  });
+
+  it("ignores notifications on other channels and empty payloads", async () => {
+    const { listener, client, deps } = await startListener();
+    client.emit("notification", {
+      channel: "other_channel",
+      payload: JSON.stringify({ event: "task.updated", id: "tsk_1" }),
+    });
+    client.emit("notification", { channel: "bv_event", payload: "" });
+    client.emit("notification", { channel: "bv_event" });
+    await tick();
+    expect(deps.manager.publish).not.toHaveBeenCalled();
+    await listener.stop();
+  });
+
+  it.each([
+    ["malformed JSON", "{not json"],
+    ["a missing id", JSON.stringify({ event: "task.updated" })],
+    ["a missing event name", JSON.stringify({ id: "tsk_1" })],
+    ["a non-string id", JSON.stringify({ event: "task.updated", id: 7 })],
+    ["a non-string event name", JSON.stringify({ event: 7, id: "tsk_1" })],
+    ["a JSON scalar", "42"],
+  ])("drops a payload with %s", async (_label, payload) => {
+    const { listener, client, deps } = await startListener();
+    client.emit("notification", { channel: "bv_event", payload });
+    await tick();
+    expect(deps.manager.publish).not.toHaveBeenCalled();
+    await listener.stop();
+  });
+
+  it.each([
+    ["an array", JSON.stringify({ event: "e", id: "i", data: [1, 2] })],
+    ["null", JSON.stringify({ event: "e", id: "i", data: null })],
+    ["a scalar", JSON.stringify({ event: "e", id: "i", data: "nope" })],
+  ])("omits a data field that is %s", async (_label, payload) => {
+    const { listener, client, deps } = await startListener();
+    client.emit("notification", { channel: "bv_event", payload });
+    await tick();
+    expect(deps.published[0]!.event).toEqual({ event: "e", id: "i" });
+    await listener.stop();
+  });
+});
+
+describe("SseListener — onEvent side channel", () => {
+  it("fires onEvent synchronously, before the async owner fan-out", async () => {
+    const order: string[] = [];
+    const onEvent = vi.fn(() => {
+      order.push("onEvent");
+    });
+    const { listener, client, deps } = await startListener({ onEvent });
+    deps.manager.publish.mockImplementation(() => {
+      order.push("publish");
+    });
+
+    client.emit("notification", {
+      channel: "bv_event",
+      payload: JSON.stringify({ event: "session.terminated", id: "sess_1" }),
+    });
+    // onEvent has already run; publish has not.
+    expect(order).toEqual(["onEvent"]);
+
+    await tick();
+    expect(order).toEqual(["onEvent", "publish"]);
+    await listener.stop();
+  });
+
+  it("does not fire onEvent for a payload that fails to parse", async () => {
+    const onEvent = vi.fn();
+    const { listener, client } = await startListener({ onEvent });
+    client.emit("notification", { channel: "bv_event", payload: "{bad" });
+    await tick();
+    expect(onEvent).not.toHaveBeenCalled();
+    await listener.stop();
+  });
+
+  it("logs an onEvent subscriber throw and still completes the fan-out", async () => {
+    const onEvent = vi.fn(() => {
+      throw new Error("subscriber blew up");
+    });
+    const { listener, client, deps } = await startListener({ onEvent });
+    client.emit("notification", {
+      channel: "bv_event",
+      payload: JSON.stringify({ event: "session.terminated", id: "sess_1" }),
+    });
+    await tick();
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[SseListener] onEvent subscriber threw:",
+      "subscriber blew up",
+    );
+    expect(deps.manager.publish).toHaveBeenCalledTimes(1);
+    await listener.stop();
+  });
+});

--- a/packages/api/src/views/activity.test.ts
+++ b/packages/api/src/views/activity.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Mock-Pool tests for views/activity.ts. Validates row → DTO mapping
+ * (short ids, task linkage, duration/started_at derivation) without a
+ * database.
+ */
+import { describe, it, expect } from "vitest";
+import { listActivity } from "./activity.js";
+import { makeMockPool } from "./test-helpers.js";
+
+const baseRow = {
+  id: "sess_abcdef123",
+  agent_id: "agt_9911",
+  agent_label: "Alice",
+  agent_hierarchy: "ic" as const,
+  type: "chat" as const,
+  status: "running" as const,
+  intent: "refactor the auth flow",
+  task_id: null,
+  task_title: null,
+  started_at: new Date("2026-04-30T10:00:00Z"),
+  completed_at: null,
+};
+
+describe("listActivity", () => {
+  it("forwards owner + default limit to the SQL", async () => {
+    const pool = makeMockPool([]);
+    await listActivity(pool, "per_w");
+    expect(pool._spy).toHaveBeenCalledWith(expect.any(String), ["per_w", 20]);
+  });
+
+  it("forwards an explicit limit verbatim", async () => {
+    const pool = makeMockPool([]);
+    await listActivity(pool, "per_w", 5);
+    expect(pool._spy).toHaveBeenCalledWith(expect.any(String), ["per_w", 5]);
+  });
+
+  it("returns an empty list when the owner has no sessions", async () => {
+    const pool = makeMockPool([]);
+    await expect(listActivity(pool, "per_w")).resolves.toEqual([]);
+  });
+
+  it("maps a task-less session, deriving short_id and leaving task fields null", async () => {
+    const pool = makeMockPool([baseRow]);
+    const entries = await listActivity(pool, "per_w");
+    const entry = entries[0]!;
+    expect(entry).toEqual({
+      id: "sess_abcdef123",
+      short_id: "abcdef",
+      agent_id: "agt_9911",
+      agent_label: "Alice",
+      agent_hierarchy: "ic",
+      type: "chat",
+      status: "running",
+      intent: "refactor the auth flow",
+      task_id: null,
+      task_title: null,
+      task_short_id: null,
+      started_at: "2026-04-30T10:00:00.000Z",
+      duration_label: expect.any(String),
+    });
+  });
+
+  it("derives task_short_id from task_id when a task is linked", async () => {
+    const pool = makeMockPool([
+      {
+        ...baseRow,
+        type: "task",
+        task_id: "tsk_ff00aa9911",
+        task_title: "refactor auth flow",
+      },
+    ]);
+    const entries = await listActivity(pool, "per_w");
+    const entry = entries[0]!;
+    expect(entry.task_id).toBe("tsk_ff00aa9911");
+    expect(entry.task_short_id).toBe("ff00aa");
+    expect(entry.task_title).toBe("refactor auth flow");
+  });
+
+  it("computes duration_label from the started/completed span", async () => {
+    const pool = makeMockPool([
+      {
+        ...baseRow,
+        started_at: new Date("2026-04-30T10:00:00Z"),
+        completed_at: new Date("2026-04-30T10:05:00Z"),
+      },
+    ]);
+    const entries = await listActivity(pool, "per_w");
+    const entry = entries[0]!;
+    expect(entry.duration_label).toBe("5m");
+  });
+
+  it("falls back to the epoch when started_at is null", async () => {
+    const pool = makeMockPool([{ ...baseRow, started_at: null }]);
+    const entries = await listActivity(pool, "per_w");
+    const entry = entries[0]!;
+    expect(entry.started_at).toBe("1970-01-01T00:00:00.000Z");
+    // formatDurationLabel has no start to measure from.
+    expect(entry.duration_label).toBe("—");
+  });
+
+  it("preserves row order across a multi-row result", async () => {
+    const pool = makeMockPool([
+      { ...baseRow, id: "sess_aaa111" },
+      { ...baseRow, id: "sess_bbb222" },
+      { ...baseRow, id: "sess_ccc333" },
+    ]);
+    const entries = await listActivity(pool, "per_w");
+    expect(entries.map((e) => e.short_id)).toEqual(["aaa111", "bbb222", "ccc333"]);
+  });
+});

--- a/packages/api/src/views/memory-activity.test.ts
+++ b/packages/api/src/views/memory-activity.test.ts
@@ -1,0 +1,432 @@
+/**
+ * Mock-Pool tests for views/memory-activity.ts.
+ *
+ * The view fans out to seven queries (plus two more when `since` is set)
+ * via `Promise.all`. The array elements are evaluated left to right and
+ * each helper runs synchronously up to its `pool.query`, so the call
+ * order is deterministic and the ordered `makeMockPool([[...], ...])`
+ * shape lines up 1:1 with QUERY below.
+ *
+ * What's actually under test is the mapping layer: Postgres returns
+ * COUNT() as a string and `::date` as a JS Date, so every numeric field
+ * goes through `Number()` and every date through `localDate()`. The
+ * ratio fields additionally guard divide-by-zero.
+ */
+import { describe, it, expect } from "vitest";
+import { getMemoryActivity } from "./memory-activity.js";
+import { makeMockPool } from "./test-helpers.js";
+
+/** Index of each query in the ordered mock-pool response array. */
+const QUERY = {
+  weekly: 0,
+  scopeType: 1,
+  topAgents: 2,
+  dormant: 3,
+  coreSnapshot: 4,
+  ratio: 5,
+  kpis: 6,
+  beforeAfterByType: 7,
+  beforeAfterAgg: 8,
+} as const;
+
+const KPI_ROW = {
+  archival_writes_30d: "0",
+  core_touched_30d: "0",
+  active_agents_30d: "0",
+};
+
+/**
+ * `localDate` reads local-timezone components, mirroring how node-postgres
+ * parses a `::date` column (local midnight). Building fixtures the same way
+ * keeps assertions stable regardless of the runner's TZ.
+ */
+function localMidnight(y: number, m: number, d: number): Date {
+  return new Date(y, m - 1, d);
+}
+
+/** Ordered responses with every slot empty except the ones provided. */
+function responses(overrides: Partial<Record<number, unknown[]>>): unknown[][] {
+  const slots: unknown[][] = Array.from({ length: 9 }, () => []);
+  slots[QUERY.kpis] = [KPI_ROW];
+  for (const [i, rows] of Object.entries(overrides)) {
+    slots[Number(i)] = rows as unknown[];
+  }
+  return slots;
+}
+
+describe("getMemoryActivity — options", () => {
+  it("passes the requested window to the interval-scoped queries", async () => {
+    const pool = makeMockPool(responses({}));
+    const summary = await getMemoryActivity(pool, { weeks: 8 });
+    expect(summary.weeks).toBe(8);
+    expect(pool._spy.mock.calls[QUERY.weekly]![1]).toEqual(["8 weeks"]);
+    expect(pool._spy.mock.calls[QUERY.scopeType]![1]).toEqual(["8 weeks"]);
+  });
+
+  it.each([
+    ["clamps above the max", 999, 52],
+    ["clamps at the max boundary", 52, 52],
+    ["accepts the min", 1, 1],
+    ["truncates a fractional week count", 8.9, 8],
+  ])("%s", async (_label, input, expected) => {
+    const pool = makeMockPool(responses({}));
+    const summary = await getMemoryActivity(pool, { weeks: input });
+    expect(summary.weeks).toBe(expected);
+  });
+
+  it.each([
+    ["below the min", 0],
+    ["negative", -5],
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+  ])("falls back to 12 weeks when weeks is %s", async (_label, input) => {
+    const pool = makeMockPool(responses({}));
+    const summary = await getMemoryActivity(pool, { weeks: input });
+    expect(summary.weeks).toBe(12);
+  });
+
+  it("omits before_after and reports since=null when no since is given", async () => {
+    const pool = makeMockPool(responses({}));
+    const summary = await getMemoryActivity(pool, { weeks: 12 });
+    expect(summary.since).toBeNull();
+    expect(summary.before_after).toBeUndefined();
+    // Only the seven always-on queries ran.
+    expect(pool._spy).toHaveBeenCalledTimes(7);
+  });
+});
+
+describe("getMemoryActivity — mapping", () => {
+  it("returns empty collections when nothing has been written", async () => {
+    const pool = makeMockPool(responses({}));
+    const summary = await getMemoryActivity(pool, { weeks: 12 });
+    expect(summary).toMatchObject({
+      weekly_archival: [],
+      by_scope_and_type: [],
+      top_agents: [],
+      dormant_agents: [],
+      core_snapshot: [],
+      archival_to_core_per_agent: [],
+    });
+  });
+
+  it("coerces the weekly counts to numbers and the bucket to YYYY-MM-DD", async () => {
+    const pool = makeMockPool(
+      responses({
+        [QUERY.weekly]: [
+          {
+            week: localMidnight(2026, 4, 6),
+            total: "42",
+            belief: "10",
+            pattern: "12",
+            gotcha: "8",
+            preference: "7",
+            decision: "5",
+            active_agents: "3",
+          },
+        ],
+      }),
+    );
+    const summary = await getMemoryActivity(pool, { weeks: 12 });
+    expect(summary.weekly_archival).toEqual([
+      {
+        week: "2026-04-06",
+        total: 42,
+        belief: 10,
+        pattern: 12,
+        gotcha: 8,
+        preference: 7,
+        decision: 5,
+        active_agents: 3,
+      },
+    ]);
+  });
+
+  it("zero-pads single-digit months and days in date buckets", async () => {
+    const pool = makeMockPool(
+      responses({
+        [QUERY.weekly]: [
+          {
+            week: localMidnight(2026, 1, 5),
+            total: "1",
+            belief: "0",
+            pattern: "0",
+            gotcha: "0",
+            preference: "0",
+            decision: "1",
+            active_agents: "1",
+          },
+        ],
+      }),
+    );
+    const summary = await getMemoryActivity(pool, { weeks: 12 });
+    expect(summary.weekly_archival[0]!.week).toBe("2026-01-05");
+  });
+
+  it("maps the scope × type breakdown", async () => {
+    const pool = makeMockPool(
+      responses({
+        [QUERY.scopeType]: [
+          { scope: "ic", fact_type: "pattern", writes: "9" },
+          { scope: "team", fact_type: "gotcha", writes: "4" },
+        ],
+      }),
+    );
+    const summary = await getMemoryActivity(pool, { weeks: 12 });
+    expect(summary.by_scope_and_type).toEqual([
+      { scope: "ic", fact_type: "pattern", writes: 9 },
+      { scope: "team", fact_type: "gotcha", writes: 4 },
+    ]);
+  });
+
+  it("renames id → agent_id and formats last_write for top agents", async () => {
+    const pool = makeMockPool(
+      responses({
+        [QUERY.topAgents]: [
+          {
+            id: "agt_1",
+            name: "Alice",
+            tier: "ic",
+            writes_30d: "31",
+            type_variety: "4",
+            last_write: localMidnight(2026, 4, 29),
+          },
+        ],
+      }),
+    );
+    const summary = await getMemoryActivity(pool, { weeks: 12 });
+    expect(summary.top_agents).toEqual([
+      {
+        agent_id: "agt_1",
+        name: "Alice",
+        tier: "ic",
+        writes_30d: 31,
+        type_variety: 4,
+        last_write: "2026-04-29",
+      },
+    ]);
+  });
+
+  it("keeps last_write_ever null for an agent that has never written", async () => {
+    const pool = makeMockPool(
+      responses({
+        [QUERY.dormant]: [
+          {
+            id: "agt_new",
+            name: "Newbie",
+            tier: "ic",
+            last_write_ever: null,
+            agent_created: localMidnight(2026, 4, 20),
+          },
+          {
+            id: "agt_stale",
+            name: "Stale",
+            tier: "team",
+            last_write_ever: localMidnight(2026, 2, 1),
+            agent_created: localMidnight(2026, 1, 15),
+          },
+        ],
+      }),
+    );
+    const summary = await getMemoryActivity(pool, { weeks: 12 });
+    expect(summary.dormant_agents).toEqual([
+      {
+        agent_id: "agt_new",
+        name: "Newbie",
+        tier: "ic",
+        last_write_ever: null,
+        agent_created: "2026-04-20",
+      },
+      {
+        agent_id: "agt_stale",
+        name: "Stale",
+        tier: "team",
+        last_write_ever: "2026-02-01",
+        agent_created: "2026-01-15",
+      },
+    ]);
+  });
+
+  it("maps the core snapshot, treating a null AVG as 0 chars", async () => {
+    const pool = makeMockPool(
+      responses({
+        [QUERY.coreSnapshot]: [
+          {
+            tier: "ic",
+            block_name: "persona",
+            blocks: "5",
+            non_empty: "4",
+            ever_updated: "3",
+            updated_30d: "1",
+            avg_chars: "812",
+          },
+          {
+            tier: "ic",
+            block_name: "scratch",
+            blocks: "5",
+            non_empty: "0",
+            ever_updated: "0",
+            updated_30d: "0",
+            avg_chars: null,
+          },
+        ],
+      }),
+    );
+    const summary = await getMemoryActivity(pool, { weeks: 12 });
+    expect(summary.core_snapshot[0]!.avg_chars).toBe(812);
+    expect(summary.core_snapshot[1]!.avg_chars).toBe(0);
+  });
+});
+
+describe("getMemoryActivity — ratios", () => {
+  it("rounds the per-agent archival:core ratio to one decimal", async () => {
+    const pool = makeMockPool(
+      responses({
+        [QUERY.ratio]: [
+          {
+            id: "agt_1",
+            name: "Alice",
+            tier: "ic",
+            archival_30d: "10",
+            core_touched_30d: "3",
+          },
+        ],
+      }),
+    );
+    const summary = await getMemoryActivity(pool, { weeks: 12 });
+    // 10/3 = 3.333… → 3.3
+    expect(summary.archival_to_core_per_agent[0]).toEqual({
+      agent_id: "agt_1",
+      name: "Alice",
+      tier: "ic",
+      archival_30d: 10,
+      core_touched_30d: 3,
+      ratio: 3.3,
+    });
+  });
+
+  it("returns a null per-agent ratio rather than Infinity when core is 0", async () => {
+    const pool = makeMockPool(
+      responses({
+        [QUERY.ratio]: [
+          {
+            id: "agt_1",
+            name: "Alice",
+            tier: "ic",
+            archival_30d: "7",
+            core_touched_30d: "0",
+          },
+        ],
+      }),
+    );
+    const summary = await getMemoryActivity(pool, { weeks: 12 });
+    expect(summary.archival_to_core_per_agent[0]!.ratio).toBeNull();
+  });
+
+  it("coerces the KPI counts and rounds the overall ratio", async () => {
+    const pool = makeMockPool(
+      responses({
+        [QUERY.kpis]: [
+          {
+            archival_writes_30d: "125",
+            core_touched_30d: "20",
+            active_agents_30d: "9",
+          },
+        ],
+      }),
+    );
+    const summary = await getMemoryActivity(pool, { weeks: 12 });
+    expect(summary.kpis).toEqual({
+      archival_writes_30d: 125,
+      core_touched_30d: 20,
+      active_agents_30d: 9,
+      archival_to_core_ratio: 6.3,
+    });
+  });
+
+  it("returns a null overall ratio when nothing touched core memory", async () => {
+    const pool = makeMockPool(
+      responses({
+        [QUERY.kpis]: [
+          {
+            archival_writes_30d: "40",
+            core_touched_30d: "0",
+            active_agents_30d: "4",
+          },
+        ],
+      }),
+    );
+    const summary = await getMemoryActivity(pool, { weeks: 12 });
+    expect(summary.kpis.archival_to_core_ratio).toBeNull();
+  });
+});
+
+describe("getMemoryActivity — before/after split", () => {
+  const since = "2026-04-15T00:00:00Z";
+
+  it("runs the two extra queries with the since cutoff and echoes it back", async () => {
+    const pool = makeMockPool(
+      responses({
+        [QUERY.beforeAfterAgg]: [
+          { agents_pre: "3", agents_post: "5", writes_pre: "40", writes_post: "70" },
+        ],
+      }),
+    );
+    const summary = await getMemoryActivity(pool, { weeks: 12, since });
+    expect(pool._spy).toHaveBeenCalledTimes(9);
+    expect(pool._spy.mock.calls[QUERY.beforeAfterByType]![1]).toEqual([since]);
+    expect(pool._spy.mock.calls[QUERY.beforeAfterAgg]![1]).toEqual([since]);
+    expect(summary.since).toBe(since);
+    expect(summary.before_after).toEqual({
+      since,
+      by_type: [],
+      agg: { agents_pre: 3, agents_post: 5, writes_pre: 40, writes_post: 70 },
+    });
+  });
+
+  it("coerces the per-type pre/post counts and percentages", async () => {
+    const pool = makeMockPool(
+      responses({
+        [QUERY.beforeAfterByType]: [
+          {
+            fact_type: "pattern",
+            pre: "12",
+            post: "30",
+            pre_pct: "30.0",
+            post_pct: "42.9",
+          },
+        ],
+        [QUERY.beforeAfterAgg]: [
+          { agents_pre: "3", agents_post: "5", writes_pre: "40", writes_post: "70" },
+        ],
+      }),
+    );
+    const summary = await getMemoryActivity(pool, { weeks: 12, since });
+    expect(summary.before_after?.by_type).toEqual([
+      { fact_type: "pattern", pre: 12, post: 30, pre_pct: 30, post_pct: 42.9 },
+    ]);
+  });
+
+  it("keeps a null percentage null instead of coercing it to 0", async () => {
+    const pool = makeMockPool(
+      responses({
+        [QUERY.beforeAfterByType]: [
+          {
+            fact_type: "decision",
+            pre: "0",
+            post: "4",
+            pre_pct: null,
+            post_pct: "100.0",
+          },
+        ],
+        [QUERY.beforeAfterAgg]: [
+          { agents_pre: "0", agents_post: "2", writes_pre: "0", writes_post: "4" },
+        ],
+      }),
+    );
+    const summary = await getMemoryActivity(pool, { weeks: 12, since });
+    expect(summary.before_after?.by_type[0]).toMatchObject({
+      pre_pct: null,
+      post_pct: 100,
+    });
+  });
+});

--- a/packages/api/src/views/work-product.test.ts
+++ b/packages/api/src/views/work-product.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for views/work-product.ts — the row → DTO mapping and, more
+ * importantly, `readArtifactBody`'s three-step resolution chain
+ * (`body` column → `file://` url → `metadata.host_path`) plus the
+ * 256 KB truncation cap.
+ *
+ * The file:// / host_path cases need real files, so each writes into a
+ * per-suite temp dir rather than mocking node:fs — the code under test
+ * `stat`s before reading and we want that path exercised for real.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getWorkProduct, readArtifactBody } from "./work-product.js";
+import { makeMockPool } from "./test-helpers.js";
+
+const MAX_BODY_BYTES = 256 * 1024;
+
+let dir: string;
+
+beforeAll(async () => {
+  dir = await mkdtemp(join(tmpdir(), "beevibe-wp-"));
+});
+
+afterAll(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+async function tempFile(name: string, content: string): Promise<string> {
+  const path = join(dir, name);
+  await writeFile(path, content, "utf-8");
+  return path;
+}
+
+const baseRow = {
+  id: "wp_abc123def",
+  task_id: "tsk_998877ff",
+  agent_id: "agt_5150",
+  type: "document" as const,
+  title: "Auth migration plan",
+  summary: null,
+  body: null,
+  url: null,
+  metadata: null,
+  provider: null,
+  external_id: null,
+  created_at: new Date("2026-04-30T10:00:00Z"),
+  updated_at: new Date("2026-05-01T11:30:00Z"),
+  task_title: "Migrate auth",
+  agent_label: "Alice",
+};
+
+describe("readArtifactBody", () => {
+  it("prefers the body column and never touches the filesystem", async () => {
+    const body = await readArtifactBody({
+      body: "from the column",
+      url: "file:///definitely/does/not/exist.md",
+      metadata: { host_path: "/also/missing" },
+    });
+    expect(body).toBe("from the column");
+  });
+
+  it("returns undefined when there is no body, url, or metadata", async () => {
+    await expect(readArtifactBody({})).resolves.toBeUndefined();
+    await expect(
+      readArtifactBody({ body: null, url: null, metadata: null }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("treats an empty body column as absent and falls through to the url", async () => {
+    const path = await tempFile("empty-fallthrough.md", "from the file");
+    const body = await readArtifactBody({
+      body: "",
+      url: pathToFileURL(path).href,
+    });
+    expect(body).toBe("from the file");
+  });
+
+  it("reads a file:// url when the body column is empty", async () => {
+    const path = await tempFile("from-url.md", "# Plan\n\nstep one");
+    const body = await readArtifactBody({ url: pathToFileURL(path).href });
+    expect(body).toBe("# Plan\n\nstep one");
+  });
+
+  it("ignores non-file:// urls rather than trying to fetch them", async () => {
+    const body = await readArtifactBody({
+      url: "https://example.com/doc.md",
+      metadata: null,
+    });
+    expect(body).toBeUndefined();
+  });
+
+  it("falls back to metadata.host_path when the file:// url is missing on disk", async () => {
+    const path = await tempFile("host-path-fallback.md", "sandbox artifact");
+    const body = await readArtifactBody({
+      url: pathToFileURL(join(dir, "gone.md")).href,
+      metadata: { host_path: path },
+    });
+    expect(body).toBe("sandbox artifact");
+  });
+
+  it("reads metadata.host_path when there is no url at all", async () => {
+    const path = await tempFile("host-path-only.md", "sandbox only");
+    const body = await readArtifactBody({ metadata: { host_path: path } });
+    expect(body).toBe("sandbox only");
+  });
+
+  it("ignores a host_path that is absent, empty, or not a string", async () => {
+    await expect(readArtifactBody({ metadata: {} })).resolves.toBeUndefined();
+    await expect(
+      readArtifactBody({ metadata: { host_path: "" } }),
+    ).resolves.toBeUndefined();
+    await expect(
+      readArtifactBody({ metadata: { host_path: 42 } }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("returns undefined when neither the url nor the host_path exists", async () => {
+    const body = await readArtifactBody({
+      url: pathToFileURL(join(dir, "nope-a.md")).href,
+      metadata: { host_path: join(dir, "nope-b.md") },
+    });
+    expect(body).toBeUndefined();
+  });
+
+  it("passes a body exactly at the 256 KB cap through untouched", async () => {
+    const exact = "x".repeat(MAX_BODY_BYTES);
+    const body = await readArtifactBody({ body: exact });
+    expect(body).toBe(exact);
+    expect(body).not.toContain("[truncated]");
+  });
+
+  it("truncates an over-cap body and marks it", async () => {
+    const body = await readArtifactBody({ body: "y".repeat(MAX_BODY_BYTES + 1_000) });
+    expect(body).toBe("y".repeat(MAX_BODY_BYTES) + "\n\n[truncated]");
+  });
+
+  it("truncates an over-cap file body too", async () => {
+    const path = await tempFile("huge.md", "z".repeat(MAX_BODY_BYTES + 500));
+    const body = await readArtifactBody({ url: pathToFileURL(path).href });
+    expect(body?.endsWith("\n\n[truncated]")).toBe(true);
+    expect(body?.startsWith("z".repeat(1_000))).toBe(true);
+  });
+});
+
+describe("getWorkProduct", () => {
+  it("queries by id and returns undefined when the row is missing", async () => {
+    const pool = makeMockPool([]);
+    await expect(getWorkProduct(pool, "wp_missing")).resolves.toBeUndefined();
+    expect(pool._spy).toHaveBeenCalledWith(expect.any(String), ["wp_missing"]);
+  });
+
+  it("maps a minimal row, omitting every optional field", async () => {
+    const pool = makeMockPool([baseRow]);
+    const wp = await getWorkProduct(pool, "wp_abc123def");
+    expect(wp).toEqual({
+      id: "wp_abc123def",
+      task_id: "tsk_998877ff",
+      task_short_id: "998877",
+      task_title: "Migrate auth",
+      agent_id: "agt_5150",
+      agent_label: "Alice",
+      type: "document",
+      title: "Auth migration plan",
+      url_is_local: false,
+      created_at: "2026-04-30T10:00:00.000Z",
+      updated_at: "2026-05-01T11:30:00.000Z",
+    });
+    // Optional keys are omitted, not set to undefined.
+    expect(Object.keys(wp!)).not.toContain("summary");
+    expect(Object.keys(wp!)).not.toContain("body");
+    expect(Object.keys(wp!)).not.toContain("url");
+  });
+
+  it("includes the optional fields when the row carries them", async () => {
+    const pool = makeMockPool([
+      {
+        ...baseRow,
+        summary: "one paragraph",
+        body: "full content",
+        url: "https://example.com/wp",
+        provider: "github",
+        external_id: "PR-42",
+      },
+    ]);
+    const wp = await getWorkProduct(pool, "wp_abc123def");
+    expect(wp).toMatchObject({
+      summary: "one paragraph",
+      body: "full content",
+      url: "https://example.com/wp",
+      provider: "github",
+      external_id: "PR-42",
+      url_is_local: false,
+    });
+  });
+
+  it("flags url_is_local and inlines the body for a file:// url", async () => {
+    const path = await tempFile("detail.md", "on-disk deliverable");
+    const pool = makeMockPool([{ ...baseRow, url: pathToFileURL(path).href }]);
+    const wp = await getWorkProduct(pool, "wp_abc123def");
+    expect(wp?.url_is_local).toBe(true);
+    expect(wp?.body).toBe("on-disk deliverable");
+  });
+
+  it("keeps url_is_local false for an http url", async () => {
+    const pool = makeMockPool([{ ...baseRow, url: "https://example.com/doc" }]);
+    const wp = await getWorkProduct(pool, "wp_abc123def");
+    expect(wp?.url_is_local).toBe(false);
+  });
+
+  it("resolves the body from metadata.host_path when the column is empty", async () => {
+    const path = await tempFile("detail-host.md", "sandbox deliverable");
+    const pool = makeMockPool([{ ...baseRow, metadata: { host_path: path } }]);
+    const wp = await getWorkProduct(pool, "wp_abc123def");
+    expect(wp?.body).toBe("sandbox deliverable");
+  });
+
+  it("omits body when the file:// url points at nothing", async () => {
+    const pool = makeMockPool([
+      { ...baseRow, url: pathToFileURL(join(dir, "vanished.md")).href },
+    ]);
+    const wp = await getWorkProduct(pool, "wp_abc123def");
+    expect(wp?.url_is_local).toBe(true);
+    expect(Object.keys(wp!)).not.toContain("body");
+  });
+});


### PR DESCRIPTION
## Why

A coverage sweep across the monorepo put `@beevibe/api` at **40.6% lines**, well behind core (83.5%) and daemon (80.4%) after #264 and #268. Ranking api source files that have **no test file at all**, six stood out as both DB-free — every collaborator is either injected or a `Pool` the existing `makeMockPool` fixture can stand in for — and carrying real branching worth pinning down.

## What's covered

| Module | Before | After | What the tests pin down |
| --- | --- | --- | --- |
| `views/work-product.ts` | 0% | 100% | The `body` column → `file://` url → `metadata.host_path` resolution chain, and the 256 KB truncation cap |
| `views/memory-activity.ts` | 0% | 100% | Mapping over seven fan-out queries; `weeks` clamping; both divide-by-zero-guarded ratios |
| `views/activity.ts` | 0% | 100% | Row → DTO mapping, short-id derivation, epoch fallback when `started_at` is null |
| `sse/listener.ts` | 0% | 100% | Payload parser accept/reject rules, `onEvent` error isolation, the reconnect loop |
| `routes/capabilities.ts` | 0% | 100% | Authorization ladder, validation, tool-error mapping |
| `routes/find-repo.ts` | 0% | 100% | `limit` coercion/clamping, auth, error mapping |

**Package total: 40.6% → 46.2% lines.**

## Notes on approach

- **`views/*`** follow the established `makeMockPool` convention from `views/promotions.test.ts`.
- **`work-product`** writes real temp files instead of mocking `node:fs`, so the `stat`-then-read path runs as written. Fixtures land in a per-suite `mkdtemp` dir and are removed in `afterAll`.
- **`memory-activity`** fans out via `Promise.all`. Array elements evaluate left to right and each helper runs synchronously up to its `pool.query`, so call order is deterministic and the ordered mock-pool shape lines up 1:1 — a `QUERY` index map documents this rather than leaving it implicit. Date fixtures are built at local midnight to mirror how node-postgres parses a `::date` column, keeping assertions TZ-independent.
- **`sse/listener`** replaces `pg.Client` with an EventEmitter stand-in so `notification` / `end` / `error` can be driven by hand. Reconnect assertions poll the clock rather than the microtask queue, since the reconnect goes through a real `setTimeout`.
- **routers** mount on a bare Express app with stub repos and a mocked tool factory, using `vi.hoisted` per the daemon's existing pattern.

## Verification

Every new suite was checked against a deliberate mutation of the code it covers — removing the divide-by-zero guard, raising the truncation cap, dropping the LISTEN channel filter, deleting the cross-owner authorization check, removing the `limit` clamp, and dropping the short-id derivation. **All six mutants were caught.**

- 116 new tests, all passing.
- `typecheck` and `lint` clean (the 4 remaining lint warnings are pre-existing and in other files).
- Full api suite: **9 failed files, unchanged from before this branch** — all of them the DB/key-gated suites that can't run without Postgres, exactly the environmental baseline documented in CLAUDE.md. No new failures.

Tests only — no source files changed. `@vitest/coverage-v8` was installed to take the measurement and deliberately not committed, per the CLAUDE.md guidance.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AzSBS5NmgQ4jhkvBZJuXqt)_