### PR TITLE
chore(web): remove dead API-client surface left behind by removed UI

### DIFF
--- a/packages/web/lib/api/client-mutations.test.ts
+++ b/packages/web/lib/api/client-mutations.test.ts
@@ -73,34 +73,6 @@ describe("api mutations", () => {
         body: { reason: "scope changed" },
       });
     });
-
-    it("create({title}) POSTs to /api/tasks", async () => {
-      await api.tasks.create({ title: "wire it" });
-      expect(fetchJsonMock).toHaveBeenCalledWith("/task", {
-        method: "POST",
-        body: { title: "wire it" },
-      });
-    });
-
-    it("create forwards full input", async () => {
-      await api.tasks.create({
-        title: "wire it",
-        description: "hook the kanban",
-        priority: "high",
-        assignee_id: "agt_1",
-        parent_task_id: "t_root",
-      });
-      expect(fetchJsonMock).toHaveBeenCalledWith("/task", {
-        method: "POST",
-        body: {
-          title: "wire it",
-          description: "hook the kanban",
-          priority: "high",
-          assignee_id: "agt_1",
-          parent_task_id: "t_root",
-        },
-      });
-    });
   });
 
   describe("escalations", () => {

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -7,10 +7,7 @@ import type {
   RepoRun,
   RepoRunStatus,
   ReviewPolicy,
-  SessionStatus,
-  SessionType,
   Task,
-  TaskPriority,
 } from "@beevibe/core";
 export type { RepoRun, RepoRunStatus, LearnedSkill };
 import type {
@@ -60,14 +57,6 @@ export interface ReviseTaskInput {
 
 export interface CancelTaskInput {
   reason?: string;
-}
-
-export interface CreateTaskInput {
-  title: string;
-  description?: string;
-  priority?: TaskPriority;
-  assignee_id?: string;
-  parent_task_id?: string;
 }
 
 export interface UserPreferences {
@@ -240,22 +229,6 @@ export interface WorkProductDetail {
   updated_at: string;
 }
 
-export interface ActivityEntry {
-  id: string;
-  short_id: string;
-  agent_id: string;
-  agent_label: string;
-  agent_hierarchy: HierarchyLevel;
-  type: SessionType;
-  status: SessionStatus;
-  intent: string;
-  task_id: string | null;
-  task_title: string | null;
-  task_short_id: string | null;
-  started_at: string;
-  duration_label: string;
-}
-
 export interface RuntimePanelEntry {
   id: string;
   cli: string;
@@ -409,9 +382,6 @@ export const api = {
         `/task/${encodeURIComponent(id)}/retry`,
         { method: "POST" },
       ),
-    // Backend hasn't shipped POST /task (create) yet — see #30.
-    create: (input: CreateTaskInput) =>
-      fetchJson<Task>("/task", { method: "POST", body: input }),
   },
   agents: {
     list: (opts: ReadOptions = {}) =>
@@ -613,14 +583,6 @@ export const api = {
         { method: "DELETE" },
       ),
   },
-  activity: {
-    /** Recent sessions across the caller's agent tree. Used by the live chat rail. */
-    list: (opts: ReadOptions & { limit?: number } = {}) =>
-      fetchJson<ActivityEntry[]>("/activity", {
-        signal: opts.signal,
-        ...(opts.limit ? { query: { limit: opts.limit } } : {}),
-      }),
-  },
   workProducts: {
     get: (id: string, opts: ReadOptions = {}) =>
       fetchJson<WorkProductDetail>(`/work-product/${encodeURIComponent(id)}`, {
@@ -728,8 +690,6 @@ export const api = {
       fetchJson<{ skills: LearnedSkill[] }>("/learned-skills", { signal: opts.signal }),
     create: (input: { name: string; goal_pattern: string; repo_run_id: string }) =>
       fetchJson<{ skill: LearnedSkill }>("/learned-skills", { method: "POST", body: input }),
-    delete: (id: string) =>
-      fetchJson<void>(`/learned-skills/${encodeURIComponent(id)}`, { method: "DELETE" }),
   },
   findRepo: {
     /** Ranked search across all 4 find_repo tiers. Empty `goal` is a 400. */

--- a/packages/web/lib/hooks/use-task-mutations.test.tsx
+++ b/packages/web/lib/hooks/use-task-mutations.test.tsx
@@ -10,7 +10,6 @@ vi.mock("@/lib/api/client", () => ({
       reject: vi.fn(),
       revise: vi.fn(),
       cancel: vi.fn(),
-      create: vi.fn(),
     },
   },
 }));
@@ -20,7 +19,6 @@ import {
   useRejectTask,
   useReviseTask,
   useCancelTask,
-  useCreateTask,
 } from "./use-task-mutations";
 import { api } from "@/lib/api/client";
 import { queryKeys } from "./keys";
@@ -29,7 +27,6 @@ const approveMock = vi.mocked(api.tasks.approve);
 const rejectMock = vi.mocked(api.tasks.reject);
 const reviseMock = vi.mocked(api.tasks.revise);
 const cancelMock = vi.mocked(api.tasks.cancel);
-const createMock = vi.mocked(api.tasks.create);
 
 function makeWrapper() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -45,7 +42,6 @@ beforeEach(() => {
   rejectMock.mockReset();
   reviseMock.mockReset();
   cancelMock.mockReset();
-  createMock.mockReset();
 });
 
 afterEach(() => {
@@ -172,25 +168,5 @@ describe("useCancelTask", () => {
     });
 
     await waitFor(() => expect(cancelMock).toHaveBeenCalledWith("t_1", { reason: "scope" }));
-  });
-});
-
-describe("useCreateTask", () => {
-  it("calls api.tasks.create and invalidates the task list", async () => {
-    createMock.mockResolvedValue({} as never);
-    const { invalidateSpy, Wrapper } = makeWrapper();
-
-    const { result } = renderHook(() => useCreateTask(), { wrapper: Wrapper });
-
-    await act(async () => {
-      result.current.mutate({ title: "wire" });
-    });
-
-    await waitFor(() => expect(createMock).toHaveBeenCalledWith({ title: "wire" }));
-
-    const invalidated = invalidateSpy.mock.calls.map((c) => c[0]?.queryKey);
-    expect(invalidated).toEqual(
-      expect.arrayContaining([queryKeys.tasks.all, queryKeys.dashboard.all]),
-    );
   });
 });

--- a/packages/web/lib/hooks/use-task-mutations.ts
+++ b/packages/web/lib/hooks/use-task-mutations.ts
@@ -5,7 +5,6 @@ import {
   type RejectTaskInput,
   type ReviseTaskInput,
   type CancelTaskInput,
-  type CreateTaskInput,
 } from "@/lib/api/client";
 import { queryKeys } from "./keys";
 
@@ -61,16 +60,5 @@ export function useRetryTask(taskId: string) {
   return useMutation({
     mutationFn: () => api.tasks.retry(taskId),
     onSuccess,
-  });
-}
-
-export function useCreateTask() {
-  const client = useQueryClient();
-  return useMutation({
-    mutationFn: (input: CreateTaskInput) => api.tasks.create(input),
-    onSuccess: () => {
-      client.invalidateQueries({ queryKey: queryKeys.tasks.all });
-      client.invalidateQueries({ queryKey: queryKeys.dashboard.all });
-    },
   });
 }


### PR DESCRIPTION
Scheduled dead-code sweep. 104 lines removed, all of them unreachable from any component, hook, page or route. No behavior change.

## Static + dynamic analysis

| Check | Result |
| --- | --- |
| `tsc --noUnusedLocals --noUnusedParameters` (all 6 packages) | clean |
| `tsc --allowUnreachableCode false` (TS7027) | clean |
| `pnpm lint` | 0 errors (10 pre-existing `import/no-duplicates` / `no-named-as-default` / test-local warnings) |
| repo-wide export-reference sweep (every exported symbol) | 36 zero-reference hits, **all** Next.js App Router convention exports (`page`/`layout`/`loading`/`error`) — loaded by filename, not import |
| orphan-file sweep (nothing imports this file) | 19 hits, all entrypoints, migrations, config, or documented manual scripts |
| "only a test consumes it" sweep | 6 hits — 5 are deliberate test infrastructure, 1 was real (`useCreateTask`) |
| "re-exported from a barrel but never consumed" sweep | 1 hit, `PostgresMemoryPromotionEventRepository` — see below, **not** dead |
| `knip` | 7 unused files, 2 unused deps, 13 unused exports, 106 unused types |
| `depcheck` | same deps as the documented false-positive table |
| `next build` (bundle) | green |
| web suite | 22 files / 189 tests passing |

Last sweep (#267) already cleared the export surface, so the static tools came back clean this time. What they structurally miss is dead surface on the **web API client**: entries on the `api` object literal that nothing calls. They still ship in the bundle — `api` is one object, so a per-method removal is a real bundle-size win — and each one carries a doc comment that is now false.

## What was removed

**`packages/web/lib/api/client.ts`**

- **`tasks.create` + `CreateTaskInput`** — leftover from the `+ New task` kanban affordance removed in #48. `components/tasks/board-column.tsx` still carries the note explaining why: *"Tasks are minted by team agents through human-agent conversation, not by the human clicking '+' in a kanban column… when the human chat surface lands, the 'create' entry point lives there."* The chat surface has since landed. The method's own comment claimed `// Backend hasn't shipped POST /task (create) yet — see #30`, which is stale — `POST /task` shipped — and its declared return type (`Task`) never matched what the route actually returns (`{ ok: true, task }`). That mismatch is the proof nobody ever called it.
- **`activity.list` + `ActivityEntry`** — wrapper for a "live chat rail" panel that was never built. Zero references anywhere, tests included; its doc comment claims *"Used by the live chat rail."* `knip` flagged `ActivityEntry` as an unused type.
- **`learnedSkills.delete`** — the capabilities UI lists and creates learned skills; nothing deletes one.

**`packages/web/lib/hooks/use-task-mutations.ts`**

- **`useCreateTask`** — sole caller of `api.tasks.create`, and itself called only by its own test.

Test blocks that existed only to exercise the above come out with them: 2 cases in `client-mutations.test.ts`, 1 in `use-task-mutations.test.tsx`.

## Deliberately kept

- **The server side of all three endpoints.** `GET /activity`, `DELETE /learned-skills/:id` and `POST /task` are live authenticated HTTP routes. Retiring product API surface is a different call from deleting unreachable client code, so they stay — worth a follow-up decision on `GET /activity` in particular, whose only intended consumer was the panel that was never built.
- Everything in the CLAUDE.md false-positive table, which `knip` and `depcheck` flagged again this sweep: `node-pg-migrate`, root `prettier`, `migrations/*.js`, the manual dev/ops scripts, the deliberate `@beevibe/core` subpath exports.
- The 13 `knip` "unused exports" — every one has ≥2 repo-wide references, i.e. it is used *within its own file*. The `export` is redundant, not dead.

## Two things worth flagging (not touched here)

1. **`api.sessions.tree` reads as dead to a line-based grep but is not.** `useChatStreamTree` calls it across a line break (`api.sessions\n  .tree(...)`), so `grep "sessions.tree"` finds nothing. Caught during verification — noting it so the next sweep doesn't delete it.

2. **The M8.D promotion audit log is wired on the read side only.** `PostgresMemoryPromotionEventRepository` is the sole writer to `memory_promotion_event`, and it is never constructed — both `packages/api/src/bootstrap.ts:275` and `packages/scheduler/src/bootstrap.ts:108` call `createMemoryAgent({ agentId, coreMemory, factStore, promoter, embed })` without the optional `promotionEventRepo`. `packages/api/src/views/promotions.ts` reads that table to power `/promotions`, so the page renders permanently empty. This looks like a missing-wiring bug rather than dead code, so the adapter stays and nothing here changes it.

## Verification

- `pnpm typecheck` — 9/9
- `pnpm lint` — 9/9, identical warning set to `main`
- `pnpm --filter @beevibe/web exec next build` — green (direct invocation bypasses the documented Turbo strict-env-mode / `next/font` proxy failure; `pnpm build` is 5/6 on `main` for the same reason)
- `@beevibe/web` tests — 22 files / 189 tests, all passing
- Re-ran every sweep above after the edits: `knip` unused types 106 → 105, everything else unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01UaMvdfx7bE77cpPeVtQYkc)_