### PR TITLE
chore: remove dead code found by a static + dynamic sweep

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,6 @@ BEEVIBE_CORS_ORIGINS=
 # WORKSPACE_ROOT=/absolute/path/to/workspaces
 # Health endpoint port (GET /health → 200/503). Default 3001.
 BEEVIBE_SCHEDULER_HEALTH_PORT=3001
-ORG_ID=beevibe
 
 # ─── Web frontend (packages/web) ───────────────────────────────────────
 # Base URL the browser hits. Same value as BEEVIBE_API_PORT, just origin

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,34 @@ so an unused parameter followed by a used one is **not** reported — only
 `--noUnusedParameters` catches it. Convention here is to prefix a
 deliberately-unused param with `_`.
 
+### knip's blind spot: symbols behind `@beevibe/core` subpath barrels
+
+`packages/core/package.json` declares 26 `exports` subpaths. knip treats
+each one as an **entry point**, so anything re-exported from a barrel
+(`domain/index.ts`, `adapters/postgres/index.ts`, …) is "reachable" and
+never flagged — no matter how many packages actually import it. Every
+core dead-export found so far was invisible to knip for this reason.
+
+Sweep it by name instead — for each `export function|class|const` under
+`packages/*/src/**`, grep the whole monorepo and discount (a) the
+declaring file and (b) pure re-export lines in `index.ts`:
+
+```bash
+git grep -n -w -- "<symbol>" -- 'packages/**' 'scripts/**' | grep -v /dist/
+```
+
+Zero surviving hits = dead. Hits only from `*.test.ts` = alive only for
+its own test — check whether it's a deliberate test seam (`clearCache()`
+in `api/src/sse/owner-lookup.ts` is marked `@internal Tests only`) before
+touching it.
+
+### Dead in-repo, but not ours to delete
+
+| Thing | Why it survived the sweep |
+| --- | --- |
+| `GET /activity` → `api/src/views/activity.ts` | No caller anywhere in the monorepo, but it's a **documented public endpoint** (`packages/api/README.md`). Retiring it is a product call. The web stub that used to reach it (`api.activity.list`) is removed by #273; `queryKeys.activity` + its `lib/sse.ts` invalidations are inert once that lands. |
+| `PostgresMemoryPromotionEventRepository` | Never constructed — `bootstrap.ts` builds the MemoryAgent without `promotionEventRepo`, so the M8.D promotion audit log never writes even though the port, the service branch, its tests and the read-side `views/promotions.ts` all exist. That's **unfinished wiring, not dead code**; deleting the adapter makes finishing it harder. |
+
 ## Deploying
 
 ```bash

--- a/packages/core/src/domain/session-search.test.ts
+++ b/packages/core/src/domain/session-search.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  lineageKey,
-  parseUserMessageId,
-  userMessageId,
-} from "./session-search.js";
+import { lineageKey, userMessageId } from "./session-search.js";
 
 describe("lineageKey", () => {
   it("uses conversation_id when the session belongs to a chat thread", () => {
@@ -25,24 +21,11 @@ describe("lineageKey", () => {
   });
 });
 
-describe("userMessageId / parseUserMessageId", () => {
-  it("round-trips a session id through the intent: marker", () => {
-    const id = userMessageId("sess_abc");
-    expect(id).toBe("intent:sess_abc");
-    expect(parseUserMessageId(id)).toBe("sess_abc");
-  });
-
-  it("returns null for session_event row ids", () => {
-    expect(parseUserMessageId("evt_123")).toBeNull();
-  });
-
-  it("returns null when the marker is not at the start", () => {
-    expect(parseUserMessageId("evt_intent:sess_abc")).toBeNull();
-  });
-
-  it("returns an empty session id rather than null for a bare marker", () => {
-    // scroll() passes this straight to the repo, which finds no row — the
-    // parse step deliberately does not second-guess the caller.
-    expect(parseUserMessageId("intent:")).toBe("");
+describe("userMessageId", () => {
+  it("prefixes the session id with the intent: marker", () => {
+    // Must stay byte-identical to userMessageIdExpr() in
+    // adapters/postgres/session-search-repo.ts — scroll() matches the
+    // anchor id against the SQL-built string by equality.
+    expect(userMessageId("sess_abc")).toBe("intent:sess_abc");
   });
 });

--- a/packages/core/src/domain/session-search.ts
+++ b/packages/core/src/domain/session-search.ts
@@ -198,18 +198,10 @@ export function lineageKey(session: {
 
 /**
  * Stable synthetic id for the user-turn message synthesised from
- * {@link Session.intent}. Matches the parsing in
- * {@link parseUserMessageId}.
+ * {@link Session.intent}. The repo builds the same string in SQL — see
+ * `userMessageIdExpr()` in `adapters/postgres/session-search-repo.ts`,
+ * which must agree with this.
  */
 export function userMessageId(sessionId: string): string {
   return `intent:${sessionId}`;
-}
-
-/**
- * Reverse of {@link userMessageId}. Returns the underlying session id
- * when the input is a user-turn marker, or null otherwise.
- */
-export function parseUserMessageId(messageId: string): string | null {
-  if (messageId.startsWith("intent:")) return messageId.slice("intent:".length);
-  return null;
 }


### PR DESCRIPTION
## What this is

A full dead-code sweep across the monorepo. Four prior sweeps (#256, #260, #262, #267) already took the easy wins, so the yield here is small — **that's the honest result of the sweep, not an incomplete run.** The more useful output is the analysis blind spot documented below, which explains why the one real finding survived all four.

## Analyses run

| Analysis | Result |
| --- | --- |
| `tsc --noUnusedLocals --noUnusedParameters` (all 6 packages) | clean |
| `tsc --allowUnreachableCode false` (TS7027, all 6 packages) | clean |
| `turbo lint` (eslint) | 0 errors — only pre-existing style warnings |
| `knip` (files, exports, types, deps) | only the documented false positives in CLAUDE.md, plus self-used exports |
| `depcheck` (per package) | only the documented false positives (`node-pg-migrate`, `zod`, `postcss`, `autoprefixer`) |
| By-name cross-package export scan | **1 real finding** (knip's blind spot — see below) |
| Symbols alive only via their own tests | all legitimate test seams |
| Unimported-file scan | only the documented manual dev/ops scripts |
| Unreferenced `public/` + CSS assets | clean |
| `.env.example` vs. actual env reads | **1 real finding** |
| SSE event names, web ↔ backend | clean — no orphans in either direction |

## Removed

**`parseUserMessageId`** (`packages/core/src/domain/session-search.ts`) and its four tests.

Nothing has called it since `scroll()` stopped parsing the anchor. The repo builds `intent:<session_id>` in SQL (`userMessageIdExpr()`) and `scroll()` matches the anchor by string equality, so the reverse direction has no caller. Its only two references were a `{@link}` in a sibling doc comment and its own test file.

The surviving `userMessageId` test now asserts the invariant that actually matters — that it stays byte-identical to the SQL expression — rather than round-tripping through a function no production path uses.

**`ORG_ID=beevibe`** from `.env.example`. Nothing in the repo reads it: no `process.env.ORG_ID`, no compose file, no deploy doc, no script.

## Documented rather than deleted

**knip cannot see dead code behind `@beevibe/core`'s subpath barrels.** `packages/core/package.json` declares 26 `exports` subpaths; knip treats each as an entry point, so every barrel-reachable symbol reads as "used" no matter who actually imports it. That is why `parseUserMessageId` survived four sweeps. CLAUDE.md now records the blind spot and the by-name grep that works around it.

Two things the sweep flagged that I deliberately did **not** remove, both now in CLAUDE.md so the next sweep doesn't re-derive them:

- **`GET /activity` → `packages/api/src/views/activity.ts`** — no caller anywhere in the monorepo (the only web stub that reached it, `api.activity.list`, is itself uncalled and is removed by #273). But it's a **documented public endpoint** in `packages/api/README.md`, so retiring it is a product decision rather than a mechanical cleanup.
- **`PostgresMemoryPromotionEventRepository`** — never constructed. `bootstrap.ts` builds the MemoryAgent without `promotionEventRepo`, so the promotion audit log never writes, even though the port, the service branch, its tests, and the read-side `views/promotions.ts` all exist. That's **unfinished wiring, not dead code** — deleting the adapter would only make it harder to finish.

## Verification

- `turbo typecheck` — clean, 9/9 tasks
- `turbo lint` — 0 errors across all packages
- `turbo build` — clean for core, api, daemon, scheduler
- `packages/core` tests — at the documented sandbox baseline (7 provider-key failures, 18 DB-gated files). Unchanged by this diff; the touched suite passes.

## Note on overlap

Does not conflict with #273 — that PR touches `packages/web/lib/api/*`, this one touches core, `.env.example`, and CLAUDE.md.

---
_Generated by [Claude Code](https://claude.ai/code/session_015scXshFZt4Nskp22wCfjqR)_