### PR TITLE
refactor: unify four more clusters of near-duplicate abstractions

### DIFF
--- a/packages/api/src/bootstrap.ts
+++ b/packages/api/src/bootstrap.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import {
   PostgresAgentRepository,
   PostgresCoreMemoryRepository,
@@ -23,17 +22,11 @@ import {
   createPool,
 } from "@beevibe/core/adapters/postgres";
 import type { Pool } from "@beevibe/core/adapters/postgres";
-import { OpenAIEmbeddingService } from "@beevibe/core/adapters/openai";
-import { AnthropicLlmProvider } from "@beevibe/core/adapters/anthropic";
-import { LocalWorkspaceManager } from "@beevibe/core/adapters/local-workspace";
-import { createDefaultRuntimeRegistry } from "@beevibe/core/adapters/runtime-registry";
 import {
-  CoreMemory,
-  FactPromoter,
-  FactStore,
-  createMemoryAgent,
-  type MemoryAgent,
-} from "@beevibe/core/services/memory";
+  createMemoryStack,
+  createWorkspaceStack,
+  resolveSkillsSourceDir,
+} from "@beevibe/core/composition";
 import { TaskService } from "@beevibe/core/services/task-service";
 import { EscalationService } from "@beevibe/core/services/escalation-service";
 import { NegotiationService } from "@beevibe/core/services/negotiation-service";
@@ -149,14 +142,18 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
   const skillOutcomeRepo = new PostgresSkillOutcomeRepository(pool);
   const taskWatchRepo = new PostgresTaskWatchRepository(pool);
 
-  // External services (LLM + embeddings) for memory pipeline
-  const embed = new OpenAIEmbeddingService({ apiKey: cfg.openaiApiKey });
-  const llm = new AnthropicLlmProvider({ apiKey: cfg.anthropicApiKey });
-
-  // M3 memory services
-  const coreMemory = new CoreMemory({ repo: coreMemoryRepo });
-  const factStore = new FactStore({ repo: memoryFactRepo, embed, llm });
-  const promoter = new FactPromoter({ llm });
+  // M3 memory pipeline: embeddings + LLM + the three services + the
+  // per-agent MemoryAgent factory. Shared with the scheduler composition
+  // root — `makeMemoryAgent` is closed over the services above and is used
+  // by `buildInstructions` for human callers (full briefing on initialize)
+  // and by SessionCache's onEvict to fire `onTaskComplete` for fact
+  // promotion when a chat session ends (DELETE /mcp or 30-min idle).
+  const { embed, coreMemory, factStore, makeMemoryAgent } = createMemoryStack({
+    coreMemoryRepo,
+    memoryFactRepo,
+    openaiApiKey: cfg.openaiApiKey,
+    anthropicApiKey: cfg.anthropicApiKey,
+  });
 
   // M3+M6.4 task service (review_policy gate, work-product CRUD, parent
   // rollup, plus the M6.4 approve/reject/revise split — reviseTask needs
@@ -255,24 +252,8 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
   // + runtime registry from M5 (shared across executor + api per the M6
   // composition-root design — both processes can spawn target agent CLIs
   // and the mcp-config.json file-existence guard handles cross-process
-  // contention). M9.3: workspaceManager needs the runtime registry to look
-  // up each agent's declared runtime per-call; construct registry first.
-  const runtimeRegistry = createDefaultRuntimeRegistry();
-  const workspaceManager = new LocalWorkspaceManager({
-    workspaceRoot: cfg.workspaceRoot,
-    mcpServerUrl: cfg.mcpServerUrl,
-    runtimeRegistry,
-    skillsSourceDir: cfg.skillsSourceDir ?? path.resolve(process.cwd(), "skills"),
-  });
-
-  /**
-   * Per-agent MemoryAgent factory. Closed over shared services. Used by:
-   *   - `buildInstructions` for human callers (full briefing on initialize)
-   *   - SessionCache's onEvict to fire `onTaskComplete` for fact promotion
-   *     when a chat session ends (DELETE /mcp or 30-min idle eviction)
-   */
-  const makeMemoryAgent = (agentId: string): MemoryAgent =>
-    createMemoryAgent({ agentId, coreMemory, factStore, promoter, embed });
+  // contention).
+  const { runtimeRegistry, workspaceManager } = createWorkspaceStack(cfg);
 
   // M6.4 mesh server. Phase 4: spawn path goes through dispatchService —
   // daemon claims the pending session for daemon-bound targets, executor
@@ -451,7 +432,7 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
     hub: daemonHub,
     makeMemoryAgent,
     mcpServerUrl: cfg.mcpServerUrl,
-    skillsSourceDir: cfg.skillsSourceDir ?? path.resolve(process.cwd(), "skills"),
+    skillsSourceDir: resolveSkillsSourceDir(cfg.skillsSourceDir),
     onSessionComplete: async (session) => {
       if (session.type === "chat") {
         chatResolver.resolve(session.id, session);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./composition": {
+      "types": "./dist/composition.d.ts",
+      "default": "./dist/composition.js"
+    },
     "./domain": {
       "types": "./dist/domain/index.d.ts",
       "default": "./dist/domain/index.js"

--- a/packages/core/src/adapters/postgres/agent-repo.ts
+++ b/packages/core/src/adapters/postgres/agent-repo.ts
@@ -1,18 +1,14 @@
 import type { Agent, HierarchyLevel, ReviewPolicy, RuntimeConfig } from "../../domain/agent.js";
 import type { AgentRepository, NewAgent, AgentPatch } from "../../ports/agent-repo.js";
 import type { Pool } from "./client.js";
-import { buildPatchClause } from "./pg-helpers.js";
+import { findRowById, updateRowById } from "./pg-helpers.js";
 import type { AgentRow } from "./row-types.js";
 
 export class PostgresAgentRepository implements AgentRepository {
   constructor(private pool: Pool) {}
 
   async findById(id: string): Promise<Agent | undefined> {
-    const { rows } = await this.pool.query<AgentRow>(
-      `SELECT * FROM agent WHERE id = $1 LIMIT 1`,
-      [id],
-    );
-    return rows[0] ? rowToAgent(rows[0]) : undefined;
+    return findRowById(this.pool, "agent", id, rowToAgent);
   }
 
   async findByApiKey(apiKey: string): Promise<Agent | undefined> {
@@ -134,35 +130,28 @@ export class PostgresAgentRepository implements AgentRepository {
   }
 
   async update(id: string, patch: AgentPatch): Promise<Agent> {
-    const clause = buildPatchClause<AgentPatch>(patch, {
-      name: "name",
-      owner_id: "owner_id",
-      parent_agent_id: "parent_agent_id",
-      hierarchy_level: "hierarchy_level",
-      api_key: "api_key",
-      review_policy: "review_policy",
-      runtime_config: "runtime_config",
-      max_task_sessions: "max_task_sessions",
-      max_mesh_sessions: "max_mesh_sessions",
-      max_negotiation_rounds: "max_negotiation_rounds",
-      preferred_runtime_id: "preferred_runtime_id",
-      archived_at: "archived_at",
+    return updateRowById<AgentRow, AgentPatch, Agent>({
+      pool: this.pool,
+      table: "agent",
+      id,
+      patch,
+      columns: {
+        name: "name",
+        owner_id: "owner_id",
+        parent_agent_id: "parent_agent_id",
+        hierarchy_level: "hierarchy_level",
+        api_key: "api_key",
+        review_policy: "review_policy",
+        runtime_config: "runtime_config",
+        max_task_sessions: "max_task_sessions",
+        max_mesh_sessions: "max_mesh_sessions",
+        max_negotiation_rounds: "max_negotiation_rounds",
+        preferred_runtime_id: "preferred_runtime_id",
+        archived_at: "archived_at",
+      },
+      map: rowToAgent,
+      notFound: (id) => `Agent not found: ${id}`,
     });
-
-    if (clause.fields.length === 0) {
-      const existing = await this.findById(id);
-      if (!existing) throw new Error(`Agent not found: ${id}`);
-      return existing;
-    }
-
-    clause.fields.push(`updated_at = NOW()`);
-
-    const { rows } = await this.pool.query<AgentRow>(
-      `UPDATE agent SET ${clause.fields.join(", ")} WHERE id = $${clause.nextIndex} RETURNING *`,
-      [...clause.values, id],
-    );
-    if (!rows[0]) throw new Error(`Agent not found: ${id}`);
-    return rowToAgent(rows[0]);
   }
 
   async delete(id: string): Promise<void> {

--- a/packages/core/src/adapters/postgres/client.ts
+++ b/packages/core/src/adapters/postgres/client.ts
@@ -3,6 +3,7 @@ import pg from "pg";
 const { Pool } = pg;
 export type Pool = pg.Pool;
 export type PoolClient = pg.PoolClient;
+export type QueryResultRow = pg.QueryResultRow;
 
 export interface CreatePoolOptions {
   connectionString: string;

--- a/packages/core/src/adapters/postgres/daemon-repo.ts
+++ b/packages/core/src/adapters/postgres/daemon-repo.ts
@@ -4,7 +4,7 @@ import type {
   DaemonRepository,
 } from "../../ports/daemon-repo.js";
 import type { Pool } from "./client.js";
-import { buildPatchClause } from "./pg-helpers.js";
+import { findRowById, updateRowById } from "./pg-helpers.js";
 import type { DaemonRow } from "./row-types.js";
 
 function rowToDaemon(row: DaemonRow): Daemon {
@@ -24,11 +24,7 @@ export class PostgresDaemonRepository implements DaemonRepository {
   constructor(private pool: Pool) {}
 
   async findById(id: string): Promise<Daemon | undefined> {
-    const { rows } = await this.pool.query<DaemonRow>(
-      `SELECT * FROM daemon WHERE id = $1 LIMIT 1`,
-      [id],
-    );
-    return rows[0] ? rowToDaemon(rows[0]) : undefined;
+    return findRowById(this.pool, "daemon", id, rowToDaemon);
   }
 
   async findByOwnerAndExternalId(
@@ -86,23 +82,21 @@ export class PostgresDaemonRepository implements DaemonRepository {
   }
 
   async update(id: string, patch: DaemonPatch): Promise<Daemon> {
-    const clause = buildPatchClause<DaemonPatch>(patch, {
-      device_name: "device_name",
-      token_hash: "token_hash",
-      last_seen_at: "last_seen_at",
-      revoked_at: "revoked_at",
+    return updateRowById<DaemonRow, DaemonPatch, Daemon>({
+      pool: this.pool,
+      table: "daemon",
+      id,
+      patch,
+      columns: {
+        device_name: "device_name",
+        token_hash: "token_hash",
+        last_seen_at: "last_seen_at",
+        revoked_at: "revoked_at",
+      },
+      map: rowToDaemon,
+      notFound: (id) => `daemon ${id} not found`,
+      touchUpdatedAt: false,
     });
-    if (clause.fields.length === 0) {
-      const found = await this.findById(id);
-      if (!found) throw new Error(`daemon ${id} not found`);
-      return found;
-    }
-    const { rows } = await this.pool.query<DaemonRow>(
-      `UPDATE daemon SET ${clause.fields.join(", ")} WHERE id = $${clause.nextIndex} RETURNING *`,
-      [...clause.values, id],
-    );
-    if (!rows[0]) throw new Error(`daemon ${id} not found`);
-    return rowToDaemon(rows[0]);
   }
 
   async touchLastSeen(id: string): Promise<void> {

--- a/packages/core/src/adapters/postgres/escalation-repo.ts
+++ b/packages/core/src/adapters/postgres/escalation-repo.ts
@@ -9,7 +9,7 @@ import type {
   EscalationRepository,
   NewEscalation,
 } from "../../ports/escalation-repo.js";
-import { buildPatchClause } from "./pg-helpers.js";
+import { findRowById, updateRowById } from "./pg-helpers.js";
 import type { Pool } from "./client.js";
 import type { EscalationRow } from "./row-types.js";
 
@@ -17,11 +17,7 @@ export class PostgresEscalationRepository implements EscalationRepository {
   constructor(private pool: Pool) {}
 
   async findById(id: string): Promise<Escalation | undefined> {
-    const { rows } = await this.pool.query<EscalationRow>(
-      `SELECT * FROM escalation WHERE id = $1 LIMIT 1`,
-      [id],
-    );
-    return rows[0] ? rowToEscalation(rows[0]) : undefined;
+    return findRowById(this.pool, "escalation", id, rowToEscalation);
   }
 
   async findByNegotiation(negotiationId: string): Promise<Escalation | undefined> {
@@ -92,34 +88,27 @@ export class PostgresEscalationRepository implements EscalationRepository {
       }),
     };
 
-    const clause = buildPatchClause<EscalationPatch>(stringified, {
-      counterparty_proposals: "counterparty_proposals",
-      counterparty_open_questions: "counterparty_open_questions",
-      counterparty_submitted_at: "counterparty_submitted_at",
-      initiator_proposals: "initiator_proposals",
-      initiator_open_questions: "initiator_open_questions",
-      initiator_submitted_at: "initiator_submitted_at",
-      status: "status",
-      resolution_proposal: "resolution_proposal",
-      resolution_notes: "resolution_notes",
-      resolved_by: "resolved_by",
-      resolved_at: "resolved_at",
+    return updateRowById<EscalationRow, EscalationPatch, Escalation>({
+      pool: this.pool,
+      table: "escalation",
+      id,
+      patch: stringified,
+      columns: {
+        counterparty_proposals: "counterparty_proposals",
+        counterparty_open_questions: "counterparty_open_questions",
+        counterparty_submitted_at: "counterparty_submitted_at",
+        initiator_proposals: "initiator_proposals",
+        initiator_open_questions: "initiator_open_questions",
+        initiator_submitted_at: "initiator_submitted_at",
+        status: "status",
+        resolution_proposal: "resolution_proposal",
+        resolution_notes: "resolution_notes",
+        resolved_by: "resolved_by",
+        resolved_at: "resolved_at",
+      },
+      map: rowToEscalation,
+      notFound: (id) => `Escalation not found: ${id}`,
     });
-
-    if (clause.fields.length === 0) {
-      const existing = await this.findById(id);
-      if (!existing) throw new Error(`Escalation not found: ${id}`);
-      return existing;
-    }
-
-    clause.fields.push(`updated_at = NOW()`);
-
-    const { rows } = await this.pool.query<EscalationRow>(
-      `UPDATE escalation SET ${clause.fields.join(", ")} WHERE id = $${clause.nextIndex} RETURNING *`,
-      [...clause.values, id],
-    );
-    if (!rows[0]) throw new Error(`Escalation not found: ${id}`);
-    return rowToEscalation(rows[0]);
   }
 }
 

--- a/packages/core/src/adapters/postgres/negotiation-repo.ts
+++ b/packages/core/src/adapters/postgres/negotiation-repo.ts
@@ -11,7 +11,7 @@ import type {
   NewNegotiation,
   NewNegotiationRound,
 } from "../../ports/negotiation-repo.js";
-import { buildPatchClause } from "./pg-helpers.js";
+import { findRowById, updateRowById } from "./pg-helpers.js";
 import type { Pool } from "./client.js";
 import type { NegotiationRoundRow, NegotiationRow } from "./row-types.js";
 
@@ -19,11 +19,7 @@ export class PostgresNegotiationRepository implements NegotiationRepository {
   constructor(private pool: Pool) {}
 
   async findById(id: string): Promise<Negotiation | undefined> {
-    const { rows } = await this.pool.query<NegotiationRow>(
-      `SELECT * FROM negotiation WHERE id = $1 LIMIT 1`,
-      [id],
-    );
-    return rows[0] ? rowToNegotiation(rows[0]) : undefined;
+    return findRowById(this.pool, "negotiation", id, rowToNegotiation);
   }
 
   async findActiveBetween(
@@ -68,26 +64,19 @@ export class PostgresNegotiationRepository implements NegotiationRepository {
   }
 
   async update(id: string, patch: NegotiationPatch): Promise<Negotiation> {
-    const clause = buildPatchClause<NegotiationPatch>(patch, {
-      status: "status",
-      counterparty_session_id: "counterparty_session_id",
-      rounds_completed: "rounds_completed",
+    return updateRowById<NegotiationRow, NegotiationPatch, Negotiation>({
+      pool: this.pool,
+      table: "negotiation",
+      id,
+      patch,
+      columns: {
+        status: "status",
+        counterparty_session_id: "counterparty_session_id",
+        rounds_completed: "rounds_completed",
+      },
+      map: rowToNegotiation,
+      notFound: (id) => `Negotiation not found: ${id}`,
     });
-
-    if (clause.fields.length === 0) {
-      const existing = await this.findById(id);
-      if (!existing) throw new Error(`Negotiation not found: ${id}`);
-      return existing;
-    }
-
-    clause.fields.push(`updated_at = NOW()`);
-
-    const { rows } = await this.pool.query<NegotiationRow>(
-      `UPDATE negotiation SET ${clause.fields.join(", ")} WHERE id = $${clause.nextIndex} RETURNING *`,
-      [...clause.values, id],
-    );
-    if (!rows[0]) throw new Error(`Negotiation not found: ${id}`);
-    return rowToNegotiation(rows[0]);
   }
 }
 

--- a/packages/core/src/adapters/postgres/person-repo.ts
+++ b/packages/core/src/adapters/postgres/person-repo.ts
@@ -1,18 +1,14 @@
 import type { Person } from "../../domain/person.js";
 import type { PersonRepository, NewPerson, PersonPatch } from "../../ports/person-repo.js";
 import type { Pool } from "./client.js";
-import { buildPatchClause } from "./pg-helpers.js";
+import { findRowById, updateRowById } from "./pg-helpers.js";
 import type { PersonRow } from "./row-types.js";
 
 export class PostgresPersonRepository implements PersonRepository {
   constructor(private pool: Pool) {}
 
   async findById(id: string): Promise<Person | undefined> {
-    const { rows } = await this.pool.query<PersonRow>(
-      `SELECT * FROM person WHERE id = $1 LIMIT 1`,
-      [id],
-    );
-    return rows[0] ? rowToPerson(rows[0]) : undefined;
+    return findRowById(this.pool, "person", id, rowToPerson);
   }
 
   async findByEmail(email: string): Promise<Person | undefined> {
@@ -57,29 +53,22 @@ export class PostgresPersonRepository implements PersonRepository {
   }
 
   async update(id: string, patch: PersonPatch): Promise<Person> {
-    const clause = buildPatchClause<PersonPatch>(patch, {
-      name: "name",
-      email: "email",
-      api_key: "api_key",
-      password_hash: "password_hash",
-      onboarding_completed_at: "onboarding_completed_at",
-      capability_network_enabled: "capability_network_enabled",
+    return updateRowById<PersonRow, PersonPatch, Person>({
+      pool: this.pool,
+      table: "person",
+      id,
+      patch,
+      columns: {
+        name: "name",
+        email: "email",
+        api_key: "api_key",
+        password_hash: "password_hash",
+        onboarding_completed_at: "onboarding_completed_at",
+        capability_network_enabled: "capability_network_enabled",
+      },
+      map: rowToPerson,
+      notFound: (id) => `Person not found: ${id}`,
     });
-
-    if (clause.fields.length === 0) {
-      const existing = await this.findById(id);
-      if (!existing) throw new Error(`Person not found: ${id}`);
-      return existing;
-    }
-
-    clause.fields.push(`updated_at = NOW()`);
-
-    const { rows } = await this.pool.query<PersonRow>(
-      `UPDATE person SET ${clause.fields.join(", ")} WHERE id = $${clause.nextIndex} RETURNING *`,
-      [...clause.values, id],
-    );
-    if (!rows[0]) throw new Error(`Person not found: ${id}`);
-    return rowToPerson(rows[0]);
   }
 
   async delete(id: string): Promise<void> {

--- a/packages/core/src/adapters/postgres/pg-helpers.test.ts
+++ b/packages/core/src/adapters/postgres/pg-helpers.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import type { Pool } from "./client.js";
+import { buildPatchClause, findRowById, updateRowById } from "./pg-helpers.js";
+
+interface WidgetRow {
+  id: string;
+  name: string;
+  size: number | null;
+}
+
+interface Widget {
+  id: string;
+  name: string;
+  size?: number;
+}
+
+interface WidgetPatch {
+  name?: string;
+  size?: number | null;
+}
+
+const rowToWidget = (row: WidgetRow): Widget => ({
+  id: row.id,
+  name: row.name,
+  size: row.size ?? undefined,
+});
+
+interface Call {
+  sql: string;
+  params: unknown[];
+}
+
+/**
+ * Minimal `Pool` stand-in: records every query and replays a canned rows
+ * array per call. These helpers are pure SQL construction, so a real
+ * Postgres would only slow the assertions down.
+ */
+function fakePool(responses: WidgetRow[][]) {
+  const calls: Call[] = [];
+  const pool = {
+    query: (sql: string, params: unknown[]) => {
+      calls.push({ sql, params });
+      return Promise.resolve({ rows: responses[calls.length - 1] ?? [] });
+    },
+  } as unknown as Pool;
+  return { pool, calls };
+}
+
+const widgetRow: WidgetRow = { id: "w_1", name: "Sprocket", size: 3 };
+
+const COLUMNS = { name: "name", size: "size" } as const;
+
+describe("findRowById", () => {
+  it("selects by id and maps the row", async () => {
+    const { pool, calls } = fakePool([[widgetRow]]);
+    const got = await findRowById(pool, "widget", "w_1", rowToWidget);
+    expect(got).toEqual({ id: "w_1", name: "Sprocket", size: 3 });
+    expect(calls[0]!.sql).toBe("SELECT * FROM widget WHERE id = $1 LIMIT 1");
+    expect(calls[0]!.params).toEqual(["w_1"]);
+  });
+
+  it("returns undefined rather than mapping a missing row", async () => {
+    const { pool } = fakePool([[]]);
+    expect(await findRowById(pool, "widget", "nope", rowToWidget)).toBeUndefined();
+  });
+});
+
+describe("updateRowById", () => {
+  it("sets only the keys present in the patch", async () => {
+    const { pool, calls } = fakePool([[{ ...widgetRow, name: "Cog" }]]);
+    const got = await updateRowById<WidgetRow, WidgetPatch, Widget>({
+      pool,
+      table: "widget",
+      id: "w_1",
+      patch: { name: "Cog" },
+      columns: COLUMNS,
+      map: rowToWidget,
+      notFound: (id) => `Widget not found: ${id}`,
+    });
+    expect(got.name).toBe("Cog");
+    expect(calls[0]!.sql).toBe(
+      "UPDATE widget SET name = $1, updated_at = NOW() WHERE id = $2 RETURNING *",
+    );
+    expect(calls[0]!.params).toEqual(["Cog", "w_1"]);
+  });
+
+  it("writes an explicit null but skips an undefined", async () => {
+    const { pool, calls } = fakePool([[{ ...widgetRow, size: null }]]);
+    await updateRowById<WidgetRow, WidgetPatch, Widget>({
+      pool,
+      table: "widget",
+      id: "w_1",
+      patch: { name: undefined, size: null },
+      columns: COLUMNS,
+      map: rowToWidget,
+      notFound: (id) => `Widget not found: ${id}`,
+    });
+    expect(calls[0]!.sql).toContain("SET size = $1");
+    expect(calls[0]!.sql).not.toContain("name =");
+    expect(calls[0]!.params).toEqual([null, "w_1"]);
+  });
+
+  it("omits updated_at for tables that don't carry the column", async () => {
+    const { pool, calls } = fakePool([[widgetRow]]);
+    await updateRowById<WidgetRow, WidgetPatch, Widget>({
+      pool,
+      table: "widget",
+      id: "w_1",
+      patch: { name: "Cog" },
+      columns: COLUMNS,
+      map: rowToWidget,
+      notFound: (id) => `Widget not found: ${id}`,
+      touchUpdatedAt: false,
+    });
+    expect(calls[0]!.sql).not.toContain("updated_at");
+  });
+
+  // An all-undefined patch would build `UPDATE widget SET  WHERE …`. The
+  // helper degrades to a read instead of emitting that.
+  it("degrades an empty patch to a read", async () => {
+    const { pool, calls } = fakePool([[widgetRow]]);
+    const got = await updateRowById<WidgetRow, WidgetPatch, Widget>({
+      pool,
+      table: "widget",
+      id: "w_1",
+      patch: {},
+      columns: COLUMNS,
+      map: rowToWidget,
+      notFound: (id) => `Widget not found: ${id}`,
+    });
+    expect(got).toEqual({ id: "w_1", name: "Sprocket", size: 3 });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.sql).toContain("SELECT");
+  });
+
+  it("throws on an empty patch for a row that doesn't exist", async () => {
+    const { pool } = fakePool([[]]);
+    await expect(
+      updateRowById<WidgetRow, WidgetPatch, Widget>({
+        pool,
+        table: "widget",
+        id: "gone",
+        patch: {},
+        columns: COLUMNS,
+        map: rowToWidget,
+        notFound: (id) => `Widget not found: ${id}`,
+      }),
+    ).rejects.toThrow("Widget not found: gone");
+  });
+
+  it("throws when the UPDATE matches no row", async () => {
+    const { pool } = fakePool([[]]);
+    await expect(
+      updateRowById<WidgetRow, WidgetPatch, Widget>({
+        pool,
+        table: "widget",
+        id: "gone",
+        patch: { name: "Cog" },
+        columns: COLUMNS,
+        map: rowToWidget,
+        notFound: (id) => `Widget not found: ${id}`,
+      }),
+    ).rejects.toThrow("Widget not found: gone");
+  });
+});
+
+describe("buildPatchClause", () => {
+  it("numbers placeholders in column-map order and reports the next index", () => {
+    const clause = buildPatchClause<WidgetPatch>({ size: 5, name: "Cog" }, COLUMNS);
+    expect(clause.fields).toEqual(["name = $1", "size = $2"]);
+    expect(clause.values).toEqual(["Cog", 5]);
+    expect(clause.nextIndex).toBe(3);
+  });
+
+  it("ignores patch keys with no column mapping", () => {
+    const clause = buildPatchClause<WidgetPatch & { bogus?: string }>(
+      { name: "Cog", bogus: "x" },
+      COLUMNS,
+    );
+    expect(clause.fields).toEqual(["name = $1"]);
+  });
+});

--- a/packages/core/src/adapters/postgres/pg-helpers.ts
+++ b/packages/core/src/adapters/postgres/pg-helpers.ts
@@ -1,3 +1,5 @@
+import type { Pool, QueryResultRow } from "./client.js";
+
 export interface PatchClause {
   /** `"col = $N"` fragments for the SET clause */
   fields: string[];
@@ -21,6 +23,10 @@ export interface PatchClause {
  *   [...clause.values, id],
  * );
  * ```
+ *
+ * Most repositories don't call this directly — `updateRowById` wraps the
+ * whole sequence above. Reach for `buildPatchClause` when the UPDATE needs
+ * something extra (a compound WHERE, a non-`id` key, an extra SET fragment).
  */
 export function buildPatchClause<T extends object>(
   patch: Partial<T>,
@@ -37,6 +43,74 @@ export function buildPatchClause<T extends object>(
     }
   }
   return { fields, values, nextIndex: i };
+}
+
+/**
+ * Fetch a single row by primary key and map it into its domain type, or
+ * `undefined` when there is no such row. Every repository's `findById` is
+ * this query; `table` is always a literal from this package, never caller
+ * input, so interpolating it is safe.
+ */
+export async function findRowById<Row extends QueryResultRow, T>(
+  pool: Pool,
+  table: string,
+  id: string,
+  map: (row: Row) => T,
+): Promise<T | undefined> {
+  const { rows } = await pool.query<Row>(
+    `SELECT * FROM ${table} WHERE id = $1 LIMIT 1`,
+    [id],
+  );
+  return rows[0] ? map(rows[0]) : undefined;
+}
+
+export interface UpdateRowOptions<Row extends QueryResultRow, Patch extends object, T> {
+  pool: Pool;
+  /** Table name — a literal from this package, interpolated into the SQL. */
+  table: string;
+  id: string;
+  patch: Patch;
+  /** Patch key → column name, as taken by `buildPatchClause`. */
+  columns: Partial<Record<keyof Patch, string>>;
+  map: (row: Row) => T;
+  /**
+   * Message for the "row doesn't exist" Error. Per-table because the
+   * existing wording is not uniform (`Agent not found: x` vs
+   * `daemon x not found`) and tests assert on it.
+   */
+  notFound: (id: string) => string;
+  /** Append `updated_at = NOW()` to the SET clause. Default true. */
+  touchUpdatedAt?: boolean;
+}
+
+/**
+ * Partial-update a row by primary key and return the updated domain object.
+ *
+ * An all-`undefined` patch produces no SET fragments; rather than emit
+ * invalid SQL, that case degrades to a read — which still throws if the row
+ * is gone, so `update` never silently reports success for a missing id.
+ */
+export async function updateRowById<Row extends QueryResultRow, Patch extends object, T>(
+  opts: UpdateRowOptions<Row, Patch, T>,
+): Promise<T> {
+  const clause = buildPatchClause<Patch>(opts.patch, opts.columns);
+
+  if (clause.fields.length === 0) {
+    const existing = await findRowById<Row, T>(opts.pool, opts.table, opts.id, opts.map);
+    if (!existing) throw new Error(opts.notFound(opts.id));
+    return existing;
+  }
+
+  if (opts.touchUpdatedAt !== false) {
+    clause.fields.push(`updated_at = NOW()`);
+  }
+
+  const { rows } = await opts.pool.query<Row>(
+    `UPDATE ${opts.table} SET ${clause.fields.join(", ")} WHERE id = $${clause.nextIndex} RETURNING *`,
+    [...clause.values, opts.id],
+  );
+  if (!rows[0]) throw new Error(opts.notFound(opts.id));
+  return opts.map(rows[0]);
 }
 
 /**

--- a/packages/core/src/adapters/postgres/promotion-event-repo.ts
+++ b/packages/core/src/adapters/postgres/promotion-event-repo.ts
@@ -4,6 +4,7 @@ import type {
   NewMemoryPromotionEvent,
 } from "../../ports/promotion-event-repo.js";
 import type { Pool } from "./client.js";
+import { findRowById } from "./pg-helpers.js";
 
 interface PromotionEventRow {
   id: string;
@@ -75,10 +76,6 @@ export class PostgresMemoryPromotionEventRepository
   }
 
   async findById(id: string): Promise<MemoryPromotionEvent | undefined> {
-    const { rows } = await this.pool.query<PromotionEventRow>(
-      `SELECT * FROM memory_promotion_event WHERE id = $1 LIMIT 1`,
-      [id],
-    );
-    return rows[0] ? rowToEvent(rows[0]) : undefined;
+    return findRowById(this.pool, "memory_promotion_event", id, rowToEvent);
   }
 }

--- a/packages/core/src/adapters/postgres/repo-run-repo.ts
+++ b/packages/core/src/adapters/postgres/repo-run-repo.ts
@@ -20,6 +20,7 @@ import type {
   SkillOutcomeStats,
 } from "../../ports/repo-run-repo.js";
 import type { Pool } from "./client.js";
+import { findRowById } from "./pg-helpers.js";
 
 interface RepoRunRow {
   id: string;
@@ -97,11 +98,7 @@ export class PostgresRepoRunRepository implements RepoRunRepository {
   }
 
   async findById(id: string): Promise<RepoRun | undefined> {
-    const { rows } = await this.pool.query<RepoRunRow>(
-      `SELECT * FROM repo_run WHERE id = $1 LIMIT 1`,
-      [id],
-    );
-    return rows[0] ? rowToRepoRun(rows[0]) : undefined;
+    return findRowById(this.pool, "repo_run", id, rowToRepoRun);
   }
 
   async findBySessionId(sessionId: string): Promise<RepoRun | undefined> {
@@ -202,11 +199,7 @@ export class PostgresLearnedSkillRepository implements LearnedSkillRepository {
   }
 
   async findById(id: string): Promise<LearnedSkill | undefined> {
-    const { rows } = await this.pool.query<LearnedSkillRow>(
-      `SELECT * FROM learned_skill WHERE id = $1 LIMIT 1`,
-      [id],
-    );
-    return rows[0] ? rowToLearnedSkill(rows[0]) : undefined;
+    return findRowById(this.pool, "learned_skill", id, rowToLearnedSkill);
   }
 
   async findByOwnerAndName(

--- a/packages/core/src/adapters/postgres/runtime-repo.ts
+++ b/packages/core/src/adapters/postgres/runtime-repo.ts
@@ -4,7 +4,7 @@ import type {
   RuntimeRepository,
 } from "../../ports/runtime-repo.js";
 import type { Pool } from "./client.js";
-import { buildPatchClause } from "./pg-helpers.js";
+import { findRowById, updateRowById } from "./pg-helpers.js";
 import type { RuntimeRow } from "./row-types.js";
 
 function rowToRuntime(row: RuntimeRow): Runtime {
@@ -23,11 +23,7 @@ export class PostgresRuntimeRepository implements RuntimeRepository {
   constructor(private pool: Pool) {}
 
   async findById(id: string): Promise<Runtime | undefined> {
-    const { rows } = await this.pool.query<RuntimeRow>(
-      `SELECT * FROM runtime WHERE id = $1 LIMIT 1`,
-      [id],
-    );
-    return rows[0] ? rowToRuntime(rows[0]) : undefined;
+    return findRowById(this.pool, "runtime", id, rowToRuntime);
   }
 
   async findByDaemonAndCli(
@@ -93,22 +89,20 @@ export class PostgresRuntimeRepository implements RuntimeRepository {
     const normalized: RuntimePatch = patch.capabilities
       ? { ...patch, capabilities: JSON.stringify(patch.capabilities) as unknown as Record<string, unknown> }
       : patch;
-    const clause = buildPatchClause<RuntimePatch>(normalized, {
-      cli_version: "cli_version",
-      last_heartbeat: "last_heartbeat",
-      capabilities: "capabilities",
+    return updateRowById<RuntimeRow, RuntimePatch, Runtime>({
+      pool: this.pool,
+      table: "runtime",
+      id,
+      patch: normalized,
+      columns: {
+        cli_version: "cli_version",
+        last_heartbeat: "last_heartbeat",
+        capabilities: "capabilities",
+      },
+      map: rowToRuntime,
+      notFound: (id) => `runtime ${id} not found`,
+      touchUpdatedAt: false,
     });
-    if (clause.fields.length === 0) {
-      const found = await this.findById(id);
-      if (!found) throw new Error(`runtime ${id} not found`);
-      return found;
-    }
-    const { rows } = await this.pool.query<RuntimeRow>(
-      `UPDATE runtime SET ${clause.fields.join(", ")} WHERE id = $${clause.nextIndex} RETURNING *`,
-      [...clause.values, id],
-    );
-    if (!rows[0]) throw new Error(`runtime ${id} not found`);
-    return rowToRuntime(rows[0]);
   }
 
   async heartbeat(id: string): Promise<void> {

--- a/packages/core/src/adapters/postgres/session-repo.ts
+++ b/packages/core/src/adapters/postgres/session-repo.ts
@@ -12,18 +12,14 @@ import type {
   SessionPatch,
 } from "../../ports/session-repo.js";
 import type { Pool } from "./client.js";
-import { buildPatchClause, taskPriorityRankSql } from "./pg-helpers.js";
+import { findRowById, taskPriorityRankSql, updateRowById } from "./pg-helpers.js";
 import type { SessionRow } from "./row-types.js";
 
 export class PostgresSessionRepository implements SessionRepository {
   constructor(private pool: Pool) {}
 
   async findById(id: string): Promise<Session | undefined> {
-    const { rows } = await this.pool.query<SessionRow>(
-      `SELECT * FROM session WHERE id = $1 LIMIT 1`,
-      [id],
-    );
-    return rows[0] ? rowToSession(rows[0]) : undefined;
+    return findRowById(this.pool, "session", id, rowToSession);
   }
 
   async findLatestForTask(taskId: string): Promise<Session | undefined> {
@@ -346,38 +342,34 @@ export class PostgresSessionRepository implements SessionRepository {
   }
 
   async update(id: string, patch: SessionPatch): Promise<Session> {
-    const clause = buildPatchClause<SessionPatch>(patch, {
-      prior_session_id: "prior_session_id",
-      status: "status",
-      intent: "intent",
-      cli_session_id: "cli_session_id",
-      workspace_path: "workspace_path",
-      process_pid: "process_pid",
-      process_group_id: "process_group_id",
-      result_summary: "result_summary",
-      exit_code: "exit_code",
-      error: "error",
-      usage: "usage",
-      briefing: "briefing",
-      runtime_id: "runtime_id",
-      spawn_mode: "spawn_mode",
-      last_event_at: "last_event_at",
-      started_at: "started_at",
-      completed_at: "completed_at",
+    return updateRowById<SessionRow, SessionPatch, Session>({
+      pool: this.pool,
+      table: "session",
+      id,
+      patch,
+      columns: {
+        prior_session_id: "prior_session_id",
+        status: "status",
+        intent: "intent",
+        cli_session_id: "cli_session_id",
+        workspace_path: "workspace_path",
+        process_pid: "process_pid",
+        process_group_id: "process_group_id",
+        result_summary: "result_summary",
+        exit_code: "exit_code",
+        error: "error",
+        usage: "usage",
+        briefing: "briefing",
+        runtime_id: "runtime_id",
+        spawn_mode: "spawn_mode",
+        last_event_at: "last_event_at",
+        started_at: "started_at",
+        completed_at: "completed_at",
+      },
+      map: rowToSession,
+      notFound: (id) => `Session not found: ${id}`,
+      touchUpdatedAt: false,
     });
-
-    if (clause.fields.length === 0) {
-      const existing = await this.findById(id);
-      if (!existing) throw new Error(`Session not found: ${id}`);
-      return existing;
-    }
-
-    const { rows } = await this.pool.query<SessionRow>(
-      `UPDATE session SET ${clause.fields.join(", ")} WHERE id = $${clause.nextIndex} RETURNING *`,
-      [...clause.values, id],
-    );
-    if (!rows[0]) throw new Error(`Session not found: ${id}`);
-    return rowToSession(rows[0]);
   }
 }
 

--- a/packages/core/src/adapters/postgres/task-repo.ts
+++ b/packages/core/src/adapters/postgres/task-repo.ts
@@ -11,18 +11,14 @@ import type {
   TaskListFilter,
 } from "../../ports/task-repo.js";
 import type { Pool } from "./client.js";
-import { buildPatchClause, taskPriorityRankSql } from "./pg-helpers.js";
+import { findRowById, taskPriorityRankSql, updateRowById } from "./pg-helpers.js";
 import type { TaskRow } from "./row-types.js";
 
 export class PostgresTaskRepository implements TaskRepository {
   constructor(private pool: Pool) {}
 
   async findById(id: string): Promise<Task | undefined> {
-    const { rows } = await this.pool.query<TaskRow>(
-      `SELECT * FROM task WHERE id = $1 LIMIT 1`,
-      [id],
-    );
-    return rows[0] ? rowToTask(rows[0]) : undefined;
+    return findRowById(this.pool, "task", id, rowToTask);
   }
 
   async findByIds(ids: string[]): Promise<Task[]> {
@@ -186,36 +182,29 @@ export class PostgresTaskRepository implements TaskRepository {
   }
 
   async update(id: string, patch: TaskPatch): Promise<Task> {
-    const clause = buildPatchClause<TaskPatch>(patch, {
-      title: "title",
-      description: "description",
-      status: "status",
-      priority: "priority",
-      assignee_id: "assignee_id",
-      creator_id: "creator_id",
-      creator_type: "creator_type",
-      parent_task_id: "parent_task_id",
-      result_summary: "result_summary",
-      blocker_agent_id: "blocker_agent_id",
-      blocker_reason: "blocker_reason",
-      repo_url: "repo_url",
-      next_dispatch_context: "next_dispatch_context",
+    return updateRowById<TaskRow, TaskPatch, Task>({
+      pool: this.pool,
+      table: "task",
+      id,
+      patch,
+      columns: {
+        title: "title",
+        description: "description",
+        status: "status",
+        priority: "priority",
+        assignee_id: "assignee_id",
+        creator_id: "creator_id",
+        creator_type: "creator_type",
+        parent_task_id: "parent_task_id",
+        result_summary: "result_summary",
+        blocker_agent_id: "blocker_agent_id",
+        blocker_reason: "blocker_reason",
+        repo_url: "repo_url",
+        next_dispatch_context: "next_dispatch_context",
+      },
+      map: rowToTask,
+      notFound: (id) => `Task not found: ${id}`,
     });
-
-    if (clause.fields.length === 0) {
-      const existing = await this.findById(id);
-      if (!existing) throw new Error(`Task not found: ${id}`);
-      return existing;
-    }
-
-    clause.fields.push(`updated_at = NOW()`);
-
-    const { rows } = await this.pool.query<TaskRow>(
-      `UPDATE task SET ${clause.fields.join(", ")} WHERE id = $${clause.nextIndex} RETURNING *`,
-      [...clause.values, id],
-    );
-    if (!rows[0]) throw new Error(`Task not found: ${id}`);
-    return rowToTask(rows[0]);
   }
 
   async updateProgress(id: string, status: TaskStatus, summary: string): Promise<Task> {

--- a/packages/core/src/adapters/postgres/task-watch-repo.ts
+++ b/packages/core/src/adapters/postgres/task-watch-repo.ts
@@ -8,17 +8,14 @@ import type {
   TaskWatchRepository,
 } from "../../ports/task-watch-repo.js";
 import type { Pool } from "./client.js";
+import { findRowById } from "./pg-helpers.js";
 import type { TaskWatchRow } from "./row-types.js";
 
 export class PostgresTaskWatchRepository implements TaskWatchRepository {
   constructor(private pool: Pool) {}
 
   async findById(id: string): Promise<TaskWatch | undefined> {
-    const { rows } = await this.pool.query<TaskWatchRow>(
-      `SELECT * FROM task_watch WHERE id = $1 LIMIT 1`,
-      [id],
-    );
-    return rows[0] ? rowToTaskWatch(rows[0]) : undefined;
+    return findRowById(this.pool, "task_watch", id, rowToTaskWatch);
   }
 
   async listByWaiterSession(waiterSessionId: string): Promise<TaskWatch[]> {

--- a/packages/core/src/adapters/postgres/work-product-repo.ts
+++ b/packages/core/src/adapters/postgres/work-product-repo.ts
@@ -9,6 +9,7 @@ import type {
   WorkProductPatch,
 } from "../../ports/work-product-repo.js";
 import type { Pool } from "./client.js";
+import { findRowById } from "./pg-helpers.js";
 import type { WorkProductListRow, WorkProductRow } from "./row-types.js";
 
 // List queries skip the (potentially huge) body and surface its byte size via
@@ -22,11 +23,7 @@ export class PostgresWorkProductRepository implements WorkProductRepository {
   constructor(private pool: Pool) {}
 
   async findById(id: string): Promise<WorkProduct | undefined> {
-    const { rows } = await this.pool.query<WorkProductRow>(
-      `SELECT * FROM work_product WHERE id = $1 LIMIT 1`,
-      [id],
-    );
-    return rows[0] ? rowToWorkProduct(rows[0]) : undefined;
+    return findRowById(this.pool, "work_product", id, rowToWorkProduct);
   }
 
   async listByTask(taskId: string): Promise<WorkProductListItem[]> {

--- a/packages/core/src/composition.test.ts
+++ b/packages/core/src/composition.test.ts
@@ -1,0 +1,94 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createMemoryStack,
+  createWorkspaceStack,
+  resolveSkillsSourceDir,
+} from "./composition.js";
+import type { CoreMemoryBlockRepository } from "./ports/core-memory-repo.js";
+import type { MemoryFactRepository } from "./ports/memory-fact-repo.js";
+
+// The stacks construct real adapters, and the two provider SDKs read their
+// key from the environment when the config omits one. Supplying keys keeps
+// these tests independent of whether the sandbox has any.
+const KEYS = { openaiApiKey: "sk-openai-test", anthropicApiKey: "sk-anthropic-test" };
+
+const repos = {
+  coreMemoryRepo: {} as CoreMemoryBlockRepository,
+  memoryFactRepo: {} as MemoryFactRepository,
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("resolveSkillsSourceDir", () => {
+  it("prefers an explicit directory", () => {
+    expect(resolveSkillsSourceDir("/srv/skills")).toBe("/srv/skills");
+  });
+
+  it("falls back to <cwd>/skills", () => {
+    vi.spyOn(process, "cwd").mockReturnValue("/srv/app");
+    expect(resolveSkillsSourceDir()).toBe(path.resolve("/srv/app", "skills"));
+  });
+
+  // An empty string is a real failure mode here — a stray `BEEVIBE_SKILLS_DIR=`
+  // line in .env reaches this as "". `??` accepts it, which is the existing
+  // behavior both bootstraps had; pinning it means a change to `||` is a
+  // deliberate edit rather than a silent one.
+  it("treats an empty string as configured, matching the previous inline default", () => {
+    expect(resolveSkillsSourceDir("")).toBe("");
+  });
+});
+
+describe("createMemoryStack", () => {
+  it("hands back every service the bootstraps destructure", () => {
+    const stack = createMemoryStack({ ...repos, ...KEYS });
+    expect(stack.embed).toBeDefined();
+    expect(stack.llm).toBeDefined();
+    expect(stack.coreMemory).toBeDefined();
+    expect(stack.factStore).toBeDefined();
+    expect(stack.promoter).toBeDefined();
+    expect(typeof stack.makeMemoryAgent).toBe("function");
+  });
+
+  // The factory has to close over the stack's own services rather than
+  // rebuild them per agent: SessionCache calls it once per evicted session.
+  it("builds a distinct MemoryAgent per id from one shared stack", () => {
+    const stack = createMemoryStack({ ...repos, ...KEYS });
+    const a = stack.makeMemoryAgent("agent_1");
+    const b = stack.makeMemoryAgent("agent_2");
+    expect(a).not.toBe(b);
+    expect(typeof a.prepareBriefing).toBe("function");
+  });
+});
+
+describe("createWorkspaceStack", () => {
+  const cfg = { mcpServerUrl: "https://api.example.com/mcp", workspaceRoot: "/srv/workspaces" };
+
+  it("registers the three CLI runtimes", () => {
+    const { runtimeRegistry } = createWorkspaceStack(cfg);
+    expect(Object.keys(runtimeRegistry).sort()).toEqual(["claude", "codex", "opencode"]);
+  });
+
+  // The two facts the call sites can no longer get wrong, asserted from the
+  // manager's own config: it holds the very registry that was returned
+  // alongside it (it can't be built before one exists — it looks up each
+  // agent's runtime per call), and its skills dir went through the shared
+  // default rather than being left undefined.
+  it("wires the returned registry and a defaulted skills dir into the manager", () => {
+    vi.spyOn(process, "cwd").mockReturnValue("/srv/app");
+    const { runtimeRegistry, workspaceManager } = createWorkspaceStack(cfg);
+    const { config } = workspaceManager as unknown as {
+      config: { runtimeRegistry: unknown; skillsSourceDir: string };
+    };
+    expect(config.runtimeRegistry).toBe(runtimeRegistry);
+    expect(config.skillsSourceDir).toBe(path.resolve("/srv/app", "skills"));
+  });
+
+  it("rejects a relative workspace root at construction time", () => {
+    expect(() => createWorkspaceStack({ ...cfg, workspaceRoot: "relative/path" })).toThrow(
+      /must be absolute/,
+    );
+  });
+});

--- a/packages/core/src/composition.ts
+++ b/packages/core/src/composition.ts
@@ -1,0 +1,119 @@
+/**
+ * Composition-root scaffolding shared by the `api` and `scheduler`
+ * bootstraps.
+ *
+ * Both processes assemble the same two stacks from the same config fields
+ * before they diverge into their own wiring: the memory pipeline (embedding
+ * service → LLM → CoreMemory / FactStore / FactPromoter → per-agent
+ * `MemoryAgent` factory) and the workspace pair (runtime registry →
+ * `LocalWorkspaceManager`). The `scheduler` bootstrap's own doc comment
+ * already said as much — "the MCP server will do the same wiring in its own
+ * bootstrap" — but the wiring itself stayed duplicated, in a different order
+ * in each file, with the same defaulting expression written out three times.
+ *
+ * As with `process-lifecycle.ts`, this takes only the parts that were
+ * identical. Each bootstrap keeps its own repositories, its own services and
+ * its own start order.
+ */
+
+import path from "node:path";
+import { LocalWorkspaceManager } from "./adapters/local-workspace/index.js";
+import { OpenAIEmbeddingService } from "./adapters/openai/index.js";
+import { AnthropicLlmProvider } from "./adapters/anthropic/index.js";
+import { createDefaultRuntimeRegistry } from "./adapters/runtime-registry.js";
+import {
+  CoreMemory,
+  FactPromoter,
+  FactStore,
+  createMemoryAgent,
+  type MemoryAgent,
+} from "./services/memory/index.js";
+import type { CoreMemoryBlockRepository } from "./ports/core-memory-repo.js";
+import type { MemoryFactRepository } from "./ports/memory-fact-repo.js";
+import type { RuntimeRegistry } from "./ports/runtime.js";
+
+/**
+ * Resolve the canonical skills directory a bootstrap tier-syncs from.
+ *
+ * The `?? path.resolve(process.cwd(), "skills")` fallback was written out at
+ * three call sites (api twice, scheduler once) — meaning a change to where
+ * skills live had three edits and could half-land, with the runtime router
+ * reading one directory and the workspace manager another in the same
+ * process.
+ */
+export function resolveSkillsSourceDir(configured?: string): string {
+  return configured ?? path.resolve(process.cwd(), "skills");
+}
+
+export interface MemoryStackConfig {
+  coreMemoryRepo: CoreMemoryBlockRepository;
+  memoryFactRepo: MemoryFactRepository;
+  openaiApiKey: string;
+  anthropicApiKey: string;
+}
+
+export interface MemoryStack {
+  embed: OpenAIEmbeddingService;
+  llm: AnthropicLlmProvider;
+  coreMemory: CoreMemory;
+  factStore: FactStore;
+  promoter: FactPromoter;
+  /**
+   * Per-agent `MemoryAgent` factory, closed over the shared services above.
+   * Both processes hand this to anything that needs to brief an agent or
+   * promote its facts when a session ends.
+   */
+  makeMemoryAgent: (agentId: string) => MemoryAgent;
+}
+
+/** Embeddings + LLM + the three memory services + the per-agent factory. */
+export function createMemoryStack(cfg: MemoryStackConfig): MemoryStack {
+  const embed = new OpenAIEmbeddingService({ apiKey: cfg.openaiApiKey });
+  const llm = new AnthropicLlmProvider({ apiKey: cfg.anthropicApiKey });
+
+  const coreMemory = new CoreMemory({ repo: cfg.coreMemoryRepo });
+  const factStore = new FactStore({ repo: cfg.memoryFactRepo, embed, llm });
+  const promoter = new FactPromoter({ llm });
+
+  return {
+    embed,
+    llm,
+    coreMemory,
+    factStore,
+    promoter,
+    makeMemoryAgent: (agentId: string): MemoryAgent =>
+      createMemoryAgent({ agentId, coreMemory, factStore, promoter, embed }),
+  };
+}
+
+export interface WorkspaceStackConfig {
+  /** Defaults to `~/.beevibe/workspaces` inside LocalWorkspaceManager. */
+  workspaceRoot?: string;
+  mcpServerUrl: string;
+  /** Passed through {@link resolveSkillsSourceDir}. */
+  skillsSourceDir?: string;
+}
+
+export interface WorkspaceStack {
+  runtimeRegistry: RuntimeRegistry;
+  workspaceManager: LocalWorkspaceManager;
+}
+
+/**
+ * Runtime registry + workspace manager, in that order — the manager needs
+ * the registry to resolve each agent's skills discovery dir per call, so
+ * the two can't be constructed independently.
+ *
+ * Adding a runtime stays one line in `createDefaultRuntimeRegistry`, which
+ * every composition root now reaches through here.
+ */
+export function createWorkspaceStack(cfg: WorkspaceStackConfig): WorkspaceStack {
+  const runtimeRegistry = createDefaultRuntimeRegistry();
+  const workspaceManager = new LocalWorkspaceManager({
+    workspaceRoot: cfg.workspaceRoot,
+    mcpServerUrl: cfg.mcpServerUrl,
+    runtimeRegistry,
+    skillsSourceDir: resolveSkillsSourceDir(cfg.skillsSourceDir),
+  });
+  return { runtimeRegistry, workspaceManager };
+}

--- a/packages/scheduler/src/bootstrap.ts
+++ b/packages/scheduler/src/bootstrap.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import {
   PostgresAgentRepository,
@@ -10,16 +9,7 @@ import {
   PostgresWorkProductRepository,
   createPool,
 } from "@beevibe/core/adapters/postgres";
-import { LocalWorkspaceManager } from "@beevibe/core/adapters/local-workspace";
-import { OpenAIEmbeddingService } from "@beevibe/core/adapters/openai";
-import { AnthropicLlmProvider } from "@beevibe/core/adapters/anthropic";
-import { createDefaultRuntimeRegistry } from "@beevibe/core/adapters/runtime-registry";
-import {
-  CoreMemory,
-  FactPromoter,
-  FactStore,
-  createMemoryAgent,
-} from "@beevibe/core/services/memory";
+import { createMemoryStack, createWorkspaceStack } from "@beevibe/core/composition";
 import { TaskService } from "@beevibe/core/services/task-service";
 import { DispatchService } from "@beevibe/core/services/dispatch-service";
 import { CancelListener } from "./cancel-listener.js";
@@ -83,29 +73,15 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
   const coreMemoryRepo = new PostgresCoreMemoryRepository(pool);
   const memoryFactRepo = new PostgresMemoryFactRepository(pool);
 
-  // External-service adapters
-  const embed = new OpenAIEmbeddingService({ apiKey: cfg.openaiApiKey });
-  const llm = new AnthropicLlmProvider({ apiKey: cfg.anthropicApiKey });
-
-  // Workspace + runtime (shared with M6 via the factory).
-  // M9.3: workspaceManager needs the runtime registry to look up the agent's
-  // declared runtime per-call and resolve its skills discovery dir; construct
-  // registry first so we can pass it in.
-  const runtimeRegistry = createDefaultRuntimeRegistry();
-  const workspaceManager = new LocalWorkspaceManager({
-    workspaceRoot: cfg.workspaceRoot,
-    mcpServerUrl: cfg.mcpServerUrl,
-    runtimeRegistry,
-    skillsSourceDir: cfg.skillsSourceDir ?? path.resolve(process.cwd(), "skills"),
+  // Workspace + runtime, and the memory pipeline — both shared with the
+  // api composition root.
+  const { runtimeRegistry, workspaceManager } = createWorkspaceStack(cfg);
+  const { makeMemoryAgent } = createMemoryStack({
+    coreMemoryRepo,
+    memoryFactRepo,
+    openaiApiKey: cfg.openaiApiKey,
+    anthropicApiKey: cfg.anthropicApiKey,
   });
-
-  // Memory services
-  const coreMemory = new CoreMemory({ repo: coreMemoryRepo });
-  const factStore = new FactStore({ repo: memoryFactRepo, embed, llm });
-  const promoter = new FactPromoter({ llm });
-
-  const makeMemoryAgent = (agentId: string) =>
-    createMemoryAgent({ agentId, coreMemory, factStore, promoter, embed });
 
   const taskService = new TaskService({
     taskRepo,

--- a/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
+++ b/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
@@ -4,10 +4,9 @@ import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, AlertTriangle, Bot, Archive } from "lucide-react";
+import { ArrowLeft, Bot, Archive } from "lucide-react";
 import { useAgent } from "@/lib/hooks/use-agents";
 import { useIsOwner, useMe } from "@/lib/hooks/use-me";
-import { isApiConfigured } from "@/lib/api/config";
 import { formatReviewPolicy } from "@/lib/format";
 import { api } from "@/lib/api/client";
 import { queryKeys } from "@/lib/hooks/keys";
@@ -20,10 +19,9 @@ import { RecentChatThreadRow } from "@/components/agents/recent-chat-thread-row"
 import { RuntimePicker } from "@/components/agents/pickers/runtime-picker";
 import { ModelPicker } from "@/components/agents/pickers/model-picker";
 import { ReviewPolicyPicker } from "@/components/agents/pickers/review-policy-picker";
-import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
-import { DetailShell } from "@/components/detail/detail-shell";
+import { DetailGate } from "@/components/detail/detail-gate";
 import { FooterField } from "@/components/detail/footer-field";
 import { Metric } from "@/components/detail/metric";
 import { cn } from "@/lib/utils";
@@ -40,48 +38,31 @@ const AgentsBackLink = () => (
 );
 
 export function AgentDetailClient({ agentId }: { agentId: string }) {
-  const { data, isLoading, isError } = useAgent(agentId);
+  const query = useAgent(agentId);
 
-  if (!isApiConfigured) {
-    return (
-      <DetailShell nav={<AgentsBackLink />}>
-        <EmptyState
-          icon={Bot}
-          title="API not configured"
-          description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load this agent."
-        />
-      </DetailShell>
-    );
-  }
-
-  if (isLoading) {
-    return (
-      <DetailShell nav={<AgentsBackLink />}>
-        <Skeleton className="h-14 w-full mb-6" />
-        <div className="grid grid-cols-3 gap-6">
-          <div className="col-span-2 space-y-4">
-            <Skeleton className="h-32 w-full rounded-lg" />
+  return (
+    <DetailGate
+      nav={<AgentsBackLink />}
+      icon={Bot}
+      noun="agent"
+      id={agentId}
+      query={query}
+      skeleton={
+        <>
+          <Skeleton className="h-14 w-full mb-6" />
+          <div className="grid grid-cols-3 gap-6">
+            <div className="col-span-2 space-y-4">
+              <Skeleton className="h-32 w-full rounded-lg" />
+              <Skeleton className="h-40 w-full rounded-lg" />
+            </div>
             <Skeleton className="h-40 w-full rounded-lg" />
           </div>
-          <Skeleton className="h-40 w-full rounded-lg" />
-        </div>
-      </DetailShell>
-    );
-  }
-
-  if (isError || !data) {
-    return (
-      <DetailShell nav={<AgentsBackLink />}>
-        <EmptyState
-          icon={AlertTriangle}
-          title="Couldn't load agent"
-          description={`Agent ${agentId} could not be fetched.`}
-        />
-      </DetailShell>
-    );
-  }
-
-  return <AgentDetailLoaded agent={data} />;
+        </>
+      }
+    >
+      {(data) => <AgentDetailLoaded agent={data} />}
+    </DetailGate>
+  );
 }
 
 function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
@@ -117,7 +98,7 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
   const showAside = isOwner === true || agent.outgoing_mesh_hints.length > 0;
 
   return (
-    <DetailShell nav={<AgentsBackLink />}>
+    <>
       <header className="mb-6">
         <div className="flex items-start gap-4">
           <Avatar
@@ -314,6 +295,6 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
           </FooterField>
         ) : null}
       </footer>
-    </DetailShell>
+    </>
   );
 }

--- a/packages/web/app/(authed)/escalations/[id]/escalation-detail-client.tsx
+++ b/packages/web/app/(authed)/escalations/[id]/escalation-detail-client.tsx
@@ -2,16 +2,14 @@
 
 import Link from "next/link";
 import { useState, type ReactNode } from "react";
-import { AlertTriangle, Info, Scale } from "lucide-react";
+import { Info, Scale } from "lucide-react";
 import { MeshBackLink } from "@/components/detail/mesh-back-link";
 import { useEscalation } from "@/lib/hooks/use-escalations";
 import { useResolveEscalation } from "@/lib/hooks/use-escalation-mutations";
-import { isApiConfigured } from "@/lib/api/config";
 import { ChatMarkdown } from "@/components/chat/markdown";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
-import { DetailShell } from "@/components/detail/detail-shell";
+import { DetailGate } from "@/components/detail/detail-gate";
 import { FooterField } from "@/components/detail/footer-field";
-import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
 import { EscalationStatusPill } from "@/components/detail/status-pill";
 import { MutationError } from "@/components/mutation-error";
@@ -36,46 +34,29 @@ interface SideView {
 }
 
 export function EscalationDetailClient({ escalationId }: { escalationId: string }) {
-  const { data, isLoading, isError } = useEscalation(escalationId);
+  const query = useEscalation(escalationId);
 
-  if (!isApiConfigured) {
-    return (
-      <DetailShell nav={<MeshBackLink />}>
-        <EmptyState
-          icon={Scale}
-          title="API not configured"
-          description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load this escalation."
-        />
-      </DetailShell>
-    );
-  }
-
-  if (isLoading) {
-    return (
-      <DetailShell nav={<MeshBackLink />}>
-        <Skeleton className="h-7 w-40 mb-4" />
-        <Skeleton className="h-24 w-full rounded-lg mb-6" />
-        <div className="grid grid-cols-2 gap-4">
-          <Skeleton className="h-48 w-full rounded-lg" />
-          <Skeleton className="h-48 w-full rounded-lg" />
-        </div>
-      </DetailShell>
-    );
-  }
-
-  if (isError || !data) {
-    return (
-      <DetailShell nav={<MeshBackLink />}>
-        <EmptyState
-          icon={AlertTriangle}
-          title="Couldn't load escalation"
-          description={`Escalation ${escalationId} could not be fetched. Check the MCP server logs.`}
-        />
-      </DetailShell>
-    );
-  }
-
-  return <EscalationDetailLoaded esc={data.escalation} />;
+  return (
+    <DetailGate
+      nav={<MeshBackLink />}
+      icon={Scale}
+      noun="escalation"
+      id={escalationId}
+      query={query}
+      skeleton={
+        <>
+          <Skeleton className="h-7 w-40 mb-4" />
+          <Skeleton className="h-24 w-full rounded-lg mb-6" />
+          <div className="grid grid-cols-2 gap-4">
+            <Skeleton className="h-48 w-full rounded-lg" />
+            <Skeleton className="h-48 w-full rounded-lg" />
+          </div>
+        </>
+      }
+    >
+      {(data) => <EscalationDetailLoaded esc={data.escalation} />}
+    </DetailGate>
+  );
 }
 
 function EscalationDetailLoaded({ esc }: { esc: EscalationReviewDetail }) {
@@ -99,7 +80,7 @@ function EscalationDetailLoaded({ esc }: { esc: EscalationReviewDetail }) {
   };
 
   return (
-    <DetailShell nav={<MeshBackLink />}>
+    <>
       <header className="mb-6">
         <div className="flex items-start justify-between gap-6 mb-3">
           <div className="min-w-0">
@@ -144,7 +125,7 @@ function EscalationDetailLoaded({ esc }: { esc: EscalationReviewDetail }) {
           <FooterField label="Resolved">{formatRelativeTime(esc.resolved_at)}</FooterField>
         ) : null}
       </footer>
-    </DetailShell>
+    </>
   );
 }
 

--- a/packages/web/app/(authed)/negotiations/[id]/negotiation-detail-client.tsx
+++ b/packages/web/app/(authed)/negotiations/[id]/negotiation-detail-client.tsx
@@ -1,16 +1,14 @@
 "use client";
 
 import Link from "next/link";
-import { AlertTriangle, MessagesSquare, Scale } from "lucide-react";
+import { MessagesSquare, Scale } from "lucide-react";
 import { MeshBackLink } from "@/components/detail/mesh-back-link";
 import { useNegotiation } from "@/lib/hooks/use-negotiations";
-import { isApiConfigured } from "@/lib/api/config";
 import { ChatMarkdown } from "@/components/chat/markdown";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
-import { DetailShell } from "@/components/detail/detail-shell";
+import { DetailGate } from "@/components/detail/detail-gate";
 import { FooterField } from "@/components/detail/footer-field";
 import { NegotiationStatusPill } from "@/components/detail/status-pill";
-import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
 import { formatRelativeTime } from "@/lib/format";
 import type {
@@ -20,46 +18,29 @@ import type {
 } from "@/lib/types/negotiations";
 
 export function NegotiationDetailClient({ negotiationId }: { negotiationId: string }) {
-  const { data, isLoading, isError } = useNegotiation(negotiationId);
+  const query = useNegotiation(negotiationId);
 
-  if (!isApiConfigured) {
-    return (
-      <DetailShell nav={<MeshBackLink />}>
-        <EmptyState
-          icon={MessagesSquare}
-          title="API not configured"
-          description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load this negotiation."
-        />
-      </DetailShell>
-    );
-  }
-
-  if (isLoading) {
-    return (
-      <DetailShell nav={<MeshBackLink />}>
-        <Skeleton className="h-7 w-40 mb-4" />
-        <Skeleton className="h-24 w-full rounded-lg mb-6" />
-        <div className="space-y-3">
-          <Skeleton className="h-32 w-full rounded-lg" />
-          <Skeleton className="h-32 w-full rounded-lg" />
-        </div>
-      </DetailShell>
-    );
-  }
-
-  if (isError || !data) {
-    return (
-      <DetailShell nav={<MeshBackLink />}>
-        <EmptyState
-          icon={AlertTriangle}
-          title="Couldn't load negotiation"
-          description={`Negotiation ${negotiationId} could not be fetched. Check the MCP server logs.`}
-        />
-      </DetailShell>
-    );
-  }
-
-  return <NegotiationDetailLoaded neg={data.negotiation} />;
+  return (
+    <DetailGate
+      nav={<MeshBackLink />}
+      icon={MessagesSquare}
+      noun="negotiation"
+      id={negotiationId}
+      query={query}
+      skeleton={
+        <>
+          <Skeleton className="h-7 w-40 mb-4" />
+          <Skeleton className="h-24 w-full rounded-lg mb-6" />
+          <div className="space-y-3">
+            <Skeleton className="h-32 w-full rounded-lg" />
+            <Skeleton className="h-32 w-full rounded-lg" />
+          </div>
+        </>
+      }
+    >
+      {(data) => <NegotiationDetailLoaded neg={data.negotiation} />}
+    </DetailGate>
+  );
 }
 
 const DECISION_BADGE: Record<NegotiationDecision, string> = {
@@ -88,7 +69,7 @@ function NegotiationDetailLoaded({ neg }: { neg: NegotiationReviewDetail }) {
         : id;
 
   return (
-    <DetailShell nav={<MeshBackLink />}>
+    <>
       <header className="mb-6">
         <div className="flex items-start justify-between gap-6 mb-3">
           <div className="min-w-0">
@@ -161,7 +142,7 @@ function NegotiationDetailLoaded({ neg }: { neg: NegotiationReviewDetail }) {
           <FooterField label="Updated">{formatRelativeTime(neg.updated_at)}</FooterField>
         ) : null}
       </footer>
-    </DetailShell>
+    </>
   );
 }
 

--- a/packages/web/app/(authed)/sessions/[sid]/chat-session-detail-client.tsx
+++ b/packages/web/app/(authed)/sessions/[sid]/chat-session-detail-client.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import { AlertTriangle, ArrowLeft, ChevronRight, Terminal, Wrench } from "lucide-react";
+import { ArrowLeft, ChevronRight, Terminal, Wrench } from "lucide-react";
 import { useConversation } from "@/lib/hooks/use-sessions";
-import { isApiConfigured } from "@/lib/api/config";
-import { DetailShell } from "@/components/detail/detail-shell";
+import { DetailGate } from "@/components/detail/detail-gate";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
 import { SessionStatusPill } from "@/components/detail/status-pill";
@@ -33,66 +32,41 @@ import { cn } from "@/lib/utils";
  * `/tasks/[id]/sessions/[sid]`, so we redirect those out.
  */
 export function ChatSessionDetailClient({ sessionShortId }: { sessionShortId: string }) {
-  const { data, isLoading, isError } = useConversation(sessionShortId);
-
-  const nav = <BackToChat />;
-
-  if (!isApiConfigured) {
-    return (
-      <DetailShell nav={nav}>
-        <EmptyState
-          icon={Terminal}
-          title="API not configured"
-          description="Set NEXT_PUBLIC_BV_API_URL and run the API server to load this session."
-        />
-      </DetailShell>
-    );
-  }
-
-  if (isLoading) {
-    return (
-      <DetailShell nav={nav}>
-        <Skeleton className="h-14 w-full mb-6" />
-        <Skeleton className="h-32 w-full mb-5 rounded-lg" />
-        <Skeleton className="h-64 w-full rounded-lg" />
-      </DetailShell>
-    );
-  }
-
-  if (isError || !data) {
-    return (
-      <DetailShell nav={nav}>
-        <EmptyState
-          icon={AlertTriangle}
-          title="Couldn't load session"
-          description={`Session ${sessionShortId} could not be fetched.`}
-        />
-      </DetailShell>
-    );
-  }
-
-  // Task-typed sessions belong on the task-scoped detail page; redirect via a
-  // visible link rather than auto-routing so the user keeps control.
-  if (data.type === "task" && data.task_id) {
-    return (
-      <DetailShell nav={nav}>
-        <EmptyState
-          icon={Terminal}
-          title="This is a task session"
-          description="Open the task-scoped session view for full context."
-          cta={{
-            href: `/tasks/${data.task_id}/sessions/${data.short_id}`,
-            label: "Open task session",
-          }}
-        />
-      </DetailShell>
-    );
-  }
+  const query = useConversation(sessionShortId);
 
   return (
-    <DetailShell nav={nav}>
-      <ConversationBody conversation={data} />
-    </DetailShell>
+    <DetailGate
+      nav={<BackToChat />}
+      icon={Terminal}
+      noun="session"
+      id={sessionShortId}
+      query={query}
+      skeleton={
+        <>
+          <Skeleton className="h-14 w-full mb-6" />
+          <Skeleton className="h-32 w-full mb-5 rounded-lg" />
+          <Skeleton className="h-64 w-full rounded-lg" />
+        </>
+      }
+    >
+      {(conversation) =>
+        // Task-typed sessions belong on the task-scoped detail page; redirect
+        // via a visible link rather than auto-routing so the user keeps control.
+        conversation.type === "task" && conversation.task_id ? (
+          <EmptyState
+            icon={Terminal}
+            title="This is a task session"
+            description="Open the task-scoped session view for full context."
+            cta={{
+              href: `/tasks/${conversation.task_id}/sessions/${conversation.short_id}`,
+              label: "Open task session",
+            }}
+          />
+        ) : (
+          <ConversationBody conversation={conversation} />
+        )
+      }
+    </DetailGate>
   );
 }
 

--- a/packages/web/app/(authed)/tasks/[id]/sessions/[sid]/session-detail-client.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/sessions/[sid]/session-detail-client.tsx
@@ -1,18 +1,16 @@
 "use client";
 
 import Link from "next/link";
-import { AlertTriangle, ChevronRight, Terminal } from "lucide-react";
+import { ChevronRight, Terminal } from "lucide-react";
 import { useSession } from "@/lib/hooks/use-sessions";
-import { isApiConfigured } from "@/lib/api/config";
 import { Avatar } from "@/components/avatar";
 import { HierChip } from "@/components/hier-chip";
 import { SessionStatusPill } from "@/components/detail/status-pill";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
-import { DetailShell } from "@/components/detail/detail-shell";
+import { DetailGate } from "@/components/detail/detail-gate";
 import { FooterField } from "@/components/detail/footer-field";
 import { BriefingComposer } from "@/components/sessions/briefing-composer";
 import { Transcript } from "@/components/sessions/transcript";
-import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
 import { formatIntent, shortId } from "@/lib/format";
 import type { SessionDisplay } from "@/lib/types/sessions";
@@ -23,50 +21,31 @@ interface Props {
 }
 
 export function SessionDetailClient({ taskId, sessionShortId }: Props) {
-  const { data, isLoading, isError } = useSession(sessionShortId);
-
-  const nav = (
-    <Breadcrumbs taskId={taskId} taskTitle={data?.task_title ?? null} sessionShortId={sessionShortId} />
-  );
-
-  if (!isApiConfigured) {
-    return (
-      <DetailShell nav={nav}>
-        <EmptyState
-          icon={Terminal}
-          title="API not configured"
-          description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load this session."
-        />
-      </DetailShell>
-    );
-  }
-
-  if (isLoading) {
-    return (
-      <DetailShell nav={nav}>
-        <Skeleton className="h-14 w-full mb-6" />
-        <Skeleton className="h-32 w-full mb-5 rounded-lg" />
-        <Skeleton className="h-64 w-full rounded-lg" />
-      </DetailShell>
-    );
-  }
-
-  if (isError || !data) {
-    return (
-      <DetailShell nav={nav}>
-        <EmptyState
-          icon={AlertTriangle}
-          title="Couldn't load session"
-          description={`Session ${sessionShortId} could not be fetched.`}
-        />
-      </DetailShell>
-    );
-  }
+  const query = useSession(sessionShortId);
 
   return (
-    <DetailShell nav={nav}>
-      <SessionDetailBody session={data} taskId={taskId} />
-    </DetailShell>
+    <DetailGate
+      nav={
+        <Breadcrumbs
+          taskId={taskId}
+          taskTitle={query.data?.task_title ?? null}
+          sessionShortId={sessionShortId}
+        />
+      }
+      icon={Terminal}
+      noun="session"
+      id={sessionShortId}
+      query={query}
+      skeleton={
+        <>
+          <Skeleton className="h-14 w-full mb-6" />
+          <Skeleton className="h-32 w-full mb-5 rounded-lg" />
+          <Skeleton className="h-64 w-full rounded-lg" />
+        </>
+      }
+    >
+      {(session) => <SessionDetailBody session={session} taskId={taskId} />}
+    </DetailGate>
   );
 }
 

--- a/packages/web/app/(authed)/tasks/[id]/task-detail-client.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/task-detail-client.tsx
@@ -21,14 +21,12 @@ import {
 } from "@/lib/hooks/use-task-mutations";
 import { TaskLifecycleActions } from "@/components/tasks/task-lifecycle-actions";
 import { isTerminalTaskStatus } from "@/lib/task-status";
-import { isApiConfigured } from "@/lib/api/config";
 import { TaskStatusPill, SessionStatusPill } from "@/components/detail/status-pill";
 import { ChatMarkdown } from "@/components/chat/markdown";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
-import { DetailShell } from "@/components/detail/detail-shell";
+import { DetailGate } from "@/components/detail/detail-gate";
 import { FooterField } from "@/components/detail/footer-field";
 import { HierChip } from "@/components/hier-chip";
-import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
 import { richTextToMarkdown } from "@/components/rich-text";
 import { formatRelativeTime, shortId } from "@/lib/format";
@@ -48,49 +46,32 @@ const TasksBackLink = () => (
 );
 
 export function TaskDetailClient({ taskId }: { taskId: string }) {
-  const { data, isLoading, isError } = useTask(taskId);
+  const query = useTask(taskId);
 
-  if (!isApiConfigured) {
-    return (
-      <DetailShell nav={<TasksBackLink />}>
-        <EmptyState
-          icon={ListChecks}
-          title="API not configured"
-          description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load this task."
-        />
-      </DetailShell>
-    );
-  }
-
-  if (isLoading) {
-    return (
-      <DetailShell nav={<TasksBackLink />}>
-        <Skeleton className="h-8 w-2/3 mb-2" />
-        <Skeleton className="h-4 w-1/3 mb-6" />
-        <div className="grid grid-cols-3 gap-6">
-          <div className="col-span-2 space-y-4">
-            <Skeleton className="h-32 w-full rounded-lg" />
-            <Skeleton className="h-24 w-full rounded-lg" />
+  return (
+    <DetailGate
+      nav={<TasksBackLink />}
+      icon={ListChecks}
+      noun="task"
+      id={taskId}
+      query={query}
+      skeleton={
+        <>
+          <Skeleton className="h-8 w-2/3 mb-2" />
+          <Skeleton className="h-4 w-1/3 mb-6" />
+          <div className="grid grid-cols-3 gap-6">
+            <div className="col-span-2 space-y-4">
+              <Skeleton className="h-32 w-full rounded-lg" />
+              <Skeleton className="h-24 w-full rounded-lg" />
+            </div>
+            <Skeleton className="h-40 w-full rounded-lg" />
           </div>
-          <Skeleton className="h-40 w-full rounded-lg" />
-        </div>
-      </DetailShell>
-    );
-  }
-
-  if (isError || !data) {
-    return (
-      <DetailShell nav={<TasksBackLink />}>
-        <EmptyState
-          icon={AlertTriangle}
-          title="Couldn't load task"
-          description={`Task ${taskId} could not be fetched. Check the MCP server logs.`}
-        />
-      </DetailShell>
-    );
-  }
-
-  return <TaskDetailLoaded task={data} />;
+        </>
+      }
+    >
+      {(data) => <TaskDetailLoaded task={data} />}
+    </DetailGate>
+  );
 }
 
 type ReviewMutation = "approve" | "reject" | "revise";
@@ -137,7 +118,7 @@ function TaskDetailLoaded({ task }: { task: TaskDetail }) {
   };
 
   return (
-    <DetailShell nav={<TasksBackLink />}>
+    <>
       <header className="mb-6">
         <div className="flex items-start justify-between gap-6 mb-2">
           <h1 className="text-base font-semibold tracking-tight leading-tight flex-1 min-w-0">{task.title}</h1>
@@ -336,7 +317,7 @@ function TaskDetailLoaded({ task }: { task: TaskDetail }) {
           </FooterField>
         ) : null}
       </footer>
-    </DetailShell>
+    </>
   );
 }
 

--- a/packages/web/app/(authed)/work-products/[id]/work-product-detail-client.tsx
+++ b/packages/web/app/(authed)/work-products/[id]/work-product-detail-client.tsx
@@ -3,7 +3,6 @@
 import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
 import {
-  AlertTriangle,
   ArrowLeft,
   ChevronRight,
   ExternalLink,
@@ -12,7 +11,7 @@ import {
 import { api, type WorkProductDetail } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
 import { queryKeys } from "@/lib/hooks/keys";
-import { DetailShell } from "@/components/detail/detail-shell";
+import { DetailGate } from "@/components/detail/detail-gate";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
 import { ChatMarkdown } from "@/components/chat/markdown";
@@ -21,51 +20,36 @@ import { FooterField } from "@/components/detail/footer-field";
 import { formatRelativeTime, shortId } from "@/lib/format";
 
 export function WorkProductDetailClient({ workProductId }: { workProductId: string }) {
-  const { data, isLoading, isError } = useQuery<WorkProductDetail>({
+  const query = useQuery<WorkProductDetail>({
     queryKey: queryKeys.workProducts.detail(workProductId),
     queryFn: ({ signal }) => api.workProducts.get(workProductId, { signal }),
     enabled: isApiConfigured && !!workProductId,
     staleTime: 30_000,
   });
 
-  if (!isApiConfigured) {
-    return (
-      <DetailShell>
-        <EmptyState
-          icon={FileText}
-          title="API not configured"
-          description="Set NEXT_PUBLIC_BV_API_URL and run the api server to load this work product."
-        />
-      </DetailShell>
-    );
-  }
-
-  if (isLoading) {
-    return (
-      <DetailShell>
-        <Skeleton className="h-14 w-full mb-6" />
-        <Skeleton className="h-64 w-full rounded-lg" />
-      </DetailShell>
-    );
-  }
-
-  if (isError || !data) {
-    return (
-      <DetailShell>
-        <EmptyState
-          icon={AlertTriangle}
-          title="Couldn't load work product"
-          description={`Work product ${workProductId} could not be fetched.`}
-        />
-      </DetailShell>
-    );
-  }
-
-  return <Body wp={data} />;
+  return (
+    <DetailGate
+      // The breadcrumb names the parent task, so it can only be drawn once
+      // the row is in hand — the pre-data states render without one.
+      nav={query.data ? <Breadcrumbs wp={query.data} /> : undefined}
+      icon={FileText}
+      noun="work product"
+      id={workProductId}
+      query={query}
+      skeleton={
+        <>
+          <Skeleton className="h-14 w-full mb-6" />
+          <Skeleton className="h-64 w-full rounded-lg" />
+        </>
+      }
+    >
+      {(wp) => <Body wp={wp} />}
+    </DetailGate>
+  );
 }
 
-function Body({ wp }: { wp: WorkProductDetail }) {
-  const breadcrumbs = (
+function Breadcrumbs({ wp }: { wp: WorkProductDetail }) {
+  return (
     <nav className="flex items-center gap-1.5 text-xs text-muted-foreground mb-4" aria-label="Breadcrumb">
       <Link href="/tasks" className="hover:text-foreground transition-colors">
         Tasks
@@ -81,7 +65,9 @@ function Body({ wp }: { wp: WorkProductDetail }) {
       <span className="text-foreground/80 truncate max-w-[14rem]">{wp.title}</span>
     </nav>
   );
+}
 
+function Body({ wp }: { wp: WorkProductDetail }) {
   // Body precedence: inlined file content > free-form summary. The
   // server tries to read file:// URLs from disk and inline them as
   // `body`; if that worked, prefer it. Otherwise fall back to summary
@@ -90,7 +76,7 @@ function Body({ wp }: { wp: WorkProductDetail }) {
   const renderable = wp.body ?? wp.summary ?? "";
 
   return (
-    <DetailShell nav={breadcrumbs}>
+    <>
       <header className="mb-5">
         <div className="flex items-center gap-2 mb-2">
           <Link
@@ -158,6 +144,6 @@ function Body({ wp }: { wp: WorkProductDetail }) {
         ) : null}
         {wp.provider ? <FooterField label="Provider">{wp.provider}</FooterField> : null}
       </footer>
-    </DetailShell>
+    </>
   );
 }

--- a/packages/web/app/sign-in/sign-in-client.tsx
+++ b/packages/web/app/sign-in/sign-in-client.tsx
@@ -6,7 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { AlertTriangle, KeyRound, Loader2, LogIn } from "lucide-react";
 import { SIGNIN_NO_PASSWORD_SET } from "@beevibe/core/auth/constants";
 import { api } from "@/lib/api/client";
-import { ApiError } from "@/lib/api/http";
+import { asApiError } from "@/lib/api/http";
 import {
   getUserKey,
   isApiConfigured,
@@ -65,21 +65,19 @@ export function SignInClient() {
       setUserKey(res.api_key);
       router.replace(next);
     } catch (err) {
-      const status = err instanceof ApiError ? err.status : undefined;
-      const body =
-        err instanceof ApiError ? (err.body as { error?: string; message?: string } | undefined) : undefined;
+      const apiErr = asApiError(err);
       // Friendly fallback for legacy users whose accounts predate
       // passwords — push them to the paste-key path.
-      if (status === 409 && body?.error === SIGNIN_NO_PASSWORD_SET) {
+      if (apiErr?.status === 409 && apiErr.errorCode === SIGNIN_NO_PASSWORD_SET) {
         setMode("key");
         setError(
-          body.message ??
+          apiErr.serverMessage ??
             "This account predates passwords — sign in with your bv_u_ key once, then re-sign-up to set a password.",
         );
-      } else if (status === 401) {
+      } else if (apiErr?.status === 401) {
         setError("Email or password is incorrect.");
       } else {
-        setError(body?.message ?? `Couldn't sign you in — ${(err as Error).message}`);
+        setError(apiErr?.serverMessage ?? `Couldn't sign you in — ${(err as Error).message}`);
       }
     } finally {
       setSubmitting(false);
@@ -105,9 +103,8 @@ export function SignInClient() {
       router.replace(next);
     } catch (err) {
       window.localStorage.removeItem("bv:user_key");
-      const status = err instanceof ApiError ? err.status : undefined;
       setError(
-        status === 401
+        asApiError(err)?.status === 401
           ? "Key wasn't recognized. Double-check it or ask your admin to provision a new one."
           : `Couldn't verify the key — ${(err as Error).message}`,
       );

--- a/packages/web/app/sign-up/sign-up-client.tsx
+++ b/packages/web/app/sign-up/sign-up-client.tsx
@@ -6,7 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { AlertTriangle, Loader2, Sparkles, UserPlus } from "lucide-react";
 import { PASSWORD_MIN_LENGTH } from "@beevibe/core/auth/constants";
 import { api } from "@/lib/api/client";
-import { ApiError } from "@/lib/api/http";
+import { asApiError } from "@/lib/api/http";
 import { getUserKey, isApiConfigured, setUserKey } from "@/lib/api/config";
 
 /**
@@ -76,12 +76,11 @@ export function SignUpClient() {
       // case `/welcome` does the right thing via /me's needs_onboarding.
       router.replace(res.existed ? "/" : "/welcome");
     } catch (err) {
-      const status = err instanceof ApiError ? err.status : undefined;
-      const body = err instanceof ApiError ? (err.body as { message?: string } | undefined) : undefined;
+      const apiErr = asApiError(err);
       setError(
-        status === 404
+        apiErr?.status === 404
           ? "Sign-up isn't enabled on this server. Ask the admin to provision a key for you."
-          : body?.message ?? `Couldn't sign you up — ${(err as Error).message}`,
+          : apiErr?.serverMessage ?? `Couldn't sign you up — ${(err as Error).message}`,
       );
     } finally {
       setSubmitting(false);

--- a/packages/web/components/detail/detail-gate.test.tsx
+++ b/packages/web/components/detail/detail-gate.test.tsx
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const apiState = { isApiConfigured: true };
+
+vi.mock("@/lib/api/config", () => ({
+  get isApiConfigured() {
+    return apiState.isApiConfigured;
+  },
+}));
+
+import { DetailGate } from "./detail-gate";
+
+interface Row {
+  name: string;
+}
+
+function renderGate(
+  query: { data: Row | undefined; isLoading: boolean; isError: boolean },
+  nav?: React.ReactNode,
+) {
+  return render(
+    <DetailGate
+      nav={nav}
+      noun="work product"
+      id="wp_42"
+      query={query}
+      skeleton={<div data-testid="skeleton" />}
+    >
+      {(row) => <div data-testid="body">{row.name}</div>}
+    </DetailGate>,
+  );
+}
+
+const loaded = { data: { name: "Design doc" }, isLoading: false, isError: false };
+
+describe("DetailGate", () => {
+  beforeEach(() => {
+    apiState.isApiConfigured = true;
+  });
+
+  it("renders the body once the row is in hand", () => {
+    renderGate(loaded);
+    expect(screen.getByTestId("body")).toHaveTextContent("Design doc");
+    expect(screen.queryByTestId("skeleton")).toBeNull();
+  });
+
+  it("renders the skeleton while loading, never the body", () => {
+    renderGate({ data: undefined, isLoading: true, isError: false });
+    expect(screen.getByTestId("skeleton")).toBeInTheDocument();
+    expect(screen.queryByTestId("body")).toBeNull();
+  });
+
+  it("reports an unconfigured API before it reports a failed fetch", () => {
+    apiState.isApiConfigured = false;
+    renderGate({ data: undefined, isLoading: false, isError: true });
+    expect(screen.getByText("API not configured")).toBeInTheDocument();
+    expect(screen.queryByText(/Couldn't load/)).toBeNull();
+  });
+
+  it("derives both messages from the noun", () => {
+    apiState.isApiConfigured = false;
+    renderGate({ data: undefined, isLoading: false, isError: false });
+    expect(
+      screen.getByText(/run the API server to load this work product\./),
+    ).toBeInTheDocument();
+  });
+
+  it("echoes the id in the fetch-error message", () => {
+    renderGate({ data: undefined, isLoading: false, isError: true });
+    expect(screen.getByText("Couldn't load work product")).toBeInTheDocument();
+    expect(screen.getByText(/Work product wp_42 could not be fetched\./)).toBeInTheDocument();
+  });
+
+  // A query can settle without erroring and still hand back nothing (a 404
+  // mapped to undefined). That has to land on the error state, not render
+  // the body with a missing row.
+  it("treats settled-but-empty as a failed fetch", () => {
+    renderGate({ data: undefined, isLoading: false, isError: false });
+    expect(screen.getByText("Couldn't load work product")).toBeInTheDocument();
+    expect(screen.queryByTestId("body")).toBeNull();
+  });
+
+  // The nav is what gets the user off a page that failed to load, so it has
+  // to survive every branch — not just the happy one.
+  it("keeps the nav in the loading and error states", () => {
+    const nav = <a href="/tasks">Back</a>;
+    renderGate({ data: undefined, isLoading: true, isError: false }, nav).unmount();
+    renderGate({ data: undefined, isLoading: false, isError: true }, nav);
+    expect(screen.getByText("Back")).toBeInTheDocument();
+  });
+});

--- a/packages/web/components/detail/detail-gate.tsx
+++ b/packages/web/components/detail/detail-gate.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { AlertTriangle, type LucideIcon } from "lucide-react";
+import { isApiConfigured } from "@/lib/api/config";
+import { DetailShell } from "./detail-shell";
+import { EmptyState } from "@/components/empty-state";
+
+interface Props<T> {
+  /**
+   * Breadcrumb or back-link, rendered above the body in every state so the
+   * user can navigate away from a page that failed to load. Pages whose
+   * breadcrumb needs the fetched row pass `data ? <Crumbs row={data}/> : undefined`.
+   */
+  nav?: ReactNode;
+  /** Icon for the "API not configured" state. The error state is always AlertTriangle. */
+  icon?: LucideIcon;
+  /** Lowercase singular of what the page shows — "task", "work product". */
+  noun: string;
+  /** Id echoed back in the error message so a failed fetch is identifiable. */
+  id: string;
+  /** The react-query result driving the page. */
+  query: { data: T | undefined; isLoading: boolean; isError: boolean };
+  /**
+   * Loading placeholder. Per-page rather than generic: the skeleton mirrors
+   * the layout it stands in for, so a shared one would jump on hydration.
+   */
+  skeleton: ReactNode;
+  /** Rendered inside the shell once the fetch succeeded. */
+  children: (data: T) => ReactNode;
+}
+
+/**
+ * The three-branch preamble every detail page opens with — API not
+ * configured, still loading, failed to load — plus the `DetailShell` all
+ * four states share.
+ *
+ * Written out by hand on each page before this existed, which is why the
+ * copy had drifted: the same condition variously said "run the API server",
+ * "run the api server" and "run the MCP server" (one process, three names),
+ * and half the pages ended the fetch error with "Check the MCP server logs"
+ * while the other half dropped the hint. Both messages are derived from
+ * `noun` here, so a page can't word them a fourth way.
+ */
+export function DetailGate<T>({ nav, icon, noun, id, query, skeleton, children }: Props<T>) {
+  if (!isApiConfigured) {
+    return (
+      <DetailShell nav={nav}>
+        <EmptyState
+          icon={icon}
+          title="API not configured"
+          description={`Set NEXT_PUBLIC_BV_API_URL and run the API server to load this ${noun}.`}
+        />
+      </DetailShell>
+    );
+  }
+
+  if (query.isLoading) {
+    return <DetailShell nav={nav}>{skeleton}</DetailShell>;
+  }
+
+  if (query.isError || !query.data) {
+    const Noun = noun.charAt(0).toUpperCase() + noun.slice(1);
+    return (
+      <DetailShell nav={nav}>
+        <EmptyState
+          icon={AlertTriangle}
+          title={`Couldn't load ${noun}`}
+          description={`${Noun} ${id} could not be fetched. Check the API server logs.`}
+        />
+      </DetailShell>
+    );
+  }
+
+  return <DetailShell nav={nav}>{children(query.data)}</DetailShell>;
+}

--- a/packages/web/lib/api/http.test.ts
+++ b/packages/web/lib/api/http.test.ts
@@ -6,7 +6,7 @@ vi.mock("./config", () => ({
   getUserKey: () => null,
 }));
 
-import { fetchJson, ApiError } from "./http";
+import { asApiError, fetchJson, ApiError } from "./http";
 
 const fetchMock = vi.fn();
 
@@ -178,5 +178,37 @@ describe("fetchJson with userKey configured", () => {
 
     vi.doUnmock("./config");
     vi.resetModules();
+  });
+});
+
+describe("asApiError", () => {
+  it("returns the error when it came from the api layer", () => {
+    const err = new ApiError("HTTP 409", 409, { error: "no_password_set", message: "set one" });
+    const got = asApiError(err);
+    expect(got).toBe(err);
+    expect(got?.status).toBe(409);
+    expect(got?.errorCode).toBe("no_password_set");
+    expect(got?.serverMessage).toBe("set one");
+  });
+
+  it("returns undefined for a throw from anywhere else", () => {
+    expect(asApiError(new TypeError("fetch failed"))).toBeUndefined();
+    expect(asApiError("a string")).toBeUndefined();
+    expect(asApiError(undefined)).toBeUndefined();
+  });
+
+  // The call sites used to reach into `err.body` behind an `as
+  // { message?: string }` cast, which asserts rather than checks — a
+  // non-string `message` reached setError() as-is. `serverMessage` is
+  // populated only after a typeof check, so it drops instead.
+  it("leaves serverMessage unset when the body's message isn't a string", () => {
+    expect(asApiError(new ApiError("HTTP 500", 500, { message: 42 }))?.serverMessage).toBeUndefined();
+  });
+
+  it("survives a body that isn't an object at all", () => {
+    const got = asApiError(new ApiError("HTTP 502", 502, "<html>bad gateway</html>"));
+    expect(got?.status).toBe(502);
+    expect(got?.serverMessage).toBeUndefined();
+    expect(got?.errorCode).toBeUndefined();
   });
 });

--- a/packages/web/lib/api/http.ts
+++ b/packages/web/lib/api/http.ts
@@ -21,6 +21,21 @@ export class ApiError extends Error {
   }
 }
 
+/**
+ * Narrow a caught `unknown` to an `ApiError`, or `undefined` when the throw
+ * came from somewhere else (a network failure, a bug in our own code).
+ *
+ * The three auth-form handlers each opened their catch block with the same
+ * `err instanceof ApiError ? … : undefined` pair, once for `status` and once
+ * for `body` — and then re-derived from `body` what the constructor above
+ * has already extracted into `errorCode` and `serverMessage`. Going through
+ * this instead means a call site reads the validated fields rather than
+ * casting `unknown`.
+ */
+export function asApiError(err: unknown): ApiError | undefined {
+  return err instanceof ApiError ? err : undefined;
+}
+
 /** Best-effort human-readable message: server message > error.message > raw status. */
 export function describeError(err: unknown): string {
   if (err instanceof ApiError) {


### PR DESCRIPTION
Fourth pass of the near-duplicate sweep (after #259, #263, #266). Token-level
duplication is down to 0.17% across the monorepo, so the clusters left are
structural rather than copy-paste — same shape, different names, which a
clone detector at default thresholds walks straight past.

Four clusters, one commit each. All behavior-preserving except where noted.

---

### 1. `core` — one `findById` and one `update` tail for twelve repositories (`a60e498`)

Every Postgres repository opened with the same four-line `findById` and eight
of them closed with the same `update` tail (`buildPatchClause` → empty-clause
fallback → `updated_at = NOW()` → `UPDATE … RETURNING *` → `if (!rows[0])
throw` → map). Thirteen and eight copies respectively.

`pg-helpers.ts` gains `findRowById` and `updateRowById`. Two things the
copies had diverged on stay per-call-site rather than being invented by the
helper:

- **the not-found message** — five repositories say `Agent not found: x`,
  three say `daemon x not found`, and tests assert on both spellings.
- **`updated_at = NOW()`** — five append it; `daemon`, `runtime` and
  `session` don't. Reads like drift, but isn't verifiable from the
  TypeScript alone, so `touchUpdatedAt: false` preserves each table's
  behavior exactly.

The empty-patch path is the subtle one: an all-`undefined` patch produces no
SET fragments, which would emit `UPDATE t SET  WHERE …`. Every copy degraded
to a read — and still threw when the row was missing, so `update` never
silently reports success for an id that doesn't exist. One implementation
now, with a comment saying why it's a read.

### 2. `web` — one gate for the seven detail pages (`2cf6d03`)

Each detail page opened with the same three-branch preamble before it could
render anything (`!isApiConfigured` → EmptyState, `isLoading` → skeletons,
`isError || !data` → EmptyState), each branch wrapped in its own
`<DetailShell nav={…}>`. Seven copies, ~30 lines apiece.

`components/detail/detail-gate.tsx` takes the nav, icon, a `noun`, the id,
the query result and a skeleton, and hands back a `children(data)` callback
that only runs with a row in hand — so "data is defined here" is the
component's job rather than something each page re-derives.

**This one changes user-visible copy**, deliberately: both messages are now
derived from `noun`, which settles drift the duplication had been hiding. The
same condition variously read "run the API server", "run the api server" and
"run the MCP server" — one process, three names, now "the API server"
everywhere. Four pages ended the fetch error with "Check the MCP server logs"
and three dropped the hint; all seven carry it now, pointed at the API
server. No page loses information.

### 3. `core` — one memory stack and one workspace stack for both bootstraps (`5c20da2`)

`api/src/bootstrap.ts` and `scheduler/src/bootstrap.ts` each assembled the
same memory pipeline (embeddings → LLM → `CoreMemory`/`FactStore`/
`FactPromoter` → the `makeMemoryAgent` closure) and the same workspace pair
(runtime registry → `LocalWorkspaceManager`). Same constructors, same
arguments, opposite order in each file — part of why it survived three
previous passes.

Extracted to `core/src/composition.ts`, reached through a new
`@beevibe/core/composition` subpath rather than the root barrel: these
construct adapters, and the barrel's contract is "adapters are composed by
binaries directly; not re-exported here".

`resolveSkillsSourceDir` folds in the third copy of the same idea — the
`cfg.skillsSourceDir ?? path.resolve(process.cwd(), "skills")` default was
written out at three call sites, **two of them in the same process**, so a
change to where skills live could half-land and leave the runtime router
reading one directory while the workspace manager reads another.

### 4. `web` — unpack an `ApiError` once, through the fields it already parses (`c7470ea`)

The three auth-form catch blocks each opened with the same `err instanceof
ApiError ? … : undefined` pair, once for `status` and once for `body`, then
read `body.error` / `body.message` — which `ApiError`'s constructor already
extracts into `errorCode` / `serverMessage` behind a `typeof === "string"`
check. The copies weren't repeating a narrowing so much as re-deriving, less
carefully, something the class had already done.

`asApiError(err)` replaces all three. Dropping the `as { message?: string }`
casts closes a small latent hole: that's an assertion, not a check, so a 500
whose body is `{"message": 42}` put the number straight into `setError`,
typed `string | null`. Rendering survives it, but nothing downstream was
entitled to assume so; it now falls through to the generic message.

---

## Tests

**+29 tests**, all against code paths that previously had no direct coverage:

| Suite | Tests | Covers |
| --- | --- | --- |
| `core/adapters/postgres/pg-helpers.test.ts` | 10 | placeholder numbering, explicit-null vs undefined, the `updated_at` opt-out, the empty-patch read, both throw paths |
| `web/components/detail/detail-gate.test.tsx` | 7 | branch precedence when several conditions hold, settled-but-empty treated as a failed fetch, both derived messages, the nav surviving loading and error |
| `core/composition.test.ts` | 8 | the skills-dir default and its empty-string edge, a distinct MemoryAgent per id off one shared stack, registry contents, manager wiring |
| `web/lib/api/http.test.ts` | +4 | the narrowing both ways, a non-string `message`, a non-object body (the HTML page a 502 usually delivers) |

## Verification

Ran against a **real Postgres 16 + pgvector**, not just typecheck — which
matters here, since the twelve-repository refactor is only exercised by the
DB-gated suites:

| Package | Result |
| --- | --- |
| `@beevibe/core` | 831 pass, 7 fail |
| `@beevibe/api` | 441 pass, 0 fail |
| `@beevibe/scheduler` | 27 pass, 0 fail |
| `@beevibe/web` | 203 pass, 0 fail |
| all 14 `adapters/postgres` suites | 207 pass |

The 7 core failures are the live-provider adapter tests (`AnthropicLlmProvider`,
`OpenAILlmProvider`, `OpenAIEmbeddingService`) failing for want of API keys —
the environmental class CLAUDE.md documents, unrelated to this diff.

`pnpm typecheck` and `pnpm lint` clean across all 9 tasks. `pnpm build` fails
only on `@beevibe/web` via the documented Turbo strict-env-mode proxy-CA
gotcha; `pnpm --filter @beevibe/web exec next build` succeeds.

---

## Clusters found and deliberately left alone

- **`view.ts` — five identical `loadOwned(…agentRepo…)` calls** (plus two in
  `learned-skills.ts`). Real, but the generic helper already exists from #266;
  what's left is a one-line-per-site file-local wrapper. Low impact.
- **`sign-in` / `sign-up` form markup** — a byte-identical error banner and a
  submit-button shell differing only in label and disabled predicate. Both
  pages have no test coverage, and the extraction is cosmetic; not worth
  touching auth pages blind.
- **`error.tsx` / `global-error.tsx`**, the `escalations` / `negotiations`
  `loading.tsx` pair, `model-picker` / `review-policy-picker` — near-identical,
  but each is under 15 lines and the Next.js file-convention ones are required
  to exist separately.
- **`AnthropicLlmProvider` / `OpenAILlmProvider` constructors** — same
  key-resolution and timeout shape, but over different SDK client types; a
  shared helper would save ~6 lines and add an indirection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9kBa5biPU9vZTfAauMU7D

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9kBa5biPU9vZTfAauMU7D)_