### PR TITLE
refactor(core): one definition of the two dispatch-context shapes

### DIFF
--- a/packages/api/src/views/tasks.ts
+++ b/packages/api/src/views/tasks.ts
@@ -180,7 +180,9 @@ function rowToTaskListItem(row: TaskListRow): TaskListItem {
     blocker_agent_id: row.blocker_agent_id ?? undefined,
     blocker_reason: row.blocker_reason ?? undefined,
     repo_url: row.repo_url ?? undefined,
-    next_dispatch_context: row.next_dispatch_context as Task["next_dispatch_context"],
+    // JSONB column read back as an untyped `Record` — an assertion about
+    // data the write path typed, not something TS can narrow.
+    next_dispatch_context: row.next_dispatch_context as unknown as Task["next_dispatch_context"],
     created_at: row.created_at,
     updated_at: row.updated_at,
     assignee_hierarchy: row.assignee_hier ?? undefined,

--- a/packages/core/src/adapters/postgres/task-repo.ts
+++ b/packages/core/src/adapters/postgres/task-repo.ts
@@ -272,9 +272,12 @@ function rowToTask(row: TaskRow): Task {
     blocker_reason: row.blocker_reason ?? undefined,
     repo_url: row.repo_url ?? undefined,
     // The DB column is JSONB; the typed shape is enforced via NextDispatchContext
-    // when written by reviseTask + EscalationService.
+    // when written by reviseTask + EscalationService. The row type is an
+    // untyped `Record`, so this is an assertion about data we wrote, not a
+    // narrowing TS can check — hence the trip through `unknown`.
     next_dispatch_context:
-      (row.next_dispatch_context as Task["next_dispatch_context"]) ?? undefined,
+      (row.next_dispatch_context as unknown as Task["next_dispatch_context"]) ??
+      undefined,
     created_at: row.created_at,
     updated_at: row.updated_at,
   };

--- a/packages/core/src/domain/task.ts
+++ b/packages/core/src/domain/task.ts
@@ -1,3 +1,5 @@
+import type { ResolutionProposal } from "./escalation.js";
+
 export type TaskStatus =
   | "pending"
   | "assigned"
@@ -54,28 +56,25 @@ export type CreatorType = "person" | "agent";
  * doesn't need to call `findLatestForTask` for synthetic tasks (B-side
  * post-escalation tasks have no own prior session via that path).
  */
-export type NextDispatchContext =
-  | {
-      kind: "revision";
-      feedback: string;
-      source: "human" | "parent_agent";
-      from_status: "review" | "needs_revision" | "blocked";
-      reviser_agent_id?: string;
-      prior_session_id?: string;
-    }
-  | {
-      kind: "post_escalation";
-      role: "initiator" | "counterparty";
-      /** Stored as JSONB; structurally matches ResolutionProposal. */
-      resolution: {
-        title: string;
-        description: string;
-        source: "initiator" | "counterparty" | "human";
-        source_index?: number;
-      };
-      notes?: string;
-      prior_session_id?: string;
-    };
+export interface RevisionContext {
+  kind: "revision";
+  feedback: string;
+  source: "human" | "parent_agent";
+  from_status: "review" | "needs_revision" | "blocked";
+  reviser_agent_id?: string;
+  prior_session_id?: string;
+}
+
+export interface PostEscalationContext {
+  kind: "post_escalation";
+  role: "initiator" | "counterparty";
+  /** Stored as JSONB, so this is the serialized form of the same shape. */
+  resolution: ResolutionProposal;
+  notes?: string;
+  prior_session_id?: string;
+}
+
+export type NextDispatchContext = RevisionContext | PostEscalationContext;
 
 export interface Task {
   id: string;

--- a/packages/core/src/services/agent-session.ts
+++ b/packages/core/src/services/agent-session.ts
@@ -1,4 +1,4 @@
-import type { ResolutionProposal } from "../domain/escalation.js";
+import type { NextDispatchContext } from "../domain/task.js";
 import type { Session, SessionEventKind, SessionType } from "../domain/session.js";
 import { sessionEventId, sessionId as newSessionId } from "../domain/ids.js";
 import type { AgentRepository } from "../ports/agent-repo.js";
@@ -373,21 +373,11 @@ export type ResumeReason =
       kind: "chat_continuation";
       prior_session_id: string;
     }
-  | {
-      kind: "revision";
-      feedback: string;
-      source: "human" | "parent_agent";
-      from_status: "review" | "needs_revision" | "blocked";
-      reviser_agent_id?: string;
-      prior_session_id?: string;
-    }
-  | {
-      kind: "post_escalation";
-      role: "initiator" | "counterparty";
-      resolution: ResolutionProposal;
-      notes?: string;
-      prior_session_id?: string;
-    };
+  // The explicit-context kinds ARE `task.next_dispatch_context` — dispatch
+  // reads the JSONB column straight into this union, so they have to stay
+  // structurally identical. Referencing the domain type keeps that a fact
+  // rather than a convention two files have to remember.
+  | NextDispatchContext;
 
 /**
  * The minimal Task fields buildIntent needs. Avoids importing the full Task


### PR DESCRIPTION
Rebased onto `main` and **reduced from four clusters to one**. See the note at the bottom — three of the four were landed independently by #276 while this was open.

## The change

`ResumeReason` (`services/agent-session.ts`) and `NextDispatchContext` (`domain/task.ts`) each spelled out a `revision` arm and a `post_escalation` arm, and the two had to stay structurally identical: dispatch reads the `task.next_dispatch_context` JSONB column straight into a `ResumeReason`. Nothing enforced that — it was a convention two files had to remember.

They had already drifted. The domain copy inlined `{ title; description; source; source_index? }` where the service copy used `ResolutionProposal`, so the same JSONB payload had two type names and only one of them carried the doc comment explaining `source_index`.

`domain/task.ts` now names the two arms (`RevisionContext`, `PostEscalationContext`), builds `NextDispatchContext` from them, and uses `ResolutionProposal` for the resolution rather than re-describing it. `ResumeReason` keeps its own three kinds (`fresh`, `crash_recovery`, `chat_continuation`) and unions in `NextDispatchContext` for the rest — which is what its existing doc comment already claimed the relationship was.

No import cycle: `domain/escalation.ts` only reaches for `negotiation.js`.

Two JSONB read sites needed a cast through `unknown`. Turning the inline object type into a named interface removes the implicit index signature TS was using to let `Record<string, unknown>` compare directly. The assertion is unchanged in kind — it was always a claim about data the write path typed, not a narrowing the compiler could check — and both sites now say so.

Type-only; no runtime change.

## Verification

`pnpm typecheck` and `pnpm lint`: 9/9 tasks each. All six packages build. Core suite 608 pass, with only the documented env-gated failures (no local Postgres, no provider keys).

## Note on scope

This PR originally carried four clusters. While it was open, #276 landed three of them independently — the Postgres `findById`/`update` skeleton (as `findRowById`/`updateRowById`), the web detail-page gate (an equivalent `DetailGate`, taking `noun`+`id` rather than pre-built strings), and the shared bootstrap composition (as `createMemoryStack`/`createWorkspaceStack`). Those three are now redundant, and #276's versions are at least as good, so they've been dropped rather than reconciled. What remains is the one cluster #276 did not touch.