### PR TITLE
test(api): cover the five untested REST routers (0% → ~100% lines)

### DIFF
--- a/packages/api/src/routes/learned-skills.test.ts
+++ b/packages/api/src/routes/learned-skills.test.ts
@@ -1,0 +1,604 @@
+/**
+ * /learned-skills REST surface — unit tests with vitest fakes (no DB).
+ *
+ * Create is the branchy one: it gates on slug shape, run status and
+ * name collision, then writes SKILL.md to disk as a *non-fatal* side
+ * effect. The tests point `repoRoot` at a tmpdir and read the file back,
+ * which is what pins the two content shapes (agent artifact wrapped vs.
+ * generated template) and the "a write failure still 201s" contract.
+ *
+ * Publish talks to the GitHub API, so the token path stubs `fetch` and
+ * asserts the four-call sequence rather than reaching the network.
+ */
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import express, { json } from "express";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  LearnedSkill,
+  LearnedSkillRepository,
+  RepoRun,
+  RepoRunRepository,
+  WorkProduct,
+  WorkProductListItem,
+  WorkProductRepository,
+} from "@beevibe/core";
+import { createLearnedSkillsRouter } from "./learned-skills.js";
+
+const PERSON = "person_1";
+
+// ── Fakes ────────────────────────────────────────────────────────────────
+
+function fakeRun(overrides: Partial<RepoRun> = {}): RepoRun {
+  return {
+    id: "run_1",
+    agent_id: "agent_a",
+    goal: "add a linter",
+    repo_url: "https://github.com/acme/tool",
+    repo_ref: "abc123def456789",
+    status: "succeeded",
+    transcript: [],
+    install_log: "pnpm install",
+    invocation: "pnpm lint",
+    started_at: new Date("2026-05-01"),
+    ...overrides,
+  };
+}
+
+function fakeSkill(overrides: Partial<LearnedSkill> = {}): LearnedSkill {
+  return {
+    id: "lskill_1",
+    name: "acme-lint",
+    goal_pattern: "lint a repo with acme",
+    repo_url: "https://github.com/acme/tool",
+    repo_ref: "abc123def456789",
+    install_steps: "pnpm install",
+    invocation: "pnpm lint",
+    source_run_id: "run_1",
+    owner_id: PERSON,
+    created_at: new Date("2026-05-01"),
+    updated_at: new Date("2026-05-01"),
+    ...overrides,
+  };
+}
+
+function makeSkillRepo(): LearnedSkillRepository {
+  return {
+    create: vi.fn(),
+    findById: vi.fn(),
+    findByOwnerAndName: vi.fn(),
+    listByOwner: vi.fn(),
+    searchByGoal: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+
+function makeRunRepo(): RepoRunRepository {
+  return {
+    create: vi.fn(),
+    findById: vi.fn(),
+    findBySessionId: vi.fn(),
+    listByAgent: vi.fn(),
+    listRecent: vi.fn(),
+    update: vi.fn(),
+  };
+}
+
+function makeWorkProductRepo(): WorkProductRepository {
+  return {
+    findById: vi.fn(),
+    listByTask: vi.fn(),
+    listByAgent: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+
+function stubAuth(source: "human" | "agent" | "none" = "human") {
+  return (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    if (source === "human") {
+      req.caller = {
+        source: "human",
+        agentId: "agent_a",
+        hierarchyLevel: "team",
+        personId: PERSON,
+      };
+    } else if (source === "agent") {
+      req.caller = { source: "agent", agentId: "agent_a", hierarchyLevel: "ic" };
+    }
+    next();
+  };
+}
+
+interface Deps {
+  learnedSkillRepo: LearnedSkillRepository;
+  repoRunRepo: RepoRunRepository;
+  workProductRepo: WorkProductRepository;
+}
+
+function makeDeps(): Deps {
+  return {
+    learnedSkillRepo: makeSkillRepo(),
+    repoRunRepo: makeRunRepo(),
+    workProductRepo: makeWorkProductRepo(),
+  };
+}
+
+let repoRoot: string;
+
+function makeApp(deps: Deps, source: "human" | "agent" | "none" = "human", root = repoRoot) {
+  const app = express();
+  app.use(json());
+  app.use(
+    "/learned-skills",
+    createLearnedSkillsRouter({ authMiddleware: stubAuth(source), ...deps, repoRoot: root }),
+  );
+  return app;
+}
+
+function skillMdPath(name: string) {
+  return join(repoRoot, "skills", "learned", name, "SKILL.md");
+}
+
+beforeEach(async () => {
+  repoRoot = await mkdtemp(join(tmpdir(), "beevibe-learned-skills-"));
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(async () => {
+  await rm(repoRoot, { recursive: true, force: true });
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  delete process.env.BEEVIBE_REGISTRY_TOKEN;
+});
+
+// ── GET /learned-skills ──────────────────────────────────────────────────
+
+describe("GET /learned-skills", () => {
+  it("lists the caller's own skills", async () => {
+    const deps = makeDeps();
+    vi.mocked(deps.learnedSkillRepo.listByOwner).mockResolvedValue([fakeSkill()]);
+
+    const res = await request(makeApp(deps)).get("/learned-skills");
+
+    expect(res.status).toBe(200);
+    expect(res.body.skills).toHaveLength(1);
+    expect(deps.learnedSkillRepo.listByOwner).toHaveBeenCalledWith(PERSON);
+  });
+
+  it("500s when the repo throws", async () => {
+    const deps = makeDeps();
+    vi.mocked(deps.learnedSkillRepo.listByOwner).mockRejectedValue(new Error("pg down"));
+
+    const res = await request(makeApp(deps)).get("/learned-skills");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("list_failed");
+  });
+
+  it("403s an agent caller", async () => {
+    const deps = makeDeps();
+    const res = await request(makeApp(deps, "agent")).get("/learned-skills");
+
+    expect(res.status).toBe(403);
+    expect(deps.learnedSkillRepo.listByOwner).not.toHaveBeenCalled();
+  });
+});
+
+// ── POST /learned-skills ─────────────────────────────────────────────────
+
+describe("POST /learned-skills — validation", () => {
+  const valid = { name: "acme-lint", goal_pattern: "lint it", repo_run_id: "run_1" };
+
+  it.each([
+    ["name", { ...valid, name: undefined }],
+    ["goal_pattern", { ...valid, goal_pattern: undefined }],
+    ["repo_run_id", { ...valid, repo_run_id: undefined }],
+  ])("400s when %s is missing", async (_field, body) => {
+    const deps = makeDeps();
+    const res = await request(makeApp(deps)).post("/learned-skills").send(body);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_body");
+    expect(deps.repoRunRepo.findById).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["uppercase", "Acme-Lint"],
+    ["underscores", "acme_lint"],
+    ["a single character", "a"],
+    ["over 64 characters", "a".repeat(65)],
+    ["a path separator", "acme/lint"],
+    ["traversal", "../escape"],
+  ])("400s on a name with %s", async (_label, name) => {
+    const deps = makeDeps();
+    const res = await request(makeApp(deps)).post("/learned-skills").send({ ...valid, name });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_name");
+    expect(deps.repoRunRepo.findById).not.toHaveBeenCalled();
+  });
+
+  it("404s when the source run is unknown", async () => {
+    const deps = makeDeps();
+    vi.mocked(deps.repoRunRepo.findById).mockResolvedValue(undefined);
+
+    const res = await request(makeApp(deps)).post("/learned-skills").send(valid);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("repo_run_not_found");
+  });
+
+  it.each(["running", "failed", "cancelled"] as const)(
+    "409s when the source run is %s rather than succeeded",
+    async (status) => {
+      const deps = makeDeps();
+      vi.mocked(deps.repoRunRepo.findById).mockResolvedValue(fakeRun({ status }));
+
+      const res = await request(makeApp(deps)).post("/learned-skills").send(valid);
+
+      expect(res.status).toBe(409);
+      expect(res.body).toMatchObject({ error: "run_not_succeeded", current_status: status });
+      expect(deps.learnedSkillRepo.create).not.toHaveBeenCalled();
+    },
+  );
+
+  it("409s when the caller already has a skill with that name", async () => {
+    const deps = makeDeps();
+    vi.mocked(deps.repoRunRepo.findById).mockResolvedValue(fakeRun());
+    vi.mocked(deps.learnedSkillRepo.findByOwnerAndName).mockResolvedValue(fakeSkill());
+
+    const res = await request(makeApp(deps)).post("/learned-skills").send(valid);
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe("name_taken");
+    expect(deps.learnedSkillRepo.findByOwnerAndName).toHaveBeenCalledWith(PERSON, "acme-lint");
+    expect(deps.learnedSkillRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("403s an agent caller", async () => {
+    const deps = makeDeps();
+    const res = await request(makeApp(deps, "agent")).post("/learned-skills").send(valid);
+
+    expect(res.status).toBe(403);
+    expect(deps.repoRunRepo.findById).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /learned-skills — creation", () => {
+  const valid = { name: "acme-lint", goal_pattern: "lint a repo with acme", repo_run_id: "run_1" };
+
+  function wireCreate(deps: Deps, run = fakeRun()) {
+    vi.mocked(deps.repoRunRepo.findById).mockResolvedValue(run);
+    vi.mocked(deps.learnedSkillRepo.findByOwnerAndName).mockResolvedValue(undefined);
+    vi.mocked(deps.learnedSkillRepo.create).mockImplementation(async (input) =>
+      fakeSkill(input as Partial<LearnedSkill>),
+    );
+    vi.mocked(deps.workProductRepo.listByTask).mockResolvedValue([]);
+    vi.mocked(deps.repoRunRepo.update).mockResolvedValue(run);
+  }
+
+  it("creates the row from the run and back-links the run", async () => {
+    const deps = makeDeps();
+    wireCreate(deps);
+
+    const res = await request(makeApp(deps)).post("/learned-skills").send(valid);
+
+    expect(res.status).toBe(201);
+    expect(res.body.skill).toMatchObject({
+      name: "acme-lint",
+      goal_pattern: "lint a repo with acme",
+      repo_url: "https://github.com/acme/tool",
+      owner_id: PERSON,
+      source_run_id: "run_1",
+    });
+    expect(deps.repoRunRepo.update).toHaveBeenCalledWith("run_1", {
+      learned_skill_id: res.body.skill.id,
+    });
+  });
+
+  it("defaults repo_ref, install_steps and invocation when the run lacks them", async () => {
+    const deps = makeDeps();
+    const bare = fakeRun();
+    delete bare.repo_ref;
+    delete bare.install_log;
+    delete bare.invocation;
+    wireCreate(deps, bare);
+
+    const res = await request(makeApp(deps)).post("/learned-skills").send(valid);
+
+    expect(res.status).toBe(201);
+    const created = vi.mocked(deps.learnedSkillRepo.create).mock.calls[0]![0];
+    expect(created.repo_ref).toBe("HEAD");
+    expect(created.install_steps).toBe("(see run transcript)");
+    expect(created.invocation).toBe("(see run transcript)");
+  });
+
+  it("writes a generated SKILL.md when no artifact is reachable", async () => {
+    const deps = makeDeps();
+    wireCreate(deps);
+
+    await request(makeApp(deps)).post("/learned-skills").send(valid);
+
+    const md = await readFile(skillMdPath("acme-lint"), "utf8");
+    expect(md).toContain("name: acme-lint");
+    expect(md).toContain("source_repo: https://github.com/acme/tool");
+    // Title-cased from the slug.
+    expect(md).toContain("# Acme Lint");
+    expect(md).toContain("## Known install steps");
+    expect(md).toContain("pnpm lint");
+    // The generated template truncates the ref to 12 chars in the prose.
+    expect(md).toContain("abc123def456");
+  });
+
+  it("inlines the agent's artifact body instead of the template when one exists", async () => {
+    const deps = makeDeps();
+    const run = fakeRun({ task_id: "task_9" });
+    wireCreate(deps, run);
+    vi.mocked(deps.workProductRepo.listByTask).mockResolvedValue([
+      { id: "wp_1", type: "artifact" } as WorkProductListItem,
+    ]);
+    vi.mocked(deps.workProductRepo.findById).mockResolvedValue({
+      id: "wp_1",
+      type: "artifact",
+      body: "# Real findings\n\nThe agent wrote this.",
+    } as WorkProduct);
+
+    await request(makeApp(deps)).post("/learned-skills").send(valid);
+
+    const md = await readFile(skillMdPath("acme-lint"), "utf8");
+    expect(md).toContain("# Real findings");
+    expect(md).toContain("The agent wrote this.");
+    expect(md).toContain("## Provenance");
+    // The generated template's headings must NOT appear — the artifact
+    // replaces the body wholesale rather than being appended to it.
+    expect(md).not.toContain("## Known install steps");
+  });
+
+  it("prefers the artifact stamped with this run over the first artifact", async () => {
+    const deps = makeDeps();
+    wireCreate(deps, fakeRun({ task_id: "task_9" }));
+    vi.mocked(deps.workProductRepo.listByTask).mockResolvedValue([
+      { id: "wp_other", type: "artifact" } as WorkProductListItem,
+      {
+        id: "wp_ours",
+        type: "artifact",
+        metadata: { repo_run_id: "run_1" },
+      } as unknown as WorkProductListItem,
+    ]);
+    vi.mocked(deps.workProductRepo.findById).mockResolvedValue({
+      id: "wp_ours",
+      type: "artifact",
+      body: "# Ours",
+    } as WorkProduct);
+
+    await request(makeApp(deps)).post("/learned-skills").send(valid);
+
+    expect(deps.workProductRepo.findById).toHaveBeenCalledWith("wp_ours");
+  });
+
+  it("indents a multi-line goal so the YAML frontmatter stays valid", async () => {
+    const deps = makeDeps();
+    wireCreate(deps, fakeRun({ task_id: "task_9" }));
+    vi.mocked(deps.workProductRepo.listByTask).mockResolvedValue([
+      { id: "wp_1", type: "artifact" } as WorkProductListItem,
+    ]);
+    vi.mocked(deps.workProductRepo.findById).mockResolvedValue({
+      id: "wp_1",
+      type: "artifact",
+      body: "body",
+    } as WorkProduct);
+
+    await request(makeApp(deps))
+      .post("/learned-skills")
+      .send({ ...valid, goal_pattern: "line one\nline two" });
+
+    const md = await readFile(skillMdPath("acme-lint"), "utf8");
+    expect(md).toContain("description: >\n  line one\n  line two\n");
+  });
+
+  it("falls back to the template when the artifact lookup throws", async () => {
+    const deps = makeDeps();
+    wireCreate(deps, fakeRun({ task_id: "task_9" }));
+    vi.mocked(deps.workProductRepo.listByTask).mockRejectedValue(new Error("pg down"));
+
+    const res = await request(makeApp(deps)).post("/learned-skills").send(valid);
+
+    expect(res.status).toBe(201);
+    const md = await readFile(skillMdPath("acme-lint"), "utf8");
+    expect(md).toContain("## Known install steps");
+  });
+
+  it("still 201s when the SKILL.md write fails — the DB row is the source of truth", async () => {
+    const deps = makeDeps();
+    wireCreate(deps);
+    // Point repoRoot at a regular file, so `mkdir -p <root>/skills/learned/...`
+    // fails with ENOTDIR and the write path throws.
+    const asFile = join(repoRoot, "not-a-dir");
+    await writeFile(asFile, "i am a file", "utf8");
+
+    const res = await request(makeApp(deps, "human", asFile))
+      .post("/learned-skills")
+      .send(valid);
+
+    expect(res.status).toBe(201);
+    expect(res.body.skill.name).toBe("acme-lint");
+    // The row still gets back-linked — only the filesystem sync was lost.
+    expect(deps.repoRunRepo.update).toHaveBeenCalled();
+  });
+
+  it("500s when the create itself throws", async () => {
+    const deps = makeDeps();
+    wireCreate(deps);
+    vi.mocked(deps.learnedSkillRepo.create).mockRejectedValue(new Error("pg down"));
+
+    const res = await request(makeApp(deps)).post("/learned-skills").send(valid);
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("create_failed");
+  });
+});
+
+// ── DELETE /learned-skills/:id ───────────────────────────────────────────
+
+describe("DELETE /learned-skills/:id", () => {
+  it("deletes a skill the caller owns", async () => {
+    const deps = makeDeps();
+    vi.mocked(deps.learnedSkillRepo.findById).mockResolvedValue(fakeSkill());
+
+    const res = await request(makeApp(deps)).delete("/learned-skills/lskill_1");
+
+    expect(res.status).toBe(204);
+    expect(deps.learnedSkillRepo.delete).toHaveBeenCalledWith("lskill_1");
+  });
+
+  it("404s an unknown skill", async () => {
+    const deps = makeDeps();
+    vi.mocked(deps.learnedSkillRepo.findById).mockResolvedValue(undefined);
+
+    const res = await request(makeApp(deps)).delete("/learned-skills/lskill_x");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("not_found");
+    expect(deps.learnedSkillRepo.delete).not.toHaveBeenCalled();
+  });
+
+  it("403s — and does not delete — somebody else's skill", async () => {
+    const deps = makeDeps();
+    vi.mocked(deps.learnedSkillRepo.findById).mockResolvedValue(
+      fakeSkill({ owner_id: "person_other" }),
+    );
+
+    const res = await request(makeApp(deps)).delete("/learned-skills/lskill_1");
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("not_owner");
+    expect(deps.learnedSkillRepo.delete).not.toHaveBeenCalled();
+  });
+
+  it("500s when the delete throws", async () => {
+    const deps = makeDeps();
+    vi.mocked(deps.learnedSkillRepo.findById).mockResolvedValue(fakeSkill());
+    vi.mocked(deps.learnedSkillRepo.delete).mockRejectedValue(new Error("pg down"));
+
+    const res = await request(makeApp(deps)).delete("/learned-skills/lskill_1");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("delete_failed");
+  });
+
+  it("403s an agent caller", async () => {
+    const deps = makeDeps();
+    const res = await request(makeApp(deps, "agent")).delete("/learned-skills/lskill_1");
+
+    expect(res.status).toBe(403);
+    expect(deps.learnedSkillRepo.findById).not.toHaveBeenCalled();
+  });
+});
+
+// ── POST /learned-skills/:id/publish ─────────────────────────────────────
+
+describe("POST /learned-skills/:id/publish", () => {
+  it("returns manual-PR instructions plus the SKILL.md when no token is set", async () => {
+    const deps = makeDeps();
+    vi.mocked(deps.learnedSkillRepo.findById).mockResolvedValue(fakeSkill());
+
+    const res = await request(makeApp(deps)).post("/learned-skills/lskill_1/publish");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: false,
+      reason: "no_token",
+      target_repo: "beevibe-ai/beevibe-capabilities",
+      target_path: "skills/acme-lint/SKILL.md",
+    });
+    expect(res.body.skill_md).toContain("name: acme-lint");
+    expect(deps.learnedSkillRepo.update).not.toHaveBeenCalled();
+  });
+
+  it("404s an unknown skill and 403s somebody else's", async () => {
+    const deps = makeDeps();
+    vi.mocked(deps.learnedSkillRepo.findById).mockResolvedValue(undefined);
+    const missing = await request(makeApp(deps)).post("/learned-skills/lskill_x/publish");
+    expect(missing.status).toBe(404);
+
+    vi.mocked(deps.learnedSkillRepo.findById).mockResolvedValue(
+      fakeSkill({ owner_id: "person_other" }),
+    );
+    const foreign = await request(makeApp(deps)).post("/learned-skills/lskill_1/publish");
+    expect(foreign.status).toBe(403);
+  });
+
+  it("opens a PR through the GitHub API when a token is set", async () => {
+    process.env.BEEVIBE_REGISTRY_TOKEN = "ghp_test";
+    const deps = makeDeps();
+    vi.mocked(deps.learnedSkillRepo.findById).mockResolvedValue(fakeSkill());
+    vi.mocked(deps.learnedSkillRepo.update).mockResolvedValue(fakeSkill());
+
+    const json200 = (payload: unknown) =>
+      ({ ok: true, status: 200, json: async () => payload }) as Response;
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(json200({ default_branch: "main" }))
+      .mockResolvedValueOnce(json200({ object: { sha: "basesha" } }))
+      .mockResolvedValueOnce(json200({}))
+      .mockResolvedValueOnce(json200({}))
+      .mockResolvedValueOnce(json200({ html_url: "https://github.com/x/y/pull/7" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await request(makeApp(deps)).post("/learned-skills/lskill_1/publish");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, pr_url: "https://github.com/x/y/pull/7" });
+
+    const urls = fetchMock.mock.calls.map((c) => String(c[0]));
+    expect(urls[0]).toBe("https://api.github.com/repos/beevibe-ai/beevibe-capabilities");
+    expect(urls[1]).toContain("/git/ref/heads/main");
+    expect(urls[2]).toContain("/git/refs");
+    expect(urls[3]).toContain("/contents/skills/acme-lint/SKILL.md");
+    expect(urls[4]).toContain("/pulls");
+
+    // The file body is sent base64-encoded and must round-trip to the md.
+    const filePut = JSON.parse(String(fetchMock.mock.calls[3]![1].body)) as { content: string };
+    expect(Buffer.from(filePut.content, "base64").toString("utf8")).toContain("name: acme-lint");
+
+    const [id, patch] = vi.mocked(deps.learnedSkillRepo.update).mock.calls[0]!;
+    expect(id).toBe("lskill_1");
+    expect(patch).toMatchObject({
+      published_to: "community",
+      published_pr: "https://github.com/x/y/pull/7",
+    });
+    expect(patch.published_at).toBeInstanceOf(Date);
+  });
+
+  it("500s with the upstream status when a GitHub call fails", async () => {
+    process.env.BEEVIBE_REGISTRY_TOKEN = "ghp_test";
+    const deps = makeDeps();
+    vi.mocked(deps.learnedSkillRepo.findById).mockResolvedValue(fakeSkill());
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 403, json: async () => ({}) } as Response),
+    );
+
+    const res = await request(makeApp(deps)).post("/learned-skills/lskill_1/publish");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("publish_failed");
+    expect(res.body.message).toContain("403");
+    // The skill must not be marked published when the PR never opened.
+    expect(deps.learnedSkillRepo.update).not.toHaveBeenCalled();
+  });
+
+  it("403s an agent caller", async () => {
+    const deps = makeDeps();
+    const res = await request(makeApp(deps, "agent")).post("/learned-skills/lskill_1/publish");
+
+    expect(res.status).toBe(403);
+    expect(deps.learnedSkillRepo.findById).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/routes/me.test.ts
+++ b/packages/api/src/routes/me.test.ts
@@ -1,0 +1,408 @@
+/**
+ * /me identity + onboarding surface — unit tests with vitest fakes (no DB).
+ *
+ * Three handlers with distinct risks: `GET /me` shapes the payload the
+ * web's `/welcome` gate branches on, `PATCH /me/preferences` is the only
+ * write that must reject a non-boolean, and `GET /health/runtime` folds
+ * two independent probes (claude CLI, OpenAI embeddings) into one `ok`
+ * with a deliberate "skipped counts as ok" rule.
+ */
+import express, { json } from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  EmbeddingService,
+  Person,
+  PersonRepository,
+  RuntimeRegistry,
+} from "@beevibe/core";
+import { createMeRouter } from "./me.js";
+
+const PERSON = "person_1";
+
+function makePersonRepo(): PersonRepository {
+  return {
+    findById: vi.fn(),
+    findByEmail: vi.fn(),
+    findByApiKey: vi.fn(),
+    findManyByIds: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+
+function makeAgentRepo(): AgentRepository {
+  return {
+    findById: vi.fn(),
+    findByApiKey: vi.fn(),
+    findByOwnerId: vi.fn(),
+    findTopLevelForOwner: vi.fn(),
+    findSubordinates: vi.fn(),
+    findPeers: vi.fn(),
+    findParent: vi.fn(),
+    findByLevel: vi.fn(),
+    findDescendantIds: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+
+function fakePerson(overrides: Partial<Person> = {}): Person {
+  return {
+    id: PERSON,
+    name: "Ada",
+    email: "ada@example.com",
+    capability_network_enabled: true,
+    created_at: new Date("2026-04-01"),
+    updated_at: new Date("2026-04-01"),
+    ...overrides,
+  };
+}
+
+function fakeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: "agent_a",
+    name: "Ada's team",
+    owner_id: PERSON,
+    hierarchy_level: "team",
+    runtime_config: { type: "claude" },
+    created_at: new Date("2026-04-01"),
+    updated_at: new Date("2026-04-01"),
+    ...overrides,
+  };
+}
+
+/** A registry carrying only the `healthCheck` the route actually calls. */
+function makeRegistry(
+  healthCheck?: () => Promise<{ healthy: boolean; error?: string }>,
+): RuntimeRegistry {
+  if (!healthCheck) return {} as RuntimeRegistry;
+  return { claude: { healthCheck } } as unknown as RuntimeRegistry;
+}
+
+function makeEmbed(impl: () => Promise<number[]>): EmbeddingService {
+  return {
+    type: "fake",
+    embed: vi.fn(impl),
+    embedBatch: vi.fn(),
+  } as unknown as EmbeddingService;
+}
+
+function stubAuth(source: "human" | "agent" | "none" = "human") {
+  return (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    if (source === "human") {
+      req.caller = {
+        source: "human",
+        agentId: "agent_a",
+        hierarchyLevel: "team",
+        personId: PERSON,
+      };
+    } else if (source === "agent") {
+      req.caller = { source: "agent", agentId: "agent_a", hierarchyLevel: "ic" };
+    }
+    next();
+  };
+}
+
+interface AppOpts {
+  personRepo?: PersonRepository;
+  agentRepo?: AgentRepository;
+  runtimeRegistry?: RuntimeRegistry;
+  embed?: EmbeddingService;
+  source?: "human" | "agent" | "none";
+}
+
+function makeApp(opts: AppOpts = {}) {
+  const personRepo = opts.personRepo ?? makePersonRepo();
+  const agentRepo = opts.agentRepo ?? makeAgentRepo();
+  const app = express();
+  app.use(json());
+  app.use(
+    "/",
+    createMeRouter({
+      authMiddleware: stubAuth(opts.source ?? "human"),
+      personRepo,
+      agentRepo,
+      runtimeRegistry: opts.runtimeRegistry ?? makeRegistry(),
+      ...(opts.embed ? { embed: opts.embed } : {}),
+    }),
+  );
+  return { app, personRepo, agentRepo };
+}
+
+// ── GET /me ──────────────────────────────────────────────────────────────
+
+describe("GET /me", () => {
+  it("returns person, primary agent and preferences", async () => {
+    const personRepo = makePersonRepo();
+    const agentRepo = makeAgentRepo();
+    vi.mocked(personRepo.findById).mockResolvedValue(
+      fakePerson({ onboarding_completed_at: new Date("2026-04-02T10:00:00Z") }),
+    );
+    vi.mocked(agentRepo.findTopLevelForOwner).mockResolvedValue(fakeAgent());
+
+    const { app } = makeApp({ personRepo, agentRepo });
+    const res = await request(app).get("/me");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      person: {
+        id: PERSON,
+        name: "Ada",
+        email: "ada@example.com",
+        onboarding_completed_at: "2026-04-02T10:00:00.000Z",
+      },
+      primary_agent: { id: "agent_a", name: "Ada's team", hierarchy: "team" },
+      preferences: { capability_network_enabled: true },
+      needs_onboarding: false,
+    });
+  });
+
+  it("flags needs_onboarding when the stamp is absent", async () => {
+    const personRepo = makePersonRepo();
+    const agentRepo = makeAgentRepo();
+    vi.mocked(personRepo.findById).mockResolvedValue(fakePerson());
+    vi.mocked(agentRepo.findTopLevelForOwner).mockResolvedValue(fakeAgent());
+
+    const { app } = makeApp({ personRepo, agentRepo });
+    const res = await request(app).get("/me");
+
+    expect(res.body.needs_onboarding).toBe(true);
+    expect(res.body.person.onboarding_completed_at).toBeNull();
+  });
+
+  it("returns a null primary_agent rather than 404ing when no agent exists", async () => {
+    const personRepo = makePersonRepo();
+    const agentRepo = makeAgentRepo();
+    vi.mocked(personRepo.findById).mockResolvedValue(fakePerson());
+    vi.mocked(agentRepo.findTopLevelForOwner).mockResolvedValue(undefined);
+
+    const { app } = makeApp({ personRepo, agentRepo });
+    const res = await request(app).get("/me");
+
+    expect(res.status).toBe(200);
+    expect(res.body.primary_agent).toBeNull();
+  });
+
+  it("404s when the caller's person row is gone", async () => {
+    const personRepo = makePersonRepo();
+    const agentRepo = makeAgentRepo();
+    vi.mocked(personRepo.findById).mockResolvedValue(undefined);
+    vi.mocked(agentRepo.findTopLevelForOwner).mockResolvedValue(undefined);
+
+    const { app } = makeApp({ personRepo, agentRepo });
+    const res = await request(app).get("/me");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("person_not_found");
+  });
+
+  it("403s an agent caller", async () => {
+    const { app, personRepo } = makeApp({ source: "agent" });
+    const res = await request(app).get("/me");
+
+    expect(res.status).toBe(403);
+    expect(personRepo.findById).not.toHaveBeenCalled();
+  });
+});
+
+// ── POST /me/onboarding/complete ─────────────────────────────────────────
+
+describe("POST /me/onboarding/complete", () => {
+  it("stamps the completion time for the caller", async () => {
+    const personRepo = makePersonRepo();
+    const stamped = new Date("2026-04-03T12:00:00Z");
+    vi.mocked(personRepo.update).mockResolvedValue(
+      fakePerson({ onboarding_completed_at: stamped }),
+    );
+
+    const { app } = makeApp({ personRepo });
+    const res = await request(app).post("/me/onboarding/complete");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      onboarding_completed_at: "2026-04-03T12:00:00.000Z",
+    });
+    const [id, patch] = vi.mocked(personRepo.update).mock.calls[0]!;
+    expect(id).toBe(PERSON);
+    expect(patch.onboarding_completed_at).toBeInstanceOf(Date);
+  });
+
+  it("is idempotent — a second call just re-stamps", async () => {
+    const personRepo = makePersonRepo();
+    vi.mocked(personRepo.update).mockResolvedValue(
+      fakePerson({ onboarding_completed_at: new Date("2026-04-03T12:00:00Z") }),
+    );
+
+    const { app } = makeApp({ personRepo });
+    await request(app).post("/me/onboarding/complete");
+    const res = await request(app).post("/me/onboarding/complete");
+
+    expect(res.status).toBe(200);
+    expect(personRepo.update).toHaveBeenCalledTimes(2);
+  });
+
+  it("403s an unauthenticated caller", async () => {
+    const { app, personRepo } = makeApp({ source: "none" });
+    const res = await request(app).post("/me/onboarding/complete");
+
+    expect(res.status).toBe(403);
+    expect(personRepo.update).not.toHaveBeenCalled();
+  });
+});
+
+// ── PATCH /me/preferences ────────────────────────────────────────────────
+
+describe("PATCH /me/preferences", () => {
+  it("persists the capability-network toggle", async () => {
+    const personRepo = makePersonRepo();
+    vi.mocked(personRepo.update).mockResolvedValue(
+      fakePerson({ capability_network_enabled: false }),
+    );
+
+    const { app } = makeApp({ personRepo });
+    const res = await request(app)
+      .patch("/me/preferences")
+      .send({ capability_network_enabled: false });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, preferences: { capability_network_enabled: false } });
+    expect(personRepo.update).toHaveBeenCalledWith(PERSON, {
+      capability_network_enabled: false,
+    });
+  });
+
+  it.each([
+    ["a missing field", {}],
+    ["a string 'true'", { capability_network_enabled: "true" }],
+    ["a numeric 1", { capability_network_enabled: 1 }],
+    ["an explicit null", { capability_network_enabled: null }],
+  ])("400s on %s rather than coercing", async (_label, body) => {
+    const personRepo = makePersonRepo();
+    const { app } = makeApp({ personRepo });
+
+    const res = await request(app).patch("/me/preferences").send(body);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_body");
+    expect(personRepo.update).not.toHaveBeenCalled();
+  });
+
+  it("403s an agent caller", async () => {
+    const { app, personRepo } = makeApp({ source: "agent" });
+    const res = await request(app)
+      .patch("/me/preferences")
+      .send({ capability_network_enabled: true });
+
+    expect(res.status).toBe(403);
+    expect(personRepo.update).not.toHaveBeenCalled();
+  });
+});
+
+// ── GET /health/runtime ──────────────────────────────────────────────────
+
+describe("GET /health/runtime", () => {
+  it("reports ok when the CLI is healthy and embeddings resolve", async () => {
+    const { app } = makeApp({
+      runtimeRegistry: makeRegistry(async () => ({ healthy: true })),
+      embed: makeEmbed(async () => [0.1, 0.2]),
+    });
+
+    const res = await request(app).get("/health/runtime");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      claude_cli: { ok: true },
+      openai: { ok: true },
+    });
+  });
+
+  it("treats a missing embed service as skipped-but-ok", async () => {
+    const { app } = makeApp({
+      runtimeRegistry: makeRegistry(async () => ({ healthy: true })),
+    });
+
+    const res = await request(app).get("/health/runtime");
+
+    expect(res.body.ok).toBe(true);
+    expect(res.body.openai).toEqual({ ok: true, skipped: true });
+  });
+
+  it("surfaces the CLI's own error message when the probe returns unhealthy", async () => {
+    const { app } = makeApp({
+      runtimeRegistry: makeRegistry(async () => ({ healthy: false, error: "claude: not found" })),
+    });
+
+    const res = await request(app).get("/health/runtime");
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.claude_cli).toEqual({ ok: false, message: "claude: not found" });
+  });
+
+  it("falls back to a default message when an unhealthy probe carries no error", async () => {
+    const { app } = makeApp({
+      runtimeRegistry: makeRegistry(async () => ({ healthy: false })),
+    });
+
+    const res = await request(app).get("/health/runtime");
+
+    expect(res.body.claude_cli.message).toBe("claude --version exited non-zero");
+  });
+
+  it("reports the registry gap when no claude runtime is registered", async () => {
+    const { app } = makeApp({ runtimeRegistry: makeRegistry() });
+
+    const res = await request(app).get("/health/runtime");
+
+    expect(res.body.ok).toBe(false);
+    expect(res.body.claude_cli).toEqual({
+      ok: false,
+      message: "claude runtime not registered",
+    });
+  });
+
+  it("reports a failing embed probe without taking down the CLI verdict", async () => {
+    const { app } = makeApp({
+      runtimeRegistry: makeRegistry(async () => ({ healthy: true })),
+      embed: makeEmbed(async () => {
+        throw new Error("401 Unauthorized\nkey revoked");
+      }),
+    });
+
+    const res = await request(app).get("/health/runtime");
+
+    expect(res.body.ok).toBe(false);
+    expect(res.body.claude_cli).toEqual({ ok: true });
+    // First line only, so a multi-line provider error can't flood the UI.
+    expect(res.body.openai).toEqual({ ok: false, message: "401 Unauthorized" });
+  });
+
+  it("stringifies a non-Error rejection and caps its length", async () => {
+    const { app } = makeApp({
+      runtimeRegistry: makeRegistry(() => Promise.reject("x".repeat(500))),
+    });
+
+    const res = await request(app).get("/health/runtime");
+
+    expect(res.body.claude_cli.ok).toBe(false);
+    expect(res.body.claude_cli.message).toHaveLength(200);
+  });
+
+  it("403s a non-human caller", async () => {
+    const { app } = makeApp({
+      source: "agent",
+      runtimeRegistry: makeRegistry(async () => ({ healthy: true })),
+    });
+
+    const res = await request(app).get("/health/runtime");
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/packages/api/src/routes/repo-runs.test.ts
+++ b/packages/api/src/routes/repo-runs.test.ts
@@ -1,0 +1,389 @@
+/**
+ * /repo-runs REST surface — unit tests with vitest fakes (no DB).
+ *
+ * The router is a thin closure over two ports, so a pair of `vi.fn()`
+ * repos plus a stub auth middleware exercises every branch: the human
+ * gate, transcript hydration from session_event, the terminal-status
+ * guard on cancel, and the path-traversal guard on the artifact route.
+ */
+import express, { json } from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  RepoRun,
+  RepoRunRepository,
+  SessionEvent,
+  SessionEventRepository,
+} from "@beevibe/core";
+import { createRepoRunsRouter } from "./repo-runs.js";
+
+// ── Fakes ────────────────────────────────────────────────────────────────
+
+const PERSON = "person_1";
+
+function fakeRun(overrides: Partial<RepoRun> = {}): RepoRun {
+  return {
+    id: "run_1",
+    agent_id: "agent_a",
+    goal: "add a linter",
+    repo_url: "https://github.com/acme/tool",
+    status: "running",
+    transcript: [],
+    started_at: new Date("2026-05-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+function fakeEvent(overrides: Partial<SessionEvent> = {}): SessionEvent {
+  return {
+    id: "ev_1",
+    session_id: "sess_1",
+    kind: "agent",
+    content: "hello",
+    created_at: new Date("2026-05-01T01:00:00Z"),
+    ...overrides,
+  };
+}
+
+function makeRepoRunRepo(): RepoRunRepository {
+  return {
+    create: vi.fn(),
+    findById: vi.fn(),
+    findBySessionId: vi.fn(),
+    listByAgent: vi.fn(),
+    listRecent: vi.fn(),
+    update: vi.fn(),
+  };
+}
+
+function makeSessionEventRepo(): SessionEventRepository {
+  return { append: vi.fn(), listBySession: vi.fn() };
+}
+
+/**
+ * Stand-in for `createAuthMiddleware`. The real one resolves a bv_ token
+ * against Postgres; these tests only care that handlers see the caller
+ * shape `requireHuman` gates on, so the source is set per-app.
+ */
+function stubAuth(source: "human" | "agent" | "none" = "human") {
+  return (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    if (source === "human") {
+      req.caller = {
+        source: "human",
+        agentId: "agent_a",
+        hierarchyLevel: "team",
+        personId: PERSON,
+      };
+    } else if (source === "agent") {
+      req.caller = { source: "agent", agentId: "agent_a", hierarchyLevel: "ic" };
+    }
+    next();
+  };
+}
+
+function makeApp(
+  repoRunRepo: RepoRunRepository,
+  sessionEventRepo: SessionEventRepository,
+  source: "human" | "agent" | "none" = "human",
+) {
+  const app = express();
+  app.use(json());
+  app.use(
+    "/repo-runs",
+    createRepoRunsRouter({
+      authMiddleware: stubAuth(source),
+      repoRunRepo,
+      sessionEventRepo,
+    }),
+  );
+  return app;
+}
+
+// Handlers log to console.error on the 500 paths; keep the suite output clean.
+function silenceConsole() {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+}
+
+// ── GET /repo-runs ───────────────────────────────────────────────────────
+
+describe("GET /repo-runs", () => {
+  it("returns the last 50 runs", async () => {
+    const runs = makeRepoRunRepo();
+    const listed = [fakeRun(), fakeRun({ id: "run_2" })];
+    vi.mocked(runs.listRecent).mockResolvedValue(listed);
+
+    const res = await request(makeApp(runs, makeSessionEventRepo())).get("/repo-runs");
+
+    expect(res.status).toBe(200);
+    expect(res.body.runs).toHaveLength(2);
+    expect(runs.listRecent).toHaveBeenCalledWith({ limit: 50 });
+  });
+
+  it("403s an agent caller", async () => {
+    const runs = makeRepoRunRepo();
+    const res = await request(makeApp(runs, makeSessionEventRepo(), "agent")).get("/repo-runs");
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("human_required");
+    expect(runs.listRecent).not.toHaveBeenCalled();
+  });
+
+  it("403s an unauthenticated caller", async () => {
+    const res = await request(makeApp(makeRepoRunRepo(), makeSessionEventRepo(), "none")).get(
+      "/repo-runs",
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  it("500s when the repo throws", async () => {
+    silenceConsole();
+    const runs = makeRepoRunRepo();
+    vi.mocked(runs.listRecent).mockRejectedValue(new Error("pg down"));
+
+    const res = await request(makeApp(runs, makeSessionEventRepo())).get("/repo-runs");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("list_failed");
+  });
+});
+
+// ── GET /repo-runs/:id ───────────────────────────────────────────────────
+
+describe("GET /repo-runs/:id", () => {
+  it("404s an unknown run", async () => {
+    const runs = makeRepoRunRepo();
+    vi.mocked(runs.findById).mockResolvedValue(undefined);
+
+    const res = await request(makeApp(runs, makeSessionEventRepo())).get("/repo-runs/run_missing");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("not_found");
+  });
+
+  it("returns the stored transcript when the run has no session", async () => {
+    const runs = makeRepoRunRepo();
+    const events = makeSessionEventRepo();
+    vi.mocked(runs.findById).mockResolvedValue(
+      fakeRun({ transcript: [{ at: "2026-05-01T00:00:00.000Z", kind: "log", text: "booted" }] }),
+    );
+
+    const res = await request(makeApp(runs, events)).get("/repo-runs/run_1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.run.transcript).toEqual([
+      { at: "2026-05-01T00:00:00.000Z", kind: "log", text: "booted" },
+    ]);
+    expect(events.listBySession).not.toHaveBeenCalled();
+  });
+
+  it("hydrates the transcript from session_event, inverting the daemon's kind mapping", async () => {
+    const runs = makeRepoRunRepo();
+    const events = makeSessionEventRepo();
+    vi.mocked(runs.findById).mockResolvedValue(fakeRun({ session_id: "sess_1" }));
+    vi.mocked(events.listBySession).mockResolvedValue([
+      fakeEvent({ kind: "agent", content: "thinking" }),
+      fakeEvent({ id: "ev_2", kind: "tool_call", content: "bash" }),
+      fakeEvent({ id: "ev_3", kind: "tool_result", content: "boom" }),
+      fakeEvent({ id: "ev_4", kind: "summary", content: "installed" }),
+    ]);
+
+    const res = await request(makeApp(runs, events)).get("/repo-runs/run_1");
+
+    expect(res.status).toBe(200);
+    // tool_result → error and summary → log is the inverse of the
+    // daemon's mapKind; a regression here silently miscolors the UI.
+    expect(res.body.run.transcript.map((e: { kind: string }) => e.kind)).toEqual([
+      "agent",
+      "tool_call",
+      "error",
+      "log",
+    ]);
+    expect(res.body.run.transcript[0]).toEqual({
+      at: "2026-05-01T01:00:00.000Z",
+      kind: "agent",
+      text: "thinking",
+    });
+    expect(events.listBySession).toHaveBeenCalledWith("sess_1");
+  });
+
+  it("falls back to the stored transcript when hydration fails", async () => {
+    silenceConsole();
+    const runs = makeRepoRunRepo();
+    const events = makeSessionEventRepo();
+    vi.mocked(runs.findById).mockResolvedValue(
+      fakeRun({
+        session_id: "sess_1",
+        transcript: [{ at: "2026-05-01T00:00:00.000Z", kind: "log", text: "stored" }],
+      }),
+    );
+    vi.mocked(events.listBySession).mockRejectedValue(new Error("join failed"));
+
+    const res = await request(makeApp(runs, events)).get("/repo-runs/run_1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.run.transcript).toEqual([
+      { at: "2026-05-01T00:00:00.000Z", kind: "log", text: "stored" },
+    ]);
+  });
+
+  it("500s when the lookup throws", async () => {
+    silenceConsole();
+    const runs = makeRepoRunRepo();
+    vi.mocked(runs.findById).mockRejectedValue(new Error("pg down"));
+
+    const res = await request(makeApp(runs, makeSessionEventRepo())).get("/repo-runs/run_1");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("get_failed");
+  });
+
+  it("403s an agent caller before touching the repo", async () => {
+    const runs = makeRepoRunRepo();
+    const res = await request(makeApp(runs, makeSessionEventRepo(), "agent")).get("/repo-runs/run_1");
+
+    expect(res.status).toBe(403);
+    expect(runs.findById).not.toHaveBeenCalled();
+  });
+});
+
+// ── POST /repo-runs/:id/cancel ───────────────────────────────────────────
+
+describe("POST /repo-runs/:id/cancel", () => {
+  it("404s an unknown run", async () => {
+    const runs = makeRepoRunRepo();
+    vi.mocked(runs.findById).mockResolvedValue(undefined);
+
+    const res = await request(makeApp(runs, makeSessionEventRepo())).post(
+      "/repo-runs/run_x/cancel",
+    );
+
+    expect(res.status).toBe(404);
+    expect(runs.update).not.toHaveBeenCalled();
+  });
+
+  it.each(["succeeded", "failed", "blocked", "cancelled"] as const)(
+    "409s a run already in terminal status %s",
+    async (status) => {
+      const runs = makeRepoRunRepo();
+      vi.mocked(runs.findById).mockResolvedValue(fakeRun({ status }));
+
+      const res = await request(makeApp(runs, makeSessionEventRepo())).post(
+        "/repo-runs/run_1/cancel",
+      );
+
+      expect(res.status).toBe(409);
+      expect(res.body).toMatchObject({ error: "already_terminal", current_status: status });
+      expect(runs.update).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["pending", "running"] as const)("cancels a %s run", async (status) => {
+    const runs = makeRepoRunRepo();
+    vi.mocked(runs.findById).mockResolvedValue(fakeRun({ status }));
+    vi.mocked(runs.update).mockImplementation(async (_id, patch) =>
+      fakeRun({ status: patch.status ?? status }),
+    );
+
+    const res = await request(makeApp(runs, makeSessionEventRepo())).post(
+      "/repo-runs/run_1/cancel",
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.run.status).toBe("cancelled");
+    const patch = vi.mocked(runs.update).mock.calls[0]![1];
+    expect(patch.status).toBe("cancelled");
+    expect(patch.ended_at).toBeInstanceOf(Date);
+  });
+
+  it("500s when the update throws", async () => {
+    silenceConsole();
+    const runs = makeRepoRunRepo();
+    vi.mocked(runs.findById).mockResolvedValue(fakeRun({ status: "running" }));
+    vi.mocked(runs.update).mockRejectedValue(new Error("pg down"));
+
+    const res = await request(makeApp(runs, makeSessionEventRepo())).post(
+      "/repo-runs/run_1/cancel",
+    );
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("cancel_failed");
+  });
+
+  it("403s an agent caller", async () => {
+    const runs = makeRepoRunRepo();
+    const res = await request(makeApp(runs, makeSessionEventRepo(), "agent")).post(
+      "/repo-runs/run_1/cancel",
+    );
+
+    expect(res.status).toBe(403);
+    expect(runs.findById).not.toHaveBeenCalled();
+  });
+});
+
+// ── GET /repo-runs/:id/artifacts/:file ───────────────────────────────────
+
+describe("GET /repo-runs/:id/artifacts/:file", () => {
+  it("404s an unknown run", async () => {
+    const runs = makeRepoRunRepo();
+    vi.mocked(runs.findById).mockResolvedValue(undefined);
+
+    const res = await request(makeApp(runs, makeSessionEventRepo())).get(
+      "/repo-runs/run_x/artifacts/report.md",
+    );
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("run_not_found");
+  });
+
+  it("rejects a filename that isn't its own basename", async () => {
+    const runs = makeRepoRunRepo();
+    vi.mocked(runs.findById).mockResolvedValue(fakeRun());
+
+    // Express decodes %2F before the handler sees it, so this reaches
+    // the basename() guard as a real traversal attempt rather than 404ing
+    // on an unmatched route.
+    const res = await request(makeApp(runs, makeSessionEventRepo())).get(
+      "/repo-runs/run_1/artifacts/..%2F..%2Fetc%2Fpasswd",
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_filename");
+  });
+
+  it("501s a well-formed request, pointing the caller at the work_product endpoint", async () => {
+    const runs = makeRepoRunRepo();
+    vi.mocked(runs.findById).mockResolvedValue(fakeRun({ task_id: "task_9" }));
+
+    const res = await request(makeApp(runs, makeSessionEventRepo())).get(
+      "/repo-runs/run_1/artifacts/report.md",
+    );
+
+    expect(res.status).toBe(501);
+    expect(res.body).toMatchObject({ error: "not_implemented", task_id: "task_9" });
+  });
+
+  it("500s when the lookup throws", async () => {
+    silenceConsole();
+    const runs = makeRepoRunRepo();
+    vi.mocked(runs.findById).mockRejectedValue(new Error("pg down"));
+
+    const res = await request(makeApp(runs, makeSessionEventRepo())).get(
+      "/repo-runs/run_1/artifacts/report.md",
+    );
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("artifact_failed");
+  });
+
+  it("403s an agent caller", async () => {
+    const runs = makeRepoRunRepo();
+    const res = await request(makeApp(runs, makeSessionEventRepo(), "agent")).get(
+      "/repo-runs/run_1/artifacts/report.md",
+    );
+
+    expect(res.status).toBe(403);
+    expect(runs.findById).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/routes/signin.test.ts
+++ b/packages/api/src/routes/signin.test.ts
@@ -1,0 +1,231 @@
+/**
+ * `POST /signin` — unit tests with a vitest fake PersonRepository.
+ *
+ * The route's whole job is deciding which of four responses an
+ * (email, password) pair earns, so the tests are organised around that
+ * decision table. The 401-collapsing behaviour is deliberate — three
+ * distinct failures must be indistinguishable on the wire or the
+ * endpoint becomes an email-existence oracle.
+ */
+import express, { json } from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Person, PersonRepository } from "@beevibe/core";
+import { SIGNIN_NO_PASSWORD_SET, hashPassword } from "@beevibe/core/auth";
+import { createSigninRouter } from "./signin.js";
+
+const PASSWORD = "correct-horse-battery";
+
+function makePersonRepo(): PersonRepository {
+  return {
+    findById: vi.fn(),
+    findByEmail: vi.fn(),
+    findByApiKey: vi.fn(),
+    findManyByIds: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+
+function fakePerson(overrides: Partial<Person> = {}): Person {
+  return {
+    id: "person_1",
+    name: "Ada",
+    email: "ada@example.com",
+    api_key: "bv_u_secret",
+    capability_network_enabled: true,
+    created_at: new Date("2026-04-01"),
+    updated_at: new Date("2026-04-01"),
+    ...overrides,
+  };
+}
+
+function makeApp(personRepo: PersonRepository, enabled?: boolean) {
+  const app = express();
+  app.use(json());
+  app.use("/", createSigninRouter({ personRepo, ...(enabled === undefined ? {} : { enabled }) }));
+  return app;
+}
+
+// scrypt hashing is the slowest thing in this file; hash the one password
+// the happy paths need a single time.
+let hash: string;
+beforeEach(async () => {
+  hash ??= await hashPassword(PASSWORD);
+});
+
+describe("POST /signin — request shape", () => {
+  it.each([
+    ["missing email", {}],
+    ["blank email", { email: "   ", password: PASSWORD }],
+    ["email with no @", { email: "ada.example.com", password: PASSWORD }],
+    ["email with no dot in the domain", { email: "ada@example", password: PASSWORD }],
+    ["email with whitespace", { email: "a b@example.com", password: PASSWORD }],
+  ])("400s on %s", async (_label, body) => {
+    const repo = makePersonRepo();
+    const res = await request(makeApp(repo)).post("/signin").send(body);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_email");
+    expect(repo.findByEmail).not.toHaveBeenCalled();
+  });
+
+  it("400s when the password is missing", async () => {
+    const repo = makePersonRepo();
+    const res = await request(makeApp(repo)).post("/signin").send({ email: "ada@example.com" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_password");
+    expect(repo.findByEmail).not.toHaveBeenCalled();
+  });
+
+  it("400s on a non-string password rather than coercing it", async () => {
+    const repo = makePersonRepo();
+    const res = await request(makeApp(repo))
+      .post("/signin")
+      .send({ email: "ada@example.com", password: 12345 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_password");
+  });
+
+  it("lowercases and trims the email before lookup", async () => {
+    const repo = makePersonRepo();
+    vi.mocked(repo.findByEmail).mockResolvedValue(undefined);
+
+    await request(makeApp(repo))
+      .post("/signin")
+      .send({ email: "  ADA@Example.COM  ", password: PASSWORD });
+
+    expect(repo.findByEmail).toHaveBeenCalledWith("ada@example.com");
+  });
+});
+
+describe("POST /signin — credentials", () => {
+  it("returns the caller's existing key on a match", async () => {
+    const repo = makePersonRepo();
+    vi.mocked(repo.findByEmail).mockResolvedValue(fakePerson({ password_hash: hash }));
+
+    const res = await request(makeApp(repo))
+      .post("/signin")
+      .send({ email: "ada@example.com", password: PASSWORD });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      api_key: "bv_u_secret",
+      person: { id: "person_1", name: "Ada", email: "ada@example.com" },
+    });
+  });
+
+  it("reports a null email rather than omitting the field", async () => {
+    const repo = makePersonRepo();
+    const person = fakePerson({ password_hash: hash });
+    delete person.email;
+    vi.mocked(repo.findByEmail).mockResolvedValue(person);
+
+    const res = await request(makeApp(repo))
+      .post("/signin")
+      .send({ email: "ada@example.com", password: PASSWORD });
+
+    expect(res.status).toBe(200);
+    expect(res.body.person.email).toBeNull();
+  });
+
+  it("401s on a wrong password", async () => {
+    const repo = makePersonRepo();
+    vi.mocked(repo.findByEmail).mockResolvedValue(fakePerson({ password_hash: hash }));
+
+    const res = await request(makeApp(repo))
+      .post("/signin")
+      .send({ email: "ada@example.com", password: "wrong-password" });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("invalid_credentials");
+    expect(res.body.api_key).toBeUndefined();
+  });
+
+  it("409s a legacy account that has a key but no password", async () => {
+    const repo = makePersonRepo();
+    vi.mocked(repo.findByEmail).mockResolvedValue(fakePerson());
+
+    const res = await request(makeApp(repo))
+      .post("/signin")
+      .send({ email: "ada@example.com", password: PASSWORD });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe(SIGNIN_NO_PASSWORD_SET);
+    expect(res.body.api_key).toBeUndefined();
+  });
+
+  it("gives an unknown email and a wrong password the identical 401 body", async () => {
+    // The three failure modes must be indistinguishable, otherwise the
+    // endpoint tells an attacker which emails have accounts.
+    const unknown = makePersonRepo();
+    vi.mocked(unknown.findByEmail).mockResolvedValue(undefined);
+    const wrongPwd = makePersonRepo();
+    vi.mocked(wrongPwd.findByEmail).mockResolvedValue(fakePerson({ password_hash: hash }));
+
+    const unknownRes = await request(makeApp(unknown))
+      .post("/signin")
+      .send({ email: "nobody@example.com", password: PASSWORD });
+    const wrongRes = await request(makeApp(wrongPwd))
+      .post("/signin")
+      .send({ email: "ada@example.com", password: "nope-nope-nope" });
+
+    expect(unknownRes.status).toBe(wrongRes.status);
+    expect(unknownRes.body).toEqual(wrongRes.body);
+  });
+
+  it("401s a person row with a password but no api_key", async () => {
+    const repo = makePersonRepo();
+    const person = fakePerson({ password_hash: hash });
+    delete person.api_key;
+    vi.mocked(repo.findByEmail).mockResolvedValue(person);
+
+    const res = await request(makeApp(repo))
+      .post("/signin")
+      .send({ email: "ada@example.com", password: PASSWORD });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("invalid_credentials");
+  });
+});
+
+describe("POST /signin — lockdown and failures", () => {
+  it("404s when the route is disabled", async () => {
+    const repo = makePersonRepo();
+    const res = await request(makeApp(repo, false))
+      .post("/signin")
+      .send({ email: "ada@example.com", password: PASSWORD });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("signin_disabled");
+    expect(repo.findByEmail).not.toHaveBeenCalled();
+  });
+
+  it("is enabled when the flag is omitted", async () => {
+    const repo = makePersonRepo();
+    vi.mocked(repo.findByEmail).mockResolvedValue(undefined);
+
+    const res = await request(makeApp(repo))
+      .post("/signin")
+      .send({ email: "ada@example.com", password: PASSWORD });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("500s when the lookup throws", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const repo = makePersonRepo();
+    vi.mocked(repo.findByEmail).mockRejectedValue(new Error("pg down"));
+
+    const res = await request(makeApp(repo))
+      .post("/signin")
+      .send({ email: "ada@example.com", password: PASSWORD });
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: "internal_error", message: "pg down" });
+  });
+});

--- a/packages/api/src/routes/signup.test.ts
+++ b/packages/api/src/routes/signup.test.ts
@@ -1,0 +1,331 @@
+/**
+ * `POST /signup` — unit tests with vitest fakes (no DB).
+ *
+ * Signup is unauthenticated and idempotent on email, which makes the
+ * "email already exists" branch the interesting one: it must verify the
+ * supplied password before handing back the existing key, or the route
+ * turns into a credential-stuffing oracle. The other axis is the
+ * provision path — new person → new key → team agent, with the agent
+ * step skipped when one already exists.
+ */
+import express, { json } from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  CoreMemoryBlockRepository,
+  NewAgent,
+  NewPerson,
+  Person,
+  PersonRepository,
+} from "@beevibe/core";
+import { hashPassword } from "@beevibe/core/auth";
+import { createSignupRouter } from "./signup.js";
+
+const PASSWORD = "correct-horse-battery";
+
+function makePersonRepo(): PersonRepository {
+  return {
+    findById: vi.fn(),
+    findByEmail: vi.fn(),
+    findByApiKey: vi.fn(),
+    findManyByIds: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+
+function makeAgentRepo(): AgentRepository {
+  return {
+    findById: vi.fn(),
+    findByApiKey: vi.fn(),
+    findByOwnerId: vi.fn(),
+    findTopLevelForOwner: vi.fn(),
+    findSubordinates: vi.fn(),
+    findPeers: vi.fn(),
+    findParent: vi.fn(),
+    findByLevel: vi.fn(),
+    findDescendantIds: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+
+function makeCoreMemoryRepo(): CoreMemoryBlockRepository {
+  return {
+    findByAgentId: vi.fn(),
+    findByNames: vi.fn(),
+    upsert: vi.fn(),
+    updateContent: vi.fn(),
+    initDefaults: vi.fn().mockResolvedValue([]),
+  } as unknown as CoreMemoryBlockRepository;
+}
+
+function fakePerson(overrides: Partial<Person> = {}): Person {
+  return {
+    id: "person_1",
+    name: "Ada",
+    email: "ada@example.com",
+    api_key: "bv_u_existing",
+    capability_network_enabled: true,
+    created_at: new Date("2026-04-01"),
+    updated_at: new Date("2026-04-01"),
+    ...overrides,
+  };
+}
+
+function fakeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: "agent_a",
+    name: "Ada's team",
+    owner_id: "person_1",
+    hierarchy_level: "team",
+    runtime_config: { type: "claude" },
+    created_at: new Date("2026-04-01"),
+    updated_at: new Date("2026-04-01"),
+    ...overrides,
+  };
+}
+
+interface Fakes {
+  personRepo: PersonRepository;
+  agentRepo: AgentRepository;
+  coreMemoryRepo: CoreMemoryBlockRepository;
+}
+
+/**
+ * Wire the fakes so `provisionUser` / `provisionAgent` (the real core
+ * functions — the route calls them directly) echo back rows built from
+ * the input they were handed.
+ */
+function makeFakes(): Fakes {
+  const personRepo = makePersonRepo();
+  const agentRepo = makeAgentRepo();
+  vi.mocked(personRepo.create).mockImplementation(async (input: NewPerson) =>
+    fakePerson({ ...input, id: input.id ?? "person_new" } as Partial<Person>),
+  );
+  vi.mocked(agentRepo.create).mockImplementation(async (input: NewAgent) =>
+    fakeAgent(input as Partial<Agent>),
+  );
+  return { personRepo, agentRepo, coreMemoryRepo: makeCoreMemoryRepo() };
+}
+
+function makeApp(fakes: Fakes, enabled?: boolean) {
+  const app = express();
+  app.use(json());
+  app.use("/", createSignupRouter({ ...fakes, ...(enabled === undefined ? {} : { enabled }) }));
+  return app;
+}
+
+function body(overrides: Record<string, unknown> = {}) {
+  return { name: "Ada", email: "ada@example.com", password: PASSWORD, ...overrides };
+}
+
+let hash: string;
+beforeEach(async () => {
+  hash ??= await hashPassword(PASSWORD);
+});
+
+describe("POST /signup — validation", () => {
+  it.each([
+    ["missing name", { name: undefined }],
+    ["blank name", { name: "   " }],
+    ["name over 80 chars", { name: "a".repeat(81) }],
+    ["name with a control character", { name: "Ada\u0007" }],
+    ["name with markup", { name: "<script>" }],
+  ])("400s on %s", async (_label, overrides) => {
+    const fakes = makeFakes();
+    const res = await request(makeApp(fakes)).post("/signup").send(body(overrides));
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_name");
+    expect(fakes.personRepo.findByEmail).not.toHaveBeenCalled();
+  });
+
+  it("accepts unicode letters, digits and the allowed punctuation in a name", async () => {
+    const fakes = makeFakes();
+    vi.mocked(fakes.personRepo.findByEmail).mockResolvedValue(undefined);
+    vi.mocked(fakes.agentRepo.findTopLevelForOwner).mockResolvedValue(undefined);
+
+    const res = await request(makeApp(fakes)).post("/signup").send(body({ name: "Ada O'Hára-Lövelace 2" }));
+
+    expect(res.status).toBe(200);
+  });
+
+  it("400s on an invalid email", async () => {
+    const fakes = makeFakes();
+    const res = await request(makeApp(fakes)).post("/signup").send(body({ email: "not-an-email" }));
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_email");
+  });
+
+  it("400s on a password below the minimum length", async () => {
+    const fakes = makeFakes();
+    const res = await request(makeApp(fakes)).post("/signup").send(body({ password: "short" }));
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_password");
+    expect(res.body.message).toMatch(/at least/);
+  });
+
+  it("400s on an empty body", async () => {
+    const fakes = makeFakes();
+    const res = await request(makeApp(fakes)).post("/signup").send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_name");
+  });
+});
+
+describe("POST /signup — new user", () => {
+  it("provisions a person, a bv_u_ key and a team agent", async () => {
+    const fakes = makeFakes();
+    vi.mocked(fakes.personRepo.findByEmail).mockResolvedValue(undefined);
+    vi.mocked(fakes.agentRepo.findTopLevelForOwner).mockResolvedValue(undefined);
+
+    const res = await request(makeApp(fakes)).post("/signup").send(body());
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.existed).toBe(false);
+    expect(res.body.api_key).toMatch(/^bv_u_/);
+    expect(res.body.person).toMatchObject({ name: "Ada", email: "ada@example.com" });
+    expect(res.body.primary_agent.hierarchy).toBe("team");
+
+    const created = vi.mocked(fakes.agentRepo.create).mock.calls[0]![0];
+    expect(created).toMatchObject({
+      name: "Ada's team",
+      hierarchy_level: "team",
+      runtime_config: { type: "claude" },
+    });
+  });
+
+  it("stores a hash rather than the plaintext password", async () => {
+    const fakes = makeFakes();
+    vi.mocked(fakes.personRepo.findByEmail).mockResolvedValue(undefined);
+    vi.mocked(fakes.agentRepo.findTopLevelForOwner).mockResolvedValue(undefined);
+
+    await request(makeApp(fakes)).post("/signup").send(body());
+
+    const created = vi.mocked(fakes.personRepo.create).mock.calls[0]![0];
+    expect(created.password_hash).toBeTruthy();
+    expect(created.password_hash).not.toBe(PASSWORD);
+  });
+
+  it("normalises the email to lowercase and trims it", async () => {
+    const fakes = makeFakes();
+    vi.mocked(fakes.personRepo.findByEmail).mockResolvedValue(undefined);
+    vi.mocked(fakes.agentRepo.findTopLevelForOwner).mockResolvedValue(undefined);
+
+    const res = await request(makeApp(fakes)).post("/signup").send(body({ email: " ADA@Example.COM " }));
+
+    expect(fakes.personRepo.findByEmail).toHaveBeenCalledWith("ada@example.com");
+    expect(res.body.person.email).toBe("ada@example.com");
+  });
+});
+
+describe("POST /signup — existing email", () => {
+  it("returns the existing key when the password matches", async () => {
+    const fakes = makeFakes();
+    vi.mocked(fakes.personRepo.findByEmail).mockResolvedValue(
+      fakePerson({ password_hash: hash }),
+    );
+    vi.mocked(fakes.agentRepo.findTopLevelForOwner).mockResolvedValue(fakeAgent());
+
+    const res = await request(makeApp(fakes)).post("/signup").send(body());
+
+    expect(res.status).toBe(200);
+    expect(res.body.existed).toBe(true);
+    expect(res.body.api_key).toBe("bv_u_existing");
+    expect(fakes.personRepo.create).not.toHaveBeenCalled();
+    expect(fakes.agentRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("401s — and leaks no key — when the password does not match", async () => {
+    const fakes = makeFakes();
+    vi.mocked(fakes.personRepo.findByEmail).mockResolvedValue(
+      fakePerson({ password_hash: hash }),
+    );
+
+    const res = await request(makeApp(fakes))
+      .post("/signup")
+      .send(body({ password: "not-the-right-password" }));
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("invalid_credentials");
+    expect(res.body.api_key).toBeUndefined();
+    expect(fakes.personRepo.update).not.toHaveBeenCalled();
+  });
+
+  it("adopts the supplied password for a legacy account that has none", async () => {
+    const fakes = makeFakes();
+    vi.mocked(fakes.personRepo.findByEmail).mockResolvedValue(fakePerson());
+    vi.mocked(fakes.agentRepo.findTopLevelForOwner).mockResolvedValue(fakeAgent());
+
+    const res = await request(makeApp(fakes)).post("/signup").send(body());
+
+    expect(res.status).toBe(200);
+    expect(res.body.api_key).toBe("bv_u_existing");
+    const [id, patch] = vi.mocked(fakes.personRepo.update).mock.calls[0]!;
+    expect(id).toBe("person_1");
+    expect(patch.password_hash).toBeTruthy();
+    expect(patch.password_hash).not.toBe(PASSWORD);
+  });
+
+  it("backfills a missing team agent for an existing person", async () => {
+    const fakes = makeFakes();
+    vi.mocked(fakes.personRepo.findByEmail).mockResolvedValue(
+      fakePerson({ password_hash: hash }),
+    );
+    vi.mocked(fakes.agentRepo.findTopLevelForOwner).mockResolvedValue(undefined);
+
+    const res = await request(makeApp(fakes)).post("/signup").send(body());
+
+    expect(res.status).toBe(200);
+    expect(res.body.existed).toBe(true);
+    expect(fakes.agentRepo.create).toHaveBeenCalledTimes(1);
+    // The agent is named after the stored person, not the request body,
+    // so a re-signup with a different display name can't rename the team.
+    expect(vi.mocked(fakes.agentRepo.create).mock.calls[0]![0]!.name).toBe("Ada's team");
+  });
+
+  it("treats a row with no api_key as a fresh signup", async () => {
+    const fakes = makeFakes();
+    const person = fakePerson({ password_hash: hash });
+    delete person.api_key;
+    vi.mocked(fakes.personRepo.findByEmail).mockResolvedValue(person);
+    vi.mocked(fakes.agentRepo.findTopLevelForOwner).mockResolvedValue(fakeAgent());
+
+    const res = await request(makeApp(fakes)).post("/signup").send(body());
+
+    expect(res.status).toBe(200);
+    expect(res.body.existed).toBe(false);
+    expect(fakes.personRepo.create).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("POST /signup — lockdown and failures", () => {
+  it("404s when signup is disabled", async () => {
+    const fakes = makeFakes();
+    const res = await request(makeApp(fakes, false)).post("/signup").send(body());
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("signup_disabled");
+    expect(fakes.personRepo.findByEmail).not.toHaveBeenCalled();
+  });
+
+  it("500s when a repo throws", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const fakes = makeFakes();
+    vi.mocked(fakes.personRepo.findByEmail).mockRejectedValue(new Error("pg down"));
+
+    const res = await request(makeApp(fakes)).post("/signup").send(body());
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: "internal_error", message: "pg down" });
+  });
+});


### PR DESCRIPTION
## What

A coverage sweep over `packages/api` (v8, `--coverage.all`) found five route modules sitting at **0% line coverage** that no DB-gated suite reaches either. This adds 119 hermetic tests covering them.

| File | Before | After (lines) | Branches |
| --- | --- | --- | --- |
| `routes/signup.ts` | 0% | **100%** | 96.9% |
| `routes/signin.ts` | 0% | **100%** | 96.2% |
| `routes/me.ts` | 0% | **100%** | 95.2% |
| `routes/repo-runs.ts` | 0% | **100%** | 89.1% |
| `routes/learned-skills.ts` | 0% | **99.4%** | 83.9% |

Package total: **40.6% → 48.6%** lines.

## Why these five

They were picked by crossing the 0%-coverage list with churn (`git log --since="6 months ago"`) and blast radius:

- `signup` and `signin` are **unauthenticated and internet-facing** — the entire self-serve auth surface had no tests.
- `learned-skills` writes to the filesystem and opens PRs against a public repo.
- `repo-runs` + `learned-skills` are the whole capability-network REST API, and both have been modified in the last few months.

Deliberately **not** touched, to avoid colliding with open PRs: the api modules in #272 and the `sandbox` package in #275/#278.

## How they run

Each router is a closure over injected ports, so the tests are hermetic: `vi.fn()` repos plus a stub auth middleware standing in for bv_ token resolution, driven through supertest. **No Postgres, no network, no provider keys** — they pass in the same bare sandbox where the DB-gated suites skip.

## Beyond line count

The tests are written against the behaviour that would actually hurt if it regressed:

- **signup/signin refuse to become an email-existence oracle.** The re-signup path must verify the password before returning the existing key; signin's three distinct failures (unknown email, no password set, wrong password) are asserted to produce *byte-identical* 401 bodies.
- **repo-runs inverts the daemon's `session_event` kind mapping** (`tool_result → error`, `summary → log`). A regression there silently miscolors the transcript UI and no type catches it.
- **The artifact route's traversal guard** is exercised with an encoded `../` that Express decodes before the `basename()` check sees it — so the test hits the guard rather than 404ing on an unmatched route.
- **The SKILL.md write is a non-fatal side effect.** The test points `repoRoot` at a regular file so `mkdir -p` fails with ENOTDIR, then asserts the request still 201s *and* still back-links the run.
- **publish** stubs `fetch` and asserts the four-call GitHub sequence, that the file body round-trips through base64, and that a failed call leaves the skill unmarked rather than half-published.

## Verification

- `npx tsc -p packages/api/tsconfig.json --noEmit` — clean
- `pnpm --filter @beevibe/api lint` — 0 errors (4 pre-existing warnings in other files)
- Full api suite: **454 passed**, 9 files failing — the same nine pre-existing DB-gated suites documented in `CLAUDE.md`, unchanged by this PR.

The coverage provider was installed only to measure and is **not** committed (`pnpm-lock.yaml` is untouched; the diff is five new test files and nothing else).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBRuBV628my4sbZG81k3Cc)_