### PR TITLE
refactor: one declaration for the api↔daemon wire contract

### DIFF
--- a/packages/api/src/runtime/router.ts
+++ b/packages/api/src/runtime/router.ts
@@ -20,6 +20,17 @@ import {
   type RuntimeRepository,
   type TaskRepository,
   type WorkProductRepository,
+  type DispatchPayload,
+  type RuntimeDoneRequest,
+  type RuntimeEventInput,
+  type RuntimeEventsRequest,
+  type RuntimeHeartbeatRequest,
+  type RuntimeRegisterRequest,
+  type RuntimeRegisterResponse,
+  type RuntimeSkill,
+  type RuntimeSkillsResponse,
+  type RuntimeSyncRequest,
+  type RuntimeSyncResponse,
 } from "@beevibe/core";
 import {
   generateDaemonApiKey,
@@ -34,19 +45,6 @@ import {
 import { transitionTaskOnClaim } from "@beevibe/core/services/dispatch-service";
 import { requireDaemon, requireHuman } from "../auth/middleware.js";
 import type { DaemonHub } from "./hub.js";
-import type {
-  DispatchPayload,
-  RuntimeDoneRequest,
-  RuntimeEventInput,
-  RuntimeEventsRequest,
-  RuntimeHeartbeatRequest,
-  RuntimeRegisterRequest,
-  RuntimeRegisterResponse,
-  RuntimeSkill,
-  RuntimeSkillsResponse,
-  RuntimeSyncRequest,
-  RuntimeSyncResponse,
-} from "./types.js";
 
 export interface RuntimeRouterDeps {
   /** Required on every /runtime/* request. Resolves bv_u_ or bv_d_. */

--- a/packages/core/src/domain/daemon-protocol.ts
+++ b/packages/core/src/domain/daemon-protocol.ts
@@ -1,18 +1,26 @@
 /**
- * Wire types for the /runtime/* surface. Shared between the api server
- * (handlers in router.ts) and any daemon implementation (packages/daemon
- * lands in Phase 5). Kept in @beevibe/api for now; promote to a shared
- * package if more consumers need them.
+ * Wire types for the /runtime/* surface — the contract between the api
+ * server (handlers in `packages/api/src/runtime/router.ts`) and the
+ * daemon that claims sessions and spawns CLIs (`packages/daemon`).
+ *
+ * These lived in `@beevibe/api` with a note to "promote to a shared
+ * package if more consumers need them". The daemon then landed and,
+ * having no way to import from the api, hand-copied six of them:
+ * `DispatchPayload`, `RunRepoDispatch` and `RunRepoArtifact` into
+ * `spawner.ts`, and the three skills-bundle shapes into
+ * `skills-cache.ts`. Both halves of a wire contract declared twice is a
+ * drift risk with teeth — the copies had already diverged, with the
+ * daemon spelling `agent_hierarchy_level` and `type` as inline literal
+ * unions instead of `HierarchyLevel` / `SessionType`, so adding a
+ * session type in core would leave the daemon's payload type silently
+ * stale while the server started sending it.
+ *
+ * Types only, no runtime values: safe anywhere core is importable.
  */
 
-import type {
-  HierarchyLevel,
-  KnownCli,
-  SessionEventKind,
-  SessionStatus,
-  SessionType,
-  SessionUsage,
-} from "@beevibe/core";
+import type { HierarchyLevel } from "./agent.js";
+import type { KnownCli } from "./runtime.js";
+import type { SessionEventKind, SessionStatus, SessionType, SessionUsage } from "./session.js";
 
 /* ─── Register ───────────────────────────────────────────────────────── */
 

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -9,6 +9,7 @@ export * from "./memory.js";
 export * from "./negotiation.js";
 export * from "./escalation.js";
 export * from "./daemon.js";
+export * from "./daemon-protocol.js";
 export * from "./runtime.js";
 export * from "./room.js";
 export * from "./repo-run.js";

--- a/packages/daemon/src/repo-runs.ts
+++ b/packages/daemon/src/repo-runs.ts
@@ -13,7 +13,11 @@
  * work_product rows and update the repo_run record.
  */
 
-import type { SessionEventKind, TerminalSessionStatus } from "@beevibe/core";
+import type {
+  RuntimeDoneRequest,
+  SessionEventKind,
+  TerminalSessionStatus,
+} from "@beevibe/core";
 import { runRepoAgent, type TranscriptEvent } from "@beevibe/sandbox/orchestrator";
 import type { ApiClient } from "./api-client.js";
 import { createEventBatcher } from "./event-batcher.js";
@@ -134,7 +138,10 @@ export async function runRepoDispatch(
     sandbox_path: a.sandbox_path,
   }));
 
-  const done = {
+  // Typed against the shared contract rather than inferred: this body is
+  // the /runtime/done request the api parses, so a field renamed on the
+  // server side should break the build here, not in production.
+  const done: RuntimeDoneRequest = {
     session_id: payload.session_id,
     status,
     result_summary:

--- a/packages/daemon/src/skills-cache.ts
+++ b/packages/daemon/src/skills-cache.ts
@@ -12,21 +12,9 @@
 
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
+import type { RuntimeSkillsResponse } from "@beevibe/core";
 import type { ApiClient } from "./api-client.js";
 import { getConfigRoot } from "./config.js";
-
-interface RuntimeSkillFile {
-  path: string;
-  content: string;
-}
-interface RuntimeSkill {
-  name: string;
-  files: RuntimeSkillFile[];
-}
-interface RuntimeSkillsResponse {
-  version: string;
-  skills: RuntimeSkill[];
-}
 
 export function skillsCacheDir(configRoot?: string): string {
   return join(getConfigRoot(configRoot), "skills");

--- a/packages/daemon/src/spawner.ts
+++ b/packages/daemon/src/spawner.ts
@@ -1,7 +1,12 @@
 /**
  * Spawn the CLI for a claimed session and stream events back to the
  * api server. The dispatch payload is the contract between
- * /runtime/claim and this module.
+ * /runtime/claim and this module — it lives in `@beevibe/core`'s
+ * `domain/daemon-protocol.ts` alongside the rest of the /runtime/*
+ * wire types, so the api's response type and the daemon's request type
+ * are one declaration rather than two copies that can drift apart.
+ * Re-exported here because this module's own consumers
+ * (`claimer.ts`, `repo-runs.ts`) import it from `./spawner.js`.
  *
  * Workspace + skills sync run through `LocalWorkspaceManager` from
  * `@beevibe/core` so the daemon's filesystem layout matches the
@@ -15,7 +20,7 @@ import {
 } from "@beevibe/core/adapters/runtime-registry";
 import type {
   Agent,
-  KnownCli,
+  DispatchPayload,
   RuntimeRegistry,
   RuntimeStep,
   RuntimeResult,
@@ -27,52 +32,11 @@ import { createEventBatcher } from "./event-batcher.js";
 import { error, log } from "./logger.js";
 import { runRepoDispatch } from "./repo-runs.js";
 
-export interface DispatchPayload {
-  session_id: string;
-  agent_id: string;
-  agent_api_key: string;
-  agent_hierarchy_level: "ic" | "team" | "org";
-  runtime_type: KnownCli;
-  intent: string;
-  system_prompt_append: string;
-  resume_session_id?: string;
-  model?: string;
-  max_turns?: number;
-  env: Record<string, string>;
-  type: "task" | "mesh_ask" | "mesh_negotiate" | "blocker" | "chat" | "run_repo";
-  mcp_server_url: string;
-  /**
-   * Set when type === 'run_repo'. The spawner branches into the
-   * Docker-sandbox orchestrator instead of the CLI runtime path.
-   * Capability Network (#149).
-   */
-  run_repo?: RunRepoDispatch;
-}
-
-export interface RunRepoDispatch {
-  /** Pre-created repo_run row id the daemon reports back against. */
-  repo_run_id: string;
-  /** GitHub repo the child agent should borrow. */
-  repo_url: string;
-  /** What the child agent is being asked to do, in plain language. */
-  goal: string;
-  /** Optional input file to pre-stage into the sandbox before the agent starts. */
-  input_url?: string;
-  input_filename?: string;
-  limits?: {
-    wall_clock_minutes?: number;
-    max_install_attempts?: number;
-    disk_mb?: number;
-  };
-}
-
-export interface RunRepoArtifact {
-  filename: string;
-  title: string;
-  size_bytes: number;
-  host_path: string;
-  sandbox_path?: string;
-}
+export type {
+  DispatchPayload,
+  RunRepoArtifact,
+  RunRepoDispatch,
+} from "@beevibe/core";
 
 export interface SpawnDeps {
   api: ApiClient;


### PR DESCRIPTION
Rebased onto `main`. **Scope is now one commit** — #276 landed two of this PR's three original clusters independently while it was open, so those are dropped. See the note at the bottom.

---

## The api↔daemon wire contract was declared twice

`packages/api/src/runtime/types.ts` carried a note saying *"promote to a shared package if more consumers need them."* The daemon then landed, had no way to import from the api, and hand-copied **six** of the types instead — `DispatchPayload`, `RunRepoDispatch` and `RunRepoArtifact` into `spawner.ts`, plus the three skills-bundle shapes into `skills-cache.ts`.

This is the duplication that costs something, because the copies had **already drifted**. The daemon spelled `agent_hierarchy_level` and `type` as inline literal unions:

```ts
agent_hierarchy_level: "ic" | "team" | "org";
type: "task" | "mesh_ask" | "mesh_negotiate" | "blocker" | "chat" | "run_repo";
```

rather than `HierarchyLevel` and `SessionType`. Those happen to match today, but adding a session type in core would have left the daemon's payload type silently stale while the server started sending the new value — a wire mismatch that typechecks clean on both sides.

**Change:** move the module to `@beevibe/core` as `domain/daemon-protocol.ts` (types only, no runtime values, so it's safe anywhere core is importable). Both sides import one declaration. The daemon re-exports the three from `spawner.ts`, since `claimer.ts` and `repo-runs.ts` already import them from there.

Also types `repo-runs.ts`'s `/runtime/done` body as `RuntimeDoneRequest`. It was inferred before, so a field renamed on the server would have surfaced in production rather than at the build.

-88 / +54 across 6 files.

## Verification

Local Postgres 16 + pgvector with migrations applied, so the repository suites actually ran rather than skipping:

| Package | Result |
| --- | --- |
| `@beevibe/core` | **831 pass**, 7 fail |
| `@beevibe/api` | **569 pass** |
| `@beevibe/daemon` | **156 pass** |
| `@beevibe/scheduler` | **27 pass** |
| `@beevibe/web` | **200 pass** |

The 7 core failures are the key-gated adapter suites (`anthropic/llm-provider`, `openai/llm-provider`, `openai/embeddings`) — they make live provider calls and this environment has no API keys. CI runs them with the `production` environment secrets.

`build`, `typecheck` and `lint` clean across all 9 tasks (0 errors; remaining warnings are pre-existing `import/no-duplicates` in files this PR doesn't touch).

## What was dropped, and why

This PR originally carried three clusters. #276 landed two of them independently:

- **Postgres repo `update()` skeleton** — #276's `updateRowById` covers the same eight repos, and also unifies `findById` across twelve. Strictly broader than mine, and it ships `pg-helpers.test.ts` (10 tests against a recording fake pool) where mine relied only on the DB-gated suites. Dropped.
- **Web async-state ladder** — #276's `detail-gate.tsx` covers the same seven detail pages, with a test file. Dropped. Amusingly it reached the same diagnosis independently, down to the "one process, three names" observation about the drifted copy.

Only the wire contract survives; #276 touched no files under `packages/daemon/` or `packages/api/src/runtime/`, so there is no overlap and the branch rebased with a clean cherry-pick.

## Follow-up left on the table

`DetailGate` is hardwired to `DetailShell`, so it can't serve the two **peek panels** — `components/agents/agent-detail-panel.tsx` and `components/tasks/task-detail-panel.tsx` — which still carry the hand-written three-branch ladder on `main` (and still say `"Set NEXT_PUBLIC_BV_API_URL to load this agent."`, a fourth wording of the sentence #276 normalized elsewhere). Closing that gap means generalizing `DetailGate`'s wrapper, which is a change to freshly-landed code and belongs in its own PR rather than being folded in here.