### PR TITLE
refactor: one declaration for the chat wire contract

### DIFF
--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -29,6 +29,7 @@ import {
   isInFlightSessionStatus,
   isKnownCli,
   type AgentRepository,
+  type ChatHistoryMessage,
   type KnownCli,
   type PersonRepository,
   type RuntimeRepository,
@@ -42,7 +43,7 @@ import { requireHuman } from "../auth/middleware.js";
 import type { ChatResolver } from "../runtime/chat-resolver.js";
 import type { DaemonHub } from "../runtime/hub.js";
 import { ChatRateLimiter } from "./chat-rate-limit.js";
-import { processResponse, type RepoCard, type SuggestedAction } from "./directives.js";
+import { processResponse } from "./directives.js";
 import { requireParam } from "./http-errors.js";
 import { truncate } from "../views/format.js";
 import { CHAT_THREAD_TITLE_MAX } from "../views/types.js";
@@ -73,24 +74,8 @@ export interface ChatRoutesDeps {
 // #63 signup PR (it depends on person.onboarding_completed_at, which doesn't
 // land until that work).
 
-interface HistoryMessage {
-  id: string;
-  /**
-   * `system` is used for autonomous trigger messages — currently just the
-   * watch_tasks fire ("Watch fired — 2 tasks completed: …"). It tells the
-   * chat surface "the agent's next reply is responding to THIS, not to a
-   * user message," so the UI can render a compact pill above the agent
-   * bubble. The agent never produces system messages directly — they're
-   * derived from the wake session's `<system-wake>`-wrapped intent.
-   */
-  role: "user" | "agent" | "system";
-  content: string;
-  session_id?: string;
-  view_refs?: string[];
-  open_view?: { path: string; label?: string };
-  suggested_actions?: SuggestedAction[];
-  repo_cards?: RepoCard[];
-}
+// The history message shape lives in @beevibe/core as ChatHistoryMessage —
+// the web client renders it, so both halves read one declaration.
 
 /**
  * Extract the user-facing summary out of a `<system-wake>`-wrapped intent.
@@ -267,8 +252,8 @@ export function failureMessageFor(s: {
   return DAEMON_LOG_POINTER;
 }
 
-export function chainToMessages(chain: ConversationChain): HistoryMessage[] {
-  const messages: HistoryMessage[] = [];
+export function chainToMessages(chain: ConversationChain): ChatHistoryMessage[] {
+  const messages: ChatHistoryMessage[] = [];
   for (const s of chain.sessions) {
     if (s.intent.startsWith(SYSTEM_WAKE_INTENT_OPEN)) {
       // System-generated wake turn (watch_tasks fired). Emit a `system`

--- a/packages/api/src/routes/directives.ts
+++ b/packages/api/src/routes/directives.ts
@@ -21,7 +21,13 @@
  *     Hydrated as reference cards by the UI; collected as `view_refs`.
  */
 
-import { extractGitHubRepoRefs } from "@beevibe/core";
+import {
+  extractGitHubRepoRefs,
+  type ChatDirectives,
+  type OpenView,
+  type RepoCard,
+  type SuggestedAction,
+} from "@beevibe/core";
 
 const ENTITY_ID_RE = /\b((?:task|agent|sess)_[A-Za-z0-9]{12})\b/g;
 const OPEN_VIEW_RE =
@@ -72,42 +78,11 @@ const SUGGEST_ACTION_RE =
 const ATTR_LABEL_RE = /\blabel\s*=\s*"([^"]*)"/i;
 const ATTR_PROMPT_RE = /\bprompt\s*=\s*"([^"]*)"/i;
 
-export interface SuggestedAction {
-  /** Short text shown on the chip. */
-  label: string;
-  /** Optional fuller text sent on click — defaults to label. */
-  prompt?: string;
-}
-
-export interface OpenView {
-  path: string;
-  label?: string;
-}
-
-export interface RepoCard {
-  /** Canonical https://github.com/owner/name. */
-  repo_url: string;
-  /** Owner/name parsed out of repo_url; convenience for the renderer. */
-  owner: string;
-  name: string;
-  /** Stars (lifetime, from GitHub search) when the agent knew it. */
-  stars?: number;
-  /** Primary language label when known. */
-  language?: string;
-  /** Source tier — one of learned / trending / community / github. */
-  source?: "learned" | "trending" | "community" | "github";
-  /** Short description string for the card body. */
-  description?: string;
-}
-
-export interface ProcessedResponse {
+export interface ProcessedResponse extends ChatDirectives {
   /** Directive-stripped, ready for markdown render. */
   visible: string;
-  /** Entity ids referenced inline (e.g. task_xxx, agent_yyy). */
+  /** Always present here — the parser emits `[]` rather than omitting it. */
   view_refs: string[];
-  open_view?: OpenView;
-  suggested_actions?: SuggestedAction[];
-  repo_cards?: RepoCard[];
 }
 
 export function processResponse(raw: string): ProcessedResponse {

--- a/packages/api/src/routes/room.ts
+++ b/packages/api/src/routes/room.ts
@@ -32,23 +32,21 @@ import {
   roomMessageId as makeRoomMessageId,
   type Agent,
   type AgentRepository,
+  type OpenView,
   type PersonRepository,
+  type RepoCard,
   type RoomMessage,
   type RoomRepository,
   type RuntimeRegistry,
   type SessionEventRepository,
   type SessionRepository,
+  type SuggestedAction,
   type WorkspaceManager,
 } from "@beevibe/core";
 import type { MemoryAgent } from "@beevibe/core/services/memory";
 import { requireHuman } from "../auth/middleware.js";
 import { makeErrorHandler } from "./http-errors.js";
-import {
-  processResponse,
-  type OpenView,
-  type RepoCard,
-  type SuggestedAction,
-} from "./directives.js";
+import { processResponse } from "./directives.js";
 
 export interface RoomRoutesDeps {
   authMiddleware: RequestHandler;

--- a/packages/core/src/domain/chat-protocol.ts
+++ b/packages/core/src/domain/chat-protocol.ts
@@ -1,0 +1,101 @@
+/**
+ * Wire types for the chat surface — the contract between the api server
+ * (`packages/api/src/routes/chat.ts` and `room.ts`, which parse agent
+ * output into directives) and the web client that renders them
+ * (`packages/web/lib/api/client.ts`, `lib/hooks/use-chat.ts`).
+ *
+ * Every shape here was declared twice, once per package, because web has
+ * no way to import from api. The copies had already started to drift in
+ * the ways hand-copied types always do: the api spells the repo card
+ * `RepoCard` and web spells it `ChatRepoCard`, api gave `OpenView` a
+ * name while web inlined `{ path: string; label?: string }` at four
+ * separate call sites, and the `source` union on the repo card is
+ * written out twice — so adding a fifth source tier in the parser would
+ * leave the renderer's badge/label maps silently missing a case.
+ *
+ * The message shape had drifted three ways: `HistoryMessage` in the api
+ * route, `ChatHistoryMessage` in the web api client, and `ChatMessage`
+ * in the web chat hook, all with the same eight fields.
+ *
+ * Types only, no runtime values: safe anywhere core is importable.
+ */
+
+/** A `<suggest_action>` directive — rendered as a clickable chip. */
+export interface SuggestedAction {
+  /** Short text shown on the chip. */
+  label: string;
+  /** Optional fuller text sent on click — defaults to label. */
+  prompt?: string;
+}
+
+/** A resolved `<open_view>` directive — rendered as an "Open this →" CTA. */
+export interface OpenView {
+  /** Absolute in-app path, validated against the allowed-prefix list. */
+  path: string;
+  label?: string;
+}
+
+/**
+ * Where a repo card came from. The renderer keys its badge and label
+ * maps off this union, so the parser's accepted values and the UI's
+ * cases stay in lockstep.
+ */
+export type RepoCardSource = "learned" | "trending" | "community" | "github";
+
+/**
+ * A `<repo_card>` directive. Agents emit one per find_repo result after
+ * grouping; the chat UI renders them as styled rows with stars +
+ * language + source-tier badge instead of a markdown bullet list.
+ */
+export interface RepoCard {
+  /** Canonical https://github.com/owner/name. */
+  repo_url: string;
+  /** Owner/name parsed out of repo_url; convenience for the renderer. */
+  owner: string;
+  name: string;
+  /** Stars (lifetime, from GitHub search) when the agent knew it. */
+  stars?: number;
+  /** Primary language label when known. */
+  language?: string;
+  /** Source tier — one of learned / trending / community / github. */
+  source?: RepoCardSource;
+  /** Short description string for the card body. */
+  description?: string;
+}
+
+/**
+ * The four directive-derived fields that travel together on every chat
+ * payload — the parser's output, a turn response, a room message and a
+ * history message all carry exactly this set.
+ */
+export interface ChatDirectives {
+  /** Entity ids referenced inline (e.g. task_xxx, agent_yyy). */
+  view_refs?: string[];
+  open_view?: OpenView;
+  suggested_actions?: SuggestedAction[];
+  repo_cards?: RepoCard[];
+}
+
+/**
+ * `system` marks autonomous trigger annotations (e.g. watch_tasks fired —
+ * "2 tasks completed: …"). The UI renders them as a compact pill between
+ * user/agent bubbles so the user can see *why* the agent is suddenly
+ * running. Agents never produce system messages directly — they're
+ * derived from the wake session's `<system-wake>`-wrapped intent.
+ */
+export type ChatMessageRole = "user" | "agent" | "system";
+
+/**
+ * One rendered message in a chat transcript. Reconstructed server-side
+ * from a conversation chain (`chainToMessages`) and minted client-side
+ * for optimistic local turns, which is why `id` is only a stable render
+ * key — it is not a persisted entity id.
+ */
+export interface ChatHistoryMessage extends ChatDirectives {
+  /** Stable key for React; not a persisted id. */
+  id: string;
+  role: ChatMessageRole;
+  content: string;
+  /** Set on agent messages so the UI can link to the session detail page. */
+  session_id?: string;
+}

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -10,6 +10,7 @@ export * from "./negotiation.js";
 export * from "./escalation.js";
 export * from "./daemon.js";
 export * from "./daemon-protocol.js";
+export * from "./chat-protocol.js";
 export * from "./runtime.js";
 export * from "./room.js";
 export * from "./repo-run.js";

--- a/packages/web/app/(authed)/chat/chat-client.tsx
+++ b/packages/web/app/(authed)/chat/chat-client.tsx
@@ -18,7 +18,7 @@ import { isApiConfigured } from "@/lib/api/config";
 import {
   api,
   type ChatConversationsResponse,
-  type ChatRepoCard,
+  type RepoCard,
   type SuggestedAction,
 } from "@/lib/api/client";
 import { useChat, type ChatMessage } from "@/lib/hooks/use-chat";
@@ -707,21 +707,21 @@ function SuggestedActions({
   );
 }
 
-const SOURCE_BADGE_CLASS: Record<NonNullable<ChatRepoCard["source"]>, string> = {
+const SOURCE_BADGE_CLASS: Record<NonNullable<RepoCard["source"]>, string> = {
   learned: "bg-emerald-500/15 text-emerald-300 border-emerald-500/30",
   trending: "bg-amber-500/15 text-amber-300 border-amber-500/30",
   community: "bg-sky-500/15 text-sky-300 border-sky-500/30",
   github: "bg-muted text-muted-foreground border-border",
 };
 
-const SOURCE_LABEL: Record<NonNullable<ChatRepoCard["source"]>, string> = {
+const SOURCE_LABEL: Record<NonNullable<RepoCard["source"]>, string> = {
   learned: "Learned",
   trending: "Trending",
   community: "Community",
   github: "GitHub",
 };
 
-function RepoCards({ cards }: { cards: ChatRepoCard[] }) {
+function RepoCards({ cards }: { cards: RepoCard[] }) {
   return (
     <div className="mt-2 flex flex-col gap-1.5">
       {cards.map((card) => (
@@ -737,7 +737,7 @@ function RepoCards({ cards }: { cards: ChatRepoCard[] }) {
  * use_repo sandbox run with a sensible default goal, then the button
  * swaps to a deep-link into the playground (the run detail page).
  */
-function RepoCardRow({ card }: { card: ChatRepoCard }) {
+function RepoCardRow({ card }: { card: RepoCard }) {
   const [watchUrl, setWatchUrl] = useState<string | null>(null);
   const tryRun = useMutation({
     mutationFn: () =>

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -1,15 +1,25 @@
 import { fetchJson } from "./http";
 import type {
+  ChatHistoryMessage,
   HierarchyLevel,
   KnownCli,
   LearnedSkill,
   MemoryScope,
+  OpenView,
+  RepoCard,
   RepoRun,
   RepoRunStatus,
   ReviewPolicy,
+  SuggestedAction,
   Task,
 } from "@beevibe/core";
 export type { RepoRun, RepoRunStatus, LearnedSkill };
+/**
+ * Chat wire types come from `@beevibe/core` so the api server that emits
+ * them and this client that renders them read one declaration. Re-exported
+ * here because the chat UI imports its types from the api client.
+ */
+export type { ChatHistoryMessage, OpenView, RepoCard, SuggestedAction };
 import type {
   TaskDetail,
   AgentDetail,
@@ -91,29 +101,6 @@ export interface ChatSendInput {
   session_id?: string;
 }
 
-export interface SuggestedAction {
-  /** Short text shown on the chip. */
-  label: string;
-  /** Optional longer message sent on click — defaults to label. */
-  prompt?: string;
-}
-
-/**
- * Rich repo card from a `<repo_card>` chat directive. Agents emit one
- * per find_repo result after grouping; the chat UI renders them as
- * styled rows with stars + language + source-tier badge instead of a
- * markdown bullet list.
- */
-export interface ChatRepoCard {
-  repo_url: string;
-  owner: string;
-  name: string;
-  stars?: number;
-  language?: string;
-  source?: "learned" | "trending" | "community" | "github";
-  description?: string;
-}
-
 export interface ChatTurnResponse {
   ok: true;
   agent: { id: string; name: string; hierarchy: "ic" | "team" | "org" };
@@ -126,7 +113,7 @@ export interface ChatTurnResponse {
    * If the agent emitted an `<open_view path="..."/>` directive, the
    * resolved path is here so the chat UI can render a prominent "Open this →" CTA.
    */
-  open_view?: { path: string; label?: string };
+  open_view?: OpenView;
   /**
    * If the agent ended its reply with `<suggest_action>` directives, each
    * label becomes a clickable chip below the bubble that re-sends the
@@ -137,7 +124,7 @@ export interface ChatTurnResponse {
    * `<repo_card>` directives the agent emitted (typically after find_repo).
    * Rendered as a structured repo list with stars + language + source.
    */
-  repo_cards?: ChatRepoCard[];
+  repo_cards?: RepoCard[];
 }
 
 export interface Room {
@@ -168,9 +155,9 @@ export interface RoomMessage {
   session_id?: string;
   /** Entity ids the agent referenced in this message, hydrated as cards. */
   view_refs?: string[];
-  open_view?: { path: string; label?: string };
+  open_view?: OpenView;
   suggested_actions?: SuggestedAction[];
-  repo_cards?: ChatRepoCard[];
+  repo_cards?: RepoCard[];
   created_at: string;
 }
 
@@ -269,22 +256,6 @@ export interface SignupResponse {
   primary_agent: { id: string; name: string; hierarchy: "ic" | "team" | "org" };
   /** True when an existing person with this email was returned instead of created. */
   existed: boolean;
-}
-
-export interface ChatHistoryMessage {
-  id: string;
-  /**
-   * `system` marks autonomous trigger annotations (e.g. watch_tasks fired —
-   * "2 tasks completed: …"). Rendered as a compact pill between user/agent
-   * bubbles so the user can see *why* the agent is suddenly running.
-   */
-  role: "user" | "agent" | "system";
-  content: string;
-  session_id?: string;
-  view_refs?: string[];
-  open_view?: { path: string; label?: string };
-  suggested_actions?: SuggestedAction[];
-  repo_cards?: ChatRepoCard[];
 }
 
 export interface ChatHistoryResponse {

--- a/packages/web/lib/hooks/use-chat.ts
+++ b/packages/web/lib/hooks/use-chat.ts
@@ -6,34 +6,18 @@ import {
   api,
   type ChatHistoryMessage,
   type ChatHistoryResponse,
-  type ChatRepoCard,
   type ChatTurnResponse,
-  type SuggestedAction,
 } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
 import { ApiError } from "@/lib/api/http";
 import { queryKeys } from "./keys";
 
-export interface ChatMessage {
-  /** Stable key for React; not persisted. */
-  id: string;
-  /**
-   * `system` is used for autonomous trigger annotations (currently just
-   * watch_tasks fires). UI renders them as compact pills between bubbles.
-   */
-  role: "user" | "agent" | "system";
-  content: string;
-  /** Set on agent messages so the UI can link to the session detail page. */
-  session_id?: string;
-  /** Entity ids the agent referenced — rendered as inline cards. */
-  view_refs?: string[];
-  /** Resolved `<open_view>` directive — rendered as an "Open this →" CTA. */
-  open_view?: { path: string; label?: string };
-  /** Resolved `<suggest_action>` chips — chip shows label, clicking sends prompt (or label). */
-  suggested_actions?: SuggestedAction[];
-  /** Resolved `<repo_card>` directives — rendered as a structured repo list. */
-  repo_cards?: ChatRepoCard[];
-}
+/**
+ * A message on the chat surface. Locally-minted optimistic turns and
+ * server-rendered history are the same shape, so this is the wire type
+ * itself — re-exported under the name the chat components already use.
+ */
+export type ChatMessage = ChatHistoryMessage;
 
 let nextLocalId = 0;
 const localId = (): string => `m_${++nextLocalId}`;
@@ -46,19 +30,6 @@ function mintSessionId(): string {
   let suffix = "";
   for (const b of bytes) suffix += SID_ALPHABET[b % SID_ALPHABET.length];
   return `sess_${suffix}`;
-}
-
-function fromHistory(m: ChatHistoryMessage): ChatMessage {
-  return {
-    id: m.id,
-    role: m.role,
-    content: m.content,
-    ...(m.session_id ? { session_id: m.session_id } : {}),
-    ...(m.view_refs ? { view_refs: m.view_refs } : {}),
-    ...(m.open_view ? { open_view: m.open_view } : {}),
-    ...(m.suggested_actions ? { suggested_actions: m.suggested_actions } : {}),
-    ...(m.repo_cards ? { repo_cards: m.repo_cards } : {}),
-  };
 }
 
 export interface UseChatOptions {
@@ -167,7 +138,7 @@ export function useChat(opts: UseChatOptions = {}) {
   // from the URL — first click looks like a no-op, second click works.
   // Suppress the stale read until the seed has fired this entry.
   const messages = useMemo<ChatMessage[]>(
-    () => (fresh && !freshSeeded ? [] : (history.data?.messages ?? []).map(fromHistory)),
+    () => (fresh && !freshSeeded ? [] : (history.data?.messages ?? [])),
     [fresh, freshSeeded, history.data],
   );
 


### PR DESCRIPTION
## What

The chat surface's wire types were declared **twice** — once in the api that emits them, once in the web client that renders them — because `packages/web` has no way to import from `packages/api`. Five shapes, ten declarations:

| Shape | Where it was declared |
| --- | --- |
| `SuggestedAction` | `api/src/routes/directives.ts` **and** `web/lib/api/client.ts` |
| `RepoCard` | `api/src/routes/directives.ts`, spelled `ChatRepoCard` in `web/lib/api/client.ts` |
| `OpenView` | named in api; inlined as `{ path: string; label?: string }` at **four** separate web call sites |
| the message shape | three ways: `HistoryMessage` (`api/src/routes/chat.ts`), `ChatHistoryMessage` (`web/lib/api/client.ts`), `ChatMessage` (`web/lib/hooks/use-chat.ts`) — same eight fields each |
| the directive quartet | `view_refs` / `open_view` / `suggested_actions` / `repo_cards`, repeated on all four payload types |

## Why it matters

The copies had already started to drift in the ways hand-copied types always do:

- The repo card's `source` union (`learned \| trending \| community \| github`) is written out on **both** sides. Adding a fifth source tier in the parser would leave the renderer's `SOURCE_BADGE_CLASS` and `SOURCE_LABEL` maps silently missing a case — they key off `NonNullable<RepoCard["source"]>`, so the exhaustiveness check only bites if the union is shared.
- `ChatMessage` being nominally distinct from `ChatHistoryMessage` forced a `fromHistory` mapper that copied all eight fields across for no reason beyond the two names differing.
- api gave `OpenView` a name while web inlined the same object literal four times.

This is the same class of problem — and the same fix — as #281, which pulled the api↔daemon `/runtime/*` contract into core after the daemon had hand-copied six of its types.

## How

New `packages/core/src/domain/chat-protocol.ts`, exported from the `domain` barrel, declaring `SuggestedAction`, `OpenView`, `RepoCard`, `RepoCardSource`, `ChatDirectives`, `ChatMessageRole` and `ChatHistoryMessage`. Types only, no runtime values — safe anywhere core is importable, matching the `daemon-protocol.ts` precedent.

Both halves now import from core:

- `api/src/routes/directives.ts` drops its four declarations; `ProcessedResponse` extends `ChatDirectives`.
- `api/src/routes/chat.ts` drops `HistoryMessage`; `chainToMessages` returns `ChatHistoryMessage[]`.
- `api/src/routes/room.ts` imports the directive types from core rather than from `./directives.js`.
- `web/lib/api/client.ts` re-exports the core types (the chat UI imports its types from the api client) and drops its own copies.
- `web/lib/hooks/use-chat.ts`: `ChatMessage` becomes an alias of `ChatHistoryMessage`, and `fromHistory` goes with it — with the types identical it was an identity copy, so `.map(fromHistory)` is now just the array.

Net **−145 / +46** lines across 7 files, plus the new 100-line core module.

`RepoCardSource` is now a named union both halves key off, so the parser's accepted values and the renderer's cases stay in lockstep.

## Testing

- `typecheck` clean across `@beevibe/core`, `@beevibe/api`, `@beevibe/web`
- `lint` clean — 9/9 tasks, 0 errors (remaining warnings are pre-existing)
- `build` clean for core and api
- `@beevibe/api`: **579 tests pass**, 0 test failures
- `@beevibe/web`: **203 tests pass** (24/24 files)
- `@beevibe/core`: 609 pass

Remaining suite-level failures are the documented no-Postgres / no-provider-key sandbox baseline (`DATABASE_URL_TEST env var is required`, `OPENAI_API_KEY missing`, and the `pool.end()` knock-on in `afterAll`) — see CLAUDE.md. No behavior change: this is a types-only move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEpdMragM3xvuRiSvuM3Cv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEpdMragM3xvuRiSvuM3Cv)_