### PR TITLE
test: drop duplicated re-export coverage, cover the untested local logic

### DIFF
--- a/packages/api/src/tools/mesh.test.ts
+++ b/packages/api/src/tools/mesh.test.ts
@@ -3,8 +3,8 @@
  *
  * Per-tool handler behavior is covered indirectly by the m6/m7 e2e scripts
  * (mesh flows require live Postgres + spawned CLI subprocesses). This file
- * locks the static tier inventory so future skill-loader work can rely on
- * the tool counts being stable.
+ * locks the static tier inventory — the exact tool *names* each tier gets,
+ * so future skill-loader work can rely on the surface being stable.
  */
 import { describe, expect, it } from "vitest";
 import type { ResolvedCaller } from "@beevibe/core/auth";
@@ -22,28 +22,19 @@ const fakeCaller: ResolvedCaller = {
 const fakeCtx = { caller: fakeCaller, beevibeSid: "ses_x" };
 
 describe("buildIcMeshTools (M9.1)", () => {
-  it("returns exactly 2 tools: respond_ask + report_blocker", () => {
+  // Exact set, not a superset: ICs are responders, not initiators, so the
+  // absences matter as much as the presences. No `respond_negotiate`
+  // (M9.1 dropped it — ICs are workers, not deciders) and none of the
+  // initiator-side surface (`ask`, `negotiate`, `escalate_to_humans`).
+  it("gets exactly respond_ask + report_blocker", () => {
     const tools = buildIcMeshTools(fakeCtx, fakeServices);
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual(["report_blocker", "respond_ask"]);
   });
-
-  it("does NOT include respond_negotiate (M9.1 dropped it; ICs are workers, not deciders)", () => {
-    const tools = buildIcMeshTools(fakeCtx, fakeServices);
-    expect(tools.some((t) => t.name === "respond_negotiate")).toBe(false);
-  });
-
-  it("does NOT include any initiator-side tools", () => {
-    const tools = buildIcMeshTools(fakeCtx, fakeServices);
-    const names = tools.map((t) => t.name);
-    expect(names).not.toContain("ask");
-    expect(names).not.toContain("negotiate");
-    expect(names).not.toContain("escalate_to_humans");
-  });
 });
 
 describe("buildTeamMeshTools", () => {
-  it("returns exactly 6 tools (full mesh surface)", () => {
+  it("gets the full mesh surface — initiator and responder sides both", () => {
     const tools = buildTeamMeshTools(fakeCtx, fakeServices);
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual([

--- a/packages/api/src/views/format.test.ts
+++ b/packages/api/src/views/format.test.ts
@@ -1,28 +1,12 @@
 import { describe, it, expect } from "vitest";
-import {
-  deriveShortId,
-  formatRelativeShort,
-  formatDurationLabel,
-} from "./format.js";
+import { computeCacheHitRatio, formatRelativeShort } from "./format.js";
 
-describe("deriveShortId", () => {
-  it("strips the type prefix and keeps 6 chars", () => {
-    expect(deriveShortId("sess_abc123def456")).toBe("abc123");
-    expect(deriveShortId("task_zzyx99")).toBe("zzyx99");
-    expect(deriveShortId("agt_xx")).toBe("xx");
-  });
-
-  it("handles ids without a prefix by truncating to 6 chars", () => {
-    expect(deriveShortId("abcdefghij")).toBe("abcdef");
-  });
-
-  it("matches the web's shortId logic minus the leading '#'", () => {
-    // packages/web/lib/format.ts:shortId returns "#" + first 6 chars of trimmed.
-    // Our backend produces just the 6 chars (URL-friendly).
-    const id = "sess_0123456789abcdef";
-    expect("#" + deriveShortId(id)).toBe("#012345");
-  });
-});
+// `deriveShortId`, `formatDurationLabel`, `firstNonEmptyLine` and
+// `truncate` are re-exported here verbatim from
+// `@beevibe/core/domain/format` and are covered by that module's own
+// suite. This file tests the two things that are actually this
+// package's: the suffix-less relative-time form the wire uses, and the
+// cache-hit ratio.
 
 describe("formatRelativeShort", () => {
   const now = new Date("2026-04-30T12:00:00Z");
@@ -42,44 +26,37 @@ describe("formatRelativeShort", () => {
   it("uses day granularity under a month", () => {
     expect(formatRelativeShort(new Date(now.getTime() - 4 * 86400_000), now)).toBe("4d");
   });
+
+  // The whole point of the api-local wrapper: the web renders "2m ago",
+  // the wire carries the bare "2m". Same ladder, no suffix.
+  it("emits the bare label with no ' ago' suffix", () => {
+    expect(formatRelativeShort(new Date(now.getTime() - 2 * 60_000), now)).toBe("2m");
+  });
 });
 
-describe("formatDurationLabel", () => {
-  const now = new Date("2026-04-30T12:00:00Z");
-
-  it("returns dash when start is missing", () => {
-    expect(formatDurationLabel(null, null, now)).toBe("—");
-    expect(formatDurationLabel(undefined, undefined, now)).toBe("—");
+describe("computeCacheHitRatio", () => {
+  // The denominator is the sum of all three input slices, not `input`
+  // alone — on a warm session cache_read routinely exceeds input, so
+  // `cache_read / input` would report over 100%.
+  it("scores cache_read against the full three-slice input total", () => {
+    expect(computeCacheHitRatio({ input: 100, cacheCreation: 300, cacheRead: 600 })).toBe(0.6);
   });
 
-  it("renders seconds under a minute", () => {
-    const start = new Date(now.getTime() - 30_000);
-    expect(formatDurationLabel(start, null, now)).toBe("30s");
+  it("stays at or below 1 when cache_read dwarfs input (the warm-session case)", () => {
+    const ratio = computeCacheHitRatio({ input: 10, cacheCreation: 0, cacheRead: 9_990 });
+    expect(ratio).toBeLessThanOrEqual(1);
+    expect(ratio).toBeCloseTo(0.999, 3);
   });
 
-  it("renders minutes when started_at is set and completed_at is null (running)", () => {
-    const start = new Date(now.getTime() - 6 * 60_000);
-    expect(formatDurationLabel(start, null, now)).toBe("6m");
+  it("returns 1 when every input token came from cache", () => {
+    expect(computeCacheHitRatio({ input: 0, cacheCreation: 0, cacheRead: 500 })).toBe(1);
   });
 
-  it("renders 'h m' when over an hour", () => {
-    const start = new Date(now.getTime() - (3 * 3600_000 + 12 * 60_000));
-    expect(formatDurationLabel(start, null, now)).toBe("3h 12m");
+  it("returns 0 on a cold session with no cache reads", () => {
+    expect(computeCacheHitRatio({ input: 500, cacheCreation: 200, cacheRead: 0 })).toBe(0);
   });
 
-  it("renders pure 'h' when minutes are zero", () => {
-    const start = new Date(now.getTime() - 2 * 3600_000);
-    expect(formatDurationLabel(start, null, now)).toBe("2h");
-  });
-
-  it("uses the completion time when provided rather than now", () => {
-    const start = new Date("2026-04-30T10:00:00Z");
-    const end = new Date("2026-04-30T11:30:00Z");
-    expect(formatDurationLabel(start, end, now)).toBe("1h 30m");
-  });
-
-  it("clamps negatives to zero", () => {
-    const start = new Date(now.getTime() + 10_000);
-    expect(formatDurationLabel(start, null, now)).toBe("0s");
+  it("returns 0 rather than NaN when there is no input to score against", () => {
+    expect(computeCacheHitRatio({ input: 0, cacheCreation: 0, cacheRead: 0 })).toBe(0);
   });
 });


### PR DESCRIPTION
Sweep of the suite for tests that no longer earn their place.

## What the sweep did *not* find

Reporting the negatives, since they were the bulk of the search:

- **No stale skips.** Every `.skip` / `.skipIf` / `describeOrSkip` in the tree is a live environment gate with a documented opt-in — `BEEVIBE_E2E_DOCKER`, `BEEVIBE_E2E_MULTI_INSTANCE`, `RUN_CLAUDE_SMOKE`, `HAS_LIVE_API_KEYS`, and `process.platform === "win32"` on the POSIX-only spawn/workspace suites. No `todo`, no `failing`, no `xit`.
- **No tests of removed APIs.** `turbo run typecheck lint` is clean across all 15 tasks, so every symbol a test imports still exists. No test file has lost its subject module (the nine without a same-named sibling are the `.db` / `.e2e` / `.integration` / smoke suites, all intentional).
- **No assertion-free tests.** A pass over every `it` / `test` block in the monorepo found zero with no `expect`.

## What it did find

### Duplicated coverage of moved code — `packages/api/src/views/format.test.ts`

#263 moved `deriveShortId`, `formatDurationLabel`, `truncate` and `firstNonEmptyLine` into `@beevibe/core/domain/format`, leaving `views/format.ts` as a re-export line. Its test file kept testing them anyway, so the same four implementations are exercised twice — and every api case is strictly subsumed by `packages/core/src/domain/format.test.ts`:

| api case (dropped) | core case that already covers it |
| --- | --- |
| strips the type prefix / handles unprefixed ids / `agt_xx` | "strips the typed-id prefix and takes 6 chars", "leaves an unprefixed id alone", "returns short ids whole rather than padding" |
| `30s` / `6m` / `3h 12m` / pure `2h` | "formats each unit band" |
| running (`completed_at` null) | "measures against now while still running" |
| dash when start is missing | "returns a placeholder without a start" |
| clamps negatives to zero | "clamps a completion that precedes the start to zero" |

The sibling re-export module `packages/web/lib/format.ts` has no test file at all, which is the consistent treatment.

One dropped case had also gone circular: *"matches the web's shortId logic minus the leading `#`"* asserted `"#" + deriveShortId(id)` against a literal, but web's `shortId` is now **defined** as exactly that expression over the same function — it can no longer detect drift, because there are no longer two implementations to drift.

### The logic that is local here had no test

`computeCacheHitRatio` is the only real logic left in `views/format.ts` — read by both `views/dashboard.ts` and `views/sessions.ts` — and it had no direct coverage while ten tests re-covered the re-exports. It now has five, including the case its doc comment calls out: on a warm session `cache_read` exceeds `input`, so the three-slice denominator is what keeps the ratio from reading over 100%. `formatRelativeShort` gains the case that justifies the api-local wrapper existing at all — the bare label with no `" ago"` suffix, which is what the wire carries.

### Assertions subsumed by an exact-set assertion — `packages/api/src/tools/mesh.test.ts`

`"does NOT include respond_negotiate"` and `"does NOT include any initiator-side tools"` both check absences from a list the test above already pins with `toEqual(["report_blocker", "respond_ask"])`. An exact array match already proves nothing else is present, so neither can fail unless the first fails too. Their rationale — why ICs get no `respond_negotiate` and none of the initiator surface — is the part worth keeping, so it moves into a comment on the surviving assertion.

The file's header comment also still promised stable *"tool counts"*; #270 moved this file to asserting names, so it now says so.

## Verification

`@beevibe/api` goes **579 → 573 passing**, failed-file count unchanged at **9** — all environmental (no Postgres, no provider keys), per the baseline table in `CLAUDE.md`. That delta is exactly the twelve removed tests less the six added, and nothing else. `packages/core/src/domain/format.test.ts` runs green at 18 tests, unchanged. `turbo run typecheck lint` clean.

## Noted, not touched

`queryKeys.activity` in `packages/web/lib/hooks/keys.ts` is now referenced only by `lib/sse.ts`'s own invalidation map — nothing registers a query under `["activity"]` since #273 removed `api.activity.list`, so those six invalidations are inert. That is dead **production** code rather than a stale test, and `CLAUDE.md` already flags retiring the `GET /activity` endpoint behind it as a product call, so it is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6ToarWWuWedSAgXbbo6xV

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6ToarWWuWedSAgXbbo6xV)_