### PR TITLE
chore: remove dead code found by a static + dynamic sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,7 +248,8 @@ touching it.
 
 | Thing | Why it survived the sweep |
 | --- | --- |
-| `GET /activity` → `api/src/views/activity.ts` | No caller anywhere in the monorepo, but it's a **documented public endpoint** (`packages/api/README.md`). Retiring it is a product call. The web stub that used to reach it (`api.activity.list`) is removed by #273; `queryKeys.activity` + its `lib/sse.ts` invalidations are inert once that lands. |
+| `GET /activity` → `api/src/views/activity.ts` | No caller anywhere in the monorepo, but it's a **documented public endpoint** (`packages/api/README.md`). Retiring it is a product call. The web side is fully gone: the client stub (`api.activity.list`) went with #273, and `queryKeys.activity` + its no-op `lib/sse.ts` invalidations went with #283. |
+| `SkillOutcomeRepository.listBySkill` / `.statsForSkill`, `AgentProvisionEventRepository.listByParent` | Uncalled **read** halves of audit trails whose write side is live and accumulating rows (`skill_outcome` via `recordCapabilityOutcome`, `agent_provision_event` via `create_subordinate_agent`). Same call as the promotion repo below — the consumers (discovery-ranker feedback, agents-page audit panel) are unbuilt, not removed. Deleting the queries makes finishing them harder. |
 | `PostgresMemoryPromotionEventRepository` | Never constructed — `bootstrap.ts` builds the MemoryAgent without `promotionEventRepo`, so the M8.D promotion audit log never writes even though the port, the service branch, its tests and the read-side `views/promotions.ts` all exist. That's **unfinished wiring, not dead code**; deleting the adapter makes finishing it harder. |
 
 ## Deploying

--- a/packages/api/src/routes/me.test.ts
+++ b/packages/api/src/routes/me.test.ts
@@ -38,7 +38,6 @@ function makeAgentRepo(): AgentRepository {
   return {
     findById: vi.fn(),
     findByApiKey: vi.fn(),
-    findByOwnerId: vi.fn(),
     findTopLevelForOwner: vi.fn(),
     findSubordinates: vi.fn(),
     findPeers: vi.fn(),

--- a/packages/api/src/routes/signup.test.ts
+++ b/packages/api/src/routes/signup.test.ts
@@ -41,7 +41,6 @@ function makeAgentRepo(): AgentRepository {
   return {
     findById: vi.fn(),
     findByApiKey: vi.fn(),
-    findByOwnerId: vi.fn(),
     findTopLevelForOwner: vi.fn(),
     findSubordinates: vi.fn(),
     findPeers: vi.fn(),

--- a/packages/core/src/adapters/postgres/agent-repo.ts
+++ b/packages/core/src/adapters/postgres/agent-repo.ts
@@ -19,14 +19,6 @@ export class PostgresAgentRepository implements AgentRepository {
     return rows[0] ? rowToAgent(rows[0]) : undefined;
   }
 
-  async findByOwnerId(ownerId: string): Promise<Agent[]> {
-    const { rows } = await this.pool.query<AgentRow>(
-      `SELECT * FROM agent WHERE owner_id = $1 ORDER BY created_at ASC`,
-      [ownerId],
-    );
-    return rows.map(rowToAgent);
-  }
-
   async findTopLevelForOwner(ownerId: string): Promise<Agent | undefined> {
     // team before org — alphabetical DESC picks 'team' over 'org'
     const { rows } = await this.pool.query<AgentRow>(

--- a/packages/core/src/adapters/postgres/room-repo.ts
+++ b/packages/core/src/adapters/postgres/room-repo.ts
@@ -122,15 +122,6 @@ export class PostgresRoomRepository implements RoomRepository {
     return rows;
   }
 
-  async listMemberPersonIds(roomId: string): Promise<string[]> {
-    const { rows } = await this.pool.query<{ person_id: string }>(
-      `SELECT person_id FROM room_member
-       WHERE room_id = $1 AND kind = 'person' AND person_id IS NOT NULL`,
-      [roomId],
-    );
-    return rows.map((r) => r.person_id);
-  }
-
   async listMemberAgentIds(roomId: string): Promise<string[]> {
     const { rows } = await this.pool.query<{ agent_id: string }>(
       `SELECT agent_id FROM room_member
@@ -147,22 +138,6 @@ export class PostgresRoomRepository implements RoomRepository {
          WHERE room_id = $1 AND kind = 'person' AND person_id = $2
        ) AS exists`,
       [roomId, personId],
-    );
-    return !!rows[0]?.exists;
-  }
-
-  async areAgentsCoMembers(agentA: string, agentB: string): Promise<boolean> {
-    if (agentA === agentB) return false;
-    const { rows } = await this.pool.query<{ exists: boolean }>(
-      `SELECT EXISTS (
-         SELECT 1
-         FROM room_member ra
-         JOIN room_member rb
-           ON ra.room_id = rb.room_id
-         WHERE ra.kind = 'agent' AND ra.agent_id = $1
-           AND rb.kind = 'agent' AND rb.agent_id = $2
-       ) AS exists`,
-      [agentA, agentB],
     );
     return !!rows[0]?.exists;
   }

--- a/packages/core/src/auth/test-fakes.ts
+++ b/packages/core/src/auth/test-fakes.ts
@@ -15,7 +15,6 @@ export function makeAgentRepoFake(): AgentRepository {
   return {
     findById: vi.fn(),
     findByApiKey: vi.fn(),
-    findByOwnerId: vi.fn(),
     findTopLevelForOwner: vi.fn(),
     findSubordinates: vi.fn(),
     findPeers: vi.fn(),

--- a/packages/core/src/ports/agent-repo.ts
+++ b/packages/core/src/ports/agent-repo.ts
@@ -9,8 +9,6 @@ export interface AgentRepository {
 
   findByApiKey(apiKey: string): Promise<Agent | undefined>;
 
-  findByOwnerId(ownerId: string): Promise<Agent[]>;
-
   /**
    * Find the user's primary agent — team-level if it exists, otherwise org-level.
    * IC agents are intentionally excluded (they're subordinates, not entry points).

--- a/packages/core/src/ports/room-repo.ts
+++ b/packages/core/src/ports/room-repo.ts
@@ -22,13 +22,9 @@ export interface RoomRepository {
   addPersonMember(roomId: string, personId: string): Promise<void>;
   addAgentMember(roomId: string, agentId: string): Promise<void>;
   listMembers(roomId: string): Promise<RoomMember[]>;
-  /** All person ids that are members of this room. Used for SSE fanout. */
-  listMemberPersonIds(roomId: string): Promise<string[]>;
   /** All agent ids that are members of this room. */
   listMemberAgentIds(roomId: string): Promise<string[]>;
   isMember(roomId: string, personId: string): Promise<boolean>;
-  /** True if both agents are co-members of any room. Used by the mesh ask gate. */
-  areAgentsCoMembers(agentA: string, agentB: string): Promise<boolean>;
 
   // ── Messages ──────────────────────────────────────────────────────────
   appendMessage(input: NewRoomMessage): Promise<RoomMessage>;

--- a/packages/core/src/services/agent-session.test.ts
+++ b/packages/core/src/services/agent-session.test.ts
@@ -68,7 +68,6 @@ beforeEach(() => {
   agentRepo = {
     findById: vi.fn(),
     findByApiKey: vi.fn(),
-    findByOwnerId: vi.fn(),
     findTopLevelForOwner: vi.fn(),
     findSubordinates: vi.fn(),
     findPeers: vi.fn(),

--- a/packages/core/src/services/dispatch-service.test.ts
+++ b/packages/core/src/services/dispatch-service.test.ts
@@ -44,7 +44,6 @@ beforeEach(() => {
   agentRepo = {
     findById: vi.fn(),
     findByApiKey: vi.fn(),
-    findByOwnerId: vi.fn(),
     findTopLevelForOwner: vi.fn(),
     findSubordinates: vi.fn(),
     findPeers: vi.fn(),

--- a/packages/core/src/services/escalation-service.test.ts
+++ b/packages/core/src/services/escalation-service.test.ts
@@ -108,7 +108,6 @@ beforeEach(() => {
   agentRepo = {
     findById: vi.fn(),
     findByApiKey: vi.fn(),
-    findByOwnerId: vi.fn(),
     findTopLevelForOwner: vi.fn(),
     findSubordinates: vi.fn(),
     findPeers: vi.fn(),

--- a/packages/core/src/services/negotiation-service.test.ts
+++ b/packages/core/src/services/negotiation-service.test.ts
@@ -61,7 +61,6 @@ beforeEach(() => {
   agentRepo = {
     findById: vi.fn(),
     findByApiKey: vi.fn(),
-    findByOwnerId: vi.fn(),
     findTopLevelForOwner: vi.fn(),
     findSubordinates: vi.fn(),
     findPeers: vi.fn(),

--- a/packages/core/src/services/task-service.test.ts
+++ b/packages/core/src/services/task-service.test.ts
@@ -101,7 +101,6 @@ beforeEach(() => {
   agentRepo = {
     findById: vi.fn(),
     findByApiKey: vi.fn(),
-    findByOwnerId: vi.fn(),
     findTopLevelForOwner: vi.fn(),
     findSubordinates: vi.fn(),
     findPeers: vi.fn(),

--- a/packages/scheduler/src/dispatch.test.ts
+++ b/packages/scheduler/src/dispatch.test.ts
@@ -60,7 +60,6 @@ beforeEach(() => {
   agentRepo = {
     findById: vi.fn(),
     findByApiKey: vi.fn(),
-    findByOwnerId: vi.fn(),
     findTopLevelForOwner: vi.fn(),
     findSubordinates: vi.fn(),
     findPeers: vi.fn(),

--- a/packages/web/lib/hooks/keys.ts
+++ b/packages/web/lib/hooks/keys.ts
@@ -41,10 +41,6 @@ export const queryKeys = {
     all: ["me"] as const,
     self: () => ["me", "self"] as const,
   },
-  activity: {
-    all: ["activity"] as const,
-    feed: () => ["activity", "feed"] as const,
-  },
   inbox: {
     all: ["inbox"] as const,
     list: () => ["inbox", "list"] as const,

--- a/packages/web/lib/sse.ts
+++ b/packages/web/lib/sse.ts
@@ -22,24 +22,20 @@ const eventInvalidations: Record<string, InvalidationKey[]> = {
   "task.updated": [
     queryKeys.tasks.all,
     queryKeys.dashboard.all,
-    queryKeys.activity.all,
     queryKeys.inbox.all,
   ],
   "task.created": [
     queryKeys.tasks.all,
     queryKeys.dashboard.all,
-    queryKeys.activity.all,
     queryKeys.inbox.all,
   ],
   "agent.updated": [
     queryKeys.agents.all,
-    queryKeys.activity.all,
     queryKeys.agentNetwork.all,
   ],
   "session.updated": [
     queryKeys.sessions.all,
     queryKeys.tasks.all,
-    queryKeys.activity.all,
     // Match ALL chat history slots, not just the `<latest>` one. A user
     // viewing a specific conversation (cacheId = conv head) needs the
     // same auto-recovery: when their pending chat session completes, the
@@ -63,8 +59,8 @@ const eventInvalidations: Record<string, InvalidationKey[]> = {
   "memory.fact.created": [queryKeys.memory.all],
   "memory.fact.deleted": [queryKeys.memory.all],
   "promotion.created": [queryKeys.promotions.all, queryKeys.memory.all],
-  "mesh.activity": [queryKeys.mesh.all, queryKeys.activity.all, queryKeys.inbox.all],
-  "room.message": [queryKeys.rooms.all, queryKeys.activity.all],
+  "mesh.activity": [queryKeys.mesh.all, queryKeys.inbox.all],
+  "room.message": [queryKeys.rooms.all],
   "runtime.updated": [queryKeys.runtimes.all, queryKeys.agents.all],
 };
 


### PR DESCRIPTION
## What this removes

The usual passes came back **clean** — `tsc --noUnusedLocals --noUnusedParameters`, `tsc --allowUnreachableCode false`, eslint (0 errors), knip, and an import-graph reachability pass over every package found no unreachable files and no unused top-level exports. The previous sweeps (#273, #274) already took that layer.

What was left sits one level down, where knip structurally cannot see it: **methods on port interfaces**. knip treats each of core's 26 `exports` subpaths as an entry point, so a port is always "reachable" and its individual members are never checked. Sweeping port members *by name* turned up four with no call site anywhere in the monorepo — production, tests, or scripts.

### Dead port methods

| Removed | Why it's dead |
| --- | --- |
| `AgentRepository.findByOwnerId` | Superseded by `findTopLevelForOwner`, which is what every caller actually uses. Its only surviving references were `vi.fn()` stubs in **eight** test fakes, present purely to satisfy the interface. |
| `RoomRepository.listMemberPersonIds` | Doc claimed *"used for SSE fanout"* — but room fanout happens in the `bv_event` **database trigger**, not application code. Routes that need members call `listMembers`. |
| `RoomRepository.areAgentsCoMembers` | Doc claimed *"used by the mesh ask gate"*. There is no ask gate: `ask` accepts any `target_agent_id` and performs no peer check at all. |

Worth flagging that both room comments asserted call sites that **do not exist**, so the code read as load-bearing to anyone grepping for it.

### Dead web query key

#273 removed the client stub that reached `GET /activity` but left `queryKeys.activity` behind, referenced only by six `lib/sse.ts` invalidations. No `useQuery` anywhere registers an `["activity"]` key, so those six were **provably no-ops** on every task, agent, session, mesh and room event.

- `queryKeys.memory.activity` is a different, live key — untouched.
- The `GET /activity` **endpoint stays**. It's documented public API (`packages/api/README.md`); retiring it is a product call, not a cleanup.

## Deliberately kept

`SkillOutcomeRepository.listBySkill` / `.statsForSkill` and `AgentProvisionEventRepository.listByParent` are also uncalled, but they're the **read halves of audit trails whose write side is live and accumulating rows** (`skill_outcome` via `recordCapabilityOutcome`, `agent_provision_event` via `create_subordinate_agent`). By the same reasoning already applied to `PostgresMemoryPromotionEventRepository`, their consumers — discovery-ranker feedback and the agents-page audit panel — are *unbuilt rather than removed*, and deleting the queries would make finishing them harder. Both are now recorded in `CLAUDE.md` so the next sweep doesn't churn on them.

## Verification

- `typecheck`, `lint`, `build` clean across all packages (web built directly to bypass the known Turbo/proxy font issue).
- Tests: **api 579 pass, daemon 156, sandbox 109, web 203, scheduler 10.**
- Core's 7 failures and the DB-gated suites are the documented bare-sandbox baseline (no Docker, no provider keys) — verified **byte-identical before and after** this change by diffing failure lists across a `git stash`.

Net: **59 deletions, 4 insertions** across 16 files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xqn2kVxT2CFkBAqjdAFkJm)_