### PR TITLE
test: cover the four largest untested modules (0–2% → ~100% lines)

### DIFF
--- a/packages/api/src/routes/room.test.ts
+++ b/packages/api/src/routes/room.test.ts
@@ -1,0 +1,1060 @@
+/**
+ * /room REST surface + addressee resolution — unit tests with vitest
+ * fakes (no DB).
+ *
+ * The router is a closure over seven ports, so a bag of `vi.fn()` repos
+ * plus a stub auth middleware reaches every branch: the human gate,
+ * membership 404s, the create/join/invite team-agent attach, the
+ * fire-and-forget agent run behind `POST /:id/message`, and the
+ * `@mention` / vocative / name / team-keyword ladder in
+ * `resolveAddressees`.
+ *
+ * `AgentSession` is mocked at the module boundary — the background run
+ * is the one path that would otherwise spawn a CLI. Everything else
+ * (`processResponse`, `failureMessageFor`, `teamAgentRoutingDirective`)
+ * runs for real, since those are pure and their output is part of the
+ * wire contract this suite is pinning.
+ */
+import express, { json } from "express";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  PersonRepository,
+  Room,
+  RoomMember,
+  RoomMessage,
+  RoomRepository,
+  RuntimeRegistry,
+  Session,
+  SessionEvent,
+  SessionEventRepository,
+  SessionRepository,
+  WorkspaceManager,
+} from "@beevibe/core";
+import type { MemoryAgent } from "@beevibe/core/services/memory";
+
+// ── AgentSession stub ────────────────────────────────────────────────────
+// `runMentionedAgents` news up an AgentSession and calls `.run()`. Mock
+// the class but keep `teamAgentRoutingDirective` real — the router
+// concatenates its output into extraSystemPromptAppend and the tests
+// below assert on that string.
+const sessionRun = vi.fn();
+vi.mock("@beevibe/core/services/agent-session", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("@beevibe/core/services/agent-session")
+  >();
+  return {
+    ...actual,
+    AgentSession: class {
+      run = sessionRun;
+    },
+  };
+});
+
+const { createRoomRouter, resolveAddressees } = await import("./room.js");
+
+// ── Fixtures ─────────────────────────────────────────────────────────────
+
+const PERSON = "person_alice";
+const TEAM_AGENT = "agent_alicesteam";
+
+function fakeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: TEAM_AGENT,
+    name: "Alice's Team",
+    owner_id: PERSON,
+    hierarchy_level: "team",
+    runtime_config: { type: "claude" },
+    created_at: new Date("2026-01-01T00:00:00Z"),
+    updated_at: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+function fakeRoom(overrides: Partial<Room> = {}): Room {
+  return {
+    id: "room_1",
+    name: "Launch war room",
+    owner_person_id: PERSON,
+    created_at: new Date("2026-01-01T00:00:00Z"),
+    updated_at: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+function fakeMessage(overrides: Partial<RoomMessage> = {}): RoomMessage {
+  return {
+    id: "rmsg_1",
+    room_id: "room_1",
+    kind: "human",
+    sender_person_id: PERSON,
+    content: "hello room",
+    created_at: new Date("2026-01-02T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+function fakeMember(overrides: Partial<RoomMember> = {}): RoomMember {
+  return {
+    room_id: "room_1",
+    kind: "person",
+    subject_id: PERSON,
+    joined_at: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+function fakeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "sess_1",
+    agent_id: TEAM_AGENT,
+    type: "chat",
+    status: "running",
+    intent: "hi",
+    created_at: new Date("2026-01-02T00:00:00Z"),
+    updated_at: new Date("2026-01-02T00:00:00Z"),
+    ...overrides,
+  } as Session;
+}
+
+function fakeEvent(overrides: Partial<SessionEvent> = {}): SessionEvent {
+  return {
+    id: "ev_1",
+    session_id: "sess_1",
+    kind: "tool_call",
+    content: "bash ls",
+    created_at: new Date("2026-01-02T00:01:00Z"),
+    ...overrides,
+  };
+}
+
+// ── Fake ports ───────────────────────────────────────────────────────────
+
+function makeRoomRepo(): RoomRepository {
+  return {
+    create: vi.fn(async (input) => fakeRoom({ ...input })),
+    findById: vi.fn(async () => fakeRoom()),
+    listForPerson: vi.fn(async () => []),
+    addPersonMember: vi.fn(async () => {}),
+    addAgentMember: vi.fn(async () => {}),
+    listMembers: vi.fn(async () => []),
+    listMemberPersonIds: vi.fn(async () => []),
+    listMemberAgentIds: vi.fn(async () => []),
+    isMember: vi.fn(async () => true),
+    areAgentsCoMembers: vi.fn(async () => true),
+    appendMessage: vi.fn(async (input) => fakeMessage({ ...input })),
+    listMessages: vi.fn(async () => []),
+  } as unknown as RoomRepository;
+}
+
+function makeAgentRepo(): AgentRepository {
+  return {
+    findById: vi.fn(async () => fakeAgent()),
+    findTopLevelForOwner: vi.fn(async () => fakeAgent()),
+    findSubordinates: vi.fn(async () => []),
+  } as unknown as AgentRepository;
+}
+
+function makePersonRepo(): PersonRepository {
+  return {
+    findById: vi.fn(async (id: string) => ({ id, name: "Alice", email: "alice@x.dev" })),
+    findByEmail: vi.fn(async () => undefined),
+  } as unknown as PersonRepository;
+}
+
+function makeSessionRepo(): SessionRepository {
+  return {
+    listRunningInRoom: vi.fn(async () => []),
+    findLatestForAgentInRoom: vi.fn(async () => undefined),
+  } as unknown as SessionRepository;
+}
+
+function makeSessionEventRepo(): SessionEventRepository {
+  return {
+    append: vi.fn(),
+    listBySession: vi.fn(async () => []),
+  } as unknown as SessionEventRepository;
+}
+
+interface Ports {
+  roomRepo: RoomRepository;
+  agentRepo: AgentRepository;
+  personRepo: PersonRepository;
+  sessionRepo: SessionRepository;
+  sessionEventRepo: SessionEventRepository;
+  workspaceManager: WorkspaceManager;
+  runtimeRegistry: RuntimeRegistry;
+}
+
+function makePorts(overrides: Partial<Ports> = {}): Ports {
+  return {
+    roomRepo: makeRoomRepo(),
+    agentRepo: makeAgentRepo(),
+    personRepo: makePersonRepo(),
+    sessionRepo: makeSessionRepo(),
+    sessionEventRepo: makeSessionEventRepo(),
+    workspaceManager: {
+      ensureWorkspace: vi.fn(async () => ({ path: "/ws/agent", agentId: TEAM_AGENT })),
+      removeWorkspace: vi.fn(),
+    } as unknown as WorkspaceManager,
+    runtimeRegistry: { claude: {} } as unknown as RuntimeRegistry,
+    ...overrides,
+  };
+}
+
+/**
+ * Stand-in for `createAuthMiddleware`. The real one resolves a bv_ token
+ * against Postgres; these tests only care about the caller shape
+ * `requireHuman` gates on, so the source is set per-app.
+ */
+function stubAuth(source: "human" | "agent" | "none") {
+  return (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    if (source === "human") {
+      req.caller = {
+        source: "human",
+        agentId: TEAM_AGENT,
+        hierarchyLevel: "team",
+        personId: PERSON,
+      };
+    } else if (source === "agent") {
+      req.caller = { source: "agent", agentId: TEAM_AGENT, hierarchyLevel: "ic" };
+    }
+    next();
+  };
+}
+
+function makeApp(ports: Ports, source: "human" | "agent" | "none" = "human") {
+  const app = express();
+  app.use(json());
+  app.use(
+    "/room",
+    createRoomRouter({
+      authMiddleware: stubAuth(source),
+      ...ports,
+      makeMemoryAgent: () => ({}) as MemoryAgent,
+    }),
+  );
+  return app;
+}
+
+beforeEach(() => {
+  sessionRun.mockReset();
+  sessionRun.mockResolvedValue(
+    fakeSession({ status: "succeeded", result_summary: "done" }),
+  );
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── POST /room ───────────────────────────────────────────────────────────
+
+describe("POST /room", () => {
+  it("creates a room, adds the caller and their team agent", async () => {
+    const ports = makePorts();
+    const res = await request(makeApp(ports)).post("/room").send({ name: "  Launch  " });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.room.name).toBe("Launch");
+    expect(ports.roomRepo.addPersonMember).toHaveBeenCalledWith(res.body.room.id, PERSON);
+    expect(ports.roomRepo.addAgentMember).toHaveBeenCalledWith(res.body.room.id, TEAM_AGENT);
+  });
+
+  it("still creates the room when the caller has no team agent", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.agentRepo.findTopLevelForOwner).mockResolvedValue(undefined);
+
+    const res = await request(makeApp(ports)).post("/room").send({ name: "Solo" });
+
+    expect(res.status).toBe(200);
+    expect(ports.roomRepo.addAgentMember).not.toHaveBeenCalled();
+  });
+
+  it.each([{}, { name: "   " }, { name: 42 }])("400s a nameless body %j", async (body) => {
+    const ports = makePorts();
+    const res = await request(makeApp(ports)).post("/room").send(body);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("name_required");
+    expect(ports.roomRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("403s an agent caller", async () => {
+    const ports = makePorts();
+    const res = await request(makeApp(ports, "agent")).post("/room").send({ name: "x" });
+
+    expect(res.status).toBe(403);
+    expect(ports.roomRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("403s an unauthenticated caller", async () => {
+    const res = await request(makeApp(makePorts(), "none")).post("/room").send({ name: "x" });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("500s when the repo throws", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.roomRepo.create).mockRejectedValue(new Error("pg down"));
+
+    const res = await request(makeApp(ports)).post("/room").send({ name: "x" });
+
+    expect(res.status).toBe(500);
+    expect(res.body).toMatchObject({ error: "internal_error", message: "pg down" });
+  });
+});
+
+// ── GET /room ────────────────────────────────────────────────────────────
+
+describe("GET /room", () => {
+  it("lists the caller's rooms", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.roomRepo.listForPerson).mockResolvedValue([fakeRoom()]);
+
+    const res = await request(makeApp(ports)).get("/room");
+
+    expect(res.status).toBe(200);
+    expect(res.body.rooms).toHaveLength(1);
+    expect(ports.roomRepo.listForPerson).toHaveBeenCalledWith(PERSON);
+  });
+
+  it("500s when the repo throws", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.roomRepo.listForPerson).mockRejectedValue(new Error("pg down"));
+
+    const res = await request(makeApp(ports)).get("/room");
+
+    expect(res.status).toBe(500);
+  });
+
+  it("403s an agent caller", async () => {
+    const ports = makePorts();
+    const res = await request(makeApp(ports, "agent")).get("/room");
+
+    expect(res.status).toBe(403);
+    expect(ports.roomRepo.listForPerson).not.toHaveBeenCalled();
+  });
+});
+
+// ── GET /room/:id ────────────────────────────────────────────────────────
+
+describe("GET /room/:id", () => {
+  it("404s a non-member", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.roomRepo.isMember).mockResolvedValue(false);
+
+    const res = await request(makeApp(ports)).get("/room/room_1");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("room_not_found");
+    expect(ports.roomRepo.listMembers).not.toHaveBeenCalled();
+  });
+
+  it("404s when the room row is gone despite the membership row", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.roomRepo.findById).mockResolvedValue(undefined);
+
+    const res = await request(makeApp(ports)).get("/room/room_1");
+
+    expect(res.status).toBe(404);
+  });
+
+  it("hydrates members, messages and typing indicators", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.roomRepo.listMembers).mockResolvedValue([
+      fakeMember(),
+      fakeMember({ kind: "agent", subject_id: TEAM_AGENT }),
+      // A member row whose subject row was deleted — filtered out, not crashed on.
+      fakeMember({ kind: "agent", subject_id: "agent_ghost" }),
+    ]);
+    vi.mocked(ports.agentRepo.findById).mockImplementation(async (id: string) =>
+      id === TEAM_AGENT ? fakeAgent() : undefined,
+    );
+    vi.mocked(ports.roomRepo.listMessages).mockResolvedValue([
+      fakeMessage(),
+      fakeMessage({
+        id: "rmsg_2",
+        kind: "agent",
+        sender_person_id: undefined,
+        sender_agent_id: TEAM_AGENT,
+        session_id: "sess_1",
+        content: "shipping it\n<suggest_action>Ship now</suggest_action>",
+      }),
+    ]);
+    vi.mocked(ports.sessionRepo.listRunningInRoom).mockResolvedValue([
+      fakeSession({ started_at: new Date("2026-01-02T00:00:30Z") }),
+      // Running session for an agent that isn't a room member — excluded.
+      fakeSession({ id: "sess_other", agent_id: "agent_stranger" }),
+    ]);
+    vi.mocked(ports.sessionEventRepo.listBySession).mockResolvedValue([
+      fakeEvent({ tool_name: "Bash" }),
+      fakeEvent({ id: "ev_2", content: "x".repeat(500) }),
+    ]);
+
+    const res = await request(makeApp(ports)).get("/room/room_1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.members).toEqual([
+      { kind: "person", id: PERSON, name: "Alice", email: "alice@x.dev" },
+      {
+        kind: "agent",
+        id: TEAM_AGENT,
+        name: "Alice's Team",
+        hierarchy: "team",
+        owner_person_id: PERSON,
+      },
+    ]);
+    // Directives are stripped from the visible content and surfaced as siblings.
+    expect(res.body.messages[1].content).toBe("shipping it");
+    expect(res.body.messages[1].suggested_actions).toEqual([{ label: "Ship now" }]);
+    expect(res.body.messages[1].session_id).toBe("sess_1");
+    expect(res.body.typing).toHaveLength(1);
+    expect(res.body.typing[0]).toMatchObject({
+      session_id: "sess_1",
+      agent_id: TEAM_AGENT,
+      agent_name: "Alice's Team",
+      started_at: "2026-01-02T00:00:30.000Z",
+      total_steps: 2,
+    });
+    expect(res.body.typing[0].recent_steps[0]).toEqual({
+      event_id: "ev_1",
+      kind: "tool_call",
+      tool_name: "Bash",
+      content: "bash ls",
+    });
+    // Event content is truncated so a giant tool result can't bloat the poll.
+    expect(res.body.typing[0].recent_steps[1].content).toHaveLength(200);
+    expect(res.body.typing[0].recent_steps[1].tool_name).toBeNull();
+  });
+
+  it("falls back to created_at when a running session has no started_at", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.roomRepo.listMembers).mockResolvedValue([
+      fakeMember({ kind: "agent", subject_id: TEAM_AGENT }),
+    ]);
+    vi.mocked(ports.sessionRepo.listRunningInRoom).mockResolvedValue([fakeSession()]);
+
+    const res = await request(makeApp(ports)).get("/room/room_1");
+
+    expect(res.body.typing[0].started_at).toBe("2026-01-02T00:00:00.000Z");
+    expect(res.body.typing[0].total_steps).toBe(0);
+  });
+
+  it("500s when a hydration query throws", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.roomRepo.listMembers).mockRejectedValue(new Error("pg down"));
+
+    const res = await request(makeApp(ports)).get("/room/room_1");
+
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── POST /room/:id/join ──────────────────────────────────────────────────
+
+describe("POST /room/:id/join", () => {
+  it("adds the caller and their team agent — no prior membership needed", async () => {
+    const ports = makePorts();
+    const res = await request(makeApp(ports)).post("/room/room_1/join");
+
+    expect(res.status).toBe(200);
+    expect(ports.roomRepo.isMember).not.toHaveBeenCalled();
+    expect(ports.roomRepo.addPersonMember).toHaveBeenCalledWith("room_1", PERSON);
+    expect(ports.roomRepo.addAgentMember).toHaveBeenCalledWith("room_1", TEAM_AGENT);
+  });
+
+  it("joins a caller with no team agent", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.agentRepo.findTopLevelForOwner).mockResolvedValue(undefined);
+
+    const res = await request(makeApp(ports)).post("/room/room_1/join");
+
+    expect(res.status).toBe(200);
+    expect(ports.roomRepo.addAgentMember).not.toHaveBeenCalled();
+  });
+
+  it("404s an unknown room", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.roomRepo.findById).mockResolvedValue(undefined);
+
+    const res = await request(makeApp(ports)).post("/room/room_x/join");
+
+    expect(res.status).toBe(404);
+    expect(ports.roomRepo.addPersonMember).not.toHaveBeenCalled();
+  });
+
+  it("500s when the join write throws", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.roomRepo.addPersonMember).mockRejectedValue(new Error("pg down"));
+
+    const res = await request(makeApp(ports)).post("/room/room_1/join");
+
+    expect(res.status).toBe(500);
+  });
+
+  it("403s an agent caller", async () => {
+    const ports = makePorts();
+    const res = await request(makeApp(ports, "agent")).post("/room/room_1/join");
+
+    expect(res.status).toBe(403);
+  });
+});
+
+// ── POST /room/:id/invite ────────────────────────────────────────────────
+
+describe("POST /room/:id/invite", () => {
+  it("invites an existing person plus their team agent", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.personRepo.findByEmail).mockResolvedValue({
+      id: "person_bob",
+      name: "Bob",
+      email: "bob@x.dev",
+    } as never);
+    vi.mocked(ports.agentRepo.findTopLevelForOwner).mockResolvedValue(
+      fakeAgent({ id: "agent_bobsteam", owner_id: "person_bob" }),
+    );
+
+    const res = await request(makeApp(ports))
+      .post("/room/room_1/invite")
+      .send({ email: "  BOB@X.dev  " });
+
+    expect(res.status).toBe(200);
+    // Email is normalized before the lookup, so casing/whitespace in the
+    // invite box can't produce a spurious person_not_found.
+    expect(ports.personRepo.findByEmail).toHaveBeenCalledWith("bob@x.dev");
+    expect(res.body.invited).toEqual({
+      person_id: "person_bob",
+      name: "Bob",
+      email: "bob@x.dev",
+    });
+    expect(ports.roomRepo.addAgentMember).toHaveBeenCalledWith("room_1", "agent_bobsteam");
+  });
+
+  it("invites a person who has no team agent", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.personRepo.findByEmail).mockResolvedValue({
+      id: "person_bob",
+      name: "Bob",
+      email: "bob@x.dev",
+    } as never);
+    vi.mocked(ports.agentRepo.findTopLevelForOwner).mockResolvedValue(undefined);
+
+    const res = await request(makeApp(ports))
+      .post("/room/room_1/invite")
+      .send({ email: "bob@x.dev" });
+
+    expect(res.status).toBe(200);
+    expect(ports.roomRepo.addAgentMember).not.toHaveBeenCalled();
+  });
+
+  it("404s a non-member inviter", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.roomRepo.isMember).mockResolvedValue(false);
+
+    const res = await request(makeApp(ports))
+      .post("/room/room_1/invite")
+      .send({ email: "bob@x.dev" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("room_not_found");
+    expect(ports.personRepo.findByEmail).not.toHaveBeenCalled();
+  });
+
+  it.each([{}, { email: "  " }, { email: 7 }])("400s a body without an email %j", async (body) => {
+    const ports = makePorts();
+    const res = await request(makeApp(ports)).post("/room/room_1/invite").send(body);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("email_required");
+  });
+
+  it("404s an email with no account", async () => {
+    const ports = makePorts();
+    const res = await request(makeApp(ports))
+      .post("/room/room_1/invite")
+      .send({ email: "nobody@x.dev" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("person_not_found");
+    expect(res.body.message).toContain("nobody@x.dev");
+    expect(ports.roomRepo.addPersonMember).not.toHaveBeenCalled();
+  });
+
+  it("500s when the lookup throws", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.personRepo.findByEmail).mockRejectedValue(new Error("pg down"));
+
+    const res = await request(makeApp(ports))
+      .post("/room/room_1/invite")
+      .send({ email: "bob@x.dev" });
+
+    expect(res.status).toBe(500);
+  });
+
+  it("403s an agent caller", async () => {
+    const ports = makePorts();
+    const res = await request(makeApp(ports, "agent"))
+      .post("/room/room_1/invite")
+      .send({ email: "bob@x.dev" });
+
+    expect(res.status).toBe(403);
+  });
+});
+
+// ── POST /room/:id/message ───────────────────────────────────────────────
+
+describe("POST /room/:id/message", () => {
+  it("404s a non-member", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.roomRepo.isMember).mockResolvedValue(false);
+
+    const res = await request(makeApp(ports))
+      .post("/room/room_1/message")
+      .send({ content: "hi" });
+
+    expect(res.status).toBe(404);
+    expect(ports.roomRepo.appendMessage).not.toHaveBeenCalled();
+  });
+
+  it.each([{}, { content: "   " }, { content: null }])(
+    "400s a body without content %j",
+    async (body) => {
+      const ports = makePorts();
+      const res = await request(makeApp(ports)).post("/room/room_1/message").send(body);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("content_required");
+      expect(ports.roomRepo.appendMessage).not.toHaveBeenCalled();
+    },
+  );
+
+  it("persists a pure human turn and invokes nobody", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.roomRepo.listMemberAgentIds).mockResolvedValue([TEAM_AGENT]);
+
+    const res = await request(makeApp(ports))
+      .post("/room/room_1/message")
+      .send({ content: "  standup at 10  " });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message.content).toBe("standup at 10");
+    expect(res.body.message.sender_person_id).toBe(PERSON);
+    expect(res.body.invoked_agents).toEqual([]);
+    expect(res.body.invoked_reason).toBe("none");
+    expect(sessionRun).not.toHaveBeenCalled();
+  });
+
+  it("responds before the agent run finishes, then persists the reply", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.roomRepo.listMemberAgentIds).mockResolvedValue([TEAM_AGENT]);
+    sessionRun.mockResolvedValue(
+      fakeSession({ id: "sess_9", status: "succeeded", result_summary: "on it" }),
+    );
+
+    const res = await request(makeApp(ports))
+      .post("/room/room_1/message")
+      .send({ content: `@${TEAM_AGENT} status?` });
+
+    expect(res.status).toBe(200);
+    expect(res.body.invoked_agents).toEqual([{ id: TEAM_AGENT, name: "Alice's Team" }]);
+    expect(res.body.invoked_reason).toBe("mention");
+
+    await vi.waitFor(() =>
+      expect(ports.roomRepo.appendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: "agent",
+          sender_agent_id: TEAM_AGENT,
+          content: "on it",
+          session_id: "sess_9",
+        }),
+      ),
+    );
+  });
+
+  it("500s when persisting the human turn throws", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.roomRepo.appendMessage).mockRejectedValue(new Error("pg down"));
+
+    const res = await request(makeApp(ports))
+      .post("/room/room_1/message")
+      .send({ content: "hi" });
+
+    expect(res.status).toBe(500);
+  });
+
+  it("403s an agent caller", async () => {
+    const ports = makePorts();
+    const res = await request(makeApp(ports, "agent"))
+      .post("/room/room_1/message")
+      .send({ content: "hi" });
+
+    expect(res.status).toBe(403);
+  });
+});
+
+// ── Background agent run ─────────────────────────────────────────────────
+//
+// `runMentionedAgents` is fire-and-forget, so each test posts a mention
+// and then waits on the agent-kind `appendMessage` that closes the turn.
+
+/** The agent-kind message the background run appends, once it lands. */
+async function agentReply(ports: Ports): Promise<Record<string, unknown>> {
+  const calls = vi.mocked(ports.roomRepo.appendMessage).mock.calls;
+  let found: Record<string, unknown> | undefined;
+  await vi.waitFor(() => {
+    found = calls.map((c) => c[0] as Record<string, unknown>).find((m) => m.kind === "agent");
+    expect(found).toBeDefined();
+  });
+  return found!;
+}
+
+async function postMention(ports: Ports, content = `@${TEAM_AGENT} status?`) {
+  vi.mocked(ports.roomRepo.listMemberAgentIds).mockResolvedValue([TEAM_AGENT]);
+  await request(makeApp(ports)).post("/room/room_1/message").send({ content });
+}
+
+describe("runMentionedAgents", () => {
+  it("inlines the room transcript, member list and directives into the intent", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.roomRepo.listMembers).mockResolvedValue([
+      fakeMember(),
+      fakeMember({ kind: "agent", subject_id: TEAM_AGENT }),
+    ]);
+    vi.mocked(ports.roomRepo.listMessages).mockResolvedValue([
+      fakeMessage({ content: "kickoff" }),
+      fakeMessage({
+        id: "rmsg_2",
+        kind: "agent",
+        sender_agent_id: TEAM_AGENT,
+        content: "ack",
+      }),
+      // The triggering message is already persisted, so it must be
+      // trimmed off the history slice or the agent sees it twice.
+      fakeMessage({ id: "rmsg_3", content: `@${TEAM_AGENT} status?` }),
+    ]);
+    vi.mocked(ports.agentRepo.findSubordinates).mockResolvedValue([
+      fakeAgent({ id: "agent_ic", name: "Backend IC", hierarchy_level: "ic" }),
+    ]);
+
+    await postMention(ports);
+    await agentReply(ports);
+
+    const arg = sessionRun.mock.calls[0]![0];
+    expect(arg.agentId).toBe(TEAM_AGENT);
+    expect(arg.type).toBe("chat");
+    expect(arg.roomId).toBe("room_1");
+    expect(arg.workspace).toEqual({ path: "/ws/agent", agentId: TEAM_AGENT });
+    expect(arg.intent).toContain('<room name="Launch war room" id="room_1">');
+    expect(arg.intent).toContain(`- Alice's Team (agent, ${TEAM_AGENT}) [you]`);
+    expect(arg.intent).toContain("Alice: kickoff");
+    expect(arg.intent).toContain(`Alice's Team (${TEAM_AGENT}): ack`);
+    // Trigger appears once — in the "latest message" block, not the history.
+    expect(arg.intent.match(/status\?/g)).toHaveLength(1);
+    // A team agent gets room directives AND the routing rubric.
+    expect(arg.extraSystemPromptAppend).toContain("SHARED ROOM");
+    expect(arg.extraSystemPromptAppend).toContain("Backend IC");
+  });
+
+  it("omits the routing directive for an IC agent", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.agentRepo.findById).mockResolvedValue(
+      fakeAgent({ hierarchy_level: "ic" }),
+    );
+
+    await postMention(ports);
+    await agentReply(ports);
+
+    expect(ports.agentRepo.findSubordinates).not.toHaveBeenCalled();
+    const arg = sessionRun.mock.calls[0]![0];
+    expect(arg.extraSystemPromptAppend).toContain("SHARED ROOM");
+    expect(arg.extraSystemPromptAppend).not.toContain("<team_agent_routing>");
+  });
+
+  it("resumes the agent's prior session in this room", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.sessionRepo.findLatestForAgentInRoom).mockResolvedValue(
+      fakeSession({ id: "sess_prior" }),
+    );
+
+    await postMention(ports);
+    await agentReply(ports);
+
+    expect(sessionRun.mock.calls[0]![0].priorSessionId).toBe("sess_prior");
+  });
+
+  it("starts cold when the agent has no prior session in the room", async () => {
+    const ports = makePorts();
+    await postMention(ports);
+    await agentReply(ports);
+
+    expect(sessionRun.mock.calls[0]![0]).not.toHaveProperty("priorSessionId");
+  });
+
+  it("falls back to the raw trigger when the room row vanishes mid-turn", async () => {
+    const ports = makePorts();
+    // isMember passes, but the room is deleted before buildRoomIntent reads it.
+    vi.mocked(ports.roomRepo.findById).mockResolvedValue(undefined);
+
+    await postMention(ports);
+    await agentReply(ports);
+
+    expect(sessionRun.mock.calls[0]![0].intent).toBe(`@${TEAM_AGENT} status?`);
+  });
+
+  it("truncates an overlong history turn", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.roomRepo.listMessages).mockResolvedValue([
+      fakeMessage({ content: "z".repeat(2000) }),
+      fakeMessage({ id: "rmsg_2", content: "trigger" }),
+    ]);
+
+    await postMention(ports);
+    await agentReply(ports);
+
+    expect(sessionRun.mock.calls[0]![0].intent).toContain("z".repeat(799) + "…");
+  });
+
+  it("labels messages from unknown senders rather than crashing", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.roomRepo.listMessages).mockResolvedValue([
+      fakeMessage({ sender_person_id: "person_ghost" }),
+      fakeMessage({ id: "rmsg_2", kind: "agent", sender_agent_id: "agent_ghost" }),
+      fakeMessage({ id: "rmsg_3", kind: "agent", sender_agent_id: undefined }),
+      fakeMessage({ id: "rmsg_4", content: "trigger" }),
+    ]);
+    vi.mocked(ports.personRepo.findById).mockResolvedValue(undefined as never);
+    vi.mocked(ports.roomRepo.listMembers).mockResolvedValue([fakeMember()]);
+
+    await postMention(ports);
+    await agentReply(ports);
+
+    const intent = sessionRun.mock.calls[0]![0].intent as string;
+    expect(intent).toContain("human: hello room");
+    expect(intent).toContain("agent: hello room");
+    expect(intent).toContain("?: hello room");
+    expect(intent).toContain("a human said:");
+  });
+
+  it("notes an empty room history explicitly", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.roomRepo.listMessages).mockResolvedValue([fakeMessage()]);
+
+    await postMention(ports);
+    await agentReply(ports);
+
+    expect(sessionRun.mock.calls[0]![0].intent).toContain("(none yet — this is the first turn)");
+  });
+
+  it("escapes a room name containing quotes", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.roomRepo.findById).mockResolvedValue(
+      fakeRoom({ name: 'the "war" room' }),
+    );
+
+    await postMention(ports);
+    await agentReply(ports);
+
+    expect(sessionRun.mock.calls[0]![0].intent).toContain(
+      '<room name="the &quot;war&quot; room"',
+    );
+  });
+
+  it("posts a visible error when the agent's runtime isn't registered", async () => {
+    const ports = makePorts({ runtimeRegistry: {} as RuntimeRegistry });
+
+    await postMention(ports);
+    const msg = await agentReply(ports);
+
+    expect(msg.content).toBe("(error: runtime 'claude' not registered)");
+    expect(sessionRun).not.toHaveBeenCalled();
+  });
+
+  it("maps a failed session through the chat failure mapper", async () => {
+    const ports = makePorts();
+    sessionRun.mockResolvedValue(
+      fakeSession({ status: "failed", error: "disk full" }),
+    );
+
+    await postMention(ports);
+    const msg = await agentReply(ports);
+
+    // Not the raw "CLI exited with code N" — the room sees the same
+    // mapped text the 1:1 chat surface shows.
+    expect(msg.content).toBe("disk full");
+  });
+
+  it("posts an empty reply when a completed session has no summary", async () => {
+    const ports = makePorts();
+    sessionRun.mockResolvedValue(fakeSession({ status: "succeeded" }));
+
+    await postMention(ports);
+    const msg = await agentReply(ports);
+
+    expect(msg.content).toBe("");
+  });
+
+  it("surfaces a thrown run as an agent-kind message", async () => {
+    const ports = makePorts();
+    sessionRun.mockRejectedValue(new Error("spawn EACCES"));
+
+    await postMention(ports);
+    const msg = await agentReply(ports);
+
+    expect(msg.content).toBe("(error: spawn EACCES)");
+  });
+
+  it("swallows a failure to persist the failure notice", async () => {
+    const ports = makePorts();
+    sessionRun.mockRejectedValue(new Error("spawn EACCES"));
+    vi.mocked(ports.roomRepo.appendMessage).mockImplementation(async (input) => {
+      if (input.kind === "agent") throw new Error("pg down");
+      return fakeMessage({ ...input });
+    });
+
+    // The turn still returns 200; the best-effort catch keeps the
+    // fire-and-forget run from producing an unhandled rejection.
+    await expect(postMention(ports)).resolves.toBeUndefined();
+    await vi.waitFor(() => expect(console.error).toHaveBeenCalled());
+  });
+
+  it("runs several mentioned agents sequentially", async () => {
+    const ports = makePorts();
+    const second = fakeAgent({ id: "agent_bobsteam", name: "Bob's Team" });
+    vi.mocked(ports.roomRepo.listMemberAgentIds).mockResolvedValue([
+      TEAM_AGENT,
+      "agent_bobsteam",
+    ]);
+    vi.mocked(ports.agentRepo.findById).mockImplementation(async (id: string) =>
+      id === TEAM_AGENT ? fakeAgent() : second,
+    );
+
+    await request(makeApp(ports))
+      .post("/room/room_1/message")
+      .send({ content: `@${TEAM_AGENT} and @bobsteam — sync up?` });
+
+    await vi.waitFor(() => expect(sessionRun).toHaveBeenCalledTimes(2));
+    expect(sessionRun.mock.calls.map((c) => c[0].agentId)).toEqual([
+      TEAM_AGENT,
+      "agent_bobsteam",
+    ]);
+  });
+
+  it("skips member ids whose agent row is gone", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.roomRepo.listMemberAgentIds).mockResolvedValue([TEAM_AGENT, "agent_ghost"]);
+    vi.mocked(ports.agentRepo.findById).mockImplementation(async (id: string) =>
+      id === TEAM_AGENT ? fakeAgent() : undefined,
+    );
+
+    const res = await request(makeApp(ports))
+      .post("/room/room_1/message")
+      .send({ content: "team, status?" });
+
+    expect(res.body.invoked_agents).toEqual([{ id: TEAM_AGENT, name: "Alice's Team" }]);
+  });
+});
+
+// ── resolveAddressees ────────────────────────────────────────────────────
+
+describe("resolveAddressees", () => {
+  const alice = { id: "agent_alicesteam", name: "Alice's Team" };
+  const bob = { id: "agent_bobsteam", name: "Bob's Team" };
+  const members = [alice, bob];
+
+  it.each([
+    ["full id", "@agent_bobsteam ping"],
+    ["short id", "@bobsteam ping"],
+    ["normalized name", "@bobsteam ping"],
+    ["mixed case", "@AGENT_BOBSTEAM ping"],
+  ])("routes an @mention by %s", (_label, content) => {
+    expect(resolveAddressees(content, members, alice.id)).toEqual({
+      agents: [bob],
+      reason: "mention",
+    });
+  });
+
+  it("dedupes repeated mentions of the same agent, preserving order", () => {
+    const out = resolveAddressees("@bobsteam @alicesteam @bobsteam", members, alice.id);
+
+    expect(out.agents).toEqual([bob, alice]);
+    expect(out.reason).toBe("mention");
+  });
+
+  it("ignores an @mention that matches no member", () => {
+    expect(resolveAddressees("@nobody hi", members, undefined)).toEqual({
+      agents: [],
+      reason: "none",
+    });
+  });
+
+  it("prefers a named vocative over the generic team keyword", () => {
+    // "team, ..." would otherwise route to the speaker's own agent; the
+    // more specific "Bob's team" in the vocative wins.
+    expect(resolveAddressees("Bob's team, what's the ETA?", members, alice.id)).toEqual({
+      agents: [bob],
+      reason: "name",
+    });
+  });
+
+  it("accepts a single-word first-name vocative", () => {
+    expect(resolveAddressees("bob: ship it", members, alice.id)).toEqual({
+      agents: [bob],
+      reason: "name",
+    });
+  });
+
+  it("does not first-name-match a multi-word vocative", () => {
+    expect(resolveAddressees("hey there people, hi", members, undefined).agents).toEqual([]);
+  });
+
+  it("routes a bare team vocative to the speaker's own agent", () => {
+    expect(resolveAddressees("team, status?", members, alice.id)).toEqual({
+      agents: [alice],
+      reason: "team-default",
+    });
+  });
+
+  it("stays silent on a team vocative when the speaker has no agent", () => {
+    expect(resolveAddressees("team, status?", members, undefined).reason).toBe("none");
+  });
+
+  it("stays silent when the speaker's agent isn't a room member", () => {
+    expect(resolveAddressees("team, status?", members, "agent_elsewhere").reason).toBe("none");
+  });
+
+  it("matches an agent name anywhere in the message", () => {
+    expect(resolveAddressees("what does Bob's Team think?", members, alice.id)).toEqual({
+      agents: [bob],
+      reason: "name",
+    });
+  });
+
+  it("matches the team keyword anywhere when nobody is named", () => {
+    expect(resolveAddressees("what do the agents think?", members, alice.id)).toEqual({
+      agents: [alice],
+      reason: "team-default",
+    });
+  });
+
+  it("ignores agent names shorter than four characters", () => {
+    const tiny = [{ id: "agent_x", name: "Ax" }];
+    expect(resolveAddressees("is Ax around", tiny, undefined).agents).toEqual([]);
+  });
+
+  it("returns nobody for pure human chat", () => {
+    expect(resolveAddressees("lunch at noon?", members, alice.id)).toEqual({
+      agents: [],
+      reason: "none",
+    });
+  });
+
+  it("ignores a vocative longer than 80 characters", () => {
+    const content = `${"long ".repeat(20)}team, hi`;
+    expect(resolveAddressees(content, members, alice.id).reason).toBe("team-default");
+  });
+});

--- a/packages/api/src/routes/view.test.ts
+++ b/packages/api/src/routes/view.test.ts
@@ -1,0 +1,1177 @@
+/**
+ * Read-only view routes — unit tests with vitest fakes (no DB).
+ *
+ * Every handler in `view.ts` is a thin shell around a `views/*.ts`
+ * composer that talks pg directly, so the composers are mocked at the
+ * module boundary and the pool is a `vi.fn()`. What's left — and what
+ * this suite pins — is the shell itself: the human gate, query-param
+ * parsing and validation, the "mine" → primary-agent resolution, the
+ * ownership checks on every mutation, and the 400/403/404/409/500
+ * error contract clients branch on.
+ */
+import express, { json } from "express";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  DaemonRepository,
+  MemoryFactRepository,
+  RuntimeRepository,
+} from "@beevibe/core";
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import type { CoreMemory } from "@beevibe/core/services/memory";
+import {
+  BlockCharLimitExceededError,
+  BlockNotFoundError,
+} from "@beevibe/core/services/memory";
+
+// ── View-composer mocks ──────────────────────────────────────────────────
+// Each is pure SQL over the pool; the router's job is deciding *what* to
+// pass them and *how* to translate the result, which is what's asserted.
+
+vi.mock("../views/tasks.js", () => ({
+  listTasks: vi.fn(async () => [{ id: "task_1" }]),
+  getTask: vi.fn(async () => ({ id: "task_1" })),
+}));
+vi.mock("../views/agents.js", () => ({
+  listAgents: vi.fn(async () => [{ id: "agent_1" }]),
+  getAgent: vi.fn(async () => ({ id: "agent_1" })),
+}));
+vi.mock("../views/sessions.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../views/sessions.js")>();
+  return {
+    AmbiguousShortIdError: actual.AmbiguousShortIdError,
+    getSessionByShortId: vi.fn(async () => ({ id: "sess_1" })),
+    getConversationByShortId: vi.fn(async () => ({ sessions: [] })),
+    getSessionTree: vi.fn(async () => ({ root: "sess_1", nodes: [] })),
+  };
+});
+vi.mock("../views/memory.js", () => ({
+  listMemoryFacts: vi.fn(async () => [{ id: "fact_1" }]),
+  listMemoryFactCounts: vi.fn(async () => ({ ic: 1 })),
+}));
+vi.mock("../views/dashboard.js", () => ({
+  getDashboardSummary: vi.fn(async () => ({ tasks: 0 })),
+}));
+vi.mock("../views/memory-activity.js", () => ({
+  getMemoryActivity: vi.fn(async () => ({ weeks: [] })),
+}));
+vi.mock("../views/mesh.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../views/mesh.js")>();
+  return {
+    DEFAULT_MESH_WINDOW: actual.DEFAULT_MESH_WINDOW,
+    isMeshWindow: actual.isMeshWindow,
+    getMeshOverview: vi.fn(async () => ({ edges: [] })),
+  };
+});
+vi.mock("../views/promotions.js", () => ({ listPromotions: vi.fn(async () => []) }));
+vi.mock("../views/activity.js", () => ({ listActivity: vi.fn(async () => []) }));
+vi.mock("../views/work-product.js", () => ({
+  getWorkProduct: vi.fn(async () => ({ id: "wp_1" })),
+}));
+vi.mock("../views/inbox.js", () => ({ listInbox: vi.fn(async () => []) }));
+vi.mock("../views/agent-network.js", () => ({
+  getAgentNetwork: vi.fn(async () => ({ nodes: [] })),
+}));
+
+const { listTasks, getTask } = await import("../views/tasks.js");
+const { listAgents, getAgent } = await import("../views/agents.js");
+const {
+  AmbiguousShortIdError,
+  getSessionByShortId,
+  getConversationByShortId,
+  getSessionTree,
+} = await import("../views/sessions.js");
+const { listMemoryFacts, listMemoryFactCounts } = await import("../views/memory.js");
+const { getDashboardSummary } = await import("../views/dashboard.js");
+const { getMemoryActivity } = await import("../views/memory-activity.js");
+const { getMeshOverview } = await import("../views/mesh.js");
+const { listPromotions } = await import("../views/promotions.js");
+const { listActivity } = await import("../views/activity.js");
+const { getWorkProduct } = await import("../views/work-product.js");
+const { listInbox } = await import("../views/inbox.js");
+const { getAgentNetwork } = await import("../views/agent-network.js");
+const { createViewRouter } = await import("./view.js");
+
+// ── Fixtures ─────────────────────────────────────────────────────────────
+
+const PERSON = "person_alice";
+const OTHER = "person_bob";
+const AGENT = "agent_alicesteam";
+
+function fakeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: AGENT,
+    name: "Alice's Team",
+    owner_id: PERSON,
+    hierarchy_level: "team",
+    runtime_config: { type: "claude" },
+    created_at: new Date("2026-01-01T00:00:00Z"),
+    updated_at: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+interface Ports {
+  pool: Pool;
+  agentRepo: AgentRepository;
+  runtimeRepo: RuntimeRepository;
+  daemonRepo: DaemonRepository;
+  coreMemory: CoreMemory;
+  memoryFactRepo: MemoryFactRepository;
+}
+
+function makePorts(overrides: Partial<Ports> = {}): Ports {
+  return {
+    pool: { query: vi.fn(async () => ({ rows: [{ owner_id: PERSON }] })) } as unknown as Pool,
+    agentRepo: {
+      findById: vi.fn(async () => fakeAgent()),
+      findTopLevelForOwner: vi.fn(async () => fakeAgent()),
+      update: vi.fn(async (_id: string, patch: Partial<Agent>) => fakeAgent(patch)),
+    } as unknown as AgentRepository,
+    runtimeRepo: {
+      findById: vi.fn(async () => ({ id: "rt_1", daemon_id: "dmn_1", cli: "claude" })),
+    } as unknown as RuntimeRepository,
+    daemonRepo: {
+      findById: vi.fn(async () => ({ id: "dmn_1", owner_person_id: PERSON })),
+    } as unknown as DaemonRepository,
+    coreMemory: { setContent: vi.fn(async () => {}) } as unknown as CoreMemory,
+    memoryFactRepo: {
+      findById: vi.fn(async () => ({ id: "fact_1", agent_id: AGENT })),
+      delete: vi.fn(async () => {}),
+    } as unknown as MemoryFactRepository,
+    ...overrides,
+  };
+}
+
+function stubAuth(source: "human" | "agent" | "none") {
+  return (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    if (source === "human") {
+      req.caller = {
+        source: "human",
+        agentId: AGENT,
+        hierarchyLevel: "team",
+        personId: PERSON,
+      };
+    } else if (source === "agent") {
+      req.caller = { source: "agent", agentId: AGENT, hierarchyLevel: "ic" };
+    }
+    next();
+  };
+}
+
+function makeApp(ports: Ports = makePorts(), source: "human" | "agent" | "none" = "human") {
+  const app = express();
+  app.use(json());
+  app.use("/", createViewRouter({ authMiddleware: stubAuth(source), ...ports }));
+  return app;
+}
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+});
+
+/**
+ * Every route sits behind `requireHuman`. Rather than repeat the same
+ * two 403 cases 20 times, drive them off the route table.
+ */
+const ALL_ROUTES: ReadonlyArray<[method: "get" | "post" | "delete", path: string]> = [
+  ["get", "/task"],
+  ["get", "/task/task_1"],
+  ["get", "/agent"],
+  ["get", "/agent/network"],
+  ["get", "/agent/agent_1"],
+  ["post", "/agent/agent_1/runtime"],
+  ["post", "/agent/agent_1/model"],
+  ["post", "/agent/agent_1/review-policy"],
+  ["post", "/agent/agent_1/core-memory/persona"],
+  ["post", "/agent/agent_1/archive"],
+  ["get", "/session/abc123"],
+  ["get", "/session/abc123/conversation"],
+  ["get", "/session/sess_1/tree"],
+  ["get", "/dashboard"],
+  ["get", "/memory/activity"],
+  ["get", "/mesh"],
+  ["get", "/promotion"],
+  ["get", "/memory/fact"],
+  ["get", "/memory/fact/counts"],
+  ["delete", "/memory/fact/fact_1"],
+  ["get", "/work-product/wp_1"],
+  ["get", "/inbox"],
+  ["get", "/activity"],
+];
+
+describe("human gate", () => {
+  it.each(ALL_ROUTES)("403s an agent caller on %s %s", async (method, path) => {
+    const res = await request(makeApp(makePorts(), "agent"))[method](path);
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("human_required");
+  });
+
+  it.each(ALL_ROUTES)("403s an unauthenticated caller on %s %s", async (method, path) => {
+    const res = await request(makeApp(makePorts(), "none"))[method](path);
+    expect(res.status).toBe(403);
+  });
+});
+
+// ── GET /task ────────────────────────────────────────────────────────────
+
+describe("GET /task", () => {
+  it("always scopes to the caller's owner tree", async () => {
+    const res = await request(makeApp()).get("/task");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: "task_1" }]);
+    expect(vi.mocked(listTasks).mock.calls[0]![1]).toEqual({ caller_person_id: PERSON });
+  });
+
+  it.each(["pending", "in_progress", "in_review", "done"])(
+    "passes through the %s lifecycle filter",
+    async (lifecycle) => {
+      await request(makeApp()).get(`/task?lifecycle=${lifecycle}`);
+
+      expect(vi.mocked(listTasks).mock.calls[0]![1]).toMatchObject({ lifecycle });
+    },
+  );
+
+  it.each(["nonsense", ""])("drops an unknown lifecycle value %j", async (lifecycle) => {
+    await request(makeApp()).get(`/task?lifecycle=${lifecycle}`);
+
+    expect(vi.mocked(listTasks).mock.calls[0]![1]).not.toHaveProperty("lifecycle");
+  });
+
+  it.each(["all", "sprint", "timeline"])("passes through the %s view", async (view) => {
+    await request(makeApp()).get(`/task?view=${view}`);
+
+    expect(vi.mocked(listTasks).mock.calls[0]![1]).toMatchObject({ view });
+  });
+
+  it("drops an unknown view value", async () => {
+    await request(makeApp()).get("/task?view=kanban");
+
+    expect(vi.mocked(listTasks).mock.calls[0]![1]).not.toHaveProperty("view");
+  });
+
+  it("resolves view=mine to the caller's primary agent", async () => {
+    const ports = makePorts();
+    await request(makeApp(ports)).get("/task?view=mine");
+
+    expect(ports.agentRepo.findTopLevelForOwner).toHaveBeenCalledWith(PERSON);
+    expect(vi.mocked(listTasks).mock.calls[0]![1]).toMatchObject({
+      view: "mine",
+      assignee_id: AGENT,
+    });
+  });
+
+  it("short-circuits view=mine to an empty list when the caller has no agent", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.agentRepo.findTopLevelForOwner).mockResolvedValue(undefined);
+
+    const res = await request(makeApp(ports)).get("/task?view=mine");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+    expect(listTasks).not.toHaveBeenCalled();
+  });
+
+  it("honours an explicit assignee_id outside view=mine", async () => {
+    await request(makeApp()).get("/task?assignee_id=agent_other");
+
+    expect(vi.mocked(listTasks).mock.calls[0]![1]).toMatchObject({
+      assignee_id: "agent_other",
+    });
+  });
+
+  it("ignores assignee_id when view=mine already resolved one", async () => {
+    await request(makeApp()).get("/task?view=mine&assignee_id=agent_other");
+
+    expect(vi.mocked(listTasks).mock.calls[0]![1]).toMatchObject({ assignee_id: AGENT });
+  });
+
+  it("500s when the composer throws", async () => {
+    vi.mocked(listTasks).mockRejectedValueOnce(new Error("pg down"));
+
+    const res = await request(makeApp()).get("/task");
+
+    expect(res.status).toBe(500);
+    expect(res.body).toMatchObject({ error: "internal_error", message: "pg down" });
+  });
+});
+
+// ── GET /task/:id ────────────────────────────────────────────────────────
+
+describe("GET /task/:id", () => {
+  it("returns the detail row", async () => {
+    const res = await request(makeApp()).get("/task/task_1");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ id: "task_1" });
+  });
+
+  it("404s an unknown task", async () => {
+    vi.mocked(getTask).mockResolvedValueOnce(undefined as never);
+
+    const res = await request(makeApp()).get("/task/task_x");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("task_not_found");
+  });
+
+  it("500s when the composer throws", async () => {
+    vi.mocked(getTask).mockRejectedValueOnce(new Error("pg down"));
+
+    const res = await request(makeApp()).get("/task/task_1");
+
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── GET /agent, /agent/network, /agent/:id ───────────────────────────────
+
+describe("GET /agent", () => {
+  it("scopes the list to the caller's tree", async () => {
+    const res = await request(makeApp()).get("/agent");
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(listAgents).mock.calls[0]![1]).toBe(PERSON);
+  });
+
+  it("500s when the composer throws", async () => {
+    vi.mocked(listAgents).mockRejectedValueOnce(new Error("pg down"));
+
+    expect((await request(makeApp()).get("/agent")).status).toBe(500);
+  });
+});
+
+describe("GET /agent/network", () => {
+  it("matches before /agent/:id rather than being read as an id", async () => {
+    const res = await request(makeApp()).get("/agent/network");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ nodes: [] });
+    expect(getAgentNetwork).toHaveBeenCalled();
+    expect(getAgent).not.toHaveBeenCalled();
+  });
+
+  it("500s when the composer throws", async () => {
+    vi.mocked(getAgentNetwork).mockRejectedValueOnce(new Error("pg down"));
+
+    expect((await request(makeApp()).get("/agent/network")).status).toBe(500);
+  });
+});
+
+describe("GET /agent/:id", () => {
+  it("returns the detail row", async () => {
+    const res = await request(makeApp()).get("/agent/agent_1");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ id: "agent_1" });
+  });
+
+  it("404s an unknown agent", async () => {
+    vi.mocked(getAgent).mockResolvedValueOnce(undefined as never);
+
+    const res = await request(makeApp()).get("/agent/agent_x");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("agent_not_found");
+  });
+
+  it("500s when the composer throws", async () => {
+    vi.mocked(getAgent).mockRejectedValueOnce(new Error("pg down"));
+
+    expect((await request(makeApp()).get("/agent/agent_1")).status).toBe(500);
+  });
+});
+
+// ── POST /agent/:id/runtime ──────────────────────────────────────────────
+
+describe("POST /agent/:id/runtime", () => {
+  it("binds a runtime the caller owns and syncs runtime_config.type", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.agentRepo.findById).mockResolvedValue(
+      fakeAgent({ runtime_config: { type: "codex", model: "o3" } }),
+    );
+    vi.mocked(ports.runtimeRepo.findById).mockResolvedValue({
+      id: "rt_1",
+      daemon_id: "dmn_1",
+      cli: "claude",
+    } as never);
+
+    const res = await request(makeApp(ports))
+      .post(`/agent/${AGENT}/runtime`)
+      .send({ runtime_id: "rt_1" });
+
+    expect(res.status).toBe(200);
+    // The model (and every other config field) survives the type sync.
+    expect(vi.mocked(ports.agentRepo.update).mock.calls[0]![1]).toEqual({
+      preferred_runtime_id: "rt_1",
+      runtime_config: { type: "claude", model: "o3" },
+    });
+  });
+
+  it("leaves runtime_config alone when the CLI already matches", async () => {
+    const ports = makePorts();
+
+    const res = await request(makeApp(ports))
+      .post(`/agent/${AGENT}/runtime`)
+      .send({ runtime_id: "rt_1" });
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(ports.agentRepo.update).mock.calls[0]![1]).toEqual({
+      preferred_runtime_id: "rt_1",
+    });
+  });
+
+  it("unbinds on an explicit null without touching the CLI preference", async () => {
+    const ports = makePorts();
+
+    const res = await request(makeApp(ports))
+      .post(`/agent/${AGENT}/runtime`)
+      .send({ runtime_id: null });
+
+    expect(res.status).toBe(200);
+    expect(res.body.preferred_runtime_id).toBeNull();
+    expect(ports.runtimeRepo.findById).not.toHaveBeenCalled();
+    expect(vi.mocked(ports.agentRepo.update).mock.calls[0]![1]).toEqual({
+      preferred_runtime_id: null,
+    });
+  });
+
+  it.each([{}, { runtime_id: "" }, { runtime_id: 3 }])(
+    "400s a malformed body %j",
+    async (body) => {
+      const ports = makePorts();
+      const res = await request(makeApp(ports)).post(`/agent/${AGENT}/runtime`).send(body);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("invalid_body");
+      expect(ports.agentRepo.update).not.toHaveBeenCalled();
+    },
+  );
+
+  it("404s an unknown agent", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.agentRepo.findById).mockResolvedValue(undefined);
+
+    const res = await request(makeApp(ports))
+      .post("/agent/agent_x/runtime")
+      .send({ runtime_id: "rt_1" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("agent_not_found");
+  });
+
+  it("403s an agent the caller doesn't own", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.agentRepo.findById).mockResolvedValue(fakeAgent({ owner_id: OTHER }));
+
+    const res = await request(makeApp(ports))
+      .post(`/agent/${AGENT}/runtime`)
+      .send({ runtime_id: "rt_1" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("not_owner");
+  });
+
+  it("404s an unknown runtime", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.runtimeRepo.findById).mockResolvedValue(undefined);
+
+    const res = await request(makeApp(ports))
+      .post(`/agent/${AGENT}/runtime`)
+      .send({ runtime_id: "rt_x" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("runtime_not_found");
+  });
+
+  it.each([
+    ["a daemon owned by someone else", { id: "dmn_1", owner_person_id: OTHER }],
+    ["a daemon row that's gone", undefined],
+  ])("403s %s — cross-tenant escalation guard", async (_label, daemon) => {
+    const ports = makePorts();
+    vi.mocked(ports.daemonRepo.findById).mockResolvedValue(daemon as never);
+
+    const res = await request(makeApp(ports))
+      .post(`/agent/${AGENT}/runtime`)
+      .send({ runtime_id: "rt_1" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("runtime_not_owned");
+    expect(ports.agentRepo.update).not.toHaveBeenCalled();
+  });
+
+  it("409s a runtime advertising a CLI beevibe doesn't know", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.runtimeRepo.findById).mockResolvedValue({
+      id: "rt_1",
+      daemon_id: "dmn_1",
+      cli: "cursor",
+    } as never);
+
+    const res = await request(makeApp(ports))
+      .post(`/agent/${AGENT}/runtime`)
+      .send({ runtime_id: "rt_1" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe("unknown_runtime_cli");
+    expect(res.body.message).toContain("cursor");
+  });
+
+  it("500s when the update throws", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.agentRepo.update).mockRejectedValue(new Error("pg down"));
+
+    const res = await request(makeApp(ports))
+      .post(`/agent/${AGENT}/runtime`)
+      .send({ runtime_id: "rt_1" });
+
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── POST /agent/:id/model ────────────────────────────────────────────────
+
+describe("POST /agent/:id/model", () => {
+  it("sets the model, preserving the rest of runtime_config", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.agentRepo.findById).mockResolvedValue(
+      fakeAgent({ runtime_config: { type: "claude", max_turns: 12 } }),
+    );
+
+    const res = await request(makeApp(ports))
+      .post(`/agent/${AGENT}/model`)
+      .send({ model: "opus" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.model).toBe("opus");
+    expect(vi.mocked(ports.agentRepo.update).mock.calls[0]![1]).toEqual({
+      runtime_config: { type: "claude", max_turns: 12, model: "opus" },
+    });
+  });
+
+  it("clears the model on an explicit null so the CLI default applies", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.agentRepo.findById).mockResolvedValue(
+      fakeAgent({ runtime_config: { type: "claude", model: "opus" } }),
+    );
+
+    const res = await request(makeApp(ports))
+      .post(`/agent/${AGENT}/model`)
+      .send({ model: null });
+
+    expect(res.status).toBe(200);
+    expect(res.body.model).toBeNull();
+    expect(vi.mocked(ports.agentRepo.update).mock.calls[0]![1]).toEqual({
+      runtime_config: { type: "claude" },
+    });
+  });
+
+  it("400s a malformed body", async () => {
+    const res = await request(makeApp()).post(`/agent/${AGENT}/model`).send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_body");
+  });
+
+  it("403s an agent the caller doesn't own", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.agentRepo.findById).mockResolvedValue(fakeAgent({ owner_id: OTHER }));
+
+    const res = await request(makeApp(ports))
+      .post(`/agent/${AGENT}/model`)
+      .send({ model: "opus" });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("500s when the update throws", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.agentRepo.update).mockRejectedValue(new Error("pg down"));
+
+    const res = await request(makeApp(ports))
+      .post(`/agent/${AGENT}/model`)
+      .send({ model: "opus" });
+
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── POST /agent/:id/review-policy ────────────────────────────────────────
+
+describe("POST /agent/:id/review-policy", () => {
+  it.each(["auto_done", "require_human"])("accepts %s", async (policy) => {
+    const ports = makePorts();
+    const res = await request(makeApp(ports))
+      .post(`/agent/${AGENT}/review-policy`)
+      .send({ review_policy: policy });
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(ports.agentRepo.update).mock.calls[0]![1]).toEqual({
+      review_policy: policy,
+    });
+  });
+
+  it.each([{}, { review_policy: "yolo" }, { review_policy: 1 }])(
+    "400s an unknown policy %j",
+    async (body) => {
+      const ports = makePorts();
+      const res = await request(makeApp(ports))
+        .post(`/agent/${AGENT}/review-policy`)
+        .send(body);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("invalid_body");
+      expect(res.body.message).toContain("review_policy");
+      expect(ports.agentRepo.findById).not.toHaveBeenCalled();
+    },
+  );
+
+  it("404s an unknown agent", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.agentRepo.findById).mockResolvedValue(undefined);
+
+    const res = await request(makeApp(ports))
+      .post("/agent/agent_x/review-policy")
+      .send({ review_policy: "auto_done" });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("500s when the update throws", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.agentRepo.update).mockRejectedValue(new Error("pg down"));
+
+    const res = await request(makeApp(ports))
+      .post(`/agent/${AGENT}/review-policy`)
+      .send({ review_policy: "auto_done" });
+
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── POST /agent/:id/core-memory/:blockName ───────────────────────────────
+
+describe("POST /agent/:id/core-memory/:blockName", () => {
+  it("overwrites the named block", async () => {
+    const ports = makePorts();
+    const res = await request(makeApp(ports))
+      .post(`/agent/${AGENT}/core-memory/persona`)
+      .send({ content: "Brand new." });
+
+    expect(res.status).toBe(200);
+    expect(ports.coreMemory.setContent).toHaveBeenCalledWith(AGENT, "persona", "Brand new.");
+  });
+
+  it("accepts an empty string — clearing a block is legal", async () => {
+    const ports = makePorts();
+    const res = await request(makeApp(ports))
+      .post(`/agent/${AGENT}/core-memory/persona`)
+      .send({ content: "" });
+
+    expect(res.status).toBe(200);
+    expect(ports.coreMemory.setContent).toHaveBeenCalledWith(AGENT, "persona", "");
+  });
+
+  it.each([{}, { content: 42 }, { content: null }])(
+    "400s a non-string content %j",
+    async (body) => {
+      const ports = makePorts();
+      const res = await request(makeApp(ports))
+        .post(`/agent/${AGENT}/core-memory/persona`)
+        .send(body);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("invalid_body");
+      expect(ports.coreMemory.setContent).not.toHaveBeenCalled();
+    },
+  );
+
+  it("403s an agent the caller doesn't own", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.agentRepo.findById).mockResolvedValue(fakeAgent({ owner_id: OTHER }));
+
+    const res = await request(makeApp(ports))
+      .post(`/agent/${AGENT}/core-memory/persona`)
+      .send({ content: "x" });
+
+    expect(res.status).toBe(403);
+    expect(ports.coreMemory.setContent).not.toHaveBeenCalled();
+  });
+
+  it("404s an unseeded block", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.coreMemory.setContent).mockRejectedValue(
+      new BlockNotFoundError(AGENT, "never_seeded"),
+    );
+
+    const res = await request(makeApp(ports))
+      .post(`/agent/${AGENT}/core-memory/never_seeded`)
+      .send({ content: "x" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("block_not_found");
+    expect(res.body.message).toContain("never_seeded");
+  });
+
+  it("400s content over the block's char limit", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.coreMemory.setContent).mockRejectedValue(
+      new BlockCharLimitExceededError("persona", 11, 10),
+    );
+
+    const res = await request(makeApp(ports))
+      .post(`/agent/${AGENT}/core-memory/persona`)
+      .send({ content: "01234567890" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("char_limit_exceeded");
+  });
+
+  it("500s on any other failure", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.coreMemory.setContent).mockRejectedValue(new Error("pg down"));
+
+    const res = await request(makeApp(ports))
+      .post(`/agent/${AGENT}/core-memory/persona`)
+      .send({ content: "x" });
+
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── POST /agent/:id/archive ──────────────────────────────────────────────
+
+describe("POST /agent/:id/archive", () => {
+  it("stamps archived_at", async () => {
+    const ports = makePorts();
+    const archivedAt = new Date("2026-06-01T00:00:00Z");
+    vi.mocked(ports.agentRepo.update).mockResolvedValue(fakeAgent({ archived_at: archivedAt }));
+
+    const res = await request(makeApp(ports)).post(`/agent/${AGENT}/archive`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.archived_at).toBe(archivedAt.toISOString());
+    expect(vi.mocked(ports.agentRepo.update).mock.calls[0]![1].archived_at).toBeInstanceOf(Date);
+  });
+
+  it("is idempotent — an already-archived agent isn't re-stamped", async () => {
+    const ports = makePorts();
+    const archivedAt = new Date("2026-05-01T00:00:00Z");
+    vi.mocked(ports.agentRepo.findById).mockResolvedValue(fakeAgent({ archived_at: archivedAt }));
+
+    const res = await request(makeApp(ports)).post(`/agent/${AGENT}/archive`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.archived_at).toBe(archivedAt.toISOString());
+    expect(ports.agentRepo.update).not.toHaveBeenCalled();
+  });
+
+  it("403s an agent the caller doesn't own", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.agentRepo.findById).mockResolvedValue(fakeAgent({ owner_id: OTHER }));
+
+    expect((await request(makeApp(ports)).post(`/agent/${AGENT}/archive`)).status).toBe(403);
+  });
+
+  it("500s when the update throws", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.agentRepo.update).mockRejectedValue(new Error("pg down"));
+
+    expect((await request(makeApp(ports)).post(`/agent/${AGENT}/archive`)).status).toBe(500);
+  });
+});
+
+// ── GET /session/:shortId (+ /conversation) ──────────────────────────────
+
+const SHORT_ID_ROUTES = [
+  ["/session/abc123", getSessionByShortId],
+  ["/session/abc123/conversation", getConversationByShortId],
+] as const;
+
+describe("short_id session routes", () => {
+  it.each(SHORT_ID_ROUTES)("%s returns the row", async (path, fetch) => {
+    const res = await request(makeApp()).get(path);
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(fetch).mock.calls[0]![1]).toBe("abc123");
+  });
+
+  it.each(SHORT_ID_ROUTES)("%s 404s a miss", async (path, fetch) => {
+    vi.mocked(fetch).mockResolvedValueOnce(undefined as never);
+
+    const res = await request(makeApp()).get(path);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("session_not_found");
+  });
+
+  it.each(SHORT_ID_ROUTES)("%s 409s an ambiguous prefix", async (path, fetch) => {
+    vi.mocked(fetch).mockRejectedValueOnce(new AmbiguousShortIdError("abc123"));
+
+    const res = await request(makeApp()).get(path);
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe("ambiguous_short_id");
+    expect(res.body.message).toContain("abc123");
+  });
+
+  it.each(SHORT_ID_ROUTES)("%s 500s on any other failure", async (path, fetch) => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error("pg down"));
+
+    expect((await request(makeApp()).get(path)).status).toBe(500);
+  });
+});
+
+// ── GET /session/:id/tree ────────────────────────────────────────────────
+
+describe("GET /session/:id/tree", () => {
+  it("returns the tree when the caller owns the root session's agent", async () => {
+    const ports = makePorts();
+    const res = await request(makeApp(ports)).get("/session/sess_1/tree");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ root: "sess_1", nodes: [] });
+    expect(vi.mocked(getSessionTree).mock.calls[0]![1]).toBe("sess_1");
+  });
+
+  it("400s an id that isn't a session id", async () => {
+    // `/session/:shortId` also matches this shape, so the sess_ prefix
+    // check is what keeps a short_id from reaching the tree query.
+    const res = await request(makeApp()).get("/session/abc123/tree");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("missing_session_id");
+    expect(getSessionTree).not.toHaveBeenCalled();
+  });
+
+  it("404s an unknown session", async () => {
+    vi.mocked(getSessionTree).mockResolvedValueOnce(undefined as never);
+
+    const res = await request(makeApp()).get("/session/sess_x/tree");
+
+    expect(res.status).toBe(404);
+  });
+
+  it.each([
+    ["someone else's session", [{ owner_id: OTHER }]],
+    ["a session whose owner row is gone", []],
+  ])("404s %s rather than confirming it exists", async (_label, rows) => {
+    const ports = makePorts({
+      pool: { query: vi.fn(async () => ({ rows })) } as unknown as Pool,
+    });
+
+    const res = await request(makeApp(ports)).get("/session/sess_1/tree");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("session_not_found");
+  });
+
+  it("500s when the ownership query throws", async () => {
+    const ports = makePorts({
+      pool: {
+        query: vi.fn(async () => {
+          throw new Error("pg down");
+        }),
+      } as unknown as Pool,
+    });
+
+    expect((await request(makeApp(ports)).get("/session/sess_1/tree")).status).toBe(500);
+  });
+});
+
+// ── GET /dashboard ───────────────────────────────────────────────────────
+
+describe("GET /dashboard", () => {
+  it("returns the summary", async () => {
+    const res = await request(makeApp()).get("/dashboard");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ tasks: 0 });
+  });
+
+  it("500s when the composer throws", async () => {
+    vi.mocked(getDashboardSummary).mockRejectedValueOnce(new Error("pg down"));
+
+    expect((await request(makeApp()).get("/dashboard")).status).toBe(500);
+  });
+});
+
+// ── GET /memory/activity ─────────────────────────────────────────────────
+
+describe("GET /memory/activity", () => {
+  it("defaults to 12 weeks with no since", async () => {
+    await request(makeApp()).get("/memory/activity");
+
+    expect(vi.mocked(getMemoryActivity).mock.calls[0]![1]).toEqual({
+      weeks: 12,
+      since: undefined,
+    });
+  });
+
+  it("passes through weeks and a well-formed since", async () => {
+    await request(makeApp()).get("/memory/activity?weeks=4&since=2026-06-14");
+
+    expect(vi.mocked(getMemoryActivity).mock.calls[0]![1]).toEqual({
+      weeks: 4,
+      since: "2026-06-14",
+    });
+  });
+
+  it("treats a blank since as absent", async () => {
+    await request(makeApp()).get("/memory/activity?weeks=&since=%20");
+
+    expect(vi.mocked(getMemoryActivity).mock.calls[0]![1]).toEqual({
+      weeks: 12,
+      since: undefined,
+    });
+  });
+
+  it.each(["2026", "0", "14-06-2026", "2026-13-45", "not-a-date"])(
+    "400s a malformed since %j before it reaches Postgres",
+    async (since) => {
+      const res = await request(makeApp()).get(
+        `/memory/activity?since=${encodeURIComponent(since)}`,
+      );
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("invalid_since");
+      expect(getMemoryActivity).not.toHaveBeenCalled();
+    },
+  );
+
+  it("500s when the composer throws", async () => {
+    vi.mocked(getMemoryActivity).mockRejectedValueOnce(new Error("pg down"));
+
+    expect((await request(makeApp()).get("/memory/activity")).status).toBe(500);
+  });
+});
+
+// ── GET /mesh ────────────────────────────────────────────────────────────
+
+describe("GET /mesh", () => {
+  it.each(["24h", "7d", "30d", "all"])("passes through the %s window", async (window) => {
+    await request(makeApp()).get(`/mesh?window=${window}`);
+
+    expect(vi.mocked(getMeshOverview).mock.calls[0]![1]).toBe(window);
+  });
+
+  it.each(["", "1y", "99"])("falls back to the default window for %j", async (window) => {
+    await request(makeApp()).get(`/mesh?window=${window}`);
+
+    expect(vi.mocked(getMeshOverview).mock.calls[0]![1]).toBe("24h");
+  });
+
+  it("500s when the composer throws", async () => {
+    vi.mocked(getMeshOverview).mockRejectedValueOnce(new Error("pg down"));
+
+    expect((await request(makeApp()).get("/mesh")).status).toBe(500);
+  });
+});
+
+// ── GET /promotion ───────────────────────────────────────────────────────
+
+describe("GET /promotion", () => {
+  it("scopes to the caller and passes a numeric limit", async () => {
+    await request(makeApp()).get("/promotion?limit=5");
+
+    expect(vi.mocked(listPromotions).mock.calls[0]![1]).toBe(PERSON);
+    expect(vi.mocked(listPromotions).mock.calls[0]![2]).toEqual({ limit: 5 });
+  });
+
+  it("drops a non-numeric limit", async () => {
+    await request(makeApp()).get("/promotion?limit=abc");
+
+    expect(vi.mocked(listPromotions).mock.calls[0]![2]).toEqual({ limit: undefined });
+  });
+
+  it("passes an empty limit through as 0", async () => {
+    // `Number("")` is 0, which is finite — so `?limit=` reaches the
+    // composer as an explicit zero rather than falling back to the
+    // default. Pinned as current behavior, not endorsed: unlike /inbox
+    // and /activity this route has no lower-bound clamp.
+    await request(makeApp()).get("/promotion?limit=");
+
+    expect(vi.mocked(listPromotions).mock.calls[0]![2]).toEqual({ limit: 0 });
+  });
+
+  it("500s when the composer throws", async () => {
+    vi.mocked(listPromotions).mockRejectedValueOnce(new Error("pg down"));
+
+    expect((await request(makeApp()).get("/promotion")).status).toBe(500);
+  });
+});
+
+// ── GET /memory/fact + counts ────────────────────────────────────────────
+
+describe("GET /memory/fact", () => {
+  it.each(["ic", "team", "org"])("passes through the %s scope", async (scope) => {
+    await request(makeApp()).get(`/memory/fact?scope=${scope}`);
+
+    expect(vi.mocked(listMemoryFacts).mock.calls[0]![2]).toMatchObject({ scope });
+  });
+
+  it("drops an unknown scope and a non-numeric limit", async () => {
+    await request(makeApp()).get("/memory/fact?scope=galaxy&limit=lots");
+
+    expect(vi.mocked(listMemoryFacts).mock.calls[0]![1]).toBe(PERSON);
+    expect(vi.mocked(listMemoryFacts).mock.calls[0]![2]).toEqual({
+      scope: undefined,
+      limit: undefined,
+    });
+  });
+
+  it("500s when the composer throws", async () => {
+    vi.mocked(listMemoryFacts).mockRejectedValueOnce(new Error("pg down"));
+
+    expect((await request(makeApp()).get("/memory/fact")).status).toBe(500);
+  });
+});
+
+describe("GET /memory/fact/counts", () => {
+  it("matches before /memory/fact/:id-style routes and scopes to the caller", async () => {
+    const res = await request(makeApp()).get("/memory/fact/counts");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ic: 1 });
+    expect(vi.mocked(listMemoryFactCounts).mock.calls[0]![1]).toBe(PERSON);
+  });
+
+  it("500s when the composer throws", async () => {
+    vi.mocked(listMemoryFactCounts).mockRejectedValueOnce(new Error("pg down"));
+
+    expect((await request(makeApp()).get("/memory/fact/counts")).status).toBe(500);
+  });
+});
+
+// ── DELETE /memory/fact/:id ──────────────────────────────────────────────
+
+describe("DELETE /memory/fact/:id", () => {
+  it("deletes a fact belonging to an agent the caller owns", async () => {
+    const ports = makePorts();
+    const res = await request(makeApp(ports)).delete("/memory/fact/fact_1");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, fact_id: "fact_1" });
+    expect(ports.memoryFactRepo.delete).toHaveBeenCalledWith("fact_1");
+  });
+
+  it("404s an unknown fact", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.memoryFactRepo.findById).mockResolvedValue(undefined);
+
+    const res = await request(makeApp(ports)).delete("/memory/fact/fact_x");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("fact_not_found");
+    expect(ports.memoryFactRepo.delete).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["the owning agent belongs to someone else", fakeAgent({ owner_id: OTHER })],
+    ["the owning agent is missing", undefined],
+  ])("403s when %s", async (_label, agent) => {
+    const ports = makePorts();
+    vi.mocked(ports.agentRepo.findById).mockResolvedValue(agent);
+
+    const res = await request(makeApp(ports)).delete("/memory/fact/fact_1");
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("not_owner");
+    expect(ports.memoryFactRepo.delete).not.toHaveBeenCalled();
+  });
+
+  it("500s when the delete throws", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.memoryFactRepo.delete).mockRejectedValue(new Error("pg down"));
+
+    expect((await request(makeApp(ports)).delete("/memory/fact/fact_1")).status).toBe(500);
+  });
+});
+
+// ── GET /work-product/:id ────────────────────────────────────────────────
+
+describe("GET /work-product/:id", () => {
+  it("returns the row", async () => {
+    const res = await request(makeApp()).get("/work-product/wp_1");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ id: "wp_1" });
+  });
+
+  it("404s a miss", async () => {
+    vi.mocked(getWorkProduct).mockResolvedValueOnce(undefined as never);
+
+    const res = await request(makeApp()).get("/work-product/wp_x");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("work_product_not_found");
+  });
+
+  it("500s when the composer throws", async () => {
+    vi.mocked(getWorkProduct).mockRejectedValueOnce(new Error("pg down"));
+
+    expect((await request(makeApp()).get("/work-product/wp_1")).status).toBe(500);
+  });
+});
+
+// ── GET /inbox and /activity ─────────────────────────────────────────────
+
+describe("GET /inbox", () => {
+  it("defaults the limit to 50", async () => {
+    await request(makeApp()).get("/inbox");
+
+    expect(vi.mocked(listInbox).mock.calls[0]![2]).toEqual({ limit: 50 });
+  });
+
+  it("honours a limit inside the 1..200 band", async () => {
+    await request(makeApp()).get("/inbox?limit=200");
+
+    expect(vi.mocked(listInbox).mock.calls[0]![2]).toEqual({ limit: 200 });
+  });
+
+  it.each(["0", "-5", "201", "abc"])("clamps an out-of-band limit %j to 50", async (limit) => {
+    await request(makeApp()).get(`/inbox?limit=${limit}`);
+
+    expect(vi.mocked(listInbox).mock.calls[0]![2]).toEqual({ limit: 50 });
+  });
+
+  it("500s when the composer throws", async () => {
+    vi.mocked(listInbox).mockRejectedValueOnce(new Error("pg down"));
+
+    expect((await request(makeApp()).get("/inbox")).status).toBe(500);
+  });
+});
+
+describe("GET /activity", () => {
+  it("defaults the limit to 20", async () => {
+    await request(makeApp()).get("/activity");
+
+    expect(vi.mocked(listActivity).mock.calls[0]![2]).toBe(20);
+  });
+
+  it("honours a limit inside the 1..100 band", async () => {
+    await request(makeApp()).get("/activity?limit=100");
+
+    expect(vi.mocked(listActivity).mock.calls[0]![2]).toBe(100);
+  });
+
+  it.each(["0", "-1", "101", "abc"])("clamps an out-of-band limit %j to 20", async (limit) => {
+    await request(makeApp()).get(`/activity?limit=${limit}`);
+
+    expect(vi.mocked(listActivity).mock.calls[0]![2]).toBe(20);
+  });
+
+  it("500s when the composer throws", async () => {
+    vi.mocked(listActivity).mockRejectedValueOnce(new Error("pg down"));
+
+    expect((await request(makeApp()).get("/activity")).status).toBe(500);
+  });
+});

--- a/packages/core/src/adapters/postgres/repo-run-repo.test.ts
+++ b/packages/core/src/adapters/postgres/repo-run-repo.test.ts
@@ -1,0 +1,627 @@
+/**
+ * Capability-network adapters — integration tests against beevibe_test.
+ *
+ * These three repos back `use_repo`: the run log, the recipes captured
+ * from successful runs, and the review verdicts that rank them. The
+ * parts worth pinning against a real engine are the ones a fake pool
+ * can't show — the `COALESCE`-based patch semantics (undefined and null
+ * both mean "leave alone"), jsonb round-tripping of the transcript,
+ * `websearch_to_tsquery` ranking, and the `ON CONFLICT` upsert that
+ * keeps a re-review from stacking rows.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_RUNTIME_CONFIG } from "../../domain/agent.js";
+import {
+  agentId,
+  learnedSkillId,
+  personId,
+  repoRunId,
+  sessionId,
+  skillOutcomeId,
+  taskId,
+} from "../../domain/ids.js";
+import type { RepoRunTranscriptEvent } from "../../domain/repo-run.js";
+import { createTestPool, truncateAll } from "../../test-helpers.js";
+import type { Pool } from "./client.js";
+import { PostgresAgentRepository } from "./agent-repo.js";
+import { PostgresPersonRepository } from "./person-repo.js";
+import {
+  PostgresLearnedSkillRepository,
+  PostgresRepoRunRepository,
+  PostgresSkillOutcomeRepository,
+  newSkillOutcomeId,
+} from "./repo-run-repo.js";
+import { PostgresSessionRepository } from "./session-repo.js";
+import { PostgresTaskRepository } from "./task-repo.js";
+
+describe("capability-network postgres repositories", () => {
+  let pool: Pool;
+  let runs: PostgresRepoRunRepository;
+  let skills: PostgresLearnedSkillRepository;
+  let outcomes: PostgresSkillOutcomeRepository;
+  let agents: PostgresAgentRepository;
+  let persons: PostgresPersonRepository;
+  let sessions: PostgresSessionRepository;
+  let tasks: PostgresTaskRepository;
+
+  let owner: string;
+  let agent: string;
+
+  beforeAll(() => {
+    pool = createTestPool();
+    runs = new PostgresRepoRunRepository(pool);
+    skills = new PostgresLearnedSkillRepository(pool);
+    outcomes = new PostgresSkillOutcomeRepository(pool);
+    agents = new PostgresAgentRepository(pool);
+    persons = new PostgresPersonRepository(pool);
+    sessions = new PostgresSessionRepository(pool);
+    tasks = new PostgresTaskRepository(pool);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await truncateAll(pool);
+    const p = await persons.create({ id: personId(), name: "Owner" });
+    owner = p.id;
+    const a = await agents.create({
+      id: agentId(),
+      name: "Runner",
+      owner_id: owner,
+      hierarchy_level: "ic",
+      runtime_config: DEFAULT_RUNTIME_CONFIG,
+    });
+    agent = a.id;
+  });
+
+  async function newRun(overrides: Record<string, unknown> = {}) {
+    return runs.create({
+      id: repoRunId(),
+      agent_id: agent,
+      goal: "extract tables from a PDF",
+      repo_url: "https://github.com/acme/pdf-tools",
+      ...overrides,
+    });
+  }
+
+  async function newSkill(overrides: Record<string, unknown> = {}) {
+    return skills.create({
+      id: learnedSkillId(),
+      name: "pdf-tables",
+      goal_pattern: "extract tables from PDF documents",
+      repo_url: "https://github.com/acme/pdf-tools",
+      repo_ref: "main",
+      install_steps: "pip install -e .",
+      invocation: "python -m pdftools extract",
+      owner_id: owner,
+      ...overrides,
+    });
+  }
+
+  // ── repo_run ───────────────────────────────────────────────────────────
+
+  describe("PostgresRepoRunRepository", () => {
+    it("defaults status to pending and the transcript to an empty array", async () => {
+      const run = await newRun();
+
+      expect(run.status).toBe("pending");
+      expect(run.transcript).toEqual([]);
+      expect(run.started_at).toBeInstanceOf(Date);
+      // Absent columns come back as undefined, never null — the domain
+      // type has no nullable fields.
+      expect(run.session_id).toBeUndefined();
+      expect(run.task_id).toBeUndefined();
+      expect(run.repo_ref).toBeUndefined();
+      expect(run.ended_at).toBeUndefined();
+      expect(run.error).toBeUndefined();
+      expect(run.learned_skill_id).toBeUndefined();
+      expect(run.ranker_candidates).toBeUndefined();
+    });
+
+    it("round-trips every optional column and the jsonb transcript", async () => {
+      const session = await sessions.create({
+        id: sessionId(),
+        agent_id: agent,
+        type: "task",
+        status: "running",
+        intent: "run the repo",
+      });
+      const task = await tasks.create({
+        id: taskId(),
+        title: "T",
+        priority: "medium",
+        creator_id: owner,
+        creator_type: "person",
+      });
+      const transcript: RepoRunTranscriptEvent[] = [
+        { at: "2026-05-01T00:00:00.000Z", kind: "log", text: "cloned" },
+        { at: "2026-05-01T00:00:01.000Z", kind: "tool_call", text: "pip install" },
+      ];
+
+      const run = await newRun({
+        session_id: session.id,
+        task_id: task.id,
+        repo_ref: "v2.1.0",
+        status: "running",
+        transcript,
+      });
+
+      expect(run).toMatchObject({
+        session_id: session.id,
+        task_id: task.id,
+        repo_ref: "v2.1.0",
+        status: "running",
+      });
+      // jsonb survives the round trip as structured data, not a string.
+      expect(await runs.findById(run.id)).toMatchObject({ transcript });
+    });
+
+    it("finds by id and by session id, and misses cleanly", async () => {
+      const session = await sessions.create({
+        id: sessionId(),
+        agent_id: agent,
+        type: "task",
+        status: "running",
+        intent: "x",
+      });
+      const run = await newRun({ session_id: session.id });
+
+      expect((await runs.findById(run.id))?.id).toBe(run.id);
+      expect((await runs.findBySessionId(session.id))?.id).toBe(run.id);
+      expect(await runs.findById("repo_missing")).toBeUndefined();
+      expect(await runs.findBySessionId("sess_missing")).toBeUndefined();
+    });
+
+    it("lists by agent newest-first, scoped to that agent and capped", async () => {
+      const other = await agents.create({
+        id: agentId(),
+        name: "Other",
+        owner_id: owner,
+        hierarchy_level: "ic",
+        runtime_config: DEFAULT_RUNTIME_CONFIG,
+      });
+      const first = await newRun();
+      const second = await newRun();
+      await newRun({ agent_id: other.id });
+      // started_at defaults to NOW() at millisecond-or-better resolution;
+      // nudge them apart so the ordering assertion isn't a coin flip.
+      await pool.query(`UPDATE repo_run SET started_at = $2 WHERE id = $1`, [
+        first.id,
+        new Date("2026-01-01T00:00:00Z"),
+      ]);
+      await pool.query(`UPDATE repo_run SET started_at = $2 WHERE id = $1`, [
+        second.id,
+        new Date("2026-02-01T00:00:00Z"),
+      ]);
+
+      expect((await runs.listByAgent(agent)).map((r) => r.id)).toEqual([
+        second.id,
+        first.id,
+      ]);
+      expect((await runs.listByAgent(agent, { limit: 1 })).map((r) => r.id)).toEqual([
+        second.id,
+      ]);
+      expect(await runs.listByAgent("agent_nobody")).toEqual([]);
+    });
+
+    it("lists recent runs across every agent", async () => {
+      const other = await agents.create({
+        id: agentId(),
+        name: "Other",
+        owner_id: owner,
+        hierarchy_level: "ic",
+        runtime_config: DEFAULT_RUNTIME_CONFIG,
+      });
+      await newRun();
+      await newRun({ agent_id: other.id });
+
+      expect(await runs.listRecent()).toHaveLength(2);
+      expect(await runs.listRecent({ limit: 1 })).toHaveLength(1);
+    });
+
+    it("patches only the fields supplied", async () => {
+      const run = await newRun({ repo_ref: "main", status: "running" });
+      const endedAt = new Date("2026-05-02T00:00:00Z");
+
+      const updated = await runs.update(run.id, {
+        status: "succeeded",
+        install_log: "ok",
+        invocation: "python -m pdftools",
+        ended_at: endedAt,
+        ranker_candidates: [{ skill: "pdf-tables", score: 0.9 }],
+      });
+
+      expect(updated).toMatchObject({
+        status: "succeeded",
+        install_log: "ok",
+        invocation: "python -m pdftools",
+        // Untouched by this patch.
+        repo_ref: "main",
+        goal: run.goal,
+      });
+      expect(updated.ended_at?.toISOString()).toBe(endedAt.toISOString());
+      expect(updated.ranker_candidates).toEqual([{ skill: "pdf-tables", score: 0.9 }]);
+    });
+
+    it("treats an explicit null as no-change, not as a clear", async () => {
+      // Documented MVP behavior: `normalizeNullable` collapses null onto
+      // the COALESCE fallback so a partial patch can't wipe a column.
+      const run = await newRun({ repo_ref: "v1" });
+      await runs.update(run.id, { install_log: "first", error: "boom" });
+
+      const updated = await runs.update(run.id, {
+        install_log: null,
+        error: null,
+        repo_ref: null,
+        learned_skill_id: null,
+        ended_at: null,
+      });
+
+      expect(updated).toMatchObject({
+        install_log: "first",
+        error: "boom",
+        repo_ref: "v1",
+      });
+      expect(updated.ended_at).toBeUndefined();
+    });
+
+    it("replaces the transcript wholesale, and an empty patch is a no-op", async () => {
+      const run = await newRun({
+        transcript: [{ at: "2026-05-01T00:00:00.000Z", kind: "log", text: "one" }],
+      });
+
+      const replaced = await runs.update(run.id, {
+        transcript: [{ at: "2026-05-01T00:00:02.000Z", kind: "agent", text: "two" }],
+      });
+      expect(replaced.transcript).toEqual([
+        { at: "2026-05-01T00:00:02.000Z", kind: "agent", text: "two" },
+      ]);
+
+      const untouched = await runs.update(run.id, {});
+      expect(untouched.transcript).toEqual(replaced.transcript);
+      expect(untouched.status).toBe("pending");
+    });
+
+    it("links a captured skill back onto the run", async () => {
+      const run = await newRun();
+      const skill = await newSkill({ source_run_id: run.id });
+
+      const updated = await runs.update(run.id, { learned_skill_id: skill.id });
+
+      expect(updated.learned_skill_id).toBe(skill.id);
+    });
+
+    it("throws on updating a run that doesn't exist", async () => {
+      await expect(runs.update("repo_missing", { status: "failed" })).rejects.toThrow(
+        "repo_run repo_missing not found",
+      );
+    });
+  });
+
+  // ── learned_skill ──────────────────────────────────────────────────────
+
+  describe("PostgresLearnedSkillRepository", () => {
+    it("creates a skill with publication columns unset", async () => {
+      const skill = await newSkill();
+
+      expect(skill).toMatchObject({
+        name: "pdf-tables",
+        repo_ref: "main",
+        owner_id: owner,
+      });
+      expect(skill.source_run_id).toBeUndefined();
+      expect(skill.published_to).toBeUndefined();
+      expect(skill.published_pr).toBeUndefined();
+      expect(skill.published_at).toBeUndefined();
+    });
+
+    it("records the run it was captured from", async () => {
+      const run = await newRun();
+      const skill = await newSkill({ source_run_id: run.id });
+
+      expect((await skills.findById(skill.id))?.source_run_id).toBe(run.id);
+    });
+
+    it("finds by id and by (owner, name), and misses cleanly", async () => {
+      const skill = await newSkill();
+      const stranger = await persons.create({ id: personId(), name: "Stranger" });
+
+      expect((await skills.findByOwnerAndName(owner, "pdf-tables"))?.id).toBe(skill.id);
+      // Names are unique per owner, so the same name under another owner
+      // must not resolve — that would be a cross-tenant read.
+      expect(await skills.findByOwnerAndName(stranger.id, "pdf-tables")).toBeUndefined();
+      expect(await skills.findByOwnerAndName(owner, "nope")).toBeUndefined();
+      expect(await skills.findById("skill_missing")).toBeUndefined();
+    });
+
+    it("lists an owner's skills newest-first", async () => {
+      const stranger = await persons.create({ id: personId(), name: "Stranger" });
+      const older = await newSkill({ name: "older" });
+      const newer = await newSkill({ name: "newer" });
+      await newSkill({ name: "theirs", owner_id: stranger.id });
+      await pool.query(`UPDATE learned_skill SET created_at = $2 WHERE id = $1`, [
+        older.id,
+        new Date("2026-01-01T00:00:00Z"),
+      ]);
+      await pool.query(`UPDATE learned_skill SET created_at = $2 WHERE id = $1`, [
+        newer.id,
+        new Date("2026-02-01T00:00:00Z"),
+      ]);
+
+      expect((await skills.listByOwner(owner)).map((s) => s.name)).toEqual([
+        "newer",
+        "older",
+      ]);
+      expect((await skills.listByOwner(stranger.id)).map((s) => s.name)).toEqual(["theirs"]);
+    });
+
+    it("matches a bare phrase through websearch_to_tsquery", async () => {
+      const pdf = await newSkill();
+      await newSkill({
+        name: "csv-merge",
+        goal_pattern: "merge CSV files into one workbook",
+      });
+
+      // No tsquery operators — the caller passes the user's words verbatim.
+      const hits = await skills.searchByGoal(owner, "extract tables from PDF");
+
+      expect(hits.map((s) => s.id)).toEqual([pdf.id]);
+      // Stemming: "documents" in the pattern matches "document".
+      expect((await skills.searchByGoal(owner, "PDF document")).map((s) => s.id)).toEqual([
+        pdf.id,
+      ]);
+      expect(await skills.searchByGoal(owner, "kubernetes")).toEqual([]);
+    });
+
+    it("scopes the search to the owner and honours the limit", async () => {
+      const stranger = await persons.create({ id: personId(), name: "Stranger" });
+      await newSkill();
+      await newSkill({ name: "pdf-two", goal_pattern: "extract tables from PDF reports" });
+      await newSkill({
+        name: "theirs",
+        owner_id: stranger.id,
+        goal_pattern: "extract tables from PDF documents",
+      });
+
+      expect(await skills.searchByGoal(owner, "extract tables")).toHaveLength(2);
+      expect(await skills.searchByGoal(owner, "extract tables", { limit: 1 })).toHaveLength(1);
+      expect(await skills.searchByGoal(stranger.id, "extract tables")).toHaveLength(1);
+    });
+
+    it("patches recipe fields and bumps updated_at", async () => {
+      const skill = await newSkill();
+
+      const updated = await skills.update(skill.id, {
+        goal_pattern: "extract tables from PDF and DOCX",
+        install_steps: "pip install -e .[docx]",
+        invocation: "python -m pdftools extract --any",
+        repo_ref: "v3",
+      });
+
+      expect(updated).toMatchObject({
+        goal_pattern: "extract tables from PDF and DOCX",
+        install_steps: "pip install -e .[docx]",
+        invocation: "python -m pdftools extract --any",
+        repo_ref: "v3",
+        name: "pdf-tables",
+      });
+      expect(updated.updated_at.getTime()).toBeGreaterThanOrEqual(
+        skill.updated_at.getTime(),
+      );
+    });
+
+    it("records publication, and leaves it alone on a later unrelated patch", async () => {
+      const skill = await newSkill();
+      const publishedAt = new Date("2026-06-01T00:00:00Z");
+
+      const published = await skills.update(skill.id, {
+        published_to: "community",
+        published_pr: "https://github.com/beevibe-ai/skills/pull/7",
+        published_at: publishedAt,
+      });
+      expect(published).toMatchObject({
+        published_to: "community",
+        published_pr: "https://github.com/beevibe-ai/skills/pull/7",
+      });
+      expect(published.published_at?.toISOString()).toBe(publishedAt.toISOString());
+
+      // Same null-is-no-change rule as repo_run — unpublishing needs an
+      // explicit column write, not a null patch.
+      const repatched = await skills.update(skill.id, {
+        invocation: "x",
+        published_to: null,
+        published_pr: null,
+        published_at: null,
+      });
+      expect(repatched.published_to).toBe("community");
+      expect(repatched.published_pr).toBe("https://github.com/beevibe-ai/skills/pull/7");
+    });
+
+    it("throws on updating a skill that doesn't exist", async () => {
+      await expect(skills.update("skill_missing", { repo_ref: "v1" })).rejects.toThrow(
+        "learned_skill skill_missing not found",
+      );
+    });
+
+    it("deletes, and deleting a missing row is a no-op", async () => {
+      const skill = await newSkill();
+
+      await skills.delete(skill.id);
+      expect(await skills.findById(skill.id)).toBeUndefined();
+      await expect(skills.delete("skill_missing")).resolves.toBeUndefined();
+    });
+
+    it("nulls source_run_id rather than cascading when the run is deleted", async () => {
+      const run = await newRun();
+      const skill = await newSkill({ source_run_id: run.id });
+
+      await pool.query(`DELETE FROM repo_run WHERE id = $1`, [run.id]);
+
+      const reloaded = await skills.findById(skill.id);
+      expect(reloaded).toBeDefined();
+      expect(reloaded?.source_run_id).toBeUndefined();
+    });
+  });
+
+  // ── skill_outcome ──────────────────────────────────────────────────────
+
+  describe("PostgresSkillOutcomeRepository", () => {
+    it("upserts by (skill, run) so a re-review replaces the verdict", async () => {
+      const skill = await newSkill();
+      const run = await newRun();
+
+      const first = await outcomes.upsert({
+        id: skillOutcomeId(),
+        learned_skill_id: skill.id,
+        repo_run_id: run.id,
+        outcome: "revised",
+      });
+      const second = await outcomes.upsert({
+        id: skillOutcomeId(),
+        learned_skill_id: skill.id,
+        repo_run_id: run.id,
+        outcome: "approved",
+        reviewer_id: owner,
+      });
+
+      // The conflict target keeps the original row's id; only the verdict
+      // and its metadata move.
+      expect(second.id).toBe(first.id);
+      expect(second.outcome).toBe("approved");
+      expect(second.reviewer_id).toBe(owner);
+      expect(await outcomes.listBySkill(skill.id)).toHaveLength(1);
+    });
+
+    it("leaves optional columns undefined when unset", async () => {
+      const skill = await newSkill();
+      const run = await newRun();
+
+      const outcome = await outcomes.upsert({
+        id: skillOutcomeId(),
+        learned_skill_id: skill.id,
+        repo_run_id: run.id,
+        outcome: "rejected",
+      });
+
+      expect(outcome.work_product_id).toBeUndefined();
+      expect(outcome.reviewer_id).toBeUndefined();
+      expect(outcome.recorded_at).toBeInstanceOf(Date);
+    });
+
+    it("lists a skill's outcomes newest-first, scoped and capped", async () => {
+      const skill = await newSkill();
+      const otherSkill = await newSkill({ name: "other" });
+      const runA = await newRun();
+      const runB = await newRun();
+      const runC = await newRun();
+      const a = await outcomes.upsert({
+        id: skillOutcomeId(),
+        learned_skill_id: skill.id,
+        repo_run_id: runA.id,
+        outcome: "approved",
+      });
+      const b = await outcomes.upsert({
+        id: skillOutcomeId(),
+        learned_skill_id: skill.id,
+        repo_run_id: runB.id,
+        outcome: "rejected",
+      });
+      await outcomes.upsert({
+        id: skillOutcomeId(),
+        learned_skill_id: otherSkill.id,
+        repo_run_id: runC.id,
+        outcome: "approved",
+      });
+      await pool.query(`UPDATE skill_outcome SET recorded_at = $2 WHERE id = $1`, [
+        a.id,
+        new Date("2026-01-01T00:00:00Z"),
+      ]);
+      await pool.query(`UPDATE skill_outcome SET recorded_at = $2 WHERE id = $1`, [
+        b.id,
+        new Date("2026-02-01T00:00:00Z"),
+      ]);
+
+      expect((await outcomes.listBySkill(skill.id)).map((o) => o.id)).toEqual([b.id, a.id]);
+      expect(await outcomes.listBySkill(skill.id, { limit: 1 })).toHaveLength(1);
+      expect(await outcomes.listBySkill("skill_missing")).toEqual([]);
+    });
+
+    it("aggregates counts per verdict alongside the recent rows", async () => {
+      const skill = await newSkill();
+      const verdicts = [
+        "approved",
+        "approved",
+        "approved",
+        "revised",
+        "rejected",
+      ] as const;
+      for (const outcome of verdicts) {
+        const run = await newRun();
+        await outcomes.upsert({
+          id: skillOutcomeId(),
+          learned_skill_id: skill.id,
+          repo_run_id: run.id,
+          outcome,
+        });
+      }
+
+      const stats = await outcomes.statsForSkill(skill.id);
+
+      expect(stats).toMatchObject({ total: 5, approved: 3, revised: 1, rejected: 1 });
+      expect(stats.recent).toHaveLength(5);
+      expect(await outcomes.statsForSkill(skill.id, { recentLimit: 2 })).toMatchObject({
+        total: 5,
+        recent: expect.any(Array),
+      });
+      expect((await outcomes.statsForSkill(skill.id, { recentLimit: 2 })).recent).toHaveLength(
+        2,
+      );
+    });
+
+    it("reports all-zero stats for a skill nobody has reviewed", async () => {
+      const skill = await newSkill();
+
+      expect(await outcomes.statsForSkill(skill.id)).toEqual({
+        total: 0,
+        approved: 0,
+        revised: 0,
+        rejected: 0,
+        recent: [],
+      });
+    });
+
+    it("cascades outcomes away with their skill", async () => {
+      const skill = await newSkill();
+      const run = await newRun();
+      await outcomes.upsert({
+        id: skillOutcomeId(),
+        learned_skill_id: skill.id,
+        repo_run_id: run.id,
+        outcome: "approved",
+      });
+
+      await skills.delete(skill.id);
+
+      expect(await outcomes.listBySkill(skill.id)).toEqual([]);
+    });
+  });
+
+  it("newSkillOutcomeId mints a usable prefixed id", async () => {
+    const skill = await newSkill();
+    const run = await newRun();
+    const id = newSkillOutcomeId();
+
+    expect(id).toMatch(/^sout_/);
+    expect(newSkillOutcomeId()).not.toBe(id);
+    // It's the same generator the table accepts, not just a lookalike.
+    const outcome = await outcomes.upsert({
+      id,
+      learned_skill_id: skill.id,
+      repo_run_id: run.id,
+      outcome: "approved",
+    });
+    expect(outcome.id).toBe(id);
+  });
+});

--- a/packages/core/src/adapters/postgres/room-repo.test.ts
+++ b/packages/core/src/adapters/postgres/room-repo.test.ts
@@ -1,0 +1,396 @@
+/**
+ * Rooms adapter — integration tests against beevibe_test.
+ *
+ * `room_member` carries a single `subject_id` alongside separate
+ * `person_id` / `agent_id` columns, which is what makes the conflict
+ * key, the kind filters and the `areAgentsCoMembers` self-join worth
+ * exercising against a real engine rather than a fake pool: a wrong
+ * `ON CONFLICT` target silently duplicates members, and a missing kind
+ * filter leaks agents into the person list (and vice versa).
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_RUNTIME_CONFIG } from "../../domain/agent.js";
+import {
+  agentId,
+  personId,
+  roomId,
+  roomMessageId,
+  sessionId,
+} from "../../domain/ids.js";
+import { createTestPool, truncateAll } from "../../test-helpers.js";
+import type { Pool } from "./client.js";
+import { PostgresAgentRepository } from "./agent-repo.js";
+import { PostgresPersonRepository } from "./person-repo.js";
+import { PostgresRoomRepository } from "./room-repo.js";
+import { PostgresSessionRepository } from "./session-repo.js";
+
+describe("PostgresRoomRepository", () => {
+  let pool: Pool;
+  let rooms: PostgresRoomRepository;
+  let agents: PostgresAgentRepository;
+  let persons: PostgresPersonRepository;
+  let sessions: PostgresSessionRepository;
+
+  let alice: string;
+  let bob: string;
+  let alicesTeam: string;
+  let bobsTeam: string;
+
+  beforeAll(() => {
+    pool = createTestPool();
+    rooms = new PostgresRoomRepository(pool);
+    agents = new PostgresAgentRepository(pool);
+    persons = new PostgresPersonRepository(pool);
+    sessions = new PostgresSessionRepository(pool);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await truncateAll(pool);
+    alice = (await persons.create({ id: personId(), name: "Alice" })).id;
+    bob = (await persons.create({ id: personId(), name: "Bob" })).id;
+    alicesTeam = (
+      await agents.create({
+        id: agentId(),
+        name: "Alice's Team",
+        owner_id: alice,
+        hierarchy_level: "team",
+        runtime_config: DEFAULT_RUNTIME_CONFIG,
+      })
+    ).id;
+    bobsTeam = (
+      await agents.create({
+        id: agentId(),
+        name: "Bob's Team",
+        owner_id: bob,
+        hierarchy_level: "team",
+        runtime_config: DEFAULT_RUNTIME_CONFIG,
+      })
+    ).id;
+  });
+
+  async function newRoom(overrides: Record<string, unknown> = {}) {
+    return rooms.create({
+      id: roomId(),
+      name: "Launch war room",
+      owner_person_id: alice,
+      ...overrides,
+    });
+  }
+
+  // ── Room CRUD ──────────────────────────────────────────────────────────
+
+  it("creates a room and reads it back", async () => {
+    const room = await newRoom();
+
+    expect(room).toMatchObject({ name: "Launch war room", owner_person_id: alice });
+    expect(room.created_at).toBeInstanceOf(Date);
+    expect(room.updated_at).toBeInstanceOf(Date);
+    expect(await rooms.findById(room.id)).toEqual(room);
+  });
+
+  it("returns undefined for an unknown room", async () => {
+    expect(await rooms.findById("room_missing")).toBeUndefined();
+  });
+
+  it("lists a person's rooms newest-updated first, by membership not ownership", async () => {
+    const owned = await newRoom({ name: "Owned" });
+    const joined = await newRoom({ name: "Joined", owner_person_id: bob });
+    const theirs = await newRoom({ name: "Theirs", owner_person_id: bob });
+    await rooms.addPersonMember(owned.id, alice);
+    await rooms.addPersonMember(joined.id, alice);
+    await rooms.addPersonMember(theirs.id, bob);
+    await pool.query(`UPDATE room SET updated_at = $2 WHERE id = $1`, [
+      owned.id,
+      new Date("2026-01-01T00:00:00Z"),
+    ]);
+    await pool.query(`UPDATE room SET updated_at = $2 WHERE id = $1`, [
+      joined.id,
+      new Date("2026-02-01T00:00:00Z"),
+    ]);
+
+    // A room Alice owns but never joined would not appear — the join is
+    // on room_member, which is the access surface the routes gate on.
+    expect((await rooms.listForPerson(alice)).map((r) => r.name)).toEqual([
+      "Joined",
+      "Owned",
+    ]);
+    expect((await rooms.listForPerson(bob)).map((r) => r.name)).toEqual(["Theirs"]);
+    expect(await rooms.listForPerson("person_nobody")).toEqual([]);
+  });
+
+  it("omits a room the person owns but never joined", async () => {
+    await newRoom();
+
+    expect(await rooms.listForPerson(alice)).toEqual([]);
+  });
+
+  // ── Membership ─────────────────────────────────────────────────────────
+
+  it("adds person and agent members, tagging each with its kind", async () => {
+    const room = await newRoom();
+
+    await rooms.addPersonMember(room.id, alice);
+    await rooms.addAgentMember(room.id, alicesTeam);
+
+    const members = await rooms.listMembers(room.id);
+    expect(members).toHaveLength(2);
+    expect(members.map((m) => [m.kind, m.subject_id])).toEqual([
+      ["person", alice],
+      ["agent", alicesTeam],
+    ]);
+    expect(members[0]!.room_id).toBe(room.id);
+    expect(members[0]!.joined_at).toBeInstanceOf(Date);
+  });
+
+  it("is idempotent — re-adding the same member does not duplicate it", async () => {
+    const room = await newRoom();
+
+    await rooms.addPersonMember(room.id, alice);
+    await rooms.addPersonMember(room.id, alice);
+    await rooms.addAgentMember(room.id, alicesTeam);
+    await rooms.addAgentMember(room.id, alicesTeam);
+
+    expect(await rooms.listMembers(room.id)).toHaveLength(2);
+  });
+
+  it("orders members by join time", async () => {
+    const room = await newRoom();
+    await rooms.addPersonMember(room.id, alice);
+    await rooms.addPersonMember(room.id, bob);
+    await pool.query(
+      `UPDATE room_member SET joined_at = $3 WHERE room_id = $1 AND subject_id = $2`,
+      [room.id, bob, new Date("2020-01-01T00:00:00Z")],
+    );
+
+    expect((await rooms.listMembers(room.id)).map((m) => m.subject_id)).toEqual([
+      bob,
+      alice,
+    ]);
+  });
+
+  it("splits the person and agent id lists by kind", async () => {
+    const room = await newRoom();
+    await rooms.addPersonMember(room.id, alice);
+    await rooms.addPersonMember(room.id, bob);
+    await rooms.addAgentMember(room.id, alicesTeam);
+
+    expect((await rooms.listMemberPersonIds(room.id)).sort()).toEqual([alice, bob].sort());
+    expect(await rooms.listMemberAgentIds(room.id)).toEqual([alicesTeam]);
+  });
+
+  it("returns empty id lists for a room with no members", async () => {
+    const room = await newRoom();
+
+    expect(await rooms.listMembers(room.id)).toEqual([]);
+    expect(await rooms.listMemberPersonIds(room.id)).toEqual([]);
+    expect(await rooms.listMemberAgentIds(room.id)).toEqual([]);
+  });
+
+  it("answers isMember for people only, not for agents", async () => {
+    const room = await newRoom();
+    const other = await newRoom({ name: "Other" });
+    await rooms.addPersonMember(room.id, alice);
+    await rooms.addAgentMember(room.id, alicesTeam);
+
+    expect(await rooms.isMember(room.id, alice)).toBe(true);
+    expect(await rooms.isMember(room.id, bob)).toBe(false);
+    // An agent id must not satisfy the person gate even though both live
+    // in `subject_id` — the kind filter is what keeps them apart.
+    expect(await rooms.isMember(room.id, alicesTeam)).toBe(false);
+    expect(await rooms.isMember(other.id, alice)).toBe(false);
+    expect(await rooms.isMember("room_missing", alice)).toBe(false);
+  });
+
+  it("detects agent co-membership across any shared room", async () => {
+    const room = await newRoom();
+    const otherRoom = await newRoom({ name: "Other" });
+    const loner = (
+      await agents.create({
+        id: agentId(),
+        name: "Loner",
+        owner_id: bob,
+        hierarchy_level: "ic",
+        runtime_config: DEFAULT_RUNTIME_CONFIG,
+      })
+    ).id;
+    await rooms.addAgentMember(room.id, alicesTeam);
+    await rooms.addAgentMember(room.id, bobsTeam);
+    await rooms.addAgentMember(otherRoom.id, loner);
+
+    expect(await rooms.areAgentsCoMembers(alicesTeam, bobsTeam)).toBe(true);
+    // Symmetric — the mesh gate must answer the same either direction.
+    expect(await rooms.areAgentsCoMembers(bobsTeam, alicesTeam)).toBe(true);
+    expect(await rooms.areAgentsCoMembers(alicesTeam, loner)).toBe(false);
+    expect(await rooms.areAgentsCoMembers(alicesTeam, "agent_nobody")).toBe(false);
+  });
+
+  it("never reports an agent as a co-member of itself", async () => {
+    const room = await newRoom();
+    await rooms.addAgentMember(room.id, alicesTeam);
+
+    // Short-circuits before the query — an agent sharing a room with
+    // itself must not open the mesh ask path back to its own inbox.
+    expect(await rooms.areAgentsCoMembers(alicesTeam, alicesTeam)).toBe(false);
+  });
+
+  it("does not treat a person co-member as an agent co-member", async () => {
+    const room = await newRoom();
+    await rooms.addPersonMember(room.id, alice);
+    await rooms.addPersonMember(room.id, bob);
+
+    expect(await rooms.areAgentsCoMembers(alice, bob)).toBe(false);
+  });
+
+  // ── Messages ───────────────────────────────────────────────────────────
+
+  it("appends a human message with its sender", async () => {
+    const room = await newRoom();
+
+    const msg = await rooms.appendMessage({
+      id: roomMessageId(),
+      room_id: room.id,
+      kind: "human",
+      sender_person_id: alice,
+      content: "standup at 10",
+    });
+
+    expect(msg).toMatchObject({
+      room_id: room.id,
+      kind: "human",
+      sender_person_id: alice,
+      content: "standup at 10",
+    });
+    expect(msg.sender_agent_id).toBeUndefined();
+    expect(msg.session_id).toBeUndefined();
+    expect(msg.created_at).toBeInstanceOf(Date);
+  });
+
+  it("appends an agent message carrying its session id", async () => {
+    const room = await newRoom();
+    const session = await sessions.create({
+      id: sessionId(),
+      agent_id: alicesTeam,
+      type: "chat",
+      status: "succeeded",
+      intent: "reply in the room",
+    });
+
+    const msg = await rooms.appendMessage({
+      id: roomMessageId(),
+      room_id: room.id,
+      kind: "agent",
+      sender_agent_id: alicesTeam,
+      content: "on it",
+      session_id: session.id,
+    });
+
+    expect(msg).toMatchObject({
+      kind: "agent",
+      sender_agent_id: alicesTeam,
+      session_id: session.id,
+    });
+    expect(msg.sender_person_id).toBeUndefined();
+  });
+
+  it("lists messages oldest-first, scoped to the room and capped", async () => {
+    const room = await newRoom();
+    const other = await newRoom({ name: "Other" });
+    const first = await rooms.appendMessage({
+      id: roomMessageId(),
+      room_id: room.id,
+      kind: "human",
+      sender_person_id: alice,
+      content: "one",
+    });
+    const second = await rooms.appendMessage({
+      id: roomMessageId(),
+      room_id: room.id,
+      kind: "human",
+      sender_person_id: alice,
+      content: "two",
+    });
+    await rooms.appendMessage({
+      id: roomMessageId(),
+      room_id: other.id,
+      kind: "human",
+      sender_person_id: alice,
+      content: "elsewhere",
+    });
+    await pool.query(`UPDATE room_message SET created_at = $2 WHERE id = $1`, [
+      first.id,
+      new Date("2026-01-01T00:00:00Z"),
+    ]);
+    await pool.query(`UPDATE room_message SET created_at = $2 WHERE id = $1`, [
+      second.id,
+      new Date("2026-02-01T00:00:00Z"),
+    ]);
+
+    expect((await rooms.listMessages(room.id)).map((m) => m.content)).toEqual([
+      "one",
+      "two",
+    ]);
+    // The limit takes the oldest N, matching the ASC ordering.
+    expect((await rooms.listMessages(room.id, 1)).map((m) => m.content)).toEqual(["one"]);
+    expect(await rooms.listMessages("room_missing")).toEqual([]);
+  });
+
+  it("breaks a created_at tie by id so the order is stable", async () => {
+    const room = await newRoom();
+    const sameInstant = new Date("2026-03-01T00:00:00Z");
+    for (const content of ["a", "b", "c"]) {
+      const msg = await rooms.appendMessage({
+        id: roomMessageId(),
+        room_id: room.id,
+        kind: "human",
+        sender_person_id: alice,
+        content,
+      });
+      await pool.query(`UPDATE room_message SET created_at = $2 WHERE id = $1`, [
+        msg.id,
+        sameInstant,
+      ]);
+    }
+
+    const listed = await rooms.listMessages(room.id);
+    expect(listed.map((m) => m.id)).toEqual([...listed.map((m) => m.id)].sort());
+    expect(await rooms.listMessages(room.id)).toEqual(listed);
+  });
+
+  it("defaults the message limit to 200", async () => {
+    const room = await newRoom();
+    for (let i = 0; i < 201; i++) {
+      await rooms.appendMessage({
+        id: roomMessageId(),
+        room_id: room.id,
+        kind: "human",
+        sender_person_id: alice,
+        content: `m${i}`,
+      });
+    }
+
+    expect(await rooms.listMessages(room.id)).toHaveLength(200);
+    expect(await rooms.listMessages(room.id, 201)).toHaveLength(201);
+  });
+
+  it("cascades members and messages away with the room", async () => {
+    const room = await newRoom();
+    await rooms.addPersonMember(room.id, alice);
+    await rooms.appendMessage({
+      id: roomMessageId(),
+      room_id: room.id,
+      kind: "human",
+      sender_person_id: alice,
+      content: "hi",
+    });
+
+    await pool.query(`DELETE FROM room WHERE id = $1`, [room.id]);
+
+    expect(await rooms.findById(room.id)).toBeUndefined();
+    expect(await rooms.listMembers(room.id)).toEqual([]);
+    expect(await rooms.listMessages(room.id)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

A coverage sweep (v8, `--coverage.all`) put `@beevibe/api` at **64.6%** and `@beevibe/core` at **84.6%** lines. The four biggest single-file gaps were all near-zero and all load-bearing:

| File | Before | After |
| --- | ---: | ---: |
| `packages/api/src/routes/room.ts` | 2.1% | **100%** |
| `packages/api/src/routes/view.ts` | 1.8% | **99.3%** |
| `packages/core/src/adapters/postgres/repo-run-repo.ts` | 0.0% | **100%** |
| `packages/core/src/adapters/postgres/room-repo.ts` | 0.0% | **100%** |

Package totals: `@beevibe/api` 64.6% → **74.6%**, `@beevibe/core` 84.6% → **90.9%** lines.

**294 new tests. No production code touched.**

## How each was approached

**`routes/room.ts`** — the multi-tenant room surface. Covered with `vi.fn()` ports plus a stub auth middleware, following the `repo-runs.test.ts` convention already in the repo. `AgentSession` is mocked at the module boundary since the background run is the one path that would otherwise spawn a CLI; `processResponse`, `failureMessageFor` and `teamAgentRoutingDirective` run for real, because their output is part of the wire contract being pinned. The fire-and-forget run behind `POST /:id/message` is reached by posting a mention and waiting on the agent-kind `appendMessage` that closes the turn. `resolveAddressees` gets its own table-driven suite over the full mention → vocative → name → team-keyword ladder.

**`routes/view.ts`** — the read API the web app runs on. The `views/*` composers are mocked (they're pure SQL over the pool), leaving what the shell actually decides: query-param parsing and validation, `view=mine` → primary-agent resolution, the ownership checks on all five `/agent/:id/*` mutations, and the 400/403/404/409/500 contract clients branch on. The `requireHuman` gate is driven off a route table so all 23 routes are checked rather than a sample.

**The two Postgres adapters** — real integration tests against `beevibe_test`, since the parts worth pinning are the ones a fake pool can't show:
- `COALESCE` patch semantics — `undefined` *and* `null` both mean "leave alone", so a partial patch can't wipe a column
- jsonb transcript round-tripping as structured data
- `websearch_to_tsquery` matching a bare user phrase, with stemming and owner scoping
- the `ON CONFLICT (learned_skill_id, repo_run_id)` upsert that keeps a re-review from stacking rows
- the `room_member` kind filters that stop an agent id from satisfying the person gate, and the `areAgentsCoMembers` self-join the mesh ask path depends on

## Note

One quirk is **pinned rather than fixed**: `GET /promotion?limit=` reaches the composer as `limit: 0`, because `Number("")` is finite. Unlike `/inbox` and `/activity`, that route has no lower-bound clamp. Called out at the assertion so the behavior is documented, not silently baked in — worth a follow-up if it should clamp.

## Verification

- `pnpm typecheck` — 9/9 clean
- `pnpm lint` — 0 errors (the 4 remaining warnings are pre-existing `import/no-duplicates` hits in other files)
- `@beevibe/api` — 932 passed, 4 skipped
- `@beevibe/core` — 862 passed, 2 skipped (run against a live Postgres 16 + pgvector; the four provider-key-gated adapter suites were excluded locally and will run in CI)

The temporary `@vitest/coverage-v8` install used for the sweep is not committed, per CLAUDE.md.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtJhYxnDtcu3TgH8WPwR73)_