### PR TITLE
test: drop tests for two removed room-repo methods, replace two change-detectors

### DIFF
--- a/packages/api/src/routes/room.test.ts
+++ b/packages/api/src/routes/room.test.ts
@@ -140,10 +140,8 @@ function makeRoomRepo(): RoomRepository {
     addPersonMember: vi.fn(async () => {}),
     addAgentMember: vi.fn(async () => {}),
     listMembers: vi.fn(async () => []),
-    listMemberPersonIds: vi.fn(async () => []),
     listMemberAgentIds: vi.fn(async () => []),
     isMember: vi.fn(async () => true),
-    areAgentsCoMembers: vi.fn(async () => true),
     appendMessage: vi.fn(async (input) => fakeMessage({ ...input })),
     listMessages: vi.fn(async () => []),
   } as unknown as RoomRepository;

--- a/packages/core/src/adapters/postgres/room-repo.test.ts
+++ b/packages/core/src/adapters/postgres/room-repo.test.ts
@@ -3,10 +3,10 @@
  *
  * `room_member` carries a single `subject_id` alongside separate
  * `person_id` / `agent_id` columns, which is what makes the conflict
- * key, the kind filters and the `areAgentsCoMembers` self-join worth
- * exercising against a real engine rather than a fake pool: a wrong
- * `ON CONFLICT` target silently duplicates members, and a missing kind
- * filter leaks agents into the person list (and vice versa).
+ * key and the kind filters worth exercising against a real engine
+ * rather than a fake pool: a wrong `ON CONFLICT` target silently
+ * duplicates members, and a missing kind filter leaks agents into the
+ * person list (and vice versa).
  */
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { DEFAULT_RUNTIME_CONFIG } from "../../domain/agent.js";
@@ -172,13 +172,15 @@ describe("PostgresRoomRepository", () => {
     ]);
   });
 
-  it("splits the person and agent id lists by kind", async () => {
+  // The kind filter is the point: `alice`/`bob` sit in the same
+  // `subject_id` column as `alicesTeam`, so a missing `kind = 'agent'`
+  // predicate would leak the two people into the agent list.
+  it("lists only agent members, not the people sharing subject_id", async () => {
     const room = await newRoom();
     await rooms.addPersonMember(room.id, alice);
     await rooms.addPersonMember(room.id, bob);
     await rooms.addAgentMember(room.id, alicesTeam);
 
-    expect((await rooms.listMemberPersonIds(room.id)).sort()).toEqual([alice, bob].sort());
     expect(await rooms.listMemberAgentIds(room.id)).toEqual([alicesTeam]);
   });
 
@@ -186,7 +188,6 @@ describe("PostgresRoomRepository", () => {
     const room = await newRoom();
 
     expect(await rooms.listMembers(room.id)).toEqual([]);
-    expect(await rooms.listMemberPersonIds(room.id)).toEqual([]);
     expect(await rooms.listMemberAgentIds(room.id)).toEqual([]);
   });
 
@@ -203,46 +204,6 @@ describe("PostgresRoomRepository", () => {
     expect(await rooms.isMember(room.id, alicesTeam)).toBe(false);
     expect(await rooms.isMember(other.id, alice)).toBe(false);
     expect(await rooms.isMember("room_missing", alice)).toBe(false);
-  });
-
-  it("detects agent co-membership across any shared room", async () => {
-    const room = await newRoom();
-    const otherRoom = await newRoom({ name: "Other" });
-    const loner = (
-      await agents.create({
-        id: agentId(),
-        name: "Loner",
-        owner_id: bob,
-        hierarchy_level: "ic",
-        runtime_config: DEFAULT_RUNTIME_CONFIG,
-      })
-    ).id;
-    await rooms.addAgentMember(room.id, alicesTeam);
-    await rooms.addAgentMember(room.id, bobsTeam);
-    await rooms.addAgentMember(otherRoom.id, loner);
-
-    expect(await rooms.areAgentsCoMembers(alicesTeam, bobsTeam)).toBe(true);
-    // Symmetric — the mesh gate must answer the same either direction.
-    expect(await rooms.areAgentsCoMembers(bobsTeam, alicesTeam)).toBe(true);
-    expect(await rooms.areAgentsCoMembers(alicesTeam, loner)).toBe(false);
-    expect(await rooms.areAgentsCoMembers(alicesTeam, "agent_nobody")).toBe(false);
-  });
-
-  it("never reports an agent as a co-member of itself", async () => {
-    const room = await newRoom();
-    await rooms.addAgentMember(room.id, alicesTeam);
-
-    // Short-circuits before the query — an agent sharing a room with
-    // itself must not open the mesh ask path back to its own inbox.
-    expect(await rooms.areAgentsCoMembers(alicesTeam, alicesTeam)).toBe(false);
-  });
-
-  it("does not treat a person co-member as an agent co-member", async () => {
-    const room = await newRoom();
-    await rooms.addPersonMember(room.id, alice);
-    await rooms.addPersonMember(room.id, bob);
-
-    expect(await rooms.areAgentsCoMembers(alice, bob)).toBe(false);
   });
 
   // ── Messages ───────────────────────────────────────────────────────────

--- a/packages/core/src/adapters/runtime-registry.test.ts
+++ b/packages/core/src/adapters/runtime-registry.test.ts
@@ -6,22 +6,17 @@ import {
 } from "./runtime-registry.js";
 
 describe("createDefaultRuntimeRegistry", () => {
-  it("registers claude-code", () => {
-    const registry = createDefaultRuntimeRegistry();
-    expect(registry["claude"]).toBeDefined();
-    expect(registry["claude"]!.type).toBe("claude");
-  });
-
-  it("registers opencode", () => {
-    const registry = createDefaultRuntimeRegistry();
-    expect(registry["opencode"]).toBeDefined();
-    expect(registry["opencode"]!.type).toBe("opencode");
-  });
-
-  it("registers codex", () => {
-    const registry = createDefaultRuntimeRegistry();
-    expect(registry["codex"]).toBeDefined();
-    expect(registry["codex"]!.type).toBe("codex");
+  // Exact set, not per-runtime presence checks: this is the one place
+  // both composition roots (api/scheduler via composition.ts, daemon via
+  // start.ts + spawner.ts) get their runtimes from, so a runtime dropped
+  // here silently stops dispatching. An exact match also keeps the
+  // key-vs-type check below from passing vacuously on an empty registry.
+  it("registers exactly the three production runtimes", () => {
+    expect(Object.keys(createDefaultRuntimeRegistry()).sort()).toEqual([
+      "claude",
+      "codex",
+      "opencode",
+    ]);
   });
 
   it("every registry value's .type matches its registry key (sanity check against typos)", () => {

--- a/packages/web/lib/api/client.test.ts
+++ b/packages/web/lib/api/client.test.ts
@@ -92,7 +92,7 @@ describe("api client (reads)", () => {
     });
   });
 
-  describe("deferred surfaces (paths set; backend not yet shipped)", () => {
+  describe("panel surfaces", () => {
     it("promotions.list() hits /promotion", async () => {
       await api.promotions.list();
       expect(fetchJsonMock).toHaveBeenCalledWith("/promotion", { signal: undefined });

--- a/packages/web/lib/hooks/keys.test.ts
+++ b/packages/web/lib/hooks/keys.test.ts
@@ -1,18 +1,52 @@
 import { describe, expect, it } from "vitest";
 import { queryKeys } from "./keys";
 
-describe("queryKeys", () => {
-  it("namespaces every domain under a stable root tuple", () => {
-    expect(queryKeys.tasks.all).toEqual(["tasks"]);
-    expect(queryKeys.agents.all).toEqual(["agents"]);
-    expect(queryKeys.sessions.all).toEqual(["sessions"]);
-    expect(queryKeys.memory.all).toEqual(["memory"]);
-    expect(queryKeys.promotions.all).toEqual(["promotions"]);
-    expect(queryKeys.mesh.all).toEqual(["mesh"]);
-    expect(queryKeys.dashboard.all).toEqual(["dashboard"]);
-  });
+/** Every derived key in a namespace, paired with the `all` root it must sit under. */
+function derivedKeysByNamespace(): Array<[string, readonly unknown[], readonly unknown[]]> {
+  const sampleArgs: Record<string, unknown[]> = {
+    list: [{}],
+    detail: ["id_1"],
+    conversation: ["id_1"],
+    facts: [{}],
+    counts: [],
+    activity: [{}],
+    overview: [{}],
+    summary: [],
+    self: [],
+    history: ["conv_1"],
+    conversations: [],
+  };
+  const out: Array<[string, readonly unknown[], readonly unknown[]]> = [];
+  for (const [ns, group] of Object.entries(queryKeys)) {
+    const root = (group as { all: readonly unknown[] }).all;
+    for (const [member, value] of Object.entries(group)) {
+      if (member === "all") continue;
+      const derived =
+        typeof value === "function"
+          ? (value as (...a: unknown[]) => readonly unknown[])(
+              ...(sampleArgs[member] ?? [{}]),
+            )
+          : (value as readonly unknown[]);
+      out.push([`${ns}.${member}`, root, derived]);
+    }
+  }
+  return out;
+}
 
-  it("derives list/detail keys that share the root prefix (so SSE invalidation cascades work)", () => {
+describe("queryKeys", () => {
+  // The invariant SSE invalidation rests on: `lib/sse.ts` invalidates a
+  // namespace by its `all` root, and react-query matches by prefix. A
+  // derived key that doesn't start with its own root is a silent no-op
+  // on every event — the failure mode #285 found in `queryKeys.activity`.
+  // Table-driven so a namespace added later is covered without an edit.
+  it.each(derivedKeysByNamespace())(
+    "%s starts with its namespace root (so SSE invalidation cascades reach it)",
+    (_name, root, derived) => {
+      expect(derived.slice(0, root.length)).toEqual([...root]);
+    },
+  );
+
+  it("derives list/detail keys that share the root prefix but are distinct from each other", () => {
     const taskList = queryKeys.tasks.list({ view: "mine" });
     const taskDetail = queryKeys.tasks.detail("t_1");
     expect(taskList[0]).toBe("tasks");


### PR DESCRIPTION
Sweep of all 160 test files (145 `*.test.ts` + 15 `*.test.tsx`) for dead weight, following #261 / #265 / #270 / #284.

> **This also fixes a red `main`.** #285 removed two `RoomRepository` methods but left the tests calling them, so any CI run that reaches a real Postgres fails. See §1.

## 1. Tests for methods #285 removed — `main` is currently red

CI on this PR surfaced five failures in `core/src/adapters/postgres/room-repo.test.ts`, all pre-existing on `main` and unrelated to this branch's original diff:

```
TypeError: rooms.listMemberPersonIds is not a function   (×2)
TypeError: rooms.areAgentsCoMembers is not a function    (×3)
```

#285 deleted `RoomRepository.listMemberPersonIds` and `.areAgentsCoMembers` from both the port and the Postgres adapter, but left their tests behind.

**Why the sweep initially missed it — the correction that matters.** `packages/core/tsconfig.json` excludes `**/*.test.ts`, so `pnpm typecheck` never type-checks core's test files. My original claim here — *"typecheck is clean, so nothing tests a removed API"* — was an unsound inference, and this is exactly the case it let through. `core` and `scheduler` exclude tests; `api`, `daemon` and `sandbox` do not. On the api side the same two stubs survived for a different reason: the fake is cast `as unknown as RoomRepository`, which defeats excess-property checking.

Re-running `tsc` over core's sources *including* tests confirms no other test references a removed API. The one other hit — `hierarchyLevel does not exist on ResolvedCaller` in `auth/api-key.test.ts` — is a narrowing artifact of the discriminated union (the `daemon` variant has no such field), correct at runtime, not a stale test.

Fixes:
- Delete the three `areAgentsCoMembers` cases outright — the method and the "mesh ask gate" they documented are both gone (#285 notes there is no ask gate; `ask` performs no peer check).
- The two `listMemberPersonIds` cases also exercise the still-live `listMemberAgentIds`, so only the dead assertions are dropped. The first is renamed to state what it now proves — that the `kind` filter keeps people out of the agent list — since that's what earns it a real Postgres.
- Drop the two stale `vi.fn()` stubs from the api room fake.
- Update the file header, which still advertised the removed self-join.

## What else the sweep found

- **No dormant skips.** Every `.skip` / `.skipIf` is a live environment gate with a documented opt-in: `RUN_CLAUDE_SMOKE`, `BEEVIBE_E2E_DOCKER`, `BEEVIBE_E2E_MULTI_INSTANCE`, `HAS_LIVE_API_KEYS`, `win32`. No `.only`, `.todo`, `.failing`, `xit` or `xdescribe`, in either extension.
- **No test is assertion-free.**
- **No production symbol is kept alive only by its test** (counting `.test.ts` and `.test.tsx`): only `core/src/auth/test-fakes.ts`, a deliberate fixture module.

## 2. `queryKeys` root tuples (web) — change-detector

`keys.test.ts`'s *"namespaces every domain under a stable root tuple"* echoed seven root tuples verbatim from `keys.ts`. Nothing pins those strings externally — `lib/sse.ts` imports `queryKeys` rather than spelling them — and it covered 7 of 16 namespaces despite its name.

Replaced with the invariant that matters, the one #285 found broken in `queryKeys.activity`: `sse.ts` invalidates by the `all` root and react-query matches by prefix, so a derived key not prefixed by its own root is a **silent no-op on every event**. Now table-driven over all 16 namespaces / 40 derived keys. Mutation-tested — rewriting `agentNetwork.self` to `["agentNetwork", "self"]` fails the new case and passed the old one.

## 3. Runtime registry (core) — subsumed assertions

*"registers claude-code"* / *"opencode"* / *"codex"* each asserted presence plus `.type`; the `.type` half was already covered by *"every registry value's .type matches its registry key"* below them. Collapsed to one exact-set assertion on `Object.keys()`, which keeps the presence coverage that matters (single source of runtimes for both composition roots), catches an *unexpected* key, and stops the key-vs-type check passing vacuously on an empty registry.

## 4. Stale label

`client.test.ts` grouped promotions, mesh and dashboard under "backend not yet shipped". All three shipped, each with its own suite and a live hook.

## Considered and kept

`config.test.ts`'s *"getUserKey() ignores NEXT_PUBLIC_BV_USER_KEY (env fallback was removed)"* — it does test a removed feature, but as a guard against resurrecting an env var that auto-signed-in every visitor and undid sign-out.

## Verification

`typecheck`, `lint` and `build` clean. api room suite 71 passing.

| Package | Before | After | Delta |
| --- | --- | --- | --- |
| `@beevibe/web` | 203 passing | 226 passing | +23 (one test out, 24 table-driven cases in) |
| `@beevibe/core` | 609 passing / 7 failed | 607 passing / 7 failed | −2 (three tests collapsed into one) |

Core's 7 local failures are the documented bare-sandbox baseline (no provider keys), identical before and after. The DB-gated suites need a Postgres this sandbox has no Docker for — CI is the check for those, and §1 is the fix for what it found.