### PR TITLE
refactor: unify five clusters of near-duplicate abstractions

### DIFF
--- a/packages/core/src/adapters/claude-code/runtime.ts
+++ b/packages/core/src/adapters/claude-code/runtime.ts
@@ -6,19 +6,11 @@ import type {
   RuntimeResult,
   Workspace,
 } from "../../ports/runtime.js";
-import {
-  cancelledResult,
-  cliVersionHealthCheck,
-  createStdoutLineReader,
-  finalizeCliResult,
-  warnIfTruncated,
-} from "../runtime-common.js";
-import { runCliProcess } from "./spawn.js";
+import { cliVersionHealthCheck, runCliSession } from "../runtime-common.js";
 import {
   extractStepEvents,
   parseClaudeMessages,
   parseStreamJsonLine,
-  type StreamJsonMessage,
 } from "./stream-json.js";
 
 /**
@@ -103,43 +95,18 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     for (const key of ANTHROPIC_AUTH_VARS) delete env[key];
     if (context.env) Object.assign(env, context.env);
 
-    // Parse messages incrementally during streaming so we don't re-parse
-    // the entire stdout after close. A line buffer handles chunk boundaries
-    // (a single JSON message can arrive split across multiple chunks).
-    const messages: StreamJsonMessage[] = [];
-    const handleLine = (line: string): void => {
-      const msg = parseStreamJsonLine(line);
-      if (!msg) return;
-      messages.push(msg);
-      if (context.onStep) {
-        for (const step of extractStepEvents(msg)) {
-          context.onStep(step);
-        }
-      }
-    };
-    const stdout = createStdoutLineReader(handleLine);
-
-    const result = await runCliProcess({
+    return runCliSession({
+      runtimeTag: "ClaudeCodeRuntime",
+      context,
       command: this.config.command ?? "claude",
       args,
       cwd,
       env,
       stdin: context.intent,
-      abortSignal: context.abort_signal,
-      onSpawn: ({ pid, process_group_id }) => {
-        context.onSpawn?.({ process_pid: pid, process_group_id });
-      },
-      onLog: stdout.onLog,
+      parseLine: parseStreamJsonLine,
+      extractSteps: extractStepEvents,
+      parseEvents: parseClaudeMessages,
     });
-
-    // Flush any final partial line (stream without trailing \n)
-    stdout.flush();
-
-    warnIfTruncated("ClaudeCodeRuntime", result);
-
-    if (result.aborted) return cancelledResult(result);
-
-    return finalizeCliResult(parseClaudeMessages(messages, result.exitCode), result);
   }
 
   async healthCheck(): Promise<RuntimeHealth> {

--- a/packages/core/src/adapters/codex/runtime.test.ts
+++ b/packages/core/src/adapters/codex/runtime.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import type { RuntimeContext, RuntimeStep } from "../../ports/runtime.js";
 import { CodexRuntime } from "./runtime.js";
@@ -253,6 +253,19 @@ describe("CodexRuntime.execute", () => {
     mockRunCli({ ...MOCK_OK, aborted: true, stdout: "" });
     const result = await new CodexRuntime().execute(ctx());
     expect(result.status).toBe("cancelled");
+  });
+
+  it("deletes the last-message file on the abort path too", async () => {
+    // The success path reads the file and then removes it. Cancelling
+    // short-circuits before that read, so the cleanup has to be repeated on
+    // the abort branch — otherwise every cancelled turn leaves a
+    // `.beevibe-codex-last-message-*.txt` behind in the workspace.
+    mockRunCli({ ...MOCK_OK, aborted: true, stdout: "" });
+    await new CodexRuntime().execute(ctx());
+    const outputIdx = lastOptions?.args?.indexOf("--output-last-message") ?? -1;
+    const outputPath = outputIdx >= 0 ? lastOptions?.args?.[outputIdx + 1] : undefined;
+    expect(outputPath).toBeDefined();
+    expect(existsSync(outputPath as string)).toBe(false);
   });
 
   it("surfaces stderr tail on failure so /runtime/done has something actionable", async () => {

--- a/packages/core/src/adapters/codex/runtime.ts
+++ b/packages/core/src/adapters/codex/runtime.ts
@@ -8,21 +8,16 @@ import type {
   RuntimeWorkspaceContext,
   Workspace,
 } from "../../ports/runtime.js";
-import { runCliProcess } from "../claude-code/spawn.js";
 import { MCP_TOOL_TIMEOUT_MS } from "../local-workspace/manager.js";
 import {
-  cancelledResult,
   cliVersionHealthCheck,
   composePrompt,
-  createStdoutLineReader,
-  finalizeCliResult,
-  warnIfTruncated,
+  runCliSession,
 } from "../runtime-common.js";
 import {
   extractCodexStepEvents,
   parseCodexEventLine,
   parseCodexEvents,
-  type CodexEvent,
 } from "./stream-json.js";
 
 export interface CodexRuntimeConfig {
@@ -120,44 +115,26 @@ export class CodexRuntime implements AgentRuntime {
     if (context.env) Object.assign(env, context.env);
     if (prepared) env.BEEVIBE_AGENT_API_KEY = prepared.agentApiKey;
 
-    const events: CodexEvent[] = [];
-    const handleLine = (line: string): void => {
-      const evt = parseCodexEventLine(line);
-      if (!evt) return;
-      events.push(evt);
-      if (!context.onStep) return;
-      for (const step of extractCodexStepEvents(evt)) {
-        context.onStep(step);
-      }
-    };
-    const stdout = createStdoutLineReader(handleLine);
-
-    const result = await runCliProcess({
+    return runCliSession({
+      runtimeTag: "CodexRuntime",
+      context,
       command: this.config.command ?? "codex",
       args,
       cwd: context.workspace.path,
       env,
-      abortSignal: context.abort_signal,
-      onSpawn: ({ pid, process_group_id }) => {
-        context.onSpawn?.({ process_pid: pid, process_group_id });
+      parseLine: parseCodexEventLine,
+      extractSteps: extractCodexStepEvents,
+      // codex writes its final assistant message to a side file rather than
+      // the event stream, so read (and clean up) that here...
+      parseEvents: (events, exitCode) => {
+        const lastMessage = readIfExists(lastMessagePath);
+        removeIfExists(lastMessagePath);
+        return parseCodexEvents(events, exitCode, lastMessage);
       },
-      onLog: stdout.onLog,
+      // ...and on the abort path, where there is no message to read but the
+      // file still has to go — codex leaves it behind otherwise.
+      onAbort: () => removeIfExists(lastMessagePath),
     });
-    stdout.flush();
-
-    warnIfTruncated("CodexRuntime", result);
-
-    if (result.aborted) {
-      removeIfExists(lastMessagePath);
-      return cancelledResult(result);
-    }
-
-    const lastMessage = readIfExists(lastMessagePath);
-    removeIfExists(lastMessagePath);
-    return finalizeCliResult(
-      parseCodexEvents(events, result.exitCode, lastMessage),
-      result,
-    );
   }
 
   async healthCheck(): Promise<RuntimeHealth> {

--- a/packages/core/src/adapters/opencode/runtime.ts
+++ b/packages/core/src/adapters/opencode/runtime.ts
@@ -8,20 +8,15 @@ import type {
   RuntimeWorkspaceContext,
   Workspace,
 } from "../../ports/runtime.js";
-import { runCliProcess } from "../claude-code/spawn.js";
 import {
-  cancelledResult,
   cliVersionHealthCheck,
   composePrompt,
-  createStdoutLineReader,
-  finalizeCliResult,
-  warnIfTruncated,
+  runCliSession,
 } from "../runtime-common.js";
 import {
   extractOpenCodeStepEvents,
   parseOpenCodeEventLine,
   parseOpenCodeEvents,
-  type OpenCodeEvent,
 } from "./stream-json.js";
 
 export interface OpenCodeRuntimeConfig {
@@ -76,36 +71,17 @@ export class OpenCodeRuntime implements AgentRuntime {
     const env: Record<string, string | undefined> = { ...process.env };
     if (context.env) Object.assign(env, context.env);
 
-    const events: OpenCodeEvent[] = [];
-    const handleLine = (line: string): void => {
-      const evt = parseOpenCodeEventLine(line);
-      if (!evt) return;
-      events.push(evt);
-      if (!context.onStep) return;
-      for (const step of extractOpenCodeStepEvents(evt)) {
-        context.onStep(step);
-      }
-    };
-    const stdout = createStdoutLineReader(handleLine);
-
-    const result = await runCliProcess({
+    return runCliSession({
+      runtimeTag: "OpenCodeRuntime",
+      context,
       command: this.config.command ?? "opencode",
       args,
       cwd: context.workspace.path,
       env,
-      abortSignal: context.abort_signal,
-      onSpawn: ({ pid, process_group_id }) => {
-        context.onSpawn?.({ process_pid: pid, process_group_id });
-      },
-      onLog: stdout.onLog,
+      parseLine: parseOpenCodeEventLine,
+      extractSteps: extractOpenCodeStepEvents,
+      parseEvents: parseOpenCodeEvents,
     });
-    stdout.flush();
-
-    warnIfTruncated("OpenCodeRuntime", result);
-
-    if (result.aborted) return cancelledResult(result);
-
-    return finalizeCliResult(parseOpenCodeEvents(events, result.exitCode), result);
   }
 
   async healthCheck(): Promise<RuntimeHealth> {

--- a/packages/core/src/adapters/runtime-common.ts
+++ b/packages/core/src/adapters/runtime-common.ts
@@ -1,5 +1,10 @@
 import { tmpdir } from "node:os";
-import type { RuntimeContext, RuntimeHealth, RuntimeResult } from "../ports/runtime.js";
+import type {
+  RuntimeContext,
+  RuntimeHealth,
+  RuntimeResult,
+  RuntimeStep,
+} from "../ports/runtime.js";
 import { type CliProcessResult, runCliProcess } from "./claude-code/spawn.js";
 
 /**
@@ -207,4 +212,91 @@ export function finalizeCliResult(
     exit_code: result.exitCode,
     ...(stderrTail ? { stderr: stderrTail } : {}),
   };
+}
+
+export interface CliRuntimeSessionOptions<Event> {
+  /** Log tag for the truncation warning — `"CodexRuntime"`, `"OpenCodeRuntime"`, … */
+  runtimeTag: string;
+  /** The session being run; supplies `onStep`, `onSpawn` and `abort_signal`. */
+  context: RuntimeContext;
+  command: string;
+  args: string[];
+  cwd: string;
+  env: Record<string, string | undefined>;
+  /** Piped to the child's stdin. Only Claude Code uses this (prompt on stdin). */
+  stdin?: string;
+  /** Parse one stdout line into a provider event; `null` skips the line. */
+  parseLine: (line: string) => Event | null;
+  /** Step events to forward to `context.onStep` for one parsed event. */
+  extractSteps: (event: Event) => Iterable<RuntimeStep>;
+  /** Map the collected events to a `RuntimeResult` once the process exits. */
+  parseEvents: (events: Event[], exitCode: number | null) => RuntimeResult;
+  /**
+   * Cleanup for the abort path, run before the `cancelled` result is
+   * returned. `parseEvents` is not called on that path, so anything a
+   * runtime does there (codex deletes its `--output-last-message` file)
+   * has to be undone here too.
+   */
+  onAbort?: () => void;
+}
+
+/**
+ * Run one CLI session end to end: spawn the process, parse its NDJSON stdout
+ * into provider events as they stream, forward step events, then map the
+ * result.
+ *
+ * This sequence — buffer lines, push events, flush the trailing partial line,
+ * warn on truncation, short-circuit on abort, merge process metadata into the
+ * parsed result — was written out identically in all three CLI adapters. The
+ * ordering is load-bearing (flushing *after* the process settles is what
+ * captures a stream that ends without a newline; checking `aborted` *before*
+ * parsing is what keeps a cancelled session from being reported as a failure),
+ * so it is the kind of thing that should exist once rather than three times.
+ *
+ * Everything provider-specific stays at the call site: argv, env scrubbing and
+ * the event schema are passed in, not branched on here.
+ */
+export async function runCliSession<Event>(
+  opts: CliRuntimeSessionOptions<Event>,
+): Promise<RuntimeResult> {
+  const { context } = opts;
+
+  // Parse incrementally during streaming rather than re-reading the whole
+  // stdout after close. A line buffer handles chunk boundaries — a single
+  // JSON event can arrive split across chunks.
+  const events: Event[] = [];
+  const stdout = createStdoutLineReader((line) => {
+    const event = opts.parseLine(line);
+    if (!event) return;
+    events.push(event);
+    if (!context.onStep) return;
+    for (const step of opts.extractSteps(event)) {
+      context.onStep(step);
+    }
+  });
+
+  const result = await runCliProcess({
+    command: opts.command,
+    args: opts.args,
+    cwd: opts.cwd,
+    env: opts.env,
+    stdin: opts.stdin,
+    abortSignal: context.abort_signal,
+    onSpawn: ({ pid, process_group_id }) => {
+      context.onSpawn?.({ process_pid: pid, process_group_id });
+    },
+    onLog: stdout.onLog,
+  });
+
+  // Emit any final partial line (stream that ended without a trailing \n).
+  stdout.flush();
+
+  warnIfTruncated(opts.runtimeTag, result);
+
+  if (result.aborted) {
+    opts.onAbort?.();
+    return cancelledResult(result);
+  }
+
+  return finalizeCliResult(opts.parseEvents(events, result.exitCode), result);
 }

--- a/packages/web/app/(authed)/agents/[id]/loading.tsx
+++ b/packages/web/app/(authed)/agents/[id]/loading.tsx
@@ -1,93 +1,92 @@
+import { DetailShell } from "@/components/detail/detail-shell";
 import { Skeleton } from "@/components/skeleton";
 
 export default function AgentDetailLoading() {
   return (
-    <div className="flex-1 overflow-auto">
-      <div className="max-w-5xl mx-auto px-6 py-8">
-        <Skeleton className="h-4 w-20 mb-3" />
+    <DetailShell>
+      <Skeleton className="h-4 w-20 mb-3" />
 
-        <header className="mb-6">
-          <div className="flex items-start gap-4">
-            <Skeleton className="h-14 w-14 rounded-full shrink-0" />
-            <div className="flex-1 min-w-0 space-y-2">
-              <div className="flex items-center gap-2">
-                <Skeleton className="h-6 w-40 rounded" />
-                <Skeleton className="h-5 w-10 rounded" />
-                <Skeleton className="h-5 w-20 rounded" />
-              </div>
-              <Skeleton className="h-4 w-72" />
+      <header className="mb-6">
+        <div className="flex items-start gap-4">
+          <Skeleton className="h-14 w-14 rounded-full shrink-0" />
+          <div className="flex-1 min-w-0 space-y-2">
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-6 w-40 rounded" />
+              <Skeleton className="h-5 w-10 rounded" />
+              <Skeleton className="h-5 w-20 rounded" />
             </div>
-            <Skeleton className="h-8 w-24 rounded shrink-0" />
+            <Skeleton className="h-4 w-72" />
           </div>
-
-          <div className="grid grid-cols-4 gap-x-8 mt-6 pt-6 border-t border-border">
-            {[0, 1, 2, 3].map((i) => (
-              <div key={i}>
-                <Skeleton className="h-3 w-20 mb-2" />
-                <Skeleton className="h-7 w-12" />
-              </div>
-            ))}
-          </div>
-        </header>
-
-        <div className="grid grid-cols-3 gap-6">
-          <div className="col-span-2 space-y-5">
-            <section>
-              <Skeleton className="h-4 w-40 mb-3" />
-              <div className="space-y-3">
-                {[0, 1, 2].map((i) => (
-                  <div key={i} className="rounded-lg border border-border bg-card p-4">
-                    <div className="flex items-start gap-3">
-                      <Skeleton className="h-12 w-12 rounded-full shrink-0" />
-                      <div className="flex-1 min-w-0 space-y-2">
-                        <div className="flex items-center gap-2">
-                          <Skeleton className="h-3 w-16" />
-                          <Skeleton className="h-3 w-32" />
-                        </div>
-                        <Skeleton className="h-3 w-full" />
-                        <Skeleton className="h-3 w-5/6" />
-                        <Skeleton className="h-3 w-3/4" />
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </section>
-
-            <section>
-              <Skeleton className="h-4 w-44 mb-3" />
-              <div className="space-y-2">
-                {[0, 1, 2, 3].map((i) => (
-                  <div
-                    key={i}
-                    className="rounded-lg border border-border bg-card p-3 flex items-start gap-3"
-                  >
-                    <div className="flex flex-col gap-1">
-                      <Skeleton className="h-5 w-16 rounded" />
-                      <Skeleton className="h-3 w-8 rounded" />
-                    </div>
-                    <div className="flex-1 space-y-1.5">
-                      <Skeleton className="h-3 w-full" />
-                      <Skeleton className="h-3 w-4/5" />
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </section>
-          </div>
-
-          <aside className="col-span-1 space-y-4">
-            <section className="rounded-lg border border-border bg-card p-4">
-              <Skeleton className="h-3 w-24 mb-3" />
-              <Skeleton className="h-4 w-full mb-2" />
-              <Skeleton className="h-3 w-32" />
-            </section>
-            <section className="rounded-lg border border-dashed border-border p-4">
-              <Skeleton className="h-3 w-32 mx-auto" />
-            </section>
-          </aside>
+          <Skeleton className="h-8 w-24 rounded shrink-0" />
         </div>
+
+        <div className="grid grid-cols-4 gap-x-8 mt-6 pt-6 border-t border-border">
+          {[0, 1, 2, 3].map((i) => (
+            <div key={i}>
+              <Skeleton className="h-3 w-20 mb-2" />
+              <Skeleton className="h-7 w-12" />
+            </div>
+          ))}
+        </div>
+      </header>
+
+      <div className="grid grid-cols-3 gap-6">
+        <div className="col-span-2 space-y-5">
+          <section>
+            <Skeleton className="h-4 w-40 mb-3" />
+            <div className="space-y-3">
+              {[0, 1, 2].map((i) => (
+                <div key={i} className="rounded-lg border border-border bg-card p-4">
+                  <div className="flex items-start gap-3">
+                    <Skeleton className="h-12 w-12 rounded-full shrink-0" />
+                    <div className="flex-1 min-w-0 space-y-2">
+                      <div className="flex items-center gap-2">
+                        <Skeleton className="h-3 w-16" />
+                        <Skeleton className="h-3 w-32" />
+                      </div>
+                      <Skeleton className="h-3 w-full" />
+                      <Skeleton className="h-3 w-5/6" />
+                      <Skeleton className="h-3 w-3/4" />
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <Skeleton className="h-4 w-44 mb-3" />
+            <div className="space-y-2">
+              {[0, 1, 2, 3].map((i) => (
+                <div
+                  key={i}
+                  className="rounded-lg border border-border bg-card p-3 flex items-start gap-3"
+                >
+                  <div className="flex flex-col gap-1">
+                    <Skeleton className="h-5 w-16 rounded" />
+                    <Skeleton className="h-3 w-8 rounded" />
+                  </div>
+                  <div className="flex-1 space-y-1.5">
+                    <Skeleton className="h-3 w-full" />
+                    <Skeleton className="h-3 w-4/5" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+        </div>
+
+        <aside className="col-span-1 space-y-4">
+          <section className="rounded-lg border border-border bg-card p-4">
+            <Skeleton className="h-3 w-24 mb-3" />
+            <Skeleton className="h-4 w-full mb-2" />
+            <Skeleton className="h-3 w-32" />
+          </section>
+          <section className="rounded-lg border border-dashed border-border p-4">
+            <Skeleton className="h-3 w-32 mx-auto" />
+          </section>
+        </aside>
       </div>
-    </div>
+    </DetailShell>
   );
 }

--- a/packages/web/app/(authed)/escalations/[id]/loading.tsx
+++ b/packages/web/app/(authed)/escalations/[id]/loading.tsx
@@ -1,21 +1,20 @@
+import { DetailShell } from "@/components/detail/detail-shell";
 import { Skeleton } from "@/components/skeleton";
 
 export default function EscalationDetailLoading() {
   return (
-    <div className="flex-1 overflow-auto">
-      <div className="max-w-5xl mx-auto px-6 py-8">
-        <Skeleton className="h-4 w-16 mb-3" />
-        <div className="flex items-start justify-between gap-6 mb-4">
-          <Skeleton className="h-7 w-40" />
-          <Skeleton className="h-6 w-20 rounded" />
-        </div>
-        <Skeleton className="h-24 w-full rounded-lg mb-6" />
-        <div className="grid grid-cols-2 gap-4 mb-6">
-          <Skeleton className="h-48 w-full rounded-lg" />
-          <Skeleton className="h-48 w-full rounded-lg" />
-        </div>
-        <Skeleton className="h-56 w-full rounded-lg" />
+    <DetailShell>
+      <Skeleton className="h-4 w-16 mb-3" />
+      <div className="flex items-start justify-between gap-6 mb-4">
+        <Skeleton className="h-7 w-40" />
+        <Skeleton className="h-6 w-20 rounded" />
       </div>
-    </div>
+      <Skeleton className="h-24 w-full rounded-lg mb-6" />
+      <div className="grid grid-cols-2 gap-4 mb-6">
+        <Skeleton className="h-48 w-full rounded-lg" />
+        <Skeleton className="h-48 w-full rounded-lg" />
+      </div>
+      <Skeleton className="h-56 w-full rounded-lg" />
+    </DetailShell>
   );
 }

--- a/packages/web/app/(authed)/negotiations/[id]/loading.tsx
+++ b/packages/web/app/(authed)/negotiations/[id]/loading.tsx
@@ -1,20 +1,19 @@
+import { DetailShell } from "@/components/detail/detail-shell";
 import { Skeleton } from "@/components/skeleton";
 
 export default function NegotiationDetailLoading() {
   return (
-    <div className="flex-1 overflow-auto">
-      <div className="max-w-5xl mx-auto px-6 py-8">
-        <Skeleton className="h-4 w-16 mb-3" />
-        <div className="flex items-start justify-between gap-6 mb-4">
-          <Skeleton className="h-7 w-40" />
-          <Skeleton className="h-6 w-20 rounded" />
-        </div>
-        <div className="space-y-3">
-          <Skeleton className="h-32 w-full rounded-lg" />
-          <Skeleton className="h-32 w-full rounded-lg" />
-          <Skeleton className="h-32 w-full rounded-lg" />
-        </div>
+    <DetailShell>
+      <Skeleton className="h-4 w-16 mb-3" />
+      <div className="flex items-start justify-between gap-6 mb-4">
+        <Skeleton className="h-7 w-40" />
+        <Skeleton className="h-6 w-20 rounded" />
       </div>
-    </div>
+      <div className="space-y-3">
+        <Skeleton className="h-32 w-full rounded-lg" />
+        <Skeleton className="h-32 w-full rounded-lg" />
+        <Skeleton className="h-32 w-full rounded-lg" />
+      </div>
+    </DetailShell>
   );
 }

--- a/packages/web/app/(authed)/rooms/[id]/room-detail-client.tsx
+++ b/packages/web/app/(authed)/rooms/[id]/room-detail-client.tsx
@@ -17,7 +17,7 @@ import { isApiConfigured } from "@/lib/api/config";
 import { api, type RoomDetail, type RoomMemberDetail, type RoomMessage } from "@/lib/api/client";
 import { ApiError, describeError } from "@/lib/api/http";
 import { queryKeys } from "@/lib/hooks/keys";
-import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
+import { ShareLinkBox } from "@/components/share-link-box";
 import { ModalOverlay } from "@/components/modal-overlay";
 import { ChatMarkdown } from "@/components/chat/markdown";
 import { ToolStepList } from "@/components/chat/tool-step-list";
@@ -275,7 +275,6 @@ function InviteDialog({ roomId, onClose }: { roomId: string; onClose: () => void
   const [error, setError] = useState<string | null>(null);
   /** When the invitee doesn't have an account yet, surface a share link they can use to sign up + auto-join. */
   const [shareLink, setShareLink] = useState<string | null>(null);
-  const { copied, copy } = useCopyToClipboard();
 
   const invite = useMutation({
     mutationFn: () => api.rooms.invite(roomId, { email: email.trim() }),
@@ -333,27 +332,10 @@ function InviteDialog({ roomId, onClose }: { roomId: string; onClose: () => void
           </div>
         ) : null}
         {shareLink ? (
-          <div className="mt-3 rounded border border-border bg-muted/40 p-3">
-            <div className="text-[11px] text-muted-foreground mb-1.5">
-              No account for that email yet. Send them this link — they&apos;ll sign up and
-              land in this room.
-            </div>
-            <div className="flex items-center gap-1.5">
-              <input
-                readOnly
-                value={shareLink}
-                className="flex-1 rounded border border-border bg-background px-2 py-1.5 text-[11px] font-mono"
-                onFocus={(e) => e.currentTarget.select()}
-              />
-              <button
-                type="button"
-                onClick={() => void copy(shareLink ?? "")}
-                className="h-7 px-2.5 rounded text-[11px] font-medium border border-border hover:bg-secondary transition-colors cursor-pointer shrink-0"
-              >
-                {copied ? "Copied" : "Copy"}
-              </button>
-            </div>
-          </div>
+          <ShareLinkBox link={shareLink}>
+            No account for that email yet. Send them this link — they&apos;ll sign up and
+            land in this room.
+          </ShareLinkBox>
         ) : null}
         <div className="mt-4 flex items-center justify-end gap-2">
           <button

--- a/packages/web/app/(authed)/tasks/[id]/loading.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/loading.tsx
@@ -1,64 +1,63 @@
+import { DetailShell } from "@/components/detail/detail-shell";
 import { Skeleton } from "@/components/skeleton";
 
 export default function TaskDetailLoading() {
   return (
-    <div className="flex-1 overflow-auto">
-      <div className="max-w-5xl mx-auto px-6 py-8">
-        <Skeleton className="h-4 w-16 mb-3" />
+    <DetailShell>
+      <Skeleton className="h-4 w-16 mb-3" />
 
-        <div className="flex items-start justify-between gap-6 mb-1.5">
-          <Skeleton className="h-8 flex-1 max-w-2xl" />
-          <div className="flex items-center gap-1.5 mt-1.5">
-            <Skeleton className="h-6 w-20 rounded" />
-            <Skeleton className="h-6 w-12 rounded" />
-          </div>
-        </div>
-
-        <Skeleton className="h-4 w-2/3 mb-5" />
-
-        <div className="flex justify-end gap-2 mb-6">
-          <Skeleton className="h-9 w-20 rounded" />
-          <Skeleton className="h-9 w-32 rounded" />
-          <Skeleton className="h-9 w-24 rounded" />
-        </div>
-
-        <div className="border-b border-border mb-6">
-          <div className="flex items-center gap-1 -mb-px py-2">
-            <Skeleton className="h-5 w-16 rounded" />
-            <Skeleton className="h-5 w-20 rounded ml-3" />
-            <Skeleton className="h-5 w-24 rounded ml-3" />
-          </div>
-        </div>
-
-        <div className="grid grid-cols-3 gap-6">
-          <div className="col-span-2 space-y-5">
-            <section className="rounded-lg border border-border bg-card p-5">
-              <Skeleton className="h-3 w-20 mb-3" />
-              <Skeleton className="h-4 w-full mb-2" />
-              <Skeleton className="h-4 w-5/6 mb-2" />
-              <Skeleton className="h-4 w-4/6" />
-            </section>
-            <section className="rounded-lg border border-border bg-card p-5">
-              <Skeleton className="h-3 w-24 mb-3" />
-              <Skeleton className="h-4 w-full mb-2" />
-              <Skeleton className="h-4 w-3/4" />
-            </section>
-          </div>
-          <aside className="col-span-1 space-y-4">
-            <section className="rounded-lg border border-border bg-card p-4">
-              <Skeleton className="h-3 w-24 mb-3" />
-              <div className="flex items-center justify-between mb-2">
-                <Skeleton className="h-4 w-20" />
-                <Skeleton className="h-5 w-16 rounded" />
-              </div>
-              <Skeleton className="h-3 w-32" />
-            </section>
-            <section className="rounded-lg border border-dashed border-border p-4">
-              <Skeleton className="h-3 w-24 mx-auto" />
-            </section>
-          </aside>
+      <div className="flex items-start justify-between gap-6 mb-1.5">
+        <Skeleton className="h-8 flex-1 max-w-2xl" />
+        <div className="flex items-center gap-1.5 mt-1.5">
+          <Skeleton className="h-6 w-20 rounded" />
+          <Skeleton className="h-6 w-12 rounded" />
         </div>
       </div>
-    </div>
+
+      <Skeleton className="h-4 w-2/3 mb-5" />
+
+      <div className="flex justify-end gap-2 mb-6">
+        <Skeleton className="h-9 w-20 rounded" />
+        <Skeleton className="h-9 w-32 rounded" />
+        <Skeleton className="h-9 w-24 rounded" />
+      </div>
+
+      <div className="border-b border-border mb-6">
+        <div className="flex items-center gap-1 -mb-px py-2">
+          <Skeleton className="h-5 w-16 rounded" />
+          <Skeleton className="h-5 w-20 rounded ml-3" />
+          <Skeleton className="h-5 w-24 rounded ml-3" />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-6">
+        <div className="col-span-2 space-y-5">
+          <section className="rounded-lg border border-border bg-card p-5">
+            <Skeleton className="h-3 w-20 mb-3" />
+            <Skeleton className="h-4 w-full mb-2" />
+            <Skeleton className="h-4 w-5/6 mb-2" />
+            <Skeleton className="h-4 w-4/6" />
+          </section>
+          <section className="rounded-lg border border-border bg-card p-5">
+            <Skeleton className="h-3 w-24 mb-3" />
+            <Skeleton className="h-4 w-full mb-2" />
+            <Skeleton className="h-4 w-3/4" />
+          </section>
+        </div>
+        <aside className="col-span-1 space-y-4">
+          <section className="rounded-lg border border-border bg-card p-4">
+            <Skeleton className="h-3 w-24 mb-3" />
+            <div className="flex items-center justify-between mb-2">
+              <Skeleton className="h-4 w-20" />
+              <Skeleton className="h-5 w-16 rounded" />
+            </div>
+            <Skeleton className="h-3 w-32" />
+          </section>
+          <section className="rounded-lg border border-dashed border-border p-4">
+            <Skeleton className="h-3 w-24 mx-auto" />
+          </section>
+        </aside>
+      </div>
+    </DetailShell>
   );
 }

--- a/packages/web/app/(authed)/tasks/[id]/sessions/[sid]/loading.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/sessions/[sid]/loading.tsx
@@ -1,78 +1,77 @@
+import { DetailShell } from "@/components/detail/detail-shell";
 import { Skeleton } from "@/components/skeleton";
 
 export default function SessionDetailLoading() {
   return (
-    <div className="flex-1 overflow-auto">
-      <div className="max-w-5xl mx-auto px-6 py-8">
-        <div className="flex items-center gap-1.5 mb-4">
-          <Skeleton className="h-3 w-12" />
-          <Skeleton className="h-3 w-3" />
-          <Skeleton className="h-3 w-40" />
-          <Skeleton className="h-3 w-3" />
-          <Skeleton className="h-3 w-24" />
-        </div>
-
-        <header className="mb-6">
-          <div className="flex items-start gap-3">
-            <Skeleton className="h-10 w-10 rounded-full shrink-0" />
-            <div className="flex-1 min-w-0 space-y-2">
-              <div className="flex items-center gap-2">
-                <Skeleton className="h-5 w-72 rounded" />
-                <Skeleton className="h-5 w-20 rounded" />
-              </div>
-              <Skeleton className="h-4 w-96" />
-            </div>
-            <div className="flex items-center gap-1 shrink-0">
-              <Skeleton className="h-8 w-20 rounded" />
-              <Skeleton className="h-8 w-8 rounded" />
-            </div>
-          </div>
-        </header>
-
-        <section className="rounded-lg border border-border bg-card overflow-hidden mb-5">
-          <div className="px-4 py-3 flex items-center justify-between">
-            <div className="flex items-center gap-2.5">
-              <Skeleton className="h-4 w-4 rounded" />
-              <Skeleton className="h-4 w-16" />
-              <Skeleton className="h-3 w-64" />
-            </div>
-            <Skeleton className="h-3 w-48" />
-          </div>
-          <div className="border-t border-border p-4 space-y-4">
-            <div>
-              <Skeleton className="h-3 w-32 mb-2" />
-              <div className="ml-5 space-y-1.5">
-                <Skeleton className="h-3 w-full" />
-                <Skeleton className="h-3 w-5/6" />
-                <Skeleton className="h-3 w-4/6" />
-              </div>
-            </div>
-            <div>
-              <Skeleton className="h-3 w-32 mb-2" />
-              <div className="ml-5 space-y-2">
-                <Skeleton className="h-3 w-full" />
-                <Skeleton className="h-3 w-5/6" />
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <section className="rounded-lg border border-border bg-card p-5">
-          <Skeleton className="h-3 w-24 mb-4" />
-          <div className="space-y-3">
-            {[0, 1, 2, 3].map((i) => (
-              <div key={i} className="flex items-start gap-3 px-3 py-2 -mx-3">
-                <Skeleton className="h-4 w-4 rounded shrink-0 mt-0.5" />
-                <div className="flex-1 space-y-1">
-                  <Skeleton className="h-3 w-20" />
-                  <Skeleton className="h-3 w-full" />
-                  <Skeleton className="h-3 w-3/4" />
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
+    <DetailShell>
+      <div className="flex items-center gap-1.5 mb-4">
+        <Skeleton className="h-3 w-12" />
+        <Skeleton className="h-3 w-3" />
+        <Skeleton className="h-3 w-40" />
+        <Skeleton className="h-3 w-3" />
+        <Skeleton className="h-3 w-24" />
       </div>
-    </div>
+
+      <header className="mb-6">
+        <div className="flex items-start gap-3">
+          <Skeleton className="h-10 w-10 rounded-full shrink-0" />
+          <div className="flex-1 min-w-0 space-y-2">
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-5 w-72 rounded" />
+              <Skeleton className="h-5 w-20 rounded" />
+            </div>
+            <Skeleton className="h-4 w-96" />
+          </div>
+          <div className="flex items-center gap-1 shrink-0">
+            <Skeleton className="h-8 w-20 rounded" />
+            <Skeleton className="h-8 w-8 rounded" />
+          </div>
+        </div>
+      </header>
+
+      <section className="rounded-lg border border-border bg-card overflow-hidden mb-5">
+        <div className="px-4 py-3 flex items-center justify-between">
+          <div className="flex items-center gap-2.5">
+            <Skeleton className="h-4 w-4 rounded" />
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-3 w-64" />
+          </div>
+          <Skeleton className="h-3 w-48" />
+        </div>
+        <div className="border-t border-border p-4 space-y-4">
+          <div>
+            <Skeleton className="h-3 w-32 mb-2" />
+            <div className="ml-5 space-y-1.5">
+              <Skeleton className="h-3 w-full" />
+              <Skeleton className="h-3 w-5/6" />
+              <Skeleton className="h-3 w-4/6" />
+            </div>
+          </div>
+          <div>
+            <Skeleton className="h-3 w-32 mb-2" />
+            <div className="ml-5 space-y-2">
+              <Skeleton className="h-3 w-full" />
+              <Skeleton className="h-3 w-5/6" />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-border bg-card p-5">
+        <Skeleton className="h-3 w-24 mb-4" />
+        <div className="space-y-3">
+          {[0, 1, 2, 3].map((i) => (
+            <div key={i} className="flex items-start gap-3 px-3 py-2 -mx-3">
+              <Skeleton className="h-4 w-4 rounded shrink-0 mt-0.5" />
+              <div className="flex-1 space-y-1">
+                <Skeleton className="h-3 w-20" />
+                <Skeleton className="h-3 w-full" />
+                <Skeleton className="h-3 w-3/4" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </DetailShell>
   );
 }

--- a/packages/web/app/sign-in/sign-in-client.tsx
+++ b/packages/web/app/sign-in/sign-in-client.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { AlertTriangle, KeyRound, Loader2, LogIn } from "lucide-react";
+import { KeyRound, LogIn } from "lucide-react";
 import { SIGNIN_NO_PASSWORD_SET } from "@beevibe/core/auth/constants";
 import { api } from "@/lib/api/client";
 import { asApiError } from "@/lib/api/http";
@@ -13,6 +13,12 @@ import {
   isWellFormedUserKey,
   setUserKey,
 } from "@/lib/api/config";
+import {
+  AuthCard,
+  AuthError,
+  AuthField,
+  AuthSubmitButton,
+} from "@/components/auth/auth-form";
 
 type Mode = "password" | "key";
 
@@ -114,133 +120,98 @@ export function SignInClient() {
   };
 
   return (
-    <main className="min-h-screen flex items-center justify-center px-6 bg-background">
-      <form
-        onSubmit={mode === "password" ? submitPassword : submitKey}
-        className="w-full max-w-sm bg-card border border-border rounded-lg p-6 shadow-sm"
-      >
-        <header className="mb-5">
-          <div className="inline-flex items-center justify-center h-10 w-10 rounded-md bg-primary text-primary-foreground mb-3">
-            {mode === "password" ? (
-              <LogIn className="h-5 w-5" />
-            ) : (
-              <KeyRound className="h-5 w-5" />
-            )}
-          </div>
-          <h1 className="text-lg font-semibold tracking-tight">Sign in to beevibe</h1>
-          <p className="mt-1 text-xs text-muted-foreground leading-relaxed">
-            {mode === "password" ? (
-              <>Email + password. Your <span className="font-mono">bv_u_</span> key is generated server-side and never leaves the browser after.</>
-            ) : (
-              <>Paste your <span className="font-mono">bv_u_</span> key — for legacy accounts or CLI-provisioned users.</>
-            )}
-          </p>
-        </header>
-
-        {mode === "password" ? (
-          <>
-            <label className="block text-xs font-medium text-foreground mb-1.5" htmlFor="email">
-              Email
-            </label>
-            <input
-              id="email"
-              type="email"
-              autoComplete="email"
-              inputMode="email"
-              autoFocus
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="alice@example.com"
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-              disabled={submitting}
-            />
-
-            <label className="block text-xs font-medium text-foreground mb-1.5 mt-3" htmlFor="password">
-              Password
-            </label>
-            <input
-              id="password"
-              type="password"
-              autoComplete="current-password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="••••••••"
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-              disabled={submitting}
-            />
-          </>
+    <AuthCard
+      icon={mode === "password" ? LogIn : KeyRound}
+      title="Sign in to beevibe"
+      blurb={
+        mode === "password" ? (
+          <>Email + password. Your <span className="font-mono">bv_u_</span> key is generated server-side and never leaves the browser after.</>
         ) : (
-          <>
-            <label className="block text-xs font-medium text-foreground mb-1.5" htmlFor="key">
-              User API key
-            </label>
-            <input
-              id="key"
-              type="password"
-              autoComplete="off"
-              autoFocus
-              spellCheck={false}
-              value={keyDraft}
-              onChange={(e) => setKeyDraft(e.target.value)}
-              placeholder="bv_u_..."
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-ring"
-              disabled={submitting}
-            />
-          </>
-        )}
-
-        {error ? (
-          <div className="mt-3 flex items-start gap-1.5 text-xs text-status-failed">
-            <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>{error}</span>
-          </div>
-        ) : null}
-
-        <button
-          type="submit"
-          disabled={
-            submitting ||
-            (mode === "password"
-              ? email.trim().length === 0 || password.length === 0
-              : keyDraft.trim().length === 0)
-          }
-          className="mt-5 w-full inline-flex items-center justify-center gap-1.5 h-9 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {submitting ? (
-            <>
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              {mode === "password" ? "Signing in…" : "Verifying…"}
-            </>
-          ) : (
-            <>
-              <LogIn className="h-3.5 w-3.5" />
-              Sign in
-            </>
-          )}
-        </button>
-
-        <button
-          type="button"
-          onClick={() => {
-            setMode((m) => (m === "password" ? "key" : "password"));
-            setError(null);
-          }}
-          disabled={submitting}
-          className="mt-3 w-full text-[11px] text-muted-foreground hover:text-foreground transition-colors cursor-pointer disabled:opacity-50"
-        >
-          {mode === "password"
-            ? "Or sign in with your bv_u_ key"
-            : "Or sign in with email + password"}
-        </button>
-
-        <footer className="mt-5 pt-4 border-t border-border/60 text-[11px] text-muted-foreground leading-relaxed">
+          <>Paste your <span className="font-mono">bv_u_</span> key — for legacy accounts or CLI-provisioned users.</>
+        )
+      }
+      onSubmit={mode === "password" ? submitPassword : submitKey}
+      footer={
+        <>
           New here?{" "}
           <Link href="/sign-up" className="text-foreground/80 hover:underline">
             Sign up
           </Link>{" "}
           — takes about 5 seconds.
-        </footer>
-      </form>
-    </main>
+        </>
+      }
+    >
+      {mode === "password" ? (
+        <>
+          <AuthField
+            first
+            id="email"
+            label="Email"
+            type="email"
+            autoComplete="email"
+            inputMode="email"
+            autoFocus
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="alice@example.com"
+            disabled={submitting}
+          />
+
+          <AuthField
+            id="password"
+            label="Password"
+            type="password"
+            autoComplete="current-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="••••••••"
+            disabled={submitting}
+          />
+        </>
+      ) : (
+        <AuthField
+          first
+          id="key"
+          label="User API key"
+          type="password"
+          autoComplete="off"
+          autoFocus
+          spellCheck={false}
+          value={keyDraft}
+          onChange={(e) => setKeyDraft(e.target.value)}
+          placeholder="bv_u_..."
+          className="font-mono"
+          disabled={submitting}
+        />
+      )}
+
+      <AuthError message={error} />
+
+      <AuthSubmitButton
+        icon={LogIn}
+        label="Sign in"
+        pendingLabel={mode === "password" ? "Signing in…" : "Verifying…"}
+        pending={submitting}
+        disabled={
+          mode === "password"
+            ? email.trim().length === 0 || password.length === 0
+            : keyDraft.trim().length === 0
+        }
+      />
+
+      <button
+        type="button"
+        onClick={() => {
+          setMode((m) => (m === "password" ? "key" : "password"));
+          setError(null);
+        }}
+        disabled={submitting}
+        className="mt-3 w-full text-[11px] text-muted-foreground hover:text-foreground transition-colors cursor-pointer disabled:opacity-50"
+      >
+        {mode === "password"
+          ? "Or sign in with your bv_u_ key"
+          : "Or sign in with email + password"}
+      </button>
+    </AuthCard>
   );
 }

--- a/packages/web/app/sign-up/sign-up-client.tsx
+++ b/packages/web/app/sign-up/sign-up-client.tsx
@@ -3,11 +3,17 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { AlertTriangle, Loader2, Sparkles, UserPlus } from "lucide-react";
+import { Sparkles, UserPlus } from "lucide-react";
 import { PASSWORD_MIN_LENGTH } from "@beevibe/core/auth/constants";
 import { api } from "@/lib/api/client";
 import { asApiError } from "@/lib/api/http";
 import { getUserKey, isApiConfigured, setUserKey } from "@/lib/api/config";
+import {
+  AuthCard,
+  AuthError,
+  AuthField,
+  AuthSubmitButton,
+} from "@/components/auth/auth-form";
 
 /**
  * Self-serve signup. Visitor enters name + email; the api mints them a
@@ -88,105 +94,76 @@ export function SignUpClient() {
   };
 
   return (
-    <main className="min-h-screen flex items-center justify-center px-6 bg-background">
-      <form
-        onSubmit={submit}
-        className="w-full max-w-sm bg-card border border-border rounded-lg p-6 shadow-sm"
-      >
-        <header className="mb-5">
-          <div className="inline-flex items-center justify-center h-10 w-10 rounded-md bg-primary text-primary-foreground mb-3">
-            <UserPlus className="h-5 w-5" />
-          </div>
-          <h1 className="text-lg font-semibold tracking-tight">Sign up for beevibe</h1>
-          <p className="mt-1 text-xs text-muted-foreground leading-relaxed">
-            We&apos;ll mint you a personal team agent. Your key stays in your browser only — you
-            can come back and sign in with the same email later.
-          </p>
-        </header>
-
-        <label className="block text-xs font-medium text-foreground mb-1.5" htmlFor="name">
-          Name
-        </label>
-        <input
-          id="name"
-          type="text"
-          autoComplete="name"
-          autoFocus
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Alice"
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-          disabled={submitting}
-        />
-
-        <label className="block text-xs font-medium text-foreground mb-1.5 mt-3" htmlFor="email">
-          Email
-        </label>
-        <input
-          id="email"
-          type="email"
-          autoComplete="email"
-          inputMode="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          placeholder="alice@example.com"
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-          disabled={submitting}
-        />
-
-        <label className="block text-xs font-medium text-foreground mb-1.5 mt-3" htmlFor="password">
-          Password
-        </label>
-        <input
-          id="password"
-          type="password"
-          autoComplete="new-password"
-          minLength={PASSWORD_MIN_LENGTH}
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          placeholder={`at least ${PASSWORD_MIN_LENGTH} characters`}
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-          disabled={submitting}
-        />
-
-        {error ? (
-          <div className="mt-3 flex items-start gap-1.5 text-xs text-status-failed">
-            <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>{error}</span>
-          </div>
-        ) : null}
-
-        <button
-          type="submit"
-          disabled={
-            submitting ||
-            name.trim().length === 0 ||
-            email.trim().length === 0 ||
-            password.length < PASSWORD_MIN_LENGTH
-          }
-          className="mt-5 w-full inline-flex items-center justify-center gap-1.5 h-9 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {submitting ? (
-            <>
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              Provisioning…
-            </>
-          ) : (
-            <>
-              <Sparkles className="h-3.5 w-3.5" />
-              Create my team agent
-            </>
-          )}
-        </button>
-
-        <footer className="mt-5 pt-4 border-t border-border/60 text-[11px] text-muted-foreground leading-relaxed">
+    <AuthCard
+      icon={UserPlus}
+      title="Sign up for beevibe"
+      blurb={
+        <>
+          We&apos;ll mint you a personal team agent. Your key stays in your browser only — you
+          can come back and sign in with the same email later.
+        </>
+      }
+      onSubmit={submit}
+      footer={
+        <>
           Already have a key?{" "}
           <Link href="/sign-in" className="text-foreground/80 hover:underline">
             Sign in
           </Link>{" "}
           instead.
-        </footer>
-      </form>
-    </main>
+        </>
+      }
+    >
+      <AuthField
+        first
+        id="name"
+        label="Name"
+        type="text"
+        autoComplete="name"
+        autoFocus
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Alice"
+        disabled={submitting}
+      />
+
+      <AuthField
+        id="email"
+        label="Email"
+        type="email"
+        autoComplete="email"
+        inputMode="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="alice@example.com"
+        disabled={submitting}
+      />
+
+      <AuthField
+        id="password"
+        label="Password"
+        type="password"
+        autoComplete="new-password"
+        minLength={PASSWORD_MIN_LENGTH}
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder={`at least ${PASSWORD_MIN_LENGTH} characters`}
+        disabled={submitting}
+      />
+
+      <AuthError message={error} />
+
+      <AuthSubmitButton
+        icon={Sparkles}
+        label="Create my team agent"
+        pendingLabel="Provisioning…"
+        pending={submitting}
+        disabled={
+          name.trim().length === 0 ||
+          email.trim().length === 0 ||
+          password.length < PASSWORD_MIN_LENGTH
+        }
+      />
+    </AuthCard>
   );
 }

--- a/packages/web/components/agents/agent-detail-panel.tsx
+++ b/packages/web/components/agents/agent-detail-panel.tsx
@@ -1,16 +1,15 @@
 "use client";
 
-import { AlertTriangle, Bot } from "lucide-react";
+import { Bot } from "lucide-react";
 import { Avatar } from "@/components/avatar";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { PanelFooterField, PeekPanel } from "@/components/detail/peek-panel";
+import { PanelGate } from "@/components/detail/panel-gate";
 import { CoreBlockCard } from "@/components/agents/core-block-card";
 import { RecentSessionRow } from "@/components/agents/recent-session-row";
 import { RecentChatThreadRow } from "@/components/agents/recent-chat-thread-row";
-import { EmptyState } from "@/components/empty-state";
 import { HierChip } from "@/components/hier-chip";
 import { Skeleton } from "@/components/skeleton";
-import { isApiConfigured } from "@/lib/api/config";
 import { useAgent } from "@/lib/hooks/use-agents";
 import { useIsOwner } from "@/lib/hooks/use-me";
 import { formatReviewPolicy } from "@/lib/format";
@@ -42,43 +41,25 @@ export function AgentDetailPanel({
 }
 
 function PanelBody({ agentId }: { agentId: string }) {
-  const { data, isLoading, isError } = useAgent(agentId);
+  const query = useAgent(agentId);
 
-  if (!isApiConfigured) {
-    return (
-      <div className="p-4">
-        <EmptyState
-          icon={Bot}
-          title="API not configured"
-          description="Set NEXT_PUBLIC_BV_API_URL to load this agent."
-        />
-      </div>
-    );
-  }
-
-  if (isLoading) {
-    return (
-      <div className="p-5 space-y-4">
-        <Skeleton className="h-14 w-full" />
-        <Skeleton className="h-24 w-full rounded-lg" />
-        <Skeleton className="h-32 w-full rounded-lg" />
-      </div>
-    );
-  }
-
-  if (isError || !data) {
-    return (
-      <div className="p-4">
-        <EmptyState
-          icon={AlertTriangle}
-          title="Couldn't load agent"
-          description={`Agent ${agentId} could not be fetched.`}
-        />
-      </div>
-    );
-  }
-
-  return <PanelLoaded agent={data} />;
+  return (
+    <PanelGate
+      icon={Bot}
+      noun="agent"
+      id={agentId}
+      query={query}
+      skeleton={
+        <>
+          <Skeleton className="h-14 w-full" />
+          <Skeleton className="h-24 w-full rounded-lg" />
+          <Skeleton className="h-32 w-full rounded-lg" />
+        </>
+      }
+    >
+      {(agent) => <PanelLoaded agent={agent} />}
+    </PanelGate>
+  );
 }
 
 function PanelLoaded({ agent }: { agent: AgentDetail }) {

--- a/packages/web/components/auth/auth-form.tsx
+++ b/packages/web/components/auth/auth-form.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import type { InputHTMLAttributes, ReactNode } from "react";
+import { AlertTriangle, Loader2, type LucideIcon } from "lucide-react";
+
+/**
+ * The centered card the two unauthenticated pages are built out of.
+ *
+ * `/sign-in` and `/sign-up` are the same form: a card with an icon badge, a
+ * title, a blurb, a stack of labelled inputs, an error line, a submit button
+ * and a footer link to the other page. Both had it written out by hand, which
+ * meant six copies of the same twelve-line label+input pair and two copies of
+ * every wrapper class. Drift between them is directly user-visible — these are
+ * the first two screens anyone sees — so the shell lives here once.
+ *
+ * What is genuinely different stays at the call site: sign-in's
+ * password/paste-key mode toggle, sign-up's invite-room handling, and each
+ * page's copy.
+ */
+export function AuthCard({
+  icon: Icon,
+  title,
+  blurb,
+  onSubmit,
+  children,
+  footer,
+}: {
+  icon: LucideIcon;
+  title: string;
+  blurb: ReactNode;
+  onSubmit: (e: React.FormEvent) => void;
+  children: ReactNode;
+  footer: ReactNode;
+}) {
+  return (
+    <main className="min-h-screen flex items-center justify-center px-6 bg-background">
+      <form
+        onSubmit={onSubmit}
+        className="w-full max-w-sm bg-card border border-border rounded-lg p-6 shadow-sm"
+      >
+        <header className="mb-5">
+          <div className="inline-flex items-center justify-center h-10 w-10 rounded-md bg-primary text-primary-foreground mb-3">
+            <Icon className="h-5 w-5" />
+          </div>
+          <h1 className="text-lg font-semibold tracking-tight">{title}</h1>
+          <p className="mt-1 text-xs text-muted-foreground leading-relaxed">{blurb}</p>
+        </header>
+
+        {children}
+
+        <footer className="mt-5 pt-4 border-t border-border/60 text-[11px] text-muted-foreground leading-relaxed">
+          {footer}
+        </footer>
+      </form>
+    </main>
+  );
+}
+
+/**
+ * A labelled text input inside an {@link AuthCard}.
+ *
+ * `first` drops the top margin — every field after the first in a stack is
+ * separated by `mt-3`, and spelling that out per call site is what let the two
+ * pages diverge on spacing. Remaining input attributes (`type`,
+ * `autoComplete`, `minLength`, …) pass straight through.
+ */
+export function AuthField({
+  id,
+  label,
+  first = false,
+  className = "",
+  ...input
+}: {
+  id: string;
+  label: string;
+  first?: boolean;
+} & InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <>
+      <label
+        className={`block text-xs font-medium text-foreground mb-1.5${first ? "" : " mt-3"}`}
+        htmlFor={id}
+      >
+        {label}
+      </label>
+      <input
+        id={id}
+        className={`w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring${
+          className ? ` ${className}` : ""
+        }`}
+        {...input}
+      />
+    </>
+  );
+}
+
+/** The inline failure line under the fields. Renders nothing when `message` is null. */
+export function AuthError({ message }: { message: string | null }) {
+  if (!message) return null;
+  return (
+    <div className="mt-3 flex items-start gap-1.5 text-xs text-status-failed">
+      <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+      <span>{message}</span>
+    </div>
+  );
+}
+
+/**
+ * The card's primary action. Swaps to a spinner and `pendingLabel` while the
+ * request is in flight, and is disabled for the whole of it — `disabled` is
+ * OR-ed with `pending` so call sites only express their own validity rule.
+ */
+export function AuthSubmitButton({
+  icon: Icon,
+  label,
+  pendingLabel,
+  pending,
+  disabled = false,
+}: {
+  icon: LucideIcon;
+  label: string;
+  pendingLabel: string;
+  pending: boolean;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="submit"
+      disabled={pending || disabled}
+      className="mt-5 w-full inline-flex items-center justify-center gap-1.5 h-9 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      {pending ? (
+        <>
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          {pendingLabel}
+        </>
+      ) : (
+        <>
+          <Icon className="h-3.5 w-3.5" />
+          {label}
+        </>
+      )}
+    </button>
+  );
+}

--- a/packages/web/components/detail/panel-gate.tsx
+++ b/packages/web/components/detail/panel-gate.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { AlertTriangle, type LucideIcon } from "lucide-react";
+import { isApiConfigured } from "@/lib/api/config";
+import { EmptyState } from "@/components/empty-state";
+
+interface Props<T> {
+  /** Icon for the "API not configured" state. The error state is always AlertTriangle. */
+  icon: LucideIcon;
+  /** Lowercase singular of what the panel shows — "task", "agent". */
+  noun: string;
+  /** Id echoed back in the error message so a failed fetch is identifiable. */
+  id: string;
+  /** The react-query result driving the panel. */
+  query: { data: T | undefined; isLoading: boolean; isError: boolean };
+  /**
+   * Loading placeholder, rendered inside the padded stack. Per-panel rather
+   * than generic: the skeleton mirrors the layout it stands in for, so a
+   * shared one would jump on hydration.
+   */
+  skeleton: ReactNode;
+  /** Rendered once the fetch succeeded. */
+  children: (data: T) => ReactNode;
+}
+
+/**
+ * {@link DetailGate}, for peek panels.
+ *
+ * The task and agent panels each opened with the same three-branch preamble
+ * as the full pages — API not configured, still loading, failed to load —
+ * but written out by hand a second time because the panels wrap their states
+ * in a padded `div` rather than a `DetailShell`. Two copies of a gate whose
+ * whole job is to stop the failure copy from drifting is one copy too many:
+ * both messages are derived from `noun` here.
+ *
+ * Deliberately not folded into `DetailGate` itself. The wrapper is the only
+ * thing that differs, but it is what makes the two usable in different
+ * places, and threading it through as a prop would leave a component that is
+ * a shell factory rather than a gate.
+ */
+export function PanelGate<T>({ icon, noun, id, query, skeleton, children }: Props<T>) {
+  if (!isApiConfigured) {
+    return (
+      <div className="p-4">
+        <EmptyState
+          icon={icon}
+          title="API not configured"
+          description={`Set NEXT_PUBLIC_BV_API_URL to load this ${noun}.`}
+        />
+      </div>
+    );
+  }
+
+  if (query.isLoading) {
+    return <div className="p-5 space-y-4">{skeleton}</div>;
+  }
+
+  if (query.isError || !query.data) {
+    const Noun = noun.charAt(0).toUpperCase() + noun.slice(1);
+    return (
+      <div className="p-4">
+        <EmptyState
+          icon={AlertTriangle}
+          title={`Couldn't load ${noun}`}
+          description={`${Noun} ${id} could not be fetched.`}
+        />
+      </div>
+    );
+  }
+
+  return <>{children(query.data)}</>;
+}

--- a/packages/web/components/share-link-box.tsx
+++ b/packages/web/components/share-link-box.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
+
+/**
+ * A read-only link with a Copy button, in a tinted box under a one-line
+ * explanation.
+ *
+ * Both invite dialogs — "invite a teammate" in the user widget and "invite to
+ * room" on the room page — end at the same place: an email that has no
+ * beevibe account yet, and a `/sign-up?...` URL to hand the invitee instead.
+ * Each had the box written out inline, identical down to the class strings
+ * and the select-on-focus handler, with only the blurb above it differing.
+ *
+ * Owns its own copy state so the two call sites don't each have to hold a
+ * `useCopyToClipboard` for it.
+ */
+export function ShareLinkBox({ link, children }: { link: string; children: ReactNode }) {
+  const { copied, copy } = useCopyToClipboard();
+
+  return (
+    <div className="mt-3 rounded border border-border bg-muted/40 p-3">
+      <div className="text-[11px] text-muted-foreground mb-1.5">{children}</div>
+      <div className="flex items-center gap-1.5">
+        <input
+          readOnly
+          value={link}
+          className="flex-1 rounded border border-border bg-background px-2 py-1.5 text-[11px] font-mono"
+          onFocus={(e) => e.currentTarget.select()}
+        />
+        <button
+          type="button"
+          onClick={() => void copy(link)}
+          className="h-7 px-2.5 rounded text-[11px] font-medium border border-border hover:bg-secondary transition-colors cursor-pointer shrink-0"
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/tasks/task-detail-panel.tsx
+++ b/packages/web/components/tasks/task-detail-panel.tsx
@@ -2,15 +2,14 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { AlertTriangle, FileText, ListChecks, Terminal } from "lucide-react";
+import { FileText, ListChecks, Terminal } from "lucide-react";
 import { ChatMarkdown } from "@/components/chat/markdown";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { PanelFooterField, PeekPanel } from "@/components/detail/peek-panel";
+import { PanelGate } from "@/components/detail/panel-gate";
 import { TaskStatusPill, SessionStatusPill } from "@/components/detail/status-pill";
-import { EmptyState } from "@/components/empty-state";
 import { HierChip } from "@/components/hier-chip";
 import { Skeleton } from "@/components/skeleton";
-import { isApiConfigured } from "@/lib/api/config";
 import { useTask } from "@/lib/hooks/use-tasks";
 import {
   useApproveTask,
@@ -54,43 +53,25 @@ export function TaskDetailPanel({
 }
 
 function PanelBody({ taskId }: { taskId: string }) {
-  const { data, isLoading, isError } = useTask(taskId);
+  const query = useTask(taskId);
 
-  if (!isApiConfigured) {
-    return (
-      <div className="p-4">
-        <EmptyState
-          icon={ListChecks}
-          title="API not configured"
-          description="Set NEXT_PUBLIC_BV_API_URL to load this task."
-        />
-      </div>
-    );
-  }
-
-  if (isLoading) {
-    return (
-      <div className="p-5 space-y-4">
-        <Skeleton className="h-7 w-3/4" />
-        <Skeleton className="h-20 w-full rounded-lg" />
-        <Skeleton className="h-32 w-full rounded-lg" />
-      </div>
-    );
-  }
-
-  if (isError || !data) {
-    return (
-      <div className="p-4">
-        <EmptyState
-          icon={AlertTriangle}
-          title="Couldn't load task"
-          description={`Task ${taskId} could not be fetched.`}
-        />
-      </div>
-    );
-  }
-
-  return <PanelLoaded task={data} />;
+  return (
+    <PanelGate
+      icon={ListChecks}
+      noun="task"
+      id={taskId}
+      query={query}
+      skeleton={
+        <>
+          <Skeleton className="h-7 w-3/4" />
+          <Skeleton className="h-20 w-full rounded-lg" />
+          <Skeleton className="h-32 w-full rounded-lg" />
+        </>
+      }
+    >
+      {(task) => <PanelLoaded task={task} />}
+    </PanelGate>
+  );
 }
 
 function PanelLoaded({ task }: { task: TaskDetail }) {

--- a/packages/web/components/user-widget.tsx
+++ b/packages/web/components/user-widget.tsx
@@ -14,7 +14,7 @@ import {
 } from "lucide-react";
 import { useMe } from "@/lib/hooks/use-me";
 import { useDismissOnOutside } from "@/lib/hooks/use-dismiss";
-import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
+import { ShareLinkBox } from "@/components/share-link-box";
 import { ModalOverlay } from "@/components/modal-overlay";
 import { clearUserKey } from "@/lib/api/config";
 import { cn } from "@/lib/utils";
@@ -148,7 +148,6 @@ function MenuItem({
 
 function InviteTeammateDialog({ onClose }: { onClose: () => void }) {
   const [email, setEmail] = useState("");
-  const { copied, copy } = useCopyToClipboard();
   const trimmed = email.trim().toLowerCase();
   const valid = EMAIL_RE.test(trimmed);
   const origin = typeof window !== "undefined" ? window.location.origin : "";
@@ -173,26 +172,7 @@ function InviteTeammateDialog({ onClose }: { onClose: () => void }) {
           className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
         />
         {shareLink ? (
-          <div className="mt-3 rounded border border-border bg-muted/40 p-3">
-            <div className="text-[11px] text-muted-foreground mb-1.5">
-              Send them this link:
-            </div>
-            <div className="flex items-center gap-1.5">
-              <input
-                readOnly
-                value={shareLink}
-                className="flex-1 rounded border border-border bg-background px-2 py-1.5 text-[11px] font-mono"
-                onFocus={(e) => e.currentTarget.select()}
-              />
-              <button
-                type="button"
-                onClick={() => void copy(shareLink)}
-                className="h-7 px-2.5 rounded text-[11px] font-medium border border-border hover:bg-secondary transition-colors cursor-pointer shrink-0"
-              >
-                {copied ? "Copied" : "Copy"}
-              </button>
-            </div>
-          </div>
+          <ShareLinkBox link={shareLink}>Send them this link:</ShareLinkBox>
         ) : null}
         <div className="mt-4 flex items-center justify-end gap-2">
           <button


### PR DESCRIPTION
A jscpd sweep plus a by-hand pass over the packages left five clusters where the same shape had been written out more than once. **None of these change behavior** — `typecheck`, `lint` and `next build` are clean, and the test suites match the documented sandbox baseline (only the Postgres- and provider-key-gated files fail).

## 1. One CLI-runtime execution pipeline — `packages/core/src/adapters/runtime-common.ts`

The claude-code, codex and opencode runtimes each spelled out the same ~25 lines inside `execute()`: buffer stdout into lines, parse each into a provider event, forward step events to `onStep`, flush the trailing partial line, warn on truncation, short-circuit on abort, merge process metadata into the parsed result.

The ordering there is load-bearing — flushing *after* the process settles is what captures a stream that ends without a newline, and checking `aborted` *before* parsing is what keeps a cancelled session from being reported as a failure — so it is exactly the kind of thing that should exist once. It is now `runCliSession`.

Argv, env scrubbing and the event schema stay at the call sites, which is the part that genuinely differs. Codex's `--output-last-message` file lifecycle stays with codex, threaded through `parseEvents` plus a new `onAbort` hook.

Net: `claude-code/runtime.ts` −34 lines, `codex/runtime.ts` −29, `opencode/runtime.ts` −25.

**New test.** The abort path is the branch that skips the file read, so it previously had nothing asserting the last-message file still gets deleted. `codex/runtime.test.ts` now covers it.

## 2. One auth form kit — `packages/web/components/auth/auth-form.tsx`

`/sign-in` and `/sign-up` are the same card: icon badge, title, blurb, a stack of labelled inputs, an error line, a submit button, a footer link to the other page. Both had it written out by hand — six copies of an identical twelve-line label+input pair and two copies of every wrapper class. Drift between them is directly user-visible; these are the first two screens anyone sees.

`AuthCard` / `AuthField` / `AuthError` / `AuthSubmitButton` own the shell. What is genuinely different stays at the call site: sign-in's password/paste-key mode toggle, sign-up's invite-room handling, and each page's copy.

`AuthField`'s `first` prop drops the top margin — spelling `mt-3` out per call site is what let the two pages diverge on spacing.

## 3. One panel gate — `packages/web/components/detail/panel-gate.tsx`

The task and agent peek panels each repeated the three-branch preamble `DetailGate` already gives the full pages — API not configured, still loading, failed to load — because the panels wrap their states in a padded `div` rather than a `DetailShell`. Two copies of a gate whose whole job is to stop the failure copy from drifting is one copy too many; both messages are derived from `noun` now.

Deliberately *not* folded into `DetailGate` itself: the wrapper is the only thing that differs, but it is what makes the two usable in different places, and threading it through as a prop would leave a component that is a shell factory rather than a gate.

## 4. One share-link box — `packages/web/components/share-link-box.tsx`

Both invite dialogs — "invite a teammate" in the user widget, "invite to room" on the room page — end at the same place: an email with no beevibe account yet, and a `/sign-up?…` URL to hand the invitee instead. Each rendered the read-only input + Copy button inline, identical down to the class strings and the select-on-focus handler, with only the blurb differing. It owns its own `useCopyToClipboard` now, so neither call site has to hold one for it.

## 5. `DetailShell` in the loading skeletons

The five detail-route `loading.tsx` files hand-rolled the `flex-1 overflow-auto` / `max-w-5xl mx-auto px-6 py-8` wrapper that `DetailShell` exists for. The large line counts on these are the reindent from losing a nesting level (prettier), not new content.

## Considered and deliberately left alone

- **`app/error.tsx` vs `app/global-error.tsx`** — jscpd flags them, but `global-error` uses inline styles on purpose: it renders at a boundary where the stylesheet may not have loaded. Unifying them would break the one case it exists for.
- **`repo-run-repo`'s hand-written `COALESCE` updates vs `pg-helpers.updateRowById`** — the `COALESCE` form cannot set a column to `NULL`, so these are not interchangeable. Real divergence, not copy-paste.
- **The `console.error("[tag]", err)` + `{ error: "x_failed" }` 500s across 8 route files** — a different envelope from `makeErrorHandler`'s, and the error codes are per-endpoint parts of the wire contract. A helper here would factor out three tokens and obscure the codes clients branch on.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQorhcHHFNQZwqWFX7L72J)_