### PR TITLE
test(api): cover the four under-tested MCP agent tools (32–65% → 100% lines)

### DIFF
--- a/packages/api/src/tools/mesh-handlers.test.ts
+++ b/packages/api/src/tools/mesh-handlers.test.ts
@@ -1,0 +1,650 @@
+/**
+ * Mesh tool *handler* tests — validation, delegation and error mapping.
+ *
+ * Complements mesh.test.ts, which locks the per-tier tool inventory. The
+ * handlers are pure adapters over MeshServer / TaskService /
+ * EscalationService, so faking those four dependencies exercises every
+ * branch without the live Postgres + spawned CLI subprocesses the m6/m7
+ * e2e scripts need.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { ResolvedCaller } from "@beevibe/core/auth";
+import type { Agent, AgentRepository, TaskRepository } from "@beevibe/core";
+import type { TaskService } from "@beevibe/core/services/task-service";
+import type { EscalationService } from "@beevibe/core/services/escalation-service";
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import { MeshCapacityError } from "../mesh/types.js";
+import type { MeshServer } from "../mesh/server.js";
+import {
+  buildTeamMeshTools,
+  type MeshToolContext,
+  type MeshToolServices,
+} from "./mesh.js";
+
+type Impls = Partial<{
+  sendAsk: (...a: unknown[]) => unknown;
+  respondAsk: (...a: unknown[]) => unknown;
+  sendNegotiate: (...a: unknown[]) => unknown;
+  respondNegotiate: (...a: unknown[]) => unknown;
+  reportBlocker: (...a: unknown[]) => unknown;
+  unblockOnEscalate: (...a: unknown[]) => unknown;
+  findParent: (...a: unknown[]) => unknown;
+  markBlocked: (...a: unknown[]) => unknown;
+  createEscalation: (...a: unknown[]) => unknown;
+  query: (...a: unknown[]) => unknown;
+}>;
+
+interface Harness {
+  services: MeshToolServices;
+  calls: Record<string, unknown[][]>;
+}
+
+const PARENT = { id: "agent_parent" } as unknown as Agent;
+
+function harness(impls: Impls = {}): Harness {
+  const calls: Record<string, unknown[][]> = {};
+  const record =
+    (name: string, fallback: (...a: unknown[]) => unknown) =>
+    (...args: unknown[]) => {
+      (calls[name] ??= []).push(args);
+      const impl = impls[name as keyof Impls];
+      return impl ? impl(...args) : fallback(...args);
+    };
+
+  const mesh = {
+    sendAsk: vi.fn(
+      record("sendAsk", (requestId) => ({
+        request_id: requestId,
+        from_agent_id: "agent_b",
+        answer: "yes, feasible",
+        // Extra server-side fields the tool is expected to project away.
+        internal_trace: "should-not-leak",
+      })),
+    ),
+    respondAsk: vi.fn(record("respondAsk", () => undefined)),
+    sendNegotiate: vi.fn(
+      record("sendNegotiate", () => ({
+        negotiation_id: "neg_1",
+        from_agent_id: "agent_b",
+        decision: "counter",
+        message: "how about Friday",
+        counter_proposal: "ship Friday",
+      })),
+    ),
+    respondNegotiate: vi.fn(
+      record("respondNegotiate", () => ({
+        negotiation_id: "neg_1",
+        from_agent_id: "agent_b",
+        decision: "counter",
+        message: "still no",
+        counter_proposal: "ship Monday",
+      })),
+    ),
+    reportBlocker: vi.fn(record("reportBlocker", () => undefined)),
+    unblockOnEscalate: vi.fn(record("unblockOnEscalate", () => undefined)),
+  } as unknown as MeshServer;
+
+  const agentRepo = {
+    findParent: vi.fn(record("findParent", () => PARENT)),
+  } as unknown as AgentRepository;
+
+  const taskService = {
+    markBlocked: vi.fn(record("markBlocked", () => undefined)),
+  } as unknown as TaskService;
+
+  const escalationService = {
+    create: vi.fn(
+      record("createEscalation", () => ({
+        id: "esc_1",
+        status: "open",
+        negotiation_id: "neg_1",
+      })),
+    ),
+  } as unknown as EscalationService;
+
+  const pool = {
+    query: vi.fn(record("query", () => ({ rows: [] }))),
+  } as unknown as Pool;
+
+  return {
+    services: {
+      mesh,
+      agentRepo,
+      taskRepo: {} as unknown as TaskRepository,
+      taskService,
+      escalationService,
+      pool,
+    },
+    calls,
+  };
+}
+
+const CALLER: ResolvedCaller = {
+  agentId: "agent_a",
+  source: "agent",
+  hierarchyLevel: "team",
+};
+const CTX: MeshToolContext = { caller: CALLER, beevibeSid: "sess_a" };
+
+function toolNamed(h: Harness, name: string) {
+  const found = buildTeamMeshTools(CTX, h.services).find((t) => t.name === name);
+  if (!found) throw new Error(`no mesh tool named ${name}`);
+  return found;
+}
+
+describe("ask", () => {
+  it("mints a request id and forwards caller, target and question", async () => {
+    const h = harness();
+    const result = await toolNamed(h, "ask").handler({
+      target_agent_id: "agent_b",
+      question: "is X feasible?",
+    });
+
+    const [requestId, from, target, question] = h.calls.sendAsk![0]!;
+    expect(requestId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    expect([from, target, question]).toEqual([
+      "agent_a",
+      "agent_b",
+      "is X feasible?",
+    ]);
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("mints a distinct request id per call", async () => {
+    const h = harness();
+    const ask = toolNamed(h, "ask");
+    await ask.handler({ target_agent_id: "agent_b", question: "q1" });
+    await ask.handler({ target_agent_id: "agent_b", question: "q2" });
+
+    expect(h.calls.sendAsk![0]![0]).not.toBe(h.calls.sendAsk![1]![0]);
+  });
+
+  it("projects the response down to the three agent-facing fields", async () => {
+    const h = harness();
+    const result = await toolNamed(h, "ask").handler({
+      target_agent_id: "agent_b",
+      question: "q",
+    });
+
+    expect(Object.keys(result.content).sort()).toEqual([
+      "answer",
+      "from_agent_id",
+      "request_id",
+    ]);
+    expect(result.content.answer).toBe("yes, feasible");
+  });
+
+  it.each([
+    ["a missing target", { question: "q" }],
+    ["a missing question", { target_agent_id: "agent_b" }],
+    ["an empty target", { target_agent_id: "", question: "q" }],
+    ["an empty question", { target_agent_id: "agent_b", question: "" }],
+  ])("refuses %s without reaching the mesh", async (_l, input) => {
+    const h = harness();
+    const result = await toolNamed(h, "ask").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content.error).toBe("target_agent_id and question required");
+    expect(h.calls.sendAsk).toBeUndefined();
+  });
+});
+
+describe("respond_ask", () => {
+  it("stamps the responding agent id and echoes the request id", async () => {
+    const h = harness();
+    const result = await toolNamed(h, "respond_ask").handler({
+      request_id: "req_1",
+      answer: "here you go",
+    });
+
+    expect(h.calls.respondAsk![0]).toEqual([
+      "req_1",
+      {
+        request_id: "req_1",
+        from_agent_id: "agent_a",
+        answer: "here you go",
+      },
+    ]);
+    expect(result.content).toEqual({ responded: true, request_id: "req_1" });
+  });
+
+  it.each([
+    ["a missing request_id", { answer: "a" }],
+    ["a missing answer", { request_id: "req_1" }],
+  ])("refuses %s", async (_l, input) => {
+    const h = harness();
+    const result = await toolNamed(h, "respond_ask").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(h.calls.respondAsk).toBeUndefined();
+  });
+});
+
+describe("negotiate", () => {
+  it("forwards the proposal with the initiator's session id as metadata", async () => {
+    const h = harness();
+    await toolNamed(h, "negotiate").handler({
+      peer_id: "agent_b",
+      proposal: "ship Thursday",
+      task_id: "task_1",
+    });
+
+    expect(h.calls.sendNegotiate![0]).toEqual([
+      "agent_a",
+      "agent_b",
+      "ship Thursday",
+      { taskId: "task_1", initiatorSessionId: "sess_a" },
+    ]);
+  });
+
+  it.each([
+    ["omitted", undefined],
+    ["empty", ""],
+    ["a non-string", 42],
+  ])("passes taskId as undefined when %s", async (_l, task_id) => {
+    const h = harness();
+    await toolNamed(h, "negotiate").handler({
+      peer_id: "agent_b",
+      proposal: "p",
+      task_id,
+    });
+
+    expect(
+      (h.calls.sendNegotiate![0]![3] as Record<string, unknown>).taskId,
+    ).toBeUndefined();
+  });
+
+  it("projects a counter response", async () => {
+    const h = harness();
+    const result = await toolNamed(h, "negotiate").handler({
+      peer_id: "agent_b",
+      proposal: "p",
+    });
+
+    expect(result.content).toEqual({
+      negotiation_id: "neg_1",
+      from_agent_id: "agent_b",
+      decision: "counter",
+      message: "how about Friday",
+      counter_proposal: "ship Friday",
+    });
+  });
+
+  it("projects the escalated sentinel into its own shape", async () => {
+    const h = harness({
+      sendNegotiate: () => ({
+        decision: "escalated",
+        escalation_id: "esc_7",
+        negotiation_id: "neg_1",
+        message: "handed to humans",
+      }),
+    });
+    const result = await toolNamed(h, "negotiate").handler({
+      peer_id: "agent_b",
+      proposal: "p",
+    });
+
+    expect(result.content).toEqual({
+      decision: "escalated",
+      escalation_id: "esc_7",
+      negotiation_id: "neg_1",
+      message: "handed to humans",
+    });
+    expect(result.content).not.toHaveProperty("counter_proposal");
+  });
+
+  it.each([
+    ["a missing peer_id", { proposal: "p" }],
+    ["a missing proposal", { peer_id: "agent_b" }],
+  ])("refuses %s", async (_l, input) => {
+    const h = harness();
+    const result = await toolNamed(h, "negotiate").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content.error).toBe("peer_id and proposal required");
+    expect(h.calls.sendNegotiate).toBeUndefined();
+  });
+});
+
+describe("respond_negotiate", () => {
+  it("forwards the round without a round number — the server derives it", async () => {
+    const h = harness();
+    await toolNamed(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "not quite",
+      counter_proposal: "ship Monday",
+    });
+
+    expect(h.calls.respondNegotiate![0]).toEqual([
+      "neg_1",
+      {
+        negotiation_id: "neg_1",
+        from_agent_id: "agent_a",
+        decision: "counter",
+        message: "not quite",
+        counter_proposal: "ship Monday",
+      },
+      "sess_a",
+    ]);
+  });
+
+  it.each(["accept", "reject"])(
+    "reports %s as terminal when the server returns null",
+    async (decision) => {
+      const h = harness({ respondNegotiate: () => null });
+      const result = await toolNamed(h, "respond_negotiate").handler({
+        negotiation_id: "neg_1",
+        decision,
+        message: "done",
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content).toEqual({
+        negotiation_id: "neg_1",
+        decision,
+        terminal: true,
+      });
+    },
+  );
+
+  it("projects the peer's next round when the negotiation continues", async () => {
+    const h = harness();
+    const result = await toolNamed(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "m",
+      counter_proposal: "c",
+    });
+
+    expect(result.content).toMatchObject({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      counter_proposal: "ship Monday",
+    });
+  });
+
+  it("requires a counter_proposal when countering", async () => {
+    const h = harness();
+    const result = await toolNamed(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "m",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content.error).toBe(
+      "counter_proposal required when decision='counter'",
+    );
+    expect(h.calls.respondNegotiate).toBeUndefined();
+  });
+
+  it("does not require a counter_proposal for accept or reject", async () => {
+    for (const decision of ["accept", "reject"]) {
+      const h = harness({ respondNegotiate: () => null });
+      const result = await toolNamed(h, "respond_negotiate").handler({
+        negotiation_id: "neg_1",
+        decision,
+        message: "m",
+      });
+      expect(result.isError).toBeFalsy();
+    }
+  });
+
+  it.each([
+    ["an unknown decision", "maybe"],
+    ["an omitted decision", undefined],
+  ])("rejects %s", async (_l, decision) => {
+    const h = harness();
+    const result = await toolNamed(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision,
+      message: "m",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content.error).toBe(
+      "decision must be one of: counter, accept, reject",
+    );
+    expect(h.calls.respondNegotiate).toBeUndefined();
+  });
+
+  it.each([
+    ["a missing negotiation_id", { decision: "accept", message: "m" }],
+    ["a missing message", { negotiation_id: "neg_1", decision: "accept" }],
+  ])("refuses %s", async (_l, input) => {
+    const h = harness();
+    const result = await toolNamed(h, "respond_negotiate").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content.error).toBe("negotiation_id and message required");
+    expect(h.calls.respondNegotiate).toBeUndefined();
+  });
+});
+
+describe("report_blocker", () => {
+  it("marks the task blocked, then spawns the parent", async () => {
+    const h = harness();
+    const result = await toolNamed(h, "report_blocker").handler({
+      task_id: "task_1",
+      description: "the API key is missing",
+    });
+
+    expect(h.calls.findParent![0]).toEqual(["agent_a"]);
+    expect(h.calls.markBlocked![0]).toEqual([
+      "task_1",
+      "agent_a",
+      "the API key is missing",
+    ]);
+    expect(h.calls.reportBlocker![0]).toEqual([
+      "agent_parent",
+      "agent_a",
+      "task_1",
+      "the API key is missing",
+    ]);
+    expect(result.content).toEqual({
+      reported: true,
+      parent_agent_id: "agent_parent",
+      task_id: "task_1",
+    });
+  });
+
+  it("refuses a top-level agent and leaves the task untouched", async () => {
+    const h = harness({ findParent: () => null });
+    const result = await toolNamed(h, "report_blocker").handler({
+      task_id: "task_1",
+      description: "stuck",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "no_parent_to_block" });
+    expect(h.calls.markBlocked).toBeUndefined();
+    expect(h.calls.reportBlocker).toBeUndefined();
+  });
+
+  it("does not spawn the parent when marking the task blocked fails", async () => {
+    const h = harness({
+      markBlocked: () => {
+        throw new Error("task not found");
+      },
+    });
+    const result = await toolNamed(h, "report_blocker").handler({
+      task_id: "task_gone",
+      description: "stuck",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content.error).toBe("task not found");
+    expect(h.calls.reportBlocker).toBeUndefined();
+  });
+
+  it.each([
+    ["a missing task_id", { description: "d" }],
+    ["a missing description", { task_id: "task_1" }],
+  ])("refuses %s before resolving the parent", async (_l, input) => {
+    const h = harness();
+    const result = await toolNamed(h, "report_blocker").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content.error).toBe("task_id and description required");
+    expect(h.calls.findParent).toBeUndefined();
+  });
+});
+
+describe("escalate_to_humans", () => {
+  it("creates the escalation, unblocks the peer, then notifies", async () => {
+    const h = harness();
+    const result = await toolNamed(h, "escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "We're stuck on the ship date.",
+      proposals: [{ title: "Ship Friday", description: "cut scope" }],
+      open_questions: ["is the deadline hard?"],
+    });
+
+    expect(h.calls.createEscalation![0]![0]).toEqual({
+      negotiationId: "neg_1",
+      callerAgentId: "agent_a",
+      summary: "We're stuck on the ship date.",
+      proposals: [{ title: "Ship Friday", description: "cut scope" }],
+      openQuestions: ["is the deadline hard?"],
+    });
+    expect(h.calls.unblockOnEscalate![0]).toEqual(["neg_1", "esc_1"]);
+    expect(h.calls.query![0]).toEqual([
+      `SELECT pg_notify('escalation_created', $1)`,
+      ["esc_1"],
+    ]);
+    expect(result.content).toEqual({
+      escalation_id: "esc_1",
+      status: "open",
+      negotiation_id: "neg_1",
+    });
+  });
+
+  it.each([
+    ["omitted", undefined],
+    ["not an array", "a proposal"],
+  ])("passes proposals as undefined when %s", async (_l, proposals) => {
+    const h = harness();
+    await toolNamed(h, "escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "s",
+      proposals,
+    });
+
+    expect(
+      (h.calls.createEscalation![0]![0] as Record<string, unknown>).proposals,
+    ).toBeUndefined();
+  });
+
+  it("drops non-string open_questions", async () => {
+    const h = harness();
+    await toolNamed(h, "escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "s",
+      open_questions: ["real question", 42, null, "another"],
+    });
+
+    expect(
+      (h.calls.createEscalation![0]![0] as Record<string, unknown>).openQuestions,
+    ).toEqual(["real question", "another"]);
+  });
+
+  it("does not unblock the peer or notify when escalation creation fails", async () => {
+    const h = harness({
+      createEscalation: () => {
+        throw new Error("negotiation already escalated");
+      },
+    });
+    const result = await toolNamed(h, "escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "s",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content.error).toBe("negotiation already escalated");
+    expect(h.calls.unblockOnEscalate).toBeUndefined();
+    expect(h.calls.query).toBeUndefined();
+  });
+
+  it.each([
+    ["a missing negotiation_id", { summary: "s" }],
+    ["a missing summary", { negotiation_id: "neg_1" }],
+  ])("refuses %s", async (_l, input) => {
+    const h = harness();
+    const result = await toolNamed(h, "escalate_to_humans").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content.error).toBe("negotiation_id and summary required");
+    expect(h.calls.createEscalation).toBeUndefined();
+  });
+});
+
+describe("thrown-error mapping", () => {
+  it("preserves the code and meta of a CodedMeshError", async () => {
+    const meta = { agentId: "agent_b", running: 3, cap: 3 };
+    const h = harness({
+      sendAsk: () => {
+        throw new MeshCapacityError("agent_b is at capacity", meta);
+      },
+    });
+    const result = await toolNamed(h, "ask").handler({
+      target_agent_id: "agent_b",
+      question: "q",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "MESH_CAPACITY_EXCEEDED",
+      ...meta,
+      message: "agent_b is at capacity",
+    });
+  });
+
+  it("degrades a plain Error to the catch-all shape, message in `error`", async () => {
+    const h = harness({
+      sendNegotiate: () => {
+        throw new Error("peer never responded");
+      },
+    });
+    const result = await toolNamed(h, "negotiate").handler({
+      peer_id: "agent_b",
+      proposal: "p",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "peer never responded" });
+  });
+
+  it("maps a max-rounds throw out of respond_negotiate", async () => {
+    const h = harness({
+      respondNegotiate: () => {
+        throw new Error("max_rounds_exceeded");
+      },
+    });
+    const result = await toolNamed(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "m",
+      counter_proposal: "c",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "max_rounds_exceeded" });
+  });
+
+  it("stringifies a thrown non-Error", async () => {
+    const h = harness({
+      respondAsk: () => {
+        throw "channel closed";
+      },
+    });
+    const result = await toolNamed(h, "respond_ask").handler({
+      request_id: "req_1",
+      answer: "a",
+    });
+
+    expect(result.content).toEqual({ error: "channel closed" });
+  });
+});

--- a/packages/api/src/tools/session-search.test.ts
+++ b/packages/api/src/tools/session-search.test.ts
@@ -1,0 +1,363 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  SessionSearchRequest,
+  SessionSearchResult,
+} from "@beevibe/core";
+import {
+  SessionSearchError,
+  type SessionSearchService,
+} from "@beevibe/core/services/session-search";
+import {
+  createSessionSearchTool,
+  type SessionSearchToolContext,
+} from "./session-search.js";
+
+const OK = { kind: "browse", sessions: [] } as unknown as SessionSearchResult;
+
+interface Harness {
+  services: { sessionSearch: SessionSearchService };
+  calls: Array<{ req: SessionSearchRequest; ctx: Record<string, unknown> }>;
+}
+
+function harness(
+  overrides: { impl?: () => Promise<unknown> } = {},
+): Harness {
+  const calls: Array<{ req: SessionSearchRequest; ctx: Record<string, unknown> }> =
+    [];
+  const sessionSearch = {
+    search: vi.fn(
+      async (req: SessionSearchRequest, ctx: Record<string, unknown>) => {
+        if (overrides.impl) return overrides.impl();
+        calls.push({ req, ctx });
+        return OK;
+      },
+    ),
+  } as unknown as SessionSearchService;
+  return { services: { sessionSearch }, calls };
+}
+
+const CTX: SessionSearchToolContext = {
+  agentId: "agent_a",
+  hierarchyLevel: "team",
+  sessionId: "sess_current",
+};
+
+function tool(h: Harness, ctx: SessionSearchToolContext = CTX) {
+  return createSessionSearchTool(ctx, h.services);
+}
+
+/** Run the handler and return the request the service actually received. */
+async function requestFor(
+  input: Record<string, unknown>,
+): Promise<SessionSearchRequest> {
+  const h = harness();
+  await tool(h).handler(input);
+  return h.calls[0]!.req;
+}
+
+describe("session_search tool", () => {
+  describe("descriptor", () => {
+    it("names the tool and declares no required fields (browse takes no args)", () => {
+      const t = tool(harness());
+
+      expect(t.name).toBe("session_search");
+      expect(t.schema.required).toBeUndefined();
+      expect(Object.keys(t.schema.properties as object)).toEqual([
+        "query",
+        "limit",
+        "sort",
+        "session_id",
+        "around_message_id",
+        "window",
+        "filters",
+      ]);
+    });
+  });
+
+  describe("caller context", () => {
+    it("passes the caller triple through to the service unchanged", async () => {
+      const h = harness();
+      await tool(h).handler({ query: "auth refactor" });
+
+      expect(h.calls[0]?.ctx).toEqual({
+        callerAgentId: "agent_a",
+        hierarchyLevel: "team",
+        currentSessionId: "sess_current",
+      });
+    });
+
+    it("forwards the caller's own tier rather than inferring one", async () => {
+      const h = harness();
+      await tool(h, { ...CTX, hierarchyLevel: "ic" }).handler({ query: "x" });
+
+      expect(h.calls[0]?.ctx.hierarchyLevel).toBe("ic");
+    });
+  });
+
+  describe("shape inference", () => {
+    it("infers browse from no arguments at all", async () => {
+      expect(await requestFor({})).toEqual({
+        kind: "browse",
+        limit: undefined,
+        filters: undefined,
+      });
+    });
+
+    it("infers discover from a query", async () => {
+      expect(await requestFor({ query: "auth refactor", limit: 5 })).toMatchObject(
+        { kind: "discover", query: "auth refactor", limit: 5 },
+      );
+    });
+
+    it("infers read from a bare session_id", async () => {
+      expect(await requestFor({ session_id: "sess_9" })).toEqual({
+        kind: "read",
+        session_id: "sess_9",
+      });
+    });
+
+    it("infers scroll when session_id and around_message_id are both set", async () => {
+      expect(
+        await requestFor({
+          session_id: "sess_9",
+          around_message_id: "evt_3",
+          window: 10,
+        }),
+      ).toEqual({
+        kind: "scroll",
+        session_id: "sess_9",
+        around_message_id: "evt_3",
+        window: 10,
+      });
+    });
+
+    it("lets scroll win over discover when a query is also present", async () => {
+      const req = await requestFor({
+        query: "ignored",
+        session_id: "sess_9",
+        around_message_id: "evt_3",
+      });
+
+      expect(req.kind).toBe("scroll");
+    });
+
+    it("lets read win over discover when a query is also present", async () => {
+      const req = await requestFor({ query: "ignored", session_id: "sess_9" });
+
+      expect(req.kind).toBe("read");
+    });
+
+    it("falls back to read when around_message_id is present but blank", async () => {
+      const req = await requestFor({
+        session_id: "sess_9",
+        around_message_id: "   ",
+      });
+
+      expect(req).toEqual({ kind: "read", session_id: "sess_9" });
+    });
+
+    it("trims session_id and around_message_id", async () => {
+      expect(
+        await requestFor({
+          session_id: "  sess_9  ",
+          around_message_id: "  evt_3  ",
+        }),
+      ).toMatchObject({ session_id: "sess_9", around_message_id: "evt_3" });
+    });
+
+    it("trims the query and keeps it as the discover term", async () => {
+      expect(await requestFor({ query: "  auth refactor  " })).toMatchObject({
+        kind: "discover",
+        query: "auth refactor",
+      });
+    });
+
+    it.each([
+      ["blank", "   "],
+      ["a non-string", 42],
+      ["null", null],
+    ])("treats %s query as absent and browses instead", async (_l, query) => {
+      expect((await requestFor({ query })).kind).toBe("browse");
+    });
+
+    it.each([
+      ["blank", "   "],
+      ["a non-string", 42],
+    ])("treats %s session_id as absent and browses instead", async (_l, id) => {
+      expect((await requestFor({ session_id: id })).kind).toBe("browse");
+    });
+
+    it("supports the synthetic user-turn anchor id format", async () => {
+      expect(
+        await requestFor({
+          session_id: "sess_9",
+          around_message_id: "intent:sess_9",
+        }),
+      ).toMatchObject({ kind: "scroll", around_message_id: "intent:sess_9" });
+    });
+  });
+
+  describe("numeric passthrough", () => {
+    it("forwards limit and window verbatim, leaving clamping to the service", async () => {
+      expect(
+        await requestFor({ query: "x", limit: 9999 }),
+      ).toMatchObject({ limit: 9999 });
+      expect(
+        await requestFor({
+          session_id: "s",
+          around_message_id: "e",
+          window: 9999,
+        }),
+      ).toMatchObject({ window: 9999 });
+    });
+
+    it("drops non-numeric limit and window so the service applies its defaults", async () => {
+      expect(await requestFor({ query: "x", limit: "5" })).toMatchObject({
+        limit: undefined,
+      });
+      expect(
+        await requestFor({ session_id: "s", around_message_id: "e", window: "5" }),
+      ).toMatchObject({ window: undefined });
+    });
+  });
+
+  describe("sort", () => {
+    it.each(["newest", "oldest"])("passes %s through", async (sort) => {
+      expect(await requestFor({ query: "x", sort })).toMatchObject({ sort });
+    });
+
+    it.each([
+      ["an unknown value", "relevance"],
+      ["a non-string", 1],
+      ["an omitted field", undefined],
+    ])("drops %s", async (_l, sort) => {
+      expect(await requestFor({ query: "x", sort })).toMatchObject({
+        sort: undefined,
+      });
+    });
+  });
+
+  describe("filters", () => {
+    it("forwards filters on discover", async () => {
+      const filters = { status: "failed", session_type: "task" };
+      expect(await requestFor({ query: "x", filters })).toMatchObject({
+        filters,
+      });
+    });
+
+    it("forwards filters on browse", async () => {
+      const filters = { agent_id: "agent_b" };
+      expect(await requestFor({ filters })).toMatchObject({ filters });
+    });
+
+    it.each([
+      ["null", null],
+      ["a non-object", "status:failed"],
+      ["an omitted field", undefined],
+    ])("drops %s filters", async (_l, filters) => {
+      expect(await requestFor({ query: "x", filters })).toMatchObject({
+        filters: undefined,
+      });
+    });
+
+    it("does not attach filters to scroll or read", async () => {
+      const filters = { status: "failed" };
+      expect(await requestFor({ session_id: "s", filters })).not.toHaveProperty(
+        "filters",
+      );
+      expect(
+        await requestFor({ session_id: "s", around_message_id: "e", filters }),
+      ).not.toHaveProperty("filters");
+    });
+  });
+
+  describe("results", () => {
+    it("returns the service result as the tool content", async () => {
+      const h = harness();
+      const result = await tool(h).handler({ query: "x" });
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content).toBe(OK);
+    });
+
+    it("translates a null result into not_found_or_forbidden", async () => {
+      const h = harness({ impl: async () => null });
+      const result = await tool(h).handler({ session_id: "sess_other" });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({
+        error: "not_found_or_forbidden",
+      });
+    });
+  });
+
+  describe("error translation", () => {
+    it.each([
+      "forbidden_agent_filter",
+      "missing_query",
+      "missing_args",
+    ] as const)("surfaces the %s code from a SessionSearchError", async (code) => {
+      const h = harness({
+        impl: async () => {
+          throw new SessionSearchError(code, `bad: ${code}`);
+        },
+      });
+      const result = await tool(h).handler({ query: "x" });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual({ error: code, message: `bad: ${code}` });
+    });
+
+    it("matches by error name too, so a cross-bundle copy still yields its code", async () => {
+      // An src/-bundled SessionSearchError fails `instanceof` against the
+      // dist/-bundled class the api imports; the name check is the fallback.
+      class ForeignSessionSearchError extends Error {
+        code = "forbidden_agent_filter";
+        constructor(message: string) {
+          super(message);
+          this.name = "SessionSearchError";
+        }
+      }
+      const h = harness({
+        impl: async () => {
+          throw new ForeignSessionSearchError("agent_b is outside your scope");
+        },
+      });
+      const result = await tool(h).handler({ query: "x" });
+
+      expect(result.content).toEqual({
+        error: "forbidden_agent_filter",
+        message: "agent_b is outside your scope",
+      });
+    });
+
+    it("degrades an unrelated Error to internal_error", async () => {
+      const h = harness({
+        impl: async () => {
+          throw new Error("connection terminated");
+        },
+      });
+      const result = await tool(h).handler({ query: "x" });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual({
+        error: "internal_error",
+        message: "connection terminated",
+      });
+    });
+
+    it("stringifies a thrown non-Error", async () => {
+      const h = harness({
+        impl: async () => {
+          throw "pg down";
+        },
+      });
+      const result = await tool(h).handler({ query: "x" });
+
+      expect(result.content).toEqual({
+        error: "internal_error",
+        message: "pg down",
+      });
+    });
+  });
+});

--- a/packages/api/src/tools/use-repo.test.ts
+++ b/packages/api/src/tools/use-repo.test.ts
@@ -1,0 +1,388 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  RepoRun,
+  RepoRunRepository,
+  Task,
+  TaskRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import { createUseRepoTool, type UseRepoServices } from "./use-repo.js";
+
+const AGENT = { id: "agent_a", hierarchy_level: "ic" } as unknown as Agent;
+
+interface Harness {
+  services: UseRepoServices;
+  createdTasks: Array<Record<string, unknown>>;
+  dispatched: Array<Record<string, unknown>>;
+  repoRuns: Array<Record<string, unknown>>;
+}
+
+function harness(
+  overrides: {
+    agent?: Agent | null;
+    dispatchImpl?: () => Promise<unknown>;
+    repoRunCreateImpl?: () => Promise<unknown>;
+  } = {},
+): Harness {
+  const createdTasks: Array<Record<string, unknown>> = [];
+  const dispatched: Array<Record<string, unknown>> = [];
+  const repoRuns: Array<Record<string, unknown>> = [];
+
+  const agentRepo = {
+    findById: vi.fn(async () =>
+      overrides.agent === undefined ? AGENT : overrides.agent,
+    ),
+  } as unknown as AgentRepository;
+
+  const taskRepo = {
+    create: vi.fn(async (input: Record<string, unknown>) => {
+      createdTasks.push(input);
+      return { ...input, status: "todo" } as unknown as Task;
+    }),
+  } as unknown as TaskRepository;
+
+  const repoRunRepo = {
+    create: vi.fn(async (input: Record<string, unknown>) => {
+      if (overrides.repoRunCreateImpl) return overrides.repoRunCreateImpl();
+      repoRuns.push(input);
+      return input as unknown as RepoRun;
+    }),
+  } as unknown as RepoRunRepository;
+
+  const dispatchService = {
+    dispatchTask: vi.fn(async (input: Record<string, unknown>) => {
+      if (overrides.dispatchImpl) return overrides.dispatchImpl();
+      dispatched.push(input);
+      return { session: { id: input.sessionIdOverride }, runtime_id: null };
+    }),
+  } as unknown as DispatchService;
+
+  return {
+    services: { agentRepo, taskRepo, repoRunRepo, dispatchService },
+    createdTasks,
+    dispatched,
+    repoRuns,
+  };
+}
+
+function tool(h: Harness) {
+  return createUseRepoTool({ agentId: "agent_a" }, h.services);
+}
+
+const VALID = {
+  goal: "Extract the tables from this PDF as JSON",
+  repo_url: "https://github.com/acme/pdf-tables",
+};
+
+describe("use_repo tool", () => {
+  describe("descriptor", () => {
+    it("exposes the tool name and the two required inputs", () => {
+      const t = tool(harness());
+      expect(t.name).toBe("use_repo");
+      expect(t.schema.required).toEqual(["goal", "repo_url"]);
+    });
+  });
+
+  describe("input validation", () => {
+    it("rejects a missing goal without touching any repository", async () => {
+      const h = harness();
+      const result = await tool(h).handler({ repo_url: VALID.repo_url });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({ error: "invalid_goal" });
+      expect(h.services.agentRepo.findById).not.toHaveBeenCalled();
+      expect(h.createdTasks).toHaveLength(0);
+    });
+
+    it("rejects a whitespace-only goal", async () => {
+      const h = harness();
+      const result = await tool(h).handler({ ...VALID, goal: "   \n  " });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({ error: "invalid_goal" });
+    });
+
+    it.each([
+      ["a non-GitHub host", "https://gitlab.com/acme/tool"],
+      ["plain http", "http://github.com/acme/tool"],
+      ["a hostname that merely ends in the brand", "https://notgithub.com/a/b"],
+      ["an unparseable url", "not-a-url"],
+      ["an empty string", ""],
+    ])("rejects %s", async (_label, repo_url) => {
+      const h = harness();
+      const result = await tool(h).handler({ ...VALID, repo_url });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({ error: "invalid_repo_url" });
+      expect(h.createdTasks).toHaveLength(0);
+    });
+
+    it("accepts a github subdomain over https", async () => {
+      const h = harness();
+      const result = await tool(h).handler({
+        ...VALID,
+        repo_url: "https://www.github.com/acme/tool",
+      });
+
+      expect(result.isError).toBeFalsy();
+    });
+
+    it("reports agent_not_found when the caller does not resolve", async () => {
+      const h = harness({ agent: null });
+      const result = await tool(h).handler(VALID);
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({ error: "agent_not_found" });
+      expect(h.createdTasks).toHaveLength(0);
+    });
+  });
+
+  describe("happy path", () => {
+    it("creates the container task, dispatches, then inserts the repo_run", async () => {
+      const h = harness();
+      const result = await tool(h).handler(VALID);
+
+      expect(result.isError).toBeFalsy();
+
+      expect(h.createdTasks).toHaveLength(1);
+      expect(h.createdTasks[0]).toMatchObject({
+        title: VALID.goal,
+        description: VALID.goal,
+        priority: "medium",
+        assignee_id: "agent_a",
+        creator_id: "agent_a",
+        creator_type: "agent",
+      });
+
+      expect(h.dispatched).toHaveLength(1);
+      expect(h.dispatched[0]).toMatchObject({
+        agentId: "agent_a",
+        type: "run_repo",
+        intent: VALID.goal,
+        reason: { kind: "fresh" },
+      });
+
+      expect(h.repoRuns).toHaveLength(1);
+      expect(h.repoRuns[0]).toMatchObject({
+        agent_id: "agent_a",
+        goal: VALID.goal,
+        repo_url: VALID.repo_url,
+        status: "pending",
+      });
+    });
+
+    it("returns the ids that the repo_run row was actually written with", async () => {
+      const h = harness();
+      const result = await tool(h).handler(VALID);
+      const content = result.content as Record<string, string>;
+      const run = h.repoRuns[0] as Record<string, string>;
+
+      expect(content.repo_run_id).toBe(run.id);
+      expect(content.session_id).toBe(run.session_id);
+      expect(content.task_id).toBe(run.task_id);
+      expect(content.status).toBe("pending");
+      expect(content.watch_url).toBe(`/capabilities/runs/${content.repo_run_id}`);
+    });
+
+    it("pre-mints the session id and dispatches under it, so the repo_run FK resolves", async () => {
+      const h = harness();
+      const result = await tool(h).handler(VALID);
+
+      const dispatchedSid = (h.dispatched[0] as Record<string, string>)
+        .sessionIdOverride;
+      expect(dispatchedSid).toMatch(/^sess_/);
+      expect((h.repoRuns[0] as Record<string, string>).session_id).toBe(
+        dispatchedSid,
+      );
+      expect((result.content as Record<string, string>).session_id).toBe(
+        dispatchedSid,
+      );
+    });
+
+    it("hangs the repo_run off the same container task it dispatched", async () => {
+      const h = harness();
+      await tool(h).handler(VALID);
+
+      const taskId = (h.createdTasks[0] as Record<string, string>).id;
+      expect((h.dispatched[0]?.task as Record<string, string>).id).toBe(taskId);
+      expect((h.repoRuns[0] as Record<string, string>).task_id).toBe(taskId);
+    });
+
+    it("truncates a long goal for the task title but keeps it whole as the description", async () => {
+      const h = harness();
+      const goal = "x".repeat(200);
+      await tool(h).handler({ ...VALID, goal });
+
+      const created = h.createdTasks[0] as Record<string, string>;
+      expect(created.title).toHaveLength(78);
+      expect(created.title?.endsWith("…")).toBe(true);
+      expect(created.description).toBe(goal);
+    });
+
+    it("collapses whitespace in the task title", async () => {
+      const h = harness();
+      await tool(h).handler({ ...VALID, goal: "  extract\n\n  the   tables  " });
+
+      expect((h.createdTasks[0] as Record<string, string>).title).toBe(
+        "extract the tables",
+      );
+    });
+
+    it("echoes trimmed input_url / input_filename back to the caller", async () => {
+      const h = harness();
+      const result = await tool(h).handler({
+        ...VALID,
+        input_url: "  https://example.com/a.pdf  ",
+        input_filename: "  a.pdf  ",
+      });
+
+      expect(result.content).toMatchObject({
+        input_url: "https://example.com/a.pdf",
+        input_filename: "a.pdf",
+      });
+    });
+
+    it("omits input_url / input_filename when they are not strings", async () => {
+      const h = harness();
+      const result = await tool(h).handler({ ...VALID, input_url: 42 });
+
+      expect(result.content.input_url).toBeUndefined();
+      expect(result.content.input_filename).toBeUndefined();
+    });
+  });
+
+  describe("limits parsing", () => {
+    it("defaults to an empty object when limits is absent or not an object", async () => {
+      for (const limits of [undefined, null, "20", 5]) {
+        const h = harness();
+        const result = await tool(h).handler({ ...VALID, limits });
+        expect(result.content.limits).toEqual({});
+      }
+    });
+
+    it("passes through in-range values", async () => {
+      const h = harness();
+      const result = await tool(h).handler({
+        ...VALID,
+        limits: { wall_clock_minutes: 10, max_install_attempts: 3, disk_mb: 512 },
+      });
+
+      expect(result.content.limits).toEqual({
+        wall_clock_minutes: 10,
+        max_install_attempts: 3,
+        disk_mb: 512,
+      });
+    });
+
+    it("clamps each limit to its ceiling", async () => {
+      const h = harness();
+      const result = await tool(h).handler({
+        ...VALID,
+        limits: {
+          wall_clock_minutes: 999,
+          max_install_attempts: 99,
+          disk_mb: 1_000_000,
+        },
+      });
+
+      expect(result.content.limits).toEqual({
+        wall_clock_minutes: 60,
+        max_install_attempts: 5,
+        disk_mb: 10_000,
+      });
+    });
+
+    it("floors fractional attempt + disk values", async () => {
+      const h = harness();
+      const result = await tool(h).handler({
+        ...VALID,
+        limits: { max_install_attempts: 2.9, disk_mb: 100.7 },
+      });
+
+      expect(result.content.limits).toEqual({
+        max_install_attempts: 2,
+        disk_mb: 100,
+      });
+    });
+
+    it("drops non-positive and non-numeric limits rather than clamping them up", async () => {
+      const h = harness();
+      const result = await tool(h).handler({
+        ...VALID,
+        limits: {
+          wall_clock_minutes: 0,
+          max_install_attempts: -1,
+          disk_mb: "2048",
+        },
+      });
+
+      expect(result.content.limits).toEqual({});
+    });
+  });
+
+  describe("failure paths", () => {
+    it("surfaces dispatch_failed and never inserts a repo_run", async () => {
+      const h = harness({
+        dispatchImpl: async () => {
+          throw new Error("no runtime bound");
+        },
+      });
+      const result = await tool(h).handler(VALID);
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({
+        error: "dispatch_failed",
+        message: "no runtime bound",
+      });
+      expect(h.services.repoRunRepo.create).not.toHaveBeenCalled();
+    });
+
+    it("stringifies a non-Error dispatch throw", async () => {
+      const h = harness({
+        dispatchImpl: async () => {
+          throw "boom";
+        },
+      });
+      const result = await tool(h).handler(VALID);
+
+      expect(result.content).toMatchObject({
+        error: "dispatch_failed",
+        message: "boom",
+      });
+    });
+
+    it("surfaces repo_run_create_failed when the insert fails after dispatch", async () => {
+      const h = harness({
+        repoRunCreateImpl: async () => {
+          throw new Error("duplicate key");
+        },
+      });
+      const result = await tool(h).handler(VALID);
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({
+        error: "repo_run_create_failed",
+        message: "duplicate key",
+      });
+      // The dispatch already happened — the orphan session is the
+      // documented, self-recovering cost of this ordering.
+      expect(h.dispatched).toHaveLength(1);
+    });
+
+    it("stringifies a non-Error repo_run throw", async () => {
+      const h = harness({
+        repoRunCreateImpl: async () => {
+          throw "pg down";
+        },
+      });
+      const result = await tool(h).handler(VALID);
+
+      expect(result.content).toMatchObject({
+        error: "repo_run_create_failed",
+        message: "pg down",
+      });
+    });
+  });
+});

--- a/packages/api/src/tools/watch.test.ts
+++ b/packages/api/src/tools/watch.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  WatchAuthError,
+  WatchNotFoundError,
+  WatchValidationError,
+  type WatchService,
+} from "@beevibe/core/services/watch-service";
+import { buildWatchTools, type WatchToolContext } from "./watch.js";
+
+interface Harness {
+  services: { watchService: WatchService };
+  watchCalls: Array<Record<string, unknown>>;
+  unwatchCalls: Array<Record<string, unknown>>;
+}
+
+function harness(
+  overrides: {
+    watchImpl?: () => Promise<unknown>;
+    unwatchImpl?: () => Promise<unknown>;
+  } = {},
+): Harness {
+  const watchCalls: Array<Record<string, unknown>> = [];
+  const unwatchCalls: Array<Record<string, unknown>> = [];
+
+  const watchService = {
+    watchTasks: vi.fn(async (input: Record<string, unknown>) => {
+      if (overrides.watchImpl) return overrides.watchImpl();
+      watchCalls.push(input);
+      return { watchId: "twatch_1", firedImmediately: false };
+    }),
+    unwatch: vi.fn(async (input: Record<string, unknown>) => {
+      if (overrides.unwatchImpl) return overrides.unwatchImpl();
+      unwatchCalls.push(input);
+    }),
+  } as unknown as WatchService;
+
+  return { services: { watchService }, watchCalls, unwatchCalls };
+}
+
+const CTX: WatchToolContext = { agentId: "agent_a", sessionId: "sess_1" };
+
+function tools(h: Harness, ctx: WatchToolContext = CTX) {
+  const [watchTasks, unwatch] = buildWatchTools(ctx, h.services);
+  return { watchTasks: watchTasks!, unwatch: unwatch! };
+}
+
+describe("buildWatchTools", () => {
+  it("returns watch_tasks and unwatch, in that order", () => {
+    const built = buildWatchTools(CTX, harness().services);
+
+    expect(built.map((t) => t.name)).toEqual(["watch_tasks", "unwatch"]);
+  });
+
+  it("advertises both fire modes on the watch_tasks schema", () => {
+    const { watchTasks, unwatch } = tools(harness());
+    const props = watchTasks.schema.properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+
+    expect(props.mode?.enum).toEqual(["all", "any"]);
+    expect(watchTasks.schema.required).toEqual(["task_ids"]);
+    expect(unwatch.schema.required).toEqual(["watch_id"]);
+  });
+});
+
+describe("watch_tasks tool", () => {
+  it("forwards caller identity, task ids, mode and reason to the service", async () => {
+    const h = harness();
+    const result = await tools(h).watchTasks.handler({
+      task_ids: ["task_1", "task_2"],
+      mode: "any",
+      reason: "  need the first result  ",
+    });
+
+    expect(h.watchCalls).toEqual([
+      {
+        callerAgentId: "agent_a",
+        callerSessionId: "sess_1",
+        taskIds: ["task_1", "task_2"],
+        mode: "any",
+        reason: "need the first result",
+      },
+    ]);
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({
+      watch_id: "twatch_1",
+      fired_immediately: false,
+    });
+  });
+
+  it("defaults mode to 'all' when omitted or not a known mode", async () => {
+    for (const mode of [undefined, "sometimes", 3, null]) {
+      const h = harness();
+      await tools(h).watchTasks.handler({ task_ids: ["task_1"], mode });
+      expect(h.watchCalls[0]?.mode).toBe("all");
+    }
+  });
+
+  it("omits reason when it is blank or not a string", async () => {
+    for (const reason of [undefined, "   ", 7]) {
+      const h = harness();
+      await tools(h).watchTasks.handler({ task_ids: ["task_1"], reason });
+      expect(h.watchCalls[0]?.reason).toBeUndefined();
+    }
+  });
+
+  it("drops non-string entries from task_ids", async () => {
+    const h = harness();
+    await tools(h).watchTasks.handler({
+      task_ids: ["task_1", 42, null, "task_2", { id: "task_3" }],
+    });
+
+    expect(h.watchCalls[0]?.taskIds).toEqual(["task_1", "task_2"]);
+  });
+
+  it("reports fired_immediately when the condition was already met", async () => {
+    const h = harness({
+      watchImpl: async () => ({ watchId: "twatch_9", firedImmediately: true }),
+    });
+    const result = await tools(h).watchTasks.handler({ task_ids: ["task_1"] });
+
+    expect(result.content).toEqual({
+      watch_id: "twatch_9",
+      fired_immediately: true,
+    });
+  });
+
+  describe("validation", () => {
+    it.each([
+      ["an empty array", []],
+      ["a non-array", "task_1"],
+      ["an array with no strings in it", [1, null, {}]],
+      ["an omitted field", undefined],
+    ])("refuses %s of task_ids before calling the service", async (_l, task_ids) => {
+      const h = harness();
+      const result = await tools(h).watchTasks.handler({ task_ids });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({ error: "watch_validation" });
+      expect(h.services.watchService.watchTasks).not.toHaveBeenCalled();
+    });
+
+    it("refuses to register a watch with no session to wake", async () => {
+      const h = harness();
+      const result = await tools(h, { agentId: "agent_a" }).watchTasks.handler({
+        task_ids: ["task_1"],
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({
+        error: "watch_validation",
+        message: "watch_tasks must be called inside a session context",
+      });
+      expect(h.services.watchService.watchTasks).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("unwatch tool", () => {
+  it("forwards the caller agent id and watch id", async () => {
+    const h = harness();
+    const result = await tools(h).unwatch.handler({ watch_id: "twatch_1" });
+
+    expect(h.unwatchCalls).toEqual([
+      { callerAgentId: "agent_a", watchId: "twatch_1" },
+    ]);
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({ ok: true });
+  });
+
+  it.each([
+    ["an empty string", ""],
+    ["a non-string", 42],
+    ["an omitted field", undefined],
+  ])("refuses %s of watch_id before calling the service", async (_l, watch_id) => {
+    const h = harness();
+    const result = await tools(h).unwatch.handler({ watch_id });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "watch_validation" });
+    expect(h.services.watchService.unwatch).not.toHaveBeenCalled();
+  });
+});
+
+describe("service error translation", () => {
+  const cases: Array<[string, () => unknown, string, string]> = [
+    [
+      "WatchAuthError",
+      () => new WatchAuthError("task task_1 is not in your chain"),
+      "watch_auth",
+      "task task_1 is not in your chain",
+    ],
+    [
+      "WatchValidationError",
+      () => new WatchValidationError("task_ids must be non-empty"),
+      "watch_validation",
+      "task_ids must be non-empty",
+    ],
+    [
+      "WatchNotFoundError",
+      () => new WatchNotFoundError("twatch_missing"),
+      "watch_not_found",
+      "task_watch twatch_missing not found",
+    ],
+    [
+      "a plain Error",
+      () => new Error("pool exhausted"),
+      "watch_error",
+      "pool exhausted",
+    ],
+    ["a thrown non-Error", () => "kaboom", "watch_error", "kaboom"],
+  ];
+
+  it.each(cases)(
+    "maps %s thrown by watchTasks to a coded tool error",
+    async (_label, make, code, message) => {
+      const h = harness({
+        watchImpl: async () => {
+          throw make();
+        },
+      });
+      const result = await tools(h).watchTasks.handler({ task_ids: ["task_1"] });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual({ error: code, message });
+    },
+  );
+
+  it.each(cases)(
+    "maps %s thrown by unwatch to a coded tool error",
+    async (_label, make, code, message) => {
+      const h = harness({
+        unwatchImpl: async () => {
+          throw make();
+        },
+      });
+      const result = await tools(h).unwatch.handler({ watch_id: "twatch_1" });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual({ error: code, message });
+    },
+  );
+});


### PR DESCRIPTION
## What

A v8 coverage sweep across the monorepo surfaced a consistent gap in `packages/api/src/tools`: **three tools had no test file at all** while every sibling in that directory had one, and a fourth was covered only for its static tier inventory.

| Module | Lines before | Lines after | Was |
| --- | --- | --- | --- |
| `use-repo.ts` | 32.0% | **100%** | no test file |
| `watch.ts` | 46.3% | **100%** | no test file |
| `session-search.ts` | 64.7% | **100%** | no test file |
| `mesh.ts` | 45.9% | **100%** | inventory only |

Directory total: **80.0% → 87.0%** lines, **87.6% → 95.2%** functions.

## Why these

This is agent-facing surface — the sandbox capability verb (`use_repo`), the task-completion wake-up (`watch_tasks`/`unwatch`), Layer-3 conversation memory (`session_search`), and the six mesh coordination tools. An unexercised branch here is a bug an agent hits at runtime, not one CI catches.

`mesh.ts` in particular noted that handler behavior was "covered indirectly by the m6/m7 e2e scripts" — which need live Postgres plus spawned CLI subprocesses, so in practice they don't gate anything. All four modules are thin adapters over services, so faking the injected dependencies reaches every branch with no DB and no subprocess.

## What the tests assert

Behavior the handlers actually own, not their wiring:

- **`use-repo`** — GitHub-HTTPS URL validation (rejects `gitlab.com`, plain http, and the `notgithub.com` near-miss), limit clamping/flooring/dropping, and the `create task → dispatch → insert repo_run` ordering that `repo_run.session_id`'s FK depends on. Both documented failure paths are pinned, including that a `dispatch_failed` never goes on to insert a `repo_run`.
- **`watch`** — mode defaulting to `all`, non-string `task_ids` filtering, the refusal when there's no session to wake, and the full `WatchAuth`/`WatchValidation`/`WatchNotFound` → coded-error translation table across both tools.
- **`session-search`** — the four-shape inference (browse / discover / read / scroll), including scroll-wins-over-discover and the blank-anchor fallback to read. Also covers the by-**name** `SessionSearchError` match, which exists specifically so a cross-bundle (`src/` vs `dist/`) copy still yields its structured code — `instanceof` alone would silently degrade it to `internal_error`.
- **`mesh`** — per-tool validation, the response projections (including the `escalated` sentinel taking a different shape from a normal round), and the ordering invariants: a failed `markBlocked` must not spawn the parent, and a failed escalation create must not unblock the peer or `pg_notify`.

`mesh-handlers.test.ts` is a new file rather than an addition to `mesh.test.ts`, which is deliberately scoped to the per-tier tool inventory.

## Verification

- **135 new tests**, all passing (`src/tools` suite: 210 passed / 12 files).
- **No production code changed** — tests only.
- `tsc --noEmit` and `eslint` clean on `@beevibe/api`.
- Full api suite: **956 passed, 0 failed**. The 9 failing *files* are the pre-existing `DATABASE_URL_TEST env var is required` suites documented in CLAUDE.md as environmental — unchanged by this PR.
- The `@vitest/coverage-v8` provider used for the sweep was installed ad-hoc and removed; `package.json` and `pnpm-lock.yaml` are untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_018efYZhqAA5NFR5yP3JvRYP)_