### PR TITLE
chore(web): remove dead CSS left behind by removed components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,7 +203,7 @@ table before deleting anything a tool reports as unused.
 | root devDep `prettier` | Formatting is editor/CLI-driven off `.prettierrc.json`; there's no `format` script to detect. |
 | `migrations/*.js` | Applied migration history. **Never** delete a migration file. |
 | `scripts/provision-demo.ts`, `pre-deploy-fix-migration-names.cjs` | Invoked from `scripts/dev.sh` and `scripts/start-api.sh` — shell call sites are invisible to knip. |
-| `scripts/seed-session-search-demo.ts`, `test-session-search.ts`, `packages/sandbox/src/scripts/*` | Documented manual dev/ops utilities, run by hand via `pnpm tsx …`. |
+| `scripts/seed-session-search-demo.ts`, `test-session-search.ts`, `test-watch-tasks.sh`, `packages/sandbox/src/scripts/*` | Documented manual dev/ops utilities, run by hand via `pnpm tsx …` / `bash …`. `test-watch-tasks.sh` is a DB-level smoke against a live `pnpm dev` stack — it catches migration drift the `beevibe_test` vitest DB can't. |
 | `OwnerLookup.singleOwnerSet` / `.meshOwners` | Called by the module-level `RESOLVERS` table, so they must stay public. Knip only checks cross-module use. |
 | `@beevibe/core/{domain,adapters/codex,adapters/opencode,services/skills,auth/constants}` subpath exports | Deliberate library surface. The codex/opencode runtimes are wired through `runtime-registry.ts`, which imports `./codex/runtime.js` directly rather than the barrel. |
 
@@ -243,6 +243,32 @@ Zero surviving hits = dead. Hits only from `*.test.ts` = alive only for
 its own test — check whether it's a deliberate test seam (`clearCache()`
 in `api/src/sse/owner-lookup.ts` is marked `@internal Tests only`) before
 touching it.
+
+### The CSS layer is invisible to every TS tool
+
+knip, depcheck and `tsc` all stop at the TypeScript graph, so a CSS rule
+or a `tailwind.config.ts` theme key can lose its last consumer and stay
+forever. Sweep it by name — every class token in `globals.css` against
+the rest of the package:
+
+```bash
+for c in $(grep -oE '\.[a-zA-Z][a-zA-Z0-9_-]*' packages/web/app/globals.css \
+             | tr -d '.' | sort -u); do
+  n=$(git grep -l -w -- "$c" -- packages/web ':!packages/web/app/globals.css' | wc -l)
+  [ "$n" -eq 0 ] && echo "UNUSED: $c"
+done
+```
+
+Same shape works for `--custom-properties` (match `var(--x)`) and for
+`tailwind.config.ts` `keyframes`/`animation` keys (match `animate-<key>`).
+Two traps:
+
+- A tailwind `animation` key is only reachable via the generated
+  `animate-<key>` utility, so grep that, not the bare key.
+- `bg-popover` / `text-popover-foreground` appear in JSX but `popover` is
+  **not** in `tailwind.config.ts` `colors`, so those classes generate no
+  CSS and the `--popover` vars in `globals.css` read as unused. That's a
+  missing theme key, not dead code — don't delete the vars.
 
 ### Dead in-repo, but not ours to delete
 

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -119,19 +119,6 @@
   }
 }
 
-.timeline-rail {
-  position: relative;
-}
-.timeline-rail::before {
-  content: "";
-  position: absolute;
-  left: 11px;
-  top: 8px;
-  bottom: 8px;
-  width: 1px;
-  background: hsl(var(--border));
-}
-
 /* Pearl button — sidebar New chat CTA. Adapted from Uiverse.io by
    marcelodolza, recolored to the app's honey primary. The .wrap
    pseudo-elements render the glossy top cap and rising under-glow. */
@@ -268,10 +255,9 @@
    material instead of solid blocks against shiny pearls.
 
    Use `.glass-surface` for popovers, composers, peek panels — anything
-   that hosts content. Use `.glass-bubble-agent` / `.glass-bubble-user`
-   for chat message bubbles. All three need a non-solid backdrop behind
-   them to read correctly; the chat surface's gradient + the sidebar's
-   `bg-card` both qualify. */
+   that hosts content. Use `.glass-bubble-user` for chat message bubbles.
+   Both need a non-solid backdrop behind them to read correctly; the chat
+   surface's gradient + the sidebar's `bg-card` both qualify. */
 .glass-surface {
   background-color: hsl(var(--card) / 0.55);
   /* Apple Liquid Glass cues: heavy blur picks up backdrop variation, the
@@ -296,21 +282,6 @@
   .dark .glass-surface { background-color: hsl(var(--card) / 0.92); }
 }
 
-/* Agent message — neutral translucent bubble. Drops the solid
-   bg-secondary block in favor of a frosted variant that lets the
-   gradient backdrop bleed through. */
-.glass-bubble-agent {
-  background-color: hsl(var(--secondary) / 0.5);
-  backdrop-filter: blur(20px) saturate(180%);
-  -webkit-backdrop-filter: blur(20px) saturate(180%);
-  color: hsl(var(--foreground));
-  box-shadow: inset 0 1px 0 hsl(0 0% 100% / 0.06);
-}
-.dark .glass-bubble-agent {
-  background-color: hsl(var(--secondary) / 0.4);
-  box-shadow: inset 0 1px 0 hsl(0 0% 100% / 0.05);
-}
-
 /* User message — replaces the saturated bg-primary yellow with a low-
    opacity tint + brand-colored border. Brand reads as accent instead
    of dominating the column; short prompts stop looking like billboards. */
@@ -329,7 +300,6 @@
 }
 
 @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
-  .glass-bubble-agent { background-color: hsl(var(--secondary) / 0.9); }
   .glass-bubble-user { background-color: hsl(var(--primary) / 0.22); }
 }
 
@@ -843,7 +813,6 @@
 
 @media (prefers-reduced-motion: reduce) {
   .animate-pulse-breathe,
-  .animate-spin-slow,
   .animate-row-flash {
     animation: none !important;
   }

--- a/packages/web/tailwind.config.ts
+++ b/packages/web/tailwind.config.ts
@@ -79,9 +79,6 @@ const config: Config = {
           "0%, 100%": { opacity: "1", transform: "scale(1)" },
           "50%": { opacity: "0.55", transform: "scale(0.92)" },
         },
-        "spin-slow": {
-          to: { transform: "rotate(360deg)" },
-        },
         "row-flash": {
           "0%": { backgroundColor: "hsl(48 96% 53% / 0.16)" },
           "100%": { backgroundColor: "transparent" },
@@ -96,7 +93,6 @@ const config: Config = {
       },
       animation: {
         "pulse-breathe": "pulse-breathe 2s ease-in-out infinite",
-        "spin-slow": "spin-slow 2.5s linear infinite",
         "row-flash": "row-flash 1200ms ease-out",
         "step-pop": "step-pop 260ms ease-out",
       },


### PR DESCRIPTION
A full static + dynamic sweep across the monorepo turned up **nothing dead in the TypeScript graph** — the previous sweeps (#256, #267, #274, #285) got it all. What it did find is a layer no TS tool looks at: knip, depcheck and `tsc` all stop at the import graph, so a CSS rule or a `tailwind.config.ts` theme key can lose its last consumer and stay forever.

## Removed

Each verified to have zero references outside `globals.css` / `tailwind.config.ts`:

| Removed | Why it's dead |
| --- | --- |
| `.timeline-rail` + `.timeline-rail::before` | Added in #225 and never applied by any component, in any commit since. Born dead. |
| `.glass-bubble-agent`, its `.dark` variant, its `@supports` no-backdrop-filter fallback | Also from #225, also never applied. |
| `spin-slow` keyframes + animation (`tailwind.config.ts`) and the `.animate-spin-slow` entry in the `prefers-reduced-motion` block | #256 deleted the one component that used it (`config.spin && "animate-spin-slow"`) but left the generator behind. |

The sibling `.glass-bubble-user` is **live** (`chat-client.tsx:610`) and stays, along with the whole `.glass-surface` family. The block comment is updated to stop advertising the class that no longer exists.

## What the sweep ran

| Check | Result |
| --- | --- |
| `tsc --noUnusedLocals --noUnusedParameters`, `--allowUnreachableCode false`, all 6 packages | clean |
| knip | only the documented false positives (`node-pg-migrate`, `zod`, `postcss`/`autoprefixer`, migrations, shell-invoked scripts) |
| knip's 12 "unused exports" + 107 "unused exported types" | all used **within their own file** — a redundant `export`, not dead code |
| depcheck, per package | same documented set, nothing new |
| Name sweep of every `export function\|class\|const` under `packages/*/src/**` + `packages/web/**` | 16 hits, all live inside their own module |
| Same sweep for exported types, and for exports referenced only by tests | no true orphans |
| Coverage (v8, `--coverage.all`) | every 0% file is a barrel, a Postgres adapter, or `watch-service` — all DB-gated. No unreachable code behind the gaps. |

The name-based sweep matters because knip can't see past core's 26 subpath barrels — it treats each as an entry point, so anything re-exported is "reachable" no matter how many packages actually import it.

## Docs

`CLAUDE.md` picks up the CSS sweep recipe so the next pass starts there, plus two notes worth not re-deriving:

- `scripts/test-watch-tasks.sh` has zero references but is a **live manual smoke** — it catches migration drift the vitest `beevibe_test` DB can't. Added to the false-positive table.
- The `--popover` / `--popover-foreground` vars only *look* unused: `bg-popover` is used in `room-detail-client.tsx:692`, but `popover` is missing from `tailwind.config.ts` `colors`, so that class generates no CSS. That's a **missing theme key, not dead code** — the vars stay put, and deleting them would cement the bug. Flagged rather than fixed, since fixing it changes rendering and is outside this PR's scope.

## Gates

- `pnpm typecheck` — 9/9 pass
- `pnpm lint` — 0 errors (4 pre-existing `import/no-duplicates` warnings in untouched api test files)
- `pnpm --filter @beevibe/web exec next build` — succeeds (direct invocation bypasses the documented Turbo strict-env / proxy issue)
- Re-ran the CSS sweep after the edit: clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dxc2t1WgHpvU7ftewzo6fD)_