### PR TITLE
fix(test): unbreak main — drop tests of methods removed by #285, pin the tie-break test's collation

### DIFF
--- a/packages/api/src/routes/room.test.ts
+++ b/packages/api/src/routes/room.test.ts
@@ -140,10 +140,8 @@ function makeRoomRepo(): RoomRepository {
     addPersonMember: vi.fn(async () => {}),
     addAgentMember: vi.fn(async () => {}),
     listMembers: vi.fn(async () => []),
-    listMemberPersonIds: vi.fn(async () => []),
     listMemberAgentIds: vi.fn(async () => []),
     isMember: vi.fn(async () => true),
-    areAgentsCoMembers: vi.fn(async () => true),
     appendMessage: vi.fn(async (input) => fakeMessage({ ...input })),
     listMessages: vi.fn(async () => []),
   } as unknown as RoomRepository;

--- a/packages/core/src/adapters/postgres/room-repo.test.ts
+++ b/packages/core/src/adapters/postgres/room-repo.test.ts
@@ -3,10 +3,10 @@
  *
  * `room_member` carries a single `subject_id` alongside separate
  * `person_id` / `agent_id` columns, which is what makes the conflict
- * key, the kind filters and the `areAgentsCoMembers` self-join worth
- * exercising against a real engine rather than a fake pool: a wrong
- * `ON CONFLICT` target silently duplicates members, and a missing kind
- * filter leaks agents into the person list (and vice versa).
+ * key and the kind filters worth exercising against a real engine
+ * rather than a fake pool: a wrong `ON CONFLICT` target silently
+ * duplicates members, and a missing kind filter leaks persons into
+ * the agent list (and vice versa).
  */
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { DEFAULT_RUNTIME_CONFIG } from "../../domain/agent.js";
@@ -34,7 +34,6 @@ describe("PostgresRoomRepository", () => {
   let alice: string;
   let bob: string;
   let alicesTeam: string;
-  let bobsTeam: string;
 
   beforeAll(() => {
     pool = createTestPool();
@@ -57,15 +56,6 @@ describe("PostgresRoomRepository", () => {
         id: agentId(),
         name: "Alice's Team",
         owner_id: alice,
-        hierarchy_level: "team",
-        runtime_config: DEFAULT_RUNTIME_CONFIG,
-      })
-    ).id;
-    bobsTeam = (
-      await agents.create({
-        id: agentId(),
-        name: "Bob's Team",
-        owner_id: bob,
         hierarchy_level: "team",
         runtime_config: DEFAULT_RUNTIME_CONFIG,
       })
@@ -172,13 +162,14 @@ describe("PostgresRoomRepository", () => {
     ]);
   });
 
-  it("splits the person and agent id lists by kind", async () => {
+  it("keeps person members out of the agent id list", async () => {
     const room = await newRoom();
     await rooms.addPersonMember(room.id, alice);
     await rooms.addPersonMember(room.id, bob);
     await rooms.addAgentMember(room.id, alicesTeam);
 
-    expect((await rooms.listMemberPersonIds(room.id)).sort()).toEqual([alice, bob].sort());
+    // Persons and agents share the `subject_id` column — the kind
+    // filter is what keeps persons out of the agent list.
     expect(await rooms.listMemberAgentIds(room.id)).toEqual([alicesTeam]);
   });
 
@@ -186,7 +177,6 @@ describe("PostgresRoomRepository", () => {
     const room = await newRoom();
 
     expect(await rooms.listMembers(room.id)).toEqual([]);
-    expect(await rooms.listMemberPersonIds(room.id)).toEqual([]);
     expect(await rooms.listMemberAgentIds(room.id)).toEqual([]);
   });
 
@@ -203,46 +193,6 @@ describe("PostgresRoomRepository", () => {
     expect(await rooms.isMember(room.id, alicesTeam)).toBe(false);
     expect(await rooms.isMember(other.id, alice)).toBe(false);
     expect(await rooms.isMember("room_missing", alice)).toBe(false);
-  });
-
-  it("detects agent co-membership across any shared room", async () => {
-    const room = await newRoom();
-    const otherRoom = await newRoom({ name: "Other" });
-    const loner = (
-      await agents.create({
-        id: agentId(),
-        name: "Loner",
-        owner_id: bob,
-        hierarchy_level: "ic",
-        runtime_config: DEFAULT_RUNTIME_CONFIG,
-      })
-    ).id;
-    await rooms.addAgentMember(room.id, alicesTeam);
-    await rooms.addAgentMember(room.id, bobsTeam);
-    await rooms.addAgentMember(otherRoom.id, loner);
-
-    expect(await rooms.areAgentsCoMembers(alicesTeam, bobsTeam)).toBe(true);
-    // Symmetric — the mesh gate must answer the same either direction.
-    expect(await rooms.areAgentsCoMembers(bobsTeam, alicesTeam)).toBe(true);
-    expect(await rooms.areAgentsCoMembers(alicesTeam, loner)).toBe(false);
-    expect(await rooms.areAgentsCoMembers(alicesTeam, "agent_nobody")).toBe(false);
-  });
-
-  it("never reports an agent as a co-member of itself", async () => {
-    const room = await newRoom();
-    await rooms.addAgentMember(room.id, alicesTeam);
-
-    // Short-circuits before the query — an agent sharing a room with
-    // itself must not open the mesh ask path back to its own inbox.
-    expect(await rooms.areAgentsCoMembers(alicesTeam, alicesTeam)).toBe(false);
-  });
-
-  it("does not treat a person co-member as an agent co-member", async () => {
-    const room = await newRoom();
-    await rooms.addPersonMember(room.id, alice);
-    await rooms.addPersonMember(room.id, bob);
-
-    expect(await rooms.areAgentsCoMembers(alice, bob)).toBe(false);
   });
 
   // ── Messages ───────────────────────────────────────────────────────────
@@ -341,22 +291,25 @@ describe("PostgresRoomRepository", () => {
   it("breaks a created_at tie by id so the order is stable", async () => {
     const room = await newRoom();
     const sameInstant = new Date("2026-03-01T00:00:00Z");
-    for (const content of ["a", "b", "c"]) {
-      const msg = await rooms.appendMessage({
-        id: roomMessageId(),
+    // Fixed lowercase ids, inserted out of order: C, en_US.utf8 and JS
+    // code-unit ordering all agree on them, so the assertion pins the
+    // id tie-break itself rather than the database's collation.
+    for (const id of ["rmsg_tie_c", "rmsg_tie_a", "rmsg_tie_b"]) {
+      await rooms.appendMessage({
+        id,
         room_id: room.id,
         kind: "human",
         sender_person_id: alice,
-        content,
+        content: id,
       });
       await pool.query(`UPDATE room_message SET created_at = $2 WHERE id = $1`, [
-        msg.id,
+        id,
         sameInstant,
       ]);
     }
 
     const listed = await rooms.listMessages(room.id);
-    expect(listed.map((m) => m.id)).toEqual([...listed.map((m) => m.id)].sort());
+    expect(listed.map((m) => m.id)).toEqual(["rmsg_tie_a", "rmsg_tie_b", "rmsg_tie_c"]);
     expect(await rooms.listMessages(room.id)).toEqual(listed);
   });
 


### PR DESCRIPTION
## What broke

Main went red on 0323ad0 (#285). It was a two-PR race: #286 (test coverage for `room-repo.ts`) and #285 (dead-code sweep) merged 66 seconds apart, each green against its own base. #286 added DB-backed tests for `RoomRepository.listMemberPersonIds` and `areAgentsCoMembers`; #285 removed both methods — its "no call site anywhere" sweep predated the tests landing. Combined, five tests in `room-repo.test.ts` throw `TypeError: ... is not a function`.

A sixth failure was an unrelated latent flake shipped by #286: the "breaks a created_at tie by id" test compares Postgres `ORDER BY id` (CI database collation is `en_US.utf8`) against JS `.sort()` (UTF-16 code units), which disagree on random mixed-case ids — a coin flip that passed on the PR run and failed on main.

## The forward fix

The sweep's analysis holds — nothing in production calls either method, and the tests existed only to cover the adapter — so this keeps the removal and drops the tests:

- Delete the three `areAgentsCoMembers` tests and the now-unused `bobsTeam` fixture.
- Reshape "splits the person and agent id lists by kind" around the surviving `listMemberAgentIds` — the kind-filter property it pinned (persons must not leak into the agent list) is still asserted.
- Drop the `listMemberPersonIds` lines from the empty-lists test, and the two stale `vi.fn()` stubs #286 added to the `room.test.ts` fake — the same stale-stub category #285 cleaned in the other eight fakes.
- Make the tie-break test collation-proof: fixed lowercase ids inserted out of order, asserted against the explicit expected sequence, so it pins the id tie-break itself rather than the database's collation.

## Verification

No Postgres in the sandbox, so the DB-gated suite can't execute locally (per CLAUDE.md): typecheck and lint clean across all nine packages; build clean except the documented web/Google-Fonts proxy failure; api `room.test.ts` 71/71 pass with the trimmed fake; `room-repo.test.ts` collects its 16 tests and fails only on the missing `DATABASE_URL_TEST` gate. CI's Postgres run is the real gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDv9vmeLTzz1jHCPA2wZUc

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDv9vmeLTzz1jHCPA2wZUc)_