### PR TITLE
refactor: unify four more clusters of near-duplicate abstractions

### DIFF
--- a/packages/api/src/routes/escalation.ts
+++ b/packages/api/src/routes/escalation.ts
@@ -17,7 +17,7 @@
  * executor picks both up within ≤30s.
  */
 
-import { Router, type RequestHandler, type Response } from "express";
+import { Router, type RequestHandler } from "express";
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import {
   type EscalationService,
@@ -27,7 +27,7 @@ import {
 } from "@beevibe/core/services/escalation-service";
 import { NegotiationNotFoundError } from "@beevibe/core/services/negotiation-service";
 import { requireHuman } from "../auth/middleware.js";
-import { requireParam } from "./http-errors.js";
+import { makeServiceErrorHandler, requireParam } from "./http-errors.js";
 
 export interface EscalationRoutesDeps {
   authMiddleware: RequestHandler;
@@ -88,25 +88,11 @@ function buildSelector(body: unknown):
   };
 }
 
-function handleEscalationError(err: unknown, res: Response): void {
-  if (err instanceof EscalationNotFoundError) {
-    res.status(404).json({ error: "escalation_not_found", message: err.message });
-    return;
-  }
-  if (err instanceof NegotiationNotFoundError) {
-    res.status(404).json({ error: "negotiation_not_found", message: err.message });
-    return;
-  }
-  if (err instanceof EscalationStateError) {
-    res.status(409).json({ error: "invalid_state", message: err.message });
-    return;
-  }
-  console.error("[escalation route]", err);
-  res.status(500).json({
-    error: "internal_error",
-    message: err instanceof Error ? err.message : String(err),
-  });
-}
+const handleEscalationError = makeServiceErrorHandler("escalation route", [
+  [EscalationNotFoundError, 404, "escalation_not_found"],
+  [NegotiationNotFoundError, 404, "negotiation_not_found"],
+  [EscalationStateError, 409, "invalid_state"],
+]);
 
 export function createEscalationRouter(deps: EscalationRoutesDeps): Router {
   const router = Router();

--- a/packages/api/src/routes/find-repo.ts
+++ b/packages/api/src/routes/find-repo.ts
@@ -17,6 +17,8 @@ import type {
 } from "@beevibe/core";
 import { requireHuman } from "../auth/middleware.js";
 import { createFindRepoTool } from "../tools/find-repo.js";
+import { clampInt } from "../views/bounds.js";
+import { numericQuery } from "./query-params.js";
 
 export interface FindRepoRouterDeps {
   authMiddleware: RequestHandler;
@@ -37,8 +39,7 @@ export function createFindRepoRouter(deps: FindRepoRouterDeps): Router {
       res.status(400).json({ error: "missing_goal" });
       return;
     }
-    const limitParam = typeof req.query.limit === "string" ? Number(req.query.limit) : 5;
-    const limit = Number.isFinite(limitParam) ? Math.min(10, Math.max(1, Math.floor(limitParam))) : 5;
+    const limit = clampInt(numericQuery(req, "limit"), { min: 1, max: 10, fallback: 5 });
 
     try {
       // The ranker scopes learned_skill lookups to the calling agent's

--- a/packages/api/src/routes/http-errors.test.ts
+++ b/packages/api/src/routes/http-errors.test.ts
@@ -3,6 +3,7 @@ import type { Request, Response } from "express";
 import {
   invalidBody,
   loadOwned,
+  makeServiceErrorHandler,
   requireNullableString,
   requireParam,
 } from "./http-errors.js";
@@ -217,5 +218,71 @@ describe("requireNullableString", () => {
     expect(res.body).toMatchObject({
       message: "expected { runtime_id: string | null }",
     });
+  });
+});
+
+describe("makeServiceErrorHandler", () => {
+  class NotFound extends Error {}
+  class Conflict extends Error {}
+  class NarrowerConflict extends Conflict {}
+
+  const handle = makeServiceErrorHandler("widget route", [
+    [NarrowerConflict, 422, "narrower"],
+    [NotFound, 404, "widget_not_found"],
+    [Conflict, 409, "invalid_state"],
+  ]);
+
+  it("maps a known error to its status + code, carrying the message", () => {
+    const res = fakeRes();
+    handle(new NotFound("Widget w_1 not found"), res);
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({
+      error: "widget_not_found",
+      message: "Widget w_1 not found",
+    });
+  });
+
+  it("does not log a mapped error — it is an expected outcome", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    handle(new Conflict("already resolved"), fakeRes());
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  // Rows are tested in order, so a subclass listed first wins. Getting
+  // this wrong would silently downgrade a narrower error to its base.
+  it("takes the first matching row, so a subclass can precede its base", () => {
+    const res = fakeRes();
+    handle(new NarrowerConflict("nope"), res);
+    expect(res.statusCode).toBe(422);
+    expect(res.body).toMatchObject({ error: "narrower" });
+  });
+
+  it("falls through to the shared 500 for an unmapped error", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = fakeRes();
+    handle(new Error("boom"), res, "resolve");
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: "internal_error", message: "boom" });
+    expect(spy).toHaveBeenCalledWith("[widget route: resolve]", expect.any(Error));
+    spy.mockRestore();
+  });
+
+  it("stringifies a non-Error throw on the fallback path", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = fakeRes();
+    handle("just a string", res);
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: "internal_error", message: "just a string" });
+    expect(spy).toHaveBeenCalledWith("[widget route]", "just a string");
+    spy.mockRestore();
+  });
+
+  it("falls through when the table is empty", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = fakeRes();
+    makeServiceErrorHandler("bare", [])(new NotFound("x"), res);
+    expect(res.statusCode).toBe(500);
+    spy.mockRestore();
   });
 });

--- a/packages/api/src/routes/http-errors.ts
+++ b/packages/api/src/routes/http-errors.ts
@@ -150,3 +150,48 @@ export function makeErrorHandler(
     });
   };
 }
+
+/**
+ * A known service error and the HTTP response it maps to: the error class
+ * to test with `instanceof`, the status, and the wire `error` code.
+ */
+export type ServiceErrorMapping = readonly [
+  error: abstract new (...args: never[]) => Error,
+  status: number,
+  code: string,
+];
+
+/**
+ * A {@link makeErrorHandler} that first walks a table of known service
+ * errors, and only falls through to the 500 for anything unrecognised.
+ *
+ * `task`, `escalation` and `negotiation` each wrote this out by hand: an
+ * `if (err instanceof XError) { res.status(N).json({ error, message:
+ * err.message }); return; }` ladder followed by a verbatim re-implementation
+ * of `makeErrorHandler`'s body. Three copies of the 500 tail meant the
+ * "one place the error envelope lives" that #259 established was already
+ * back up to four. Here the tail is the shared one by construction — a
+ * router can only add rows to the ladder, not re-spell the fallback.
+ *
+ * Mappings are tested in order, so a subclass must be listed before its
+ * base for the narrower row to win.
+ *
+ * `context` is forwarded to the fallback and used only there: the mapped
+ * branches are expected outcomes and deliberately don't log, matching what
+ * all three routers already did.
+ */
+export function makeServiceErrorHandler(
+  tag: string,
+  mappings: readonly ServiceErrorMapping[],
+): (err: unknown, res: Response, context?: string) => void {
+  const fallback = makeErrorHandler(tag);
+  return (err, res, context) => {
+    for (const [ctor, status, code] of mappings) {
+      if (err instanceof ctor) {
+        res.status(status).json({ error: code, message: (err as Error).message });
+        return;
+      }
+    }
+    fallback(err, res, context);
+  };
+}

--- a/packages/api/src/routes/negotiation.ts
+++ b/packages/api/src/routes/negotiation.ts
@@ -14,12 +14,16 @@ import {
   NegotiationNotFoundError,
 } from "@beevibe/core/services/negotiation-service";
 import { requireHuman } from "../auth/middleware.js";
-import { requireParam } from "./http-errors.js";
+import { makeServiceErrorHandler, requireParam } from "./http-errors.js";
 
 export interface NegotiationRoutesDeps {
   authMiddleware: RequestHandler;
   negotiationService: NegotiationService;
 }
+
+const handleError = makeServiceErrorHandler("negotiation route", [
+  [NegotiationNotFoundError, 404, "negotiation_not_found"],
+]);
 
 export function createNegotiationRouter(deps: NegotiationRoutesDeps): Router {
   const router = Router();
@@ -33,15 +37,7 @@ export function createNegotiationRouter(deps: NegotiationRoutesDeps): Router {
       const negotiation = await deps.negotiationService.getReview(id);
       res.json({ ok: true, negotiation });
     } catch (err) {
-      if (err instanceof NegotiationNotFoundError) {
-        res.status(404).json({ error: "negotiation_not_found", message: err.message });
-        return;
-      }
-      console.error("[negotiation route]", err);
-      res.status(500).json({
-        error: "internal_error",
-        message: err instanceof Error ? err.message : String(err),
-      });
+      handleError(err, res);
     }
   });
 

--- a/packages/api/src/routes/query-params.test.ts
+++ b/packages/api/src/routes/query-params.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import type { Request } from "express";
+import { numericQuery } from "./query-params.js";
+
+function req(query: Record<string, unknown>): Request {
+  return { query } as unknown as Request;
+}
+
+const BAND = { min: 1, max: 200, fallback: 50 } as const;
+
+describe("numericQuery", () => {
+  it("reads an in-band value", () => {
+    expect(numericQuery(req({ limit: "25" }), "limit", BAND)).toBe(25);
+  });
+
+  it.each(["0", "-5", "201", "abc"])("falls back for an out-of-band %j", (limit) => {
+    expect(numericQuery(req({ limit }), "limit", BAND)).toBe(50);
+  });
+
+  it("falls back when the param is absent", () => {
+    expect(numericQuery(req({}), "limit", BAND)).toBe(50);
+  });
+
+  // Express hands back an array for a repeated param. Number(["1","2"]) is
+  // NaN, but the typeof guard rejects it before that ever matters.
+  it("falls back when the param is repeated", () => {
+    expect(numericQuery(req({ limit: ["1", "2"] }), "limit", BAND)).toBe(50);
+  });
+
+  it("returns undefined with no fallback configured", () => {
+    expect(numericQuery(req({}), "limit")).toBeUndefined();
+    expect(numericQuery(req({ limit: "abc" }), "limit")).toBeUndefined();
+  });
+
+  // `/promotion` and `/memory/fact` pass the raw number down to a view that
+  // owns the clamp, so an unbounded read must not invent bounds of its own.
+  it("passes any finite value through when unbounded", () => {
+    expect(numericQuery(req({ limit: "" }), "limit")).toBe(0);
+    expect(numericQuery(req({ limit: "-9" }), "limit")).toBe(-9);
+    expect(numericQuery(req({ limit: "1e6" }), "limit")).toBe(1_000_000);
+  });
+
+  it("honours a one-sided band", () => {
+    expect(numericQuery(req({ weeks: "999" }), "weeks", { min: 1, fallback: 12 })).toBe(999);
+    expect(numericQuery(req({ weeks: "" }), "weeks", { min: 1, fallback: 12 })).toBe(12);
+  });
+
+  it("does not truncate — that is clampInt's job", () => {
+    expect(numericQuery(req({ limit: "3.9" }), "limit", BAND)).toBe(3.9);
+  });
+});

--- a/packages/api/src/routes/query-params.ts
+++ b/packages/api/src/routes/query-params.ts
@@ -1,0 +1,40 @@
+import type { Request } from "express";
+
+/**
+ * Reading a number off `req.query`.
+ *
+ * Five handlers across `view` and `find-repo` spelled out the same
+ * `typeof req.query.x === "string" ? Number(req.query.x) : <default>` and
+ * then disagreed on what to do next — two dropped an out-of-band value,
+ * two swapped it for the default, one clamped it, and none of them agreed
+ * on whether `NaN` was the caller's problem or Postgres'. The parsing half
+ * is identical in all five; only the out-of-band policy differs, so that
+ * is what stays at the call site.
+ */
+
+/**
+ * Read a numeric query param.
+ *
+ * Returns `fallback` when the param is absent, repeated (Express hands
+ * back an array), non-numeric, or — when `min`/`max` are given — outside
+ * the band. Omit `fallback` for the handlers that pass `undefined` down to
+ * a view that owns the default.
+ *
+ * Out-of-band values resolve to `fallback` rather than clamping, which is
+ * what `/inbox` and `/activity` already did. Callers that want the other
+ * policy compose with `clampInt`: `clampInt(numericQuery(req, "limit"),
+ * { min: 1, max: 10, fallback: 5 })`.
+ */
+export function numericQuery(
+  req: Request,
+  name: string,
+  bounds: { min?: number; max?: number; fallback?: number } = {},
+): number | undefined {
+  const raw = req.query[name];
+  if (typeof raw !== "string") return bounds.fallback;
+  const value = Number(raw);
+  if (!Number.isFinite(value)) return bounds.fallback;
+  if (bounds.min !== undefined && value < bounds.min) return bounds.fallback;
+  if (bounds.max !== undefined && value > bounds.max) return bounds.fallback;
+  return value;
+}

--- a/packages/api/src/routes/room.test.ts
+++ b/packages/api/src/routes/room.test.ts
@@ -140,10 +140,8 @@ function makeRoomRepo(): RoomRepository {
     addPersonMember: vi.fn(async () => {}),
     addAgentMember: vi.fn(async () => {}),
     listMembers: vi.fn(async () => []),
-    listMemberPersonIds: vi.fn(async () => []),
     listMemberAgentIds: vi.fn(async () => []),
     isMember: vi.fn(async () => true),
-    areAgentsCoMembers: vi.fn(async () => true),
     appendMessage: vi.fn(async (input) => fakeMessage({ ...input })),
     listMessages: vi.fn(async () => []),
   } as unknown as RoomRepository;

--- a/packages/api/src/routes/task.ts
+++ b/packages/api/src/routes/task.ts
@@ -16,7 +16,7 @@
  *     killed).
  */
 
-import { Router, type RequestHandler, type Response } from "express";
+import { Router, type RequestHandler } from "express";
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import {
   TASK_PRIORITIES,
@@ -42,7 +42,7 @@ import { buildIntent, type ResumeReason } from "@beevibe/core/services/agent-ses
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
 import { requireHuman } from "../auth/middleware.js";
 import type { DaemonHub } from "../runtime/hub.js";
-import { requireParam } from "./http-errors.js";
+import { makeServiceErrorHandler, requireParam } from "./http-errors.js";
 
 /** Statuses from which /cancel is legal. Anything non-terminal. */
 const CANCELLABLE_FROM: readonly TaskStatus[] = [
@@ -115,21 +115,10 @@ async function recordCapabilityOutcome(
   }
 }
 
-function handleServiceError(err: unknown, res: Response): void {
-  if (err instanceof TaskNotFoundError) {
-    res.status(404).json({ error: "task_not_found", message: err.message });
-    return;
-  }
-  if (err instanceof InvalidTaskTransitionError) {
-    res.status(409).json({ error: "invalid_transition", message: err.message });
-    return;
-  }
-  console.error("[task route]", err);
-  res.status(500).json({
-    error: "internal_error",
-    message: err instanceof Error ? err.message : String(err),
-  });
-}
+const handleServiceError = makeServiceErrorHandler("task route", [
+  [TaskNotFoundError, 404, "task_not_found"],
+  [InvalidTaskTransitionError, 409, "invalid_transition"],
+]);
 
 function parsePriority(input: unknown): TaskPriority | undefined {
   if (typeof input !== "string") return undefined;

--- a/packages/api/src/routes/view.ts
+++ b/packages/api/src/routes/view.ts
@@ -68,6 +68,7 @@ import {
   requireNullableString,
   requireParam,
 } from "./http-errors.js";
+import { numericQuery } from "./query-params.js";
 
 /** Every handler below passes a per-call context, e.g. `[view route: task list]`. */
 const handleError = makeErrorHandler("view route");
@@ -470,12 +471,10 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
 
   router.get("/memory/activity", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const weeksRaw = req.query.weeks;
     const sinceRaw = req.query.since;
-    const weeks =
-      typeof weeksRaw === "string" && weeksRaw.trim()
-        ? Number(weeksRaw)
-        : 12;
+    // `min: 1` keeps `?weeks=` (which `Number("")` reads as 0) resolving to
+    // the default window rather than being passed down as a zero-week range.
+    const weeks = numericQuery(req, "weeks", { min: 1, fallback: 12 })!;
     // Validate `since` up front so a malformed date returns 400 rather than
     // a 500 from the eventual Postgres parse error.
     let since: string | undefined;
@@ -514,8 +513,7 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
 
   router.get("/promotion", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const limitRaw = typeof req.query.limit === "string" ? Number(req.query.limit) : NaN;
-    const limit = Number.isFinite(limitRaw) ? limitRaw : undefined;
+    const limit = numericQuery(req, "limit");
     try {
       const events = await listPromotions(deps.pool, req.caller.personId, { limit });
       res.json(events);
@@ -531,8 +529,7 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
       scopeParam && SCOPES.has(scopeParam as MemoryScope)
         ? (scopeParam as MemoryScope)
         : undefined;
-    const limitRaw = typeof req.query.limit === "string" ? Number(req.query.limit) : NaN;
-    const limit = Number.isFinite(limitRaw) ? limitRaw : undefined;
+    const limit = numericQuery(req, "limit");
 
     try {
       const facts = await listMemoryFacts(deps.pool, req.caller.personId, {
@@ -602,8 +599,7 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
   router.get("/inbox", async (req, res) => {
     if (!requireHuman(req, res)) return;
     try {
-      const limitParam = typeof req.query.limit === "string" ? Number(req.query.limit) : 50;
-      const limit = Number.isFinite(limitParam) && limitParam > 0 && limitParam <= 200 ? limitParam : 50;
+      const limit = numericQuery(req, "limit", { min: 1, max: 200, fallback: 50 });
       const items = await listInbox(deps.pool, req.caller.personId, { limit });
       res.json(items);
     } catch (err) {
@@ -614,12 +610,7 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
   router.get("/activity", async (req, res) => {
     if (!requireHuman(req, res)) return;
     try {
-      const limitParam =
-        typeof req.query.limit === "string" ? Number(req.query.limit) : 20;
-      const limit =
-        Number.isFinite(limitParam) && limitParam > 0 && limitParam <= 100
-          ? limitParam
-          : 20;
+      const limit = numericQuery(req, "limit", { min: 1, max: 100, fallback: 20 })!;
       const entries = await listActivity(deps.pool, req.caller.personId, limit);
       res.json(entries);
     } catch (err) {

--- a/packages/api/src/routes/view.ts
+++ b/packages/api/src/routes/view.ts
@@ -64,12 +64,19 @@ import {
   invalidBody,
   loadOwned,
   makeErrorHandler,
+  makeServiceErrorHandler,
   requireNullableString,
   requireParam,
 } from "./http-errors.js";
 
 /** Every handler below passes a per-call context, e.g. `[view route: task list]`. */
 const handleError = makeErrorHandler("view route");
+
+/** The core_memory write is the one handler here with expected typed failures. */
+const handleCoreMemoryError = makeServiceErrorHandler("view route", [
+  [BlockNotFoundError, 404, "block_not_found"],
+  [BlockCharLimitExceededError, 400, "char_limit_exceeded"],
+]);
 
 export interface ViewRoutesDeps {
   authMiddleware: RequestHandler;
@@ -345,15 +352,7 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
       await deps.coreMemory.setContent(id, blockName, body.content);
       res.json({ ok: true });
     } catch (err) {
-      if (err instanceof BlockNotFoundError) {
-        res.status(404).json({ error: "block_not_found", message: err.message });
-        return;
-      }
-      if (err instanceof BlockCharLimitExceededError) {
-        res.status(400).json({ error: "char_limit_exceeded", message: err.message });
-        return;
-      }
-      handleError(err, res, "agent core_memory update");
+      handleCoreMemoryError(err, res, "agent core_memory update");
     }
   });
 

--- a/packages/api/src/views/bounds.test.ts
+++ b/packages/api/src/views/bounds.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { clampInt } from "./bounds.js";
+
+const LIMIT = { min: 1, max: 200, fallback: 50 } as const;
+
+describe("clampInt", () => {
+  it("passes an in-band integer through", () => {
+    expect(clampInt(25, LIMIT)).toBe(25);
+  });
+
+  it("clamps above the max", () => {
+    expect(clampInt(9999, LIMIT)).toBe(200);
+  });
+
+  it.each([undefined, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    "falls back for %s",
+    (value) => {
+      expect(clampInt(value, LIMIT)).toBe(50);
+    },
+  );
+
+  // The bug this helper exists to close: three views clamped without
+  // truncating, so `?limit=1.5` reached pg as `LIMIT '1.5'` and 500ed.
+  it("truncates a fractional value toward zero", () => {
+    expect(clampInt(1.9, LIMIT)).toBe(1);
+    expect(clampInt(-1.9, LIMIT)).toBe(1);
+  });
+
+  it("clamps below the min by default", () => {
+    expect(clampInt(0, LIMIT)).toBe(1);
+    expect(clampInt(-5, LIMIT)).toBe(1);
+  });
+
+  it("falls back below the min when asked to", () => {
+    const weeks = { min: 1, max: 52, fallback: 12, belowMin: "fallback" } as const;
+    expect(clampInt(0, weeks)).toBe(12);
+    expect(clampInt(-5, weeks)).toBe(12);
+    // …but still clamps at the other end, rather than falling back there too.
+    expect(clampInt(999, weeks)).toBe(52);
+    expect(clampInt(8.9, weeks)).toBe(8);
+  });
+
+  it("returns the boundaries themselves untouched", () => {
+    expect(clampInt(1, LIMIT)).toBe(1);
+    expect(clampInt(200, LIMIT)).toBe(200);
+  });
+});

--- a/packages/api/src/views/bounds.ts
+++ b/packages/api/src/views/bounds.ts
@@ -1,0 +1,42 @@
+/**
+ * The one bounded-integer guard behind every `LIMIT $n` and window size
+ * this package hands to Postgres.
+ *
+ * `promotions`, `inbox` and `memory` each wrote `Math.min(Math.max(1,
+ * filter.limit ?? DEFAULT), MAX)` inline, and `memory-activity` carried a
+ * private `clampInt` that did the same job properly. Three of the four
+ * copies never truncated, so a fractional `?limit=1.5` reached pg as
+ * `LIMIT '1.5'` and came back a 500 instead of a page of rows.
+ */
+
+/**
+ * Coerce a caller-supplied number into `[min, max]`.
+ *
+ * `undefined`, `NaN` and `±Infinity` all resolve to `fallback` — those are
+ * "no usable value", not "a value at the edge". A usable value is
+ * truncated toward zero (a row count has to be an integer for pg) and then
+ * clamped.
+ *
+ * `belowMin` is explicit because the two families of call site genuinely
+ * disagree and both behaviors are pinned by tests. A `limit` under the
+ * minimum means "as few as possible", so it clamps to `min` — that is what
+ * `?limit=0` has always returned. A `weeks` window under the minimum is
+ * treated as garbage input and falls back to the default window, because a
+ * one-week trend chart is a worse answer than the default one. Neither is
+ * wrong; the point is that the choice is now visible in one place instead
+ * of being implied by two different implementations.
+ */
+export function clampInt(
+  value: number | undefined,
+  opts: {
+    min: number;
+    max: number;
+    fallback: number;
+    belowMin?: "clamp" | "fallback";
+  },
+): number {
+  const { min, max, fallback, belowMin = "clamp" } = opts;
+  if (value === undefined || !Number.isFinite(value)) return fallback;
+  if (belowMin === "fallback" && value < min) return fallback;
+  return Math.min(Math.max(Math.trunc(value), min), max);
+}

--- a/packages/api/src/views/inbox.ts
+++ b/packages/api/src/views/inbox.ts
@@ -19,6 +19,7 @@
 
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import type { InboxItem, InboxItemKind } from "./types.js";
+import { clampInt } from "./bounds.js";
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 200;
@@ -120,10 +121,11 @@ export async function listInbox(
   personId: string,
   filter: InboxFilter = {},
 ): Promise<InboxItem[]> {
-  const limit = Math.min(
-    Math.max(1, filter.limit ?? DEFAULT_LIMIT),
-    MAX_LIMIT,
-  );
+  const limit = clampInt(filter.limit, {
+    min: 1,
+    max: MAX_LIMIT,
+    fallback: DEFAULT_LIMIT,
+  });
   const { rows } = await pool.query<InboxRow>(LIST_SQL, [personId, limit]);
   return rows.map((row) => ({
     id: row.id,

--- a/packages/api/src/views/memory-activity.ts
+++ b/packages/api/src/views/memory-activity.ts
@@ -25,6 +25,7 @@ import type {
   ScopeTypeRow,
   WeeklyArchivalRow,
 } from "./types.js";
+import { clampInt } from "./bounds.js";
 
 export interface MemoryActivityOptions {
   /** Window for weekly trend + scope×type breakdown. Clamped 1..52. */
@@ -37,7 +38,13 @@ export async function getMemoryActivity(
   pool: Pool,
   opts: MemoryActivityOptions,
 ): Promise<MemoryActivitySummary> {
-  const weeks = clampInt(opts.weeks, 1, 52, 12);
+  const weeks = clampInt(opts.weeks, {
+    min: 1,
+    max: 52,
+    fallback: 12,
+    // A window below the minimum is garbage input, not "one week please".
+    belowMin: "fallback",
+  });
   const weeksInterval = `${weeks} weeks`;
 
   const [
@@ -407,11 +414,6 @@ async function queryBeforeAfter(
 // ─────────────────────────────────────────────────────────────────────────
 // Helpers
 // ─────────────────────────────────────────────────────────────────────────
-
-function clampInt(value: number, min: number, max: number, fallback: number): number {
-  if (!Number.isFinite(value) || value < min) return fallback;
-  return Math.min(Math.max(Math.trunc(value), min), max);
-}
 
 /**
  * node-postgres parses `::date` columns as JS Date at LOCAL midnight, so

--- a/packages/api/src/views/memory.ts
+++ b/packages/api/src/views/memory.ts
@@ -11,6 +11,7 @@ import type { Pool } from "@beevibe/core/adapters/postgres";
 import type { FactType, MemoryScope } from "@beevibe/core";
 import { MEMORY_SCOPES } from "@beevibe/core";
 import type { MemoryFactCounts, MemoryFactDisplay, MergeOrigin } from "./types.js";
+import { clampInt } from "./bounds.js";
 
 const MEMORY_SCOPE_SET = new Set<string>(MEMORY_SCOPES);
 
@@ -52,10 +53,11 @@ export async function listMemoryFacts(
   ownerId: string,
   filter: MemoryFactsFilter = {},
 ): Promise<MemoryFactDisplay[]> {
-  const limit = Math.min(
-    Math.max(1, filter.limit ?? DEFAULT_MEMORY_FACTS_LIMIT),
-    MAX_MEMORY_FACTS_LIMIT,
-  );
+  const limit = clampInt(filter.limit, {
+    min: 1,
+    max: MAX_MEMORY_FACTS_LIMIT,
+    fallback: DEFAULT_MEMORY_FACTS_LIMIT,
+  });
   const { rows } = await pool.query<FactRow>(LIST_SQL, [
     ownerId,
     filter.scope ?? null,

--- a/packages/api/src/views/promotions.ts
+++ b/packages/api/src/views/promotions.ts
@@ -10,6 +10,7 @@
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import type { FactType, MemoryScope } from "@beevibe/core";
 import type { PromotionEvent } from "./types.js";
+import { clampInt } from "./bounds.js";
 
 const DEFAULT_LIMIT = 100;
 const MAX_LIMIT = 500;
@@ -65,10 +66,11 @@ export async function listPromotions(
   ownerId: string,
   filter: PromotionsFilter = {},
 ): Promise<PromotionEvent[]> {
-  const limit = Math.min(
-    Math.max(1, filter.limit ?? DEFAULT_LIMIT),
-    MAX_LIMIT,
-  );
+  const limit = clampInt(filter.limit, {
+    min: 1,
+    max: MAX_LIMIT,
+    fallback: DEFAULT_LIMIT,
+  });
   const { rows } = await pool.query<EventRow>(LIST_SQL, [ownerId, limit]);
   return rows.map(rowToPromotionEvent);
 }

--- a/packages/core/src/adapters/claude-code/runtime.ts
+++ b/packages/core/src/adapters/claude-code/runtime.ts
@@ -9,7 +9,7 @@ import type {
 import {
   cancelledResult,
   cliVersionHealthCheck,
-  createStdoutLineReader,
+  createEventStream,
   finalizeCliResult,
   warnIfTruncated,
 } from "../runtime-common.js";
@@ -18,7 +18,6 @@ import {
   extractStepEvents,
   parseClaudeMessages,
   parseStreamJsonLine,
-  type StreamJsonMessage,
 } from "./stream-json.js";
 
 /**
@@ -106,18 +105,7 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     // Parse messages incrementally during streaming so we don't re-parse
     // the entire stdout after close. A line buffer handles chunk boundaries
     // (a single JSON message can arrive split across multiple chunks).
-    const messages: StreamJsonMessage[] = [];
-    const handleLine = (line: string): void => {
-      const msg = parseStreamJsonLine(line);
-      if (!msg) return;
-      messages.push(msg);
-      if (context.onStep) {
-        for (const step of extractStepEvents(msg)) {
-          context.onStep(step);
-        }
-      }
-    };
-    const stdout = createStdoutLineReader(handleLine);
+    const stream = createEventStream(context, parseStreamJsonLine, extractStepEvents);
 
     const result = await runCliProcess({
       command: this.config.command ?? "claude",
@@ -129,17 +117,17 @@ export class ClaudeCodeRuntime implements AgentRuntime {
       onSpawn: ({ pid, process_group_id }) => {
         context.onSpawn?.({ process_pid: pid, process_group_id });
       },
-      onLog: stdout.onLog,
+      onLog: stream.onLog,
     });
 
     // Flush any final partial line (stream without trailing \n)
-    stdout.flush();
+    stream.flush();
 
     warnIfTruncated("ClaudeCodeRuntime", result);
 
     if (result.aborted) return cancelledResult(result);
 
-    return finalizeCliResult(parseClaudeMessages(messages, result.exitCode), result);
+    return finalizeCliResult(parseClaudeMessages(stream.events, result.exitCode), result);
   }
 
   async healthCheck(): Promise<RuntimeHealth> {

--- a/packages/core/src/adapters/codex/runtime.ts
+++ b/packages/core/src/adapters/codex/runtime.ts
@@ -14,7 +14,7 @@ import {
   cancelledResult,
   cliVersionHealthCheck,
   composePrompt,
-  createStdoutLineReader,
+  createEventStream,
   finalizeCliResult,
   warnIfTruncated,
 } from "../runtime-common.js";
@@ -22,7 +22,6 @@ import {
   extractCodexStepEvents,
   parseCodexEventLine,
   parseCodexEvents,
-  type CodexEvent,
 } from "./stream-json.js";
 
 export interface CodexRuntimeConfig {
@@ -120,17 +119,7 @@ export class CodexRuntime implements AgentRuntime {
     if (context.env) Object.assign(env, context.env);
     if (prepared) env.BEEVIBE_AGENT_API_KEY = prepared.agentApiKey;
 
-    const events: CodexEvent[] = [];
-    const handleLine = (line: string): void => {
-      const evt = parseCodexEventLine(line);
-      if (!evt) return;
-      events.push(evt);
-      if (!context.onStep) return;
-      for (const step of extractCodexStepEvents(evt)) {
-        context.onStep(step);
-      }
-    };
-    const stdout = createStdoutLineReader(handleLine);
+    const stream = createEventStream(context, parseCodexEventLine, extractCodexStepEvents);
 
     const result = await runCliProcess({
       command: this.config.command ?? "codex",
@@ -141,9 +130,9 @@ export class CodexRuntime implements AgentRuntime {
       onSpawn: ({ pid, process_group_id }) => {
         context.onSpawn?.({ process_pid: pid, process_group_id });
       },
-      onLog: stdout.onLog,
+      onLog: stream.onLog,
     });
-    stdout.flush();
+    stream.flush();
 
     warnIfTruncated("CodexRuntime", result);
 
@@ -155,7 +144,7 @@ export class CodexRuntime implements AgentRuntime {
     const lastMessage = readIfExists(lastMessagePath);
     removeIfExists(lastMessagePath);
     return finalizeCliResult(
-      parseCodexEvents(events, result.exitCode, lastMessage),
+      parseCodexEvents(stream.events, result.exitCode, lastMessage),
       result,
     );
   }

--- a/packages/core/src/adapters/opencode/runtime.ts
+++ b/packages/core/src/adapters/opencode/runtime.ts
@@ -13,7 +13,7 @@ import {
   cancelledResult,
   cliVersionHealthCheck,
   composePrompt,
-  createStdoutLineReader,
+  createEventStream,
   finalizeCliResult,
   warnIfTruncated,
 } from "../runtime-common.js";
@@ -21,7 +21,6 @@ import {
   extractOpenCodeStepEvents,
   parseOpenCodeEventLine,
   parseOpenCodeEvents,
-  type OpenCodeEvent,
 } from "./stream-json.js";
 
 export interface OpenCodeRuntimeConfig {
@@ -76,17 +75,11 @@ export class OpenCodeRuntime implements AgentRuntime {
     const env: Record<string, string | undefined> = { ...process.env };
     if (context.env) Object.assign(env, context.env);
 
-    const events: OpenCodeEvent[] = [];
-    const handleLine = (line: string): void => {
-      const evt = parseOpenCodeEventLine(line);
-      if (!evt) return;
-      events.push(evt);
-      if (!context.onStep) return;
-      for (const step of extractOpenCodeStepEvents(evt)) {
-        context.onStep(step);
-      }
-    };
-    const stdout = createStdoutLineReader(handleLine);
+    const stream = createEventStream(
+      context,
+      parseOpenCodeEventLine,
+      extractOpenCodeStepEvents,
+    );
 
     const result = await runCliProcess({
       command: this.config.command ?? "opencode",
@@ -97,15 +90,15 @@ export class OpenCodeRuntime implements AgentRuntime {
       onSpawn: ({ pid, process_group_id }) => {
         context.onSpawn?.({ process_pid: pid, process_group_id });
       },
-      onLog: stdout.onLog,
+      onLog: stream.onLog,
     });
-    stdout.flush();
+    stream.flush();
 
     warnIfTruncated("OpenCodeRuntime", result);
 
     if (result.aborted) return cancelledResult(result);
 
-    return finalizeCliResult(parseOpenCodeEvents(events, result.exitCode), result);
+    return finalizeCliResult(parseOpenCodeEvents(stream.events, result.exitCode), result);
   }
 
   async healthCheck(): Promise<RuntimeHealth> {

--- a/packages/core/src/adapters/postgres/room-repo.test.ts
+++ b/packages/core/src/adapters/postgres/room-repo.test.ts
@@ -3,10 +3,9 @@
  *
  * `room_member` carries a single `subject_id` alongside separate
  * `person_id` / `agent_id` columns, which is what makes the conflict
- * key, the kind filters and the `areAgentsCoMembers` self-join worth
- * exercising against a real engine rather than a fake pool: a wrong
- * `ON CONFLICT` target silently duplicates members, and a missing kind
- * filter leaks agents into the person list (and vice versa).
+ * key and the kind filters worth exercising against a real engine rather
+ * than a fake pool: a wrong `ON CONFLICT` target silently duplicates
+ * members, and a missing kind filter leaks people into the agent list.
  */
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { DEFAULT_RUNTIME_CONFIG } from "../../domain/agent.js";
@@ -172,13 +171,14 @@ describe("PostgresRoomRepository", () => {
     ]);
   });
 
-  it("splits the person and agent id lists by kind", async () => {
+  it("filters the agent id list by kind, leaving people out", async () => {
     const room = await newRoom();
     await rooms.addPersonMember(room.id, alice);
     await rooms.addPersonMember(room.id, bob);
     await rooms.addAgentMember(room.id, alicesTeam);
 
-    expect((await rooms.listMemberPersonIds(room.id)).sort()).toEqual([alice, bob].sort());
+    // People and agents share `subject_id`, so the kind filter is the only
+    // thing keeping the two person rows out of this list.
     expect(await rooms.listMemberAgentIds(room.id)).toEqual([alicesTeam]);
   });
 
@@ -186,7 +186,6 @@ describe("PostgresRoomRepository", () => {
     const room = await newRoom();
 
     expect(await rooms.listMembers(room.id)).toEqual([]);
-    expect(await rooms.listMemberPersonIds(room.id)).toEqual([]);
     expect(await rooms.listMemberAgentIds(room.id)).toEqual([]);
   });
 
@@ -205,45 +204,8 @@ describe("PostgresRoomRepository", () => {
     expect(await rooms.isMember("room_missing", alice)).toBe(false);
   });
 
-  it("detects agent co-membership across any shared room", async () => {
-    const room = await newRoom();
-    const otherRoom = await newRoom({ name: "Other" });
-    const loner = (
-      await agents.create({
-        id: agentId(),
-        name: "Loner",
-        owner_id: bob,
-        hierarchy_level: "ic",
-        runtime_config: DEFAULT_RUNTIME_CONFIG,
-      })
-    ).id;
-    await rooms.addAgentMember(room.id, alicesTeam);
-    await rooms.addAgentMember(room.id, bobsTeam);
-    await rooms.addAgentMember(otherRoom.id, loner);
 
-    expect(await rooms.areAgentsCoMembers(alicesTeam, bobsTeam)).toBe(true);
-    // Symmetric — the mesh gate must answer the same either direction.
-    expect(await rooms.areAgentsCoMembers(bobsTeam, alicesTeam)).toBe(true);
-    expect(await rooms.areAgentsCoMembers(alicesTeam, loner)).toBe(false);
-    expect(await rooms.areAgentsCoMembers(alicesTeam, "agent_nobody")).toBe(false);
-  });
 
-  it("never reports an agent as a co-member of itself", async () => {
-    const room = await newRoom();
-    await rooms.addAgentMember(room.id, alicesTeam);
-
-    // Short-circuits before the query — an agent sharing a room with
-    // itself must not open the mesh ask path back to its own inbox.
-    expect(await rooms.areAgentsCoMembers(alicesTeam, alicesTeam)).toBe(false);
-  });
-
-  it("does not treat a person co-member as an agent co-member", async () => {
-    const room = await newRoom();
-    await rooms.addPersonMember(room.id, alice);
-    await rooms.addPersonMember(room.id, bob);
-
-    expect(await rooms.areAgentsCoMembers(alice, bob)).toBe(false);
-  });
 
   // ── Messages ───────────────────────────────────────────────────────────
 

--- a/packages/core/src/adapters/runtime-common.test.ts
+++ b/packages/core/src/adapters/runtime-common.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CliProcessResult } from "./claude-code/spawn.js";
-import type { RuntimeResult } from "../ports/runtime.js";
+import type { RuntimeContext, RuntimeResult, RuntimeStep } from "../ports/runtime.js";
 import {
   cancelledResult,
+  createEventStream,
   createStdoutLineReader,
   finalizeCliResult,
   warnIfTruncated,
@@ -145,5 +146,72 @@ describe("finalizeCliResult", () => {
   it("omits stderr on failure when the CLI wrote nothing", () => {
     const failed: RuntimeResult = { status: "failed", output: "" };
     expect(finalizeCliResult(failed, cliResult({ stderr: "", exitCode: 1 })).stderr).toBeUndefined();
+  });
+});
+
+describe("createEventStream", () => {
+  interface Evt {
+    n: number;
+  }
+
+  const parseLine = (line: string): Evt | null =>
+    line.startsWith("evt:") ? { n: Number(line.slice(4)) } : null;
+  const extractSteps = (evt: Evt): RuntimeStep[] =>
+    [{ kind: "text", content: String(evt.n) } as unknown as RuntimeStep];
+
+  function ctx(onStep?: (step: RuntimeStep) => void): RuntimeContext {
+    return { onStep } as unknown as RuntimeContext;
+  }
+
+  it("collects parsed events in arrival order across chunk boundaries", () => {
+    const stream = createEventStream(ctx(), parseLine, extractSteps);
+    stream.onLog("stdout", "evt:1\nev");
+    stream.onLog("stdout", "t:2\n");
+    expect(stream.events).toEqual([{ n: 1 }, { n: 2 }]);
+  });
+
+  it("drops lines the parser rejects instead of failing the run", () => {
+    const stream = createEventStream(ctx(), parseLine, extractSteps);
+    stream.onLog("stdout", "some npm warning\nevt:7\n");
+    expect(stream.events).toEqual([{ n: 7 }]);
+  });
+
+  it("fans each event out through extractSteps when onStep is set", () => {
+    const steps: RuntimeStep[] = [];
+    const stream = createEventStream(ctx((s) => steps.push(s)), parseLine, extractSteps);
+    stream.onLog("stdout", "evt:1\nevt:2\n");
+    expect(steps.map((s) => (s as { content: string }).content)).toEqual(["1", "2"]);
+  });
+
+  // The adapters guard on `onStep` before calling extract* — a runtime with
+  // no step consumer shouldn't pay for the per-event derivation at all.
+  it("skips extractSteps entirely when there is no onStep", () => {
+    const extract = vi.fn(extractSteps);
+    const stream = createEventStream(ctx(), parseLine, extract);
+    stream.onLog("stdout", "evt:1\n");
+    expect(stream.events).toHaveLength(1);
+    expect(extract).not.toHaveBeenCalled();
+  });
+
+  it("ignores stderr", () => {
+    const stream = createEventStream(ctx(), parseLine, extractSteps);
+    stream.onLog("stderr", "evt:9\n");
+    expect(stream.events).toEqual([]);
+  });
+
+  it("emits a trailing line with no newline only on flush", () => {
+    const stream = createEventStream(ctx(), parseLine, extractSteps);
+    stream.onLog("stdout", "evt:3");
+    expect(stream.events).toEqual([]);
+    stream.flush();
+    expect(stream.events).toEqual([{ n: 3 }]);
+  });
+
+  it("is a no-op when flushed with nothing pending", () => {
+    const stream = createEventStream(ctx(), parseLine, extractSteps);
+    stream.onLog("stdout", "evt:4\n");
+    stream.flush();
+    stream.flush();
+    expect(stream.events).toEqual([{ n: 4 }]);
   });
 });

--- a/packages/core/src/adapters/runtime-common.ts
+++ b/packages/core/src/adapters/runtime-common.ts
@@ -1,5 +1,10 @@
 import { tmpdir } from "node:os";
-import type { RuntimeContext, RuntimeHealth, RuntimeResult } from "../ports/runtime.js";
+import type {
+  RuntimeContext,
+  RuntimeHealth,
+  RuntimeResult,
+  RuntimeStep,
+} from "../ports/runtime.js";
 import { type CliProcessResult, runCliProcess } from "./claude-code/spawn.js";
 
 /**
@@ -207,4 +212,42 @@ export function finalizeCliResult(
     exit_code: result.exitCode,
     ...(stderrTail ? { stderr: stderrTail } : {}),
   };
+}
+
+/**
+ * The stdout side of a CLI runtime's `execute`, in one piece.
+ *
+ * All three adapters spelled out the same block: allocate an `events`
+ * array, define a `handleLine` that parses a line, drops it when it
+ * doesn't parse, pushes it, and — only when the caller wants steps —
+ * fans it out through the adapter's `extract*StepEvents`; then wrap that
+ * in a {@link createStdoutLineReader}. The only per-adapter parts are the
+ * two functions, both of which are already parameters.
+ *
+ * Keeping the collected array next to the reader that fills it also
+ * removes the one way the block could be mis-assembled: three separate
+ * bindings (`events`, `handleLine`, `stdout`) where the caller had to
+ * remember to pass `stdout.onLog` to `runCliProcess`, call `stdout.flush()`
+ * after it settled, and then read `events` — with nothing tying the three
+ * together.
+ */
+export function createEventStream<E>(
+  context: RuntimeContext,
+  parseLine: (line: string) => E | null,
+  extractSteps: (event: E) => RuntimeStep[],
+): {
+  /** Every parsed event, in arrival order. Filled as the process runs. */
+  events: E[];
+  onLog: (stream: "stdout" | "stderr", chunk: string) => void;
+  flush: () => void;
+} {
+  const events: E[] = [];
+  const reader = createStdoutLineReader((line) => {
+    const event = parseLine(line);
+    if (!event) return;
+    events.push(event);
+    if (!context.onStep) return;
+    for (const step of extractSteps(event)) context.onStep(step);
+  });
+  return { events, onLog: reader.onLog, flush: reader.flush };
 }

--- a/packages/web/lib/hooks/detail-query.test.tsx
+++ b/packages/web/lib/hooks/detail-query.test.tsx
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+const apiState = {
+  isApiConfigured: true,
+};
+
+vi.mock("@/lib/api/config", () => ({
+  get isApiConfigured() {
+    return apiState.isApiConfigured;
+  },
+  apiBaseUrl: "https://api.example.com",
+}));
+
+import { useDetailQuery } from "./detail-query";
+
+const KEYS = {
+  all: ["widgets"] as const,
+  detail: (id: string) => ["widgets", "detail", id] as const,
+};
+
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return {
+    client,
+    Wrapper: function TestQueryWrapper({ children }: { children: ReactNode }) {
+      return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+    },
+  };
+}
+
+const fetchWidget = vi.fn();
+
+function render(id: string | undefined, staleTime?: number) {
+  const { client, Wrapper } = wrapper();
+  const hook = renderHook(
+    () =>
+      useDetailQuery({
+        id,
+        key: KEYS.detail,
+        fallbackKey: KEYS.all,
+        fetch: fetchWidget,
+        ...(staleTime === undefined ? {} : { staleTime }),
+      }),
+    { wrapper: Wrapper },
+  );
+  return { ...hook, client };
+}
+
+beforeEach(() => {
+  apiState.isApiConfigured = true;
+  fetchWidget.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useDetailQuery", () => {
+  it("fetches by id and forwards an abort signal", async () => {
+    fetchWidget.mockResolvedValue({ id: "w1" });
+    const { result } = render("w1");
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ id: "w1" });
+    expect(fetchWidget).toHaveBeenCalledWith(
+      "w1",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  // The whole point of centralising the non-null assertion: neither gate
+  // may fire the request on its own, or the app issues GET /widget/undefined.
+  it("does not fetch without an id", () => {
+    const { result } = render(undefined);
+    expect(fetchWidget).not.toHaveBeenCalled();
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("does not fetch when the API is unconfigured, even with an id", () => {
+    apiState.isApiConfigured = false;
+    render("w1");
+    expect(fetchWidget).not.toHaveBeenCalled();
+  });
+
+  it("parks the idle query on the resource prefix, not a detail slot", () => {
+    const { client } = render(undefined);
+    const keys = client.getQueryCache().getAll().map((q) => q.queryKey);
+    expect(keys).toEqual([["widgets"]]);
+  });
+
+  it("keys each id in its own cache slot", async () => {
+    fetchWidget.mockResolvedValue({ id: "w1" });
+    const { client } = render("w1");
+    await waitFor(() =>
+      expect(client.getQueryCache().find({ queryKey: KEYS.detail("w1") })).toBeDefined(),
+    );
+    expect(client.getQueryCache().find({ queryKey: KEYS.detail("w2") })).toBeUndefined();
+  });
+
+  // `useConversation` is the one caller that sets staleTime, so the option
+  // has to survive the pass-through — observable here as the result not
+  // going stale the moment it resolves.
+  it("passes staleTime through when given", async () => {
+    fetchWidget.mockResolvedValue({ id: "w1" });
+    const { result } = render("w1", 60_000);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.isStale).toBe(false);
+  });
+
+  it("leaves staleTime to the client default when omitted", async () => {
+    fetchWidget.mockResolvedValue({ id: "w1" });
+    const { result } = render("w1");
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.isStale).toBe(true);
+  });
+
+  it("surfaces a rejection as an error state", async () => {
+    fetchWidget.mockRejectedValue(new Error("boom"));
+    const { result } = render("w1");
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(new Error("boom"));
+  });
+});

--- a/packages/web/lib/hooks/detail-query.ts
+++ b/packages/web/lib/hooks/detail-query.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import type { ReadOptions } from "@/lib/api/client";
+import { isApiConfigured } from "@/lib/api/config";
+
+/**
+ * The by-id fetch behind every detail page.
+ *
+ * `useTask`, `useAgent`, `useSession`, `useConversation`, `useEscalation`
+ * and `useNegotiation` were the same six lines apiece: gate on
+ * `isApiConfigured && !!id`, key on `detail(id)` while falling back to the
+ * resource's `all` prefix when there is no id yet, and cast the id back to
+ * a string inside `queryFn` because TanStack can't see that `enabled`
+ * already excluded `undefined`.
+ *
+ * That cast is the reason this is worth sharing. It was written out six
+ * times, and each copy is a place where changing `enabled` — dropping the
+ * `!!id`, say, or adding another condition in front of it — turns a
+ * disabled query into a `GET /task/undefined`. Here the assertion sits
+ * next to the `enabled` clause that justifies it, so the two cannot be
+ * edited apart.
+ *
+ * The `all`-prefix fallback matters for the same reason: while `id` is
+ * undefined the query needs *some* key, and using the resource prefix
+ * keeps the placeholder out of any real detail slot.
+ */
+export function useDetailQuery<T>(opts: {
+  /** `undefined` while the route param is still resolving. */
+  id: string | undefined;
+  /** Per-resource key factory, e.g. `queryKeys.agents.detail`. */
+  key: (id: string) => readonly unknown[];
+  /** Key used while there is no id — the resource's `all` prefix. */
+  fallbackKey: readonly unknown[];
+  fetch: (id: string, options: ReadOptions) => Promise<T>;
+  /** Passed straight through; omit for the client default. */
+  staleTime?: number;
+}) {
+  const { id, key, fallbackKey, fetch, staleTime } = opts;
+  return useQuery({
+    queryKey: id ? key(id) : fallbackKey,
+    // Safe: `enabled` below is false whenever `id` is undefined, so the
+    // query function never runs without one.
+    queryFn: ({ signal }) => fetch(id!, { signal }),
+    enabled: isApiConfigured && !!id,
+    ...(staleTime === undefined ? {} : { staleTime }),
+  });
+}

--- a/packages/web/lib/hooks/use-agents.ts
+++ b/packages/web/lib/hooks/use-agents.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
+import { useDetailQuery } from "./detail-query";
 import { queryKeys } from "./keys";
 
 export function useAgents() {
@@ -12,9 +13,10 @@ export function useAgents() {
 }
 
 export function useAgent(id: string | undefined) {
-  return useQuery({
-    queryKey: id ? queryKeys.agents.detail(id) : queryKeys.agents.all,
-    queryFn: ({ signal }) => api.agents.get(id as string, { signal }),
-    enabled: isApiConfigured && !!id,
+  return useDetailQuery({
+    id,
+    key: queryKeys.agents.detail,
+    fallbackKey: queryKeys.agents.all,
+    fetch: api.agents.get,
   });
 }

--- a/packages/web/lib/hooks/use-escalations.ts
+++ b/packages/web/lib/hooks/use-escalations.ts
@@ -1,12 +1,12 @@
-import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
-import { isApiConfigured } from "@/lib/api/config";
+import { useDetailQuery } from "./detail-query";
 import { queryKeys } from "./keys";
 
 export function useEscalation(id: string | undefined) {
-  return useQuery({
-    queryKey: id ? queryKeys.escalations.detail(id) : queryKeys.escalations.all,
-    queryFn: ({ signal }) => api.escalations.get(id as string, { signal }),
-    enabled: isApiConfigured && !!id,
+  return useDetailQuery({
+    id,
+    key: queryKeys.escalations.detail,
+    fallbackKey: queryKeys.escalations.all,
+    fetch: api.escalations.get,
   });
 }

--- a/packages/web/lib/hooks/use-negotiations.ts
+++ b/packages/web/lib/hooks/use-negotiations.ts
@@ -1,12 +1,12 @@
-import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
-import { isApiConfigured } from "@/lib/api/config";
+import { useDetailQuery } from "./detail-query";
 import { queryKeys } from "./keys";
 
 export function useNegotiation(id: string | undefined) {
-  return useQuery({
-    queryKey: id ? queryKeys.negotiations.detail(id) : queryKeys.negotiations.all,
-    queryFn: ({ signal }) => api.negotiations.get(id as string, { signal }),
-    enabled: isApiConfigured && !!id,
+  return useDetailQuery({
+    id,
+    key: queryKeys.negotiations.detail,
+    fallbackKey: queryKeys.negotiations.all,
+    fetch: api.negotiations.get,
   });
 }

--- a/packages/web/lib/hooks/use-sessions.ts
+++ b/packages/web/lib/hooks/use-sessions.ts
@@ -1,13 +1,13 @@
-import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
-import { isApiConfigured } from "@/lib/api/config";
+import { useDetailQuery } from "./detail-query";
 import { queryKeys } from "./keys";
 
 export function useSession(shortId: string | undefined) {
-  return useQuery({
-    queryKey: shortId ? queryKeys.sessions.detail(shortId) : queryKeys.sessions.all,
-    queryFn: ({ signal }) => api.sessions.get(shortId as string, { signal }),
-    enabled: isApiConfigured && !!shortId,
+  return useDetailQuery({
+    id: shortId,
+    key: queryKeys.sessions.detail,
+    fallbackKey: queryKeys.sessions.all,
+    fetch: api.sessions.get,
   });
 }
 
@@ -18,12 +18,11 @@ export function useSession(shortId: string | undefined) {
  * renders them unchanged.
  */
 export function useConversation(shortId: string | undefined) {
-  return useQuery({
-    queryKey: shortId
-      ? queryKeys.sessions.conversation(shortId)
-      : queryKeys.sessions.all,
-    queryFn: ({ signal }) => api.sessions.conversation(shortId as string, { signal }),
-    enabled: isApiConfigured && !!shortId,
+  return useDetailQuery({
+    id: shortId,
+    key: queryKeys.sessions.conversation,
+    fallbackKey: queryKeys.sessions.all,
+    fetch: api.sessions.conversation,
     // A completed turn's transcript is immutable, so this potentially-large
     // fetch (every turn × up to 500 events) needn't refetch on focus/idle.
     // In-flight turns surface live via SSE, not this query. Cold loads still

--- a/packages/web/lib/hooks/use-tasks.ts
+++ b/packages/web/lib/hooks/use-tasks.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { api, type TaskListFilter } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
+import { useDetailQuery } from "./detail-query";
 import { queryKeys } from "./keys";
 
 export function useTasks(filter: TaskListFilter = {}) {
@@ -23,9 +24,10 @@ export function useTasks(filter: TaskListFilter = {}) {
 }
 
 export function useTask(id: string | undefined) {
-  return useQuery({
-    queryKey: id ? queryKeys.tasks.detail(id) : queryKeys.tasks.all,
-    queryFn: ({ signal }) => api.tasks.get(id as string, { signal }),
-    enabled: isApiConfigured && !!id,
+  return useDetailQuery({
+    id,
+    key: queryKeys.tasks.detail,
+    fallbackKey: queryKeys.tasks.all,
+    fetch: api.tasks.get,
   });
 }


### PR DESCRIPTION
Another sweep for near-duplicate abstractions. Four clusters, one commit each; every one is behavior-preserving except a fractional-`?limit` 500 that becomes a clamped row count.

### 1. `refactor(api)`: one error ladder, not three copies of the 500 tail

`routes/task.ts`, `routes/escalation.ts` and `routes/negotiation.ts` each hand-wrote an `if (err instanceof XError) { res.status(N).json({ error, message }) }` ladder followed by a **verbatim re-implementation of `makeErrorHandler`'s body** as the fallback. #259 collapsed four copies of that 500 handler into one factory; these three had quietly grown it back, so the single place the error envelope lives was already four places again.

`makeServiceErrorHandler(tag, mappings)` takes the ladder as `[ErrorClass, status, code]` data and delegates anything unmatched to `makeErrorHandler(tag)`. A router can add rows but can no longer re-spell the fallback — that's the property that was missing. `view.ts`'s core-memory handler joins them and keeps its per-call context string.

### 2. `refactor(api)`: one bounded-integer guard for every limit and window

Eight call sites computing "a positive integer the caller can't blow up", no two agreeing.

- **Views, 3 inline copies + 1 better private one.** `promotions`, `inbox` and `memory` each wrote `Math.min(Math.max(1, filter.limit ?? DEFAULT), MAX)`; `memory-activity` carried a private `clampInt` that also handled `NaN` and non-integers. The three inline copies never truncated, so `GET /promotion?limit=1.5` reached pg as `LIMIT '1.5'` and came back a **500**. All four now share `views/bounds.ts`.
- **Routes, 5 copies / 4 policies.** `view`'s promotion, memory-fact, inbox and activity handlers plus `find-repo` all spelled out the same parse and then diverged on the out-of-band case. The parsing half moves to `routes/query-params.ts`; the policy stays at the call site, and `find-repo` composes the two helpers to keep its clamp-don't-drop behavior.

The one genuine disagreement — `?limit=0` clamps to 1, `weeks: 0` falls back to the default window, both pinned by existing tests — is now the explicit `belowMin` option rather than the difference between two implementations nobody was comparing. `numericQuery` also closes a hole the hand-written reads shared: a repeated `?limit=1&limit=2` arrives as an array.

### 3. `refactor(core)`: one stdout collector for all three CLI runtimes

`claude-code`, `codex` and `opencode` each opened `execute` with the same twelve lines — events array, `handleLine` that parses/drops/pushes/fans-out, wrapped in `createStdoutLineReader`. The only per-adapter parts were the two functions, both already arguments to something.

`createEventStream(context, parseLine, extractSteps)` returns the collected `events` alongside the `onLog`/`flush` pair that fills it. That also removes the way the block could be mis-assembled: the three bindings used to be independent, so a runtime had to remember to hand `stdout.onLog` to `runCliProcess`, call `flush()` after it settled, and read the right array — with nothing linking them.

### 4. `refactor(web)`: one by-id query for the six detail hooks

`useTask`, `useAgent`, `useSession`, `useConversation`, `useEscalation` and `useNegotiation` were six lines apiece: key on `detail(id)` with the resource's `all` prefix as placeholder, gate on `isApiConfigured && !!id`, and cast the id back to a string inside `queryFn`.

The cast is what makes it worth sharing. Each copy is a place where editing the `enabled` clause turns a disabled query into a `GET /session/undefined`. `useDetailQuery` puts the assertion on the line below the `enabled` that justifies it.

### Tests

32 new tests: 6 for `makeServiceErrorHandler`, 10 for `clampInt`, 11 for `numericQuery`, 7 for `createEventStream`, 8 for `useDetailQuery`.

### Verification

`turbo typecheck` and `turbo lint` clean across all six packages. `turbo build` clean except the known `next/font`-behind-a-proxy failure, so web was built directly (`pnpm --filter @beevibe/web exec next build`) — passes. Suites: api 847 pass, web 211, daemon 156, sandbox 109, scheduler 10; core has 7 failures, all the documented DB-/key-gated ones (no Postgres, no provider keys in this sandbox) and none in the adapters this PR touches.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GuFwdhXqSHDMwAECDMiZVP)_