### PR TITLE
test(api): cover the chat route and three untested MCP tools (27-65% → 100%)

### DIFF
--- a/packages/api/src/routes/chat-internals.test.ts
+++ b/packages/api/src/routes/chat-internals.test.ts
@@ -225,6 +225,25 @@ describe("chainToMessages", () => {
     expect(out[3]?.content).toBe("Both done; running tests.");
   });
 
+  it("renders a failed turn's agent bubble via failureMessageFor", () => {
+    const s = makeSession({
+      id: "sess_bad",
+      intent: "deploy",
+      status: "failed",
+      error: "ENOSPC: no space left on device",
+    });
+    const out = chainToMessages({ head_id: s.id, sessions: [s] });
+    expect(out.map((m) => m.role)).toEqual(["user", "agent"]);
+    expect(out[1]?.content).toBe("ENOSPC: no space left on device");
+    expect(out[1]?.session_id).toBe("sess_bad");
+  });
+
+  it("emits no agent bubble for an in-flight turn", () => {
+    const s = makeSession({ id: "sess_run", intent: "deploy", status: "running" });
+    const out = chainToMessages({ head_id: s.id, sessions: [s] });
+    expect(out.map((m) => m.role)).toEqual(["user"]);
+  });
+
   it("preserves a 'Wake reason:' prefix in the system message", () => {
     const s = makeSession({
       id: "sess_wake",

--- a/packages/api/src/routes/chat.test.ts
+++ b/packages/api/src/routes/chat.test.ts
@@ -1,0 +1,970 @@
+/**
+ * `createChatRouter` — the human chat surface — unit tests with vitest
+ * fakes (no DB, no CLI).
+ *
+ * `chat-internals.test.ts` already pins the pure helpers
+ * (`groupIntoConversations`, `chainToMessages`, `failureMessageFor`).
+ * This suite covers the other half of the file: the four handlers and
+ * the branches only reachable through them — the human gate, the
+ * conversation list + soft delete, history rehydration (chain
+ * selection, in-flight tail, runtime-mismatch flag) and the whole POST
+ * ladder (validation → idempotent replay → rate limit → dispatch →
+ * daemon-offline → resolver → onboarding flip → timeout).
+ *
+ * Every port is a `vi.fn()` stub. `ChatRateLimiter` is the real class
+ * with an injected clock, since the 429 bodies it drives are part of
+ * the wire contract these tests pin. `processResponse` also runs for
+ * real — the directive stripping it does is visible in every response
+ * body below.
+ */
+import express, { json } from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  Person,
+  PersonRepository,
+  Runtime,
+  RuntimeRepository,
+  Session,
+  SessionRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import type { ChatResolver } from "../runtime/chat-resolver.js";
+import type { DaemonHub } from "../runtime/hub.js";
+import { ChatRateLimiter } from "./chat-rate-limit.js";
+import { createChatRouter, type ChatRoutesDeps, type ChatSession } from "./chat.js";
+
+// ── Fixtures ─────────────────────────────────────────────────────────────
+
+const PERSON = "person_alice";
+const AGENT = "agent_alicesteam";
+// The route only accepts a caller-supplied session id matching
+// /^sess_[A-Za-z0-9]{12}$/ — anything else falls through to a fresh
+// dispatch, which is its own test below.
+const VALID_CALLER_SESSION = "sess_abc123def456";
+
+function fakeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: AGENT,
+    name: "Alice's Team",
+    owner_id: PERSON,
+    hierarchy_level: "team",
+    runtime_config: { type: "claude" },
+    created_at: new Date("2026-01-01T00:00:00Z"),
+    updated_at: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  } as Agent;
+}
+
+function fakeChat(overrides: Partial<ChatSession> & Pick<ChatSession, "id">): ChatSession {
+  return {
+    intent: "hello",
+    status: "succeeded",
+    created_at: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+function fakeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "sess_dispatched01",
+    agent_id: AGENT,
+    type: "chat",
+    status: "succeeded",
+    intent: "hello",
+    created_at: new Date("2026-01-02T00:00:00Z"),
+    updated_at: new Date("2026-01-02T00:00:00Z"),
+    ...overrides,
+  } as Session;
+}
+
+// ── Fake ports ───────────────────────────────────────────────────────────
+
+interface Ports {
+  agentRepo: AgentRepository;
+  personRepo: PersonRepository;
+  runtimeRepo: RuntimeRepository;
+  sessionRepo: SessionRepository;
+  dispatchService: DispatchService;
+  chatResolver: ChatResolver;
+  hub: DaemonHub;
+  rateLimiter?: ChatRateLimiter;
+}
+
+function makePorts(overrides: Partial<Ports> = {}): Ports {
+  return {
+    agentRepo: {
+      findTopLevelForOwner: vi.fn(async () => fakeAgent()),
+    } as unknown as AgentRepository,
+    personRepo: {
+      findById: vi.fn(
+        async (id: string) =>
+          ({ id, name: "Alice", onboarding_completed_at: new Date() }) as Person,
+      ),
+      update: vi.fn(async () => undefined),
+    } as unknown as PersonRepository,
+    runtimeRepo: {
+      findById: vi.fn(async () => undefined),
+    } as unknown as RuntimeRepository,
+    sessionRepo: {
+      listChatForAgent: vi.fn(async () => [] as ChatSession[]),
+      softDeleteChatChain: vi.fn(async () => 0),
+      findById: vi.fn(async () => undefined),
+    } as unknown as SessionRepository,
+    dispatchService: {
+      dispatchTask: vi.fn(async () => ({ session: fakeSession(), runtime_id: "rt_1" })),
+    } as unknown as DispatchService,
+    chatResolver: {
+      register: vi.fn(async () => fakeSession()),
+    } as unknown as ChatResolver,
+    hub: { isOnline: vi.fn(() => true) } as unknown as DaemonHub,
+    ...overrides,
+  };
+}
+
+/**
+ * Stand-in for `createAuthMiddleware`. The real one resolves a bv_
+ * token against Postgres; these tests only care about the caller shape
+ * `requireHuman` gates on, so the source is set per-app.
+ */
+function stubAuth(source: "human" | "agent" | "none") {
+  return (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    if (source === "human") {
+      req.caller = {
+        source: "human",
+        agentId: AGENT,
+        hierarchyLevel: "team",
+        personId: PERSON,
+      };
+    } else if (source === "agent") {
+      req.caller = { source: "agent", agentId: AGENT, hierarchyLevel: "ic" };
+    }
+    next();
+  };
+}
+
+function makeApp(ports: Ports, source: "human" | "agent" | "none" = "human") {
+  const app = express();
+  app.use(json());
+  app.use(
+    "/chat",
+    createChatRouter({
+      authMiddleware: stubAuth(source),
+      ...ports,
+    } as ChatRoutesDeps),
+  );
+  return app;
+}
+
+// ── GET /chat/conversations ──────────────────────────────────────────────
+
+describe("GET /chat/conversations", () => {
+  it("403s a non-human caller", async () => {
+    const res = await request(makeApp(makePorts(), "agent")).get("/chat/conversations");
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("human_required");
+  });
+
+  it("returns an empty list when the caller has no primary agent", async () => {
+    const ports = makePorts({
+      agentRepo: { findTopLevelForOwner: vi.fn(async () => undefined) } as unknown as AgentRepository,
+    });
+    const res = await request(makeApp(ports)).get("/chat/conversations");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, conversations: [] });
+    // No agent → no history query at all.
+    expect(ports.sessionRepo.listChatForAgent).not.toHaveBeenCalled();
+  });
+
+  it("summarizes each chain: title from the head, turn count, tail timestamp + preview", async () => {
+    const head = fakeChat({
+      id: "sess_head",
+      intent: "plan the launch",
+      result_summary: "Planned.",
+      created_at: new Date("2026-03-01T10:00:00Z"),
+    });
+    const tail = fakeChat({
+      id: "sess_tail",
+      prior_session_id: "sess_head",
+      intent: "and the docs?",
+      result_summary: "Docs drafted.",
+      created_at: new Date("2026-03-01T10:05:00Z"),
+    });
+    const ports = makePorts({
+      sessionRepo: {
+        listChatForAgent: vi.fn(async () => [tail, head]),
+      } as unknown as SessionRepository,
+    });
+    const res = await request(makeApp(ports)).get("/chat/conversations");
+    expect(res.status).toBe(200);
+    expect(res.body.conversations).toEqual([
+      {
+        head_id: "sess_head",
+        title: "plan the launch",
+        turn_count: 2,
+        last_at: "2026-03-01T10:05:00.000Z",
+        last_preview: "Docs drafted.",
+      },
+    ]);
+  });
+
+  it("truncates a long head intent into the thread title", async () => {
+    const long = "x".repeat(200);
+    const ports = makePorts({
+      sessionRepo: {
+        listChatForAgent: vi.fn(async () => [fakeChat({ id: "sess_h", intent: long })]),
+      } as unknown as SessionRepository,
+    });
+    const res = await request(makeApp(ports)).get("/chat/conversations");
+    // CHAT_THREAD_TITLE_MAX is 80; truncate keeps n-1 chars + ellipsis.
+    expect(res.body.conversations[0].title).toHaveLength(80);
+    expect(res.body.conversations[0].title.endsWith("…")).toBe(true);
+  });
+
+  it("previews the error when a failed tail has no summary, and collapses whitespace", async () => {
+    const ports = makePorts({
+      sessionRepo: {
+        listChatForAgent: vi.fn(async () => [
+          fakeChat({ id: "sess_h", status: "failed", error: "boom\n  on   line 2" }),
+        ]),
+      } as unknown as SessionRepository,
+    });
+    const res = await request(makeApp(ports)).get("/chat/conversations");
+    expect(res.body.conversations[0].last_preview).toBe("boom on line 2");
+  });
+
+  it("falls back to the intent for a preview when neither summary nor error is set", async () => {
+    const ports = makePorts({
+      sessionRepo: {
+        listChatForAgent: vi.fn(async () => [
+          fakeChat({ id: "sess_h", intent: "just asking", status: "running" }),
+        ]),
+      } as unknown as SessionRepository,
+    });
+    const res = await request(makeApp(ports)).get("/chat/conversations");
+    expect(res.body.conversations[0].last_preview).toBe("just asking");
+  });
+
+  it("ellipsizes a preview longer than the 140-char budget", async () => {
+    const ports = makePorts({
+      sessionRepo: {
+        listChatForAgent: vi.fn(async () => [
+          fakeChat({ id: "sess_h", result_summary: "y".repeat(400) }),
+        ]),
+      } as unknown as SessionRepository,
+    });
+    const res = await request(makeApp(ports)).get("/chat/conversations");
+    const preview = res.body.conversations[0].last_preview as string;
+    expect(preview).toHaveLength(140);
+    expect(preview.endsWith("…")).toBe(true);
+  });
+
+  it("caps the list at 50 conversations", async () => {
+    const many = Array.from({ length: 60 }, (_, i) =>
+      fakeChat({
+        id: `sess_${i}`,
+        created_at: new Date(Date.UTC(2026, 0, 1, 0, i)),
+      }),
+    );
+    const ports = makePorts({
+      sessionRepo: { listChatForAgent: vi.fn(async () => many) } as unknown as SessionRepository,
+    });
+    const res = await request(makeApp(ports)).get("/chat/conversations");
+    expect(res.body.conversations).toHaveLength(50);
+    // Newest-first, so the 60th (latest) chain leads.
+    expect(res.body.conversations[0].head_id).toBe("sess_59");
+  });
+});
+
+// ── DELETE /chat/conversations/:headId ───────────────────────────────────
+
+describe("DELETE /chat/conversations/:headId", () => {
+  it("403s a non-human caller", async () => {
+    const res = await request(makeApp(makePorts(), "none")).delete("/chat/conversations/sess_h");
+    expect(res.status).toBe(403);
+  });
+
+  it("404s when the caller has no primary agent", async () => {
+    const ports = makePorts({
+      agentRepo: { findTopLevelForOwner: vi.fn(async () => undefined) } as unknown as AgentRepository,
+    });
+    const res = await request(makeApp(ports)).delete("/chat/conversations/sess_h");
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("agent_not_found");
+  });
+
+  it("soft-deletes the chain scoped to the caller's agent and reports the row count", async () => {
+    const softDeleteChatChain = vi.fn(async () => 3);
+    const ports = makePorts({
+      sessionRepo: { softDeleteChatChain } as unknown as SessionRepository,
+    });
+    const res = await request(makeApp(ports)).delete("/chat/conversations/sess_head");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, deleted: 3 });
+    // Agent-scoped: a session id collision can't delete someone else's history.
+    expect(softDeleteChatChain).toHaveBeenCalledWith("sess_head", AGENT);
+  });
+
+  it("is idempotent — re-deleting an already-deleted chain still 200s with 0", async () => {
+    const ports = makePorts({
+      sessionRepo: { softDeleteChatChain: vi.fn(async () => 0) } as unknown as SessionRepository,
+    });
+    const res = await request(makeApp(ports)).delete("/chat/conversations/sess_head");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, deleted: 0 });
+  });
+
+  it("500s with a request_id and no internal detail when the repo throws", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const ports = makePorts({
+      sessionRepo: {
+        softDeleteChatChain: vi.fn(async () => {
+          throw new Error("pg: connection reset");
+        }),
+      } as unknown as SessionRepository,
+    });
+    const res = await request(makeApp(ports)).delete("/chat/conversations/sess_head");
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("internal_error");
+    expect(res.body.request_id).toMatch(/^req_/);
+    // The raw message stays in the logs, not on the wire.
+    expect(JSON.stringify(res.body)).not.toContain("connection reset");
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+// ── GET /chat ────────────────────────────────────────────────────────────
+
+describe("GET /chat", () => {
+  it("403s a non-human caller", async () => {
+    const res = await request(makeApp(makePorts(), "agent")).get("/chat");
+    expect(res.status).toBe(403);
+  });
+
+  it("returns the null-agent shape when no primary agent exists", async () => {
+    const ports = makePorts({
+      agentRepo: { findTopLevelForOwner: vi.fn(async () => undefined) } as unknown as AgentRepository,
+    });
+    const res = await request(makeApp(ports)).get("/chat");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      agent: null,
+      messages: [],
+      prior_session_id: null,
+      conversation_id: null,
+    });
+  });
+
+  it("returns the empty-state shape (not a 404) when the requested conversation doesn't exist", async () => {
+    const ports = makePorts({
+      sessionRepo: {
+        listChatForAgent: vi.fn(async () => [fakeChat({ id: "sess_other" })]),
+      } as unknown as SessionRepository,
+    });
+    const res = await request(makeApp(ports)).get("/chat").query({ c: "sess_missing" });
+    expect(res.status).toBe(200);
+    expect(res.body.messages).toEqual([]);
+    expect(res.body.conversation_id).toBeNull();
+    expect(res.body.agent).toEqual({ id: AGENT, name: "Alice's Team", hierarchy: "team" });
+  });
+
+  it("returns the empty-state shape when the agent has no chat sessions at all", async () => {
+    const res = await request(makeApp(makePorts())).get("/chat");
+    expect(res.status).toBe(200);
+    expect(res.body.messages).toEqual([]);
+    expect(res.body.prior_session_id).toBeNull();
+  });
+
+  it("rehydrates the most recent chain by default", async () => {
+    const oldChain = fakeChat({
+      id: "sess_old",
+      intent: "old topic",
+      result_summary: "old answer",
+      created_at: new Date("2026-01-01T00:00:00Z"),
+    });
+    const newChain = fakeChat({
+      id: "sess_new",
+      intent: "new topic",
+      result_summary: "new answer",
+      created_at: new Date("2026-02-01T00:00:00Z"),
+    });
+    const ports = makePorts({
+      sessionRepo: {
+        listChatForAgent: vi.fn(async () => [oldChain, newChain]),
+      } as unknown as SessionRepository,
+    });
+    const res = await request(makeApp(ports)).get("/chat");
+    expect(res.body.conversation_id).toBe("sess_new");
+    expect(res.body.prior_session_id).toBe("sess_new");
+    expect(res.body.messages.map((m: { content: string }) => m.content)).toEqual([
+      "new topic",
+      "new answer",
+    ]);
+    expect(ports.sessionRepo.listChatForAgent).toHaveBeenCalledWith(AGENT, 400);
+  });
+
+  it("selects the requested chain via ?c=", async () => {
+    const a = fakeChat({
+      id: "sess_a",
+      intent: "topic a",
+      created_at: new Date("2026-01-01T00:00:00Z"),
+    });
+    const b = fakeChat({
+      id: "sess_b",
+      intent: "topic b",
+      created_at: new Date("2026-02-01T00:00:00Z"),
+    });
+    const ports = makePorts({
+      sessionRepo: { listChatForAgent: vi.fn(async () => [a, b]) } as unknown as SessionRepository,
+    });
+    const res = await request(makeApp(ports)).get("/chat").query({ c: "sess_a" });
+    expect(res.body.conversation_id).toBe("sess_a");
+    expect(res.body.messages[0].content).toBe("topic a");
+  });
+
+  it("truncates a long chain to the last 25 sessions", async () => {
+    // 40 turns chained head→tail; HISTORY_LIMIT/2 = 25 survive.
+    const sessions = Array.from({ length: 40 }, (_, i) =>
+      fakeChat({
+        id: `sess_${i}`,
+        ...(i > 0 ? { prior_session_id: `sess_${i - 1}` } : {}),
+        intent: `turn ${i}`,
+        result_summary: `reply ${i}`,
+        created_at: new Date(Date.UTC(2026, 0, 1, 0, i)),
+      }),
+    );
+    const ports = makePorts({
+      sessionRepo: {
+        listChatForAgent: vi.fn(async () => sessions),
+      } as unknown as SessionRepository,
+    });
+    const res = await request(makeApp(ports)).get("/chat");
+    // 25 sessions × (user + agent) = 50 messages, starting at turn 15.
+    expect(res.body.messages).toHaveLength(50);
+    expect(res.body.messages[0].content).toBe("turn 15");
+    // The chain head is still reported even though its turn was dropped.
+    expect(res.body.conversation_id).toBe("sess_0");
+    expect(res.body.prior_session_id).toBe("sess_39");
+  });
+
+  it("flags an in-flight tail session so the UI can resume its thinking indicator", async () => {
+    const ports = makePorts({
+      sessionRepo: {
+        listChatForAgent: vi.fn(async () => [fakeChat({ id: "sess_h", status: "running" })]),
+      } as unknown as SessionRepository,
+    });
+    const res = await request(makeApp(ports)).get("/chat");
+    expect(res.body.in_flight_session_id).toBe("sess_h");
+  });
+
+  it("omits in_flight_session_id once the tail has reached a terminal status", async () => {
+    const ports = makePorts({
+      sessionRepo: {
+        listChatForAgent: vi.fn(async () => [fakeChat({ id: "sess_h", status: "succeeded" })]),
+      } as unknown as SessionRepository,
+    });
+    const res = await request(makeApp(ports)).get("/chat");
+    expect(res.body.in_flight_session_id).toBeUndefined();
+  });
+
+  it("reports runtime_mismatch when the chain is pinned to a CLI the agent no longer uses", async () => {
+    const ports = makePorts({
+      sessionRepo: {
+        listChatForAgent: vi.fn(async () => [fakeChat({ id: "sess_h", runtime_id: "rt_old" })]),
+      } as unknown as SessionRepository,
+      runtimeRepo: {
+        findById: vi.fn(async () => ({ id: "rt_old", cli: "codex" }) as Runtime),
+      } as unknown as RuntimeRepository,
+    });
+    const res = await request(makeApp(ports)).get("/chat");
+    expect(res.body.runtime_mismatch).toEqual({ pinned_cli: "codex", current_cli: "claude" });
+  });
+
+  it("omits runtime_mismatch when the pinned CLI matches the agent's current one", async () => {
+    const ports = makePorts({
+      sessionRepo: {
+        listChatForAgent: vi.fn(async () => [fakeChat({ id: "sess_h", runtime_id: "rt_1" })]),
+      } as unknown as SessionRepository,
+      runtimeRepo: {
+        findById: vi.fn(async () => ({ id: "rt_1", cli: "claude" }) as Runtime),
+      } as unknown as RuntimeRepository,
+    });
+    const res = await request(makeApp(ports)).get("/chat");
+    expect(res.body.runtime_mismatch).toBeUndefined();
+  });
+
+  it("omits runtime_mismatch for an unrecognized CLI string rather than surfacing garbage", async () => {
+    const ports = makePorts({
+      sessionRepo: {
+        listChatForAgent: vi.fn(async () => [fakeChat({ id: "sess_h", runtime_id: "rt_x" })]),
+      } as unknown as SessionRepository,
+      runtimeRepo: {
+        findById: vi.fn(async () => ({ id: "rt_x", cli: "cursor" }) as Runtime),
+      } as unknown as RuntimeRepository,
+    });
+    const res = await request(makeApp(ports)).get("/chat");
+    expect(res.body.runtime_mismatch).toBeUndefined();
+  });
+
+  it("skips the runtime lookup entirely when the tail session has no runtime_id", async () => {
+    const ports = makePorts({
+      sessionRepo: {
+        listChatForAgent: vi.fn(async () => [fakeChat({ id: "sess_h" })]),
+      } as unknown as SessionRepository,
+    });
+    const res = await request(makeApp(ports)).get("/chat");
+    expect(res.body.runtime_mismatch).toBeUndefined();
+    expect(ports.runtimeRepo.findById).not.toHaveBeenCalled();
+  });
+
+  it("omits runtime_mismatch when the pinned runtime row is gone", async () => {
+    const ports = makePorts({
+      sessionRepo: {
+        listChatForAgent: vi.fn(async () => [fakeChat({ id: "sess_h", runtime_id: "rt_gone" })]),
+      } as unknown as SessionRepository,
+    });
+    const res = await request(makeApp(ports)).get("/chat");
+    expect(res.body.runtime_mismatch).toBeUndefined();
+    expect(ports.runtimeRepo.findById).toHaveBeenCalledWith("rt_gone");
+  });
+});
+
+// ── POST /chat ───────────────────────────────────────────────────────────
+
+describe("POST /chat", () => {
+  it("403s a non-human caller", async () => {
+    const res = await request(makeApp(makePorts(), "agent"))
+      .post("/chat")
+      .send({ message: "hi" });
+    expect(res.status).toBe(403);
+  });
+
+  it("400s on a missing message", async () => {
+    const res = await request(makeApp(makePorts())).post("/chat").send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("message_required");
+  });
+
+  it("400s on a whitespace-only message", async () => {
+    const res = await request(makeApp(makePorts())).post("/chat").send({ message: "   \n " });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("message_required");
+  });
+
+  it("400s on a non-string message", async () => {
+    const res = await request(makeApp(makePorts())).post("/chat").send({ message: 42 });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("message_required");
+  });
+
+  it("404s when the caller has no primary agent", async () => {
+    const ports = makePorts({
+      agentRepo: { findTopLevelForOwner: vi.fn(async () => undefined) } as unknown as AgentRepository,
+    });
+    const res = await request(makeApp(ports)).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("no_primary_agent");
+    expect(ports.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("dispatches a fresh turn and returns the agent's response", async () => {
+    const ports = makePorts({
+      chatResolver: {
+        register: vi.fn(async () =>
+          fakeSession({ id: "sess_dispatched01", result_summary: "Sure thing." }),
+        ),
+      } as unknown as ChatResolver,
+    });
+    const res = await request(makeApp(ports)).post("/chat").send({ message: "  ship it  " });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      agent: { id: AGENT, name: "Alice's Team", hierarchy: "team" },
+      session_id: "sess_dispatched01",
+      response: "Sure thing.",
+      status: "succeeded",
+      view_refs: [],
+    });
+    expect(res.body.replayed).toBeUndefined();
+    // Message is trimmed, and a first turn dispatches as `fresh`.
+    expect(ports.dispatchService.dispatchTask).toHaveBeenCalledWith({
+      agentId: AGENT,
+      intent: "ship it",
+      reason: { kind: "fresh" },
+      type: "chat",
+      sessionIdOverride: undefined,
+    });
+  });
+
+  it("passes prior_session_id through as a chat_continuation resume reason", async () => {
+    const ports = makePorts();
+    await request(makeApp(ports))
+      .post("/chat")
+      .send({ message: "and then?", prior_session_id: "sess_prev" });
+    expect(ports.dispatchService.dispatchTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: { kind: "chat_continuation", prior_session_id: "sess_prev" },
+      }),
+    );
+  });
+
+  it("strips directives out of the response and surfaces them as structured fields", async () => {
+    const ports = makePorts({
+      chatResolver: {
+        register: vi.fn(async () =>
+          fakeSession({
+            result_summary:
+              'Done.<open_view path="/tasks" label="Tasks" />' +
+              '<suggest_action label="Retry" prompt="try again" />',
+          }),
+        ),
+      } as unknown as ChatResolver,
+    });
+    const res = await request(makeApp(ports)).post("/chat").send({ message: "go" });
+    expect(res.body.response).toBe("Done.");
+    expect(res.body.open_view).toEqual({ path: "/tasks", label: "Tasks" });
+    expect(res.body.suggested_actions).toEqual([{ label: "Retry", prompt: "try again" }]);
+  });
+
+  it("maps a failed turn through failureMessageFor rather than echoing the bare CLI exit", async () => {
+    const ports = makePorts({
+      chatResolver: {
+        register: vi.fn(async () =>
+          fakeSession({ status: "failed", error: "CLI exited with code 1" }),
+        ),
+      } as unknown as ChatResolver,
+    });
+    const res = await request(makeApp(ports)).post("/chat").send({ message: "go" });
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("failed");
+    expect(res.body.response).toContain("beevibe-daemon start");
+  });
+
+  // ── Idempotent replay ──────────────────────────────────────────────────
+
+  it("replays a completed turn instead of spawning a second subprocess", async () => {
+    const ports = makePorts({
+      sessionRepo: {
+        findById: vi.fn(async () =>
+          fakeSession({
+            id: VALID_CALLER_SESSION,
+            type: "chat",
+            status: "succeeded",
+            result_summary: "Already answered.",
+          }),
+        ),
+      } as unknown as SessionRepository,
+    });
+    const res = await request(makeApp(ports))
+      .post("/chat")
+      .send({ message: "hi", session_id: VALID_CALLER_SESSION });
+    expect(res.status).toBe(200);
+    expect(res.body.replayed).toBe(true);
+    expect(res.body.response).toBe("Already answered.");
+    // The whole point: no second dispatch, no second charge.
+    expect(ports.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("replays a failed turn with the same friendlier failure message", async () => {
+    const ports = makePorts({
+      sessionRepo: {
+        findById: vi.fn(async () =>
+          fakeSession({
+            id: VALID_CALLER_SESSION,
+            status: "failed",
+            error: "No runtime registered for dispatch payload type 'codex'",
+          }),
+        ),
+      } as unknown as SessionRepository,
+    });
+    const res = await request(makeApp(ports))
+      .post("/chat")
+      .send({ message: "hi", session_id: VALID_CALLER_SESSION });
+    expect(res.status).toBe(200);
+    expect(res.body.replayed).toBe(true);
+    expect(res.body.response).toContain("pinned to the codex runtime");
+  });
+
+  it("409s when the replayed session is still running", async () => {
+    const ports = makePorts({
+      sessionRepo: {
+        findById: vi.fn(async () => fakeSession({ id: VALID_CALLER_SESSION, status: "running" })),
+      } as unknown as SessionRepository,
+    });
+    const res = await request(makeApp(ports))
+      .post("/chat")
+      .send({ message: "hi", session_id: VALID_CALLER_SESSION });
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe("session_in_flight");
+    expect(ports.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("403s when the session id collides with another caller's session", async () => {
+    const ports = makePorts({
+      sessionRepo: {
+        findById: vi.fn(async () =>
+          fakeSession({ id: VALID_CALLER_SESSION, agent_id: "agent_someone_else" }),
+        ),
+      } as unknown as SessionRepository,
+    });
+    const res = await request(makeApp(ports))
+      .post("/chat")
+      .send({ message: "hi", session_id: VALID_CALLER_SESSION });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("session_belongs_to_other_caller");
+    expect(ports.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("falls through to a live dispatch when the pre-created row is still pending", async () => {
+    // `tryReplay` returns { kind: 'skip' } for a non-terminal,
+    // non-running row — the client claimed the id but nothing ran yet.
+    const ports = makePorts({
+      sessionRepo: {
+        findById: vi.fn(async () => fakeSession({ id: VALID_CALLER_SESSION, status: "pending" })),
+      } as unknown as SessionRepository,
+    });
+    const res = await request(makeApp(ports))
+      .post("/chat")
+      .send({ message: "hi", session_id: VALID_CALLER_SESSION });
+    expect(res.status).toBe(200);
+    expect(ports.dispatchService.dispatchTask).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionIdOverride: VALID_CALLER_SESSION }),
+    );
+  });
+
+  it("falls through to a live dispatch when the id belongs to a non-chat session", async () => {
+    const ports = makePorts({
+      sessionRepo: {
+        findById: vi.fn(async () => fakeSession({ id: VALID_CALLER_SESSION, type: "task" })),
+      } as unknown as SessionRepository,
+    });
+    const res = await request(makeApp(ports))
+      .post("/chat")
+      .send({ message: "hi", session_id: VALID_CALLER_SESSION });
+    expect(res.status).toBe(200);
+    expect(ports.dispatchService.dispatchTask).toHaveBeenCalled();
+  });
+
+  it("ignores a malformed session_id — no lookup, no override", async () => {
+    const ports = makePorts();
+    const res = await request(makeApp(ports))
+      .post("/chat")
+      .send({ message: "hi", session_id: "not-a-session-id" });
+    expect(res.status).toBe(200);
+    expect(ports.sessionRepo.findById).not.toHaveBeenCalled();
+    expect(ports.dispatchService.dispatchTask).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionIdOverride: undefined }),
+    );
+  });
+
+  // ── Rate limiting ──────────────────────────────────────────────────────
+
+  it("429s a second concurrent turn with Retry-After and turn_in_flight", async () => {
+    const rateLimiter = new ChatRateLimiter({ maxConcurrent: 1, now: () => 1_000 });
+    // Hold the only slot so the request below can't acquire one.
+    const held = rateLimiter.acquire(PERSON);
+    expect(held.ok).toBe(true);
+
+    const res = await request(makeApp(makePorts({ rateLimiter })))
+      .post("/chat")
+      .send({ message: "hi" });
+    expect(res.status).toBe(429);
+    expect(res.body.error).toBe("turn_in_flight");
+    expect(res.headers["retry-after"]).toBeDefined();
+    expect(res.body.retry_after_ms).toBeGreaterThan(0);
+  });
+
+  it("429s with rate_limited once the sliding window is full", async () => {
+    const rateLimiter = new ChatRateLimiter({
+      maxConcurrent: 5,
+      maxPerWindow: 2,
+      windowMs: 60_000,
+      now: () => 1_000,
+    });
+    rateLimiter.acquire(PERSON);
+    rateLimiter.acquire(PERSON);
+
+    const res = await request(makeApp(makePorts({ rateLimiter })))
+      .post("/chat")
+      .send({ message: "hi" });
+    expect(res.status).toBe(429);
+    expect(res.body.error).toBe("rate_limited");
+  });
+
+  it("releases the rate-limit slot after a successful turn", async () => {
+    const rateLimiter = new ChatRateLimiter({ maxConcurrent: 1, now: () => 1_000 });
+    const app = makeApp(makePorts({ rateLimiter }));
+    await request(app).post("/chat").send({ message: "one" });
+    // If the first turn leaked its slot this would 429.
+    const second = await request(app).post("/chat").send({ message: "two" });
+    expect(second.status).toBe(200);
+  });
+
+  // ── Dispatch + daemon liveness ─────────────────────────────────────────
+
+  it("503s when the session is bound to an offline daemon", async () => {
+    const ports = makePorts({
+      hub: { isOnline: vi.fn(() => false) } as unknown as DaemonHub,
+    });
+    const res = await request(makeApp(ports)).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe("agent_offline");
+    expect(res.body.message).toContain("beevibe-daemon start");
+    // Never registers a resolver it would just have to time out.
+    expect(ports.chatResolver.register).not.toHaveBeenCalled();
+  });
+
+  it("proceeds without a liveness check for a null-runtime (executor fallback) dispatch", async () => {
+    const ports = makePorts({
+      dispatchService: {
+        dispatchTask: vi.fn(async () => ({ session: fakeSession(), runtime_id: null })),
+      } as unknown as DispatchService,
+      hub: { isOnline: vi.fn(() => false) } as unknown as DaemonHub,
+    });
+    const res = await request(makeApp(ports)).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(200);
+    expect(ports.hub.isOnline).not.toHaveBeenCalled();
+  });
+
+  it("500s and frees the rate-limit slot when dispatch throws", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const rateLimiter = new ChatRateLimiter({ maxConcurrent: 1, now: () => 1_000 });
+    const ports = makePorts({
+      rateLimiter,
+      dispatchService: {
+        dispatchTask: vi.fn(async () => {
+          throw new Error("agent row vanished");
+        }),
+      } as unknown as DispatchService,
+    });
+    const res = await request(makeApp(ports)).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(500);
+    expect(res.body.request_id).toMatch(/^req_/);
+    // Slot released — a stuck slot would lock the user out for good.
+    expect(rateLimiter.acquire(PERSON).ok).toBe(true);
+    spy.mockRestore();
+  });
+
+  it("frees the rate-limit slot on the 503 path too", async () => {
+    const rateLimiter = new ChatRateLimiter({ maxConcurrent: 1, now: () => 1_000 });
+    const ports = makePorts({
+      rateLimiter,
+      hub: { isOnline: vi.fn(() => false) } as unknown as DaemonHub,
+    });
+    await request(makeApp(ports)).post("/chat").send({ message: "hi" });
+    expect(rateLimiter.acquire(PERSON).ok).toBe(true);
+  });
+
+  // ── Resolver outcomes ──────────────────────────────────────────────────
+
+  it("504s when the resolver times out waiting for the daemon", async () => {
+    const ports = makePorts({
+      chatResolver: {
+        register: vi.fn(async () => {
+          throw new Error("chat resolver timeout (90000ms) for sess_x");
+        }),
+      } as unknown as ChatResolver,
+    });
+    const res = await request(makeApp(ports)).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(504);
+    expect(res.body.error).toBe("chat_turn_timeout");
+    expect(res.body.timeout_ms).toBe(90_000);
+  });
+
+  it("500s on a non-timeout resolver rejection", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const ports = makePorts({
+      chatResolver: {
+        register: vi.fn(async () => {
+          throw new Error("chat resolver already registered for sess_x");
+        }),
+      } as unknown as ChatResolver,
+    });
+    const res = await request(makeApp(ports)).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("internal_error");
+    spy.mockRestore();
+  });
+
+  it("registers the resolver against the dispatched session id with the 90s budget", async () => {
+    const ports = makePorts({
+      dispatchService: {
+        dispatchTask: vi.fn(async () => ({
+          session: fakeSession({ id: "sess_freshid0001" }),
+          runtime_id: "rt_1",
+        })),
+      } as unknown as DispatchService,
+    });
+    await request(makeApp(ports)).post("/chat").send({ message: "hi" });
+    expect(ports.chatResolver.register).toHaveBeenCalledWith("sess_freshid0001", 90_000);
+  });
+
+  // ── Onboarding flip ────────────────────────────────────────────────────
+
+  it("stamps onboarding_completed_at on the first successful turn", async () => {
+    const ports = makePorts({
+      personRepo: {
+        findById: vi.fn(async (id: string) => ({ id, name: "Alice" }) as Person),
+        update: vi.fn(async () => undefined),
+      } as unknown as PersonRepository,
+    });
+    const res = await request(makeApp(ports)).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(200);
+    expect(ports.personRepo.update).toHaveBeenCalledWith(PERSON, {
+      onboarding_completed_at: expect.any(Date),
+    });
+  });
+
+  it("does not re-stamp onboarding for a person who already completed it", async () => {
+    const ports = makePorts();
+    await request(makeApp(ports)).post("/chat").send({ message: "hi" });
+    expect(ports.personRepo.update).not.toHaveBeenCalled();
+  });
+
+  it("does not stamp onboarding when the first turn fails", async () => {
+    const ports = makePorts({
+      personRepo: {
+        findById: vi.fn(async (id: string) => ({ id, name: "Alice" }) as Person),
+        update: vi.fn(async () => undefined),
+      } as unknown as PersonRepository,
+      chatResolver: {
+        register: vi.fn(async () => fakeSession({ status: "failed", error: "nope" })),
+      } as unknown as ChatResolver,
+    });
+    await request(makeApp(ports)).post("/chat").send({ message: "hi" });
+    expect(ports.personRepo.update).not.toHaveBeenCalled();
+  });
+
+  it("still answers the turn when the onboarding flip write fails", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const ports = makePorts({
+      personRepo: {
+        findById: vi.fn(async (id: string) => ({ id, name: "Alice" }) as Person),
+        update: vi.fn(async () => {
+          throw new Error("pg: deadlock detected");
+        }),
+      } as unknown as PersonRepository,
+    });
+    const res = await request(makeApp(ports)).post("/chat").send({ message: "hi" });
+    // Fire-and-forget: the write is best-effort, the turn is not.
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    spy.mockRestore();
+  });
+
+  it("treats a missing person row as not-yet-onboarded without crashing the turn", async () => {
+    const ports = makePorts({
+      personRepo: {
+        findById: vi.fn(async () => undefined),
+        update: vi.fn(async () => undefined),
+      } as unknown as PersonRepository,
+    });
+    const res = await request(makeApp(ports)).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(200);
+    expect(ports.personRepo.update).toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/tools/session-search.test.ts
+++ b/packages/api/src/tools/session-search.test.ts
@@ -1,0 +1,233 @@
+/**
+ * `createSessionSearchTool` — Layer-3 memory's MCP surface.
+ *
+ * The service does the scoping and the SQL; the tool's own job is
+ * `inferRequest` — picking one of four calling shapes out of whatever
+ * loosely-typed bag the agent sent — plus the error envelope. Both are
+ * pinned here against a `vi.fn()` service.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { SessionSearchRequest } from "@beevibe/core";
+import {
+  SessionSearchError,
+  type SessionSearchService,
+} from "@beevibe/core/services/session-search";
+import {
+  createSessionSearchTool,
+  type SessionSearchToolContext,
+} from "./session-search.js";
+
+const CTX: SessionSearchToolContext = {
+  agentId: "agent_a",
+  hierarchyLevel: "team",
+  sessionId: "sess_current0001",
+};
+
+function makeService(impl?: SessionSearchService["search"]): SessionSearchService {
+  return {
+    search: vi.fn(impl ?? (async () => ({ results: [] }))),
+  } as unknown as SessionSearchService;
+}
+
+function makeTool(service: SessionSearchService = makeService()) {
+  return createSessionSearchTool(CTX, { sessionSearch: service });
+}
+
+/** The request the tool inferred from a given raw input bag. */
+async function inferred(input: Record<string, unknown>): Promise<SessionSearchRequest> {
+  const service = makeService();
+  await makeTool(service).handler(input);
+  return vi.mocked(service.search).mock.calls[0]![0] as SessionSearchRequest;
+}
+
+describe("session_search tool definition", () => {
+  it("is named session_search and documents the four shapes", () => {
+    const tool = makeTool();
+    expect(tool.name).toBe("session_search");
+    expect(tool.description).toContain("FOUR CALLING SHAPES");
+  });
+
+  it("declares no required fields — the bare call is the browse shape", () => {
+    expect(makeTool().schema.required).toBeUndefined();
+  });
+});
+
+describe("shape inference", () => {
+  it("browses when given nothing", async () => {
+    expect(await inferred({})).toEqual({
+      kind: "browse",
+      limit: undefined,
+      filters: undefined,
+    });
+  });
+
+  it("discovers when given a query", async () => {
+    expect(await inferred({ query: "  auth refactor  ", limit: 7, sort: "newest" })).toEqual({
+      kind: "discover",
+      query: "auth refactor",
+      limit: 7,
+      sort: "newest",
+      filters: undefined,
+    });
+  });
+
+  it("reads when given a bare session_id", async () => {
+    expect(await inferred({ session_id: "  sess_x  " })).toEqual({
+      kind: "read",
+      session_id: "sess_x",
+    });
+  });
+
+  it("scrolls when given session_id + around_message_id", async () => {
+    expect(
+      await inferred({
+        session_id: "sess_x",
+        around_message_id: "  evt_1  ",
+        window: 10,
+      }),
+    ).toEqual({
+      kind: "scroll",
+      session_id: "sess_x",
+      around_message_id: "evt_1",
+      window: 10,
+    });
+  });
+
+  it("prefers scroll over discover when a query is also present", async () => {
+    const req = await inferred({
+      session_id: "sess_x",
+      around_message_id: "evt_1",
+      query: "ignored",
+    });
+    expect(req.kind).toBe("scroll");
+  });
+
+  it("prefers read over discover when a query is also present", async () => {
+    const req = await inferred({ session_id: "sess_x", query: "ignored" });
+    expect(req.kind).toBe("read");
+  });
+
+  it("treats a blank query as no query and browses", async () => {
+    expect((await inferred({ query: "   " })).kind).toBe("browse");
+  });
+
+  it("treats a blank session_id as absent", async () => {
+    expect((await inferred({ session_id: "  ", query: "x" })).kind).toBe("discover");
+  });
+
+  it("treats a blank around_message_id as absent, falling back to read", async () => {
+    expect((await inferred({ session_id: "sess_x", around_message_id: " " })).kind).toBe(
+      "read",
+    );
+  });
+
+  it("ignores non-string ids and queries", async () => {
+    expect((await inferred({ session_id: 42, query: { a: 1 } })).kind).toBe("browse");
+  });
+
+  it("drops a non-numeric window, limit and unknown sort rather than passing them on", async () => {
+    const scroll = await inferred({
+      session_id: "sess_x",
+      around_message_id: "evt_1",
+      window: "10",
+    });
+    expect(scroll).toMatchObject({ window: undefined });
+
+    const discover = await inferred({ query: "x", limit: "3", sort: "sideways" });
+    expect(discover).toMatchObject({ limit: undefined, sort: undefined });
+  });
+
+  it("passes sort=oldest through", async () => {
+    expect(await inferred({ query: "x", sort: "oldest" })).toMatchObject({ sort: "oldest" });
+  });
+
+  it("forwards a filters object on the discover and browse shapes", async () => {
+    const filters = { status: "failed", session_type: "task" };
+    expect(await inferred({ query: "x", filters })).toMatchObject({ filters });
+    expect(await inferred({ filters })).toMatchObject({ filters });
+  });
+
+  it("ignores a non-object filters value", async () => {
+    expect(await inferred({ query: "x", filters: "status:failed" })).toMatchObject({
+      filters: undefined,
+    });
+    expect(await inferred({ query: "x", filters: null })).toMatchObject({
+      filters: undefined,
+    });
+  });
+});
+
+describe("scope threading", () => {
+  it("passes the caller's agent, tier and active session to the service", async () => {
+    const service = makeService();
+    await makeTool(service).handler({ query: "x" });
+    expect(service.search).toHaveBeenCalledWith(expect.anything(), {
+      callerAgentId: "agent_a",
+      hierarchyLevel: "team",
+      currentSessionId: "sess_current0001",
+    });
+  });
+});
+
+describe("result envelope", () => {
+  it("returns the service result verbatim on success", async () => {
+    const payload = { results: [{ session: { id: "sess_1" } }] };
+    const res = await makeTool(makeService(async () => payload as never)).handler({});
+    expect(res.isError).toBeUndefined();
+    expect(res.content).toBe(payload);
+  });
+
+  it("maps a null result to not_found_or_forbidden", async () => {
+    const res = await makeTool(makeService(async () => null as never)).handler({
+      session_id: "sess_someone_elses",
+    });
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("not_found_or_forbidden");
+  });
+
+  it("surfaces a SessionSearchError's code", async () => {
+    const res = await makeTool(
+      makeService(async () => {
+        throw new SessionSearchError("forbidden_agent_filter", "agent_b is out of scope");
+      }),
+    ).handler({ query: "x", filters: { agent_id: "agent_b" } });
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("forbidden_agent_filter");
+    expect(res.content.message).toBe("agent_b is out of scope");
+  });
+
+  it("recognizes a cross-bundle SessionSearchError by name", async () => {
+    // A duplicate class identity (src/ vs dist/ copies of core) fails
+    // `instanceof`; the name check is what keeps the code structured.
+    const impostor = new Error("missing query");
+    impostor.name = "SessionSearchError";
+    (impostor as Error & { code: string }).code = "missing_query";
+    const res = await makeTool(
+      makeService(async () => {
+        throw impostor;
+      }),
+    ).handler({ query: "x" });
+    expect(res.content.error).toBe("missing_query");
+  });
+
+  it("wraps an unrelated Error as internal_error", async () => {
+    const res = await makeTool(
+      makeService(async () => {
+        throw new Error("pg: connection reset");
+      }),
+    ).handler({});
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("internal_error");
+    expect(res.content.message).toBe("pg: connection reset");
+  });
+
+  it("stringifies a non-Error throw", async () => {
+    const res = await makeTool(
+      makeService(async () => {
+        throw "kaboom";
+      }),
+    ).handler({});
+    expect(res.content.error).toBe("internal_error");
+    expect(res.content.message).toBe("kaboom");
+  });
+});

--- a/packages/api/src/tools/use-repo.test.ts
+++ b/packages/api/src/tools/use-repo.test.ts
@@ -1,0 +1,340 @@
+/**
+ * `createUseRepoTool` — the Agent App Store's verb.
+ *
+ * The handler is a five-step sequence with a failure mode at each step:
+ * validate the goal + repo URL, resolve the caller, create the
+ * container task, dispatch the sandbox session, then insert the
+ * repo_run that the daemon's payload composer looks up by session id.
+ * The ordering between those last two matters (repo_run.session_id has
+ * an FK to session.id), so this suite pins it alongside the validation
+ * and the two partial-failure envelopes.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  RepoRunRepository,
+  Task,
+  TaskRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import { createUseRepoTool, type UseRepoServices } from "./use-repo.js";
+
+const AGENT = "agent_a";
+
+function fakeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: AGENT,
+    name: "Helper",
+    owner_id: "person_1",
+    hierarchy_level: "ic",
+    runtime_config: { type: "claude" },
+    created_at: new Date("2026-01-01T00:00:00Z"),
+    updated_at: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  } as Agent;
+}
+
+function makeServices(overrides: Partial<UseRepoServices> = {}): UseRepoServices {
+  return {
+    agentRepo: { findById: vi.fn(async () => fakeAgent()) } as unknown as AgentRepository,
+    taskRepo: {
+      create: vi.fn(async (input: Partial<Task>) => ({ ...input }) as Task),
+    } as unknown as TaskRepository,
+    repoRunRepo: { create: vi.fn(async () => undefined) } as unknown as RepoRunRepository,
+    dispatchService: {
+      dispatchTask: vi.fn(async () => ({ session: { id: "sess_x" }, runtime_id: "rt_1" })),
+    } as unknown as DispatchService,
+    ...overrides,
+  };
+}
+
+function makeTool(services: UseRepoServices = makeServices()) {
+  return createUseRepoTool({ agentId: AGENT }, services);
+}
+
+const OK_INPUT = {
+  goal: "extract the tables",
+  repo_url: "https://github.com/acme/pdfplumber",
+};
+
+describe("use_repo tool definition", () => {
+  it("is named use_repo and requires goal + repo_url", () => {
+    const tool = makeTool();
+    expect(tool.name).toBe("use_repo");
+    expect(tool.schema.required).toEqual(["goal", "repo_url"]);
+  });
+});
+
+describe("use_repo input validation", () => {
+  it("rejects a missing goal before touching any port", async () => {
+    const services = makeServices();
+    const res = await makeTool(services).handler({ repo_url: OK_INPUT.repo_url });
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("invalid_goal");
+    expect(services.agentRepo.findById).not.toHaveBeenCalled();
+  });
+
+  it("rejects a whitespace-only goal", async () => {
+    const res = await makeTool().handler({ ...OK_INPUT, goal: "   " });
+    expect(res.content.error).toBe("invalid_goal");
+  });
+
+  it("rejects a non-string goal", async () => {
+    const res = await makeTool().handler({ ...OK_INPUT, goal: 42 });
+    expect(res.content.error).toBe("invalid_goal");
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["empty", ""],
+    ["non-string", 7],
+    ["plain http", "http://github.com/acme/tool"],
+    ["a non-GitHub host", "https://gitlab.com/acme/tool"],
+    ["a lookalike host", "https://github.com.evil.dev/acme/tool"],
+    ["unparseable", "not a url"],
+    ["an ssh remote", "git@github.com:acme/tool.git"],
+  ])("rejects %s repo_url", async (_label, repo_url) => {
+    const services = makeServices();
+    const res = await makeTool(services).handler({ ...OK_INPUT, repo_url });
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("invalid_repo_url");
+    expect(services.taskRepo.create).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "https://github.com/acme/tool",
+    "https://www.github.com/acme/tool",
+    "https://GitHub.com/acme/tool",
+  ])("accepts %s", async (repo_url) => {
+    const res = await makeTool().handler({ ...OK_INPUT, repo_url });
+    expect(res.isError).toBeUndefined();
+  });
+
+  it("404s the tool call when the calling agent row is gone", async () => {
+    const services = makeServices({
+      agentRepo: { findById: vi.fn(async () => undefined) } as unknown as AgentRepository,
+    });
+    const res = await makeTool(services).handler(OK_INPUT);
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("agent_not_found");
+    expect(services.taskRepo.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("use_repo happy path", () => {
+  it("returns the run ids, watch url and a poll hint", async () => {
+    const res = await makeTool().handler(OK_INPUT);
+    expect(res.isError).toBeUndefined();
+    expect(res.content.status).toBe("pending");
+    expect(res.content.repo_run_id).toMatch(/^repo_/);
+    expect(res.content.session_id).toMatch(/^sess_/);
+    expect(res.content.task_id).toMatch(/^task_/);
+    expect(res.content.watch_url).toBe(`/capabilities/runs/${res.content.repo_run_id}`);
+    expect(res.content.note).toContain("poll");
+  });
+
+  it("creates the container task assigned to and created by the calling agent", async () => {
+    const services = makeServices();
+    await makeTool(services).handler(OK_INPUT);
+    expect(services.taskRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "extract the tables",
+        description: "extract the tables",
+        priority: "medium",
+        assignee_id: AGENT,
+        creator_id: AGENT,
+        creator_type: "agent",
+      }),
+    );
+  });
+
+  it("collapses whitespace and truncates a long goal into the task title", async () => {
+    const services = makeServices();
+    const goal = "a".repeat(200);
+    await makeTool(services).handler({ ...OK_INPUT, goal });
+    const created = vi.mocked(services.taskRepo.create).mock.calls[0]![0] as Partial<Task>;
+    expect(created.title).toHaveLength(78); // 77 chars + ellipsis
+    expect(created.title!.endsWith("…")).toBe(true);
+    // The untruncated goal still reaches the child agent.
+    expect(created.description).toBe(goal);
+  });
+
+  it("keeps a multi-line goal on one line in the title", async () => {
+    const services = makeServices();
+    await makeTool(services).handler({ ...OK_INPUT, goal: "  do\n\n  this  thing  " });
+    const created = vi.mocked(services.taskRepo.create).mock.calls[0]![0] as Partial<Task>;
+    expect(created.title).toBe("do this thing");
+  });
+
+  it("dispatches a run_repo session under the pre-minted session id", async () => {
+    const services = makeServices();
+    const res = await makeTool(services).handler(OK_INPUT);
+    expect(services.dispatchService.dispatchTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: AGENT,
+        type: "run_repo",
+        intent: "extract the tables",
+        reason: { kind: "fresh" },
+        sessionIdOverride: res.content.session_id,
+      }),
+    );
+  });
+
+  it("inserts the repo_run only after the session exists (FK ordering)", async () => {
+    const order: string[] = [];
+    const services = makeServices({
+      dispatchService: {
+        dispatchTask: vi.fn(async () => {
+          order.push("dispatch");
+          return { session: { id: "sess_x" }, runtime_id: null };
+        }),
+      } as unknown as DispatchService,
+      repoRunRepo: {
+        create: vi.fn(async () => {
+          order.push("repo_run");
+        }),
+      } as unknown as RepoRunRepository,
+    });
+    const res = await makeTool(services).handler(OK_INPUT);
+    expect(order).toEqual(["dispatch", "repo_run"]);
+    expect(services.repoRunRepo.create).toHaveBeenCalledWith({
+      id: res.content.repo_run_id,
+      session_id: res.content.session_id,
+      task_id: res.content.task_id,
+      agent_id: AGENT,
+      goal: "extract the tables",
+      repo_url: OK_INPUT.repo_url,
+      status: "pending",
+    });
+  });
+
+  it("trims the goal and repo_url before persisting them", async () => {
+    const services = makeServices();
+    await makeTool(services).handler({
+      goal: "  tidy up  ",
+      repo_url: "  https://github.com/acme/tool  ",
+    });
+    expect(services.repoRunRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        goal: "tidy up",
+        repo_url: "https://github.com/acme/tool",
+      }),
+    );
+  });
+
+  it("echoes the optional input download fields back to the agent", async () => {
+    const res = await makeTool().handler({
+      ...OK_INPUT,
+      input_url: "  https://example.com/report.pdf  ",
+      input_filename: "  report.pdf  ",
+    });
+    expect(res.content.input_url).toBe("https://example.com/report.pdf");
+    expect(res.content.input_filename).toBe("report.pdf");
+  });
+
+  it("leaves the input fields undefined when not supplied", async () => {
+    const res = await makeTool().handler(OK_INPUT);
+    expect(res.content.input_url).toBeUndefined();
+    expect(res.content.input_filename).toBeUndefined();
+  });
+});
+
+describe("use_repo limits parsing", () => {
+  async function limitsFor(limits: unknown) {
+    const res = await makeTool().handler({ ...OK_INPUT, limits });
+    return res.content.limits;
+  }
+
+  it("passes sane values through, flooring the integer caps", async () => {
+    expect(
+      await limitsFor({ wall_clock_minutes: 5, max_install_attempts: 3.7, disk_mb: 512.9 }),
+    ).toEqual({ wall_clock_minutes: 5, max_install_attempts: 3, disk_mb: 512 });
+  });
+
+  it("clamps each limit to its ceiling", async () => {
+    expect(
+      await limitsFor({
+        wall_clock_minutes: 999,
+        max_install_attempts: 99,
+        disk_mb: 1_000_000,
+      }),
+    ).toEqual({ wall_clock_minutes: 60, max_install_attempts: 5, disk_mb: 10_000 });
+  });
+
+  it("drops zero, negative and non-numeric values rather than clamping them up", async () => {
+    expect(
+      await limitsFor({ wall_clock_minutes: 0, max_install_attempts: -1, disk_mb: "512" }),
+    ).toEqual({});
+  });
+
+  it("ignores unknown keys", async () => {
+    expect(await limitsFor({ gpu: true, wall_clock_minutes: 10 })).toEqual({
+      wall_clock_minutes: 10,
+    });
+  });
+
+  it.each([
+    ["absent", undefined],
+    ["null", null],
+    ["a string", "20m"],
+    ["a number", 20],
+  ])("returns {} for %s limits", async (_label, limits) => {
+    expect(await limitsFor(limits)).toEqual({});
+  });
+});
+
+describe("use_repo partial failures", () => {
+  it("reports dispatch_failed without attempting the repo_run insert", async () => {
+    const services = makeServices({
+      dispatchService: {
+        dispatchTask: vi.fn(async () => {
+          throw new Error("no runtime available");
+        }),
+      } as unknown as DispatchService,
+    });
+    const res = await makeTool(services).handler(OK_INPUT);
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("dispatch_failed");
+    expect(res.content.message).toBe("no runtime available");
+    expect(services.repoRunRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("stringifies a non-Error dispatch throw", async () => {
+    const services = makeServices({
+      dispatchService: {
+        dispatchTask: vi.fn(async () => {
+          throw "boom";
+        }),
+      } as unknown as DispatchService,
+    });
+    const res = await makeTool(services).handler(OK_INPUT);
+    expect(res.content.message).toBe("boom");
+  });
+
+  it("surfaces repo_run_create_failed so the agent doesn't wait on an orphan session", async () => {
+    const services = makeServices({
+      repoRunRepo: {
+        create: vi.fn(async () => {
+          throw new Error("duplicate key");
+        }),
+      } as unknown as RepoRunRepository,
+    });
+    const res = await makeTool(services).handler(OK_INPUT);
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("repo_run_create_failed");
+    expect(res.content.message).toBe("duplicate key");
+  });
+
+  it("stringifies a non-Error repo_run throw", async () => {
+    const services = makeServices({
+      repoRunRepo: {
+        create: vi.fn(async () => {
+          throw 500;
+        }),
+      } as unknown as RepoRunRepository,
+    });
+    const res = await makeTool(services).handler(OK_INPUT);
+    expect(res.content.message).toBe("500");
+  });
+});

--- a/packages/api/src/tools/watch.test.ts
+++ b/packages/api/src/tools/watch.test.ts
@@ -1,0 +1,247 @@
+/**
+ * `buildWatchTools` — the watch_tasks / unwatch MCP pair.
+ *
+ * Both tools are thin adapters: they normalize the agent-supplied JSON
+ * (which MCP does not validate against the declared schema — the agent
+ * can send anything), then delegate to `WatchService` and translate its
+ * typed errors into the tool-error envelope. Those two translations are
+ * what this suite pins, with a `vi.fn()` service standing in for the
+ * real one.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  WatchAuthError,
+  WatchNotFoundError,
+  WatchValidationError,
+  type WatchService,
+} from "@beevibe/core/services/watch-service";
+import { buildWatchTools, type WatchToolContext } from "./watch.js";
+import type { AgentTool } from "./types.js";
+
+const AGENT = "agent_a";
+const SESSION = "sess_caller0001";
+
+function makeService(overrides: Partial<WatchService> = {}): WatchService {
+  return {
+    watchTasks: vi.fn(async () => ({ watchId: "watch_1", firedImmediately: false })),
+    unwatch: vi.fn(async () => undefined),
+    ...overrides,
+  } as unknown as WatchService;
+}
+
+function tools(
+  service: WatchService,
+  ctx: Partial<WatchToolContext> = {},
+): { watchTasks: AgentTool; unwatch: AgentTool } {
+  const built = buildWatchTools(
+    { agentId: AGENT, sessionId: SESSION, ...ctx },
+    { watchService: service },
+  );
+  const byName = new Map(built.map((t) => [t.name, t]));
+  return {
+    watchTasks: byName.get("watch_tasks")!,
+    unwatch: byName.get("unwatch")!,
+  };
+}
+
+describe("buildWatchTools", () => {
+  it("exposes exactly watch_tasks and unwatch", () => {
+    const built = buildWatchTools(
+      { agentId: AGENT, sessionId: SESSION },
+      { watchService: makeService() },
+    );
+    expect(built.map((t) => t.name)).toEqual(["watch_tasks", "unwatch"]);
+  });
+
+  it("declares the fire modes in the watch_tasks schema so the agent sees them", () => {
+    const { watchTasks } = tools(makeService());
+    const props = watchTasks.schema.properties as Record<string, { enum?: string[] }>;
+    expect(props.mode?.enum).toEqual(["all", "any"]);
+    expect(watchTasks.schema.required).toEqual(["task_ids"]);
+  });
+});
+
+describe("watch_tasks", () => {
+  it("registers a watch and returns the service's ids", async () => {
+    const service = makeService({
+      watchTasks: vi.fn(async () => ({ watchId: "watch_42", firedImmediately: true })),
+    } as Partial<WatchService>);
+    const { watchTasks } = tools(service);
+    const res = await watchTasks.handler({ task_ids: ["task_1", "task_2"] });
+    expect(res.isError).toBeUndefined();
+    expect(res.content).toEqual({ watch_id: "watch_42", fired_immediately: true });
+    expect(service.watchTasks).toHaveBeenCalledWith({
+      callerAgentId: AGENT,
+      callerSessionId: SESSION,
+      taskIds: ["task_1", "task_2"],
+      mode: "all",
+      reason: undefined,
+    });
+  });
+
+  it("passes a valid mode through", async () => {
+    const service = makeService();
+    const { watchTasks } = tools(service);
+    await watchTasks.handler({ task_ids: ["task_1"], mode: "any" });
+    expect(service.watchTasks).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "any" }),
+    );
+  });
+
+  it("defaults an unrecognized mode to 'all' rather than rejecting the call", async () => {
+    const service = makeService();
+    const { watchTasks } = tools(service);
+    await watchTasks.handler({ task_ids: ["task_1"], mode: "eventually" });
+    expect(service.watchTasks).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "all" }),
+    );
+  });
+
+  it("trims the reason and drops a blank one", async () => {
+    const service = makeService();
+    const { watchTasks } = tools(service);
+    await watchTasks.handler({ task_ids: ["task_1"], reason: "  deploy check  " });
+    expect(service.watchTasks).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "deploy check" }),
+    );
+
+    await watchTasks.handler({ task_ids: ["task_1"], reason: "   " });
+    expect(service.watchTasks).toHaveBeenLastCalledWith(
+      expect.objectContaining({ reason: undefined }),
+    );
+  });
+
+  it("drops non-string entries from task_ids", async () => {
+    const service = makeService();
+    const { watchTasks } = tools(service);
+    await watchTasks.handler({ task_ids: ["task_1", 7, null, "task_2"] });
+    expect(service.watchTasks).toHaveBeenCalledWith(
+      expect.objectContaining({ taskIds: ["task_1", "task_2"] }),
+    );
+  });
+
+  it("rejects an empty task_ids array", async () => {
+    const service = makeService();
+    const { watchTasks } = tools(service);
+    const res = await watchTasks.handler({ task_ids: [] });
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("watch_validation");
+    expect(service.watchTasks).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-array task_ids", async () => {
+    const service = makeService();
+    const { watchTasks } = tools(service);
+    const res = await watchTasks.handler({ task_ids: "task_1" });
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("watch_validation");
+    expect(service.watchTasks).not.toHaveBeenCalled();
+  });
+
+  it("rejects an all-non-string task_ids array", async () => {
+    const service = makeService();
+    const { watchTasks } = tools(service);
+    const res = await watchTasks.handler({ task_ids: [1, 2, 3] });
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("watch_validation");
+  });
+
+  it("errors when there's no session context to identify the waiter", async () => {
+    const service = makeService();
+    const { watchTasks } = tools(service, { sessionId: undefined });
+    const res = await watchTasks.handler({ task_ids: ["task_1"] });
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("watch_validation");
+    expect(res.content.message).toContain("session context");
+    expect(service.watchTasks).not.toHaveBeenCalled();
+  });
+});
+
+describe("unwatch", () => {
+  it("cancels the watch and reports ok", async () => {
+    const service = makeService();
+    const { unwatch } = tools(service);
+    const res = await unwatch.handler({ watch_id: "watch_1" });
+    expect(res.isError).toBeUndefined();
+    expect(res.content).toEqual({ ok: true });
+    expect(service.unwatch).toHaveBeenCalledWith({
+      callerAgentId: AGENT,
+      watchId: "watch_1",
+    });
+  });
+
+  it("rejects a missing watch_id", async () => {
+    const service = makeService();
+    const { unwatch } = tools(service);
+    const res = await unwatch.handler({});
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("watch_validation");
+    expect(service.unwatch).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty-string watch_id", async () => {
+    const service = makeService();
+    const { unwatch } = tools(service);
+    const res = await unwatch.handler({ watch_id: "" });
+    expect(res.isError).toBe(true);
+    expect(service.unwatch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-string watch_id", async () => {
+    const service = makeService();
+    const { unwatch } = tools(service);
+    const res = await unwatch.handler({ watch_id: 12345 });
+    expect(res.isError).toBe(true);
+    expect(service.unwatch).not.toHaveBeenCalled();
+  });
+});
+
+describe("error translation", () => {
+  // The agent branches on these codes, so the mapping from the
+  // service's typed errors is part of the wire contract.
+  const cases: ReadonlyArray<readonly [string, Error, string]> = [
+    ["auth", new WatchAuthError("task belongs to another chain"), "watch_auth"],
+    ["validation", new WatchValidationError("too many tasks"), "watch_validation"],
+    ["not found", new WatchNotFoundError("no such watch"), "watch_not_found"],
+    ["generic Error", new Error("pg: connection reset"), "watch_error"],
+  ];
+
+  for (const [label, err, code] of cases) {
+    it(`maps a ${label} throw from watchTasks to ${code}`, async () => {
+      const service = makeService({
+        watchTasks: vi.fn(async () => {
+          throw err;
+        }),
+      } as Partial<WatchService>);
+      const { watchTasks } = tools(service);
+      const res = await watchTasks.handler({ task_ids: ["task_1"] });
+      expect(res.isError).toBe(true);
+      expect(res.content.error).toBe(code);
+      expect(res.content.message).toBe(err.message);
+    });
+
+    it(`maps a ${label} throw from unwatch to ${code}`, async () => {
+      const service = makeService({
+        unwatch: vi.fn(async () => {
+          throw err;
+        }),
+      } as Partial<WatchService>);
+      const { unwatch } = tools(service);
+      const res = await unwatch.handler({ watch_id: "watch_1" });
+      expect(res.isError).toBe(true);
+      expect(res.content.error).toBe(code);
+    });
+  }
+
+  it("stringifies a non-Error throw", async () => {
+    const service = makeService({
+      watchTasks: vi.fn(async () => {
+        throw "kaboom";
+      }),
+    } as Partial<WatchService>);
+    const { watchTasks } = tools(service);
+    const res = await watchTasks.handler({ task_ids: ["task_1"] });
+    expect(res.content.error).toBe("watch_error");
+    expect(res.content.message).toBe("kaboom");
+  });
+});


### PR DESCRIPTION
## What

Coverage sweep across all six packages, then tests for what it turned up. Four files were the only sizeable modules left in the monorepo with real branching logic and no test reaching it.

| File | Before | After | Tests added |
| --- | --- | --- | --- |
| `packages/api/src/routes/chat.ts` | 26.9% | **100%** | 58 |
| `packages/api/src/tools/use-repo.ts` | 32.0% | **100%** | 37 |
| `packages/api/src/tools/watch.ts` | 46.3% | **100%** | 24 |
| `packages/api/src/tools/session-search.ts` | 64.7% | **100%** | 23 |

`@beevibe/api` overall: **64.5% → 71.2%** lines (5797 → 6394 of 8983).

## Why these four

The sweep ran `vitest --coverage --coverage.all` per package with the DB- and key-gated suites excluded (they abort report generation from `afterAll`, per CLAUDE.md). What it showed:

- **`@beevibe/core`** — every remaining gap is a Postgres adapter or a live-API provider whose suite is gated on `DATABASE_URL_TEST` / provider keys. Covered in CI, not addressable here.
- **`@beevibe/daemon` / `@beevibe/scheduler`** — the gaps are `main.ts`, `start.ts`, `bootstrap.ts`: process entrypoints that wire dependencies, install signal handlers and never return. Deliberately left alone; the collaborators they wire (`Claimer`, `Supervisor`, `config`, `skills-cache`) each have their own tests.
- **`@beevibe/sandbox`** — remaining gaps are the documented manual ops scripts (`smoke.ts`, `reap.ts`).

That left the api package, where `routes/chat.ts` — the human-facing chat surface — was the single largest untested surface in the repo.

## What's covered

**`routes/chat.ts`** — `chat-internals.test.ts` already pinned the pure helpers (`groupIntoConversations`, `chainToMessages`, `failureMessageFor`), so the untested half was the router itself:

- `GET /conversations` — human gate, no-agent empty list, chain summarization, title/preview truncation, the 50-conversation cap
- `DELETE /conversations/:headId` — agent-scoped soft delete, idempotent re-delete, and the 500 envelope that keeps the raw error out of the response body
- `GET /` — chain selection (default vs `?c=`), the 25-session history truncation, the in-flight tail flag, and all five `runtime_mismatch` branches
- `POST /` — the full ladder: validation → idempotent replay (200 replay / 409 in-flight / 403 collision / two fall-through cases) → rate limit (429 concurrent + 429 throughput) → dispatch → daemon-offline 503 → resolver outcomes (success, failed-turn mapping, 504 timeout, 500) → onboarding flip

The POST ladder is where a regression is expensive: a dropped replay check means a second CLI spawn on every double-submit, and a leaked rate-limit slot locks a user out permanently. The tests assert the slot is released on **every** exit path, not just the success one.

**The three MCP tools** are adapters over services that already have their own tests, so these cover what the tools themselves do — normalizing the loosely-typed JSON an agent can send (MCP does not validate input against the declared schema) and translating typed service errors into the envelope the agent branches on. `use-repo` additionally pins the dispatch-before-`repo_run` ordering that its FK depends on, and the limit clamping.

Two cases added to `chat-internals.test.ts` for the failed-turn and in-flight branches of `chainToMessages`, which nothing reached.

## Verification

All fakes are `vi.fn()` stubs — no DB, no CLI, no network, so these run in the bare sandbox and in CI alike.

- `@beevibe/api`: **964 tests pass** across 47 files (DB-gated suites excluded locally; unchanged in CI)
- `pnpm typecheck`: clean, 9/9
- `pnpm lint`: clean (only the pre-existing `import/no-duplicates` warnings in `@beevibe/web`)

No production code changed — this PR is tests only. The `@vitest/coverage-v8` provider used for the sweep is not committed, per CLAUDE.md.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPyFPCFyT8Jf75GXegPKsw)_