### PR TITLE
test: drop tests for methods #285 deleted, plus three zero-signal cases

### DIFF
--- a/packages/api/src/routes/room.test.ts
+++ b/packages/api/src/routes/room.test.ts
@@ -140,10 +140,8 @@ function makeRoomRepo(): RoomRepository {
     addPersonMember: vi.fn(async () => {}),
     addAgentMember: vi.fn(async () => {}),
     listMembers: vi.fn(async () => []),
-    listMemberPersonIds: vi.fn(async () => []),
     listMemberAgentIds: vi.fn(async () => []),
     isMember: vi.fn(async () => true),
-    areAgentsCoMembers: vi.fn(async () => true),
     appendMessage: vi.fn(async (input) => fakeMessage({ ...input })),
     listMessages: vi.fn(async () => []),
   } as unknown as RoomRepository;

--- a/packages/core/src/adapters/postgres/room-repo.test.ts
+++ b/packages/core/src/adapters/postgres/room-repo.test.ts
@@ -3,10 +3,10 @@
  *
  * `room_member` carries a single `subject_id` alongside separate
  * `person_id` / `agent_id` columns, which is what makes the conflict
- * key, the kind filters and the `areAgentsCoMembers` self-join worth
- * exercising against a real engine rather than a fake pool: a wrong
- * `ON CONFLICT` target silently duplicates members, and a missing kind
- * filter leaks agents into the person list (and vice versa).
+ * key and the kind filters worth exercising against a real engine
+ * rather than a fake pool: a wrong `ON CONFLICT` target silently
+ * duplicates members, and a missing kind filter leaks agents into the
+ * person list (and vice versa).
  */
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { DEFAULT_RUNTIME_CONFIG } from "../../domain/agent.js";
@@ -178,15 +178,22 @@ describe("PostgresRoomRepository", () => {
     await rooms.addPersonMember(room.id, bob);
     await rooms.addAgentMember(room.id, alicesTeam);
 
-    expect((await rooms.listMemberPersonIds(room.id)).sort()).toEqual([alice, bob].sort());
+    // The kind filter is the whole point: `listMemberAgentIds` must not
+    // pick up the two people sharing the `subject_id` column with it.
     expect(await rooms.listMemberAgentIds(room.id)).toEqual([alicesTeam]);
+    const byKind = await rooms.listMembers(room.id);
+    expect(byKind.filter((m) => m.kind === "person").map((m) => m.subject_id).sort()).toEqual(
+      [alice, bob].sort(),
+    );
+    expect(byKind.filter((m) => m.kind === "agent").map((m) => m.subject_id)).toEqual([
+      alicesTeam,
+    ]);
   });
 
   it("returns empty id lists for a room with no members", async () => {
     const room = await newRoom();
 
     expect(await rooms.listMembers(room.id)).toEqual([]);
-    expect(await rooms.listMemberPersonIds(room.id)).toEqual([]);
     expect(await rooms.listMemberAgentIds(room.id)).toEqual([]);
   });
 
@@ -203,46 +210,6 @@ describe("PostgresRoomRepository", () => {
     expect(await rooms.isMember(room.id, alicesTeam)).toBe(false);
     expect(await rooms.isMember(other.id, alice)).toBe(false);
     expect(await rooms.isMember("room_missing", alice)).toBe(false);
-  });
-
-  it("detects agent co-membership across any shared room", async () => {
-    const room = await newRoom();
-    const otherRoom = await newRoom({ name: "Other" });
-    const loner = (
-      await agents.create({
-        id: agentId(),
-        name: "Loner",
-        owner_id: bob,
-        hierarchy_level: "ic",
-        runtime_config: DEFAULT_RUNTIME_CONFIG,
-      })
-    ).id;
-    await rooms.addAgentMember(room.id, alicesTeam);
-    await rooms.addAgentMember(room.id, bobsTeam);
-    await rooms.addAgentMember(otherRoom.id, loner);
-
-    expect(await rooms.areAgentsCoMembers(alicesTeam, bobsTeam)).toBe(true);
-    // Symmetric — the mesh gate must answer the same either direction.
-    expect(await rooms.areAgentsCoMembers(bobsTeam, alicesTeam)).toBe(true);
-    expect(await rooms.areAgentsCoMembers(alicesTeam, loner)).toBe(false);
-    expect(await rooms.areAgentsCoMembers(alicesTeam, "agent_nobody")).toBe(false);
-  });
-
-  it("never reports an agent as a co-member of itself", async () => {
-    const room = await newRoom();
-    await rooms.addAgentMember(room.id, alicesTeam);
-
-    // Short-circuits before the query — an agent sharing a room with
-    // itself must not open the mesh ask path back to its own inbox.
-    expect(await rooms.areAgentsCoMembers(alicesTeam, alicesTeam)).toBe(false);
-  });
-
-  it("does not treat a person co-member as an agent co-member", async () => {
-    const room = await newRoom();
-    await rooms.addPersonMember(room.id, alice);
-    await rooms.addPersonMember(room.id, bob);
-
-    expect(await rooms.areAgentsCoMembers(alice, bob)).toBe(false);
   });
 
   // ── Messages ───────────────────────────────────────────────────────────

--- a/packages/core/src/adapters/runtime-registry.test.ts
+++ b/packages/core/src/adapters/runtime-registry.test.ts
@@ -6,22 +6,12 @@ import {
 } from "./runtime-registry.js";
 
 describe("createDefaultRuntimeRegistry", () => {
-  it("registers claude-code", () => {
+  // Exact set, not a superset: `runtime_config.type` is persisted per agent,
+  // so a key that silently disappears strands every row pointing at it, and
+  // a key that silently appears is a runtime nothing validated.
+  it("registers exactly claude, codex and opencode", () => {
     const registry = createDefaultRuntimeRegistry();
-    expect(registry["claude"]).toBeDefined();
-    expect(registry["claude"]!.type).toBe("claude");
-  });
-
-  it("registers opencode", () => {
-    const registry = createDefaultRuntimeRegistry();
-    expect(registry["opencode"]).toBeDefined();
-    expect(registry["opencode"]!.type).toBe("opencode");
-  });
-
-  it("registers codex", () => {
-    const registry = createDefaultRuntimeRegistry();
-    expect(registry["codex"]).toBeDefined();
-    expect(registry["codex"]!.type).toBe("codex");
+    expect(Object.keys(registry).sort()).toEqual(["claude", "codex", "opencode"]);
   });
 
   it("every registry value's .type matches its registry key (sanity check against typos)", () => {

--- a/packages/web/app/(authed)/tasks/tasks-client.test.tsx
+++ b/packages/web/app/(authed)/tasks/tasks-client.test.tsx
@@ -201,14 +201,14 @@ describe("TasksClient — lane rendering", () => {
     expect(screen.getByText("cancel one")).toBeInTheDocument();
   });
 
-  it("calls the task list endpoint without a view filter (no My tasks tab)", async () => {
+  // The page has no view tabs, so the filter it sends is unconditionally
+  // empty — client-side search and the archive toggle do the narrowing.
+  it("calls the task list endpoint with an empty filter", async () => {
     listMock.mockResolvedValue([]);
     renderClient();
 
     await waitFor(() =>
       expect(listMock).toHaveBeenCalledWith({}, expect.objectContaining({})),
     );
-    // Sanity: the obsolete "My tasks" affordance shouldn't render.
-    expect(screen.queryByRole("button", { name: "My tasks" })).not.toBeInTheDocument();
   });
 });

--- a/packages/web/lib/api/client.test.ts
+++ b/packages/web/lib/api/client.test.ts
@@ -92,7 +92,10 @@ describe("api client (reads)", () => {
     });
   });
 
-  describe("deferred surfaces (paths set; backend not yet shipped)", () => {
+  // These three shipped after the label above them was written: each has a
+  // live `router.get` in api/src/routes/view.ts and a page reading it through
+  // usePromotions / useMeshOverview / useDashboard.
+  describe("promotions, mesh and dashboard reads", () => {
     it("promotions.list() hits /promotion", async () => {
       await api.promotions.list();
       expect(fetchJsonMock).toHaveBeenCalledWith("/promotion", { signal: undefined });

--- a/packages/web/lib/hooks/keys.test.ts
+++ b/packages/web/lib/hooks/keys.test.ts
@@ -25,10 +25,4 @@ describe("queryKeys", () => {
     const b = queryKeys.tasks.list({ view: "mine" });
     expect(a).not.toEqual(b);
   });
-
-  it("structural equality across separate calls with the same arg shape", () => {
-    const a = queryKeys.tasks.list({ view: "mine" });
-    const b = queryKeys.tasks.list({ view: "mine" });
-    expect(a).toEqual(b);
-  });
 });

--- a/packages/web/lib/hooks/use-tasks.test.tsx
+++ b/packages/web/lib/hooks/use-tasks.test.tsx
@@ -31,8 +31,10 @@ import { api } from "@/lib/api/client";
 const listMock = vi.mocked(api.tasks.list);
 const getMock = vi.mocked(api.tasks.get);
 
-function wrapper() {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+function wrapper(queryOptions: { staleTime?: number } = {}) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, ...queryOptions } },
+  });
   return function TestQueryWrapper({ children }: { children: ReactNode }) {
     return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
   };
@@ -81,18 +83,24 @@ describe("useTasks", () => {
     expect(listMock).toHaveBeenCalledWith({ view: "mine" }, expect.objectContaining({}));
   });
 
-  it("treats different filters as separate cache entries", async () => {
-    listMock.mockResolvedValueOnce([sampleTask]).mockResolvedValueOnce([]);
+  // `refetchOnMount: "always"` is a deliberate choice on this hook (see the
+  // comment in use-tasks.ts): landing on /tasks must re-hit the API even
+  // when the slot already holds fresh data, because a missed SSE event
+  // would otherwise leave the board stale. Pinned with `staleTime:
+  // Infinity`, which is the only setting under which a second mount would
+  // otherwise be served purely from cache.
+  it("refetches on every mount even when the cached entry is fresh", async () => {
+    listMock.mockResolvedValue([sampleTask]);
+    const wrap = wrapper({ staleTime: Infinity });
 
-    const wrap = wrapper();
     const a = renderHook(() => useTasks({ view: "mine" }), { wrapper: wrap });
     await waitFor(() => expect(a.result.current.isSuccess).toBe(true));
+    expect(listMock).toHaveBeenCalledTimes(1);
+
     const b = renderHook(() => useTasks({ view: "mine" }), { wrapper: wrap });
     await waitFor(() => expect(b.result.current.isSuccess).toBe(true));
-
     expect(listMock).toHaveBeenCalledTimes(2);
-    expect(listMock).toHaveBeenNthCalledWith(1, { view: "mine" }, expect.objectContaining({}));
-    expect(listMock).toHaveBeenNthCalledWith(2, { view: "mine" }, expect.objectContaining({}));
+    expect(listMock).toHaveBeenLastCalledWith({ view: "mine" }, expect.objectContaining({}));
   });
 
   it("surfaces errors from the api", async () => {


### PR DESCRIPTION
A sweep of all 160 test files for tests that no longer earn their place.

The headline find came from CI rather than the local sweep, and it is a **failure that exists on `main` today**.

## `room-repo.test.ts` calls two methods that no longer exist

```
TypeError: rooms.listMemberPersonIds is not a function
TypeError: rooms.areAgentsCoMembers is not a function
```

#286 added integration coverage for `PostgresRoomRepository`. #285, one commit later, deleted `listMemberPersonIds` and `areAgentsCoMembers` as dead code — from the port and the adapter — but left the five tests calling them behind. `main`'s "Unit + Integration Tests" job is red on this now.

It only fails where Postgres is available, which is why it survived: in a bare sandbox `room-repo.test.ts` is one of the ~20 DB-gated files that fail in `beforeAll` anyway, so a real breakage is indistinguishable from the documented environmental noise.

- The three `areAgentsCoMembers` tests go entirely. Nothing is left to exercise — the mesh ask gate they describe was never built (#285 established that `ask` performs no peer check at all).
- The two that used `listMemberPersonIds` keep their actual subject, the `room_member` kind filter, and get it from `listMembers`, which is live and carries the `kind` discriminator directly. The `listMemberAgentIds` assertions are unchanged.
- `routes/room.test.ts`'s repo fake carried `vi.fn()` stubs for both removed methods. #285 swept exactly these stubs for `AgentRepository.findByOwnerId` and missed the room pair.

### Why typecheck didn't catch it

`packages/core/tsconfig.json` excludes `**/*.test.ts`, so `pnpm typecheck` never sees test files. A test calling a deleted method on a **fully typed** `PostgresRoomRepository` still typechecks clean, and only the Postgres-backed job notices.

Including tests in the typecheck would have caught this at the source commit, but it surfaces 95 pre-existing errors in core alone (mostly `vi.spyOn` inference on the CLI-runtime suites), so it's flagged here rather than folded in.

## The rest of the sweep

Three of the four staleness categories came back clean, recorded so the next sweep can skip them:

- **Nothing is skipped without a reason.** Every gate is an opt-in env var with a documented rationale and a run command — `RUN_CLAUDE_SMOKE`, `BEEVIBE_E2E_DOCKER`, `BEEVIBE_E2E_MULTI_INSTANCE`, `HAS_LIVE_API_KEYS`, plus the `win32` guards. No `.only`, no `.todo`, no commented-out suites.
- **No other test targets a removed feature.** A mechanical check of every `postgres/*-repo.test.ts` against its adapter's method list comes back clean, as does a grep for every symbol the recent dead-code sweeps removed. Every relative `vi.mock` path resolves.
- **No test is assertion-free.** A parser over every `it`/`test` block found zero bodies without an `expect` / `toThrow` / `assert`.

What else was stale:

### `web/lib/hooks/use-tasks.test.tsx` — an unfalsifiable cache test

`treats different filters as separate cache entries` passed both `renderHook` calls the **same** filter, and `useTasks` sets `refetchOnMount: "always"`, so the second mount refetches no matter what the query key is. The `toHaveBeenCalledTimes(2)` measured "two mounts refetch", not "two cache slots".

Verified unfalsifiable: deleting `refetchOnMount: "always"` from `use-tasks.ts` left the entire file green. Cache-key separation is already covered by `keys.test.ts`, so the test now pins what *is* this hook's own behavior — a remount refetches even against a fresh entry, asserted under `staleTime: Infinity`. The same mutation now fails it.

### `web/app/(authed)/tasks/tasks-client.test.tsx` — guard on a removed affordance

An assertion that no `"My tasks"` button renders. That tab went when the backend stopped distinguishing mine from all; the string survives nowhere in `packages/web` except a historical comment in `view-tabs.tsx`, and `ViewTabs` has no view-tab surface left to regress.

### `web/lib/hooks/keys.test.ts` — asserts a property of vitest

`structural equality across separate calls with the same arg shape` compared two array literals from one pure function with `toEqual`. Any implementation passes.

### `core/src/adapters/runtime-registry.test.ts` — three subsumed tests

Three one-per-runtime `registers X` tests, each a subset of the `every registry value's .type matches its registry key` test below them. Collapsed into one exact-inventory assertion, which is strictly stronger — it also catches a key silently appearing or disappearing, a live concern given `runtime_config.type` is persisted per agent.

### `web/lib/api/client.test.ts` — stale label

A describe block still reading `deferred surfaces (paths set; backend not yet shipped)`. All three shipped: `/promotion`, `/mesh` and `/dashboard` each have a live `router.get` in `api/src/routes/view.ts` and a page reading them through `usePromotions` / `useMeshOverview` / `useDashboard`. Relabelled; tests unchanged.

## Verification

| | before | after |
| --- | --- | --- |
| `@beevibe/web` | 203 passed | 202 passed |
| `@beevibe/core` | 609 passed, 7 failed, 272 skipped | 607 passed, 7 failed, 269 skipped |
| `@beevibe/api` `routes/room` | 71 passed | 71 passed |

Locally the deltas are exactly the removed tests and nothing else; the 7 core failures are the pre-existing environmental set documented in CLAUDE.md (no Postgres, no provider keys) and the count is unchanged. On CI, where Postgres *is* available, all three checks are green. `pnpm typecheck` clean; `pnpm lint` warnings unchanged and all in untouched files.

No production code is modified.