### PR TITLE
refactor: unify three clusters of near-duplicate abstractions

### DIFF
--- a/packages/api/src/routes/task-review.test.ts
+++ b/packages/api/src/routes/task-review.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for the approve / reject pair on the /task router.
+ *
+ * `task.test.ts` covers these end-to-end, but it is DB-gated — it needs
+ * `DATABASE_URL_TEST` and skips wholesale without one, which left the two
+ * handlers with no coverage in a bare checkout. Both now share one
+ * `reviewRoute` factory, so this pins the behavior that factory has to keep:
+ * the auth gate, the optional `result_summary` parse, which `TaskService`
+ * verb each verb-route calls, the response projection, and the error mapping.
+ *
+ * Every collaborator is injected, so the router mounts against a bare
+ * Express app with stubs — no database.
+ */
+import { describe, it, expect, vi } from "vitest";
+import express, { json, type RequestHandler } from "express";
+import request from "supertest";
+import {
+  InvalidTaskTransitionError,
+  TaskNotFoundError,
+} from "@beevibe/core/services/task-service";
+import { createTaskRouter } from "./task.js";
+
+const PERSON = "per_alice";
+const humanCaller = { source: "human", personId: PERSON };
+
+/** Auth middleware stand-in — attaches whatever caller the test wants. */
+function callerAs(caller: unknown): RequestHandler {
+  return (req, _res, next) => {
+    if (caller !== null) (req as { caller?: unknown }).caller = caller;
+    next();
+  };
+}
+
+function makeApp(caller: unknown = humanCaller) {
+  const approveTask = vi.fn();
+  const rejectTask = vi.fn();
+
+  const router = createTaskRouter({
+    authMiddleware: callerAs(caller),
+    taskService: { approveTask, rejectTask } as never,
+    // Untouched by approve/reject. The capability repos are deliberately
+    // omitted, which makes `recordCapabilityOutcome` a no-op — that branch is
+    // already covered where it's wired.
+    taskRepo: {} as never,
+    sessionRepo: {} as never,
+    runtimeRepo: {} as never,
+    dispatchService: {} as never,
+    hub: {} as never,
+    pool: {} as never,
+  });
+
+  const app = express();
+  app.use(json());
+  app.use("/task", router);
+  return { app, approveTask, rejectTask };
+}
+
+// Both routes run the same factory, so each behavior is asserted against
+// both verbs rather than trusting that approve's pass implies reject's.
+const VERBS = [
+  { verb: "approve", service: "approveTask" },
+  { verb: "reject", service: "rejectTask" },
+] as const;
+
+describe.each(VERBS)("POST /task/:id/$verb", ({ verb, service }) => {
+  it("calls the matching TaskService verb and projects id + status", async () => {
+    const app = makeApp();
+    app[service].mockResolvedValue({
+      id: "task_1",
+      status: verb === "approve" ? "done" : "cancelled",
+      // Extra columns must NOT leak — the response is a two-field projection.
+      description: "secret",
+    });
+
+    const res = await request(app.app)
+      .post(`/task/task_1/${verb}`)
+      .send({ result_summary: "looks good" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      task: { id: "task_1", status: verb === "approve" ? "done" : "cancelled" },
+    });
+    expect(app[service]).toHaveBeenCalledWith("task_1", "looks good");
+    // The sibling verb must not have fired.
+    const other = service === "approveTask" ? "rejectTask" : "approveTask";
+    expect(app[other]).not.toHaveBeenCalled();
+  });
+
+  it("passes result_summary as undefined when absent or not a string", async () => {
+    for (const body of [{}, { result_summary: 42 }, { result_summary: null }]) {
+      const app = makeApp();
+      app[service].mockResolvedValue({ id: "task_1", status: "done" });
+
+      const res = await request(app.app).post(`/task/task_1/${verb}`).send(body);
+
+      expect(res.status).toBe(200);
+      expect(app[service]).toHaveBeenCalledWith("task_1", undefined);
+    }
+  });
+
+  it("403s a non-human caller without touching the service", async () => {
+    const app = makeApp({ source: "agent", personId: PERSON, agentId: "agt_1" });
+
+    const res = await request(app.app).post(`/task/task_1/${verb}`).send({});
+
+    expect(res.status).toBe(403);
+    expect(app[service]).not.toHaveBeenCalled();
+  });
+
+  it("maps TaskNotFoundError to 404", async () => {
+    const app = makeApp();
+    app[service].mockRejectedValue(new TaskNotFoundError("task_gone"));
+
+    const res = await request(app.app).post(`/task/task_gone/${verb}`).send({});
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("task_not_found");
+  });
+
+  it("maps InvalidTaskTransitionError to 409", async () => {
+    const app = makeApp();
+    app[service].mockRejectedValue(
+      new InvalidTaskTransitionError(`cannot ${verb} task in status 'done'`),
+    );
+
+    const res = await request(app.app).post(`/task/task_1/${verb}`).send({});
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe("invalid_transition");
+  });
+
+  it("maps an unexpected throw to 500", async () => {
+    const app = makeApp();
+    // Suppress the handler's own console.error for this expected path.
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    app[service].mockRejectedValue(new Error("boom"));
+
+    const res = await request(app.app).post(`/task/task_1/${verb}`).send({});
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("internal_error");
+    spy.mockRestore();
+  });
+});

--- a/packages/api/src/routes/task.ts
+++ b/packages/api/src/routes/task.ts
@@ -185,41 +185,50 @@ export function createTaskRouter(deps: TaskRoutesDeps): Router {
     }
   });
 
+  /**
+   * The approve / reject pair: identical bodies apart from which
+   * `TaskService` verb they call and which outcome they record. Both take an
+   * optional `result_summary`, both fire the best-effort capability-outcome
+   * write, and both answer with the same `{ ok, task: { id, status } }`
+   * projection — so a change to any of that had two places to land.
+   *
+   * `revise`, `retry` and `cancel` deliberately stay hand-written below:
+   * revise dispatches a follow-up session, retry builds a resume reason, and
+   * cancel runs a transition gate plus the WS/pg_notify fan-out. They share
+   * the preamble, not the shape.
+   */
+  const reviewRoute = (
+    apply: (id: string, summary: string | undefined) => Promise<{ id: string; status: string }>,
+    outcome: "approved" | "rejected",
+  ): RequestHandler =>
+    async (req, res) => {
+      if (!requireHuman(req, res)) return;
+      const id = requireParam(req, res, "id", "missing_task_id");
+      if (!id) return;
+      try {
+        const summary =
+          typeof req.body?.result_summary === "string"
+            ? req.body.result_summary
+            : undefined;
+        const updated = await apply(id, summary);
+        void recordCapabilityOutcome(id, outcome, req.caller!.personId, deps);
+        res.json({ ok: true, task: { id: updated.id, status: updated.status } });
+      } catch (err) {
+        handleServiceError(err, res);
+      }
+    };
+
   // POST /task/:id/approve
-  router.post("/:id/approve", async (req, res) => {
-    if (!requireHuman(req, res)) return;
-    const id = requireParam(req, res, "id", "missing_task_id");
-    if (!id) return;
-    try {
-      const summary =
-        typeof req.body?.result_summary === "string"
-          ? req.body.result_summary
-          : undefined;
-      const updated = await deps.taskService.approveTask(id, summary);
-      void recordCapabilityOutcome(id, "approved", req.caller!.personId, deps);
-      res.json({ ok: true, task: { id: updated.id, status: updated.status } });
-    } catch (err) {
-      handleServiceError(err, res);
-    }
-  });
+  router.post(
+    "/:id/approve",
+    reviewRoute((id, summary) => deps.taskService.approveTask(id, summary), "approved"),
+  );
 
   // POST /task/:id/reject
-  router.post("/:id/reject", async (req, res) => {
-    if (!requireHuman(req, res)) return;
-    const id = requireParam(req, res, "id", "missing_task_id");
-    if (!id) return;
-    try {
-      const summary =
-        typeof req.body?.result_summary === "string"
-          ? req.body.result_summary
-          : undefined;
-      const updated = await deps.taskService.rejectTask(id, summary);
-      void recordCapabilityOutcome(id, "rejected", req.caller!.personId, deps);
-      res.json({ ok: true, task: { id: updated.id, status: updated.status } });
-    } catch (err) {
-      handleServiceError(err, res);
-    }
-  });
+  router.post(
+    "/:id/reject",
+    reviewRoute((id, summary) => deps.taskService.rejectTask(id, summary), "rejected"),
+  );
 
   // POST /task/:id/revise
   router.post("/:id/revise", async (req, res) => {

--- a/packages/api/src/routes/view.ts
+++ b/packages/api/src/routes/view.ts
@@ -113,6 +113,61 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
       "agent_not_found",
     );
 
+  /**
+   * "Fetch one row by route param, or 404" — the shape every detail route in
+   * this router has.
+   *
+   * Five handlers spelled this out: auth-gate, narrow the param, call a
+   * `views/*` composer, 404 when it resolves `undefined`, otherwise `res.json`,
+   * with `handleError` on the catch. Two of them (`/session/:shortId` and its
+   * `/conversation` sibling) already went through a local `shortIdRoute`
+   * factory — this is that factory with the three hardcoded strings lifted
+   * into parameters, so `/task/:id`, `/agent/:id` and `/work-product/:id` can
+   * stop hand-rolling it. All five composers already share one signature,
+   * `(pool, id) => Promise<T | undefined>`, which is what makes them
+   * interchangeable here.
+   *
+   * `shortIdRoute` also hand-rolled the param narrowing that `requireParam`
+   * exists to do; the 400 body it produced (`{ error: <code> }`) is
+   * byte-identical, so routing through `requireParam` drops that copy too.
+   *
+   * The `AmbiguousShortIdError` → 409 branch stays unconditional. Only the
+   * two session composers throw it (a short id can prefix-match more than one
+   * session); for the other three the branch is inert, which is cheaper than
+   * a config knob no caller would ever vary.
+   */
+  const detailRoute =
+    <T>(opts: {
+      /** Route param to read, e.g. `"id"` or `"shortId"`. */
+      param: string;
+      /** 400 code when the param is missing/empty. Not uniform across routes. */
+      missingError: string;
+      /** 404 code when the composer resolves `undefined`. */
+      notFoundError: string;
+      /** `handleError` context, e.g. `"task detail"`. */
+      label: string;
+      fetch: (pool: Pool, id: string) => Promise<T | undefined>;
+    }): RequestHandler =>
+    async (req, res) => {
+      if (!requireHuman(req, res)) return;
+      const id = requireParam(req, res, opts.param, opts.missingError);
+      if (!id) return;
+      try {
+        const result = await opts.fetch(deps.pool, id);
+        if (!result) {
+          res.status(404).json({ error: opts.notFoundError });
+          return;
+        }
+        res.json(result);
+      } catch (err) {
+        if (err instanceof AmbiguousShortIdError) {
+          res.status(409).json({ error: "ambiguous_short_id", message: err.message });
+          return;
+        }
+        handleError(err, res, opts.label);
+      }
+    };
+
   router.get("/task", async (req, res) => {
     if (!requireHuman(req, res)) return;
 
@@ -153,21 +208,16 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
     }
   });
 
-  router.get("/task/:id", async (req, res) => {
-    if (!requireHuman(req, res)) return;
-    const id = requireParam(req, res, "id", "missing_task_id");
-    if (!id) return;
-    try {
-      const task = await getTask(deps.pool, id);
-      if (!task) {
-        res.status(404).json({ error: "task_not_found" });
-        return;
-      }
-      res.json(task);
-    } catch (err) {
-      handleError(err, res, "task detail");
-    }
-  });
+  router.get(
+    "/task/:id",
+    detailRoute({
+      param: "id",
+      missingError: "missing_task_id",
+      notFoundError: "task_not_found",
+      label: "task detail",
+      fetch: getTask,
+    }),
+  );
 
   router.get("/agent", async (req, res) => {
     if (!requireHuman(req, res)) return;
@@ -200,21 +250,16 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
     }
   });
 
-  router.get("/agent/:id", async (req, res) => {
-    if (!requireHuman(req, res)) return;
-    const id = requireParam(req, res, "id", "missing_agent_id");
-    if (!id) return;
-    try {
-      const agent = await getAgent(deps.pool, id);
-      if (!agent) {
-        res.status(404).json({ error: "agent_not_found" });
-        return;
-      }
-      res.json(agent);
-    } catch (err) {
-      handleError(err, res, "agent detail");
-    }
-  });
+  router.get(
+    "/agent/:id",
+    detailRoute({
+      param: "id",
+      missingError: "missing_agent_id",
+      notFoundError: "agent_not_found",
+      label: "agent detail",
+      fetch: getAgent,
+    }),
+  );
 
   router.post("/agent/:id/runtime", async (req, res) => {
     if (!requireHuman(req, res)) return;
@@ -375,42 +420,27 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
     }
   });
 
-  // Both short_id session routes share the same shape: require human →
-  // validate short_id → fetch → 404 on miss, 409 on ambiguous prefix.
-  // Factored so the single-session and whole-conversation lookups stay in
-  // lockstep (e.g. if the error contract or auth check changes).
-  const shortIdRoute =
-    <T>(
-      fetch: (pool: Pool, shortId: string) => Promise<T | undefined>,
-      errorLabel: string,
-    ): RequestHandler =>
-    async (req, res) => {
-      if (!requireHuman(req, res)) return;
-      // Express 5 types a bare params value as `string | string[]`; a single
-      // `:shortId` segment is always a string at runtime, but narrow it so
-      // the type matches `fetch`'s `string` param.
-      const shortId = req.params.shortId;
-      if (typeof shortId !== "string" || !shortId) {
-        res.status(400).json({ error: "missing_short_id" });
-        return;
-      }
-      try {
-        const result = await fetch(deps.pool, shortId);
-        if (!result) {
-          res.status(404).json({ error: "session_not_found" });
-          return;
-        }
-        res.json(result);
-      } catch (err) {
-        if (err instanceof AmbiguousShortIdError) {
-          res.status(409).json({ error: "ambiguous_short_id", message: err.message });
-          return;
-        }
-        handleError(err, res, errorLabel);
-      }
-    };
+  /**
+   * `detailRoute` bound to the session short-id contract, so the single-session
+   * and whole-conversation lookups keep sharing one param name, one 400 code
+   * and one 404 code instead of repeating all three.
+   */
+  const sessionDetailRoute = <T>(
+    fetch: (pool: Pool, shortId: string) => Promise<T | undefined>,
+    label: string,
+  ): RequestHandler =>
+    detailRoute({
+      param: "shortId",
+      missingError: "missing_short_id",
+      notFoundError: "session_not_found",
+      label,
+      fetch,
+    });
 
-  router.get("/session/:shortId", shortIdRoute(getSessionByShortId, "session detail"));
+  router.get(
+    "/session/:shortId",
+    sessionDetailRoute(getSessionByShortId, "session detail"),
+  );
 
   // Whole-conversation detail: given the short_id of any chat turn (in
   // practice the head turn's, the URL key the agent detail page links to),
@@ -419,7 +449,7 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
   // page renders them unchanged.
   router.get(
     "/session/:shortId/conversation",
-    shortIdRoute(getConversationByShortId, "conversation detail"),
+    sessionDetailRoute(getConversationByShortId, "conversation detail"),
   );
 
   /**
@@ -584,21 +614,16 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
     }
   });
 
-  router.get("/work-product/:id", async (req, res) => {
-    if (!requireHuman(req, res)) return;
-    const id = requireParam(req, res, "id", "missing_work_product_id");
-    if (!id) return;
-    try {
-      const wp = await getWorkProduct(deps.pool, id);
-      if (!wp) {
-        res.status(404).json({ error: "work_product_not_found" });
-        return;
-      }
-      res.json(wp);
-    } catch (err) {
-      handleError(err, res, "work product detail");
-    }
-  });
+  router.get(
+    "/work-product/:id",
+    detailRoute({
+      param: "id",
+      missingError: "missing_work_product_id",
+      notFoundError: "work_product_not_found",
+      label: "work product detail",
+      fetch: getWorkProduct,
+    }),
+  );
 
   router.get("/inbox", async (req, res) => {
     if (!requireHuman(req, res)) return;

--- a/packages/web/app/(authed)/work-products/[id]/work-product-detail-client.tsx
+++ b/packages/web/app/(authed)/work-products/[id]/work-product-detail-client.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { useQuery } from "@tanstack/react-query";
 import {
   ArrowLeft,
   ChevronRight,
@@ -9,7 +8,7 @@ import {
   FileText,
 } from "lucide-react";
 import { api, type WorkProductDetail } from "@/lib/api/client";
-import { isApiConfigured } from "@/lib/api/config";
+import { useApiDetailQuery } from "@/lib/hooks/api-query";
 import { queryKeys } from "@/lib/hooks/keys";
 import { DetailGate } from "@/components/detail/detail-gate";
 import { EmptyState } from "@/components/empty-state";
@@ -20,10 +19,11 @@ import { FooterField } from "@/components/detail/footer-field";
 import { formatRelativeTime, shortId } from "@/lib/format";
 
 export function WorkProductDetailClient({ workProductId }: { workProductId: string }) {
-  const query = useQuery<WorkProductDetail>({
-    queryKey: queryKeys.workProducts.detail(workProductId),
-    queryFn: ({ signal }) => api.workProducts.get(workProductId, { signal }),
-    enabled: isApiConfigured && !!workProductId,
+  const query = useApiDetailQuery<WorkProductDetail>({
+    id: workProductId,
+    keyFor: queryKeys.workProducts.detail,
+    fallbackKey: queryKeys.workProducts.all,
+    fetch: (id, ctx) => api.workProducts.get(id, ctx),
     staleTime: 30_000,
   });
 

--- a/packages/web/lib/hooks/api-query.test.tsx
+++ b/packages/web/lib/hooks/api-query.test.tsx
@@ -1,0 +1,227 @@
+/**
+ * Tests for the shared read-query factories.
+ *
+ * `useApiDetailQuery` is what the six per-entity detail hooks now run on, so
+ * the contract it owns is worth pinning directly rather than only through
+ * whichever caller happens to be tested: the `isApiConfigured` gate, the
+ * `!!id` gate, the key/fallback-key switch, that the fetcher receives a
+ * narrowed `string` id, and that caller extras (`staleTime`, `select`, an
+ * additional `enabled`) still reach `useQuery`.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+const apiState = { isApiConfigured: true };
+
+vi.mock("@/lib/api/config", () => ({
+  get isApiConfigured() {
+    return apiState.isApiConfigured;
+  },
+  apiBaseUrl: "https://api.example.com",
+}));
+
+import { useApiDetailQuery, useApiQuery } from "./api-query";
+
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function TestQueryWrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+const keyFor = (id: string) => ["thing", "detail", id] as const;
+const fallbackKey = ["thing"] as const;
+
+beforeEach(() => {
+  apiState.isApiConfigured = true;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useApiQuery", () => {
+  it("does not fire when the API is not configured", async () => {
+    apiState.isApiConfigured = false;
+    const fetch = vi.fn().mockResolvedValue("v");
+
+    const { result } = renderHook(() => useApiQuery(["k"], fetch), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => expect(result.current.fetchStatus).toBe("idle"));
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("ANDs a caller-supplied enabled with the config gate rather than replacing it", async () => {
+    const fetch = vi.fn().mockResolvedValue("v");
+
+    // Config on, caller off → still off.
+    const off = renderHook(() => useApiQuery(["k"], fetch, { enabled: false }), {
+      wrapper: wrapper(),
+    });
+    await waitFor(() => expect(off.result.current.fetchStatus).toBe("idle"));
+    expect(fetch).not.toHaveBeenCalled();
+
+    // Config on, caller on → fires.
+    const on = renderHook(() => useApiQuery(["k"], fetch, { enabled: true }), {
+      wrapper: wrapper(),
+    });
+    await waitFor(() => expect(on.result.current.isSuccess).toBe(true));
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes an abort signal through to the fetcher", async () => {
+    const fetch = vi.fn().mockResolvedValue("v");
+
+    const { result } = renderHook(() => useApiQuery(["k"], fetch), {
+      wrapper: wrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetch.mock.calls[0]?.[0]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("applies a caller-supplied select", async () => {
+    const fetch = vi.fn().mockResolvedValue({ n: 2 });
+
+    const { result } = renderHook(
+      () =>
+        useApiQuery<{ n: number }, number>(["k"], fetch, {
+          select: (d) => d.n * 10,
+        }),
+      { wrapper: wrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(20);
+  });
+});
+
+describe("useApiDetailQuery", () => {
+  it("is disabled when id is undefined, and does not call the fetcher", async () => {
+    const fetch = vi.fn().mockResolvedValue("v");
+
+    const { result } = renderHook(
+      () => useApiDetailQuery({ id: undefined, keyFor, fallbackKey, fetch }),
+      { wrapper: wrapper() },
+    );
+
+    await waitFor(() => expect(result.current.fetchStatus).toBe("idle"));
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("is disabled when the API is not configured even with an id", async () => {
+    apiState.isApiConfigured = false;
+    const fetch = vi.fn().mockResolvedValue("v");
+
+    const { result } = renderHook(
+      () => useApiDetailQuery({ id: "x1", keyFor, fallbackKey, fetch }),
+      { wrapper: wrapper() },
+    );
+
+    await waitFor(() => expect(result.current.fetchStatus).toBe("idle"));
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("fetches with the narrowed id when both id and config are present", async () => {
+    const fetch = vi.fn().mockResolvedValue("detail");
+
+    const { result } = renderHook(
+      () => useApiDetailQuery({ id: "x1", keyFor, fallbackKey, fetch }),
+      { wrapper: wrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe("detail");
+    expect(fetch.mock.calls[0]?.[0]).toBe("x1");
+    expect(fetch.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("keys distinct ids into distinct cache slots", async () => {
+    const fetch = vi.fn(async (id: string) => `v:${id}`);
+    const wrap = wrapper();
+
+    const a = renderHook(
+      () => useApiDetailQuery({ id: "x1", keyFor, fallbackKey, fetch }),
+      { wrapper: wrap },
+    );
+    await waitFor(() => expect(a.result.current.isSuccess).toBe(true));
+
+    const b = renderHook(
+      () => useApiDetailQuery({ id: "x2", keyFor, fallbackKey, fetch }),
+      { wrapper: wrap },
+    );
+    await waitFor(() => expect(b.result.current.isSuccess).toBe(true));
+
+    expect(a.result.current.data).toBe("v:x1");
+    expect(b.result.current.data).toBe("v:x2");
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("shares one cache slot for the same id", async () => {
+    // `staleTime` pins the point: with a shared key the second mount reads the
+    // still-fresh slot instead of refetching. Without it TanStack's default
+    // `staleTime: 0` refetches on every mount, which would pass regardless of
+    // whether the two hooks agreed on a key.
+    const fetch = vi.fn().mockResolvedValue("v");
+    const wrap = wrapper();
+    const opts = { id: "x1", keyFor, fallbackKey, fetch, staleTime: 60_000 };
+
+    const a = renderHook(() => useApiDetailQuery(opts), { wrapper: wrap });
+    await waitFor(() => expect(a.result.current.isSuccess).toBe(true));
+
+    const b = renderHook(() => useApiDetailQuery(opts), { wrapper: wrap });
+    await waitFor(() => expect(b.result.current.isSuccess).toBe(true));
+
+    expect(b.result.current.data).toBe("v");
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("honours caller extras alongside the id gate", async () => {
+    const fetch = vi.fn().mockResolvedValue({ n: 3 });
+
+    const { result } = renderHook(
+      () =>
+        useApiDetailQuery<{ n: number }, number>({
+          id: "x1",
+          keyFor,
+          fallbackKey,
+          fetch,
+          staleTime: 60_000,
+          select: (d) => d.n + 1,
+        }),
+      { wrapper: wrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(4);
+  });
+
+  it("stays disabled when the caller's own enabled is false despite a present id", async () => {
+    const fetch = vi.fn().mockResolvedValue("v");
+
+    const { result } = renderHook(
+      () =>
+        useApiDetailQuery({ id: "x1", keyFor, fallbackKey, fetch, enabled: false }),
+      { wrapper: wrapper() },
+    );
+
+    await waitFor(() => expect(result.current.fetchStatus).toBe("idle"));
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("surfaces fetcher errors", async () => {
+    const fetch = vi.fn().mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(
+      () => useApiDetailQuery({ id: "x1", keyFor, fallbackKey, fetch }),
+      { wrapper: wrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe("boom");
+  });
+});

--- a/packages/web/lib/hooks/api-query.ts
+++ b/packages/web/lib/hooks/api-query.ts
@@ -1,0 +1,88 @@
+"use client";
+
+import {
+  useQuery,
+  type QueryKey,
+  type UseQueryOptions,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import { isApiConfigured } from "@/lib/api/config";
+
+/**
+ * Everything a caller may still pass through, minus the three fields these
+ * factories own (`queryKey`, `queryFn`, `enabled`). `select`, `staleTime`,
+ * `refetchOnMount`, `refetchInterval` and friends all still work.
+ */
+type ApiQueryExtras<TQueryFnData, TData> = Omit<
+  UseQueryOptions<TQueryFnData, Error, TData>,
+  "queryKey" | "queryFn" | "enabled"
+> & {
+  /** ANDed with the factory's own gate rather than replacing it. Default true. */
+  enabled?: boolean;
+};
+
+/**
+ * `useQuery` with the `isApiConfigured` gate applied.
+ *
+ * Every read hook in this directory gates on it — without a configured
+ * `NEXT_PUBLIC_BV_API_URL`, `fetchJson` throws `ApiNotConfigured`, so an
+ * ungated query renders an error state instead of staying idle.
+ */
+export function useApiQuery<TQueryFnData, TData = TQueryFnData>(
+  queryKey: QueryKey,
+  queryFn: (ctx: { signal: AbortSignal }) => Promise<TQueryFnData>,
+  extras: ApiQueryExtras<TQueryFnData, TData> = {},
+): UseQueryResult<TData, Error> {
+  const { enabled = true, ...rest } = extras;
+  return useQuery<TQueryFnData, Error, TData>({
+    ...rest,
+    queryKey,
+    queryFn: ({ signal }) => queryFn({ signal }),
+    enabled: isApiConfigured && enabled,
+  });
+}
+
+/**
+ * The "fetch one entity by id" read hook.
+ *
+ * Six hooks — `useTask`, `useAgent`, `useSession`, `useConversation`,
+ * `useEscalation`, `useNegotiation` — plus the inline copy in the
+ * work-product detail page all spelled out the same three-part dance:
+ *
+ *   1. key off `detail(id)` when there's an id, else fall back to the
+ *      resource's `all` prefix, because a `queryKey` is required even while
+ *      the query is disabled;
+ *   2. gate `enabled` on `!!id`;
+ *   3. cast `id as string` inside `queryFn`, since TypeScript can't see that
+ *      (2) makes (3) safe.
+ *
+ * That cast is the reason to have this: it was written out six times, and it
+ * is only sound as long as the `enabled` gate three lines above it is
+ * present. Here the gate and the cast are adjacent and can't drift apart.
+ */
+export function useApiDetailQuery<TQueryFnData, TData = TQueryFnData>({
+  id,
+  keyFor,
+  fallbackKey,
+  fetch,
+  ...extras
+}: {
+  id: string | undefined;
+  /** Per-id query key, e.g. `queryKeys.tasks.detail`. */
+  keyFor: (id: string) => QueryKey;
+  /**
+   * Key used while `id` is undefined. The resource's `all` prefix — the
+   * query is disabled, so this slot is never populated; it just has to be
+   * stable and not collide with a real detail slot.
+   */
+  fallbackKey: QueryKey;
+  fetch: (id: string, ctx: { signal: AbortSignal }) => Promise<TQueryFnData>;
+} & ApiQueryExtras<TQueryFnData, TData>): UseQueryResult<TData, Error> {
+  const { enabled = true, ...rest } = extras;
+  return useApiQuery<TQueryFnData, TData>(
+    id ? keyFor(id) : fallbackKey,
+    // Safe: `enabled` below gates on `id`, so this never runs without one.
+    ({ signal }) => fetch(id as string, { signal }),
+    { ...rest, enabled: !!id && enabled },
+  );
+}

--- a/packages/web/lib/hooks/use-agents.ts
+++ b/packages/web/lib/hooks/use-agents.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
+import { useApiDetailQuery } from "./api-query";
 import { queryKeys } from "./keys";
 
 export function useAgents() {
@@ -12,9 +13,10 @@ export function useAgents() {
 }
 
 export function useAgent(id: string | undefined) {
-  return useQuery({
-    queryKey: id ? queryKeys.agents.detail(id) : queryKeys.agents.all,
-    queryFn: ({ signal }) => api.agents.get(id as string, { signal }),
-    enabled: isApiConfigured && !!id,
+  return useApiDetailQuery({
+    id,
+    keyFor: queryKeys.agents.detail,
+    fallbackKey: queryKeys.agents.all,
+    fetch: (agentId, ctx) => api.agents.get(agentId, ctx),
   });
 }

--- a/packages/web/lib/hooks/use-escalations.ts
+++ b/packages/web/lib/hooks/use-escalations.ts
@@ -1,12 +1,12 @@
-import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
-import { isApiConfigured } from "@/lib/api/config";
+import { useApiDetailQuery } from "./api-query";
 import { queryKeys } from "./keys";
 
 export function useEscalation(id: string | undefined) {
-  return useQuery({
-    queryKey: id ? queryKeys.escalations.detail(id) : queryKeys.escalations.all,
-    queryFn: ({ signal }) => api.escalations.get(id as string, { signal }),
-    enabled: isApiConfigured && !!id,
+  return useApiDetailQuery({
+    id,
+    keyFor: queryKeys.escalations.detail,
+    fallbackKey: queryKeys.escalations.all,
+    fetch: (escalationId, ctx) => api.escalations.get(escalationId, ctx),
   });
 }

--- a/packages/web/lib/hooks/use-negotiations.ts
+++ b/packages/web/lib/hooks/use-negotiations.ts
@@ -1,12 +1,12 @@
-import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
-import { isApiConfigured } from "@/lib/api/config";
+import { useApiDetailQuery } from "./api-query";
 import { queryKeys } from "./keys";
 
 export function useNegotiation(id: string | undefined) {
-  return useQuery({
-    queryKey: id ? queryKeys.negotiations.detail(id) : queryKeys.negotiations.all,
-    queryFn: ({ signal }) => api.negotiations.get(id as string, { signal }),
-    enabled: isApiConfigured && !!id,
+  return useApiDetailQuery({
+    id,
+    keyFor: queryKeys.negotiations.detail,
+    fallbackKey: queryKeys.negotiations.all,
+    fetch: (negotiationId, ctx) => api.negotiations.get(negotiationId, ctx),
   });
 }

--- a/packages/web/lib/hooks/use-sessions.ts
+++ b/packages/web/lib/hooks/use-sessions.ts
@@ -1,13 +1,13 @@
-import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
-import { isApiConfigured } from "@/lib/api/config";
+import { useApiDetailQuery } from "./api-query";
 import { queryKeys } from "./keys";
 
 export function useSession(shortId: string | undefined) {
-  return useQuery({
-    queryKey: shortId ? queryKeys.sessions.detail(shortId) : queryKeys.sessions.all,
-    queryFn: ({ signal }) => api.sessions.get(shortId as string, { signal }),
-    enabled: isApiConfigured && !!shortId,
+  return useApiDetailQuery({
+    id: shortId,
+    keyFor: queryKeys.sessions.detail,
+    fallbackKey: queryKeys.sessions.all,
+    fetch: (id, ctx) => api.sessions.get(id, ctx),
   });
 }
 
@@ -18,12 +18,11 @@ export function useSession(shortId: string | undefined) {
  * renders them unchanged.
  */
 export function useConversation(shortId: string | undefined) {
-  return useQuery({
-    queryKey: shortId
-      ? queryKeys.sessions.conversation(shortId)
-      : queryKeys.sessions.all,
-    queryFn: ({ signal }) => api.sessions.conversation(shortId as string, { signal }),
-    enabled: isApiConfigured && !!shortId,
+  return useApiDetailQuery({
+    id: shortId,
+    keyFor: queryKeys.sessions.conversation,
+    fallbackKey: queryKeys.sessions.all,
+    fetch: (id, ctx) => api.sessions.conversation(id, ctx),
     // A completed turn's transcript is immutable, so this potentially-large
     // fetch (every turn × up to 500 events) needn't refetch on focus/idle.
     // In-flight turns surface live via SSE, not this query. Cold loads still

--- a/packages/web/lib/hooks/use-tasks.ts
+++ b/packages/web/lib/hooks/use-tasks.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { api, type TaskListFilter } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
+import { useApiDetailQuery } from "./api-query";
 import { queryKeys } from "./keys";
 
 export function useTasks(filter: TaskListFilter = {}) {
@@ -23,9 +24,10 @@ export function useTasks(filter: TaskListFilter = {}) {
 }
 
 export function useTask(id: string | undefined) {
-  return useQuery({
-    queryKey: id ? queryKeys.tasks.detail(id) : queryKeys.tasks.all,
-    queryFn: ({ signal }) => api.tasks.get(id as string, { signal }),
-    enabled: isApiConfigured && !!id,
+  return useApiDetailQuery({
+    id,
+    keyFor: queryKeys.tasks.detail,
+    fallbackKey: queryKeys.tasks.all,
+    fetch: (taskId, ctx) => api.tasks.get(taskId, ctx),
   });
 }


### PR DESCRIPTION
A fresh duplication sweep over the monorepo. After the previous passes (#259, #263, #266, #271, #276, #277, #279, #281, #283), exact-block detection now tops out at ~12 lines and the biggest hits are deliberate wire-contract mirrors — so this pass went after **structural** clones (same shape, renamed identifiers), which token matching misses. Three clusters survived review.

## 1. `view.ts` — five detail routes, one shape

The router already had a local `shortIdRoute` factory for *auth-gate → narrow param → fetch → 404 → json → handleError*, used by the two session lookups. Three siblings hand-rolled the identical thing, because the factory hardcoded its param name and both error codes:

| Route | Was |
|---|---|
| `GET /task/:id` | hand-rolled, 15 lines |
| `GET /agent/:id` | hand-rolled, 15 lines |
| `GET /work-product/:id` | hand-rolled, 15 lines |
| `GET /session/:shortId` | via `shortIdRoute` |
| `GET /session/:shortId/conversation` | via `shortIdRoute` |

Lifting those three strings into parameters turns it into `detailRoute` and folds all five onto it. All five `views/*` composers already share the signature `(pool, id) => Promise<T | undefined>`, which is what makes them interchangeable.

`shortIdRoute` also hand-rolled the param narrowing that `requireParam` exists to do, producing a byte-identical 400 body — that copy goes too. A `sessionDetailRoute` wrapper keeps the two session routes sharing one param name and one pair of error codes rather than repeating all three.

## 2. `task.ts` — the approve / reject pair

Identical bodies apart from which `TaskService` verb they call and which outcome they record: same optional `result_summary` parse, same best-effort capability-outcome write, same `{ ok, task: { id, status } }` projection. A change to any of that had two places to land. Now one `reviewRoute` factory.

`revise`, `retry` and `cancel` deliberately stay hand-written — revise dispatches a follow-up session, retry builds a resume reason, cancel runs a transition gate plus the WS/pg_notify fan-out. They share the preamble, not the shape.

## 3. `web` — seven copies of the detail-by-id read hook

`useTask`, `useAgent`, `useSession`, `useConversation`, `useEscalation`, `useNegotiation` and the inline query in the work-product page each spelled out the same three-part dance:

1. key off `detail(id)`, falling back to the resource's `all` prefix (a `queryKey` is required even while disabled);
2. gate `enabled` on `!!id`;
3. cast `id as string` inside `queryFn`, because TypeScript can't see that (2) makes (3) safe.

**That cast is the reason to unify this.** It was written seven times and is only sound as long as the `enabled` gate three lines above it survives. `useApiDetailQuery` puts the gate and the cast adjacent so they can't drift apart, over a `useApiQuery` base that owns the `isApiConfigured` gate every read hook needs.

## Considered and deliberately left alone

- **The three CLI `stream-json.ts` parsers and their runtimes** — already share `runtime-common.ts` (#257); the per-provider event schemas genuinely differ.
- **`anthropic/llm-provider.ts` vs `openai/llm-provider.ts`** — only the api-key-or-throw preamble is common (~6 lines). The SDK surfaces diverge past that (`content` blocks vs `choices[0].message`, `output_config` vs `response_format`); merging costs more readability than it buys.
- **The `loading.tsx` skeletons** — share a two-line page shell; the bodies are per-page shapes on purpose.
- **`error.tsx` vs `global-error.tsx`** — global-error replaces the root layout, so it can't use Tailwind and carries inline styles by necessity.
- **The list-shaped read hooks** — unifying saves ~one line each and would churn eleven files for it.

## Notes

Behavior-preserving throughout.

One thing surfaced but **not** changed here: eight `useQuery` call sites in components omit the `isApiConfigured` gate that every hook in `lib/hooks` applies. Adding it would change when those queries fire, so it's left as-is rather than folded in silently — worth a follow-up decision.

## Tests

Both refactored api routes had **no coverage in a bare checkout** — `task.test.ts` is DB-gated and skips wholesale without `DATABASE_URL_TEST` — so this adds:

- `task-review.test.ts` — 12 DB-free cases across both verbs (stubbed `TaskService`): service-verb wiring, the two-field projection, `result_summary` parsing, the human-only gate, and 404/409/500 error mapping.
- `api-query.test.tsx` — 12 cases on the new web factories: both gates, `enabled` ANDing rather than replacing, the key/fallback switch, the narrowed id reaching the fetcher, abort-signal pass-through, and `select`/`staleTime` extras.

Verified the new api tests actually bite: mis-wiring `reviewRoute` to the wrong service verb fails 4 of them.

| Check | Result |
|---|---|
| `turbo run typecheck lint` | 15/15 tasks clean |
| `@beevibe/api` tests | 832 passed (was 820); same 9 pre-existing DB-gated failures |
| `@beevibe/web` tests | 215 passed (was 203) |
| builds | api, core, web all build |

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3Uyryx8jDTE52RNFhrfY8)_