### PR TITLE
docs(test): correct two stale claims the cleanup sweep tripped over

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,8 +105,13 @@ DATABASE_URL=postgresql://beevibe:beevibe@localhost:5433/beevibe
 ## Running tests
 
 `pnpm test` is **not** hermetic — integration tests need a real Postgres
-and the adapter tests make live provider calls. There is no
-`describe.skipIf`: missing prerequisites fail loudly by design.
+and the adapter tests make live provider calls. The Postgres-backed and
+provider-key suites have no skip gate: missing prerequisites fail loudly
+by design. The gates that do exist are narrow and deliberate — opt-in
+e2e (`BEEVIBE_E2E_DOCKER`, `BEEVIBE_E2E_MULTI_INSTANCE`,
+`RUN_CLAUDE_SMOKE`), `win32` platform gates, and `mcp.test.ts`'s
+`describe.skipIf` on live
+`OPENAI_API_KEY` + `ANTHROPIC_API_KEY`.
 
 ```bash
 docker compose up -d --wait postgres

--- a/packages/web/lib/api/client.test.ts
+++ b/packages/web/lib/api/client.test.ts
@@ -92,7 +92,7 @@ describe("api client (reads)", () => {
     });
   });
 
-  describe("deferred surfaces (paths set; backend not yet shipped)", () => {
+  describe("read-only surfaces with no dedicated hook", () => {
     it("promotions.list() hits /promotion", async () => {
       await api.promotions.list();
       expect(fetchJsonMock).toHaveBeenCalledWith("/promotion", { signal: undefined });


### PR DESCRIPTION
Routine sweep for outdated tests, using the #270/#284 methodology. **No test turned out to be removable.** But two claims *about* the suite are now false, and both would point the next sweep at live tests — so this PR fixes those instead.

## The two fixes

**`packages/web/lib/api/client.test.ts`** grouped `promotions` / `mesh` / `dashboard` under `describe("deferred surfaces (paths set; backend not yet shipped)")`. All three shipped: `packages/api/src/routes/view.ts` registers `GET /dashboard` (462), `/mesh` (504) and `/promotion` (516), and `routes/directives.ts` lists all three. The tests are live contract checks for live endpoints — only the label was wrong. Relabelled to what actually distinguishes them: read-only paths with no dedicated hook.

**`CLAUDE.md`** said *"There is no `describe.skipIf`: missing prerequisites fail loudly by design."* The second half holds for the Postgres- and provider-key-backed suites, but `packages/api/src/routes/mcp.test.ts:39` gates on live `OPENAI_API_KEY` + `ANTHROPIC_API_KEY`. A sweep reading the doc would conclude the tree has no conditional skips and stop looking — which is exactly what this sweep nearly did. Reworded to keep the fail-loudly rule and enumerate the four gates that do exist.

## Sweep results, for the next run

| Category | Result |
| --- | --- |
| Skipped / disabled / xfail without reason | **none** |
| Tests of removed or refactored code | **none** |
| Assertion-free or tautological tests | **none** |
| Implementation-detail tests | **one, deliberate — kept** |

- **Skips.** Every `.skip` in the tree is a live environment gate: `BEEVIBE_E2E_DOCKER`, `BEEVIBE_E2E_MULTI_INSTANCE`, `RUN_CLAUDE_SMOKE`, `win32` platform gates, and the `mcp.test.ts` key gate above. The 269 "skipped" reported in core are DB-gated suites vitest marks skipped after their `beforeAll` throws — not dormant tests.
- **Removed/refactored code.** `turbo typecheck` is clean across all 9 projects, so nothing references a deleted API. No test file is orphaned — the 7 whose names don't match a module all cover a real sibling. No re-export-only module still carries a test file, so the #284 pattern has not recurred. #285's port-member removals remain fully reconciled by #291: no `vi.fn()` stub in any fake names a method absent from source.
- **Assertion-free / tautological.** Every `it`/`test` body in the tree reaches an `expect`/`assert`, and no assertion compares an expression to itself.
- **Implementation detail.** Only `packages/api/src/views/dashboard.test.ts` asserts on SQL text, and deliberately — the three `type != 'chat'` checks pin a fixed gauge-oscillation regression that has no other unit-level expression. Kept.

## Testing

`packages/web` suite passes (24 files, 203 tests), including the relabelled `client.test.ts`. `turbo typecheck` clean across all 9 projects. The remaining suites match the documented bare-sandbox baseline — failures are the Postgres- and provider-key-gated ones only, unchanged by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJr9f8t6o9QJ2yocMEPcvv

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJr9f8t6o9QJ2yocMEPcvv)_