### PR TITLE
refactor: unify three clusters of near-duplicate abstractions

### DIFF
--- a/packages/api/src/tools/find-repo.ts
+++ b/packages/api/src/tools/find-repo.ts
@@ -40,6 +40,7 @@ import type {
   LearnedSkillRepository,
 } from "@beevibe/core";
 import type { AgentTool, AgentToolResult } from "./types.js";
+import { toolError } from "./errors.js";
 
 /**
  * Data layer URLs — all live in the public `beevibe-ai/beevibe-capabilities`
@@ -312,10 +313,7 @@ async function findRepoHandler(
 ): Promise<AgentToolResult> {
   const goal = typeof input.goal === "string" ? input.goal.trim() : "";
   if (!goal) {
-    return {
-      content: { error: "invalid_goal", message: "goal must be a non-empty string" },
-      isError: true,
-    };
+    return toolError("invalid_goal", "goal must be a non-empty string");
   }
   const limitRaw = typeof input.limit === "number" ? input.limit : 5;
   const limit = Math.min(10, Math.max(1, Math.floor(limitRaw)));
@@ -323,10 +321,7 @@ async function findRepoHandler(
   // Resolve the agent's owner so we can scope learned-skill lookups.
   const agent = await services.agentRepo.findById(ctx.agentId);
   if (!agent) {
-    return {
-      content: { error: "agent_not_found", message: "calling agent not found" },
-      isError: true,
-    };
+    return toolError("agent_not_found", "calling agent not found");
   }
 
   const notes: string[] = [];

--- a/packages/api/src/tools/hierarchy.ts
+++ b/packages/api/src/tools/hierarchy.ts
@@ -52,7 +52,7 @@ import {
   buildIntent,
   type ResumeReason,
 } from "@beevibe/core/services/agent-session";
-import { toolErrorFromThrown } from "./errors.js";
+import { toolError, toolErrorFromThrown } from "./errors.js";
 import type { AgentTool } from "./types.js";
 
 // ── Agent-callable status subsets ─────────────────────────────────────────
@@ -685,13 +685,10 @@ function createTaskTool(
         // Authz: assignee must be one of caller's subordinates.
         const subs = await services.agentRepo.findSubordinates(ctx.agentId);
         if (!subs.some((s) => s.id === targetId)) {
-          return {
-            content: {
-              error: "not_subordinate",
-              message: `Cannot assign tasks to ${targetId} — not a direct subordinate of ${ctx.agentId}.`,
-            },
-            isError: true,
-          };
+          return toolError(
+            "not_subordinate",
+            `Cannot assign tasks to ${targetId} — not a direct subordinate of ${ctx.agentId}.`,
+          );
         }
 
         const priority = (input.priority as (typeof TASK_PRIORITIES)[number]) ?? "medium";
@@ -787,13 +784,10 @@ function checkWorkStatusTool(
         if (targetId !== ctx.agentId) {
           const subs = await services.agentRepo.findSubordinates(ctx.agentId);
           if (!subs.some((s) => s.id === targetId)) {
-            return {
-              content: {
-                error: "unauthorized",
-                message: `Can only check work status for self or a direct subordinate.`,
-              },
-              isError: true,
-            };
+            return toolError(
+              "unauthorized",
+              `Can only check work status for self or a direct subordinate.`,
+            );
           }
         }
 
@@ -863,10 +857,7 @@ function reviseTaskTool(
           return { content: { error: "task_not_found", task_id: taskId }, isError: true };
         }
         if (!task.assignee_id) {
-          return {
-            content: { error: "task_unassigned", message: "task has no assignee" },
-            isError: true,
-          };
+          return toolError("task_unassigned", "task has no assignee");
         }
 
         // Authz: caller must be the assignee's direct parent.
@@ -875,13 +866,10 @@ function reviseTaskTool(
           return { content: { error: "assignee_not_found" }, isError: true };
         }
         if (assignee.parent_agent_id !== ctx.agentId) {
-          return {
-            content: {
-              error: "not_parent",
-              message: `caller ${ctx.agentId} is not the parent of task assignee ${task.assignee_id}`,
-            },
-            isError: true,
-          };
+          return toolError(
+            "not_parent",
+            `caller ${ctx.agentId} is not the parent of task assignee ${task.assignee_id}`,
+          );
         }
 
         const updated = await services.taskService.reviseTask(taskId, feedback, {
@@ -921,7 +909,7 @@ function reviseTaskTool(
         };
       } catch (err) {
         if (err instanceof InvalidTaskTransitionError) {
-          return { content: { error: "invalid_transition", message: err.message }, isError: true };
+          return toolError("invalid_transition", err.message);
         }
         return toolErrorFromThrown(err);
       }
@@ -1134,14 +1122,10 @@ function createSubordinateAgentTool(
     handler: async (input) => {
       try {
         if (ctx.hierarchyLevel === "ic") {
-          return {
-            content: {
-              error: "ic_cannot_spawn",
-              message:
-                "Only team/org agents can spawn subordinates; you are an IC.",
-            },
-            isError: true,
-          };
+          return toolError(
+            "ic_cannot_spawn",
+            "Only team/org agents can spawn subordinates; you are an IC.",
+          );
         }
 
         const name = String(input.name ?? "").trim();
@@ -1151,34 +1135,25 @@ function createSubordinateAgentTool(
         const activeContext = String(input.active_context ?? "").trim();
         const constraints = String(input.constraints ?? "").trim();
         if (!name || !tagLine || !persona || !domain) {
-          return {
-            content: {
-              error: "missing_required_fields",
-              message: "name, tag_line, persona, and domain are all required",
-            },
-            isError: true,
-          };
+          return toolError(
+            "missing_required_fields",
+            "name, tag_line, persona, and domain are all required",
+          );
         }
         // Soft-enforce the tag_line limit so the UI's agent card line stays
         // legible. Hard limit is the column char_limit.
         if (tagLine.length > 100) {
-          return {
-            content: {
-              error: "tag_line_too_long",
-              message: "tag_line must be ≤100 chars",
-              actual: tagLine.length,
-            },
-            isError: true,
-          };
+          return toolError(
+            "tag_line_too_long",
+            "tag_line must be ≤100 chars",
+            { actual: tagLine.length },
+          );
         }
         if (name.length > 80 || PROVISION_NAME_INVALID_RE.test(name)) {
-          return {
-            content: {
-              error: "invalid_name",
-              message: "name must be 1-80 chars and contain no control characters",
-            },
-            isError: true,
-          };
+          return toolError(
+            "invalid_name",
+            "name must be 1-80 chars and contain no control characters",
+          );
         }
 
         // Resolve the parent (caller) so we can inherit owner_id + runtime config.
@@ -1198,17 +1173,12 @@ function createSubordinateAgentTool(
           24 * 60 * 60,
         );
         if (recentSpawns >= SUBORDINATE_DAILY_CAP) {
-          return {
-            content: {
-              error: "subordinate_daily_cap",
-              message:
-                `Parent '${parent.name}' has spawned ${recentSpawns} subordinates in the last 24h ` +
-                `(cap: ${SUBORDINATE_DAILY_CAP}). Reuse an existing specialist or wait for the window to expire.`,
-              cap: SUBORDINATE_DAILY_CAP,
-              count: recentSpawns,
-            },
-            isError: true,
-          };
+          return toolError(
+            "subordinate_daily_cap",
+            `Parent '${parent.name}' has spawned ${recentSpawns} subordinates in the last 24h ` +
+              `(cap: ${SUBORDINATE_DAILY_CAP}). Reuse an existing specialist or wait for the window to expire.`,
+            { cap: SUBORDINATE_DAILY_CAP, count: recentSpawns },
+          );
         }
 
         // Inherit the parent's runtime so all the user's agents share the

--- a/packages/api/src/tools/mesh.ts
+++ b/packages/api/src/tools/mesh.ts
@@ -15,7 +15,7 @@ import type {
   CreateEscalationInput,
 } from "@beevibe/core/services/escalation-service";
 import type { Pool } from "@beevibe/core/adapters/postgres";
-import { toolErrorFromThrown } from "./errors.js";
+import { toolError, toolErrorFromThrown } from "./errors.js";
 import type { AgentTool } from "./types.js";
 import type { McpCaller } from "./assemble.js";
 import type { MeshServer } from "../mesh/server.js";
@@ -311,14 +311,11 @@ function reportBlockerTool(ctx: MeshToolContext, services: MeshToolServices): Ag
         // Server derives parent from caller's hierarchy. Direct parent only.
         const parent = await services.agentRepo.findParent(ctx.caller.agentId);
         if (!parent) {
-          return {
-            content: {
-              error: "no_parent_to_block",
-              message:
-                "Top-level agents have no parent to report blockers to. Use escalate_to_humans or update_progress('failed') instead.",
-            },
-            isError: true,
-          };
+          return toolError(
+            "no_parent_to_block",
+            "Top-level agents have no parent to report blockers to. " +
+              "Use escalate_to_humans or update_progress('failed') instead.",
+          );
         }
 
         // Mark the task blocked + record the blocker_agent_id + reason.

--- a/packages/api/src/tools/save-memory.ts
+++ b/packages/api/src/tools/save-memory.ts
@@ -7,6 +7,7 @@ import {
   type HierarchyLevel,
 } from "@beevibe/core";
 import type { AgentTool } from "./types.js";
+import { toolError } from "./errors.js";
 
 /**
  * Render the per-fact-type guidance for the tool's `fact_type` enum
@@ -97,19 +98,10 @@ export function createSaveMemoryTool(
       const content = input.content;
       const factType = input.fact_type;
       if (typeof content !== "string" || !content.trim()) {
-        return {
-          content: { error: "invalid_content", message: "content must be a non-empty string" },
-          isError: true,
-        };
+        return toolError("invalid_content", "content must be a non-empty string");
       }
       if (typeof factType !== "string" || !FACT_TYPES.includes(factType as FactType)) {
-        return {
-          content: {
-            error: "invalid_fact_type",
-            message: `fact_type must be one of: ${FACT_TYPES.join(", ")}`,
-          },
-          isError: true,
-        };
+        return toolError("invalid_fact_type", `fact_type must be one of: ${FACT_TYPES.join(", ")}`);
       }
       const fact = await services.factStore.addOrMerge(
         ctx.agentId,

--- a/packages/api/src/tools/session-search.ts
+++ b/packages/api/src/tools/session-search.ts
@@ -5,6 +5,7 @@ import {
 } from "@beevibe/core/services/session-search";
 import { SESSION_TYPES, SESSION_STATUSES } from "@beevibe/core";
 import type { AgentTool } from "./types.js";
+import { toolError } from "./errors.js";
 
 /**
  * session_search — Layer-3 memory: search past conversations via FTS,
@@ -250,15 +251,11 @@ export function createSessionSearchTool(
           currentSessionId: ctx.sessionId,
         });
         if (result === null) {
-          return {
-            content: {
-              error: "not_found_or_forbidden",
-              message:
-                "session_id is not in your scope, the anchor message id does not " +
-                "exist, or the anchor lives in your active conversation.",
-            },
-            isError: true,
-          };
+          return toolError(
+            "not_found_or_forbidden",
+            "session_id is not in your scope, the anchor message id does not " +
+                            "exist, or the anchor lives in your active conversation.",
+          );
         }
         return { content: result as unknown as Record<string, unknown> };
       } catch (err) {
@@ -275,13 +272,7 @@ export function createSessionSearchTool(
             isError: true,
           };
         }
-        return {
-          content: {
-            error: "internal_error",
-            message: err instanceof Error ? err.message : String(err),
-          },
-          isError: true,
-        };
+        return toolError("internal_error", err instanceof Error ? err.message : String(err));
       }
     },
   };

--- a/packages/api/src/tools/update-core-memory.ts
+++ b/packages/api/src/tools/update-core-memory.ts
@@ -2,6 +2,7 @@ import type { CoreMemory, CoreMemoryOperation } from "@beevibe/core/services/mem
 import type { HierarchyLevel } from "@beevibe/core";
 import { DEFAULT_BLOCK_TEMPLATES } from "@beevibe/core";
 import type { AgentTool } from "./types.js";
+import { toolError } from "./errors.js";
 
 const OPERATIONS: readonly CoreMemoryOperation[] = ["append", "replace"];
 
@@ -196,43 +197,19 @@ export function createUpdateCoreMemoryTool(
       const oldContent = input.old_content;
 
       if (typeof blockName !== "string" || !blockName.trim()) {
-        return {
-          content: { error: "invalid_block_name", message: "block_name must be a non-empty string" },
-          isError: true,
-        };
+        return toolError("invalid_block_name", "block_name must be a non-empty string");
       }
       if (!tierBlocks.includes(blockName)) {
-        return {
-          content: {
-            error: "unknown_block",
-            message: `block_name must be one of: ${tierBlocks.join(", ")}`,
-          },
-          isError: true,
-        };
+        return toolError("unknown_block", `block_name must be one of: ${tierBlocks.join(", ")}`);
       }
       if (typeof operation !== "string" || !OPERATIONS.includes(operation as CoreMemoryOperation)) {
-        return {
-          content: {
-            error: "invalid_operation",
-            message: `operation must be one of: ${OPERATIONS.join(", ")}`,
-          },
-          isError: true,
-        };
+        return toolError("invalid_operation", `operation must be one of: ${OPERATIONS.join(", ")}`);
       }
       if (typeof content !== "string") {
-        return {
-          content: { error: "invalid_content", message: "content must be a string" },
-          isError: true,
-        };
+        return toolError("invalid_content", "content must be a string");
       }
       if (operation === "replace" && (typeof oldContent !== "string" || !oldContent)) {
-        return {
-          content: {
-            error: "missing_old_content",
-            message: "operation='replace' requires old_content",
-          },
-          isError: true,
-        };
+        return toolError("missing_old_content", "operation='replace' requires old_content");
       }
 
       try {
@@ -251,13 +228,7 @@ export function createUpdateCoreMemoryTool(
           },
         };
       } catch (err) {
-        return {
-          content: {
-            error: "update_failed",
-            message: err instanceof Error ? err.message : String(err),
-          },
-          isError: true,
-        };
+        return toolError("update_failed", err instanceof Error ? err.message : String(err));
       }
     },
   };

--- a/packages/api/src/tools/use-repo.ts
+++ b/packages/api/src/tools/use-repo.ts
@@ -28,6 +28,7 @@ import {
 } from "@beevibe/core";
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
 import type { AgentTool } from "./types.js";
+import { toolError } from "./errors.js";
 
 const USE_REPO_SCHEMA = {
   type: "object",
@@ -126,19 +127,10 @@ export function createUseRepoTool(
       const repoUrl =
         typeof input.repo_url === "string" ? input.repo_url.trim() : "";
       if (!goal) {
-        return {
-          content: { error: "invalid_goal", message: "goal must be a non-empty string" },
-          isError: true,
-        };
+        return toolError("invalid_goal", "goal must be a non-empty string");
       }
       if (!repoUrl || !isLikelyGithubUrl(repoUrl)) {
-        return {
-          content: {
-            error: "invalid_repo_url",
-            message: "repo_url must be a GitHub HTTPS URL",
-          },
-          isError: true,
-        };
+        return toolError("invalid_repo_url", "repo_url must be a GitHub HTTPS URL");
       }
 
       const inputUrl =
@@ -153,10 +145,7 @@ export function createUseRepoTool(
       // to the actual agent id and confirm the caller exists.
       const agent = await services.agentRepo.findById(ctx.agentId);
       if (!agent) {
-        return {
-          content: { error: "agent_not_found", message: "calling agent not found" },
-          isError: true,
-        };
+        return toolError("agent_not_found", "calling agent not found");
       }
 
       // Container task — the artifact has to live somewhere, and
@@ -195,13 +184,7 @@ export function createUseRepoTool(
           sessionIdOverride: sessionIdValue,
         });
       } catch (err) {
-        return {
-          content: {
-            error: "dispatch_failed",
-            message: err instanceof Error ? err.message : String(err),
-          },
-          isError: true,
-        };
+        return toolError("dispatch_failed", err instanceof Error ? err.message : String(err));
       }
 
       try {
@@ -219,13 +202,10 @@ export function createUseRepoTool(
         // session. composeDispatchPayload will find no repo_run and
         // return null, marking the session failed. Self-recovers, but
         // surface the error so the agent doesn't silently wait.
-        return {
-          content: {
-            error: "repo_run_create_failed",
-            message: err instanceof Error ? err.message : String(err),
-          },
-          isError: true,
-        };
+        return toolError(
+          "repo_run_create_failed",
+          err instanceof Error ? err.message : String(err),
+        );
       }
 
       return {

--- a/packages/web/app/(authed)/agents/agents-client.tsx
+++ b/packages/web/app/(authed)/agents/agents-client.tsx
@@ -6,7 +6,7 @@ import { AlertTriangle, Bot, LayoutGrid, List, Maximize2, Minus, Plus } from "lu
 import type { PanZoomTransform } from "@/lib/hooks/use-pan-zoom";
 import { useAgentNetwork } from "@/lib/hooks/use-agent-network";
 import { isApiConfigured } from "@/lib/api/config";
-import { EmptyState } from "@/components/empty-state";
+import { EmptyCard } from "@/components/page-gate";
 import { TeamOrbit } from "@/components/team-orbit";
 import { AgentDetailPanel } from "@/components/agents/agent-detail-panel";
 import { AgentsListView } from "@/components/agents/agents-list-view";
@@ -400,9 +400,12 @@ function CenteredShell({
 }) {
   return (
     <div className="absolute inset-0 flex items-center justify-center p-6">
-      <div className="rounded-lg border border-dashed border-border w-full max-w-md">
-        <EmptyState icon={icon} title={title} description={description} />
-      </div>
+      <EmptyCard
+        icon={icon}
+        title={title}
+        description={description}
+        className="w-full max-w-md"
+      />
     </div>
   );
 }

--- a/packages/web/app/(authed)/dashboard/dashboard-client.tsx
+++ b/packages/web/app/(authed)/dashboard/dashboard-client.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { AlertTriangle, LayoutDashboard } from "lucide-react";
+import { LayoutDashboard } from "lucide-react";
 import { useDashboard } from "@/lib/hooks/use-dashboard";
-import { isApiConfigured } from "@/lib/api/config";
-import { EmptyState } from "@/components/empty-state";
+import { PageGate } from "@/components/page-gate";
 import { Skeleton } from "@/components/skeleton";
 import { KpiTileSkeleton } from "@/components/skeletons";
 import { KpiTile } from "@/components/home/kpi-tile";
@@ -19,63 +18,42 @@ export function DashboardClient() {
   return (
     <div className="flex-1 overflow-auto">
       <div className="max-w-6xl mx-auto pt-8 pb-12 px-6">
-        <Body data={data} isLoading={isLoading} isError={isError} />
+        <PageGate
+          query={{ data, isLoading, isError }}
+          notConfigured={{
+            icon: LayoutDashboard,
+            title: "Dashboard not connected",
+            description:
+              "Set NEXT_PUBLIC_BV_API_URL and run the API server to load KPIs and fleet status.",
+          }}
+          error={{
+            title: "Couldn't load dashboard",
+            description: "Check that the API server is reachable.",
+          }}
+          skeleton={
+            <div className="space-y-6">
+              <div className="grid grid-cols-4 gap-6">
+                {[0, 1, 2, 3].map((i) => (
+                  <KpiTileSkeleton key={i} />
+                ))}
+              </div>
+              <Skeleton className="h-32 rounded-lg" />
+              <Skeleton className="h-48 rounded-lg" />
+            </div>
+          }
+        >
+          {(loaded) => <Loaded data={loaded} />}
+        </PageGate>
       </div>
     </div>
   );
 }
 
-function Body({
-  data,
-  isLoading,
-  isError,
-}: {
-  data: DashboardDisplay | undefined;
-  isLoading: boolean;
-  isError: boolean;
-}) {
-  if (!isApiConfigured) {
-    return (
-      <div className="rounded-lg border border-dashed border-border">
-        <EmptyState
-          icon={LayoutDashboard}
-          title="Dashboard not connected"
-          description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load KPIs and fleet status."
-        />
-      </div>
-    );
-  }
-
-  if (isError) {
-    return (
-      <div className="rounded-lg border border-dashed border-border">
-        <EmptyState
-          icon={AlertTriangle}
-          title="Couldn't load dashboard"
-          description="Check that the MCP server is reachable."
-        />
-      </div>
-    );
-  }
-
-  if (isLoading || !data) {
-    return (
-      <div className="space-y-6">
-        <div className="grid grid-cols-4 gap-6">
-          {[0, 1, 2, 3].map((i) => (
-            <KpiTileSkeleton key={i} />
-          ))}
-        </div>
-        <Skeleton className="h-32 rounded-lg" />
-        <Skeleton className="h-48 rounded-lg" />
-      </div>
-    );
-  }
-
-  // /agents (the Home tab) is the front door now — that's where the
-  // orbit lives. /dashboard is the "Metrics" sub-page under
-  // Observability: KPIs, status, fleet, trend. Items needing decisions
-  // are surfaced in the sidebar Inbox, so we don't repeat them here.
+// /agents (the Home tab) is the front door now — that's where the
+// orbit lives. /dashboard is the "Metrics" sub-page under
+// Observability: KPIs, status, fleet, trend. Items needing decisions
+// are surfaced in the sidebar Inbox, so we don't repeat them here.
+function Loaded({ data }: { data: DashboardDisplay }) {
   return (
     <div className="space-y-10">
       <header>

--- a/packages/web/app/(authed)/mesh/mesh-client.tsx
+++ b/packages/web/app/(authed)/mesh/mesh-client.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import { AlertTriangle, Info, Network } from "lucide-react";
-import { EmptyState } from "@/components/empty-state";
+import { Info, Network } from "lucide-react";
+import { PageGate } from "@/components/page-gate";
 import { Skeleton } from "@/components/skeleton";
 import { MeshAskSkeleton } from "@/components/skeletons";
 import { MeshActivityFeed } from "@/components/mesh/activity-feed";
@@ -10,7 +10,6 @@ import { MeshGraphStatic } from "@/components/mesh/graph-static";
 import { ChainBudget } from "@/components/mesh/chain-budget";
 import { MeshWindowPills } from "@/components/mesh/window-pills";
 import { useMeshOverview } from "@/lib/hooks/use-mesh";
-import { isApiConfigured } from "@/lib/api/config";
 import type { MeshDisplay, MeshHover, MeshWindow } from "@/lib/types/mesh";
 
 export function MeshClient() {
@@ -32,7 +31,30 @@ export function MeshClient() {
           <MeshWindowPills value={meshWindow} onChange={setMeshWindow} />
         </div>
 
-        <Body data={data} isLoading={isLoading} isError={isError} />
+        <PageGate
+          query={{ data, isLoading, isError }}
+          notConfigured={{
+            icon: Network,
+            title: "No mesh asks yet",
+            description:
+              "Set NEXT_PUBLIC_BV_API_URL and run the API server to load mesh activity.",
+          }}
+          error={{ title: "Couldn't load mesh activity" }}
+          skeleton={
+            <div className="grid grid-cols-5 gap-6">
+              <div className="col-span-3 space-y-2">
+                {[0, 1, 2].map((i) => (
+                  <MeshAskSkeleton key={i} />
+                ))}
+              </div>
+              <div className="col-span-2">
+                <Skeleton className="h-[480px] rounded-lg" />
+              </div>
+            </div>
+          }
+        >
+          {(loaded) => <MeshContent data={loaded} />}
+        </PageGate>
 
         <div className="mt-10 text-xs text-muted-foreground flex items-start gap-2 max-w-2xl">
           <Info className="h-3.5 w-3.5 shrink-0 mt-0.5" />
@@ -45,54 +67,6 @@ export function MeshClient() {
       </div>
     </div>
   );
-}
-
-function Body({
-  data,
-  isLoading,
-  isError,
-}: {
-  data: MeshDisplay | undefined;
-  isLoading: boolean;
-  isError: boolean;
-}) {
-  if (!isApiConfigured) {
-    return (
-      <div className="rounded-lg border border-dashed border-border">
-        <EmptyState
-          icon={Network}
-          title="No mesh asks yet"
-          description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load mesh activity."
-        />
-      </div>
-    );
-  }
-
-  if (isError) {
-    return (
-      <div className="rounded-lg border border-dashed border-border">
-        <EmptyState icon={AlertTriangle} title="Couldn't load mesh activity" />
-      </div>
-    );
-  }
-
-  if (isLoading) {
-    return (
-      <div className="grid grid-cols-5 gap-6">
-        <div className="col-span-3 space-y-2">
-          {[0, 1, 2].map((i) => (
-            <MeshAskSkeleton key={i} />
-          ))}
-        </div>
-        <div className="col-span-2">
-          <Skeleton className="h-[480px] rounded-lg" />
-        </div>
-      </div>
-    );
-  }
-
-  if (!data) return null;
-  return <MeshContent data={data} />;
 }
 
 function MeshContent({ data }: { data: MeshDisplay }) {

--- a/packages/web/app/(authed)/promotions/promotions-client.tsx
+++ b/packages/web/app/(authed)/promotions/promotions-client.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { AlertTriangle, Info, TrendingUp, type LucideIcon } from "lucide-react";
-import { EmptyState } from "@/components/empty-state";
+import { Info, TrendingUp } from "lucide-react";
+import { EmptyCard, PageGate } from "@/components/page-gate";
 import { PromotionEventSkeleton } from "@/components/skeletons";
 import { PromotionEventRow } from "@/components/promotions/event-row";
 import { usePromotions } from "@/lib/hooks/use-promotions";
-import { isApiConfigured } from "@/lib/api/config";
 import type { PromotionEvent } from "@/lib/types/promotion-events";
 
 export function PromotionsClient() {
@@ -26,7 +25,25 @@ export function PromotionsClient() {
           </div>
         </div>
 
-        <Body data={data} isLoading={isLoading} isError={isError} />
+        <PageGate
+          query={{ data, isLoading, isError }}
+          notConfigured={{
+            icon: TrendingUp,
+            title: "No promotions yet",
+            description:
+              "Set NEXT_PUBLIC_BV_API_URL and run the API server to load promotion events.",
+          }}
+          error={{ title: "Couldn't load promotions" }}
+          skeleton={
+            <div className="pl-8 space-y-3">
+              {[0, 1, 2].map((i) => (
+                <PromotionEventSkeleton key={i} />
+              ))}
+            </div>
+          }
+        >
+          {(events) => <Loaded events={events} />}
+        </PageGate>
 
         <div className="mt-10 text-xs text-muted-foreground flex items-start gap-2 max-w-2xl">
           <Info className="h-3.5 w-3.5 shrink-0 mt-0.5" />
@@ -42,42 +59,10 @@ export function PromotionsClient() {
   );
 }
 
-function Body({
-  data,
-  isLoading,
-  isError,
-}: {
-  data: PromotionEvent[] | undefined;
-  isLoading: boolean;
-  isError: boolean;
-}) {
-  if (!isApiConfigured) {
+function Loaded({ events }: { events: PromotionEvent[] }) {
+  if (events.length === 0) {
     return (
-      <EmptyWrapper
-        icon={TrendingUp}
-        title="No promotions yet"
-        description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load promotion events."
-      />
-    );
-  }
-
-  if (isError) {
-    return <EmptyWrapper icon={AlertTriangle} title="Couldn't load promotions" />;
-  }
-
-  if (isLoading) {
-    return (
-      <div className="pl-8 space-y-3">
-        {[0, 1, 2].map((i) => (
-          <PromotionEventSkeleton key={i} />
-        ))}
-      </div>
-    );
-  }
-
-  if (!data || data.length === 0) {
-    return (
-      <EmptyWrapper
+      <EmptyCard
         icon={TrendingUp}
         title="No promotions yet"
         description="Promotion decisions appear here as agents accumulate facts across sessions."
@@ -87,17 +72,9 @@ function Body({
 
   return (
     <div className="pl-8 border-l border-border">
-      {data.map((event) => (
+      {events.map((event) => (
         <PromotionEventRow key={event.id} event={event} />
       ))}
-    </div>
-  );
-}
-
-function EmptyWrapper(props: { icon: LucideIcon; title: string; description?: string }) {
-  return (
-    <div className="rounded-lg border border-dashed border-border">
-      <EmptyState {...props} />
     </div>
   );
 }

--- a/packages/web/app/(authed)/runtimes/runtimes-client.tsx
+++ b/packages/web/app/(authed)/runtimes/runtimes-client.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  AlertTriangle,
   Cpu,
   HardDrive,
   Plus,
@@ -24,7 +23,7 @@ import { queryKeys } from "@/lib/hooks/keys";
 import { formatRelativeTime } from "@/lib/format";
 import { CommandBlock } from "@/components/command-block";
 import { DaemonInstallInstructions } from "@/components/daemon-install";
-import { EmptyState } from "@/components/empty-state";
+import { PageGate } from "@/components/page-gate";
 import { Skeleton } from "@/components/skeleton";
 import { cn } from "@/lib/utils";
 
@@ -54,60 +53,34 @@ export function RuntimesClient() {
         </div>
 
         <div className="max-w-3xl mx-auto">
-          <Body
-            data={query.data}
-            isLoading={query.isLoading}
-            isError={query.isError}
-            error={query.error}
-          />
+          <PageGate
+            query={query}
+            notConfigured={{
+              icon: Terminal,
+              title: "API not configured",
+              description:
+                "Set NEXT_PUBLIC_BV_API_URL and run the API server to load this page.",
+            }}
+            error={{
+              title: "Couldn't load runtimes",
+              description: describeError(query.error),
+            }}
+            skeleton={
+              <div className="space-y-3">
+                <Skeleton className="h-32 w-full rounded-lg" />
+                <Skeleton className="h-32 w-full rounded-lg" />
+              </div>
+            }
+          >
+            {(loaded) => <Loaded daemons={loaded.daemons ?? []} />}
+          </PageGate>
         </div>
       </div>
     </div>
   );
 }
 
-function Body({
-  data,
-  isLoading,
-  isError,
-  error,
-}: {
-  data: RuntimesListResponse | undefined;
-  isLoading: boolean;
-  isError: boolean;
-  error: unknown;
-}) {
-  if (!isApiConfigured) {
-    return (
-      <div className="rounded-lg border border-dashed border-border">
-        <EmptyState
-          icon={Terminal}
-          title="API not configured"
-          description="Set NEXT_PUBLIC_BV_API_URL and run the API server to load this page."
-        />
-      </div>
-    );
-  }
-  if (isLoading) {
-    return (
-      <div className="space-y-3">
-        <Skeleton className="h-32 w-full rounded-lg" />
-        <Skeleton className="h-32 w-full rounded-lg" />
-      </div>
-    );
-  }
-  if (isError) {
-    return (
-      <div className="rounded-lg border border-dashed border-border">
-        <EmptyState
-          icon={AlertTriangle}
-          title="Couldn't load runtimes"
-          description={describeError(error)}
-        />
-      </div>
-    );
-  }
-  const daemons = data?.daemons ?? [];
+function Loaded({ daemons }: { daemons: DaemonPanelEntry[] }) {
   if (daemons.length === 0) {
     return <NoDaemonsState />;
   }

--- a/packages/web/components/agents/agent-detail-panel.tsx
+++ b/packages/web/components/agents/agent-detail-panel.tsx
@@ -1,16 +1,15 @@
 "use client";
 
-import { AlertTriangle, Bot } from "lucide-react";
+import { Bot } from "lucide-react";
 import { Avatar } from "@/components/avatar";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { PanelFooterField, PeekPanel } from "@/components/detail/peek-panel";
+import { PanelGate } from "@/components/detail/panel-gate";
 import { CoreBlockCard } from "@/components/agents/core-block-card";
 import { RecentSessionRow } from "@/components/agents/recent-session-row";
 import { RecentChatThreadRow } from "@/components/agents/recent-chat-thread-row";
-import { EmptyState } from "@/components/empty-state";
 import { HierChip } from "@/components/hier-chip";
 import { Skeleton } from "@/components/skeleton";
-import { isApiConfigured } from "@/lib/api/config";
 import { useAgent } from "@/lib/hooks/use-agents";
 import { useIsOwner } from "@/lib/hooks/use-me";
 import { formatReviewPolicy } from "@/lib/format";
@@ -42,43 +41,25 @@ export function AgentDetailPanel({
 }
 
 function PanelBody({ agentId }: { agentId: string }) {
-  const { data, isLoading, isError } = useAgent(agentId);
+  const query = useAgent(agentId);
 
-  if (!isApiConfigured) {
-    return (
-      <div className="p-4">
-        <EmptyState
-          icon={Bot}
-          title="API not configured"
-          description="Set NEXT_PUBLIC_BV_API_URL to load this agent."
-        />
-      </div>
-    );
-  }
-
-  if (isLoading) {
-    return (
-      <div className="p-5 space-y-4">
-        <Skeleton className="h-14 w-full" />
-        <Skeleton className="h-24 w-full rounded-lg" />
-        <Skeleton className="h-32 w-full rounded-lg" />
-      </div>
-    );
-  }
-
-  if (isError || !data) {
-    return (
-      <div className="p-4">
-        <EmptyState
-          icon={AlertTriangle}
-          title="Couldn't load agent"
-          description={`Agent ${agentId} could not be fetched.`}
-        />
-      </div>
-    );
-  }
-
-  return <PanelLoaded agent={data} />;
+  return (
+    <PanelGate
+      icon={Bot}
+      noun="agent"
+      id={agentId}
+      query={query}
+      skeleton={
+        <>
+          <Skeleton className="h-14 w-full" />
+          <Skeleton className="h-24 w-full rounded-lg" />
+          <Skeleton className="h-32 w-full rounded-lg" />
+        </>
+      }
+    >
+      {(agent) => <PanelLoaded agent={agent} />}
+    </PanelGate>
+  );
 }
 
 function PanelLoaded({ agent }: { agent: AgentDetail }) {

--- a/packages/web/components/detail/detail-gate.tsx
+++ b/packages/web/components/detail/detail-gate.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 import { AlertTriangle, type LucideIcon } from "lucide-react";
 import { isApiConfigured } from "@/lib/api/config";
 import { DetailShell } from "./detail-shell";
+import { gateCopy } from "./gate-copy";
 import { EmptyState } from "@/components/empty-state";
 
 interface Props<T> {
@@ -43,14 +44,12 @@ interface Props<T> {
  * `noun` here, so a page can't word them a fourth way.
  */
 export function DetailGate<T>({ nav, icon, noun, id, query, skeleton, children }: Props<T>) {
+  const copy = gateCopy(noun, id);
+
   if (!isApiConfigured) {
     return (
       <DetailShell nav={nav}>
-        <EmptyState
-          icon={icon}
-          title="API not configured"
-          description={`Set NEXT_PUBLIC_BV_API_URL and run the API server to load this ${noun}.`}
-        />
+        <EmptyState icon={icon} title="API not configured" description={copy.notConfigured} />
       </DetailShell>
     );
   }
@@ -60,13 +59,12 @@ export function DetailGate<T>({ nav, icon, noun, id, query, skeleton, children }
   }
 
   if (query.isError || !query.data) {
-    const Noun = noun.charAt(0).toUpperCase() + noun.slice(1);
     return (
       <DetailShell nav={nav}>
         <EmptyState
           icon={AlertTriangle}
-          title={`Couldn't load ${noun}`}
-          description={`${Noun} ${id} could not be fetched. Check the API server logs.`}
+          title={copy.errorTitle}
+          description={copy.errorDescription}
         />
       </DetailShell>
     );

--- a/packages/web/components/detail/gate-copy.ts
+++ b/packages/web/components/detail/gate-copy.ts
@@ -1,0 +1,30 @@
+/**
+ * The copy the three "load one thing by id" gates share.
+ *
+ * `DetailGate` (full detail route) and `PanelGate` (peek panel) show the
+ * same two messages for the same two conditions, differing only in the
+ * shell they render into. Deriving both sentences from `noun`/`id` in one
+ * place is what stops them wording it differently — which is exactly what
+ * had happened before: the detail routes said "Set NEXT_PUBLIC_BV_API_URL
+ * and run the API server to load this task." while the peek panels said
+ * "Set NEXT_PUBLIC_BV_API_URL to load this task.", and only the routes
+ * ended the fetch error with "Check the API server logs."
+ *
+ * @param noun lowercase singular of what is being loaded — "task", "work product"
+ * @param id   echoed into the error so a failed fetch is identifiable
+ */
+export function gateCopy(
+  noun: string,
+  id: string,
+): {
+  notConfigured: string;
+  errorTitle: string;
+  errorDescription: string;
+} {
+  const Noun = noun.charAt(0).toUpperCase() + noun.slice(1);
+  return {
+    notConfigured: `Set NEXT_PUBLIC_BV_API_URL and run the API server to load this ${noun}.`,
+    errorTitle: `Couldn't load ${noun}`,
+    errorDescription: `${Noun} ${id} could not be fetched. Check the API server logs.`,
+  };
+}

--- a/packages/web/components/detail/panel-gate.test.tsx
+++ b/packages/web/components/detail/panel-gate.test.tsx
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const apiState = { isApiConfigured: true };
+
+vi.mock("@/lib/api/config", () => ({
+  get isApiConfigured() {
+    return apiState.isApiConfigured;
+  },
+}));
+
+import { DetailGate } from "./detail-gate";
+import { PanelGate } from "./panel-gate";
+
+interface Row {
+  name: string;
+}
+
+function renderGate(query: { data: Row | undefined; isLoading: boolean; isError: boolean }) {
+  return render(
+    <PanelGate noun="task" id="task_42" query={query} skeleton={<div data-testid="skeleton" />}>
+      {(row) => <div data-testid="body">{row.name}</div>}
+    </PanelGate>,
+  );
+}
+
+describe("PanelGate", () => {
+  beforeEach(() => {
+    apiState.isApiConfigured = true;
+  });
+
+  it("renders the body once the row is in hand", () => {
+    renderGate({ data: { name: "Ship it" }, isLoading: false, isError: false });
+    expect(screen.getByTestId("body")).toHaveTextContent("Ship it");
+    expect(screen.queryByTestId("skeleton")).toBeNull();
+  });
+
+  it("renders the skeleton while loading, never the body", () => {
+    renderGate({ data: undefined, isLoading: true, isError: false });
+    expect(screen.getByTestId("skeleton")).toBeInTheDocument();
+    expect(screen.queryByTestId("body")).toBeNull();
+  });
+
+  it("reports an unconfigured API before it reports a failed fetch", () => {
+    apiState.isApiConfigured = false;
+    renderGate({ data: undefined, isLoading: false, isError: true });
+    expect(screen.getByText("API not configured")).toBeInTheDocument();
+    expect(screen.queryByText(/Couldn't load/)).toBeNull();
+  });
+
+  it("echoes the id in the fetch-error message", () => {
+    renderGate({ data: undefined, isLoading: false, isError: true });
+    expect(screen.getByText("Couldn't load task")).toBeInTheDocument();
+    expect(screen.getByText(/Task task_42 could not be fetched\./)).toBeInTheDocument();
+  });
+
+  // A query can settle without erroring and still hand back nothing (a 404
+  // mapped to undefined). That has to land on the error state, not render
+  // the body with a missing row.
+  it("treats settled-but-empty as a failed fetch", () => {
+    renderGate({ data: undefined, isLoading: false, isError: false });
+    expect(screen.getByText("Couldn't load task")).toBeInTheDocument();
+    expect(screen.queryByTestId("body")).toBeNull();
+  });
+});
+
+// The whole point of hoisting `gateCopy` out of DetailGate is that the panel
+// and the full route can't word the same condition differently again. Assert
+// the two gates agree rather than trusting that nobody edits one in isolation.
+describe("PanelGate / DetailGate copy", () => {
+  const empty = { data: undefined, isLoading: false, isError: true };
+
+  function textsFrom(node: HTMLElement): string[] {
+    return Array.from(node.querySelectorAll("p")).map((p) => p.textContent ?? "");
+  }
+
+  it("words the fetch error identically", () => {
+    const panel = render(
+      <PanelGate noun="task" id="task_42" query={empty} skeleton={null}>
+        {() => null}
+      </PanelGate>,
+    );
+    const panelText = textsFrom(panel.container);
+    panel.unmount();
+    // Guard against the comparison passing because both sides rendered nothing.
+    expect(panelText).toContain("Couldn't load task");
+
+    const detail = render(
+      <DetailGate noun="task" id="task_42" query={empty} skeleton={null}>
+        {() => null}
+      </DetailGate>,
+    );
+    expect(textsFrom(detail.container)).toEqual(panelText);
+  });
+
+  it("words the unconfigured-API message identically", () => {
+    apiState.isApiConfigured = false;
+    const panel = render(
+      <PanelGate noun="task" id="task_42" query={empty} skeleton={null}>
+        {() => null}
+      </PanelGate>,
+    );
+    const panelText = textsFrom(panel.container);
+    panel.unmount();
+    expect(panelText).toContain("API not configured");
+
+    const detail = render(
+      <DetailGate noun="task" id="task_42" query={empty} skeleton={null}>
+        {() => null}
+      </DetailGate>,
+    );
+    expect(textsFrom(detail.container)).toEqual(panelText);
+    apiState.isApiConfigured = true;
+  });
+});

--- a/packages/web/components/detail/panel-gate.tsx
+++ b/packages/web/components/detail/panel-gate.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { AlertTriangle, type LucideIcon } from "lucide-react";
+import { isApiConfigured } from "@/lib/api/config";
+import { EmptyState } from "@/components/empty-state";
+import { gateCopy } from "./gate-copy";
+
+interface Props<T> {
+  /** Icon for the "API not configured" state. The error state is always AlertTriangle. */
+  icon?: LucideIcon;
+  /** Lowercase singular of what the panel shows — "agent", "task". */
+  noun: string;
+  /** Id echoed back in the error message so a failed fetch is identifiable. */
+  id: string;
+  /** The react-query result driving the panel. */
+  query: { data: T | undefined; isLoading: boolean; isError: boolean };
+  /**
+   * Loading placeholder, rendered inside the panel's own padding. Per-panel
+   * because it mirrors the layout it stands in for.
+   */
+  skeleton: ReactNode;
+  /** Rendered once the fetch succeeded. Owns its own padding. */
+  children: (data: T) => ReactNode;
+}
+
+/**
+ * The three-branch preamble both peek panels open with — API not
+ * configured, still loading, failed to load.
+ *
+ * The panel-shaped sibling of {@link import("./detail-gate").DetailGate}:
+ * same branches, same order, same copy (both derive it from
+ * {@link gateCopy}), rendered into the panel's padding instead of a
+ * `DetailShell`. `AgentDetailPanel` and `TaskDetailPanel` each had a
+ * byte-identical copy of it down to the class names, which is the same
+ * reason `PanelFooterField` lives in `peek-panel.tsx`.
+ */
+export function PanelGate<T>({ icon, noun, id, query, skeleton, children }: Props<T>) {
+  const copy = gateCopy(noun, id);
+
+  if (!isApiConfigured) {
+    return (
+      <div className="p-4">
+        <EmptyState icon={icon} title="API not configured" description={copy.notConfigured} />
+      </div>
+    );
+  }
+
+  if (query.isLoading) {
+    return <div className="p-5 space-y-4">{skeleton}</div>;
+  }
+
+  if (query.isError || query.data === undefined) {
+    return (
+      <div className="p-4">
+        <EmptyState
+          icon={AlertTriangle}
+          title={copy.errorTitle}
+          description={copy.errorDescription}
+        />
+      </div>
+    );
+  }
+
+  return <>{children(query.data)}</>;
+}

--- a/packages/web/components/mesh/activity-feed.tsx
+++ b/packages/web/components/mesh/activity-feed.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import { Network, X } from "lucide-react";
-import { EmptyState } from "@/components/empty-state";
+import { EmptyCard } from "@/components/page-gate";
 import { cn } from "@/lib/utils";
 import type { MeshAsk, MeshAskType, MeshHover } from "@/lib/types/mesh";
 
@@ -103,24 +103,22 @@ export function MeshActivityFeed({
       ) : null}
 
       {visible.length === 0 ? (
-        <div className="rounded-lg border border-dashed border-border">
-          <EmptyState
-            icon={Network}
-            title={
-              all.length === 0
-                ? "No mesh asks yet"
-                : selectedAgent
-                  ? `No asks for ${selectedAgent}`
-                  : `No ${filter === "all" ? "" : filter} asks in this window`
-            }
-            description={
-              all.length === 0
-                ? "When agents ask each other for help, exchanges appear here. Ask your team agent to spawn a few subordinates and assign them work."
-                : undefined
-            }
-            cta={all.length === 0 ? { href: "/", label: "Open chat" } : undefined}
-          />
-        </div>
+        <EmptyCard
+          icon={Network}
+          title={
+            all.length === 0
+              ? "No mesh asks yet"
+              : selectedAgent
+                ? `No asks for ${selectedAgent}`
+                : `No ${filter === "all" ? "" : filter} asks in this window`
+          }
+          description={
+            all.length === 0
+              ? "When agents ask each other for help, exchanges appear here. Ask your team agent to spawn a few subordinates and assign them work."
+              : undefined
+          }
+          cta={all.length === 0 ? { href: "/", label: "Open chat" } : undefined}
+        />
       ) : (
         <ul className="space-y-2">
           {visible.map((ask) => {

--- a/packages/web/components/page-gate.test.tsx
+++ b/packages/web/components/page-gate.test.tsx
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const apiState = { isApiConfigured: true };
+
+vi.mock("@/lib/api/config", () => ({
+  get isApiConfigured() {
+    return apiState.isApiConfigured;
+  },
+}));
+
+import { EmptyCard, PageGate } from "./page-gate";
+
+interface Row {
+  name: string;
+}
+
+function renderGate(query: { data: Row | undefined; isLoading: boolean; isError: boolean }) {
+  return render(
+    <PageGate
+      query={query}
+      notConfigured={{ title: "Nothing here yet", description: "Set NEXT_PUBLIC_BV_API_URL." }}
+      error={{ title: "Couldn't load rows", description: "Check the API server." }}
+      skeleton={<div data-testid="skeleton" />}
+    >
+      {(row) => <div data-testid="body">{row.name}</div>}
+    </PageGate>,
+  );
+}
+
+describe("PageGate", () => {
+  beforeEach(() => {
+    apiState.isApiConfigured = true;
+  });
+
+  it("renders the body once the data is in hand", () => {
+    renderGate({ data: { name: "Design doc" }, isLoading: false, isError: false });
+    expect(screen.getByTestId("body")).toHaveTextContent("Design doc");
+    expect(screen.queryByTestId("skeleton")).toBeNull();
+  });
+
+  it("renders the skeleton while loading, never the body", () => {
+    renderGate({ data: undefined, isLoading: true, isError: false });
+    expect(screen.getByTestId("skeleton")).toBeInTheDocument();
+    expect(screen.queryByTestId("body")).toBeNull();
+  });
+
+  it("reports an unconfigured API before it reports a failed fetch", () => {
+    apiState.isApiConfigured = false;
+    renderGate({ data: undefined, isLoading: false, isError: true });
+    expect(screen.getByText("Nothing here yet")).toBeInTheDocument();
+    expect(screen.queryByText(/Couldn't load/)).toBeNull();
+  });
+
+  it("never fires the body when the API is unconfigured, even with cached data", () => {
+    apiState.isApiConfigured = false;
+    renderGate({ data: { name: "stale" }, isLoading: false, isError: false });
+    expect(screen.getByText("Nothing here yet")).toBeInTheDocument();
+    expect(screen.queryByTestId("body")).toBeNull();
+  });
+
+  it("shows the error state on a failed fetch", () => {
+    renderGate({ data: undefined, isLoading: false, isError: true });
+    expect(screen.getByText("Couldn't load rows")).toBeInTheDocument();
+    expect(screen.getByText("Check the API server.")).toBeInTheDocument();
+  });
+
+  // A background refetch can fail while stale data is still cached. Every
+  // page this replaced checked `isError` before rendering content, so the
+  // error state wins over the stale rows rather than silently showing them.
+  it("prefers the error state over stale cached data", () => {
+    renderGate({ data: { name: "stale" }, isLoading: false, isError: true });
+    expect(screen.getByText("Couldn't load rows")).toBeInTheDocument();
+    expect(screen.queryByTestId("body")).toBeNull();
+  });
+
+  // Unlike DetailGate — where a settled-but-empty query means a 404 — a list
+  // query that has not produced data yet is still pre-first-fetch, and the
+  // pages this replaced showed their skeleton for it.
+  it("treats settled-but-empty as still loading", () => {
+    renderGate({ data: undefined, isLoading: false, isError: false });
+    expect(screen.getByTestId("skeleton")).toBeInTheDocument();
+    expect(screen.queryByTestId("body")).toBeNull();
+  });
+});
+
+describe("EmptyCard", () => {
+  it("frames the empty state in the dashed card and keeps extra classes", () => {
+    const { container } = render(
+      <EmptyCard title="No promotions yet" className="w-full max-w-md" />,
+    );
+    const card = container.firstElementChild;
+    expect(card).toHaveClass("border-dashed", "max-w-md");
+    expect(screen.getByText("No promotions yet")).toBeInTheDocument();
+  });
+
+  it("passes the cta through", () => {
+    render(<EmptyCard title="No mesh asks yet" cta={{ href: "/", label: "Open chat" }} />);
+    expect(screen.getByRole("link", { name: /Open chat/ })).toHaveAttribute("href", "/");
+  });
+});

--- a/packages/web/components/page-gate.tsx
+++ b/packages/web/components/page-gate.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { AlertTriangle, type LucideIcon } from "lucide-react";
+import { isApiConfigured } from "@/lib/api/config";
+import { EmptyState } from "@/components/empty-state";
+import { cn } from "@/lib/utils";
+
+/**
+ * The dashed-border card every list page frames an {@link EmptyState} in.
+ *
+ * `EmptyState` itself is just the centered icon/title/description stack —
+ * on a list surface it needs a border so it reads as "this panel is empty"
+ * rather than as loose body copy. Every page wrote that border by hand;
+ * `promotions-client` had already extracted a private `EmptyWrapper` doing
+ * exactly this, which is what made it worth hoisting.
+ */
+export function EmptyCard({
+  icon,
+  title,
+  description,
+  cta,
+  className,
+}: {
+  icon?: LucideIcon;
+  title: string;
+  description?: string;
+  /** Passed straight through to {@link EmptyState}. */
+  cta?: { href: string; label: string };
+  /** Extra classes on the card — width caps and backgrounds, mostly. */
+  className?: string;
+}) {
+  return (
+    <div className={cn("rounded-lg border border-dashed border-border", className)}>
+      <EmptyState icon={icon} title={title} description={description} cta={cta} />
+    </div>
+  );
+}
+
+/** Copy for one of the gate's two failure branches. */
+export interface GateMessage {
+  icon?: LucideIcon;
+  title: string;
+  description?: string;
+}
+
+interface Props<T> {
+  /** The react-query result driving the page. */
+  query: { data: T | undefined; isLoading: boolean; isError: boolean };
+  /**
+   * Shown when `NEXT_PUBLIC_BV_API_URL` is unset. Per-page rather than
+   * derived: some surfaces frame this as a setup instruction ("API not
+   * configured") and others as an empty state ("No promotions yet"),
+   * because an unconfigured web app and an idle one look the same to the
+   * user standing in front of them.
+   */
+  notConfigured: GateMessage;
+  /** Shown when the fetch failed. `icon` defaults to `AlertTriangle`. */
+  error: GateMessage;
+  /**
+   * Loading placeholder. Per-page rather than generic: the skeleton
+   * mirrors the layout it stands in for, so a shared one would jump on
+   * hydration.
+   */
+  skeleton: ReactNode;
+  /** Rendered once the fetch succeeded. */
+  children: (data: T) => ReactNode;
+}
+
+/**
+ * The three-branch preamble every list/overview page opens with — API not
+ * configured, failed to load, still loading — before it has data to render.
+ *
+ * The sibling of {@link import("./detail/detail-gate").DetailGate}, which
+ * does the same job for the `/<thing>/[id]` detail pages. That one was
+ * extracted first and the list pages were left hand-rolling the same three
+ * branches, so the same copy drift DetailGate exists to prevent had set in
+ * again on this side: the not-configured branch variously told the user to
+ * "run the API server", "run the api server" and "run the MCP server" for
+ * what is one process.
+ *
+ * The branch *copy* stays per-page (see {@link Props.notConfigured}) — what
+ * is unified here is the structure and the branch order, so a page can't
+ * grow a fourth ordering or forget a branch outright.
+ */
+export function PageGate<T>({ query, notConfigured, error, skeleton, children }: Props<T>) {
+  if (!isApiConfigured) {
+    return <EmptyCard {...notConfigured} />;
+  }
+
+  if (query.isError) {
+    return <EmptyCard icon={AlertTriangle} {...error} />;
+  }
+
+  // `data === undefined` shares the loading branch: it is the pre-first-fetch
+  // state, and showing the skeleton for it is what the pages that special-cased
+  // it already did.
+  if (query.isLoading || query.data === undefined) {
+    return <>{skeleton}</>;
+  }
+
+  return <>{children(query.data)}</>;
+}

--- a/packages/web/components/tasks/task-detail-panel.tsx
+++ b/packages/web/components/tasks/task-detail-panel.tsx
@@ -2,15 +2,14 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { AlertTriangle, FileText, ListChecks, Terminal } from "lucide-react";
+import { FileText, ListChecks, Terminal } from "lucide-react";
 import { ChatMarkdown } from "@/components/chat/markdown";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { PanelFooterField, PeekPanel } from "@/components/detail/peek-panel";
+import { PanelGate } from "@/components/detail/panel-gate";
 import { TaskStatusPill, SessionStatusPill } from "@/components/detail/status-pill";
-import { EmptyState } from "@/components/empty-state";
 import { HierChip } from "@/components/hier-chip";
 import { Skeleton } from "@/components/skeleton";
-import { isApiConfigured } from "@/lib/api/config";
 import { useTask } from "@/lib/hooks/use-tasks";
 import {
   useApproveTask,
@@ -54,43 +53,25 @@ export function TaskDetailPanel({
 }
 
 function PanelBody({ taskId }: { taskId: string }) {
-  const { data, isLoading, isError } = useTask(taskId);
+  const query = useTask(taskId);
 
-  if (!isApiConfigured) {
-    return (
-      <div className="p-4">
-        <EmptyState
-          icon={ListChecks}
-          title="API not configured"
-          description="Set NEXT_PUBLIC_BV_API_URL to load this task."
-        />
-      </div>
-    );
-  }
-
-  if (isLoading) {
-    return (
-      <div className="p-5 space-y-4">
-        <Skeleton className="h-7 w-3/4" />
-        <Skeleton className="h-20 w-full rounded-lg" />
-        <Skeleton className="h-32 w-full rounded-lg" />
-      </div>
-    );
-  }
-
-  if (isError || !data) {
-    return (
-      <div className="p-4">
-        <EmptyState
-          icon={AlertTriangle}
-          title="Couldn't load task"
-          description={`Task ${taskId} could not be fetched.`}
-        />
-      </div>
-    );
-  }
-
-  return <PanelLoaded task={data} />;
+  return (
+    <PanelGate
+      icon={ListChecks}
+      noun="task"
+      id={taskId}
+      query={query}
+      skeleton={
+        <>
+          <Skeleton className="h-7 w-3/4" />
+          <Skeleton className="h-20 w-full rounded-lg" />
+          <Skeleton className="h-32 w-full rounded-lg" />
+        </>
+      }
+    >
+      {(task) => <PanelLoaded task={task} />}
+    </PanelGate>
+  );
 }
 
 function PanelLoaded({ task }: { task: TaskDetail }) {


### PR DESCRIPTION
Swept the monorepo for near-duplicate abstractions and unified the three clusters where a shared abstraction either already existed and hadn't been adopted, or was one file away from existing. Three independent commits, reviewable in order.

Common thread: in all three cases **the codebase had already extracted the right abstraction and the migration stopped partway**, so the remaining copies drifted.

---

### 1. `PageGate` — the list-page API gate (`refactor(web)`, first commit)

`dashboard`, `mesh`, `promotions` and `runtimes` each opened with the same three branches — API not configured, failed to load, still loading — hand-rolled inline, each wrapping an `EmptyState` in its own copy of the dashed-border card.

`DetailGate` already does exactly this job for the `/<thing>/[id]` routes, and its doc-comment records why it exists: left hand-rolled, the branch copy drifts. It had drifted again on the list side — the same condition told the user to *"run the API server"*, *"run the api server"* and *"run the MCP server"* for what is one process. `promotions-client` had already extracted a private `EmptyWrapper` for the card, which is the signal the abstraction wanted hoisting.

Adds `components/page-gate.tsx` (`EmptyCard` + `PageGate`), migrates the four pages, and folds the two remaining hand-rolled dashed cards (`agents`' `CenteredShell`, the mesh activity feed's empty state) onto `EmptyCard`.

Branch **copy** stays per-page deliberately — some surfaces frame the unconfigured case as a setup instruction ("API not configured") and others as an empty state ("No promotions yet"), because an unconfigured app and an idle one look identical to the user in front of them. What is unified is the structure and branch order.

### 2. `PanelGate` + shared gate copy (`refactor(web)`, second commit)

`AgentDetailPanel` and `TaskDetailPanel` each opened their body with the same three branches `DetailGate` owns, identical down to the `p-4` / `p-5 space-y-4` class names. The task panel's own doc-comment already said *"Same pattern as AgentDetailPanel."*

Because they were separate copies, their messages had drifted from the routes they mirror: the panels said *"Set NEXT_PUBLIC_BV_API_URL to load this task."* where the route says *"…and run the API server to load this task."*, and the panels dropped the *"Check the API server logs."* hint.

Extracts `detail/gate-copy.ts` (both sentences derived from `noun`/`id` in one place) and adds `detail/panel-gate.tsx`. `DetailGate` now reads from the same helper, and a test asserts the two gates render identical text for the same noun/id rather than trusting nobody edits one in isolation.

### 3. `toolError()` adoption (`refactor(api)`, third commit)

`tools/errors.ts` exists to be the single spelling of the MCP tool error envelope, and its doc-comment names the modules that were hand-rolling it. The extraction landed but the migration didn't: `toolError` had **one** caller (`watch.ts`) while 28 sites across seven other tool modules still wrote the four-to-eight-line literal by hand.

Rewrites those 28. `toolError(code, message, extra)` produces `{ content: { error, message, ...extra }, isError: true }` — same object, same key order, **wire contract unchanged**.

Deliberately left alone:
- The three coded sites carrying no `message` (`task_not_found`, `assignee_not_found`, and the `agent_id` one in `hierarchy`) — `toolError` requires a message, so converting them would add a field to the response rather than just move code.
- The ~25 catch-all `{ error: "<human text>" }` envelopes — that shape puts the human message where the coded shape puts a stable code, and agents branch on `error`. Folding them together is a wire-contract decision, not a refactor.

---

### User-visible changes

Two, both intentional and both the point of the exercise:

- The list pages settle the drifted copy on "the API server", matching `DetailGate`.
- The peek panels adopt the detail routes' fuller wording.

No behavior changes otherwise — including error still winning over stale cached data on a failed background refetch, which is what every page this replaced already did.

### Net effect

21 files, **+665 / −491**. Excluding the 4 new files (2 components, 2 test files, +415), that is roughly **−240 lines** of duplicated branching removed.

### Verification

- `pnpm typecheck` — 9/9 tasks pass
- `pnpm lint` — 9/9 tasks pass, 0 errors (4 pre-existing `import/no-duplicates` warnings in files not touched here)
- `next build` — clean
- web: **26 files / 219 tests pass** (up from 24/203; +16 tests for the two new gates)
- api tools: **8 files / 74 tests pass**

The 9 failing api suites and 7 failing core tests are the environmental ones documented in `CLAUDE.md` — missing `DATABASE_URL_TEST` and missing provider keys. They fail identically on `main`, and this branch touches no core files.

---
_Generated by [Claude Code](https://claude.ai/code/session_018pobyvLEuqF3fsBJQeB6WQ)_