### PR TITLE
test: cover the untested MCP tool modules (use_repo, watch, session_search, mesh)

### DIFF
--- a/packages/api/src/tools/mesh.test.ts
+++ b/packages/api/src/tools/mesh.test.ts
@@ -1,13 +1,28 @@
 /**
- * Mesh tool assembly tests — IC vs team tier gating.
+ * Mesh tool tests — tier gating, plus the argument validation and
+ * response projection each handler does around the MeshServer call.
  *
- * Per-tool handler behavior is covered indirectly by the m6/m7 e2e scripts
- * (mesh flows require live Postgres + spawned CLI subprocesses). This file
- * locks the static tier inventory — the exact tool *names* each tier gets,
- * so future skill-loader work can rely on the surface being stable.
+ * The mesh *protocol* (spawning the peer, blocking on their reply, round
+ * accounting) needs live Postgres + spawned CLI subprocesses and stays in
+ * the m6/m7 e2e scripts. What runs here is everything on this side of
+ * that boundary: the tier inventory, the required-argument checks that
+ * short-circuit before a session is ever spawned, the projection that
+ * decides which server fields reach the agent, and the coded-error
+ * envelope agents branch on.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentRepository, TaskRepository } from "@beevibe/core";
 import type { ResolvedCaller } from "@beevibe/core/auth";
+import type { EscalationService } from "@beevibe/core/services/escalation-service";
+import type { TaskService } from "@beevibe/core/services/task-service";
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import type { MeshServer } from "../mesh/server.js";
+import {
+  CannotNegotiateWithIcError,
+  MeshCapacityError,
+  MeshMaxRoundsError,
+} from "../mesh/types.js";
+import type { AgentTool } from "./types.js";
 import { buildIcMeshTools, buildTeamMeshTools, type MeshToolServices } from "./mesh.js";
 
 // Fake services — the assembly itself doesn't invoke handlers, so the
@@ -45,5 +60,595 @@ describe("buildTeamMeshTools", () => {
       "respond_ask",
       "respond_negotiate",
     ]);
+  });
+});
+
+// ── Handler harness ──────────────────────────────────────────────────────
+
+type Spy = ReturnType<typeof vi.fn>;
+
+interface MeshHarness {
+  services: MeshToolServices;
+  // Spelled out rather than Record<string, …> so indexing stays
+  // non-optional under noUncheckedIndexedAccess.
+  mesh: {
+    sendAsk: Spy;
+    respondAsk: Spy;
+    sendNegotiate: Spy;
+    respondNegotiate: Spy;
+    reportBlocker: Spy;
+    unblockOnEscalate: Spy;
+  };
+  agentRepo: { findParent: ReturnType<typeof vi.fn> };
+  taskService: { markBlocked: ReturnType<typeof vi.fn> };
+  escalationService: { create: ReturnType<typeof vi.fn> };
+  pool: { query: ReturnType<typeof vi.fn> };
+}
+
+function meshHarness(): MeshHarness {
+  const mesh = {
+    sendAsk: vi.fn(async () => ({
+      request_id: "req_1",
+      from_agent_id: "agent_b",
+      answer: "yes, feasible",
+      // Extra server-side fields the projection must drop.
+      internal_session_id: "sess_leak",
+    })),
+    respondAsk: vi.fn(() => undefined),
+    sendNegotiate: vi.fn(async () => ({
+      negotiation_id: "neg_1",
+      from_agent_id: "agent_b",
+      decision: "counter",
+      message: "how about half",
+      counter_proposal: "split it",
+      internal_round: 2,
+    })),
+    respondNegotiate: vi.fn(async () => null),
+    reportBlocker: vi.fn(() => undefined),
+    unblockOnEscalate: vi.fn(() => undefined),
+  };
+
+  const agentRepo = { findParent: vi.fn(async () => ({ id: "agent_parent" })) };
+  const taskService = { markBlocked: vi.fn(async () => ({ id: "task_1" })) };
+  const escalationService = {
+    create: vi.fn(async () => ({
+      id: "esc_1",
+      status: "open",
+      negotiation_id: "neg_1",
+    })),
+  };
+  const pool = { query: vi.fn(async () => ({ rows: [] })) };
+
+  return {
+    services: {
+      mesh: mesh as unknown as MeshServer,
+      agentRepo: agentRepo as unknown as AgentRepository,
+      taskRepo: {} as unknown as TaskRepository,
+      taskService: taskService as unknown as TaskService,
+      escalationService: escalationService as unknown as EscalationService,
+      pool: pool as unknown as Pool,
+    },
+    mesh,
+    agentRepo,
+    taskService,
+    escalationService,
+    pool,
+  };
+}
+
+function teamTool(h: MeshHarness, name: string): AgentTool {
+  const tool = buildTeamMeshTools(fakeCtx, h.services).find((t) => t.name === name);
+  if (!tool) throw new Error(`no such mesh tool: ${name}`);
+  return tool;
+}
+
+// ── ask / respond_ask ────────────────────────────────────────────────────
+
+describe("ask", () => {
+  it("sends the question with a minted request id and projects the answer", async () => {
+    const h = meshHarness();
+    const result = await teamTool(h, "ask").handler({
+      target_agent_id: "agent_b",
+      question: "is X feasible?",
+    });
+
+    expect(h.mesh.sendAsk).toHaveBeenCalledTimes(1);
+    const [requestId, from, to, question] = h.mesh.sendAsk.mock.calls[0]!;
+    expect(requestId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    expect([from, to, question]).toEqual(["agent_x", "agent_b", "is X feasible?"]);
+
+    // Projection is a whitelist — server-internal fields must not leak.
+    expect(result.content).toEqual({
+      request_id: "req_1",
+      from_agent_id: "agent_b",
+      answer: "yes, feasible",
+    });
+  });
+
+  it("mints a fresh request id per call", async () => {
+    const h = meshHarness();
+    const ask = teamTool(h, "ask");
+    await ask.handler({ target_agent_id: "agent_b", question: "q1" });
+    await ask.handler({ target_agent_id: "agent_b", question: "q2" });
+
+    expect(h.mesh.sendAsk.mock.calls[0]![0]).not.toBe(
+      h.mesh.sendAsk.mock.calls[1]![0],
+    );
+  });
+
+  it.each([
+    ["target_agent_id", { question: "q" }],
+    ["question", { target_agent_id: "agent_b" }],
+    ["both", {}],
+  ])("refuses to spawn a session when %s is missing", async (_label, input) => {
+    const h = meshHarness();
+    const result = await teamTool(h, "ask").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "target_agent_id and question required" });
+    expect(h.mesh.sendAsk).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a capacity error with its code and meta", async () => {
+    const h = meshHarness();
+    h.mesh.sendAsk.mockRejectedValue(
+      new MeshCapacityError("at cap", { agentId: "agent_b", running: 3, cap: 3 }),
+    );
+
+    const result = await teamTool(h, "ask").handler({
+      target_agent_id: "agent_b",
+      question: "q",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "MESH_CAPACITY_EXCEEDED",
+      agentId: "agent_b",
+      running: 3,
+      cap: 3,
+      message: "at cap",
+    });
+  });
+});
+
+describe("respond_ask", () => {
+  it("stamps the responder's agent id onto the response", async () => {
+    const h = meshHarness();
+    const result = await teamTool(h, "respond_ask").handler({
+      request_id: "req_1",
+      answer: "here you go",
+    });
+
+    expect(h.mesh.respondAsk).toHaveBeenCalledWith("req_1", {
+      request_id: "req_1",
+      from_agent_id: "agent_x",
+      answer: "here you go",
+    });
+    expect(result.content).toEqual({ responded: true, request_id: "req_1" });
+  });
+
+  it.each([
+    ["request_id", { answer: "a" }],
+    ["answer", { request_id: "req_1" }],
+  ])("rejects a call missing %s", async (_label, input) => {
+    const h = meshHarness();
+    const result = await teamTool(h, "respond_ask").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(h.mesh.respondAsk).not.toHaveBeenCalled();
+  });
+
+  it("envelopes a plain throw from the server", async () => {
+    const h = meshHarness();
+    h.mesh.respondAsk.mockImplementation(() => {
+      throw new Error("no such pending ask");
+    });
+
+    const result = await teamTool(h, "respond_ask").handler({
+      request_id: "req_gone",
+      answer: "a",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "no such pending ask" });
+  });
+});
+
+// ── negotiate / respond_negotiate ────────────────────────────────────────
+
+describe("negotiate", () => {
+  it("passes the caller's session id as initiator and projects the reply", async () => {
+    const h = meshHarness();
+    const result = await teamTool(h, "negotiate").handler({
+      peer_id: "agent_b",
+      proposal: "ship on friday",
+      task_id: "task_1",
+    });
+
+    expect(h.mesh.sendNegotiate).toHaveBeenCalledWith(
+      "agent_x",
+      "agent_b",
+      "ship on friday",
+      { taskId: "task_1", initiatorSessionId: "ses_x" },
+    );
+    expect(result.content).toEqual({
+      negotiation_id: "neg_1",
+      from_agent_id: "agent_b",
+      decision: "counter",
+      message: "how about half",
+      counter_proposal: "split it",
+    });
+  });
+
+  it("omits task_id when absent or empty rather than passing a blank string", async () => {
+    const h = meshHarness();
+    const negotiate = teamTool(h, "negotiate");
+
+    await negotiate.handler({ peer_id: "agent_b", proposal: "p" });
+    expect(h.mesh.sendNegotiate.mock.calls[0]![3]).toEqual({
+      taskId: undefined,
+      initiatorSessionId: "ses_x",
+    });
+
+    await negotiate.handler({ peer_id: "agent_b", proposal: "p", task_id: "" });
+    expect(h.mesh.sendNegotiate.mock.calls[1]![3]).toMatchObject({
+      taskId: undefined,
+    });
+  });
+
+  it.each([
+    ["peer_id", { proposal: "p" }],
+    ["proposal", { peer_id: "agent_b" }],
+  ])("rejects a call missing %s", async (_label, input) => {
+    const h = meshHarness();
+    const result = await teamTool(h, "negotiate").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "peer_id and proposal required" });
+    expect(h.mesh.sendNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("projects the escalated sentinel through its own branch", async () => {
+    const h = meshHarness();
+    h.mesh.sendNegotiate.mockResolvedValue({
+      decision: "escalated",
+      escalation_id: "esc_1",
+      negotiation_id: "neg_1",
+      message: "handed to humans",
+    });
+
+    const result = await teamTool(h, "negotiate").handler({
+      peer_id: "agent_b",
+      proposal: "p",
+    });
+
+    expect(result.content).toEqual({
+      decision: "escalated",
+      escalation_id: "esc_1",
+      negotiation_id: "neg_1",
+      message: "handed to humans",
+    });
+  });
+
+  it("surfaces CANNOT_NEGOTIATE_WITH_IC so the agent can switch to ask()", async () => {
+    const h = meshHarness();
+    h.mesh.sendNegotiate.mockRejectedValue(
+      new CannotNegotiateWithIcError({ agentId: "agent_ic" }),
+    );
+
+    const result = await teamTool(h, "negotiate").handler({
+      peer_id: "agent_ic",
+      proposal: "p",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "CANNOT_NEGOTIATE_WITH_IC",
+      agentId: "agent_ic",
+    });
+  });
+});
+
+describe("respond_negotiate", () => {
+  it("forwards the round and reports terminal when the server returns null", async () => {
+    const h = meshHarness();
+    const result = await teamTool(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "accept",
+      message: "deal",
+    });
+
+    expect(h.mesh.respondNegotiate).toHaveBeenCalledWith(
+      "neg_1",
+      {
+        negotiation_id: "neg_1",
+        from_agent_id: "agent_x",
+        decision: "accept",
+        message: "deal",
+        counter_proposal: undefined,
+      },
+      "ses_x",
+    );
+    expect(result.content).toEqual({
+      negotiation_id: "neg_1",
+      decision: "accept",
+      terminal: true,
+    });
+  });
+
+  it("projects the peer's next round when the server returns one", async () => {
+    const h = meshHarness();
+    h.mesh.respondNegotiate.mockResolvedValue({
+      negotiation_id: "neg_1",
+      from_agent_id: "agent_b",
+      decision: "counter",
+      message: "not quite",
+      counter_proposal: "thursday",
+    });
+
+    const result = await teamTool(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "friday then",
+      counter_proposal: "friday",
+    });
+
+    expect(result.content).toMatchObject({
+      from_agent_id: "agent_b",
+      decision: "counter",
+      counter_proposal: "thursday",
+    });
+  });
+
+  it("requires a counter_proposal when the decision is counter", async () => {
+    const h = meshHarness();
+    const result = await teamTool(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "not quite",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "counter_proposal required when decision='counter'",
+    });
+    expect(h.mesh.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["negotiation_id", { decision: "accept", message: "m" }],
+    ["message", { negotiation_id: "neg_1", decision: "accept" }],
+  ])("rejects a call missing %s", async (_label, input) => {
+    const h = meshHarness();
+    const result = await teamTool(h, "respond_negotiate").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "negotiation_id and message required",
+    });
+    expect(h.mesh.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("rejects a decision outside counter/accept/reject", async () => {
+    const h = meshHarness();
+    const result = await teamTool(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "maybe",
+      message: "m",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(String(result.content.error)).toContain("decision must be one of");
+    expect(h.mesh.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("surfaces MAX_ROUNDS_EXCEEDED with its round accounting", async () => {
+    const h = meshHarness();
+    h.mesh.respondNegotiate.mockRejectedValue(
+      new MeshMaxRoundsError({
+        negotiationId: "neg_1",
+        rounds_completed: 5,
+        max_rounds: 5,
+      }),
+    );
+
+    const result = await teamTool(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "m",
+      counter_proposal: "c",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "MAX_ROUNDS_EXCEEDED",
+      rounds_completed: 5,
+      max_rounds: 5,
+    });
+  });
+});
+
+// ── report_blocker ───────────────────────────────────────────────────────
+
+describe("report_blocker", () => {
+  it("marks the task blocked, then wakes the parent with the same context", async () => {
+    const h = meshHarness();
+    const result = await teamTool(h, "report_blocker").handler({
+      task_id: "task_1",
+      description: "the API key is missing",
+    });
+
+    expect(h.agentRepo.findParent).toHaveBeenCalledWith("agent_x");
+    expect(h.taskService.markBlocked).toHaveBeenCalledWith(
+      "task_1",
+      "agent_x",
+      "the API key is missing",
+    );
+    expect(h.mesh.reportBlocker).toHaveBeenCalledWith(
+      "agent_parent",
+      "agent_x",
+      "task_1",
+      "the API key is missing",
+    );
+    expect(result.content).toEqual({
+      reported: true,
+      parent_agent_id: "agent_parent",
+      task_id: "task_1",
+    });
+  });
+
+  it("refuses for a top-level agent and leaves the task unblocked", async () => {
+    const h = meshHarness();
+    h.agentRepo.findParent.mockResolvedValue(undefined);
+
+    const result = await teamTool(h, "report_blocker").handler({
+      task_id: "task_1",
+      description: "stuck",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "no_parent_to_block" });
+    expect(h.taskService.markBlocked).not.toHaveBeenCalled();
+    expect(h.mesh.reportBlocker).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["task_id", { description: "d" }],
+    ["description", { task_id: "task_1" }],
+  ])("rejects a call missing %s before any lookup", async (_label, input) => {
+    const h = meshHarness();
+    const result = await teamTool(h, "report_blocker").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "task_id and description required" });
+    expect(h.agentRepo.findParent).not.toHaveBeenCalled();
+  });
+
+  it("does not spawn the parent when markBlocked fails", async () => {
+    const h = meshHarness();
+    h.taskService.markBlocked.mockRejectedValue(new Error("task not found"));
+
+    const result = await teamTool(h, "report_blocker").handler({
+      task_id: "task_gone",
+      description: "stuck",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "task not found" });
+    expect(h.mesh.reportBlocker).not.toHaveBeenCalled();
+  });
+
+  it("is the same handler on the IC tier", async () => {
+    const h = meshHarness();
+    const icTool = buildIcMeshTools(fakeCtx, h.services).find(
+      (t) => t.name === "report_blocker",
+    )!;
+
+    const result = await icTool.handler({ task_id: "task_1", description: "d" });
+
+    expect(result.content).toMatchObject({ parent_agent_id: "agent_parent" });
+  });
+});
+
+// ── escalate_to_humans ───────────────────────────────────────────────────
+
+describe("escalate_to_humans", () => {
+  it("creates the escalation, unblocks the peer, and notifies listeners", async () => {
+    const h = meshHarness();
+    const result = await teamTool(h, "escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "we disagree on the deadline",
+      proposals: [{ title: "ship friday", description: "cut scope" }],
+      open_questions: ["is friday a hard date?"],
+    });
+
+    expect(h.escalationService.create).toHaveBeenCalledWith({
+      negotiationId: "neg_1",
+      callerAgentId: "agent_x",
+      summary: "we disagree on the deadline",
+      proposals: [{ title: "ship friday", description: "cut scope" }],
+      openQuestions: ["is friday a hard date?"],
+    });
+    expect(h.mesh.unblockOnEscalate).toHaveBeenCalledWith("neg_1", "esc_1");
+    expect(h.pool.query).toHaveBeenCalledWith(
+      expect.stringContaining("pg_notify('escalation_created'"),
+      ["esc_1"],
+    );
+    expect(result.content).toEqual({
+      escalation_id: "esc_1",
+      status: "open",
+      negotiation_id: "neg_1",
+    });
+  });
+
+  it("passes undefined rather than [] when proposals/open_questions are absent", async () => {
+    const h = meshHarness();
+    await teamTool(h, "escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "stuck",
+    });
+
+    expect(h.escalationService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ proposals: undefined, openQuestions: undefined }),
+    );
+  });
+
+  it("drops non-string open_questions", async () => {
+    const h = meshHarness();
+    await teamTool(h, "escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "stuck",
+      open_questions: ["real question", 42, null],
+    });
+
+    expect(h.escalationService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ openQuestions: ["real question"] }),
+    );
+  });
+
+  it("ignores a non-array proposals value", async () => {
+    const h = meshHarness();
+    await teamTool(h, "escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "stuck",
+      proposals: "just ship it",
+    });
+
+    expect(h.escalationService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ proposals: undefined }),
+    );
+  });
+
+  it.each([
+    ["negotiation_id", { summary: "s" }],
+    ["summary", { negotiation_id: "neg_1" }],
+  ])("rejects a call missing %s", async (_label, input) => {
+    const h = meshHarness();
+    const result = await teamTool(h, "escalate_to_humans").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "negotiation_id and summary required" });
+    expect(h.escalationService.create).not.toHaveBeenCalled();
+  });
+
+  it("does not unblock the peer when the escalation insert fails", async () => {
+    const h = meshHarness();
+    h.escalationService.create.mockRejectedValue(
+      new Error("negotiation neg_1 already has an escalation"),
+    );
+
+    const result = await teamTool(h, "escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "stuck",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "negotiation neg_1 already has an escalation",
+    });
+    expect(h.mesh.unblockOnEscalate).not.toHaveBeenCalled();
+    expect(h.pool.query).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/tools/session-search.test.ts
+++ b/packages/api/src/tools/session-search.test.ts
@@ -1,0 +1,317 @@
+/**
+ * session_search handler tests.
+ *
+ * The interesting logic here is `inferRequest` — the tool takes one flat
+ * bag of optional args and infers which of four request shapes the agent
+ * meant. That precedence (scroll > read > discover > browse) is invisible
+ * from the schema, so it's pinned here, along with the error envelope
+ * for the null-result and thrown-error paths.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { SessionSearchError } from "@beevibe/core/services/session-search";
+import type { SessionSearchService } from "@beevibe/core/services/session-search";
+import {
+  createSessionSearchTool,
+  type SessionSearchToolContext,
+  type SessionSearchToolServices,
+} from "./session-search.js";
+
+interface Harness {
+  services: SessionSearchToolServices;
+  request: () => Record<string, unknown> | undefined;
+  callerCtx: () => Record<string, unknown> | undefined;
+}
+
+function harness(opts: { result?: unknown; throws?: unknown } = {}): Harness {
+  let request: Record<string, unknown> | undefined;
+  let callerCtx: Record<string, unknown> | undefined;
+
+  const sessionSearch = {
+    search: vi.fn(
+      async (req: Record<string, unknown>, ctx: Record<string, unknown>) => {
+        request = req;
+        callerCtx = ctx;
+        if (opts.throws !== undefined) throw opts.throws;
+        return "result" in opts ? opts.result : { sessions: [] };
+      },
+    ),
+  } as unknown as SessionSearchService;
+
+  return {
+    services: { sessionSearch },
+    request: () => request,
+    callerCtx: () => callerCtx,
+  };
+}
+
+const CTX: SessionSearchToolContext = {
+  agentId: "agent_a",
+  hierarchyLevel: "team",
+  sessionId: "sess_current",
+};
+
+function tool(h: Harness, ctx: SessionSearchToolContext = CTX) {
+  return createSessionSearchTool(ctx, h.services);
+}
+
+describe("session_search — shape inference", () => {
+  it("infers browse from no args at all", async () => {
+    const h = harness();
+    await tool(h).handler({});
+
+    expect(h.request()).toEqual({
+      kind: "browse",
+      limit: undefined,
+      filters: undefined,
+    });
+  });
+
+  it("infers discover from a query", async () => {
+    const h = harness();
+    await tool(h).handler({ query: "auth refactor", limit: 5, sort: "newest" });
+
+    expect(h.request()).toEqual({
+      kind: "discover",
+      query: "auth refactor",
+      limit: 5,
+      sort: "newest",
+      filters: undefined,
+    });
+  });
+
+  it("infers read from a bare session_id", async () => {
+    const h = harness();
+    await tool(h).handler({ session_id: "sess_42" });
+
+    expect(h.request()).toEqual({ kind: "read", session_id: "sess_42" });
+  });
+
+  it("infers scroll from session_id + around_message_id", async () => {
+    const h = harness();
+    await tool(h).handler({
+      session_id: "sess_42",
+      around_message_id: "evt_9",
+      window: 10,
+    });
+
+    expect(h.request()).toEqual({
+      kind: "scroll",
+      session_id: "sess_42",
+      around_message_id: "evt_9",
+      window: 10,
+    });
+  });
+
+  it("prefers scroll over discover when a query is also present", async () => {
+    const h = harness();
+    await tool(h).handler({
+      query: "auth",
+      session_id: "sess_42",
+      around_message_id: "evt_9",
+    });
+
+    expect(h.request()).toMatchObject({ kind: "scroll" });
+  });
+
+  it("prefers read over discover when a query is also present", async () => {
+    const h = harness();
+    await tool(h).handler({ query: "auth", session_id: "sess_42" });
+
+    expect(h.request()).toEqual({ kind: "read", session_id: "sess_42" });
+  });
+
+  it("falls back to discover when around_message_id is set without session_id", async () => {
+    const h = harness();
+    await tool(h).handler({ query: "auth", around_message_id: "evt_9" });
+
+    expect(h.request()).toMatchObject({ kind: "discover", query: "auth" });
+  });
+
+  it("falls back to browse when only around_message_id is set", async () => {
+    const h = harness();
+    await tool(h).handler({ around_message_id: "evt_9" });
+
+    expect(h.request()).toMatchObject({ kind: "browse" });
+  });
+});
+
+describe("session_search — argument coercion", () => {
+  it("trims session_id, around_message_id and query", async () => {
+    const h = harness();
+    await tool(h).handler({
+      session_id: "  sess_42  ",
+      around_message_id: "  evt_9  ",
+    });
+
+    expect(h.request()).toMatchObject({
+      session_id: "sess_42",
+      around_message_id: "evt_9",
+    });
+
+    await tool(h).handler({ query: "  auth refactor  " });
+    expect(h.request()).toMatchObject({ query: "auth refactor" });
+  });
+
+  it("treats whitespace-only strings as absent", async () => {
+    const h = harness();
+    await tool(h).handler({ session_id: "   ", query: "  ", around_message_id: " " });
+
+    expect(h.request()).toMatchObject({ kind: "browse" });
+  });
+
+  it("ignores non-string session_id / query / around_message_id", async () => {
+    const h = harness();
+    await tool(h).handler({ session_id: 42, query: ["auth"], around_message_id: {} });
+
+    expect(h.request()).toMatchObject({ kind: "browse" });
+  });
+
+  it("drops a non-numeric window, limit and an unknown sort", async () => {
+    const h = harness();
+    await tool(h).handler({
+      session_id: "sess_42",
+      around_message_id: "evt_9",
+      window: "10",
+    });
+    expect(h.request()?.window).toBeUndefined();
+
+    await tool(h).handler({ query: "auth", limit: "5", sort: "relevance" });
+    expect(h.request()).toMatchObject({
+      limit: undefined,
+      sort: undefined,
+    });
+  });
+
+  it("forwards filters on discover and browse but not on read/scroll", async () => {
+    const h = harness();
+    const filters = { session_type: "task", status: "failed" };
+
+    await tool(h).handler({ query: "auth", filters });
+    expect(h.request()?.filters).toEqual(filters);
+
+    await tool(h).handler({ filters });
+    expect(h.request()?.filters).toEqual(filters);
+
+    await tool(h).handler({ session_id: "sess_42", filters });
+    expect(h.request()).not.toHaveProperty("filters");
+  });
+
+  it("treats a null or non-object filters as absent", async () => {
+    const h = harness();
+    await tool(h).handler({ query: "auth", filters: null });
+    expect(h.request()?.filters).toBeUndefined();
+
+    await tool(h).handler({ query: "auth", filters: "session_type=task" });
+    expect(h.request()?.filters).toBeUndefined();
+  });
+});
+
+describe("session_search — caller context", () => {
+  it("passes the caller's agent id, tier and active session to the service", async () => {
+    const h = harness();
+    await tool(h).handler({ query: "auth" });
+
+    expect(h.callerCtx()).toEqual({
+      callerAgentId: "agent_a",
+      hierarchyLevel: "team",
+      currentSessionId: "sess_current",
+    });
+  });
+
+  it("carries an ic caller's tier through unchanged", async () => {
+    const h = harness();
+    await tool(h, { ...CTX, hierarchyLevel: "ic" }).handler({});
+
+    expect(h.callerCtx()).toMatchObject({ hierarchyLevel: "ic" });
+  });
+});
+
+describe("session_search — result and error envelopes", () => {
+  it("returns the service result verbatim as content", async () => {
+    const payload = { kind: "browse", sessions: [{ id: "sess_1" }] };
+    const h = harness({ result: payload });
+
+    const result = await tool(h).handler({});
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual(payload);
+  });
+
+  it("maps a null result to not_found_or_forbidden", async () => {
+    const h = harness({ result: null });
+
+    const result = await tool(h).handler({ session_id: "sess_other" });
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "not_found_or_forbidden" });
+  });
+
+  it.each(["forbidden_agent_filter", "missing_query", "missing_args"] as const)(
+    "surfaces the %s code from a SessionSearchError",
+    async (code) => {
+      const h = harness({ throws: new SessionSearchError(code, `boom: ${code}`) });
+
+      const result = await tool(h).handler({ query: "auth" });
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual({ error: code, message: `boom: ${code}` });
+    },
+  );
+
+  it("matches a cross-bundle SessionSearchError by name, not just instanceof", async () => {
+    // An integration script consuming src/ while the api consumes dist/
+    // produces a structurally identical error from a different module
+    // instance; the code must still reach the agent.
+    const foreign = new Error("agent_id outside your scope");
+    foreign.name = "SessionSearchError";
+    (foreign as Error & { code: string }).code = "forbidden_agent_filter";
+    const h = harness({ throws: foreign });
+
+    const result = await tool(h).handler({
+      query: "auth",
+      filters: { agent_id: "agent_other" },
+    });
+    expect(result.content).toEqual({
+      error: "forbidden_agent_filter",
+      message: "agent_id outside your scope",
+    });
+  });
+
+  it("degrades an unexpected throw to internal_error", async () => {
+    const h = harness({ throws: new Error("pool exhausted") });
+
+    const result = await tool(h).handler({});
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "internal_error",
+      message: "pool exhausted",
+    });
+  });
+
+  it("stringifies a non-Error throw", async () => {
+    const h = harness({ throws: "kaboom" });
+
+    const result = await tool(h).handler({});
+    expect(result.content).toEqual({ error: "internal_error", message: "kaboom" });
+  });
+});
+
+describe("session_search — tool descriptor", () => {
+  it("is named session_search and requires nothing (browse is the no-arg shape)", () => {
+    const t = tool(harness());
+    expect(t.name).toBe("session_search");
+    expect(t.schema.required).toBeUndefined();
+  });
+
+  it("advertises the four calling shapes in its description", () => {
+    const t = tool(harness());
+    for (const shape of ["DISCOVERY", "SCROLL", "READ", "BROWSE"]) {
+      expect(t.description).toContain(shape);
+    }
+  });
+
+  it("enumerates session types and statuses on the filters schema", () => {
+    const t = tool(harness());
+    const filters = (t.schema.properties as Record<string, { properties: Record<string, { enum?: string[] }> }>)
+      .filters!;
+    expect(filters.properties.session_type?.enum).toContain("run_repo");
+    expect(filters.properties.status?.enum).toContain("failed");
+  });
+});

--- a/packages/api/src/tools/use-repo.test.ts
+++ b/packages/api/src/tools/use-repo.test.ts
@@ -1,0 +1,394 @@
+/**
+ * use_repo handler tests.
+ *
+ * The handler is a four-step sequence with two failure seams that only
+ * show up in production (dispatch throws, repo_run insert throws), so
+ * they're driven here with fakes rather than left to the e2e script.
+ * Ordering matters — repo_run.session_id has an FK to session.id, so
+ * dispatch (which mints the session row) must land first; the last test
+ * in the "happy path" block locks that.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type {
+  AgentRepository,
+  RepoRunRepository,
+  TaskRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import { createUseRepoTool, type UseRepoServices } from "./use-repo.js";
+
+interface Harness {
+  services: UseRepoServices;
+  calls: string[];
+  taskCreateInput: () => Record<string, unknown> | undefined;
+  repoRunCreateInput: () => Record<string, unknown> | undefined;
+  dispatchInput: () => Record<string, unknown> | undefined;
+}
+
+function harness(
+  opts: {
+    agent?: { id: string } | undefined;
+    dispatchThrows?: Error;
+    repoRunThrows?: Error;
+  } = {},
+): Harness {
+  const calls: string[] = [];
+  let taskInput: Record<string, unknown> | undefined;
+  let repoRunInput: Record<string, unknown> | undefined;
+  let dispatchArg: Record<string, unknown> | undefined;
+
+  const agent = "agent" in opts ? opts.agent : { id: "agent_a" };
+
+  const agentRepo = {
+    findById: vi.fn(async () => {
+      calls.push("agentRepo.findById");
+      return agent;
+    }),
+  } as unknown as AgentRepository;
+
+  const taskRepo = {
+    create: vi.fn(async (input: Record<string, unknown>) => {
+      calls.push("taskRepo.create");
+      taskInput = input;
+      return { ...input, status: "pending" };
+    }),
+  } as unknown as TaskRepository;
+
+  const repoRunRepo = {
+    create: vi.fn(async (input: Record<string, unknown>) => {
+      calls.push("repoRunRepo.create");
+      repoRunInput = input;
+      if (opts.repoRunThrows) throw opts.repoRunThrows;
+      return input;
+    }),
+  } as unknown as RepoRunRepository;
+
+  const dispatchService = {
+    dispatchTask: vi.fn(async (input: Record<string, unknown>) => {
+      calls.push("dispatchService.dispatchTask");
+      dispatchArg = input;
+      if (opts.dispatchThrows) throw opts.dispatchThrows;
+      return {};
+    }),
+  } as unknown as DispatchService;
+
+  return {
+    services: { agentRepo, taskRepo, repoRunRepo, dispatchService },
+    calls,
+    taskCreateInput: () => taskInput,
+    repoRunCreateInput: () => repoRunInput,
+    dispatchInput: () => dispatchArg,
+  };
+}
+
+function tool(h: Harness, agentId = "agent_a") {
+  return createUseRepoTool({ agentId }, h.services);
+}
+
+const GOOD = {
+  goal: "Extract the tables from this PDF as JSON",
+  repo_url: "https://github.com/jsvine/pdfplumber",
+};
+
+describe("use_repo — input validation", () => {
+  it("rejects a missing goal before touching any repository", async () => {
+    const h = harness();
+    const result = await tool(h).handler({ repo_url: GOOD.repo_url });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "invalid_goal" });
+    expect(h.calls).toEqual([]);
+  });
+
+  it("rejects a whitespace-only goal", async () => {
+    const h = harness();
+    const result = await tool(h).handler({ goal: "   \n ", repo_url: GOOD.repo_url });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "invalid_goal" });
+    expect(h.calls).toEqual([]);
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["empty", ""],
+    ["not a URL at all", "jsvine/pdfplumber"],
+    ["http, not https", "http://github.com/jsvine/pdfplumber"],
+    ["a non-GitHub host", "https://gitlab.com/jsvine/pdfplumber"],
+    // Substring match must not be enough — the hostname has to *end* in
+    // github.com on a label boundary.
+    ["a lookalike host", "https://notgithub.com/jsvine/pdfplumber"],
+    ["github.com in the path only", "https://evil.example/github.com/x"],
+  ])("rejects repo_url that is %s", async (_label, repoUrl) => {
+    const h = harness();
+    const result = await tool(h).handler({ goal: GOOD.goal, repo_url: repoUrl });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "invalid_repo_url" });
+    expect(h.calls).toEqual([]);
+  });
+
+  it("accepts a github.com subdomain", async () => {
+    const h = harness();
+    const result = await tool(h).handler({
+      goal: GOOD.goal,
+      repo_url: "https://www.github.com/jsvine/pdfplumber",
+    });
+
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("returns agent_not_found when the caller's agent row is gone", async () => {
+    const h = harness({ agent: undefined });
+    const result = await tool(h).handler(GOOD);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "agent_not_found" });
+    // Looked the agent up, then stopped — no task, no dispatch.
+    expect(h.calls).toEqual(["agentRepo.findById"]);
+  });
+});
+
+describe("use_repo — happy path", () => {
+  it("returns the minted ids, a watch url, and a pending status", async () => {
+    const h = harness();
+    const result = await tool(h).handler(GOOD);
+
+    expect(result.isError).toBeFalsy();
+    const content = result.content as Record<string, string>;
+    expect(content.status).toBe("pending");
+    expect(content.repo_run_id).toMatch(/^repo_/);
+    expect(content.session_id).toMatch(/^sess_/);
+    expect(content.watch_url).toBe(`/capabilities/runs/${content.repo_run_id}`);
+    expect(String(content.note)).toContain("Sandbox run started");
+  });
+
+  it("creates the container task assigned to and created by the calling agent", async () => {
+    const h = harness();
+    await tool(h).handler(GOOD);
+
+    expect(h.taskCreateInput()).toMatchObject({
+      title: GOOD.goal,
+      description: GOOD.goal,
+      priority: "medium",
+      assignee_id: "agent_a",
+      creator_id: "agent_a",
+      creator_type: "agent",
+    });
+  });
+
+  it("collapses whitespace and truncates the container task title at 80 chars", async () => {
+    const h = harness();
+    const goal = "Extract   tables\nfrom " + "x".repeat(120);
+    await tool(h).handler({ goal, repo_url: GOOD.repo_url });
+
+    const title = String(h.taskCreateInput()?.title);
+    expect(title).toHaveLength(78); // 77 chars + the ellipsis
+    expect(title.endsWith("…")).toBe(true);
+    expect(title.startsWith("Extract tables from ")).toBe(true);
+  });
+
+  it("keeps a title of exactly 80 chars intact", async () => {
+    const h = harness();
+    await tool(h).handler({ goal: "y".repeat(80), repo_url: GOOD.repo_url });
+
+    expect(h.taskCreateInput()?.title).toBe("y".repeat(80));
+  });
+
+  it("dispatches a run_repo session pinned to the pre-minted session id", async () => {
+    const h = harness();
+    const result = await tool(h).handler(GOOD);
+
+    const dispatched = h.dispatchInput();
+    expect(dispatched).toMatchObject({
+      agentId: "agent_a",
+      type: "run_repo",
+      intent: GOOD.goal,
+      reason: { kind: "fresh" },
+      sessionIdOverride: (result.content as Record<string, string>).session_id,
+    });
+    expect(dispatched?.task).toMatchObject({ id: h.taskCreateInput()?.id });
+  });
+
+  it("writes the repo_run row against the same session and task", async () => {
+    const h = harness();
+    const result = await tool(h).handler(GOOD);
+    const content = result.content as Record<string, string>;
+
+    expect(h.repoRunCreateInput()).toMatchObject({
+      id: content.repo_run_id,
+      session_id: content.session_id,
+      task_id: content.task_id,
+      agent_id: "agent_a",
+      goal: GOOD.goal,
+      repo_url: GOOD.repo_url,
+      status: "pending",
+    });
+  });
+
+  it("dispatches BEFORE inserting repo_run (repo_run.session_id FKs to session.id)", async () => {
+    const h = harness();
+    await tool(h).handler(GOOD);
+
+    expect(h.calls).toEqual([
+      "agentRepo.findById",
+      "taskRepo.create",
+      "dispatchService.dispatchTask",
+      "repoRunRepo.create",
+    ]);
+  });
+
+  it("trims the goal and repo_url before persisting them", async () => {
+    const h = harness();
+    await tool(h).handler({
+      goal: "  summarize the readme  ",
+      repo_url: "  https://github.com/o/r  ",
+    });
+
+    expect(h.repoRunCreateInput()).toMatchObject({
+      goal: "summarize the readme",
+      repo_url: "https://github.com/o/r",
+    });
+  });
+});
+
+describe("use_repo — optional input passthrough", () => {
+  it("echoes a trimmed input_url and input_filename", async () => {
+    const h = harness();
+    const result = await tool(h).handler({
+      ...GOOD,
+      input_url: "  https://example.com/a.pdf  ",
+      input_filename: " a.pdf ",
+    });
+
+    expect(result.content).toMatchObject({
+      input_url: "https://example.com/a.pdf",
+      input_filename: "a.pdf",
+    });
+  });
+
+  it("leaves input_url and input_filename undefined when not supplied", async () => {
+    const h = harness();
+    const result = await tool(h).handler(GOOD);
+
+    expect(result.content.input_url).toBeUndefined();
+    expect(result.content.input_filename).toBeUndefined();
+  });
+});
+
+describe("use_repo — limit parsing", () => {
+  async function limitsFor(limits: unknown) {
+    const h = harness();
+    const result = await tool(h).handler({ ...GOOD, limits });
+    return result.content.limits;
+  }
+
+  it("passes sane limits through unchanged", async () => {
+    expect(
+      await limitsFor({ wall_clock_minutes: 10, max_install_attempts: 3, disk_mb: 512 }),
+    ).toEqual({ wall_clock_minutes: 10, max_install_attempts: 3, disk_mb: 512 });
+  });
+
+  it("caps each limit at its ceiling", async () => {
+    expect(
+      await limitsFor({
+        wall_clock_minutes: 999,
+        max_install_attempts: 99,
+        disk_mb: 1_000_000,
+      }),
+    ).toEqual({ wall_clock_minutes: 60, max_install_attempts: 5, disk_mb: 10_000 });
+  });
+
+  it("floors the integer-valued limits but not wall clock", async () => {
+    expect(
+      await limitsFor({
+        wall_clock_minutes: 1.5,
+        max_install_attempts: 2.9,
+        disk_mb: 100.7,
+      }),
+    ).toEqual({ wall_clock_minutes: 1.5, max_install_attempts: 2, disk_mb: 100 });
+  });
+
+  it("drops non-positive and non-numeric limits rather than passing them down", async () => {
+    expect(
+      await limitsFor({
+        wall_clock_minutes: 0,
+        max_install_attempts: -1,
+        disk_mb: "512",
+      }),
+    ).toEqual({});
+  });
+
+  it.each([
+    ["omitted", undefined],
+    ["null", null],
+    ["a string", "20"],
+    ["an empty object", {}],
+  ])("returns {} when limits is %s", async (_label, raw) => {
+    expect(await limitsFor(raw)).toEqual({});
+  });
+});
+
+describe("use_repo — failure seams", () => {
+  it("surfaces dispatch_failed and never writes repo_run", async () => {
+    const h = harness({ dispatchThrows: new Error("no runtime online") });
+    const result = await tool(h).handler(GOOD);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "dispatch_failed",
+      message: "no runtime online",
+    });
+    expect(h.calls).not.toContain("repoRunRepo.create");
+  });
+
+  it("stringifies a non-Error dispatch throw", async () => {
+    const h = harness({ dispatchThrows: "boom" as unknown as Error });
+    const result = await tool(h).handler(GOOD);
+
+    expect(result.content).toMatchObject({
+      error: "dispatch_failed",
+      message: "boom",
+    });
+  });
+
+  it("surfaces repo_run_create_failed rather than silently orphaning the session", async () => {
+    const h = harness({ repoRunThrows: new Error("duplicate key") });
+    const result = await tool(h).handler(GOOD);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "repo_run_create_failed",
+      message: "duplicate key",
+    });
+  });
+
+  it("stringifies a non-Error repo_run throw", async () => {
+    const h = harness({ repoRunThrows: 42 as unknown as Error });
+    const result = await tool(h).handler(GOOD);
+
+    expect(result.content).toMatchObject({
+      error: "repo_run_create_failed",
+      message: "42",
+    });
+  });
+});
+
+describe("use_repo — tool descriptor", () => {
+  it("is named use_repo and requires goal + repo_url", () => {
+    const t = tool(harness());
+    expect(t.name).toBe("use_repo");
+    expect(t.schema.required).toEqual(["goal", "repo_url"]);
+    expect(t.schema.additionalProperties).toBe(false);
+  });
+
+  it("advertises the three limit knobs the handler actually parses", () => {
+    const t = tool(harness());
+    const props = t.schema.properties as Record<string, { properties?: object }>;
+    expect(Object.keys(props.limits?.properties ?? {}).sort()).toEqual([
+      "disk_mb",
+      "max_install_attempts",
+      "wall_clock_minutes",
+    ]);
+  });
+});

--- a/packages/api/src/tools/watch.test.ts
+++ b/packages/api/src/tools/watch.test.ts
@@ -1,0 +1,210 @@
+/**
+ * watch_tasks + unwatch handler tests.
+ *
+ * These tools are thin adapters over WatchService, so what's worth
+ * locking is the adapter layer: the input coercion done before the
+ * service call, and the mapping from the service's four error classes
+ * onto the four `error` codes an agent branches on.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  WatchAuthError,
+  WatchNotFoundError,
+  WatchValidationError,
+  type WatchService,
+} from "@beevibe/core/services/watch-service";
+import { buildWatchTools, type WatchToolContext } from "./watch.js";
+
+interface Harness {
+  services: { watchService: WatchService };
+  watchArgs: () => Record<string, unknown> | undefined;
+  unwatchArgs: () => Record<string, unknown> | undefined;
+}
+
+function harness(
+  opts: { watchThrows?: unknown; unwatchThrows?: unknown } = {},
+): Harness {
+  let watchArgs: Record<string, unknown> | undefined;
+  let unwatchArgs: Record<string, unknown> | undefined;
+
+  const watchService = {
+    watchTasks: vi.fn(async (input: Record<string, unknown>) => {
+      watchArgs = input;
+      if (opts.watchThrows !== undefined) throw opts.watchThrows;
+      return { watchId: "tw_1", firedImmediately: false };
+    }),
+    unwatch: vi.fn(async (input: Record<string, unknown>) => {
+      unwatchArgs = input;
+      if (opts.unwatchThrows !== undefined) throw opts.unwatchThrows;
+    }),
+  } as unknown as WatchService;
+
+  return {
+    services: { watchService },
+    watchArgs: () => watchArgs,
+    unwatchArgs: () => unwatchArgs,
+  };
+}
+
+const CTX: WatchToolContext = { agentId: "agent_a", sessionId: "ses_1" };
+
+function tools(h: Harness, ctx: WatchToolContext = CTX) {
+  const built = buildWatchTools(ctx, h.services);
+  const byName = Object.fromEntries(built.map((t) => [t.name, t]));
+  return { list: built, watch: byName.watch_tasks!, unwatch: byName.unwatch! };
+}
+
+describe("buildWatchTools", () => {
+  it("returns watch_tasks then unwatch", () => {
+    expect(tools(harness()).list.map((t) => t.name)).toEqual([
+      "watch_tasks",
+      "unwatch",
+    ]);
+  });
+
+  it("declares the schemas the descriptions promise", () => {
+    const { watch, unwatch } = tools(harness());
+    expect(watch.schema.required).toEqual(["task_ids"]);
+    const props = watch.schema.properties as Record<string, { enum?: string[] }>;
+    expect(props.mode?.enum).toEqual(["all", "any"]);
+    expect(unwatch.schema.required).toEqual(["watch_id"]);
+  });
+});
+
+describe("watch_tasks", () => {
+  it("forwards caller identity, task ids, mode and reason to the service", async () => {
+    const h = harness();
+    const result = await tools(h).watch.handler({
+      task_ids: ["task_1", "task_2"],
+      mode: "any",
+      reason: "  need the first result  ",
+    });
+
+    expect(h.watchArgs()).toEqual({
+      callerAgentId: "agent_a",
+      callerSessionId: "ses_1",
+      taskIds: ["task_1", "task_2"],
+      mode: "any",
+      reason: "need the first result",
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({ watch_id: "tw_1", fired_immediately: false });
+  });
+
+  it("defaults mode to 'all' when omitted or not a known mode", async () => {
+    const h = harness();
+    await tools(h).watch.handler({ task_ids: ["task_1"] });
+    expect(h.watchArgs()?.mode).toBe("all");
+
+    await tools(h).watch.handler({ task_ids: ["task_1"], mode: "eventually" });
+    expect(h.watchArgs()?.mode).toBe("all");
+  });
+
+  it("drops a blank reason instead of forwarding an empty string", async () => {
+    const h = harness();
+    await tools(h).watch.handler({ task_ids: ["task_1"], reason: "   " });
+    expect(h.watchArgs()?.reason).toBeUndefined();
+
+    await tools(h).watch.handler({ task_ids: ["task_1"], reason: 7 });
+    expect(h.watchArgs()?.reason).toBeUndefined();
+  });
+
+  it("filters non-string entries out of task_ids", async () => {
+    const h = harness();
+    await tools(h).watch.handler({ task_ids: ["task_1", 2, null, "task_3"] });
+    expect(h.watchArgs()?.taskIds).toEqual(["task_1", "task_3"]);
+  });
+
+  it.each([
+    ["omitted", undefined],
+    ["not an array", "task_1"],
+    ["empty", []],
+    ["all non-strings", [1, 2]],
+  ])("rejects task_ids that are %s", async (_label, taskIds) => {
+    const h = harness();
+    const result = await tools(h).watch.handler({ task_ids: taskIds });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "watch_validation" });
+    expect(h.watchArgs()).toBeUndefined();
+  });
+
+  it("refuses to register without a session context", async () => {
+    const h = harness();
+    const result = await tools(h, { agentId: "agent_a" }).watch.handler({
+      task_ids: ["task_1"],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "watch_validation",
+      message: "watch_tasks must be called inside a session context",
+    });
+    expect(h.watchArgs()).toBeUndefined();
+  });
+
+  it("reports fired_immediately when the tasks were already terminal", async () => {
+    const h = harness();
+    (h.services.watchService.watchTasks as ReturnType<typeof vi.fn>).mockResolvedValue({
+      watchId: "tw_now",
+      firedImmediately: true,
+    });
+
+    const result = await tools(h).watch.handler({ task_ids: ["task_1"] });
+    expect(result.content).toEqual({ watch_id: "tw_now", fired_immediately: true });
+  });
+});
+
+describe("unwatch", () => {
+  it("forwards the caller agent id and watch id", async () => {
+    const h = harness();
+    const result = await tools(h).unwatch.handler({ watch_id: "tw_1" });
+
+    expect(h.unwatchArgs()).toEqual({ callerAgentId: "agent_a", watchId: "tw_1" });
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({ ok: true });
+  });
+
+  it.each([
+    ["omitted", undefined],
+    ["empty", ""],
+    ["not a string", 123],
+  ])("rejects watch_id that is %s", async (_label, watchId) => {
+    const h = harness();
+    const result = await tools(h).unwatch.handler({ watch_id: watchId });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "watch_validation" });
+    expect(h.unwatchArgs()).toBeUndefined();
+  });
+});
+
+describe("service error mapping", () => {
+  // Both tools funnel through the same `caughtError` helper, so each
+  // class is checked on one tool and the shared helper is exercised from
+  // both entry points.
+  it.each([
+    [new WatchAuthError("not yours"), "watch_auth", "not yours"],
+    [new WatchValidationError("bad ids"), "watch_validation", "bad ids"],
+    [new WatchNotFoundError("tw_9"), "watch_not_found", "task_watch tw_9 not found"],
+    [new Error("pool exhausted"), "watch_error", "pool exhausted"],
+    ["raw string", "watch_error", "raw string"],
+  ])("maps %s to a coded tool error", async (thrown, code, message) => {
+    const h = harness({ watchThrows: thrown });
+    const result = await tools(h).watch.handler({ task_ids: ["task_1"] });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: code, message });
+  });
+
+  it("maps errors thrown out of unwatch too", async () => {
+    const h = harness({ unwatchThrows: new WatchAuthError("not your watch") });
+    const result = await tools(h).unwatch.handler({ watch_id: "tw_1" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "watch_auth",
+      message: "not your watch",
+    });
+  });
+});

--- a/packages/core/src/env.test.ts
+++ b/packages/core/src/env.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Composition-root env helpers. Small, but both functions guard a
+ * specific production footgun the JS defaults get wrong — the Railway
+ * fallback and `Number("") === 0` — so the edge cases are pinned here.
+ */
+import { describe, expect, it } from "vitest";
+import { readPositiveInt, resolveMcpServerUrl } from "./env.js";
+
+describe("resolveMcpServerUrl", () => {
+  it("prefers an explicit BEEVIBE_MCP_SERVER_URL", () => {
+    expect(
+      resolveMcpServerUrl({
+        BEEVIBE_MCP_SERVER_URL: "https://mcp.example.com/mcp",
+        RAILWAY_PUBLIC_DOMAIN: "beevibe.up.railway.app",
+      }),
+    ).toBe("https://mcp.example.com/mcp");
+  });
+
+  it("derives the Railway URL when only the domain is set", () => {
+    expect(resolveMcpServerUrl({ RAILWAY_PUBLIC_DOMAIN: "beevibe.up.railway.app" })).toBe(
+      "https://beevibe.up.railway.app/mcp",
+    );
+  });
+
+  it("returns undefined when neither var is set", () => {
+    expect(resolveMcpServerUrl({})).toBeUndefined();
+  });
+
+  it("treats an empty explicit URL as unset and falls through", () => {
+    expect(
+      resolveMcpServerUrl({
+        BEEVIBE_MCP_SERVER_URL: "",
+        RAILWAY_PUBLIC_DOMAIN: "beevibe.up.railway.app",
+      }),
+    ).toBe("https://beevibe.up.railway.app/mcp");
+  });
+
+  it("returns undefined when both are empty", () => {
+    expect(
+      resolveMcpServerUrl({ BEEVIBE_MCP_SERVER_URL: "", RAILWAY_PUBLIC_DOMAIN: "" }),
+    ).toBeUndefined();
+  });
+});
+
+describe("readPositiveInt", () => {
+  it("parses a positive integer", () => {
+    expect(readPositiveInt("3000", 8080)).toBe(3000);
+  });
+
+  it.each([
+    ["undefined", undefined],
+    ["empty — Number('') would be 0 and bind a random port", ""],
+    ["non-numeric", "abc"],
+    ["zero", "0"],
+    ["negative", "-1"],
+  ])("falls back when the value is %s", (_label, raw) => {
+    expect(readPositiveInt(raw, 8080)).toBe(8080);
+  });
+
+  it("truncates a decimal to its integer part", () => {
+    expect(readPositiveInt("3000.9", 8080)).toBe(3000);
+  });
+
+  it("takes the leading integer of a trailing-garbage value", () => {
+    // parseInt semantics, deliberately: "3000abc" is a typo'd port, not a
+    // reason to silently fall back to a different one.
+    expect(readPositiveInt("3000abc", 8080)).toBe(3000);
+  });
+
+  it("tolerates surrounding whitespace", () => {
+    expect(readPositiveInt("  3000  ", 8080)).toBe(3000);
+  });
+});


### PR DESCRIPTION
## Why

A coverage sweep across the monorepo put `packages/api/src/tools/` at the bottom of the table. Four of the modules agents call directly had either no test file at all or only a tier-inventory check — and all four are plain closures over injected services, so the gap was opportunity rather than difficulty.

## Coverage moved

| File | Before | After |
| --- | --- | --- |
| `packages/api/src/tools/use-repo.ts` | 32.0% | **100%** (no test file existed) |
| `packages/api/src/tools/watch.ts` | 46.3% | **100%** (no test file existed) |
| `packages/api/src/tools/session-search.ts` | 64.7% | **100%** (no test file existed) |
| `packages/api/src/tools/mesh.ts` | 45.9% | **100%** (tier inventory only) |
| `packages/core/src/env.ts` | 60.0% | **100%** (no test file existed) |

Package totals: `@beevibe/api` **64.53% → 69.68%** lines, functions **83.63% → 89.09%**; `@beevibe/core` 91.34% → 91.45%.

No production code changed — tests only.

## What the tests actually pin

Line count was the trigger, not the goal. Each file targets behavior that would otherwise only fail in production:

- **`use_repo`** — writes in FK order (dispatch mints the session row before the `repo_run` insert that references it), and both failure seams report distinct codes rather than silently orphaning a session. Also the GitHub-URL check, which has to reject `notgithub.com` and a `github.com` path segment, and the limit-clamping table.
- **`watch_tasks` / `unwatch`** — all four `WatchService` error classes map onto the codes agents branch on, and input is coerced (blank reason dropped, non-string task ids filtered, unknown mode defaulted to `all`) before the service call.
- **`session_search`** — the shape inference `scroll > read > discover > browse`, which is invisible from the JSON schema, plus the cross-bundle `SessionSearchError` match-by-name path.
- **mesh's six handlers** — the required-argument checks that short-circuit *before* a peer session is ever spawned, the response projections (whitelists, so server-internal fields can't leak to the calling agent), and the coded-error envelope for `MESH_CAPACITY_EXCEEDED` / `MAX_ROUNDS_EXCEEDED` / `CANNOT_NEGOTIATE_WITH_IC`. The mesh protocol itself — spawning the peer, blocking on their reply, round accounting — still needs live Postgres and CLI subprocesses and stays in the m6/m7 e2e scripts.

## Coverage caveat worth knowing

Files whose only tests are DB- or provider-key-gated (`routes/task.ts`, `runtime/router.ts`, `services/watch-service.ts`, the postgres adapters) read as 0% in a sandbox without Docker. They were excluded from the sweep rather than treated as untested; the modules picked here are ones with genuinely no coverage.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm build` — clean.
- `@beevibe/api`: 940 tests pass, 0 failures (was 820).
- `@beevibe/core`: the only failures are the 7 provider-key-gated adapter tests, which fail identically on `main` in a sandbox with no `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`.
- The coverage provider was installed only for the sweep and is not committed — the lockfile is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F37Bn7sfnggpAWpavhiSHi

---
_Generated by [Claude Code](https://claude.ai/code/session_01F37Bn7sfnggpAWpavhiSHi)_