### PR TITLE
refactor: unify three clusters of near-duplicate abstractions

### DIFF
--- a/packages/api/src/routes/escalation.ts
+++ b/packages/api/src/routes/escalation.ts
@@ -17,7 +17,7 @@
  * executor picks both up within ≤30s.
  */
 
-import { Router, type RequestHandler, type Response } from "express";
+import { Router, type RequestHandler } from "express";
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import {
   type EscalationService,
@@ -27,7 +27,7 @@ import {
 } from "@beevibe/core/services/escalation-service";
 import { NegotiationNotFoundError } from "@beevibe/core/services/negotiation-service";
 import { requireHuman } from "../auth/middleware.js";
-import { requireParam } from "./http-errors.js";
+import { makeDomainErrorHandler, requireParam } from "./http-errors.js";
 
 export interface EscalationRoutesDeps {
   authMiddleware: RequestHandler;
@@ -88,25 +88,11 @@ function buildSelector(body: unknown):
   };
 }
 
-function handleEscalationError(err: unknown, res: Response): void {
-  if (err instanceof EscalationNotFoundError) {
-    res.status(404).json({ error: "escalation_not_found", message: err.message });
-    return;
-  }
-  if (err instanceof NegotiationNotFoundError) {
-    res.status(404).json({ error: "negotiation_not_found", message: err.message });
-    return;
-  }
-  if (err instanceof EscalationStateError) {
-    res.status(409).json({ error: "invalid_state", message: err.message });
-    return;
-  }
-  console.error("[escalation route]", err);
-  res.status(500).json({
-    error: "internal_error",
-    message: err instanceof Error ? err.message : String(err),
-  });
-}
+const handleEscalationError = makeDomainErrorHandler("escalation route", [
+  { error: EscalationNotFoundError, status: 404, code: "escalation_not_found" },
+  { error: NegotiationNotFoundError, status: 404, code: "negotiation_not_found" },
+  { error: EscalationStateError, status: 409, code: "invalid_state" },
+]);
 
 export function createEscalationRouter(deps: EscalationRoutesDeps): Router {
   const router = Router();

--- a/packages/api/src/routes/http-errors.test.ts
+++ b/packages/api/src/routes/http-errors.test.ts
@@ -3,6 +3,7 @@ import type { Request, Response } from "express";
 import {
   invalidBody,
   loadOwned,
+  makeDomainErrorHandler,
   requireNullableString,
   requireParam,
 } from "./http-errors.js";
@@ -217,5 +218,67 @@ describe("requireNullableString", () => {
     expect(res.body).toMatchObject({
       message: "expected { runtime_id: string | null }",
     });
+  });
+});
+
+class NotFound extends Error {}
+class Conflict extends Error {}
+class ConflictSubclass extends Conflict {}
+
+describe("makeDomainErrorHandler", () => {
+  const handle = makeDomainErrorHandler("test route", [
+    { error: NotFound, status: 404, code: "not_found" },
+    { error: Conflict, status: 409, code: "conflict" },
+  ]);
+
+  it("maps a listed error class to its status and code, keeping the message", () => {
+    const res = fakeRes();
+    handle(new NotFound("no such task"), res);
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({ error: "not_found", message: "no such task" });
+  });
+
+  it("picks the entry matching the thrown class, not just the first one", () => {
+    const res = fakeRes();
+    handle(new Conflict("already done"), res);
+    expect(res.statusCode).toBe(409);
+    expect(res.body).toEqual({ error: "conflict", message: "already done" });
+  });
+
+  // The three routers this replaced all relied on `instanceof`, which is
+  // true for subclasses too. Locking it in so a future domain-error
+  // hierarchy keeps answering with its base's status instead of 500-ing.
+  it("matches a subclass of a listed error via instanceof", () => {
+    const res = fakeRes();
+    handle(new ConflictSubclass("derived"), res);
+    expect(res.statusCode).toBe(409);
+    expect(res.body).toEqual({ error: "conflict", message: "derived" });
+  });
+
+  it("falls through to a logged 500 for an unrecognized error", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = fakeRes();
+    handle(new Error("boom"), res);
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: "internal_error", message: "boom" });
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("stringifies a non-Error throw on the fallthrough branch", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = fakeRes();
+    handle("just a string", res);
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: "internal_error", message: "just a string" });
+    spy.mockRestore();
+  });
+
+  it("includes the per-call context in the fallthrough log tag", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = fakeRes();
+    handle(new Error("boom"), res, "resolve");
+    expect(spy).toHaveBeenCalledWith("[test route: resolve]", expect.any(Error));
+    spy.mockRestore();
   });
 });

--- a/packages/api/src/routes/http-errors.ts
+++ b/packages/api/src/routes/http-errors.ts
@@ -150,3 +150,52 @@ export function makeErrorHandler(
     });
   };
 }
+
+/**
+ * One entry in a router's domain-error table: "instances of this error
+ * class answer with this status and this error code".
+ *
+ * The constructor is typed as an abstract-constructor-shaped value rather
+ * than `new (...) => Error` so subclasses of an abstract domain-error base
+ * can be listed too — `instanceof` works either way, but a plain
+ * `new`-signature won't accept an abstract class.
+ */
+export interface DomainErrorMapping {
+  error: abstract new (...args: never[]) => Error;
+  status: number;
+  code: string;
+}
+
+/**
+ * The catch-block every service-backed router grew its own copy of: walk a
+ * table of domain error classes, answer the first `instanceof` hit with its
+ * status + code, and fall through to {@link makeErrorHandler}'s log-and-500
+ * for anything unrecognized.
+ *
+ * `task`, `escalation` and `negotiation` each spelled this out by hand —
+ * `task.ts`'s `handleServiceError`, `escalation.ts`'s
+ * `handleEscalationError`, and an inline copy in `negotiation.ts`'s one
+ * handler. All three ended in the identical five-line 500 tail that
+ * `makeErrorHandler` already owns, so the copies were re-deriving a helper
+ * that sat one import away; only the class→code prefix differed.
+ *
+ * Order matters and is preserved: the first matching entry wins, so a
+ * subclass must be listed ahead of its base. `message` stays the error's
+ * own `err.message` for both the mapped and the fallthrough branch, which
+ * is what all three routers already did.
+ */
+export function makeDomainErrorHandler(
+  tag: string,
+  mappings: readonly DomainErrorMapping[],
+): (err: unknown, res: Response, context?: string) => void {
+  const fallback = makeErrorHandler(tag);
+  return (err, res, context) => {
+    for (const m of mappings) {
+      if (err instanceof m.error) {
+        res.status(m.status).json({ error: m.code, message: (err as Error).message });
+        return;
+      }
+    }
+    fallback(err, res, context);
+  };
+}

--- a/packages/api/src/routes/negotiation.ts
+++ b/packages/api/src/routes/negotiation.ts
@@ -14,12 +14,16 @@ import {
   NegotiationNotFoundError,
 } from "@beevibe/core/services/negotiation-service";
 import { requireHuman } from "../auth/middleware.js";
-import { requireParam } from "./http-errors.js";
+import { makeDomainErrorHandler, requireParam } from "./http-errors.js";
 
 export interface NegotiationRoutesDeps {
   authMiddleware: RequestHandler;
   negotiationService: NegotiationService;
 }
+
+const handleNegotiationError = makeDomainErrorHandler("negotiation route", [
+  { error: NegotiationNotFoundError, status: 404, code: "negotiation_not_found" },
+]);
 
 export function createNegotiationRouter(deps: NegotiationRoutesDeps): Router {
   const router = Router();
@@ -33,15 +37,7 @@ export function createNegotiationRouter(deps: NegotiationRoutesDeps): Router {
       const negotiation = await deps.negotiationService.getReview(id);
       res.json({ ok: true, negotiation });
     } catch (err) {
-      if (err instanceof NegotiationNotFoundError) {
-        res.status(404).json({ error: "negotiation_not_found", message: err.message });
-        return;
-      }
-      console.error("[negotiation route]", err);
-      res.status(500).json({
-        error: "internal_error",
-        message: err instanceof Error ? err.message : String(err),
-      });
+      handleNegotiationError(err, res);
     }
   });
 

--- a/packages/api/src/routes/task.ts
+++ b/packages/api/src/routes/task.ts
@@ -16,7 +16,7 @@
  *     killed).
  */
 
-import { Router, type RequestHandler, type Response } from "express";
+import { Router, type RequestHandler } from "express";
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import {
   TASK_PRIORITIES,
@@ -42,7 +42,7 @@ import { buildIntent, type ResumeReason } from "@beevibe/core/services/agent-ses
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
 import { requireHuman } from "../auth/middleware.js";
 import type { DaemonHub } from "../runtime/hub.js";
-import { requireParam } from "./http-errors.js";
+import { makeDomainErrorHandler, requireParam } from "./http-errors.js";
 
 /** Statuses from which /cancel is legal. Anything non-terminal. */
 const CANCELLABLE_FROM: readonly TaskStatus[] = [
@@ -115,21 +115,10 @@ async function recordCapabilityOutcome(
   }
 }
 
-function handleServiceError(err: unknown, res: Response): void {
-  if (err instanceof TaskNotFoundError) {
-    res.status(404).json({ error: "task_not_found", message: err.message });
-    return;
-  }
-  if (err instanceof InvalidTaskTransitionError) {
-    res.status(409).json({ error: "invalid_transition", message: err.message });
-    return;
-  }
-  console.error("[task route]", err);
-  res.status(500).json({
-    error: "internal_error",
-    message: err instanceof Error ? err.message : String(err),
-  });
-}
+const handleServiceError = makeDomainErrorHandler("task route", [
+  { error: TaskNotFoundError, status: 404, code: "task_not_found" },
+  { error: InvalidTaskTransitionError, status: 409, code: "invalid_transition" },
+]);
 
 function parsePriority(input: unknown): TaskPriority | undefined {
   if (typeof input !== "string") return undefined;

--- a/packages/web/app/(authed)/agents/agents-client.tsx
+++ b/packages/web/app/(authed)/agents/agents-client.tsx
@@ -6,7 +6,7 @@ import { AlertTriangle, Bot, LayoutGrid, List, Maximize2, Minus, Plus } from "lu
 import type { PanZoomTransform } from "@/lib/hooks/use-pan-zoom";
 import { useAgentNetwork } from "@/lib/hooks/use-agent-network";
 import { isApiConfigured } from "@/lib/api/config";
-import { EmptyState } from "@/components/empty-state";
+import { EmptyPanel } from "@/components/empty-state";
 import { TeamOrbit } from "@/components/team-orbit";
 import { AgentDetailPanel } from "@/components/agents/agent-detail-panel";
 import { AgentsListView } from "@/components/agents/agents-list-view";
@@ -400,9 +400,12 @@ function CenteredShell({
 }) {
   return (
     <div className="absolute inset-0 flex items-center justify-center p-6">
-      <div className="rounded-lg border border-dashed border-border w-full max-w-md">
-        <EmptyState icon={icon} title={title} description={description} />
-      </div>
+      <EmptyPanel
+        className="w-full max-w-md"
+        icon={icon}
+        title={title}
+        description={description}
+      />
     </div>
   );
 }

--- a/packages/web/app/(authed)/dashboard/dashboard-client.tsx
+++ b/packages/web/app/(authed)/dashboard/dashboard-client.tsx
@@ -3,7 +3,7 @@
 import { AlertTriangle, LayoutDashboard } from "lucide-react";
 import { useDashboard } from "@/lib/hooks/use-dashboard";
 import { isApiConfigured } from "@/lib/api/config";
-import { EmptyState } from "@/components/empty-state";
+import { EmptyPanel } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
 import { KpiTileSkeleton } from "@/components/skeletons";
 import { KpiTile } from "@/components/home/kpi-tile";
@@ -36,25 +36,21 @@ function Body({
 }) {
   if (!isApiConfigured) {
     return (
-      <div className="rounded-lg border border-dashed border-border">
-        <EmptyState
-          icon={LayoutDashboard}
-          title="Dashboard not connected"
-          description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load KPIs and fleet status."
-        />
-      </div>
+      <EmptyPanel
+        icon={LayoutDashboard}
+        title="Dashboard not connected"
+        description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load KPIs and fleet status."
+      />
     );
   }
 
   if (isError) {
     return (
-      <div className="rounded-lg border border-dashed border-border">
-        <EmptyState
-          icon={AlertTriangle}
-          title="Couldn't load dashboard"
-          description="Check that the MCP server is reachable."
-        />
-      </div>
+      <EmptyPanel
+        icon={AlertTriangle}
+        title="Couldn't load dashboard"
+        description="Check that the MCP server is reachable."
+      />
     );
   }
 

--- a/packages/web/app/(authed)/memory/eval/eval-client.tsx
+++ b/packages/web/app/(authed)/memory/eval/eval-client.tsx
@@ -8,6 +8,7 @@ import { isApiConfigured } from "@/lib/api/config";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
 import { DatePicker, todayIso } from "@/components/date-picker";
+import { cn } from "@/lib/utils";
 import type {
   AgentActivityRow,
   AgentRatioRow,
@@ -339,40 +340,32 @@ function ScopeTypeSection({ rows }: { rows: ScopeTypeRow[] }) {
     byScope[r.scope] = byScope[r.scope] ?? {};
     byScope[r.scope]![r.fact_type] = r.writes;
   }
+  const columns: Array<StatColumn<(typeof scopes)[number]>> = [
+    {
+      header: "Scope",
+      align: "left",
+      className: "text-foreground",
+      cell: (scope) => scope,
+    },
+    ...FACT_TYPES.map((ft) => ({
+      header: ft,
+      cell: (scope: (typeof scopes)[number]) => {
+        const writes = byScope[scope]?.[ft];
+        return writes ? fmt(writes) : "—";
+      },
+    })),
+    {
+      header: "Total",
+      className: "font-semibold",
+      cell: (scope) => {
+        const total = Object.values(byScope[scope] ?? {}).reduce((a, b) => a + b, 0);
+        return total ? fmt(total) : "—";
+      },
+    },
+  ];
   return (
     <Card title="Archival writes · scope × fact_type">
-      <table className="w-full text-xs">
-        <thead className="text-muted-foreground text-[10px] uppercase tracking-wider">
-          <tr className="border-b border-border/40">
-            <th className="text-left py-1.5">Scope</th>
-            {FACT_TYPES.map((ft) => (
-              <th key={ft} className="text-right py-1.5">
-                {ft}
-              </th>
-            ))}
-            <th className="text-right py-1.5">Total</th>
-          </tr>
-        </thead>
-        <tbody className="tabular-nums">
-          {scopes.map((scope) => {
-            const row = byScope[scope] ?? {};
-            const total = Object.values(row).reduce((a, b) => a + b, 0);
-            return (
-              <tr key={scope} className="border-b border-border/20 last:border-0">
-                <td className="py-1.5 text-foreground">{scope}</td>
-                {FACT_TYPES.map((ft) => (
-                  <td key={ft} className="text-right py-1.5">
-                    {row[ft] ? fmt(row[ft]!) : "—"}
-                  </td>
-                ))}
-                <td className="text-right py-1.5 font-semibold">
-                  {total ? fmt(total) : "—"}
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+      <StatTable columns={columns} rows={scopes} rowKey={(scope) => scope} />
     </Card>
   );
 }
@@ -381,42 +374,35 @@ function ScopeTypeSection({ rows }: { rows: ScopeTypeRow[] }) {
 // Top + dormant agents
 // ─────────────────────────────────────────────────────────────────────────
 
+/** Agent name + tier — the two leading columns every per-agent table opens with. */
+function agentIdentityColumns<T extends { agent_id: string; name: string; tier: string }>(
+  maxWidth = "max-w-[160px]",
+): Array<StatColumn<T>> {
+  return [
+    {
+      header: "Agent",
+      align: "left",
+      className: `text-foreground truncate ${maxWidth}`,
+      cell: (r) => <AgentLink id={r.agent_id} name={r.name} />,
+    },
+    { header: "Tier", align: "left", className: "text-muted-foreground", cell: (r) => r.tier },
+  ];
+}
+
 function TopAgentsTable({ rows }: { rows: AgentActivityRow[] }) {
   return (
     <Card title="Top writers · 30d" subtitle="by archival count">
-      {rows.length === 0 ? (
-        <EmptyHint>No agents wrote archival in the last 30 days.</EmptyHint>
-      ) : (
-        <table className="w-full text-xs">
-          <thead className="text-muted-foreground text-[10px] uppercase tracking-wider">
-            <tr className="border-b border-border/40">
-              <th className="text-left py-1.5">Agent</th>
-              <th className="text-left py-1.5">Tier</th>
-              <th className="text-right py-1.5">Writes</th>
-              <th className="text-right py-1.5">Types</th>
-              <th className="text-right py-1.5">Last</th>
-            </tr>
-          </thead>
-          <tbody className="tabular-nums">
-            {rows.map((r) => (
-              <tr key={r.agent_id} className="border-b border-border/20 last:border-0">
-                <td className="py-1.5 text-foreground truncate max-w-[160px]">
-                  <Link
-                    href={`/agents/${r.agent_id}`}
-                    className="hover:underline"
-                  >
-                    {r.name}
-                  </Link>
-                </td>
-                <td className="py-1.5 text-muted-foreground">{r.tier}</td>
-                <td className="text-right py-1.5">{fmt(r.writes_30d)}</td>
-                <td className="text-right py-1.5">{r.type_variety}</td>
-                <td className="text-right py-1.5 text-muted-foreground">{r.last_write}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
+      <StatTable
+        rows={rows}
+        rowKey={(r) => r.agent_id}
+        empty="No agents wrote archival in the last 30 days."
+        columns={[
+          ...agentIdentityColumns<AgentActivityRow>(),
+          { header: "Writes", cell: (r) => fmt(r.writes_30d) },
+          { header: "Types", cell: (r) => r.type_variety },
+          { header: "Last", className: "text-muted-foreground", cell: (r) => r.last_write },
+        ]}
+      />
     </Card>
   );
 }
@@ -424,39 +410,24 @@ function TopAgentsTable({ rows }: { rows: AgentActivityRow[] }) {
 function DormantAgentsTable({ rows }: { rows: DormantAgentRow[] }) {
   return (
     <Card title="Dormant · 0 writes in 30d" subtitle="newest agents first">
-      {rows.length === 0 ? (
-        <EmptyHint>All agents wrote archival in the last 30 days.</EmptyHint>
-      ) : (
-        <table className="w-full text-xs">
-          <thead className="text-muted-foreground text-[10px] uppercase tracking-wider">
-            <tr className="border-b border-border/40">
-              <th className="text-left py-1.5">Agent</th>
-              <th className="text-left py-1.5">Tier</th>
-              <th className="text-right py-1.5">Last write</th>
-              <th className="text-right py-1.5">Created</th>
-            </tr>
-          </thead>
-          <tbody className="tabular-nums">
-            {rows.map((r) => (
-              <tr key={r.agent_id} className="border-b border-border/20 last:border-0">
-                <td className="py-1.5 text-foreground truncate max-w-[160px]">
-                  <Link
-                    href={`/agents/${r.agent_id}`}
-                    className="hover:underline"
-                  >
-                    {r.name}
-                  </Link>
-                </td>
-                <td className="py-1.5 text-muted-foreground">{r.tier}</td>
-                <td className="text-right py-1.5 text-muted-foreground">
-                  {r.last_write_ever ?? "never"}
-                </td>
-                <td className="text-right py-1.5 text-muted-foreground">{r.agent_created}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
+      <StatTable
+        rows={rows}
+        rowKey={(r) => r.agent_id}
+        empty="All agents wrote archival in the last 30 days."
+        columns={[
+          ...agentIdentityColumns<DormantAgentRow>(),
+          {
+            header: "Last write",
+            className: "text-muted-foreground",
+            cell: (r) => r.last_write_ever ?? "never",
+          },
+          {
+            header: "Created",
+            className: "text-muted-foreground",
+            cell: (r) => r.agent_created,
+          },
+        ]}
+      />
     </Card>
   );
 }
@@ -471,41 +442,20 @@ function CoreSnapshotTable({ rows }: { rows: CoreSnapshotRow[] }) {
       title="Core memory · current state"
       subtitle="snapshot proxies (undercount churn)"
     >
-      {rows.length === 0 ? (
-        <EmptyHint>No core memory blocks exist yet.</EmptyHint>
-      ) : (
-        <table className="w-full text-xs">
-          <thead className="text-muted-foreground text-[10px] uppercase tracking-wider">
-            <tr className="border-b border-border/40">
-              <th className="text-left py-1.5">Tier</th>
-              <th className="text-left py-1.5">Block</th>
-              <th className="text-right py-1.5">Blocks</th>
-              <th className="text-right py-1.5">Non-empty</th>
-              <th className="text-right py-1.5">Ever updated</th>
-              <th className="text-right py-1.5">Updated 30d</th>
-              <th className="text-right py-1.5">Avg chars</th>
-            </tr>
-          </thead>
-          <tbody className="tabular-nums">
-            {rows.map((r) => (
-              <tr
-                key={`${r.tier}:${r.block_name}`}
-                className="border-b border-border/20 last:border-0"
-              >
-                <td className="py-1.5 text-muted-foreground">{r.tier}</td>
-                <td className="py-1.5 text-foreground">{r.block_name}</td>
-                <td className="text-right py-1.5">{fmt(r.blocks)}</td>
-                <td className="text-right py-1.5">{fmt(r.non_empty)}</td>
-                <td className="text-right py-1.5">{fmt(r.ever_updated)}</td>
-                <td className="text-right py-1.5">{fmt(r.updated_30d)}</td>
-                <td className="text-right py-1.5 text-muted-foreground">
-                  {fmt(r.avg_chars)}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
+      <StatTable
+        rows={rows}
+        rowKey={(r) => `${r.tier}:${r.block_name}`}
+        empty="No core memory blocks exist yet."
+        columns={[
+          { header: "Tier", align: "left", className: "text-muted-foreground", cell: (r) => r.tier },
+          { header: "Block", align: "left", className: "text-foreground", cell: (r) => r.block_name },
+          { header: "Blocks", cell: (r) => fmt(r.blocks) },
+          { header: "Non-empty", cell: (r) => fmt(r.non_empty) },
+          { header: "Ever updated", cell: (r) => fmt(r.ever_updated) },
+          { header: "Updated 30d", cell: (r) => fmt(r.updated_30d) },
+          { header: "Avg chars", className: "text-muted-foreground", cell: (r) => fmt(r.avg_chars) },
+        ]}
+      />
     </Card>
   );
 }
@@ -516,38 +466,17 @@ function RatioTable({ rows }: { rows: AgentRatioRow[] }) {
       title="Archival ÷ core · per agent (30d)"
       subtitle="high ratio = bias toward archival, never touches core"
     >
-      {rows.length === 0 ? (
-        <EmptyHint>No memory writes in the last 30 days.</EmptyHint>
-      ) : (
-        <table className="w-full text-xs">
-          <thead className="text-muted-foreground text-[10px] uppercase tracking-wider">
-            <tr className="border-b border-border/40">
-              <th className="text-left py-1.5">Agent</th>
-              <th className="text-left py-1.5">Tier</th>
-              <th className="text-right py-1.5">Archival</th>
-              <th className="text-right py-1.5">Core touched</th>
-              <th className="text-right py-1.5">Ratio</th>
-            </tr>
-          </thead>
-          <tbody className="tabular-nums">
-            {rows.map((r) => (
-              <tr key={r.agent_id} className="border-b border-border/20 last:border-0">
-                <td className="py-1.5 text-foreground truncate max-w-[200px]">
-                  <Link href={`/agents/${r.agent_id}`} className="hover:underline">
-                    {r.name}
-                  </Link>
-                </td>
-                <td className="py-1.5 text-muted-foreground">{r.tier}</td>
-                <td className="text-right py-1.5">{fmt(r.archival_30d)}</td>
-                <td className="text-right py-1.5">{fmt(r.core_touched_30d)}</td>
-                <td className="text-right py-1.5 font-semibold">
-                  {r.ratio === null ? "—" : r.ratio}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
+      <StatTable
+        rows={rows}
+        rowKey={(r) => r.agent_id}
+        empty="No memory writes in the last 30 days."
+        columns={[
+          ...agentIdentityColumns<AgentRatioRow>("max-w-[200px]"),
+          { header: "Archival", cell: (r) => fmt(r.archival_30d) },
+          { header: "Core touched", cell: (r) => fmt(r.core_touched_30d) },
+          { header: "Ratio", className: "font-semibold", cell: (r) => (r.ratio === null ? "—" : r.ratio) },
+        ]}
+      />
     </Card>
   );
 }
@@ -651,6 +580,88 @@ function EmptyHint({ children }: { children: React.ReactNode }) {
     <div className="text-xs text-muted-foreground py-4 text-center">
       {children}
     </div>
+  );
+}
+
+/**
+ * One column of a {@link StatTable}: its header, how to render a cell, and
+ * which way it aligns. `align` defaults to `"right"` because every table on
+ * this page is one or two label columns followed by a run of numbers.
+ *
+ * `className` is merged onto the `<td>` rather than replacing it, so a
+ * column can add emphasis (`font-semibold` on a total, `text-muted-foreground`
+ * on a de-emphasized timestamp) without restating the padding and alignment.
+ */
+interface StatColumn<T> {
+  header: React.ReactNode;
+  cell: (row: T) => React.ReactNode;
+  align?: "left" | "right";
+  className?: string;
+}
+
+/**
+ * The metrics table this page draws five times.
+ *
+ * `ScopeTypeSection`, `TopAgentsTable`, `DormantAgentsTable`,
+ * `CoreSnapshotTable` and `RatioTable` had each spelled out the same
+ * `<table>` / `<thead>` / `<tbody>` scaffold with the same six utility-class
+ * strings — `w-full text-xs`, the `text-[10px] uppercase tracking-wider`
+ * head, `border-b border-border/40`, `tabular-nums`, `border-b
+ * border-border/20 last:border-0`, `py-1.5`. Only the column list and the
+ * empty-state sentence actually differed between them, so those are the two
+ * things this takes as props.
+ *
+ * Rendering `empty` in place of the table (rather than an empty `<tbody>`)
+ * preserves what four of the five already did; `ScopeTypeSection` pivots a
+ * fixed three-scope matrix and can't be empty, so it passes no `empty`.
+ */
+function StatTable<T>({
+  columns,
+  rows,
+  rowKey,
+  empty,
+}: {
+  columns: ReadonlyArray<StatColumn<T>>;
+  rows: readonly T[];
+  rowKey: (row: T, index: number) => string;
+  empty?: React.ReactNode;
+}) {
+  if (rows.length === 0 && empty !== undefined) return <EmptyHint>{empty}</EmptyHint>;
+  return (
+    <table className="w-full text-xs">
+      <thead className="text-muted-foreground text-[10px] uppercase tracking-wider">
+        <tr className="border-b border-border/40">
+          {columns.map((c, i) => (
+            <th key={i} className={c.align === "left" ? "text-left py-1.5" : "text-right py-1.5"}>
+              {c.header}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody className="tabular-nums">
+        {rows.map((row, ri) => (
+          <tr key={rowKey(row, ri)} className="border-b border-border/20 last:border-0">
+            {columns.map((c, ci) => (
+              <td
+                key={ci}
+                className={cn(c.align === "left" ? "py-1.5" : "text-right py-1.5", c.className)}
+              >
+                {c.cell(row)}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+/** The agent-name link three of the tables render identically. */
+function AgentLink({ id, name }: { id: string; name: string }) {
+  return (
+    <Link href={`/agents/${id}`} className="hover:underline">
+      {name}
+    </Link>
   );
 }
 

--- a/packages/web/app/(authed)/mesh/mesh-client.tsx
+++ b/packages/web/app/(authed)/mesh/mesh-client.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { AlertTriangle, Info, Network } from "lucide-react";
-import { EmptyState } from "@/components/empty-state";
+import { EmptyPanel } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
 import { MeshAskSkeleton } from "@/components/skeletons";
 import { MeshActivityFeed } from "@/components/mesh/activity-feed";
@@ -58,21 +58,17 @@ function Body({
 }) {
   if (!isApiConfigured) {
     return (
-      <div className="rounded-lg border border-dashed border-border">
-        <EmptyState
-          icon={Network}
-          title="No mesh asks yet"
-          description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load mesh activity."
-        />
-      </div>
+      <EmptyPanel
+        icon={Network}
+        title="No mesh asks yet"
+        description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load mesh activity."
+      />
     );
   }
 
   if (isError) {
     return (
-      <div className="rounded-lg border border-dashed border-border">
-        <EmptyState icon={AlertTriangle} title="Couldn't load mesh activity" />
-      </div>
+      <EmptyPanel icon={AlertTriangle} title="Couldn't load mesh activity" />
     );
   }
 

--- a/packages/web/app/(authed)/promotions/promotions-client.tsx
+++ b/packages/web/app/(authed)/promotions/promotions-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { AlertTriangle, Info, TrendingUp, type LucideIcon } from "lucide-react";
-import { EmptyState } from "@/components/empty-state";
+import { AlertTriangle, Info, TrendingUp } from "lucide-react";
+import { EmptyPanel } from "@/components/empty-state";
 import { PromotionEventSkeleton } from "@/components/skeletons";
 import { PromotionEventRow } from "@/components/promotions/event-row";
 import { usePromotions } from "@/lib/hooks/use-promotions";
@@ -53,7 +53,7 @@ function Body({
 }) {
   if (!isApiConfigured) {
     return (
-      <EmptyWrapper
+      <EmptyPanel
         icon={TrendingUp}
         title="No promotions yet"
         description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load promotion events."
@@ -62,7 +62,7 @@ function Body({
   }
 
   if (isError) {
-    return <EmptyWrapper icon={AlertTriangle} title="Couldn't load promotions" />;
+    return <EmptyPanel icon={AlertTriangle} title="Couldn't load promotions" />;
   }
 
   if (isLoading) {
@@ -77,7 +77,7 @@ function Body({
 
   if (!data || data.length === 0) {
     return (
-      <EmptyWrapper
+      <EmptyPanel
         icon={TrendingUp}
         title="No promotions yet"
         description="Promotion decisions appear here as agents accumulate facts across sessions."
@@ -90,14 +90,6 @@ function Body({
       {data.map((event) => (
         <PromotionEventRow key={event.id} event={event} />
       ))}
-    </div>
-  );
-}
-
-function EmptyWrapper(props: { icon: LucideIcon; title: string; description?: string }) {
-  return (
-    <div className="rounded-lg border border-dashed border-border">
-      <EmptyState {...props} />
     </div>
   );
 }

--- a/packages/web/app/(authed)/runtimes/runtimes-client.tsx
+++ b/packages/web/app/(authed)/runtimes/runtimes-client.tsx
@@ -24,7 +24,7 @@ import { queryKeys } from "@/lib/hooks/keys";
 import { formatRelativeTime } from "@/lib/format";
 import { CommandBlock } from "@/components/command-block";
 import { DaemonInstallInstructions } from "@/components/daemon-install";
-import { EmptyState } from "@/components/empty-state";
+import { EmptyPanel } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
 import { cn } from "@/lib/utils";
 
@@ -79,13 +79,11 @@ function Body({
 }) {
   if (!isApiConfigured) {
     return (
-      <div className="rounded-lg border border-dashed border-border">
-        <EmptyState
-          icon={Terminal}
-          title="API not configured"
-          description="Set NEXT_PUBLIC_BV_API_URL and run the API server to load this page."
-        />
-      </div>
+      <EmptyPanel
+        icon={Terminal}
+        title="API not configured"
+        description="Set NEXT_PUBLIC_BV_API_URL and run the API server to load this page."
+      />
     );
   }
   if (isLoading) {
@@ -98,13 +96,11 @@ function Body({
   }
   if (isError) {
     return (
-      <div className="rounded-lg border border-dashed border-border">
-        <EmptyState
-          icon={AlertTriangle}
-          title="Couldn't load runtimes"
-          description={describeError(error)}
-        />
-      </div>
+      <EmptyPanel
+        icon={AlertTriangle}
+        title="Couldn't load runtimes"
+        description={describeError(error)}
+      />
     );
   }
   const daemons = data?.daemons ?? [];

--- a/packages/web/components/empty-state.tsx
+++ b/packages/web/components/empty-state.tsx
@@ -16,6 +16,30 @@ interface Props {
   className?: string;
 }
 
+/**
+ * `EmptyState` inside the dashed-border panel that every page-level
+ * empty / error / not-connected branch draws around it.
+ *
+ * The wrapper is one div, which is exactly why it got copy-pasted instead
+ * of shared: `dashboard`, `mesh`, `runtimes` and `activity-feed` each
+ * inlined `<div className="rounded-lg border border-dashed border-border">`
+ * around an `<EmptyState>`, and `promotions` had already extracted a
+ * private `EmptyWrapper` doing the same thing — the abstraction was
+ * wanted three times over, it just never made it out of its file.
+ *
+ * `className` merges rather than replaces so the two call sites that need
+ * sizing (`agents`' centered shell wants `w-full max-w-md`, `runtimes`'
+ * no-daemons panel wants `bg-card/40 p-8`) keep their own chrome without
+ * re-spelling the border.
+ */
+export function EmptyPanel({ className, ...props }: Props) {
+  return (
+    <div className={cn("rounded-lg border border-dashed border-border", className)}>
+      <EmptyState {...props} />
+    </div>
+  );
+}
+
 export function EmptyState({ icon: Icon, title, description, cta, className }: Props) {
   return (
     <div

--- a/packages/web/components/mesh/activity-feed.tsx
+++ b/packages/web/components/mesh/activity-feed.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import { Network, X } from "lucide-react";
-import { EmptyState } from "@/components/empty-state";
+import { EmptyPanel } from "@/components/empty-state";
 import { cn } from "@/lib/utils";
 import type { MeshAsk, MeshAskType, MeshHover } from "@/lib/types/mesh";
 
@@ -103,8 +103,7 @@ export function MeshActivityFeed({
       ) : null}
 
       {visible.length === 0 ? (
-        <div className="rounded-lg border border-dashed border-border">
-          <EmptyState
+        <EmptyPanel
             icon={Network}
             title={
               all.length === 0
@@ -119,8 +118,7 @@ export function MeshActivityFeed({
                 : undefined
             }
             cta={all.length === 0 ? { href: "/", label: "Open chat" } : undefined}
-          />
-        </div>
+        />
       ) : (
         <ul className="space-y-2">
           {visible.map((ask) => {


### PR DESCRIPTION
A duplication sweep across the monorepo (normalized-line shingle comparison over all 412 non-test sources, then manual triage) turned up three clusters where the same abstraction had been written out more than once. Behavior is unchanged in all three — this is consolidation, not a redesign.

Most of what a structural detector flags here is already shared (`runtime-common.ts`, `core/domain/format`, `picker-card.tsx`, `chip-popover.tsx`, `http-errors.ts`) — prior dedup passes did their job. These three are what survived that filter.

## 1. api: domain-error → HTTP mapping

`task.ts`'s `handleServiceError`, `escalation.ts`'s `handleEscalationError` and an inline copy in `negotiation.ts` each walked a list of domain error classes, answered the first `instanceof` hit with a status + code, and fell through to an identical five-line log-and-500 tail.

That tail is exactly what `makeErrorHandler` in the same file already owns, so all three were re-deriving a helper sitting one import away; only the class→code prefix differed.

Adds `makeDomainErrorHandler(tag, mappings)`, built on `makeErrorHandler`, and rewires the three routers to declare a table:

```ts
const handleServiceError = makeDomainErrorHandler("task route", [
  { error: TaskNotFoundError, status: 404, code: "task_not_found" },
  { error: InvalidTaskTransitionError, status: 409, code: "invalid_transition" },
]);
```

First match wins, so a subclass lists ahead of its base. `message` stays the error's own on both the mapped and fallthrough branch, which is what all three routers already did. The mapping type uses an abstract-constructor signature so subclasses of an abstract domain-error base can be listed too.

## 2. web: the dashed-border empty/error panel

`dashboard`, `mesh`, `runtimes`, `agents` and `activity-feed` each inlined the same wrapper — a plain `div` carrying `className="rounded-lg border border-dashed border-border"` with an `EmptyState` element as its only child — and `promotions` had already extracted a private `EmptyWrapper` doing exactly that. The abstraction was wanted six times over; it just never made it out of its file.

Adds `EmptyPanel` to `components/empty-state.tsx` and collapses nine call sites onto it. `className` merges rather than replaces, so `agents`' centered shell keeps its `w-full max-w-md` without restating the border.

## 3. web: the metrics table on /memory/eval

`ScopeTypeSection`, `TopAgentsTable`, `DormantAgentsTable`, `CoreSnapshotTable` and `RatioTable` each spelled out the same table / thead / tbody scaffold with the same six utility-class strings — `w-full text-xs`, the `text-[10px] uppercase tracking-wider` head, `border-b border-border/40`, `tabular-nums`, `border-b border-border/20 last:border-0`, `py-1.5`. Only the column list and the empty-state sentence actually differed.

Adds a generic `StatTable` (parameterized over the row type) taking those two as props, plus `agentIdentityColumns` for the agent-name + tier pair three of them open with. Class strings are preserved verbatim, so the rendered markup is unchanged.

## Tests

Adds six cases for `makeDomainErrorHandler` to the existing `http-errors.test.ts` (19 → 25), covering the mapped, subclass-via-`instanceof`, non-`Error` throw, and per-call-context branches. The three routers' own suites are Postgres-gated and skip without a DB, so this is the layer that can actually be exercised in CI-without-a-DB.

## Verification

| Check | Result |
| --- | --- |
| `tsc --noEmit` (api, web) | clean |
| `pnpm lint` | clean (only pre-existing `import/no-duplicates` warnings) |
| `next build` | succeeds |
| web tests | 203/203 pass |
| api tests | 820 pass, same 9 DB-gated files failing as on main (verified by stashing) |

## Follow-ups found but not fixed here

Two things the sweep surfaced that are worth their own change:

- **`Lifecycle` is two different types with the same name.** `packages/web/lib/tasks-grouping.ts` defines six lanes (adds `blocked`, `archived`); `packages/api/src/views/tasks-grouping.ts` defines four. The web one types `TaskListFilter.lifecycle`, i.e. the wire contract — so `?lifecycle=blocked` typechecks on the web side but fails the api's `LIFECYCLES` guard and silently returns *all* tasks instead of blocked ones. Nothing links to it today (`dashboard-display.ts` only emits `in_progress` / `in_review` / `done`), so this is latent rather than live, but the type currently advertises values the server doesn't honor.
- **The three CLI runtimes' `execute()` bodies** still repeat a ~20-line collect-events / `createStdoutLineReader` / `warnIfTruncated` / `cancelledResult` / `finalizeCliResult` sequence that a generic `collectNdjsonEvents` helper could absorb. Lower value than the above and it touches the live agent-spawn path, so it deserves its own PR.