### PR TITLE
test: cover the three untested MCP tool adapters (use_repo, session_search, watch_tasks)

### DIFF
--- a/packages/api/src/tools/session-search.test.ts
+++ b/packages/api/src/tools/session-search.test.ts
@@ -1,0 +1,294 @@
+/**
+ * session_search handler tests.
+ *
+ * The service (scope resolution, FTS, bookends) is covered against a real
+ * Postgres in core. The adapter's own job is shape inference — turning a
+ * loose `Record<string, unknown>` of MCP input into one of the four
+ * `SessionSearchRequest` kinds — plus the error envelope. Both are pure,
+ * so a fake service that records the request it was handed is enough.
+ *
+ * Shape inference is worth locking down precisely: the precedence rules
+ * (scroll beats read beats discover beats browse) are what decide
+ * whether an agent passing both `query` and `session_id` gets an FTS
+ * search or a transcript dump.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import type { SessionSearchRequest } from "@beevibe/core";
+import {
+  SessionSearchError,
+  type SessionSearchService,
+} from "@beevibe/core/services/session-search";
+import {
+  createSessionSearchTool,
+  type SessionSearchToolContext,
+} from "./session-search.js";
+import type { AgentTool } from "./types.js";
+
+type SearchCtx = {
+  callerAgentId: string;
+  hierarchyLevel: string;
+  currentSessionId: string;
+};
+
+class FakeSessionSearch {
+  requests: SessionSearchRequest[] = [];
+  contexts: SearchCtx[] = [];
+  /** Resolved value; `null` models not-found-or-out-of-scope. */
+  result: unknown = { kind: "browse", sessions: [] };
+  throws: unknown = null;
+
+  async search(req: SessionSearchRequest, ctx: SearchCtx): Promise<unknown> {
+    this.requests.push(req);
+    this.contexts.push(ctx);
+    if (this.throws) throw this.throws;
+    return this.result;
+  }
+}
+
+let fake: FakeSessionSearch;
+
+function tool(ctx: Partial<SessionSearchToolContext> = {}): AgentTool {
+  return createSessionSearchTool(
+    {
+      agentId: "agent_1",
+      hierarchyLevel: "team",
+      sessionId: "ses_current",
+      ...ctx,
+    },
+    { sessionSearch: fake as unknown as SessionSearchService },
+  );
+}
+
+/** Run the handler and return the request the service received. */
+async function requestFor(
+  input: Record<string, unknown>,
+): Promise<SessionSearchRequest> {
+  await tool().handler(input);
+  return fake.requests.at(-1)!;
+}
+
+beforeEach(() => {
+  fake = new FakeSessionSearch();
+});
+
+describe("createSessionSearchTool", () => {
+  it("is named session_search and takes no required args", () => {
+    const t = tool();
+    expect(t.name).toBe("session_search");
+    // Every shape is optional — the bare call is the browse shape.
+    expect((t.schema as { required?: string[] }).required).toBeUndefined();
+  });
+
+  it("passes the caller's identity and tier through as search context", async () => {
+    await tool({
+      agentId: "agent_9",
+      hierarchyLevel: "org",
+      sessionId: "ses_9",
+    }).handler({});
+
+    expect(fake.contexts).toEqual([
+      {
+        callerAgentId: "agent_9",
+        hierarchyLevel: "org",
+        currentSessionId: "ses_9",
+      },
+    ]);
+  });
+
+  it("returns the service result verbatim", async () => {
+    fake.result = { kind: "read", messages: [{ id: "evt_1" }] };
+
+    const res = await tool().handler({ session_id: "ses_x" });
+
+    expect(res.isError).toBeUndefined();
+    expect(res.content).toEqual({ kind: "read", messages: [{ id: "evt_1" }] });
+  });
+});
+
+describe("shape inference", () => {
+  it("infers browse from no arguments", async () => {
+    expect(await requestFor({})).toEqual({
+      kind: "browse",
+      limit: undefined,
+      filters: undefined,
+    });
+  });
+
+  it("carries a numeric limit onto the browse shape", async () => {
+    expect(await requestFor({ limit: 10 })).toEqual({
+      kind: "browse",
+      limit: 10,
+      filters: undefined,
+    });
+  });
+
+  it("infers discover from a query", async () => {
+    expect(
+      await requestFor({ query: "  auth refactor  ", limit: 7, sort: "newest" }),
+    ).toEqual({
+      kind: "discover",
+      query: "auth refactor",
+      limit: 7,
+      sort: "newest",
+      filters: undefined,
+    });
+  });
+
+  it("infers read from a bare session_id", async () => {
+    expect(await requestFor({ session_id: "  ses_x  " })).toEqual({
+      kind: "read",
+      session_id: "ses_x",
+    });
+  });
+
+  it("infers scroll from session_id + around_message_id", async () => {
+    expect(
+      await requestFor({
+        session_id: "ses_x",
+        around_message_id: "  evt_7  ",
+        window: 12,
+      }),
+    ).toEqual({
+      kind: "scroll",
+      session_id: "ses_x",
+      around_message_id: "evt_7",
+      window: 12,
+    });
+  });
+
+  it("lets scroll win over discover when a query is also present", async () => {
+    // The tool description promises `query` is ignored once the scroll
+    // args are set; an agent that pastes both should still get the window.
+    const req = await requestFor({
+      query: "auth",
+      session_id: "ses_x",
+      around_message_id: "evt_7",
+    });
+    expect(req.kind).toBe("scroll");
+  });
+
+  it("lets read win over discover when both session_id and query are present", async () => {
+    const req = await requestFor({ query: "auth", session_id: "ses_x" });
+    expect(req.kind).toBe("read");
+  });
+
+  it("falls back to browse when the query is blank or not a string", async () => {
+    expect((await requestFor({ query: "   " })).kind).toBe("browse");
+    expect((await requestFor({ query: 42 })).kind).toBe("browse");
+  });
+
+  it("ignores a blank session_id rather than reading an empty id", async () => {
+    expect((await requestFor({ session_id: "   " })).kind).toBe("browse");
+    expect((await requestFor({ session_id: "  ", query: "auth" })).kind).toBe(
+      "discover",
+    );
+  });
+
+  it("ignores a blank anchor, degrading scroll to read", async () => {
+    const req = await requestFor({
+      session_id: "ses_x",
+      around_message_id: "   ",
+    });
+    expect(req).toEqual({ kind: "read", session_id: "ses_x" });
+  });
+
+  it("drops non-numeric limit and window instead of forwarding them", async () => {
+    expect((await requestFor({ query: "a", limit: "5" })).kind).toBe("discover");
+    expect(fake.requests.at(-1)).toMatchObject({ limit: undefined });
+
+    await requestFor({
+      session_id: "s",
+      around_message_id: "m",
+      window: "10",
+    });
+    expect(fake.requests.at(-1)).toMatchObject({ window: undefined });
+  });
+
+  it("drops an unrecognized sort value", async () => {
+    await requestFor({ query: "a", sort: "relevance" });
+    expect(fake.requests.at(-1)).toMatchObject({ sort: undefined });
+  });
+
+  it("forwards filters on discover and browse, and only when object-shaped", async () => {
+    const filters = { session_type: "task", status: "failed" };
+
+    await requestFor({ query: "a", filters });
+    expect(fake.requests.at(-1)).toMatchObject({ kind: "discover", filters });
+
+    await requestFor({ filters });
+    expect(fake.requests.at(-1)).toMatchObject({ kind: "browse", filters });
+
+    // `null` is typeof "object" — the guard has to reject it explicitly.
+    await requestFor({ filters: null });
+    expect(fake.requests.at(-1)).toMatchObject({ filters: undefined });
+
+    await requestFor({ filters: "session_type=task" });
+    expect(fake.requests.at(-1)).toMatchObject({ filters: undefined });
+  });
+});
+
+describe("error envelope", () => {
+  it("turns a null result into not_found_or_forbidden", async () => {
+    fake.result = null;
+
+    const res = await tool().handler({ session_id: "ses_other" });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("not_found_or_forbidden");
+    expect(res.content.message).toMatch(/not in your scope/);
+  });
+
+  it("surfaces a SessionSearchError's code", async () => {
+    fake.throws = new SessionSearchError(
+      "forbidden_agent_filter",
+      "agent_z is outside your scope",
+    );
+
+    const res = await tool().handler({ query: "a" });
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "forbidden_agent_filter",
+      message: "agent_z is outside your scope",
+    });
+  });
+
+  it("matches a cross-bundle SessionSearchError by name", async () => {
+    // src/ and dist/ copies of core produce distinct classes, so
+    // `instanceof` alone would drop the code to internal_error.
+    const impostor = new Error("query is required for discovery");
+    impostor.name = "SessionSearchError";
+    (impostor as Error & { code: string }).code = "missing_query";
+    fake.throws = impostor;
+
+    const res = await tool().handler({ query: "a" });
+
+    expect(res.content).toEqual({
+      error: "missing_query",
+      message: "query is required for discovery",
+    });
+  });
+
+  it("wraps an unrelated Error as internal_error", async () => {
+    fake.throws = new Error("connection terminated");
+
+    const res = await tool().handler({});
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "internal_error",
+      message: "connection terminated",
+    });
+  });
+
+  it("stringifies a non-Error throw", async () => {
+    fake.throws = { code: 42 };
+
+    const res = await tool().handler({});
+
+    expect(res.content).toEqual({
+      error: "internal_error",
+      message: "[object Object]",
+    });
+  });
+});

--- a/packages/api/src/tools/use-repo.test.ts
+++ b/packages/api/src/tools/use-repo.test.ts
@@ -1,0 +1,365 @@
+/**
+ * use_repo handler tests.
+ *
+ * The tool mints three rows across three collaborators in a specific
+ * order — container task, then the dispatched session, then the
+ * repo_run whose FK points at that session — and each step has a
+ * failure envelope the calling agent branches on. None of that needs a
+ * database: the ordering constraint and the error mapping are adapter
+ * logic, and recording fakes assert them directly.
+ *
+ * Also covered: the input guards (goal, GitHub-URL shape) and the
+ * limits clamp, which is the only place a caller-supplied number turns
+ * into a sandbox resource cap.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import type {
+  AgentRepository,
+  RepoRunRepository,
+  TaskRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import { createUseRepoTool, type UseRepoServices } from "./use-repo.js";
+import type { AgentTool } from "./types.js";
+
+const AGENT = { id: "agent_1", name: "Scout" };
+
+class Fakes {
+  agentFound: { id: string; name: string } | undefined = AGENT;
+  taskCreates: Record<string, unknown>[] = [];
+  repoRunCreates: Record<string, unknown>[] = [];
+  dispatchCalls: Record<string, unknown>[] = [];
+  dispatchThrows: unknown = null;
+  repoRunThrows: unknown = null;
+
+  get services(): UseRepoServices {
+    return {
+      agentRepo: {
+        findById: async (id: string) =>
+          this.agentFound && this.agentFound.id === id
+            ? this.agentFound
+            : undefined,
+      } as unknown as AgentRepository,
+      taskRepo: {
+        create: async (input: Record<string, unknown>) => {
+          this.taskCreates.push(input);
+          return { ...input, status: "pending" };
+        },
+      } as unknown as TaskRepository,
+      repoRunRepo: {
+        create: async (input: Record<string, unknown>) => {
+          this.repoRunCreates.push(input);
+          if (this.repoRunThrows) throw this.repoRunThrows;
+          return input;
+        },
+      } as unknown as RepoRunRepository,
+      dispatchService: {
+        dispatchTask: async (input: Record<string, unknown>) => {
+          this.dispatchCalls.push(input);
+          if (this.dispatchThrows) throw this.dispatchThrows;
+          return { sessionId: input.sessionIdOverride };
+        },
+      } as unknown as DispatchService,
+    };
+  }
+}
+
+let fakes: Fakes;
+
+function tool(agentId = "agent_1"): AgentTool {
+  return createUseRepoTool({ agentId }, fakes.services);
+}
+
+const VALID = {
+  goal: "Extract the tables from this PDF as JSON",
+  repo_url: "https://github.com/jsvine/pdfplumber",
+};
+
+beforeEach(() => {
+  fakes = new Fakes();
+});
+
+describe("createUseRepoTool", () => {
+  it("is named use_repo and requires goal + repo_url", () => {
+    const t = tool();
+    expect(t.name).toBe("use_repo");
+    expect((t.schema as { required: string[] }).required).toEqual([
+      "goal",
+      "repo_url",
+    ]);
+  });
+});
+
+describe("input validation", () => {
+  it("rejects a missing, blank or non-string goal", async () => {
+    for (const goal of [undefined, "", "   ", 42]) {
+      const res = await tool().handler({ ...VALID, goal });
+      expect(res.isError).toBe(true);
+      expect(res.content.error).toBe("invalid_goal");
+    }
+    expect(fakes.taskCreates).toEqual([]);
+  });
+
+  it("accepts github.com and its subdomains over https", async () => {
+    for (const repo_url of [
+      "https://github.com/owner/repo",
+      "https://www.github.com/owner/repo",
+      "https://GitHub.com/owner/repo",
+    ]) {
+      const res = await tool().handler({ ...VALID, repo_url });
+      expect(res.isError).toBeUndefined();
+    }
+  });
+
+  it("rejects non-GitHub hosts, plain http, and unparseable URLs", async () => {
+    for (const repo_url of [
+      undefined,
+      "",
+      "http://github.com/owner/repo",
+      "https://gitlab.com/owner/repo",
+      "https://notgithub.com/owner/repo",
+      // Suffix match must be anchored on a dot boundary.
+      "https://evil-github.com/owner/repo",
+      "https://github.com.evil.io/owner/repo",
+      "not a url",
+      "github.com/owner/repo",
+    ]) {
+      const res = await tool().handler({ ...VALID, repo_url });
+      expect(res.isError, `expected ${String(repo_url)} to be rejected`).toBe(
+        true,
+      );
+      expect(res.content.error).toBe("invalid_repo_url");
+    }
+    expect(fakes.taskCreates).toEqual([]);
+  });
+
+  it("reports agent_not_found without creating anything", async () => {
+    fakes.agentFound = undefined;
+
+    const res = await tool().handler(VALID);
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("agent_not_found");
+    expect(fakes.taskCreates).toEqual([]);
+    expect(fakes.dispatchCalls).toEqual([]);
+  });
+});
+
+describe("happy path", () => {
+  it("creates the container task assigned and credited to the caller", async () => {
+    await tool().handler(VALID);
+
+    expect(fakes.taskCreates).toHaveLength(1);
+    expect(fakes.taskCreates[0]!).toMatchObject({
+      title: VALID.goal,
+      description: VALID.goal,
+      priority: "medium",
+      assignee_id: "agent_1",
+      creator_id: "agent_1",
+      creator_type: "agent",
+    });
+  });
+
+  it("truncates a long goal into an ellipsized task title", async () => {
+    const goal = "x".repeat(200);
+    await tool().handler({ ...VALID, goal });
+
+    // 77 kept + the ellipsis: the cut is deliberately under the 80-char
+    // budget so the inbox row never wraps.
+    const title = fakes.taskCreates[0]!.title as string;
+    expect(title).toHaveLength(78);
+    expect(title.endsWith("…")).toBe(true);
+    expect(fakes.taskCreates[0]!.description).toBe(goal);
+  });
+
+  it("leaves a title at exactly the 80-char boundary intact", async () => {
+    const goal = "y".repeat(80);
+    await tool().handler({ ...VALID, goal });
+
+    expect(fakes.taskCreates[0]!.title).toBe(goal);
+  });
+
+  it("collapses whitespace in the task title but keeps the full description", async () => {
+    const goal = "  Extract\n\ttables   from  the PDF  ";
+    await tool().handler({ ...VALID, goal });
+
+    expect(fakes.taskCreates[0]!.title).toBe("Extract tables from the PDF");
+    expect(fakes.taskCreates[0]!.description).toBe(goal.trim());
+  });
+
+  it("dispatches a run_repo session under the pre-minted session id", async () => {
+    await tool().handler(VALID);
+
+    expect(fakes.dispatchCalls).toHaveLength(1);
+    expect(fakes.dispatchCalls[0]!).toMatchObject({
+      agentId: "agent_1",
+      type: "run_repo",
+      intent: VALID.goal,
+      reason: { kind: "fresh" },
+    });
+    expect(fakes.dispatchCalls[0]!.sessionIdOverride).toEqual(
+      expect.any(String),
+    );
+  });
+
+  it("inserts repo_run only after dispatch, against the same session id", async () => {
+    // repo_run.session_id is an FK to session.id, so the session row has
+    // to exist first — this ordering is the reason the ids are minted up
+    // front rather than read back out of dispatch.
+    const res = await tool().handler(VALID);
+
+    const dispatchedSid = fakes.dispatchCalls[0]!.sessionIdOverride;
+    expect(fakes.repoRunCreates).toHaveLength(1);
+    expect(fakes.repoRunCreates[0]!).toMatchObject({
+      session_id: dispatchedSid,
+      task_id: fakes.taskCreates[0]!.id,
+      agent_id: "agent_1",
+      goal: VALID.goal,
+      repo_url: VALID.repo_url,
+      status: "pending",
+    });
+    expect(res.content.session_id).toBe(dispatchedSid);
+  });
+
+  it("returns the run ids, a pending status and the watch url", async () => {
+    const res = await tool().handler(VALID);
+
+    const runId = fakes.repoRunCreates[0]!.id as string;
+    expect(res.isError).toBeUndefined();
+    expect(res.content).toMatchObject({
+      repo_run_id: runId,
+      task_id: fakes.taskCreates[0]!.id,
+      status: "pending",
+      watch_url: `/capabilities/runs/${runId}`,
+    });
+    expect(res.content.note).toMatch(/poll/i);
+  });
+
+  it("echoes the trimmed input_url and input_filename", async () => {
+    const res = await tool().handler({
+      ...VALID,
+      input_url: "  https://example.com/a.pdf  ",
+      input_filename: "  a.pdf  ",
+    });
+
+    expect(res.content.input_url).toBe("https://example.com/a.pdf");
+    expect(res.content.input_filename).toBe("a.pdf");
+  });
+
+  it("omits the input fields when they are absent or not strings", async () => {
+    const res = await tool().handler({ ...VALID, input_url: 5 });
+
+    expect(res.content.input_url).toBeUndefined();
+    expect(res.content.input_filename).toBeUndefined();
+  });
+
+  it("mints a distinct session and repo_run id per call", async () => {
+    const first = await tool().handler(VALID);
+    const second = await tool().handler(VALID);
+
+    expect(first.content.repo_run_id).not.toBe(second.content.repo_run_id);
+    expect(first.content.session_id).not.toBe(second.content.session_id);
+    expect(first.content.task_id).not.toBe(second.content.task_id);
+  });
+});
+
+describe("limits", () => {
+  it("passes sane limits through, flooring the integer caps", async () => {
+    const res = await tool().handler({
+      ...VALID,
+      limits: {
+        wall_clock_minutes: 15,
+        max_install_attempts: 3.7,
+        disk_mb: 512.9,
+      },
+    });
+
+    expect(res.content.limits).toEqual({
+      wall_clock_minutes: 15,
+      max_install_attempts: 3,
+      disk_mb: 512,
+    });
+  });
+
+  it("clamps each limit to its ceiling", async () => {
+    const res = await tool().handler({
+      ...VALID,
+      limits: {
+        wall_clock_minutes: 600,
+        max_install_attempts: 99,
+        disk_mb: 1_000_000,
+      },
+    });
+
+    expect(res.content.limits).toEqual({
+      wall_clock_minutes: 60,
+      max_install_attempts: 5,
+      disk_mb: 10_000,
+    });
+  });
+
+  it("drops non-positive and non-numeric limits so defaults apply", async () => {
+    const res = await tool().handler({
+      ...VALID,
+      limits: {
+        wall_clock_minutes: 0,
+        max_install_attempts: -1,
+        disk_mb: "2048",
+      },
+    });
+
+    expect(res.content.limits).toEqual({});
+  });
+
+  it("treats a missing or non-object limits as empty", async () => {
+    for (const limits of [undefined, null, "20m", 20]) {
+      const res = await tool().handler({ ...VALID, limits });
+      expect(res.content.limits).toEqual({});
+    }
+  });
+});
+
+describe("failure envelopes", () => {
+  it("reports dispatch_failed and skips the repo_run insert", async () => {
+    fakes.dispatchThrows = new Error("no runtime online");
+
+    const res = await tool().handler(VALID);
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "dispatch_failed",
+      message: "no runtime online",
+    });
+    expect(fakes.repoRunCreates).toEqual([]);
+  });
+
+  it("reports repo_run_create_failed once the session already landed", async () => {
+    // Orphan-session case: it self-recovers when composeDispatchPayload
+    // finds no repo_run, but the agent must not be left waiting silently.
+    fakes.repoRunThrows = new Error("duplicate key");
+
+    const res = await tool().handler(VALID);
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "repo_run_create_failed",
+      message: "duplicate key",
+    });
+    expect(fakes.dispatchCalls).toHaveLength(1);
+  });
+
+  it("stringifies non-Error throws on both failure paths", async () => {
+    fakes.dispatchThrows = "socket hang up";
+    expect((await tool().handler(VALID)).content).toEqual({
+      error: "dispatch_failed",
+      message: "socket hang up",
+    });
+
+    fakes = new Fakes();
+    fakes.repoRunThrows = "socket hang up";
+    expect((await tool().handler(VALID)).content).toEqual({
+      error: "repo_run_create_failed",
+      message: "socket hang up",
+    });
+  });
+});

--- a/packages/api/src/tools/watch.test.ts
+++ b/packages/api/src/tools/watch.test.ts
@@ -1,0 +1,227 @@
+/**
+ * watch_tasks + unwatch handler tests.
+ *
+ * Both tools are thin adapters over WatchService: the service owns auth,
+ * the insert, the already-terminal race and the unwatch state machine
+ * (all covered by `core/src/services/watch-service.test.ts` against a
+ * real Postgres). What lives *here* is the adapter logic — input
+ * coercion, the mode default, the session-context guard, and the
+ * error-class → error-code mapping — none of which needs a database.
+ *
+ * The fake service records the input it was handed so the tests can
+ * assert on what the adapter actually forwarded, not just on what came
+ * back.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  WatchAuthError,
+  WatchNotFoundError,
+  WatchValidationError,
+  type UnwatchInput,
+  type WatchService,
+  type WatchTasksInput,
+  type WatchTasksResult,
+} from "@beevibe/core/services/watch-service";
+import { buildWatchTools, type WatchToolContext } from "./watch.js";
+import type { AgentTool } from "./types.js";
+
+class FakeWatchService {
+  watchCalls: WatchTasksInput[] = [];
+  unwatchCalls: UnwatchInput[] = [];
+  /** Set to have the next call throw instead of resolving. */
+  throws: unknown = null;
+  result: WatchTasksResult = { watchId: "tw_1", firedImmediately: false };
+
+  async watchTasks(input: WatchTasksInput): Promise<WatchTasksResult> {
+    this.watchCalls.push(input);
+    if (this.throws) throw this.throws;
+    return this.result;
+  }
+
+  async unwatch(input: UnwatchInput): Promise<void> {
+    this.unwatchCalls.push(input);
+    if (this.throws) throw this.throws;
+  }
+}
+
+let fake: FakeWatchService;
+
+function tools(ctx: Partial<WatchToolContext> = {}): {
+  watchTasks: AgentTool;
+  unwatch: AgentTool;
+} {
+  const built = buildWatchTools(
+    { agentId: "agent_1", sessionId: "ses_1", ...ctx },
+    { watchService: fake as unknown as WatchService },
+  );
+  const byName = Object.fromEntries(built.map((t) => [t.name, t]));
+  return {
+    watchTasks: byName.watch_tasks!,
+    unwatch: byName.unwatch!,
+  };
+}
+
+beforeEach(() => {
+  fake = new FakeWatchService();
+});
+
+describe("buildWatchTools", () => {
+  it("returns watch_tasks and unwatch, in that order", () => {
+    const built = buildWatchTools(
+      { agentId: "agent_1", sessionId: "ses_1" },
+      { watchService: fake as unknown as WatchService },
+    );
+    expect(built.map((t) => t.name)).toEqual(["watch_tasks", "unwatch"]);
+  });
+
+  it("advertises both modes in the watch_tasks schema", () => {
+    const schema = tools().watchTasks.schema as {
+      properties: { mode: { enum: string[] } };
+      required: string[];
+    };
+    expect(schema.properties.mode.enum).toEqual(["all", "any"]);
+    expect(schema.required).toEqual(["task_ids"]);
+  });
+});
+
+describe("watch_tasks handler", () => {
+  it("forwards ids, mode and reason, and returns the watch id", async () => {
+    fake.result = { watchId: "tw_abc", firedImmediately: true };
+
+    const res = await tools().watchTasks.handler({
+      task_ids: ["tsk_1", "tsk_2"],
+      mode: "any",
+      reason: "  need the build result  ",
+    });
+
+    expect(fake.watchCalls).toEqual([
+      {
+        callerAgentId: "agent_1",
+        callerSessionId: "ses_1",
+        taskIds: ["tsk_1", "tsk_2"],
+        mode: "any",
+        reason: "need the build result",
+      },
+    ]);
+    expect(res).toEqual({
+      content: { watch_id: "tw_abc", fired_immediately: true },
+    });
+  });
+
+  it("defaults mode to 'all' when omitted or unrecognized", async () => {
+    await tools().watchTasks.handler({ task_ids: ["tsk_1"] });
+    await tools().watchTasks.handler({ task_ids: ["tsk_1"], mode: "either" });
+    await tools().watchTasks.handler({ task_ids: ["tsk_1"], mode: 7 });
+
+    expect(fake.watchCalls.map((c) => c.mode)).toEqual(["all", "all", "all"]);
+  });
+
+  it("drops a blank reason rather than forwarding an empty string", async () => {
+    await tools().watchTasks.handler({ task_ids: ["tsk_1"], reason: "   " });
+    await tools().watchTasks.handler({ task_ids: ["tsk_1"], reason: 42 });
+
+    expect(fake.watchCalls.map((c) => c.reason)).toEqual([undefined, undefined]);
+  });
+
+  it("filters non-string entries out of task_ids", async () => {
+    await tools().watchTasks.handler({
+      task_ids: ["tsk_1", 5, null, "tsk_2", { id: "tsk_3" }],
+    });
+
+    expect(fake.watchCalls[0]!.taskIds).toEqual(["tsk_1", "tsk_2"]);
+  });
+
+  it("rejects task_ids that is missing, not an array, or empty after filtering", async () => {
+    for (const input of [
+      {},
+      { task_ids: "tsk_1" },
+      { task_ids: [] },
+      { task_ids: [1, 2, 3] },
+    ]) {
+      const res = await tools().watchTasks.handler(input);
+      expect(res.isError).toBe(true);
+      expect(res.content.error).toBe("watch_validation");
+    }
+    // None of those should have reached the service.
+    expect(fake.watchCalls).toEqual([]);
+  });
+
+  it("refuses to register a watch outside a session context", async () => {
+    const res = await tools({ sessionId: undefined }).watchTasks.handler({
+      task_ids: ["tsk_1"],
+    });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("watch_validation");
+    expect(res.content.message).toMatch(/session context/);
+    expect(fake.watchCalls).toEqual([]);
+  });
+
+  it("checks task_ids before the session guard", async () => {
+    // Both are invalid; the ids message is the more actionable one.
+    const res = await tools({ sessionId: undefined }).watchTasks.handler({});
+    expect(res.content.message).toMatch(/non-empty array/);
+  });
+});
+
+describe("unwatch handler", () => {
+  it("forwards the watch id and reports ok", async () => {
+    const res = await tools().unwatch.handler({ watch_id: "tw_abc" });
+
+    expect(fake.unwatchCalls).toEqual([
+      { callerAgentId: "agent_1", watchId: "tw_abc" },
+    ]);
+    expect(res).toEqual({ content: { ok: true } });
+  });
+
+  it("rejects a missing or non-string watch_id", async () => {
+    for (const input of [{}, { watch_id: "" }, { watch_id: 12 }]) {
+      const res = await tools().unwatch.handler(input);
+      expect(res.isError).toBe(true);
+      expect(res.content.error).toBe("watch_validation");
+    }
+    expect(fake.unwatchCalls).toEqual([]);
+  });
+});
+
+describe("error mapping", () => {
+  // The agent branches on `error`, so each service error class has to keep
+  // landing on its own stable code rather than collapsing to watch_error.
+  const cases: Array<[string, unknown, string]> = [
+    ["WatchAuthError", new WatchAuthError("not your task"), "watch_auth"],
+    [
+      "WatchValidationError",
+      new WatchValidationError("bad mode"),
+      "watch_validation",
+    ],
+    ["WatchNotFoundError", new WatchNotFoundError("tw_9"), "watch_not_found"],
+    ["a plain Error", new Error("pool exhausted"), "watch_error"],
+  ];
+
+  for (const [label, thrown, code] of cases) {
+    it(`maps ${label} to ${code} on both tools`, async () => {
+      fake.throws = thrown;
+
+      const watched = await tools().watchTasks.handler({ task_ids: ["tsk_1"] });
+      expect(watched.isError).toBe(true);
+      expect(watched.content.error).toBe(code);
+      expect(watched.content.message).toBe((thrown as Error).message);
+
+      const unwatched = await tools().unwatch.handler({ watch_id: "tw_1" });
+      expect(unwatched.isError).toBe(true);
+      expect(unwatched.content.error).toBe(code);
+    });
+  }
+
+  it("stringifies a non-Error throw under watch_error", async () => {
+    fake.throws = "connection reset";
+
+    const res = await tools().watchTasks.handler({ task_ids: ["tsk_1"] });
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "watch_error",
+      message: "connection reset",
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds test files for the three modules in `packages/api/src/tools` that had **none** — the only such gap left in the tools layer.

## How they were found

A v8 coverage sweep across all five packages (`--coverage.all`, with the DB- and key-gated suites excluded since this environment has no Postgres or provider keys). Ranking by uncovered lines and discarding entry points, barrels, and files whose only tests are DB-gated, three modules stood out as having no test file at all:

| Module | Lines | Funcs |
| --- | --- | --- |
| `tools/use-repo.ts` | 32.04% | 20.00% |
| `tools/session-search.ts` | 64.65% | 33.33% |
| `tools/watch.ts` | 46.26% | 42.86% |

Their partial numbers came entirely from `assemble.test.ts` registering them — no handler had ever been invoked. All three are agent-facing MCP tools, so an unguarded regression lands directly on the product surface.

## Why these are testable without a database

Each is a thin adapter over a service whose behavior is already covered against a real Postgres in core (`watch-service.test.ts`, the session-search repo suites). What was untested is the *adapter* logic — input coercion, shape inference, and the error envelopes the calling agent branches on — all pure. The tests use recording fakes and assert on what the adapter **forwarded**, not just on what came back.

## What's covered

- **`watch.ts`** — mode defaulting, `task_ids` filtering of non-string entries, the session-context guard and its ordering against the ids check, and each `WatchService` error class landing on its own stable code rather than collapsing to `watch_error`.
- **`session-search.ts`** — all four calling shapes and their precedence (`scroll` > `read` > `discover` > `browse`), blank/non-numeric coercion for `limit`/`window`/`sort`/`filters`, the `null` → `not_found_or_forbidden` envelope, and the by-name `SessionSearchError` match that keeps error codes intact across a src/dist bundle split.
- **`use-repo.ts`** — the GitHub-URL guard (including the dot-boundary anchoring that rejects `evil-github.com` and `github.com.evil.io`), the `task → dispatch → repo_run` ordering the FK requires, the limits clamp and floor, and both failure envelopes including the orphan-session case.

## Result

All three modules reach **100% on statements, branches, functions and lines**. Package totals move **64.53% → 67.61%** lines and **83.63% → 86.66%** functions. The api suite goes **820 → 879 tests**, all passing; `typecheck` and `lint` are clean.

## Note on one assertion

The task-title test pins the adapter's actual output — `slice(0, 77) + "…"` is 78 chars, not the round 80 the code reads like it produces. I asserted the real behavior rather than "fixing" it, since the cut is harmless (it stays under the intended budget) and changing it would be a product call, not a test change. Flagging it in case the off-by-two was unintended.

## Test plan

```bash
pnpm --filter @beevibe/api exec vitest run src/tools/
npx tsc -p packages/api/tsconfig.json --noEmit
pnpm --filter @beevibe/api lint
```

No production code is touched — this PR is test files only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENEngsvkmGQtthBb2gSBEq)_