### PR TITLE
chore(web): drop two unreferenced query-key entries

### DIFF
--- a/packages/web/lib/hooks/keys.ts
+++ b/packages/web/lib/hooks/keys.ts
@@ -58,7 +58,6 @@ export const queryKeys = {
     self: () => ["agent-network", "self"] as const,
   },
   workProducts: {
-    all: ["work-products"] as const,
     detail: (id: string) => ["work-products", "detail", id] as const,
   },
   rooms: {
@@ -71,7 +70,6 @@ export const queryKeys = {
     list: () => ["runtimes", "list"] as const,
   },
   chat: {
-    all: ["chat"] as const,
     /** Per-conversation history. `undefined` = the most recent conversation. */
     history: (conversationId?: string) =>
       ["chat", "history", conversationId ?? "<latest>"] as const,


### PR DESCRIPTION
A static + dynamic dead-code sweep across the monorepo. The headline is that the repo is essentially clean — #285 did its job — so this PR is deliberately small: **two lines**, both genuinely unreachable.

## What's removed

```
queryKeys.workProducts.all   ["work-products"]
queryKeys.chat.all           ["chat"]
```

Both are nested inside the exported `queryKeys` object literal, which is why no tool caught them: knip only resolves top-level exports, so members of an exported object are never flagged. Same blind spot that hid `queryKeys.activity` until #283.

`.all` is a bulk-invalidation prefix and is load-bearing elsewhere — 14 of the 16 groups use theirs, 59 call sites total — so this isn't a decorative convention being trimmed. These two have zero uses, static or dynamic. Nothing indexes `queryKeys` by computed key (`queryKeys[...]` appears nowhere), so property access is the only reachability path.

Why these two ended up unused:
- **chat** already carries `historyAll` (`["chat", "history"]`) for exactly the prefix role `chat.all` would serve — `lib/sse.ts:49` uses it.
- **work-products** is read-only: one detail query, no mutation to invalidate.

## Verification

- `pnpm typecheck` — clean, all 9 packages
- `pnpm lint` — clean (4 pre-existing `import/no-duplicates` warnings, unrelated)
- `packages/web` — 203 tests pass, including `lib/hooks/keys.test.ts`

## Deliberately NOT removed

Checked and found live, recorded so the next sweep doesn't re-litigate them:

| Candidate | Why it stays |
| --- | --- |
| CLAUDE.md's known-false-positive table | knip and depcheck reproduce it exactly — `node-pg-migrate`, `zod`, `prettier`, `typescript`, the sandbox script bins, `migrations/*` |
| `PostgresMemoryPromotionEventRepository` | Still unfinished wiring, not dead code |
| ~40 knip "unused exports" | Used *within their own file* — the `export` is redundant, not the code |
| `TASK_STATUSES_BY_VIEW.sprint` / `.timeline` | Reached dynamically via `TASK_STATUSES_BY_VIEW[filter.view]` (`views/tasks.ts:152`) |
| `STREAM_TYPE.System`, `CODEX_EVENT_TYPE.ItemUpdated`, `CODEX_ITEM_TYPE.Error` | Unreferenced, but these tables are complete enumerations of upstream wire protocols. Trimming them to only the members the parser branches on would misrepresent the protocol they document — a judgement call worth flagging if you'd rather they go. |

## Sweep coverage

`tsc --noUnusedLocals --noUnusedParameters` and `--allowUnreachableCode false` (all packages, clean) · eslint · knip · depcheck · by-name reference sweep of 287 exported values and 389 exported types under `packages/*/src` · orphan-file sweep · v8 coverage on core/api/daemon, with 0% files confirmed to be barrels, type-only modules, CLI entry points, or DB-gated suites excluded for lack of Docker.

One gap worth noting for future sweeps: the earlier pass globbed `packages/*/src/**`, which **misses the entire web package** — Next.js keeps its code in `app/`, `components/`, `lib/`. This sweep covered those 184 files separately (277 exported symbols, plus the nested `api` client's 58 methods and all 40 query keys); both findings came from there.

---
_Generated by [Claude Code](https://claude.ai/code/session_018PwUk1NiQsa7foVDoNVJhN)_