### PR TITLE
test: drop two zero-signal tests, correct a stale describe label

### DIFF
--- a/packages/web/components/sessions/usage-panel.test.tsx
+++ b/packages/web/components/sessions/usage-panel.test.tsx
@@ -98,12 +98,6 @@ describe("formatTokens", () => {
     expect(formatTokens(1_000_000)).toBe("1.00M");
     expect(formatTokens(2_350_000)).toBe("2.35M");
   });
-
-  it("uses thousands separator for small counts (en-US locale)", () => {
-    // Won't trip until 4 digits, but verify the locale path renders.
-    // (Below 1000 the K-suffix path doesn't kick in.)
-    expect(formatTokens(42)).toBe("42");
-  });
 });
 
 describe("<UsagePanel />", () => {

--- a/packages/web/lib/api/client.test.ts
+++ b/packages/web/lib/api/client.test.ts
@@ -92,7 +92,7 @@ describe("api client (reads)", () => {
     });
   });
 
-  describe("deferred surfaces (paths set; backend not yet shipped)", () => {
+  describe("dashboard / mesh / promotions", () => {
     it("promotions.list() hits /promotion", async () => {
       await api.promotions.list();
       expect(fetchJsonMock).toHaveBeenCalledWith("/promotion", { signal: undefined });

--- a/packages/web/lib/hooks/keys.test.ts
+++ b/packages/web/lib/hooks/keys.test.ts
@@ -25,10 +25,4 @@ describe("queryKeys", () => {
     const b = queryKeys.tasks.list({ view: "mine" });
     expect(a).not.toEqual(b);
   });
-
-  it("structural equality across separate calls with the same arg shape", () => {
-    const a = queryKeys.tasks.list({ view: "mine" });
-    const b = queryKeys.tasks.list({ view: "mine" });
-    expect(a).toEqual(b);
-  });
 });


### PR DESCRIPTION
Swept the whole suite (156 test files) for tests that no longer earn their place: skipped/disabled tests without a live reason, tests for removed or refactored features, and tests that assert implementation details or nothing at all. Three findings, all in `packages/web`.

## What went

**`packages/web/components/sessions/usage-panel.test.tsx` — `formatTokens` › "uses thousands separator for small counts (en-US locale)"**

The name describes behavior the function cannot exhibit at that input. `formatTokens` routes anything `< 1000` through `toLocaleString("en-US")`, where no separator can appear — the test's own comment conceded it ("Won't trip until 4 digits"). Its single assertion, `formatTokens(42)` → `"42"`, is a strict subset of `renders raw integer for small counts` three lines above, which already covers 0 / 619 / 999.

**`packages/web/lib/hooks/keys.test.ts` — `queryKeys` › "structural equality across separate calls with the same arg shape"**

`queryKeys.tasks.list` is `(filter) => ["tasks", "list", filter]`. Building it twice from equal literals and asserting `toEqual` tests `toEqual` and array literals, not the module — it cannot fail for any implementation that returns a plain array of its inputs.

The three surviving cases in that file carry the real contract and stay: the root tuples (load-bearing — `lib/sse.ts` invalidates against `queryKeys.tasks.all`, `.dashboard.all`, `.inbox.all` and friends), prefix sharing between list and detail keys, and filters participating in the key.

## What got relabeled

**`packages/web/lib/api/client.test.ts` — `describe("deferred surfaces (paths set; backend not yet shipped)")`**

All three surfaces are shipped: `/dashboard`, `/mesh` and `/promotion` are live in `packages/api/src/routes/view.ts:462,504,516`, and each has a hook (`use-dashboard`, `use-mesh`, `use-promotions`) plus a page on the web side. The tests still pin real URL contracts, so they stay — only the label had gone stale. Renamed to `dashboard / mesh / promotions`.

## What was checked and left alone

- **Every `skip` in the suite is an environment gate, not a disabled test**, and each has a live reason: Docker for `sandbox/docker.e2e` and `daemon/multi-instance.e2e`, provider keys for `routes/mcp` and `claude-code/smoke`, non-win32 for the `spawn` and `local-workspace/manager` suites.
- **No test file has lost its subject module**, and no `vi.mock` targets a path that no longer resolves.
- **No assertion-free tests remain** — a paren-matching scan over every `it`/`test` body across all 156 files came back clean.
- No snapshot tests or orphaned `__snapshots__` directories exist.
- The `not.toThrow()` assertions in `daemon/claimer`, `api/runtime/hub` and `api/mesh/server` pin real "malformed input doesn't crash the process" behavior.
- The private-field reads in `local-workspace/manager.test.ts` look like implementation-detail tests but pin a documented regression (the `??` → `||` fix for an empty-string `workspaceRoot`); the field access is the means, not the point.
- `views/activity.test.ts` covers an endpoint with no in-repo caller, but `CLAUDE.md` records it as a documented public endpoint whose retirement is a product call.

The thin yield is expected — #261, #265, #270, #284 and #291 all swept this suite in the last three weeks.

## Verification

`pnpm typecheck` and `pnpm lint` both clean (the two `import/no-duplicates` warnings in `lib/types/dashboard.ts` are pre-existing and untouched by this diff). `packages/web` tests: 24 files, 201 passing, down from 203 by exactly the two removed cases. `packages/daemon`: 156 passing. `packages/core` shows only the DB- and provider-key-gated failures documented in `CLAUDE.md` as the bare-sandbox baseline.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKRwh4w3nsTHu7uchPFoUn)_