### PR TITLE
refactor: unify five clusters of near-duplicate abstractions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,7 @@ table before deleting anything a tool reports as unused.
 | `scripts/seed-session-search-demo.ts`, `test-session-search.ts`, `packages/sandbox/src/scripts/*` | Documented manual dev/ops utilities, run by hand via `pnpm tsx …`. |
 | `OwnerLookup.singleOwnerSet` / `.meshOwners` | Called by the module-level `RESOLVERS` table, so they must stay public. Knip only checks cross-module use. |
 | `@beevibe/core/{domain,adapters/codex,adapters/opencode,services/skills,auth/constants}` subpath exports | Deliberate library surface. The codex/opencode runtimes are wired through `runtime-registry.ts`, which imports `./codex/runtime.js` directly rather than the barrel. |
+| `@beevibe/core/domain/{format,task}` subpath exports | The only two core modules the **web** imports as runtime *values*. They must NOT be reached via the root barrel — it re-exports `./auth`, which pulls `node:crypto` into the client bundle and fails `next build` with `UnhandledSchemeError`. Both files are pure and dependency-free so they're safe in the browser; that's the whole reason the dedicated subpaths exist. |
 
 Most "unused export" hits are symbols used *within their own file* — the
 `export` is redundant, not dead. Leave them alone unless you're already

--- a/packages/api/src/views/tasks-grouping.ts
+++ b/packages/api/src/views/tasks-grouping.ts
@@ -1,35 +1,41 @@
 /**
- * Server-side mirror of `packages/web/lib/tasks-grouping.ts`. Keeps the
- * lifecycle → status mapping and the saved-view → status mapping next to
- * the SQL that filters on them, so the web can pass either `lifecycle` or
- * `view` and get the rows it expects.
+ * Saved-view shortcuts for `GET /task`.
+ *
+ * The lifecycle vocabulary itself — the six lanes and the status → lane
+ * mapping — lives in `@beevibe/core`'s `domain/task.ts`, where the web's
+ * kanban board reads the same declaration. This file used to carry a
+ * "server-side mirror" of it that had drifted to four lanes; see the
+ * `TaskLifecycle` doc comment for what that cost.
  */
 
 import type { TaskStatus } from "@beevibe/core";
+import { TASK_STATUSES_BY_LIFECYCLE } from "@beevibe/core";
 
-export type Lifecycle = "pending" | "in_progress" | "in_review" | "done";
-
-export const TASK_STATUSES_BY_LIFECYCLE: Record<Lifecycle, readonly TaskStatus[]> = {
-  pending: ["pending", "assigned"],
-  in_progress: ["in_progress", "revision", "needs_revision"],
-  in_review: ["review", "blocked"],
-  done: ["done", "failed", "cancelled"],
-};
+export type { TaskLifecycle as Lifecycle } from "@beevibe/core";
+export { TASK_LIFECYCLES, TASK_STATUSES_BY_LIFECYCLE } from "@beevibe/core";
 
 /**
  * Saved-view shortcut → status set. "all" and "mine" are intentionally
  * absent — "all" means no filter, "mine" routes to `assignee_id`.
+ *
+ * Spelled out lane-by-lane rather than as a lifecycle range so the status
+ * sets stay exactly what they were before `blocked` and `archived` became
+ * lanes of their own: `sprint` is everything not yet finished, `timeline`
+ * is everything.
  */
 export const TASK_STATUSES_BY_VIEW: Partial<Record<string, readonly TaskStatus[]>> = {
   sprint: [
     ...TASK_STATUSES_BY_LIFECYCLE.pending,
     ...TASK_STATUSES_BY_LIFECYCLE.in_progress,
+    ...TASK_STATUSES_BY_LIFECYCLE.blocked,
     ...TASK_STATUSES_BY_LIFECYCLE.in_review,
   ],
   timeline: [
     ...TASK_STATUSES_BY_LIFECYCLE.pending,
     ...TASK_STATUSES_BY_LIFECYCLE.in_progress,
+    ...TASK_STATUSES_BY_LIFECYCLE.blocked,
     ...TASK_STATUSES_BY_LIFECYCLE.in_review,
     ...TASK_STATUSES_BY_LIFECYCLE.done,
+    ...TASK_STATUSES_BY_LIFECYCLE.archived,
   ],
 };

--- a/packages/api/src/views/tasks.test.ts
+++ b/packages/api/src/views/tasks.test.ts
@@ -5,6 +5,7 @@
  * mapping layer without needing a database.
  */
 import { describe, it, expect } from "vitest";
+import { TASK_STATUSES } from "@beevibe/core";
 import { listTasks, getTask } from "./tasks.js";
 import { makeMockPool } from "./test-helpers.js";
 
@@ -70,14 +71,43 @@ describe("listTasks", () => {
     expect(t.latest_session?.agent_label).toBe("alice");
   });
 
-  it("translates lifecycle filter into a status array param", async () => {
+  // The six lanes are the board's lanes (`@beevibe/core`'s
+  // TASK_LIFECYCLE_OF), not the four this file used to mirror — `blocked`
+  // and `archived` are their own lanes now, so `?lifecycle=blocked`
+  // filters instead of being dropped as an unknown value.
+  it.each([
+    ["pending", ["pending", "assigned"]],
+    ["in_progress", ["in_progress", "needs_revision", "revision"]],
+    ["blocked", ["blocked"]],
+    ["in_review", ["review"]],
+    ["done", ["done"]],
+    ["archived", ["failed", "cancelled"]],
+  ] as const)(
+    "translates the %s lifecycle filter into its status array param",
+    async (lifecycle, statuses) => {
+      const pool = makeMockPool([[]]);
+      const queryMock = pool._spy;
+      await listTasks(pool, { lifecycle, bypassOwnerScope: true });
+      expect(queryMock).toHaveBeenCalledWith(expect.any(String), [
+        statuses,
+        null,
+        null,
+      ]);
+    },
+  );
+
+  // `sprint` and `timeline` predate the lane split and must keep covering
+  // the same statuses they always did — every unfinished task, and every
+  // task, respectively.
+  it.each([
+    ["sprint", ["pending", "assigned", "in_progress", "needs_revision", "revision", "review", "blocked"]],
+    ["timeline", TASK_STATUSES],
+  ] as const)("keeps the %s view's status set", async (view, statuses) => {
     const pool = makeMockPool([[]]);
     const queryMock = pool._spy;
-    await listTasks(pool, { lifecycle: "in_review", bypassOwnerScope: true });
-    expect(queryMock).toHaveBeenCalledWith(
-      expect.any(String),
-      [["review", "blocked"], null, null],
-    );
+    await listTasks(pool, { view, bypassOwnerScope: true });
+    const passed = queryMock.mock.calls[0]![1]![0] as string[];
+    expect([...passed].sort()).toEqual([...statuses].sort());
   });
 
   it("forwards assignee_id when set", async () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,10 @@
       "types": "./dist/domain/format.d.ts",
       "default": "./dist/domain/format.js"
     },
+    "./domain/task": {
+      "types": "./dist/domain/task.d.ts",
+      "default": "./dist/domain/task.js"
+    },
     "./adapters/postgres": {
       "types": "./dist/adapters/postgres/index.d.ts",
       "default": "./dist/adapters/postgres/index.js"

--- a/packages/core/src/adapters/claude-code/runtime.ts
+++ b/packages/core/src/adapters/claude-code/runtime.ts
@@ -6,14 +6,7 @@ import type {
   RuntimeResult,
   Workspace,
 } from "../../ports/runtime.js";
-import {
-  cancelledResult,
-  cliVersionHealthCheck,
-  createStdoutLineReader,
-  finalizeCliResult,
-  warnIfTruncated,
-} from "../runtime-common.js";
-import { runCliProcess } from "./spawn.js";
+import { cliVersionHealthCheck, runCliSession } from "../runtime-common.js";
 import {
   extractStepEvents,
   parseClaudeMessages,
@@ -103,43 +96,23 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     for (const key of ANTHROPIC_AUTH_VARS) delete env[key];
     if (context.env) Object.assign(env, context.env);
 
-    // Parse messages incrementally during streaming so we don't re-parse
-    // the entire stdout after close. A line buffer handles chunk boundaries
-    // (a single JSON message can arrive split across multiple chunks).
-    const messages: StreamJsonMessage[] = [];
-    const handleLine = (line: string): void => {
-      const msg = parseStreamJsonLine(line);
-      if (!msg) return;
-      messages.push(msg);
-      if (context.onStep) {
-        for (const step of extractStepEvents(msg)) {
-          context.onStep(step);
-        }
-      }
-    };
-    const stdout = createStdoutLineReader(handleLine);
-
-    const result = await runCliProcess({
+    // Messages are parsed incrementally during streaming so we don't
+    // re-parse the entire stdout after close; `runCliSession` owns the line
+    // buffering that makes that safe across chunk boundaries.
+    return runCliSession<StreamJsonMessage>({
+      runtimeTag: "ClaudeCodeRuntime",
       command: this.config.command ?? "claude",
       args,
       cwd,
       env,
+      // Claude Code takes the intent on stdin (`--print -`); the other two
+      // runtimes pass it on argv via `composePrompt`.
       stdin: context.intent,
-      abortSignal: context.abort_signal,
-      onSpawn: ({ pid, process_group_id }) => {
-        context.onSpawn?.({ process_pid: pid, process_group_id });
-      },
-      onLog: stdout.onLog,
+      context,
+      parseLine: parseStreamJsonLine,
+      extractSteps: extractStepEvents,
+      parseResult: parseClaudeMessages,
     });
-
-    // Flush any final partial line (stream without trailing \n)
-    stdout.flush();
-
-    warnIfTruncated("ClaudeCodeRuntime", result);
-
-    if (result.aborted) return cancelledResult(result);
-
-    return finalizeCliResult(parseClaudeMessages(messages, result.exitCode), result);
   }
 
   async healthCheck(): Promise<RuntimeHealth> {

--- a/packages/core/src/adapters/codex/runtime.ts
+++ b/packages/core/src/adapters/codex/runtime.ts
@@ -8,15 +8,11 @@ import type {
   RuntimeWorkspaceContext,
   Workspace,
 } from "../../ports/runtime.js";
-import { runCliProcess } from "../claude-code/spawn.js";
 import { MCP_TOOL_TIMEOUT_MS } from "../local-workspace/manager.js";
 import {
-  cancelledResult,
   cliVersionHealthCheck,
   composePrompt,
-  createStdoutLineReader,
-  finalizeCliResult,
-  warnIfTruncated,
+  runCliSession,
 } from "../runtime-common.js";
 import {
   extractCodexStepEvents,
@@ -120,44 +116,22 @@ export class CodexRuntime implements AgentRuntime {
     if (context.env) Object.assign(env, context.env);
     if (prepared) env.BEEVIBE_AGENT_API_KEY = prepared.agentApiKey;
 
-    const events: CodexEvent[] = [];
-    const handleLine = (line: string): void => {
-      const evt = parseCodexEventLine(line);
-      if (!evt) return;
-      events.push(evt);
-      if (!context.onStep) return;
-      for (const step of extractCodexStepEvents(evt)) {
-        context.onStep(step);
-      }
-    };
-    const stdout = createStdoutLineReader(handleLine);
-
-    const result = await runCliProcess({
+    return runCliSession<CodexEvent>({
+      runtimeTag: "CodexRuntime",
       command: this.config.command ?? "codex",
       args,
       cwd: context.workspace.path,
       env,
-      abortSignal: context.abort_signal,
-      onSpawn: ({ pid, process_group_id }) => {
-        context.onSpawn?.({ process_pid: pid, process_group_id });
-      },
-      onLog: stdout.onLog,
+      context,
+      parseLine: parseCodexEventLine,
+      extractSteps: extractCodexStepEvents,
+      // Codex writes its final assistant message to a side-channel file
+      // rather than the event stream, so the parse reads it — which is why
+      // `cleanup` deletes the file after the parse rather than before.
+      parseResult: (events, exitCode) =>
+        parseCodexEvents(events, exitCode, readIfExists(lastMessagePath)),
+      cleanup: () => removeIfExists(lastMessagePath),
     });
-    stdout.flush();
-
-    warnIfTruncated("CodexRuntime", result);
-
-    if (result.aborted) {
-      removeIfExists(lastMessagePath);
-      return cancelledResult(result);
-    }
-
-    const lastMessage = readIfExists(lastMessagePath);
-    removeIfExists(lastMessagePath);
-    return finalizeCliResult(
-      parseCodexEvents(events, result.exitCode, lastMessage),
-      result,
-    );
   }
 
   async healthCheck(): Promise<RuntimeHealth> {

--- a/packages/core/src/adapters/opencode/runtime.ts
+++ b/packages/core/src/adapters/opencode/runtime.ts
@@ -8,14 +8,10 @@ import type {
   RuntimeWorkspaceContext,
   Workspace,
 } from "../../ports/runtime.js";
-import { runCliProcess } from "../claude-code/spawn.js";
 import {
-  cancelledResult,
   cliVersionHealthCheck,
   composePrompt,
-  createStdoutLineReader,
-  finalizeCliResult,
-  warnIfTruncated,
+  runCliSession,
 } from "../runtime-common.js";
 import {
   extractOpenCodeStepEvents,
@@ -76,36 +72,17 @@ export class OpenCodeRuntime implements AgentRuntime {
     const env: Record<string, string | undefined> = { ...process.env };
     if (context.env) Object.assign(env, context.env);
 
-    const events: OpenCodeEvent[] = [];
-    const handleLine = (line: string): void => {
-      const evt = parseOpenCodeEventLine(line);
-      if (!evt) return;
-      events.push(evt);
-      if (!context.onStep) return;
-      for (const step of extractOpenCodeStepEvents(evt)) {
-        context.onStep(step);
-      }
-    };
-    const stdout = createStdoutLineReader(handleLine);
-
-    const result = await runCliProcess({
+    return runCliSession<OpenCodeEvent>({
+      runtimeTag: "OpenCodeRuntime",
       command: this.config.command ?? "opencode",
       args,
       cwd: context.workspace.path,
       env,
-      abortSignal: context.abort_signal,
-      onSpawn: ({ pid, process_group_id }) => {
-        context.onSpawn?.({ process_pid: pid, process_group_id });
-      },
-      onLog: stdout.onLog,
+      context,
+      parseLine: parseOpenCodeEventLine,
+      extractSteps: extractOpenCodeStepEvents,
+      parseResult: parseOpenCodeEvents,
     });
-    stdout.flush();
-
-    warnIfTruncated("OpenCodeRuntime", result);
-
-    if (result.aborted) return cancelledResult(result);
-
-    return finalizeCliResult(parseOpenCodeEvents(events, result.exitCode), result);
   }
 
   async healthCheck(): Promise<RuntimeHealth> {

--- a/packages/core/src/adapters/runtime-common.ts
+++ b/packages/core/src/adapters/runtime-common.ts
@@ -1,5 +1,10 @@
 import { tmpdir } from "node:os";
-import type { RuntimeContext, RuntimeHealth, RuntimeResult } from "../ports/runtime.js";
+import type {
+  RuntimeContext,
+  RuntimeHealth,
+  RuntimeResult,
+  RuntimeStep,
+} from "../ports/runtime.js";
 import { type CliProcessResult, runCliProcess } from "./claude-code/spawn.js";
 
 /**
@@ -207,4 +212,91 @@ export function finalizeCliResult(
     exit_code: result.exitCode,
     ...(stderrTail ? { stderr: stderrTail } : {}),
   };
+}
+
+/**
+ * Everything a CLI runtime's `execute` needs beyond the argv it built.
+ *
+ * The three provider-specific hooks are the only parts that genuinely
+ * differ between the adapters: which event type comes off the wire, which
+ * steps that event yields to the live transcript, and how the collected
+ * events map to a `RuntimeResult`.
+ */
+export interface CliSessionSpec<Event> {
+  /** Tag for the truncation warning, e.g. `"CodexRuntime"`. */
+  runtimeTag: string;
+  command: string;
+  args: string[];
+  cwd: string;
+  env: Record<string, string | undefined>;
+  /** Piped to the child's stdin. Claude Code feeds the intent this way. */
+  stdin?: string;
+  /** The session being run — read for `onStep` / `onSpawn` / `abort_signal`. */
+  context: RuntimeContext;
+  /** One NDJSON line → one provider event, or `null` to skip the line. */
+  parseLine: (line: string) => Event | null;
+  /** Provider event → the steps it contributes to the live transcript. */
+  extractSteps: (event: Event) => Iterable<RuntimeStep>;
+  /** Collected events + exit code → the provider's `RuntimeResult`. */
+  parseResult: (events: Event[], exitCode: number | null) => RuntimeResult;
+  /**
+   * Per-spawn scratch cleanup, run on both the cancelled and the completed
+   * path. Runs *after* `parseResult`, so a spec whose parse reads a
+   * side-channel file (codex's `--output-last-message`) can still find it.
+   */
+  cleanup?: () => void;
+}
+
+/**
+ * Drive one CLI subprocess session end to end: stream stdout as NDJSON,
+ * push steps live, then map the outcome to a `RuntimeResult`.
+ *
+ * This sequence — accumulate events off a line reader, spawn, flush the
+ * trailing partial line, warn on truncation, short-circuit an abort into
+ * `cancelledResult`, otherwise parse and `finalizeCliResult` — was written
+ * out identically in all three adapters. Identically, but not
+ * interchangeably: the ordering carries real constraints (flush must
+ * precede parse or the last event is dropped; the abort check must precede
+ * parse or a cancelled session reports as failed) that were only enforced
+ * by each copy happening to be right.
+ */
+export async function runCliSession<Event>(
+  spec: CliSessionSpec<Event>,
+): Promise<RuntimeResult> {
+  const { context } = spec;
+  const events: Event[] = [];
+  const stdout = createStdoutLineReader((line) => {
+    const event = spec.parseLine(line);
+    if (!event) return;
+    events.push(event);
+    if (!context.onStep) return;
+    for (const step of spec.extractSteps(event)) context.onStep(step);
+  });
+
+  const result = await runCliProcess({
+    command: spec.command,
+    args: spec.args,
+    cwd: spec.cwd,
+    env: spec.env,
+    ...(spec.stdin !== undefined ? { stdin: spec.stdin } : {}),
+    abortSignal: context.abort_signal,
+    onSpawn: ({ pid, process_group_id }) => {
+      context.onSpawn?.({ process_pid: pid, process_group_id });
+    },
+    onLog: stdout.onLog,
+  });
+  // Flush any final partial line (a stream that ended without a trailing
+  // newline) before anything reads `events`.
+  stdout.flush();
+
+  warnIfTruncated(spec.runtimeTag, result);
+
+  if (result.aborted) {
+    spec.cleanup?.();
+    return cancelledResult(result);
+  }
+
+  const parsed = spec.parseResult(events, result.exitCode);
+  spec.cleanup?.();
+  return finalizeCliResult(parsed, result);
 }

--- a/packages/core/src/domain/task.ts
+++ b/packages/core/src/domain/task.ts
@@ -39,6 +39,88 @@ export const TERMINAL_TASK_STATUSES: readonly TaskStatus[] = [
   "cancelled",
 ] as const;
 
+/**
+ * The board lane a task's status belongs to.
+ *
+ * This vocabulary existed twice — `packages/web/lib/tasks-grouping.ts`
+ * (six lanes, drives the kanban board) and
+ * `packages/api/src/views/tasks-grouping.ts` (four lanes, filters the
+ * `GET /task` SQL), the latter labelled "server-side mirror" of the
+ * former. The two had already drifted: the api folded `blocked` into
+ * `in_review` and `failed`/`cancelled` into `done`, so the six lanes the
+ * user sees on the board were not the lanes the api could filter by.
+ * `TaskListFilter.lifecycle` on the web is typed from the six-lane union,
+ * and `GET /task` silently drops any value it doesn't recognize — so
+ * `?lifecycle=blocked` returned every task rather than the blocked ones.
+ *
+ * One declaration, here, because it is one concept: the api filters on
+ * the same lanes the board renders.
+ */
+export type TaskLifecycle =
+  | "pending"
+  | "in_progress"
+  | "blocked"
+  | "in_review"
+  | "done"
+  | "archived";
+
+/**
+ * Workflow order, left-to-right — the order the board renders lanes in,
+ * and the order {@link TASK_STATUSES_BY_LIFECYCLE} is keyed in. `blocked`
+ * sits between `in_progress` and `in_review` because that is where
+ * blockers arise: work started, hit an impasse, needs unblocking before
+ * it can land in review.
+ */
+export const TASK_LIFECYCLES: readonly TaskLifecycle[] = [
+  "pending",
+  "in_progress",
+  "blocked",
+  "in_review",
+  "done",
+  "archived",
+] as const;
+
+/**
+ * Status → lane. Exhaustive over {@link TaskStatus} by its `Record` type,
+ * so a new status is a compile error here rather than a task that
+ * silently vanishes from the board.
+ *
+ * - `blocked` gets its own lane rather than folding into `in_review`:
+ *   blocked means waiting on an external dependency, which asks something
+ *   different of the human reading the board than "waiting on a verdict".
+ * - `failed` and `cancelled` are terminal-but-not-success, so they go to
+ *   `archived` (hidden behind a toggle) — `done` should read as "this
+ *   shipped".
+ */
+export const TASK_LIFECYCLE_OF: Record<TaskStatus, TaskLifecycle> = {
+  pending: "pending",
+  assigned: "pending",
+  in_progress: "in_progress",
+  revision: "in_progress",
+  needs_revision: "in_progress",
+  review: "in_review",
+  blocked: "blocked",
+  done: "done",
+  failed: "archived",
+  cancelled: "archived",
+};
+
+/**
+ * {@link TASK_LIFECYCLE_OF} inverted — the statuses in each lane, for the
+ * `WHERE status = ANY($1)` side of the api's task list. Derived rather
+ * than written out so the two directions cannot disagree.
+ */
+export const TASK_STATUSES_BY_LIFECYCLE: Record<TaskLifecycle, readonly TaskStatus[]> =
+  TASK_LIFECYCLES.reduce(
+    (acc, lifecycle) => {
+      acc[lifecycle] = TASK_STATUSES.filter(
+        (status) => TASK_LIFECYCLE_OF[status] === lifecycle,
+      );
+      return acc;
+    },
+    {} as Record<TaskLifecycle, TaskStatus[]>,
+  );
+
 export type TaskPriority = "low" | "medium" | "high" | "critical";
 
 export const TASK_PRIORITIES: readonly TaskPriority[] = ["low", "medium", "high", "critical"] as const;

--- a/packages/web/app/(authed)/agents/agents-client.tsx
+++ b/packages/web/app/(authed)/agents/agents-client.tsx
@@ -6,6 +6,12 @@ import { AlertTriangle, Bot, LayoutGrid, List, Maximize2, Minus, Plus } from "lu
 import type { PanZoomTransform } from "@/lib/hooks/use-pan-zoom";
 import { useAgentNetwork } from "@/lib/hooks/use-agent-network";
 import { isApiConfigured } from "@/lib/api/config";
+import {
+  API_NOT_CONFIGURED_TITLE,
+  API_UNREACHABLE_DESCRIPTION,
+  apiNotConfiguredDescription,
+  couldNotLoadTitle,
+} from "@/lib/api/messages";
 import { EmptyState } from "@/components/empty-state";
 import { TeamOrbit } from "@/components/team-orbit";
 import { AgentDetailPanel } from "@/components/agents/agent-detail-panel";
@@ -101,11 +107,15 @@ export function AgentsClient() {
       {!isApiConfigured ? (
         <CenteredShell
           icon={Bot}
-          title="API not configured"
-          description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load agents."
+          title={API_NOT_CONFIGURED_TITLE}
+          description={apiNotConfiguredDescription("agents")}
         />
       ) : isError ? (
-        <CenteredShell icon={AlertTriangle} title="Couldn't load the network" />
+        <CenteredShell
+          icon={AlertTriangle}
+          title={couldNotLoadTitle("the network")}
+          description={API_UNREACHABLE_DESCRIPTION}
+        />
       ) : view === "list" ? (
         <AgentsListView
           agents={selfAgents}

--- a/packages/web/app/(authed)/dashboard/dashboard-client.test.tsx
+++ b/packages/web/app/(authed)/dashboard/dashboard-client.test.tsx
@@ -79,7 +79,7 @@ describe("DashboardClient", () => {
   it("renders the not-configured empty state and never fetches", () => {
     apiState.isApiConfigured = false;
     renderHome();
-    expect(screen.getByText("Dashboard not connected")).toBeInTheDocument();
+    expect(screen.getByText("API not configured")).toBeInTheDocument();
     expect(summaryMock).not.toHaveBeenCalled();
   });
 

--- a/packages/web/app/(authed)/dashboard/dashboard-client.tsx
+++ b/packages/web/app/(authed)/dashboard/dashboard-client.tsx
@@ -3,6 +3,12 @@
 import { AlertTriangle, LayoutDashboard } from "lucide-react";
 import { useDashboard } from "@/lib/hooks/use-dashboard";
 import { isApiConfigured } from "@/lib/api/config";
+import {
+  API_NOT_CONFIGURED_TITLE,
+  API_UNREACHABLE_DESCRIPTION,
+  apiNotConfiguredDescription,
+  couldNotLoadTitle,
+} from "@/lib/api/messages";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
 import { KpiTileSkeleton } from "@/components/skeletons";
@@ -39,8 +45,8 @@ function Body({
       <div className="rounded-lg border border-dashed border-border">
         <EmptyState
           icon={LayoutDashboard}
-          title="Dashboard not connected"
-          description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load KPIs and fleet status."
+          title={API_NOT_CONFIGURED_TITLE}
+          description={apiNotConfiguredDescription("KPIs and fleet status")}
         />
       </div>
     );
@@ -51,8 +57,8 @@ function Body({
       <div className="rounded-lg border border-dashed border-border">
         <EmptyState
           icon={AlertTriangle}
-          title="Couldn't load dashboard"
-          description="Check that the MCP server is reachable."
+          title={couldNotLoadTitle("dashboard")}
+          description={API_UNREACHABLE_DESCRIPTION}
         />
       </div>
     );

--- a/packages/web/app/(authed)/memory/eval/eval-client.tsx
+++ b/packages/web/app/(authed)/memory/eval/eval-client.tsx
@@ -5,6 +5,12 @@ import Link from "next/link";
 import { AlertTriangle, ArrowLeft, BarChart3 } from "lucide-react";
 import { useMemoryActivity } from "@/lib/hooks/use-memory-activity";
 import { isApiConfigured } from "@/lib/api/config";
+import {
+  API_NOT_CONFIGURED_TITLE,
+  API_UNREACHABLE_DESCRIPTION,
+  apiNotConfiguredDescription,
+  couldNotLoadTitle,
+} from "@/lib/api/messages";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
 import { DatePicker, todayIso } from "@/components/date-picker";
@@ -50,8 +56,8 @@ export function MemoryEvalClient() {
     return (
       <EmptyState
         icon={BarChart3}
-        title="Memory eval not connected"
-        description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load Layer A activity telemetry."
+        title={API_NOT_CONFIGURED_TITLE}
+        description={apiNotConfiguredDescription("Layer A activity telemetry")}
       />
     );
   }
@@ -59,8 +65,8 @@ export function MemoryEvalClient() {
     return (
       <EmptyState
         icon={AlertTriangle}
-        title="Couldn't load memory activity"
-        description="Check that the api server is reachable."
+        title={couldNotLoadTitle("memory activity")}
+        description={API_UNREACHABLE_DESCRIPTION}
       />
     );
   }

--- a/packages/web/app/(authed)/memory/memory-client.tsx
+++ b/packages/web/app/(authed)/memory/memory-client.tsx
@@ -27,6 +27,12 @@ import { RichTextRender } from "@/components/rich-text";
 import { useMemoryFactCounts, useMemoryFacts } from "@/lib/hooks/use-memory";
 import { useSlashFocus } from "@/lib/hooks/use-slash-focus";
 import { isApiConfigured } from "@/lib/api/config";
+import {
+  API_NOT_CONFIGURED_TITLE,
+  API_UNREACHABLE_DESCRIPTION,
+  apiNotConfiguredDescription,
+  couldNotLoadTitle,
+} from "@/lib/api/messages";
 import { api } from "@/lib/api/client";
 import { queryKeys } from "@/lib/hooks/keys";
 import { formatRelativeTime } from "@/lib/format";
@@ -142,8 +148,8 @@ function Body({
         <td colSpan={6}>
           <EmptyState
             icon={Sparkles}
-            title="No facts learned yet"
-            description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load memory."
+            title={API_NOT_CONFIGURED_TITLE}
+            description={apiNotConfiguredDescription("memory")}
           />
         </td>
       </tr>
@@ -154,7 +160,11 @@ function Body({
     return (
       <tr>
         <td colSpan={6}>
-          <EmptyState icon={AlertTriangle} title="Couldn't load memory" />
+          <EmptyState
+            icon={AlertTriangle}
+            title={couldNotLoadTitle("memory")}
+            description={API_UNREACHABLE_DESCRIPTION}
+          />
         </td>
       </tr>
     );

--- a/packages/web/app/(authed)/mesh/mesh-client.tsx
+++ b/packages/web/app/(authed)/mesh/mesh-client.tsx
@@ -11,6 +11,12 @@ import { ChainBudget } from "@/components/mesh/chain-budget";
 import { MeshWindowPills } from "@/components/mesh/window-pills";
 import { useMeshOverview } from "@/lib/hooks/use-mesh";
 import { isApiConfigured } from "@/lib/api/config";
+import {
+  API_NOT_CONFIGURED_TITLE,
+  API_UNREACHABLE_DESCRIPTION,
+  apiNotConfiguredDescription,
+  couldNotLoadTitle,
+} from "@/lib/api/messages";
 import type { MeshDisplay, MeshHover, MeshWindow } from "@/lib/types/mesh";
 
 export function MeshClient() {
@@ -61,8 +67,8 @@ function Body({
       <div className="rounded-lg border border-dashed border-border">
         <EmptyState
           icon={Network}
-          title="No mesh asks yet"
-          description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load mesh activity."
+          title={API_NOT_CONFIGURED_TITLE}
+          description={apiNotConfiguredDescription("mesh activity")}
         />
       </div>
     );
@@ -71,7 +77,11 @@ function Body({
   if (isError) {
     return (
       <div className="rounded-lg border border-dashed border-border">
-        <EmptyState icon={AlertTriangle} title="Couldn't load mesh activity" />
+        <EmptyState
+          icon={AlertTriangle}
+          title={couldNotLoadTitle("mesh activity")}
+          description={API_UNREACHABLE_DESCRIPTION}
+        />
       </div>
     );
   }

--- a/packages/web/app/(authed)/promotions/promotions-client.tsx
+++ b/packages/web/app/(authed)/promotions/promotions-client.tsx
@@ -6,6 +6,12 @@ import { PromotionEventSkeleton } from "@/components/skeletons";
 import { PromotionEventRow } from "@/components/promotions/event-row";
 import { usePromotions } from "@/lib/hooks/use-promotions";
 import { isApiConfigured } from "@/lib/api/config";
+import {
+  API_NOT_CONFIGURED_TITLE,
+  API_UNREACHABLE_DESCRIPTION,
+  apiNotConfiguredDescription,
+  couldNotLoadTitle,
+} from "@/lib/api/messages";
 import type { PromotionEvent } from "@/lib/types/promotion-events";
 
 export function PromotionsClient() {
@@ -55,14 +61,20 @@ function Body({
     return (
       <EmptyWrapper
         icon={TrendingUp}
-        title="No promotions yet"
-        description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load promotion events."
+        title={API_NOT_CONFIGURED_TITLE}
+        description={apiNotConfiguredDescription("promotion events")}
       />
     );
   }
 
   if (isError) {
-    return <EmptyWrapper icon={AlertTriangle} title="Couldn't load promotions" />;
+    return (
+      <EmptyWrapper
+        icon={AlertTriangle}
+        title={couldNotLoadTitle("promotions")}
+        description={API_UNREACHABLE_DESCRIPTION}
+      />
+    );
   }
 
   if (isLoading) {

--- a/packages/web/app/(authed)/rooms/[id]/room-detail-client.tsx
+++ b/packages/web/app/(authed)/rooms/[id]/room-detail-client.tsx
@@ -17,7 +17,7 @@ import { isApiConfigured } from "@/lib/api/config";
 import { api, type RoomDetail, type RoomMemberDetail, type RoomMessage } from "@/lib/api/client";
 import { ApiError, describeError } from "@/lib/api/http";
 import { queryKeys } from "@/lib/hooks/keys";
-import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
+import { ShareLinkBox } from "@/components/share-link-box";
 import { ModalOverlay } from "@/components/modal-overlay";
 import { ChatMarkdown } from "@/components/chat/markdown";
 import { ToolStepList } from "@/components/chat/tool-step-list";
@@ -275,7 +275,6 @@ function InviteDialog({ roomId, onClose }: { roomId: string; onClose: () => void
   const [error, setError] = useState<string | null>(null);
   /** When the invitee doesn't have an account yet, surface a share link they can use to sign up + auto-join. */
   const [shareLink, setShareLink] = useState<string | null>(null);
-  const { copied, copy } = useCopyToClipboard();
 
   const invite = useMutation({
     mutationFn: () => api.rooms.invite(roomId, { email: email.trim() }),
@@ -333,27 +332,15 @@ function InviteDialog({ roomId, onClose }: { roomId: string; onClose: () => void
           </div>
         ) : null}
         {shareLink ? (
-          <div className="mt-3 rounded border border-border bg-muted/40 p-3">
-            <div className="text-[11px] text-muted-foreground mb-1.5">
-              No account for that email yet. Send them this link — they&apos;ll sign up and
-              land in this room.
-            </div>
-            <div className="flex items-center gap-1.5">
-              <input
-                readOnly
-                value={shareLink}
-                className="flex-1 rounded border border-border bg-background px-2 py-1.5 text-[11px] font-mono"
-                onFocus={(e) => e.currentTarget.select()}
-              />
-              <button
-                type="button"
-                onClick={() => void copy(shareLink ?? "")}
-                className="h-7 px-2.5 rounded text-[11px] font-medium border border-border hover:bg-secondary transition-colors cursor-pointer shrink-0"
-              >
-                {copied ? "Copied" : "Copy"}
-              </button>
-            </div>
-          </div>
+          <ShareLinkBox
+            lead={
+              <>
+                No account for that email yet. Send them this link — they&apos;ll sign up and
+                land in this room.
+              </>
+            }
+            link={shareLink}
+          />
         ) : null}
         <div className="mt-4 flex items-center justify-end gap-2">
           <button

--- a/packages/web/app/(authed)/rooms/rooms-list-client.tsx
+++ b/packages/web/app/(authed)/rooms/rooms-list-client.tsx
@@ -7,6 +7,12 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, Loader2, MessageCircleMore, Plus, Users } from "lucide-react";
 import { api, type Room } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
+import {
+  API_NOT_CONFIGURED_TITLE,
+  API_UNREACHABLE_DESCRIPTION,
+  apiNotConfiguredDescription,
+  couldNotLoadTitle,
+} from "@/lib/api/messages";
 import { queryKeys } from "@/lib/hooks/keys";
 import { Skeleton } from "@/components/skeleton";
 import { EmptyState } from "@/components/empty-state";
@@ -46,8 +52,8 @@ export function RoomsListClient() {
       <div className="p-6">
         <EmptyState
           icon={MessageCircleMore}
-          title="Web isn't configured"
-          description="Set NEXT_PUBLIC_BV_API_URL and run the api server."
+          title={API_NOT_CONFIGURED_TITLE}
+          description={apiNotConfiguredDescription("rooms")}
         />
       </div>
     );
@@ -111,8 +117,8 @@ export function RoomsListClient() {
         ) : isError ? (
           <EmptyState
             icon={AlertTriangle}
-            title="Couldn't load rooms"
-            description="Check that the api server is reachable."
+            title={couldNotLoadTitle("rooms")}
+            description={API_UNREACHABLE_DESCRIPTION}
           />
         ) : (data?.rooms ?? []).length === 0 ? (
           <EmptyState

--- a/packages/web/app/(authed)/runtimes/runtimes-client.tsx
+++ b/packages/web/app/(authed)/runtimes/runtimes-client.tsx
@@ -19,6 +19,11 @@ import {
   type RuntimesListResponse,
 } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
+import {
+  API_NOT_CONFIGURED_TITLE,
+  apiNotConfiguredDescription,
+  couldNotLoadTitle,
+} from "@/lib/api/messages";
 import { describeError } from "@/lib/api/http";
 import { queryKeys } from "@/lib/hooks/keys";
 import { formatRelativeTime } from "@/lib/format";
@@ -82,8 +87,8 @@ function Body({
       <div className="rounded-lg border border-dashed border-border">
         <EmptyState
           icon={Terminal}
-          title="API not configured"
-          description="Set NEXT_PUBLIC_BV_API_URL and run the API server to load this page."
+          title={API_NOT_CONFIGURED_TITLE}
+          description={apiNotConfiguredDescription("your runtimes")}
         />
       </div>
     );
@@ -101,7 +106,7 @@ function Body({
       <div className="rounded-lg border border-dashed border-border">
         <EmptyState
           icon={AlertTriangle}
-          title="Couldn't load runtimes"
+          title={couldNotLoadTitle("runtimes")}
           description={describeError(error)}
         />
       </div>

--- a/packages/web/app/(authed)/settings/settings-client.tsx
+++ b/packages/web/app/(authed)/settings/settings-client.tsx
@@ -9,6 +9,11 @@ import {
   type UserPreferences,
 } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
+import {
+  API_NOT_CONFIGURED_TITLE,
+  apiNotConfiguredDescription,
+  couldNotLoadTitle,
+} from "@/lib/api/messages";
 import { queryKeys } from "@/lib/hooks/keys";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
@@ -35,7 +40,10 @@ export function SettingsClient() {
     return (
       <div className="flex-1 overflow-auto">
         <div className="max-w-3xl mx-auto px-6 py-8">
-          <EmptyState title="API not configured" description="Set NEXT_PUBLIC_BV_API_URL." />
+          <EmptyState
+            title={API_NOT_CONFIGURED_TITLE}
+            description={apiNotConfiguredDescription("your preferences")}
+          />
         </div>
       </div>
     );
@@ -62,7 +70,7 @@ export function SettingsClient() {
             <Skeleton className="h-20 w-full rounded-lg" />
           ) : isError || !data ? (
             <EmptyState
-              title="Couldn't load preferences"
+              title={couldNotLoadTitle("preferences")}
               description="Try refreshing the page."
             />
           ) : (

--- a/packages/web/app/(authed)/tasks/[id]/task-detail-client.test.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/task-detail-client.test.tsx
@@ -67,7 +67,7 @@ describe("TaskDetailClient", () => {
     renderDetail("t_abc");
 
     expect(await screen.findByText("Couldn't load task")).toBeInTheDocument();
-    expect(screen.getByText(/Task t_abc could not be fetched/)).toBeInTheDocument();
+    expect(screen.getByText(/\(t_abc\)/)).toBeInTheDocument();
   });
 
   it("renders the loaded task with title, status, and footer fields", async () => {

--- a/packages/web/app/(authed)/tasks/tasks-client.test.tsx
+++ b/packages/web/app/(authed)/tasks/tasks-client.test.tsx
@@ -72,9 +72,9 @@ describe("TasksClient — empty-state branches", () => {
     apiState.isApiConfigured = false;
     renderClient();
 
-    expect(await screen.findByText("No tasks yet")).toBeInTheDocument();
+    expect(await screen.findByText("API not configured")).toBeInTheDocument();
     expect(
-      screen.getByText(/Set NEXT_PUBLIC_BV_API_URL and run the MCP server/i),
+      screen.getByText(/Set NEXT_PUBLIC_BV_API_URL and run the API server/i),
     ).toBeInTheDocument();
     expect(listMock).not.toHaveBeenCalled();
   });

--- a/packages/web/app/(authed)/tasks/tasks-client.tsx
+++ b/packages/web/app/(authed)/tasks/tasks-client.tsx
@@ -9,6 +9,12 @@ import { EmptyState } from "@/components/empty-state";
 import { TaskDetailPanel } from "@/components/tasks/task-detail-panel";
 import { useTasks } from "@/lib/hooks/use-tasks";
 import { isApiConfigured } from "@/lib/api/config";
+import {
+  API_NOT_CONFIGURED_TITLE,
+  API_UNREACHABLE_DESCRIPTION,
+  apiNotConfiguredDescription,
+  couldNotLoadTitle,
+} from "@/lib/api/messages";
 import { countArchivedTasks, groupTasks } from "@/lib/tasks-grouping";
 
 interface EmptyMessage {
@@ -129,16 +135,15 @@ function pickEmptyMessage(state: {
   if (state.isError) {
     return {
       icon: AlertTriangle,
-      title: "Couldn't load tasks",
-      description:
-        "The API is configured but unreachable. Check that the MCP server is running.",
+      title: couldNotLoadTitle("tasks"),
+      description: API_UNREACHABLE_DESCRIPTION,
     };
   }
   if (!state.isApiConfigured) {
     return {
       icon: ListChecks,
-      title: "No tasks yet",
-      description: "Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load tasks.",
+      title: API_NOT_CONFIGURED_TITLE,
+      description: apiNotConfiguredDescription("tasks"),
     };
   }
   // Suppress the empty state while ANY fetch is in flight — including a

--- a/packages/web/app/sign-in/sign-in-client.tsx
+++ b/packages/web/app/sign-in/sign-in-client.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { AlertTriangle, KeyRound, Loader2, LogIn } from "lucide-react";
+import { KeyRound, LogIn } from "lucide-react";
 import { SIGNIN_NO_PASSWORD_SET } from "@beevibe/core/auth/constants";
 import { api } from "@/lib/api/client";
 import { asApiError } from "@/lib/api/http";
@@ -13,6 +13,7 @@ import {
   isWellFormedUserKey,
   setUserKey,
 } from "@/lib/api/config";
+import { AUTH_API_NOT_CONFIGURED, AuthCard, AuthField } from "@/components/auth/auth-card";
 
 type Mode = "password" | "key";
 
@@ -52,7 +53,7 @@ export function SignInClient() {
   const submitPassword = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!isApiConfigured) {
-      setError("Web isn't configured to talk to an api server.");
+      setError(AUTH_API_NOT_CONFIGURED);
       return;
     }
     setError(null);
@@ -87,7 +88,7 @@ export function SignInClient() {
   const submitKey = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!isApiConfigured) {
-      setError("Web isn't configured to talk to an api server.");
+      setError(AUTH_API_NOT_CONFIGURED);
       return;
     }
     const key = keyDraft.trim();
@@ -113,112 +114,37 @@ export function SignInClient() {
     }
   };
 
+  const passwordMode = mode === "password";
+
   return (
-    <main className="min-h-screen flex items-center justify-center px-6 bg-background">
-      <form
-        onSubmit={mode === "password" ? submitPassword : submitKey}
-        className="w-full max-w-sm bg-card border border-border rounded-lg p-6 shadow-sm"
-      >
-        <header className="mb-5">
-          <div className="inline-flex items-center justify-center h-10 w-10 rounded-md bg-primary text-primary-foreground mb-3">
-            {mode === "password" ? (
-              <LogIn className="h-5 w-5" />
-            ) : (
-              <KeyRound className="h-5 w-5" />
-            )}
-          </div>
-          <h1 className="text-lg font-semibold tracking-tight">Sign in to beevibe</h1>
-          <p className="mt-1 text-xs text-muted-foreground leading-relaxed">
-            {mode === "password" ? (
-              <>Email + password. Your <span className="font-mono">bv_u_</span> key is generated server-side and never leaves the browser after.</>
-            ) : (
-              <>Paste your <span className="font-mono">bv_u_</span> key — for legacy accounts or CLI-provisioned users.</>
-            )}
-          </p>
-        </header>
-
-        {mode === "password" ? (
+    <AuthCard
+      icon={passwordMode ? LogIn : KeyRound}
+      title="Sign in to beevibe"
+      blurb={
+        passwordMode ? (
           <>
-            <label className="block text-xs font-medium text-foreground mb-1.5" htmlFor="email">
-              Email
-            </label>
-            <input
-              id="email"
-              type="email"
-              autoComplete="email"
-              inputMode="email"
-              autoFocus
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="alice@example.com"
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-              disabled={submitting}
-            />
-
-            <label className="block text-xs font-medium text-foreground mb-1.5 mt-3" htmlFor="password">
-              Password
-            </label>
-            <input
-              id="password"
-              type="password"
-              autoComplete="current-password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="••••••••"
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-              disabled={submitting}
-            />
+            Email + password. Your <span className="font-mono">bv_u_</span> key is generated
+            server-side and never leaves the browser after.
           </>
         ) : (
           <>
-            <label className="block text-xs font-medium text-foreground mb-1.5" htmlFor="key">
-              User API key
-            </label>
-            <input
-              id="key"
-              type="password"
-              autoComplete="off"
-              autoFocus
-              spellCheck={false}
-              value={keyDraft}
-              onChange={(e) => setKeyDraft(e.target.value)}
-              placeholder="bv_u_..."
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-ring"
-              disabled={submitting}
-            />
+            Paste your <span className="font-mono">bv_u_</span> key — for legacy accounts or
+            CLI-provisioned users.
           </>
-        )}
-
-        {error ? (
-          <div className="mt-3 flex items-start gap-1.5 text-xs text-status-failed">
-            <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>{error}</span>
-          </div>
-        ) : null}
-
-        <button
-          type="submit"
-          disabled={
-            submitting ||
-            (mode === "password"
-              ? email.trim().length === 0 || password.length === 0
-              : keyDraft.trim().length === 0)
-          }
-          className="mt-5 w-full inline-flex items-center justify-center gap-1.5 h-9 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {submitting ? (
-            <>
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              {mode === "password" ? "Signing in…" : "Verifying…"}
-            </>
-          ) : (
-            <>
-              <LogIn className="h-3.5 w-3.5" />
-              Sign in
-            </>
-          )}
-        </button>
-
+        )
+      }
+      onSubmit={passwordMode ? submitPassword : submitKey}
+      error={error}
+      submit={{
+        label: "Sign in",
+        icon: LogIn,
+        pendingLabel: passwordMode ? "Signing in…" : "Verifying…",
+        pending: submitting,
+        disabled: passwordMode
+          ? email.trim().length === 0 || password.length === 0
+          : keyDraft.trim().length === 0,
+      }}
+      secondary={
         <button
           type="button"
           onClick={() => {
@@ -228,19 +154,62 @@ export function SignInClient() {
           disabled={submitting}
           className="mt-3 w-full text-[11px] text-muted-foreground hover:text-foreground transition-colors cursor-pointer disabled:opacity-50"
         >
-          {mode === "password"
+          {passwordMode
             ? "Or sign in with your bv_u_ key"
             : "Or sign in with email + password"}
         </button>
-
-        <footer className="mt-5 pt-4 border-t border-border/60 text-[11px] text-muted-foreground leading-relaxed">
+      }
+      footer={
+        <>
           New here?{" "}
           <Link href="/sign-up" className="text-foreground/80 hover:underline">
             Sign up
           </Link>{" "}
           — takes about 5 seconds.
-        </footer>
-      </form>
-    </main>
+        </>
+      }
+    >
+      {passwordMode ? (
+        <>
+          <AuthField
+            id="email"
+            label="Email"
+            type="email"
+            autoComplete="email"
+            inputMode="email"
+            autoFocus
+            value={email}
+            onChange={setEmail}
+            placeholder="alice@example.com"
+            disabled={submitting}
+          />
+          <AuthField
+            id="password"
+            label="Password"
+            type="password"
+            autoComplete="current-password"
+            value={password}
+            onChange={setPassword}
+            placeholder="••••••••"
+            disabled={submitting}
+            spaced
+          />
+        </>
+      ) : (
+        <AuthField
+          id="key"
+          label="User API key"
+          type="password"
+          autoComplete="off"
+          autoFocus
+          spellCheck={false}
+          value={keyDraft}
+          onChange={setKeyDraft}
+          placeholder="bv_u_..."
+          disabled={submitting}
+          inputClassName="font-mono"
+        />
+      )}
+    </AuthCard>
   );
 }

--- a/packages/web/app/sign-up/sign-up-client.tsx
+++ b/packages/web/app/sign-up/sign-up-client.tsx
@@ -3,11 +3,12 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { AlertTriangle, Loader2, Sparkles, UserPlus } from "lucide-react";
+import { Sparkles, UserPlus } from "lucide-react";
 import { PASSWORD_MIN_LENGTH } from "@beevibe/core/auth/constants";
 import { api } from "@/lib/api/client";
 import { asApiError } from "@/lib/api/http";
 import { getUserKey, isApiConfigured, setUserKey } from "@/lib/api/config";
+import { AUTH_API_NOT_CONFIGURED, AuthCard, AuthField } from "@/components/auth/auth-card";
 
 /**
  * Self-serve signup. Visitor enters name + email; the api mints them a
@@ -41,7 +42,7 @@ export function SignUpClient() {
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!isApiConfigured) {
-      setError("Web isn't configured to talk to an api server.");
+      setError(AUTH_API_NOT_CONFIGURED);
       return;
     }
     if (password.length < PASSWORD_MIN_LENGTH) {
@@ -88,105 +89,72 @@ export function SignUpClient() {
   };
 
   return (
-    <main className="min-h-screen flex items-center justify-center px-6 bg-background">
-      <form
-        onSubmit={submit}
-        className="w-full max-w-sm bg-card border border-border rounded-lg p-6 shadow-sm"
-      >
-        <header className="mb-5">
-          <div className="inline-flex items-center justify-center h-10 w-10 rounded-md bg-primary text-primary-foreground mb-3">
-            <UserPlus className="h-5 w-5" />
-          </div>
-          <h1 className="text-lg font-semibold tracking-tight">Sign up for beevibe</h1>
-          <p className="mt-1 text-xs text-muted-foreground leading-relaxed">
-            We&apos;ll mint you a personal team agent. Your key stays in your browser only — you
-            can come back and sign in with the same email later.
-          </p>
-        </header>
-
-        <label className="block text-xs font-medium text-foreground mb-1.5" htmlFor="name">
-          Name
-        </label>
-        <input
-          id="name"
-          type="text"
-          autoComplete="name"
-          autoFocus
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Alice"
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-          disabled={submitting}
-        />
-
-        <label className="block text-xs font-medium text-foreground mb-1.5 mt-3" htmlFor="email">
-          Email
-        </label>
-        <input
-          id="email"
-          type="email"
-          autoComplete="email"
-          inputMode="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          placeholder="alice@example.com"
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-          disabled={submitting}
-        />
-
-        <label className="block text-xs font-medium text-foreground mb-1.5 mt-3" htmlFor="password">
-          Password
-        </label>
-        <input
-          id="password"
-          type="password"
-          autoComplete="new-password"
-          minLength={PASSWORD_MIN_LENGTH}
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          placeholder={`at least ${PASSWORD_MIN_LENGTH} characters`}
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-          disabled={submitting}
-        />
-
-        {error ? (
-          <div className="mt-3 flex items-start gap-1.5 text-xs text-status-failed">
-            <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>{error}</span>
-          </div>
-        ) : null}
-
-        <button
-          type="submit"
-          disabled={
-            submitting ||
-            name.trim().length === 0 ||
-            email.trim().length === 0 ||
-            password.length < PASSWORD_MIN_LENGTH
-          }
-          className="mt-5 w-full inline-flex items-center justify-center gap-1.5 h-9 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {submitting ? (
-            <>
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              Provisioning…
-            </>
-          ) : (
-            <>
-              <Sparkles className="h-3.5 w-3.5" />
-              Create my team agent
-            </>
-          )}
-        </button>
-
-        <footer className="mt-5 pt-4 border-t border-border/60 text-[11px] text-muted-foreground leading-relaxed">
+    <AuthCard
+      icon={UserPlus}
+      title="Sign up for beevibe"
+      blurb={
+        <>
+          We&apos;ll mint you a personal team agent. Your key stays in your browser only — you
+          can come back and sign in with the same email later.
+        </>
+      }
+      onSubmit={submit}
+      error={error}
+      submit={{
+        label: "Create my team agent",
+        icon: Sparkles,
+        pendingLabel: "Provisioning…",
+        pending: submitting,
+        disabled:
+          name.trim().length === 0 ||
+          email.trim().length === 0 ||
+          password.length < PASSWORD_MIN_LENGTH,
+      }}
+      footer={
+        <>
           Already have a key?{" "}
           <Link href="/sign-in" className="text-foreground/80 hover:underline">
             Sign in
           </Link>{" "}
           instead.
-        </footer>
-      </form>
-    </main>
+        </>
+      }
+    >
+      <AuthField
+        id="name"
+        label="Name"
+        type="text"
+        autoComplete="name"
+        autoFocus
+        value={name}
+        onChange={setName}
+        placeholder="Alice"
+        disabled={submitting}
+      />
+      <AuthField
+        id="email"
+        label="Email"
+        type="email"
+        autoComplete="email"
+        inputMode="email"
+        value={email}
+        onChange={setEmail}
+        placeholder="alice@example.com"
+        disabled={submitting}
+        spaced
+      />
+      <AuthField
+        id="password"
+        label="Password"
+        type="password"
+        autoComplete="new-password"
+        minLength={PASSWORD_MIN_LENGTH}
+        value={password}
+        onChange={setPassword}
+        placeholder={`at least ${PASSWORD_MIN_LENGTH} characters`}
+        disabled={submitting}
+        spaced
+      />
+    </AuthCard>
   );
 }

--- a/packages/web/components/auth/auth-card.tsx
+++ b/packages/web/components/auth/auth-card.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import type { FormEvent, ReactNode } from "react";
+import { AlertTriangle, Loader2, type LucideIcon } from "lucide-react";
+
+/**
+ * The card `/sign-in` and `/sign-up` are both built out of.
+ *
+ * The two pages had the same page shell, the same header (icon badge,
+ * title, blurb), the same labeled inputs, the same error banner and the
+ * same submit button written out twice — five copies of one 90-character
+ * `className` between them, and two copies of the pending-vs-idle button
+ * body. What actually differs between the pages is the fields and what
+ * submitting does, which is what stays in the page.
+ *
+ * The pieces are separate exports rather than one do-everything component
+ * because sign-in renders two different field sets (password mode and
+ * paste-your-key mode) inside the same card.
+ */
+
+/** Shared input styling — the one place the form's text-field look lives. */
+const FIELD_CLASS =
+  "w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring";
+
+interface AuthCardProps {
+  icon: LucideIcon;
+  title: string;
+  /** Prose under the title. Rich rather than string — both pages inline `<span className="font-mono">`. */
+  blurb: ReactNode;
+  onSubmit: (e: FormEvent) => void;
+  children: ReactNode;
+  /** Message from a failed submit, rendered above the button. */
+  error?: string | null;
+  submit: {
+    label: string;
+    icon: LucideIcon;
+    /** Label while the request is in flight; the spinner replaces `icon`. */
+    pendingLabel: string;
+    pending: boolean;
+    disabled: boolean;
+  };
+  /** Optional link-style button between submit and footer (sign-in's mode switch). */
+  secondary?: ReactNode;
+  footer: ReactNode;
+}
+
+export function AuthCard({
+  icon: Icon,
+  title,
+  blurb,
+  onSubmit,
+  children,
+  error,
+  submit,
+  secondary,
+  footer,
+}: AuthCardProps) {
+  const SubmitIcon = submit.icon;
+  return (
+    <main className="min-h-screen flex items-center justify-center px-6 bg-background">
+      <form
+        onSubmit={onSubmit}
+        className="w-full max-w-sm bg-card border border-border rounded-lg p-6 shadow-sm"
+      >
+        <header className="mb-5">
+          <div className="inline-flex items-center justify-center h-10 w-10 rounded-md bg-primary text-primary-foreground mb-3">
+            <Icon className="h-5 w-5" />
+          </div>
+          <h1 className="text-lg font-semibold tracking-tight">{title}</h1>
+          <p className="mt-1 text-xs text-muted-foreground leading-relaxed">{blurb}</p>
+        </header>
+
+        {children}
+
+        {error ? (
+          <div className="mt-3 flex items-start gap-1.5 text-xs text-status-failed">
+            <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+            <span>{error}</span>
+          </div>
+        ) : null}
+
+        <button
+          type="submit"
+          disabled={submit.pending || submit.disabled}
+          className="mt-5 w-full inline-flex items-center justify-center gap-1.5 h-9 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {submit.pending ? (
+            <>
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              {submit.pendingLabel}
+            </>
+          ) : (
+            <>
+              <SubmitIcon className="h-3.5 w-3.5" />
+              {submit.label}
+            </>
+          )}
+        </button>
+
+        {secondary}
+
+        <footer className="mt-5 pt-4 border-t border-border/60 text-[11px] text-muted-foreground leading-relaxed">
+          {footer}
+        </footer>
+      </form>
+    </main>
+  );
+}
+
+interface AuthFieldProps {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  type?: "text" | "email" | "password";
+  autoComplete?: string;
+  inputMode?: "email";
+  autoFocus?: boolean;
+  spellCheck?: boolean;
+  minLength?: number;
+  placeholder?: string;
+  disabled?: boolean;
+  /** Extra classes on the input — the key field adds `font-mono`. */
+  inputClassName?: string;
+  /** Adds the top margin every field after the first one carries. */
+  spaced?: boolean;
+}
+
+/** A labeled text input. Six of these existed across the two pages. */
+export function AuthField({
+  id,
+  label,
+  value,
+  onChange,
+  type = "text",
+  inputClassName,
+  spaced,
+  ...input
+}: AuthFieldProps) {
+  return (
+    <>
+      <label
+        className={`block text-xs font-medium text-foreground mb-1.5${spaced ? " mt-3" : ""}`}
+        htmlFor={id}
+      >
+        {label}
+      </label>
+      <input
+        id={id}
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className={inputClassName ? `${FIELD_CLASS} ${inputClassName}` : FIELD_CLASS}
+        {...input}
+      />
+    </>
+  );
+}
+
+/**
+ * The message both pages show when `NEXT_PUBLIC_BV_API_URL` is unset and
+ * the user submits anyway. Distinct from `lib/api/messages` — that copy
+ * addresses a page that can't load, this one a form that can't post.
+ */
+export const AUTH_API_NOT_CONFIGURED = "Web isn't configured to talk to an api server.";

--- a/packages/web/components/detail/detail-gate.test.tsx
+++ b/packages/web/components/detail/detail-gate.test.tsx
@@ -69,7 +69,7 @@ describe("DetailGate", () => {
   it("echoes the id in the fetch-error message", () => {
     renderGate({ data: undefined, isLoading: false, isError: true });
     expect(screen.getByText("Couldn't load work product")).toBeInTheDocument();
-    expect(screen.getByText(/Work product wp_42 could not be fetched\./)).toBeInTheDocument();
+    expect(screen.getByText(/\(wp_42\)/)).toBeInTheDocument();
   });
 
   // A query can settle without erroring and still hand back nothing (a 404

--- a/packages/web/components/detail/detail-gate.tsx
+++ b/packages/web/components/detail/detail-gate.tsx
@@ -3,6 +3,12 @@
 import type { ReactNode } from "react";
 import { AlertTriangle, type LucideIcon } from "lucide-react";
 import { isApiConfigured } from "@/lib/api/config";
+import {
+  API_NOT_CONFIGURED_TITLE,
+  API_UNREACHABLE_DESCRIPTION,
+  apiNotConfiguredDescription,
+  couldNotLoadTitle,
+} from "@/lib/api/messages";
 import { DetailShell } from "./detail-shell";
 import { EmptyState } from "@/components/empty-state";
 
@@ -48,8 +54,8 @@ export function DetailGate<T>({ nav, icon, noun, id, query, skeleton, children }
       <DetailShell nav={nav}>
         <EmptyState
           icon={icon}
-          title="API not configured"
-          description={`Set NEXT_PUBLIC_BV_API_URL and run the API server to load this ${noun}.`}
+          title={API_NOT_CONFIGURED_TITLE}
+          description={apiNotConfiguredDescription(`this ${noun}`)}
         />
       </DetailShell>
     );
@@ -60,13 +66,12 @@ export function DetailGate<T>({ nav, icon, noun, id, query, skeleton, children }
   }
 
   if (query.isError || !query.data) {
-    const Noun = noun.charAt(0).toUpperCase() + noun.slice(1);
     return (
       <DetailShell nav={nav}>
         <EmptyState
           icon={AlertTriangle}
-          title={`Couldn't load ${noun}`}
-          description={`${Noun} ${id} could not be fetched. Check the API server logs.`}
+          title={couldNotLoadTitle(noun)}
+          description={`${API_UNREACHABLE_DESCRIPTION} (${id})`}
         />
       </DetailShell>
     );

--- a/packages/web/components/share-link-box.tsx
+++ b/packages/web/components/share-link-box.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
+
+/**
+ * A copyable link in a bordered box, with a lead line above it.
+ *
+ * Both invite dialogs — "Invite to room" in `rooms/[id]` and "Invite a
+ * teammate" in the user widget — end at the same place: a sign-up URL the
+ * user is meant to send to someone. Each had its own copy of the box, the
+ * select-on-focus input, the copy button and its own `useCopyToClipboard`,
+ * differing only in the sentence above the link.
+ */
+export function ShareLinkBox({ lead, link }: { lead: ReactNode; link: string }) {
+  const { copied, copy } = useCopyToClipboard();
+  return (
+    <div className="mt-3 rounded border border-border bg-muted/40 p-3">
+      <div className="text-[11px] text-muted-foreground mb-1.5">{lead}</div>
+      <div className="flex items-center gap-1.5">
+        <input
+          readOnly
+          value={link}
+          className="flex-1 rounded border border-border bg-background px-2 py-1.5 text-[11px] font-mono"
+          onFocus={(e) => e.currentTarget.select()}
+        />
+        <button
+          type="button"
+          onClick={() => void copy(link)}
+          className="h-7 px-2.5 rounded text-[11px] font-medium border border-border hover:bg-secondary transition-colors cursor-pointer shrink-0"
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/user-widget.tsx
+++ b/packages/web/components/user-widget.tsx
@@ -14,7 +14,7 @@ import {
 } from "lucide-react";
 import { useMe } from "@/lib/hooks/use-me";
 import { useDismissOnOutside } from "@/lib/hooks/use-dismiss";
-import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
+import { ShareLinkBox } from "@/components/share-link-box";
 import { ModalOverlay } from "@/components/modal-overlay";
 import { clearUserKey } from "@/lib/api/config";
 import { cn } from "@/lib/utils";
@@ -148,7 +148,6 @@ function MenuItem({
 
 function InviteTeammateDialog({ onClose }: { onClose: () => void }) {
   const [email, setEmail] = useState("");
-  const { copied, copy } = useCopyToClipboard();
   const trimmed = email.trim().toLowerCase();
   const valid = EMAIL_RE.test(trimmed);
   const origin = typeof window !== "undefined" ? window.location.origin : "";
@@ -173,26 +172,7 @@ function InviteTeammateDialog({ onClose }: { onClose: () => void }) {
           className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
         />
         {shareLink ? (
-          <div className="mt-3 rounded border border-border bg-muted/40 p-3">
-            <div className="text-[11px] text-muted-foreground mb-1.5">
-              Send them this link:
-            </div>
-            <div className="flex items-center gap-1.5">
-              <input
-                readOnly
-                value={shareLink}
-                className="flex-1 rounded border border-border bg-background px-2 py-1.5 text-[11px] font-mono"
-                onFocus={(e) => e.currentTarget.select()}
-              />
-              <button
-                type="button"
-                onClick={() => void copy(shareLink)}
-                className="h-7 px-2.5 rounded text-[11px] font-medium border border-border hover:bg-secondary transition-colors cursor-pointer shrink-0"
-              >
-                {copied ? "Copied" : "Copy"}
-              </button>
-            </div>
-          </div>
+          <ShareLinkBox lead="Send them this link:" link={shareLink} />
         ) : null}
         <div className="mt-4 flex items-center justify-end gap-2">
           <button

--- a/packages/web/lib/api/messages.ts
+++ b/packages/web/lib/api/messages.ts
@@ -1,0 +1,45 @@
+/**
+ * The two things every page says when it can't show data, in one place.
+ *
+ * Eleven surfaces — nine list pages, the detail gate, and the room detail
+ * panel — each spelled out their own version of "the web isn't wired to a
+ * backend" and "the backend didn't answer". The wording had drifted three
+ * ways on the same process: "run the MCP server" (six pages), "run the api
+ * server" (two), "run the API server" (one). There is one server; a user
+ * comparing two pages should not have to guess whether they name the same
+ * thing.
+ *
+ * The titles had drifted further, and misleadingly: an unconfigured web
+ * showed "No mesh asks yet" / "No promotions yet" / "No facts learned yet"
+ * — which reads as "your account is empty" when the truth is that
+ * `NEXT_PUBLIC_BV_API_URL` was never set. {@link API_NOT_CONFIGURED_TITLE}
+ * is what those branches say now.
+ *
+ * Only the copy is shared. Each page keeps its own envelope (a dashed-
+ * border card, a table row spanning six columns, a centered shell), which
+ * is genuinely per-layout and not worth a component seam.
+ */
+
+/** Title for the "no `NEXT_PUBLIC_BV_API_URL`" branch. */
+export const API_NOT_CONFIGURED_TITLE = "API not configured";
+
+/**
+ * Description for the same branch. `noun` completes "…to load {noun}" —
+ * lowercase, and the thing the page shows: "agents", "tasks", "mesh
+ * activity", "this task".
+ */
+export function apiNotConfiguredDescription(noun: string): string {
+  return `Set NEXT_PUBLIC_BV_API_URL and run the API server to load ${noun}.`;
+}
+
+/** Title for the "configured, but the fetch failed" branch. */
+export function couldNotLoadTitle(noun: string): string {
+  return `Couldn't load ${noun}`;
+}
+
+/**
+ * Description for the same branch. The api is configured, so the actionable
+ * hint is about reachability rather than configuration.
+ */
+export const API_UNREACHABLE_DESCRIPTION =
+  "The API is configured but didn't answer. Check that the API server is running.";

--- a/packages/web/lib/tasks-grouping.ts
+++ b/packages/web/lib/tasks-grouping.ts
@@ -1,63 +1,42 @@
-import type { TaskStatus } from "@beevibe/core";
+import { TASK_LIFECYCLES, TASK_LIFECYCLE_OF } from "@beevibe/core/domain/task";
 import type { TaskListItem } from "@/lib/types/tasks";
 import type { BoardLane } from "@/components/tasks/board-column";
 
-export type Lifecycle =
-  | "pending"
-  | "in_progress"
-  | "blocked"
-  | "in_review"
-  | "done"
-  | "archived";
+/**
+ * Board-lane presentation — labels and dot colors — over the lifecycle
+ * vocabulary in `@beevibe/core`'s `domain/task.ts`.
+ *
+ * The lanes and the status → lane mapping used to be declared here and
+ * mirrored, four-lanes-deep and already drifted, in
+ * `packages/api/src/views/tasks-grouping.ts`. Only the styling below is
+ * web-specific, so only the styling lives here now.
+ *
+ * Imported via `@beevibe/core/domain/task`, NOT the package root: these
+ * are runtime *values* in a module the client bundle pulls in, and the
+ * root barrel re-exports `./auth`, which reaches for `node:crypto` and
+ * fails `next build` with `UnhandledSchemeError`. Same reasoning as
+ * `domain/format` — see its header.
+ */
+
+export type { TaskLifecycle as Lifecycle } from "@beevibe/core";
+
+type Lane = (typeof TASK_LIFECYCLES)[number];
+
+const LANE_STYLE: Record<Lane, { label: string; dot: string }> = {
+  pending: { label: "Pending", dot: "bg-muted-foreground/50" },
+  in_progress: { label: "In progress", dot: "bg-status-running" },
+  blocked: { label: "Blocked", dot: "bg-status-blocked" },
+  in_review: { label: "In review", dot: "bg-status-review" },
+  done: { label: "Done", dot: "bg-status-done" },
+  archived: { label: "Archived", dot: "bg-muted-foreground/40" },
+};
 
 /**
- * Status → lifecycle lane.
- *
- * - `blocked` lives in its own lane (was previously folded into
- *   In review). Blocked = waiting on an external dependency, semantically
- *   different from "waiting on a human verdict." Different action by the
- *   human reading the board, so different column.
- * - `failed` and `cancelled` are terminal states that aren't success.
- *   They go into the `archived` lane, hidden by default — `Done` should
- *   read as "this shipped." Archive toggle exposes them when the user
- *   wants to see what didn't ship.
+ * Lanes rendered by default. `archived` (failed + cancelled) is appended
+ * only when the user flips the archive toggle — `Done` should read as
+ * "this shipped".
  */
-const LIFECYCLE_OF: Record<TaskStatus, Lifecycle> = {
-  pending: "pending",
-  assigned: "pending",
-  in_progress: "in_progress",
-  revision: "in_progress",
-  needs_revision: "in_progress",
-  review: "in_review",
-  blocked: "blocked",
-  done: "done",
-  failed: "archived",
-  cancelled: "archived",
-};
-
-interface LaneTemplate {
-  key: Lifecycle;
-  label: string;
-  dot: string;
-}
-
-// Workflow-order, left-to-right. Blocked sits between In progress and
-// In review because that's where blockers actually arise — work
-// started, hit an impasse, needs unblocking before it can land in
-// review.
-const VISIBLE_LANES: LaneTemplate[] = [
-  { key: "pending", label: "Pending", dot: "bg-muted-foreground/50" },
-  { key: "in_progress", label: "In progress", dot: "bg-status-running" },
-  { key: "blocked", label: "Blocked", dot: "bg-status-blocked" },
-  { key: "in_review", label: "In review", dot: "bg-status-review" },
-  { key: "done", label: "Done", dot: "bg-status-done" },
-];
-
-const ARCHIVED_LANE: LaneTemplate = {
-  key: "archived",
-  label: "Archived",
-  dot: "bg-muted-foreground/40",
-};
+const VISIBLE_LANES = TASK_LIFECYCLES.filter((l) => l !== "archived");
 
 interface GroupOptions {
   /** Append the Archived lane (failed + cancelled). Default: false. */
@@ -68,22 +47,16 @@ export function groupTasks(
   tasks: TaskListItem[],
   options: GroupOptions = {},
 ): BoardLane[] {
-  const buckets: Record<Lifecycle, TaskListItem[]> = {
-    pending: [],
-    in_progress: [],
-    blocked: [],
-    in_review: [],
-    done: [],
-    archived: [],
-  };
-  for (const t of tasks) buckets[LIFECYCLE_OF[t.status]].push(t);
-  const template = options.showArchived
-    ? [...VISIBLE_LANES, ARCHIVED_LANE]
-    : VISIBLE_LANES;
-  return template.map((l) => ({
-    ...l,
-    count: buckets[l.key].length,
-    tasks: buckets[l.key],
+  const buckets = Object.fromEntries(
+    TASK_LIFECYCLES.map((l) => [l, [] as TaskListItem[]]),
+  ) as Record<Lane, TaskListItem[]>;
+  for (const t of tasks) buckets[TASK_LIFECYCLE_OF[t.status]].push(t);
+  const lanes = options.showArchived ? TASK_LIFECYCLES : VISIBLE_LANES;
+  return lanes.map((key) => ({
+    key,
+    ...LANE_STYLE[key],
+    count: buckets[key].length,
+    tasks: buckets[key],
   }));
 }
 
@@ -91,7 +64,7 @@ export function groupTasks(
 export function countArchivedTasks(tasks: TaskListItem[]): number {
   let n = 0;
   for (const t of tasks) {
-    if (t.status === "failed" || t.status === "cancelled") n += 1;
+    if (TASK_LIFECYCLE_OF[t.status] === "archived") n += 1;
   }
   return n;
 }


### PR DESCRIPTION
Five things declared twice (or nine times) that are one thing. Prior sweeps (#259, #263, #266, #271, #276, #277, #279, #281, #283) covered `core` and `api`; most of what's left lives in `web`, which hadn't been swept.

## 1. Task lifecycle vocabulary — api ↔ web, and already drifted

`packages/web/lib/tasks-grouping.ts` declared six board lanes and a status → lane map. `packages/api/src/views/tasks-grouping.ts` declared **four** and called itself a "server-side mirror" of the first.

They disagreed. The api folded `blocked` into `in_review` and `failed`/`cancelled` into `done`, so the lanes the user sees on the board were not the lanes the api can filter by. Because `GET /task` silently drops a `lifecycle` value it doesn't recognize, `?lifecycle=blocked` returned **every** task rather than the blocked ones. The web types `TaskListFilter.lifecycle` from its own six-lane union, so the mismatch was reachable — it just isn't currently exercised (the web declares the filter but doesn't send it yet).

Both sides now read `TaskLifecycle` / `TASK_LIFECYCLE_OF` / `TASK_STATUSES_BY_LIFECYCLE` from `@beevibe/core`'s `domain/task.ts`, with the status sets **derived by inverting** the map so the two directions can't disagree again.

- The api gains working `blocked` and `archived` filters.
- `sprint` and `timeline` are respelled lane-by-lane so their status sets are byte-for-byte what they were before the lane split.

Reached via a new `@beevibe/core/domain/task` subpath rather than the root barrel — these are runtime *values* in a client-bundled module, and the root re-exports `./auth` (`node:crypto`), which fails `next build` with `UnhandledSchemeError`. Same reasoning as the existing `domain/format` subpath; recorded in `CLAUDE.md`.

## 2. CLI runtime session plumbing — three copies

claude-code, codex and opencode each wrote out the same sequence: accumulate events off a line reader, spawn, flush the trailing partial line, warn on truncation, short-circuit an abort into `cancelledResult`, otherwise parse and `finalizeCliResult`.

Identical, but not interchangeably so — the ordering carries real constraints (flush must precede parse or the last event is dropped; the abort check must precede parse or a cancelled session reports as failed) that were enforced only by each copy happening to be right.

Now `runCliSession` in `runtime-common.ts`, with the three genuinely provider-specific pieces passed in as hooks: `parseLine`, `extractSteps`, `parseResult`. Codex's `--output-last-message` side-channel file has to outlive the parse, hence the `cleanup` hook that runs after it.

## 3. "The web can't reach the api" copy — eleven surfaces, three names for one process

Nine list pages, the detail gate and the room detail panel each had their own wording for the same two states. On one process, the copy said "run the MCP server" (six pages), "run the api server" (two) and "run the API server" (one).

The titles had drifted further, and misleadingly: an unconfigured web showed **"No mesh asks yet" / "No promotions yet" / "No facts learned yet"** — which reads as an empty account when the actual problem is that `NEXT_PUBLIC_BV_API_URL` was never set.

One `lib/api/messages.ts` holds the copy. Each page keeps its own envelope (a dashed-border card, a table row spanning six columns, a centered shell) — that part is genuinely per-layout and not worth a component seam.

## 4. The auth form shell — sign-in ↔ sign-up

Same page shell, same header, same error banner, same submit button written out twice, including five copies of one 90-character input `className` between them. Now `AuthCard` + `AuthField`; each page keeps its own fields and its own submit logic. They're separate exports because sign-in renders two different field sets (password mode, paste-your-key mode) inside one card.

## 5. The invite dialogs' share-link box

The room invite and the teammate invite both end at a sign-up URL to send someone. Each had its own copy of the bordered box, the select-on-focus input, the copy button and its own `useCopyToClipboard` — differing only in the sentence above the link. Now `ShareLinkBox`.

## Behavior change worth flagging

`GET /task?lifecycle=in_review` no longer includes `blocked` tasks, and `?lifecycle=done` no longer includes `failed`/`cancelled` — those are now `?lifecycle=blocked` and `?lifecycle=archived`. This aligns the api with the six lanes the board already renders. `view=sprint` and `view=timeline` are unchanged.

## Verification

- Monorepo `typecheck` + `lint` clean (15/15 turbo tasks).
- All packages build, including a full `next build` — which is what proves the new core subpath doesn't pull `node:crypto` into the client bundle.
- **web** 203/203 pass · **api** 827/827 pass · **core** 609 pass, with only the documented no-Postgres / no-provider-key failures (`CLAUDE.md`'s environmental-failure table).
- Updated the four tests that asserted the old drifted copy, and the one that pinned the api's four-lane grouping; added exhaustive per-lane coverage plus a regression test asserting `sprint`/`timeline` keep their exact status sets.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tf7cMmFDBEezvxZfaV9d9L)_