### PR TITLE
test: cover the six worst-tested critical paths (api 75% → 81% lines)

### DIFF
--- a/packages/api/src/routes/chat.test.ts
+++ b/packages/api/src/routes/chat.test.ts
@@ -1,0 +1,819 @@
+/**
+ * `createChatRouter` — the human chat surface, unit-tested with vitest
+ * fakes (no DB, no CLI).
+ *
+ * The pure helpers (`groupIntoConversations`, `chainToMessages`,
+ * `failureMessageFor`) are pinned by `chat-internals.test.ts`. This
+ * suite covers the four handlers around them, which is where the
+ * product-critical branching lives: the human gate, the primary-agent
+ * lookups, idempotent replay of a retried POST, the rate limiter, the
+ * daemon-offline 503, the resolver timeout 504, and the onboarding
+ * flag flip on the first successful turn.
+ *
+ * Everything the router closes over is a port, so a bag of `vi.fn()`s
+ * plus a stub auth middleware reaches every branch. `processResponse`
+ * and `truncate` run for real — their output is part of the wire
+ * contract these tests are pinning.
+ */
+import express, { json } from "express";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  PersonRepository,
+  Runtime,
+  RuntimeRepository,
+  Session,
+  SessionRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import type { ChatResolver } from "../runtime/chat-resolver.js";
+import type { DaemonHub } from "../runtime/hub.js";
+import { ChatRateLimiter } from "./chat-rate-limit.js";
+import { createChatRouter, type ChatRoutesDeps } from "./chat.js";
+
+const PERSON = "person_alice";
+const AGENT = "agent_alicesteam";
+
+// ── Fixtures ─────────────────────────────────────────────────────────────
+
+function fakeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: AGENT,
+    name: "Alice's Team",
+    owner_id: PERSON,
+    hierarchy_level: "team",
+    runtime_config: { type: "claude" },
+    created_at: new Date("2026-01-01T00:00:00Z"),
+    updated_at: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  } as Agent;
+}
+
+function fakeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "sess_aaaaaaaaaaaa",
+    agent_id: AGENT,
+    type: "chat",
+    status: "succeeded",
+    intent: "hello",
+    created_at: new Date("2026-01-02T00:00:00Z"),
+    updated_at: new Date("2026-01-02T00:00:00Z"),
+    ...overrides,
+  } as Session;
+}
+
+// ── Fake ports ───────────────────────────────────────────────────────────
+
+function stubAuth(source: "human" | "agent" = "human") {
+  return (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    req.caller =
+      source === "human"
+        ? { source: "human", agentId: AGENT, hierarchyLevel: "team", personId: PERSON }
+        : { source: "agent", agentId: AGENT, hierarchyLevel: "ic" };
+    next();
+  };
+}
+
+interface Ports {
+  agentRepo: AgentRepository;
+  personRepo: PersonRepository;
+  runtimeRepo: RuntimeRepository;
+  sessionRepo: SessionRepository;
+  dispatchService: DispatchService;
+  chatResolver: ChatResolver;
+  hub: DaemonHub;
+  rateLimiter?: ChatRateLimiter;
+}
+
+function makePorts(overrides: Partial<Ports> = {}): Ports {
+  return {
+    agentRepo: {
+      findTopLevelForOwner: vi.fn(async () => fakeAgent()),
+    } as unknown as AgentRepository,
+    personRepo: {
+      findById: vi.fn(async () => ({
+        id: PERSON,
+        onboarding_completed_at: new Date("2026-01-01T00:00:00Z"),
+      })),
+      update: vi.fn(async () => undefined),
+    } as unknown as PersonRepository,
+    runtimeRepo: {
+      findById: vi.fn(async () => undefined),
+    } as unknown as RuntimeRepository,
+    sessionRepo: {
+      findById: vi.fn(async () => undefined),
+      listChatForAgent: vi.fn(async () => []),
+      softDeleteChatChain: vi.fn(async () => 0),
+    } as unknown as SessionRepository,
+    dispatchService: {
+      dispatchTask: vi.fn(async () => ({
+        session: fakeSession({ status: "pending" }),
+        runtime_id: null,
+      })),
+    } as unknown as DispatchService,
+    chatResolver: {
+      register: vi.fn(async () => fakeSession({ result_summary: "done" })),
+    } as unknown as ChatResolver,
+    hub: { isOnline: vi.fn(() => true) } as unknown as DaemonHub,
+    ...overrides,
+  };
+}
+
+function makeApp(ports: Ports, source: "human" | "agent" = "human") {
+  const app = express();
+  app.use(json());
+  app.use(
+    "/chat",
+    createChatRouter({ authMiddleware: stubAuth(source), ...ports } as ChatRoutesDeps),
+  );
+  return app;
+}
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── GET /chat/conversations ──────────────────────────────────────────────
+
+describe("GET /chat/conversations", () => {
+  it("403s an agent-token caller", async () => {
+    const res = await request(makeApp(makePorts(), "agent")).get("/chat/conversations");
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("human_required");
+  });
+
+  it("returns an empty list when the caller has no primary agent", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.agentRepo.findTopLevelForOwner).mockResolvedValue(undefined);
+
+    const res = await request(makeApp(ports)).get("/chat/conversations");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, conversations: [] });
+    // Never reaches the session repo when there's nothing to list for.
+    expect(ports.sessionRepo.listChatForAgent).not.toHaveBeenCalled();
+  });
+
+  it("summarises each chain: title, turn count, last activity, preview", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.sessionRepo.listChatForAgent).mockResolvedValue([
+      fakeSession({
+        id: "sess_head00000001",
+        intent: "ship the launch checklist",
+        created_at: new Date("2026-01-02T10:00:00Z"),
+        result_summary: "first reply",
+      }),
+      fakeSession({
+        id: "sess_tail00000001",
+        prior_session_id: "sess_head00000001",
+        intent: "and the rollout plan",
+        created_at: new Date("2026-01-02T10:05:00Z"),
+        result_summary: "second   reply\nwith whitespace",
+      } as Partial<Session>),
+    ]);
+
+    const res = await request(makeApp(ports)).get("/chat/conversations");
+
+    expect(res.status).toBe(200);
+    expect(res.body.conversations).toHaveLength(1);
+    expect(res.body.conversations[0]).toMatchObject({
+      head_id: "sess_head00000001",
+      title: "ship the launch checklist",
+      turn_count: 2,
+      last_at: "2026-01-02T10:05:00.000Z",
+      // Preview is collapsed to a single line off the *last* turn.
+      last_preview: "second reply with whitespace",
+    });
+  });
+
+  it("truncates a long first message into the thread title", async () => {
+    const ports = makePorts();
+    const longIntent = "x".repeat(200);
+    vi.mocked(ports.sessionRepo.listChatForAgent).mockResolvedValue([
+      fakeSession({ intent: longIntent }),
+    ]);
+
+    const res = await request(makeApp(ports)).get("/chat/conversations");
+
+    expect(res.body.conversations[0].title.length).toBeLessThanOrEqual(80);
+    expect(res.body.conversations[0].title.endsWith("…")).toBe(true);
+  });
+
+  it("previews the error, then the intent, when a turn produced no summary", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.sessionRepo.listChatForAgent)
+      .mockResolvedValueOnce([
+        fakeSession({ id: "sess_err000000a1", error: "boom", result_summary: undefined }),
+      ])
+      .mockResolvedValueOnce([
+        fakeSession({ id: "sess_bare00000a1", result_summary: undefined }),
+      ]);
+
+    const app = makeApp(ports);
+    const withError = await request(app).get("/chat/conversations");
+    const bare = await request(app).get("/chat/conversations");
+
+    expect(withError.body.conversations[0].last_preview).toBe("boom");
+    expect(bare.body.conversations[0].last_preview).toBe("hello");
+  });
+});
+
+// ── DELETE /chat/conversations/:headId ───────────────────────────────────
+
+describe("DELETE /chat/conversations/:headId", () => {
+  it("soft-deletes the chain scoped to the caller's agent", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.sessionRepo.softDeleteChatChain).mockResolvedValue(3);
+
+    const res = await request(makeApp(ports)).delete("/chat/conversations/sess_head00000001");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, deleted: 3 });
+    expect(ports.sessionRepo.softDeleteChatChain).toHaveBeenCalledWith(
+      "sess_head00000001",
+      AGENT,
+    );
+  });
+
+  it("404s when the caller has no primary agent", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.agentRepo.findTopLevelForOwner).mockResolvedValue(undefined);
+
+    const res = await request(makeApp(ports)).delete("/chat/conversations/sess_head00000001");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("agent_not_found");
+  });
+
+  it("403s an agent-token caller", async () => {
+    const res = await request(makeApp(makePorts(), "agent")).delete(
+      "/chat/conversations/sess_head00000001",
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  it("turns a repo failure into a 500 with a request id, not a stack trace", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.sessionRepo.softDeleteChatChain).mockRejectedValue(
+      new Error("connection terminated unexpectedly"),
+    );
+
+    const res = await request(makeApp(ports)).delete("/chat/conversations/sess_head00000001");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("internal_error");
+    expect(res.body.request_id).toMatch(/^req_/);
+    expect(JSON.stringify(res.body)).not.toContain("connection terminated");
+  });
+});
+
+// ── GET /chat ────────────────────────────────────────────────────────────
+
+describe("GET /chat", () => {
+  it("403s an agent-token caller", async () => {
+    const res = await request(makeApp(makePorts(), "agent")).get("/chat");
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns a null agent and no messages when none is provisioned", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.agentRepo.findTopLevelForOwner).mockResolvedValue(undefined);
+
+    const res = await request(makeApp(ports)).get("/chat");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      agent: null,
+      messages: [],
+      prior_session_id: null,
+      conversation_id: null,
+    });
+  });
+
+  it("returns the most recent chain rehydrated as user/agent messages", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.sessionRepo.listChatForAgent).mockResolvedValue([
+      fakeSession({
+        id: "sess_old000000a1",
+        intent: "older thread",
+        created_at: new Date("2026-01-01T00:00:00Z"),
+        result_summary: "older reply",
+      }),
+      fakeSession({
+        id: "sess_new000000a1",
+        intent: "newer thread",
+        created_at: new Date("2026-01-03T00:00:00Z"),
+        result_summary: "newer reply",
+      }),
+    ]);
+
+    const res = await request(makeApp(ports)).get("/chat");
+
+    expect(res.status).toBe(200);
+    expect(res.body.agent).toEqual({ id: AGENT, name: "Alice's Team", hierarchy: "team" });
+    expect(res.body.conversation_id).toBe("sess_new000000a1");
+    expect(res.body.prior_session_id).toBe("sess_new000000a1");
+    expect(res.body.messages).toEqual([
+      { id: "u_sess_new000000a1", role: "user", content: "newer thread" },
+      {
+        id: "a_sess_new000000a1",
+        role: "agent",
+        content: "newer reply",
+        session_id: "sess_new000000a1",
+      },
+    ]);
+  });
+
+  it("renders a failed turn as an agent message carrying the failure text", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.sessionRepo.listChatForAgent).mockResolvedValue([
+      fakeSession({
+        id: "sess_failed0001",
+        intent: "do the thing",
+        status: "failed",
+        result_summary: undefined,
+        error: "claude runtime 'claude' is not installed on this daemon",
+      }),
+    ]);
+
+    const res = await request(makeApp(ports)).get("/chat");
+
+    expect(res.body.messages).toHaveLength(2);
+    expect(res.body.messages[1]).toMatchObject({
+      id: "a_sess_failed0001",
+      role: "agent",
+      session_id: "sess_failed0001",
+    });
+    expect(res.body.messages[1].content).toContain("not installed");
+  });
+
+  it("selects a specific conversation via ?c=", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.sessionRepo.listChatForAgent).mockResolvedValue([
+      fakeSession({
+        id: "sess_old000000a1",
+        intent: "older thread",
+        created_at: new Date("2026-01-01T00:00:00Z"),
+      }),
+      fakeSession({
+        id: "sess_new000000a1",
+        intent: "newer thread",
+        created_at: new Date("2026-01-03T00:00:00Z"),
+      }),
+    ]);
+
+    const res = await request(makeApp(ports)).get("/chat?c=sess_old000000a1");
+
+    expect(res.body.conversation_id).toBe("sess_old000000a1");
+    expect(res.body.messages[0].content).toBe("older thread");
+  });
+
+  it("renders the empty state (not a 404) for an unknown ?c=", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.sessionRepo.listChatForAgent).mockResolvedValue([fakeSession()]);
+
+    const res = await request(makeApp(ports)).get("/chat?c=sess_nosuchchain");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      agent: { id: AGENT, name: "Alice's Team", hierarchy: "team" },
+      messages: [],
+      prior_session_id: null,
+      conversation_id: null,
+    });
+  });
+
+  it("flags an in-flight tail session so the UI can resume its thinking indicator", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.sessionRepo.listChatForAgent).mockResolvedValue([
+      fakeSession({ id: "sess_running0001", status: "running", result_summary: undefined }),
+    ]);
+
+    const res = await request(makeApp(ports)).get("/chat");
+
+    expect(res.body.in_flight_session_id).toBe("sess_running0001");
+    // The agent reply slot stays empty until /runtime/done lands.
+    expect(res.body.messages).toHaveLength(1);
+  });
+
+  it("omits in_flight_session_id once the tail is terminal", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.sessionRepo.listChatForAgent).mockResolvedValue([fakeSession()]);
+
+    const res = await request(makeApp(ports)).get("/chat");
+
+    expect(res.body.in_flight_session_id).toBeUndefined();
+  });
+
+  it("surfaces a runtime mismatch when the chain is pinned to another CLI", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.sessionRepo.listChatForAgent).mockResolvedValue([
+      fakeSession({ runtime_id: "rt_1" } as Partial<Session>),
+    ]);
+    vi.mocked(ports.runtimeRepo.findById).mockResolvedValue({
+      id: "rt_1",
+      cli: "codex",
+    } as unknown as Runtime);
+
+    const res = await request(makeApp(ports)).get("/chat");
+
+    expect(res.body.runtime_mismatch).toEqual({ pinned_cli: "codex", current_cli: "claude" });
+  });
+
+  it("stays silent when the pinned runtime matches the agent's current CLI", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.sessionRepo.listChatForAgent).mockResolvedValue([
+      fakeSession({ runtime_id: "rt_1" } as Partial<Session>),
+    ]);
+    vi.mocked(ports.runtimeRepo.findById).mockResolvedValue({
+      id: "rt_1",
+      cli: "claude",
+    } as unknown as Runtime);
+
+    const res = await request(makeApp(ports)).get("/chat");
+
+    expect(res.body.runtime_mismatch).toBeUndefined();
+  });
+
+  it("stays silent when the pinned runtime row is gone or runs an unknown CLI", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.sessionRepo.listChatForAgent).mockResolvedValue([
+      fakeSession({ runtime_id: "rt_gone" } as Partial<Session>),
+    ]);
+    vi.mocked(ports.runtimeRepo.findById)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({ id: "rt_gone", cli: "totally-unknown" } as unknown as Runtime);
+
+    const app = makeApp(ports);
+    const missing = await request(app).get("/chat");
+    const unknownCli = await request(app).get("/chat");
+
+    expect(missing.body.runtime_mismatch).toBeUndefined();
+    expect(unknownCli.body.runtime_mismatch).toBeUndefined();
+  });
+
+  it("skips the runtime lookup entirely for an unpinned chain", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.sessionRepo.listChatForAgent).mockResolvedValue([fakeSession()]);
+
+    await request(makeApp(ports)).get("/chat");
+
+    expect(ports.runtimeRepo.findById).not.toHaveBeenCalled();
+  });
+});
+
+// ── POST /chat ───────────────────────────────────────────────────────────
+
+describe("POST /chat", () => {
+  it("403s an agent-token caller", async () => {
+    const res = await request(makeApp(makePorts(), "agent"))
+      .post("/chat")
+      .send({ message: "hi" });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("400s on a missing or whitespace-only message", async () => {
+    const app = makeApp(makePorts());
+
+    const missing = await request(app).post("/chat").send({});
+    const blank = await request(app).post("/chat").send({ message: "   " });
+
+    expect(missing.status).toBe(400);
+    expect(missing.body.error).toBe("message_required");
+    expect(blank.status).toBe(400);
+  });
+
+  it("404s when the caller has no primary agent", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.agentRepo.findTopLevelForOwner).mockResolvedValue(undefined);
+
+    const res = await request(makeApp(ports)).post("/chat").send({ message: "hi" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("no_primary_agent");
+  });
+
+  it("dispatches a fresh turn and returns the resolved reply", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.chatResolver.register).mockResolvedValue(
+      fakeSession({
+        id: "sess_done00000a1",
+        result_summary: "shipped it — see sess_aaaaaaaaaaaa",
+      }),
+    );
+
+    const res = await request(makeApp(ports)).post("/chat").send({ message: "  ship it  " });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      agent: { id: AGENT, name: "Alice's Team", hierarchy: "team" },
+      session_id: "sess_done00000a1",
+      status: "succeeded",
+    });
+    // processResponse ran for real: the inline id became a view ref.
+    expect(res.body.view_refs).toEqual(["sess_aaaaaaaaaaaa"]);
+    expect(ports.dispatchService.dispatchTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: AGENT,
+        intent: "ship it",
+        type: "chat",
+        reason: { kind: "fresh" },
+      }),
+    );
+  });
+
+  it("passes prior_session_id through as a chat_continuation resume reason", async () => {
+    const ports = makePorts();
+
+    await request(makeApp(ports))
+      .post("/chat")
+      .send({ message: "and then?", prior_session_id: "sess_prior00001" });
+
+    expect(ports.dispatchService.dispatchTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: { kind: "chat_continuation", prior_session_id: "sess_prior00001" },
+      }),
+    );
+  });
+
+  it("honours a well-formed client session_id and ignores a malformed one", async () => {
+    const ports = makePorts();
+    const app = makeApp(ports);
+
+    await request(app).post("/chat").send({ message: "a", session_id: "sess_abc123DEF456" });
+    await request(app).post("/chat").send({ message: "b", session_id: "not-a-session-id" });
+
+    expect(vi.mocked(ports.dispatchService.dispatchTask).mock.calls[0]?.[0]).toMatchObject({
+      sessionIdOverride: "sess_abc123DEF456",
+    });
+    expect(
+      vi.mocked(ports.dispatchService.dispatchTask).mock.calls[1]?.[0].sessionIdOverride,
+    ).toBeUndefined();
+  });
+
+  it("replays a finished turn instead of spawning a second CLI", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.sessionRepo.findById).mockResolvedValue(
+      fakeSession({ id: "sess_abc123DEF456", result_summary: "already answered" }),
+    );
+
+    const res = await request(makeApp(ports))
+      .post("/chat")
+      .send({ message: "hi", session_id: "sess_abc123DEF456" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.replayed).toBe(true);
+    expect(res.body.response).toBe("already answered");
+    expect(ports.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("replays a failed turn with the friendly failure message", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.sessionRepo.findById).mockResolvedValue(
+      fakeSession({
+        id: "sess_abc123DEF456",
+        status: "failed",
+        result_summary: undefined,
+        error: "CLI exited with code 1",
+      }),
+    );
+
+    const res = await request(makeApp(ports))
+      .post("/chat")
+      .send({ message: "hi", session_id: "sess_abc123DEF456" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("failed");
+    // The bare exit line is swapped for the daemon-log pointer.
+    expect(res.body.response).toContain("beevibe-daemon start");
+  });
+
+  it("409s while the referenced session is still running", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.sessionRepo.findById).mockResolvedValue(
+      fakeSession({ id: "sess_abc123DEF456", status: "running" }),
+    );
+
+    const res = await request(makeApp(ports))
+      .post("/chat")
+      .send({ message: "hi", session_id: "sess_abc123DEF456" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe("session_in_flight");
+  });
+
+  it("403s when the session id belongs to a different caller's agent", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.sessionRepo.findById).mockResolvedValue(
+      fakeSession({ id: "sess_abc123DEF456", agent_id: "agent_someoneelse" }),
+    );
+
+    const res = await request(makeApp(ports))
+      .post("/chat")
+      .send({ message: "hi", session_id: "sess_abc123DEF456" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("session_belongs_to_other_caller");
+  });
+
+  it("falls through to a live dispatch when the id is unknown, non-chat, or still pending", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.sessionRepo.findById)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(fakeSession({ id: "sess_abc123DEF456", type: "task" }))
+      .mockResolvedValueOnce(fakeSession({ id: "sess_abc123DEF456", status: "pending" }));
+
+    const app = makeApp(ports);
+    for (const _ of [0, 1, 2]) {
+      const res = await request(app)
+        .post("/chat")
+        .send({ message: "hi", session_id: "sess_abc123DEF456" });
+      expect(res.status).toBe(200);
+      expect(res.body.replayed).toBeUndefined();
+    }
+    expect(ports.dispatchService.dispatchTask).toHaveBeenCalledTimes(3);
+  });
+
+  it("429s a second concurrent turn and releases the slot afterwards", async () => {
+    const ports = makePorts({ rateLimiter: new ChatRateLimiter({ maxConcurrent: 1 }) });
+    let unblock: (s: Session) => void = () => {};
+    // Only the first turn hangs; later turns fall back to the default
+    // immediately-resolving fake.
+    vi.mocked(ports.chatResolver.register).mockImplementationOnce(
+      () =>
+        new Promise<Session>((resolve) => {
+          unblock = resolve;
+        }),
+    );
+
+    const app = makeApp(ports);
+    // `.then()` is what actually fires a supertest request — without it
+    // the first turn would never reach the handler and the slot would
+    // still be free when the second arrives.
+    const first = request(app)
+      .post("/chat")
+      .send({ message: "one" })
+      .then((r) => r);
+    // Let the first request reach `chatResolver.register` before firing
+    // the second, so the concurrency slot is genuinely held.
+    await vi.waitFor(() => expect(ports.chatResolver.register).toHaveBeenCalled());
+
+    const second = await request(app).post("/chat").send({ message: "two" });
+    expect(second.status).toBe(429);
+    expect(second.body.error).toBe("turn_in_flight");
+    expect(second.headers["retry-after"]).toBeDefined();
+
+    unblock(fakeSession({ result_summary: "ok" }));
+    expect((await first).status).toBe(200);
+
+    // Slot released — a follow-up turn is accepted again.
+    const third = await request(app).post("/chat").send({ message: "three" });
+    expect(third.status).toBe(200);
+  });
+
+  it("429s once the sliding window is exhausted", async () => {
+    const ports = makePorts({
+      rateLimiter: new ChatRateLimiter({ maxPerWindow: 1, now: () => 1_000 }),
+    });
+
+    const app = makeApp(ports);
+    expect((await request(app).post("/chat").send({ message: "one" })).status).toBe(200);
+    const second = await request(app).post("/chat").send({ message: "two" });
+
+    expect(second.status).toBe(429);
+    expect(second.body.error).toBe("rate_limited");
+    expect(second.body.retry_after_ms).toBeGreaterThan(0);
+  });
+
+  it("503s when the session is bound to an offline daemon", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.dispatchService.dispatchTask).mockResolvedValue({
+      session: fakeSession({ status: "pending" }),
+      runtime_id: "rt_offline",
+    });
+    vi.mocked(ports.hub.isOnline).mockReturnValue(false);
+
+    const res = await request(makeApp(ports)).post("/chat").send({ message: "hi" });
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe("agent_offline");
+    expect(ports.chatResolver.register).not.toHaveBeenCalled();
+  });
+
+  it("proceeds for a null-runtime agent even with no daemon online", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.hub.isOnline).mockReturnValue(false);
+
+    const res = await request(makeApp(ports)).post("/chat").send({ message: "hi" });
+
+    expect(res.status).toBe(200);
+    expect(ports.hub.isOnline).not.toHaveBeenCalled();
+  });
+
+  it("504s when the resolver times out", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.chatResolver.register).mockRejectedValue(
+      new Error("chat resolver timeout (90000ms) for sess_aaaaaaaaaaaa"),
+    );
+
+    const res = await request(makeApp(ports)).post("/chat").send({ message: "hi" });
+
+    expect(res.status).toBe(504);
+    expect(res.body.error).toBe("chat_turn_timeout");
+    expect(res.body.timeout_ms).toBe(90_000);
+  });
+
+  it("500s on a non-timeout resolver failure", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.chatResolver.register).mockRejectedValue(new Error("resolver exploded"));
+
+    const res = await request(makeApp(ports)).post("/chat").send({ message: "hi" });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("internal_error");
+  });
+
+  it("500s and releases the rate-limit slot when dispatch throws", async () => {
+    const ports = makePorts({ rateLimiter: new ChatRateLimiter({ maxConcurrent: 1 }) });
+    vi.mocked(ports.dispatchService.dispatchTask).mockRejectedValueOnce(
+      new Error("insert failed"),
+    );
+
+    const app = makeApp(ports);
+    const failed = await request(app).post("/chat").send({ message: "hi" });
+    expect(failed.status).toBe(500);
+
+    // If the slot had leaked, this would come back 429.
+    const retry = await request(app).post("/chat").send({ message: "hi" });
+    expect(retry.status).toBe(200);
+  });
+
+  it("flips onboarding_completed_at on the first successful turn", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.personRepo.findById).mockResolvedValue({
+      id: PERSON,
+      onboarding_completed_at: null,
+    } as unknown as Awaited<ReturnType<PersonRepository["findById"]>>);
+
+    const res = await request(makeApp(ports)).post("/chat").send({ message: "hi" });
+
+    expect(res.status).toBe(200);
+    expect(ports.personRepo.update).toHaveBeenCalledWith(
+      PERSON,
+      expect.objectContaining({ onboarding_completed_at: expect.any(Date) }),
+    );
+  });
+
+  it("does not re-flip onboarding for an already-onboarded person", async () => {
+    const ports = makePorts();
+
+    await request(makeApp(ports)).post("/chat").send({ message: "hi" });
+
+    expect(ports.personRepo.update).not.toHaveBeenCalled();
+  });
+
+  it("does not flip onboarding when the first turn failed", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.personRepo.findById).mockResolvedValue({
+      id: PERSON,
+      onboarding_completed_at: null,
+    } as unknown as Awaited<ReturnType<PersonRepository["findById"]>>);
+    vi.mocked(ports.chatResolver.register).mockResolvedValue(
+      fakeSession({ status: "failed", result_summary: undefined, error: "nope" }),
+    );
+
+    const res = await request(makeApp(ports)).post("/chat").send({ message: "hi" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("failed");
+    expect(res.body.response).toBe("nope");
+    expect(ports.personRepo.update).not.toHaveBeenCalled();
+  });
+
+  it("still answers the turn when the onboarding flip write fails", async () => {
+    const ports = makePorts();
+    vi.mocked(ports.personRepo.findById).mockResolvedValue({
+      id: PERSON,
+      onboarding_completed_at: null,
+    } as unknown as Awaited<ReturnType<PersonRepository["findById"]>>);
+    vi.mocked(ports.personRepo.update).mockRejectedValue(new Error("write failed"));
+
+    const res = await request(makeApp(ports)).post("/chat").send({ message: "hi" });
+
+    expect(res.status).toBe(200);
+    await vi.waitFor(() => expect(console.error).toHaveBeenCalled());
+  });
+});

--- a/packages/api/src/tools/session-search.test.ts
+++ b/packages/api/src/tools/session-search.test.ts
@@ -1,0 +1,262 @@
+/**
+ * `session_search` MCP tool — unit tests with a fake SessionSearchService.
+ *
+ * The tool's own logic is `inferRequest`: four calling shapes picked
+ * apart from one loose bag of LLM-supplied keys, with a documented
+ * precedence (scroll beats read beats discover beats browse). Getting
+ * that wrong silently answers a different question than the agent
+ * asked, so the shape table is what these tests pin — plus the two
+ * error surfaces (`null` → not_found_or_forbidden, SessionSearchError →
+ * its own code), which agents branch on.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { SessionSearchRequest } from "@beevibe/core";
+import {
+  SessionSearchError,
+  type SessionSearchService,
+} from "@beevibe/core/services/session-search";
+import {
+  createSessionSearchTool,
+  type SessionSearchToolContext,
+} from "./session-search.js";
+
+const CTX: SessionSearchToolContext = {
+  agentId: "agent_searcher01",
+  hierarchyLevel: "team",
+  sessionId: "sess_current0001",
+};
+
+function makeTool(ctx: Partial<SessionSearchToolContext> = {}) {
+  const sessionSearch = {
+    search: vi.fn(async () => ({ kind: "browse", sessions: [] })),
+  } as unknown as SessionSearchService;
+  const tool = createSessionSearchTool({ ...CTX, ...ctx }, { sessionSearch });
+  return { tool, sessionSearch };
+}
+
+/** The request the tool handed to the service on its first call. */
+function requestFrom(service: SessionSearchService): SessionSearchRequest {
+  return vi.mocked(service.search).mock.calls[0]?.[0] as SessionSearchRequest;
+}
+
+describe("session_search shape inference", () => {
+  it("browses when called with no arguments", async () => {
+    const { tool, sessionSearch } = makeTool();
+
+    await tool.handler({});
+
+    expect(requestFrom(sessionSearch)).toEqual({
+      kind: "browse",
+      limit: undefined,
+      filters: undefined,
+    });
+  });
+
+  it("discovers when given a query", async () => {
+    const { tool, sessionSearch } = makeTool();
+
+    await tool.handler({ query: "  auth refactor  ", limit: 7, sort: "newest" });
+
+    expect(requestFrom(sessionSearch)).toEqual({
+      kind: "discover",
+      query: "auth refactor",
+      limit: 7,
+      sort: "newest",
+      filters: undefined,
+    });
+  });
+
+  it("reads the whole conversation for a bare session_id", async () => {
+    const { tool, sessionSearch } = makeTool();
+
+    await tool.handler({ session_id: "  sess_target0001  " });
+
+    expect(requestFrom(sessionSearch)).toEqual({
+      kind: "read",
+      session_id: "sess_target0001",
+    });
+  });
+
+  it("scrolls when session_id and around_message_id are both present", async () => {
+    const { tool, sessionSearch } = makeTool();
+
+    await tool.handler({
+      session_id: "sess_target0001",
+      around_message_id: "  evt_anchor0001  ",
+      window: 12,
+    });
+
+    expect(requestFrom(sessionSearch)).toEqual({
+      kind: "scroll",
+      session_id: "sess_target0001",
+      around_message_id: "evt_anchor0001",
+      window: 12,
+    });
+  });
+
+  it("prefers scroll over the query the caller also sent", async () => {
+    const { tool, sessionSearch } = makeTool();
+
+    await tool.handler({
+      query: "ignored",
+      session_id: "sess_target0001",
+      around_message_id: "evt_anchor0001",
+    });
+
+    expect(requestFrom(sessionSearch).kind).toBe("scroll");
+  });
+
+  it("prefers read over discover when both session_id and query are set", async () => {
+    const { tool, sessionSearch } = makeTool();
+
+    await tool.handler({ query: "auth refactor", session_id: "sess_target0001" });
+
+    expect(requestFrom(sessionSearch)).toEqual({
+      kind: "read",
+      session_id: "sess_target0001",
+    });
+  });
+
+  it("treats blank and non-string ids or queries as absent", async () => {
+    const { tool, sessionSearch } = makeTool();
+
+    await tool.handler({ query: "   ", session_id: "  ", around_message_id: 5 });
+
+    expect(requestFrom(sessionSearch).kind).toBe("browse");
+  });
+
+  it("falls back to read when the anchor is blank", async () => {
+    const { tool, sessionSearch } = makeTool();
+
+    await tool.handler({ session_id: "sess_target0001", around_message_id: "   " });
+
+    expect(requestFrom(sessionSearch).kind).toBe("read");
+  });
+
+  it("drops non-numeric limit/window and unknown sort values", async () => {
+    const { tool, sessionSearch } = makeTool();
+
+    await tool.handler({ query: "x", limit: "3", sort: "sideways" });
+    await tool.handler({
+      session_id: "sess_target0001",
+      around_message_id: "evt_a",
+      window: "10",
+    });
+
+    const calls = vi.mocked(sessionSearch.search).mock.calls;
+    expect(calls[0]?.[0]).toMatchObject({ limit: undefined, sort: undefined });
+    expect(calls[1]?.[0]).toMatchObject({ window: undefined });
+  });
+
+  it("forwards filters on the discover and browse shapes", async () => {
+    const { tool, sessionSearch } = makeTool();
+    const filters = { session_type: "task", status: "failed" };
+
+    await tool.handler({ query: "deploy", filters });
+    await tool.handler({ filters });
+
+    const calls = vi.mocked(sessionSearch.search).mock.calls;
+    expect(calls[0]?.[0]).toMatchObject({ kind: "discover", filters });
+    expect(calls[1]?.[0]).toMatchObject({ kind: "browse", filters });
+  });
+
+  it("ignores a non-object filters value instead of passing it down", async () => {
+    const { tool, sessionSearch } = makeTool();
+
+    await tool.handler({ filters: "status:failed" });
+    await tool.handler({ filters: null });
+
+    for (const call of vi.mocked(sessionSearch.search).mock.calls) {
+      expect((call[0] as { filters?: unknown }).filters).toBeUndefined();
+    }
+  });
+
+  it("passes the caller's identity and active session through as scope", async () => {
+    const { tool, sessionSearch } = makeTool({ hierarchyLevel: "org" });
+
+    await tool.handler({});
+
+    expect(vi.mocked(sessionSearch.search).mock.calls[0]?.[1]).toEqual({
+      callerAgentId: CTX.agentId,
+      hierarchyLevel: "org",
+      currentSessionId: CTX.sessionId,
+    });
+  });
+});
+
+describe("session_search results and errors", () => {
+  it("returns the service payload unchanged on success", async () => {
+    const { tool, sessionSearch } = makeTool();
+    const payload = { kind: "read", session_id: "sess_target0001", messages: [] };
+    vi.mocked(sessionSearch.search).mockResolvedValue(
+      payload as unknown as Awaited<ReturnType<SessionSearchService["search"]>>,
+    );
+
+    const res = await tool.handler({ session_id: "sess_target0001" });
+
+    expect(res.isError).toBeFalsy();
+    expect(res.content).toEqual(payload);
+  });
+
+  it("maps a null result to the shared not-found/forbidden error", async () => {
+    const { tool, sessionSearch } = makeTool();
+    vi.mocked(sessionSearch.search).mockResolvedValue(
+      null as unknown as Awaited<ReturnType<SessionSearchService["search"]>>,
+    );
+
+    const res = await tool.handler({ session_id: "sess_other00001" });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("not_found_or_forbidden");
+  });
+
+  it("surfaces a SessionSearchError's own code", async () => {
+    const { tool, sessionSearch } = makeTool();
+    vi.mocked(sessionSearch.search).mockRejectedValue(
+      new SessionSearchError("forbidden_agent_filter", "agent_x is outside your scope"),
+    );
+
+    const res = await tool.handler({ query: "x", filters: { agent_id: "agent_x" } });
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "forbidden_agent_filter",
+      message: "agent_x is outside your scope",
+    });
+  });
+
+  it("recognises a SessionSearchError from a different bundle by name", async () => {
+    // src/ and dist/ copies of core are distinct classes, so `instanceof`
+    // alone would silently downgrade the code to internal_error.
+    const { tool, sessionSearch } = makeTool();
+    const crossBundle = new Error("query is required for discovery");
+    crossBundle.name = "SessionSearchError";
+    (crossBundle as Error & { code: string }).code = "missing_query";
+    vi.mocked(sessionSearch.search).mockRejectedValue(crossBundle);
+
+    const res = await tool.handler({ query: "x" });
+
+    expect(res.content).toEqual({
+      error: "missing_query",
+      message: "query is required for discovery",
+    });
+  });
+
+  it("degrades any other throw to internal_error", async () => {
+    const { tool, sessionSearch } = makeTool();
+    vi.mocked(sessionSearch.search).mockRejectedValue(new Error("pool timeout"));
+
+    const res = await tool.handler({});
+
+    expect(res.content).toEqual({ error: "internal_error", message: "pool timeout" });
+  });
+
+  it("stringifies a non-Error throw", async () => {
+    const { tool, sessionSearch } = makeTool();
+    vi.mocked(sessionSearch.search).mockRejectedValue("connection reset");
+
+    const res = await tool.handler({});
+
+    expect(res.content).toEqual({ error: "internal_error", message: "connection reset" });
+  });
+});

--- a/packages/api/src/tools/use-repo.test.ts
+++ b/packages/api/src/tools/use-repo.test.ts
@@ -1,0 +1,337 @@
+/**
+ * `use_repo` MCP tool — unit tests with vitest fakes.
+ *
+ * The handler is a four-step sequence with a bail-out at each step:
+ * validate → resolve the caller → create the container task → dispatch
+ * the sandbox session → insert the repo_run row. Two of those steps can
+ * fail after side effects have already landed, and the ordering
+ * (session row before repo_run, because of the FK) is load-bearing, so
+ * the tests pin the call order as well as the responses.
+ *
+ * The limit clamps are the other half: they're the only thing stopping
+ * a hallucinated `disk_mb: 999999` from reaching the sandbox runner.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  RepoRunRepository,
+  Task,
+  TaskRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import { createUseRepoTool, type UseRepoServices } from "./use-repo.js";
+
+const AGENT = "agent_caller0001";
+
+function fakeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: AGENT,
+    name: "Sandbox Caller",
+    owner_id: "person_1",
+    hierarchy_level: "ic",
+    runtime_config: { type: "claude" },
+    created_at: new Date("2026-01-01T00:00:00Z"),
+    updated_at: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  } as Agent;
+}
+
+function makeServices(overrides: Partial<UseRepoServices> = {}): UseRepoServices {
+  return {
+    agentRepo: { findById: vi.fn(async () => fakeAgent()) } as unknown as AgentRepository,
+    taskRepo: {
+      create: vi.fn(async (input: Partial<Task>) => ({ ...input }) as Task),
+    } as unknown as TaskRepository,
+    repoRunRepo: { create: vi.fn(async () => undefined) } as unknown as RepoRunRepository,
+    dispatchService: {
+      dispatchTask: vi.fn(async () => ({ session: { id: "sess_x" }, runtime_id: null })),
+    } as unknown as DispatchService,
+    ...overrides,
+  };
+}
+
+function makeTool(services = makeServices()) {
+  return { tool: createUseRepoTool({ agentId: AGENT }, services), services };
+}
+
+const VALID = { goal: "extract the tables", repo_url: "https://github.com/acme/pdf-tools" };
+
+describe("use_repo tool metadata", () => {
+  it("advertises the required inputs so MCP clients can validate ahead of the call", () => {
+    const { tool } = makeTool();
+
+    expect(tool.name).toBe("use_repo");
+    expect(tool.schema.required).toEqual(["goal", "repo_url"]);
+    expect(tool.schema.additionalProperties).toBe(false);
+  });
+});
+
+describe("use_repo input validation", () => {
+  it("rejects a missing or whitespace-only goal before touching any repo", async () => {
+    const { tool, services } = makeTool();
+
+    const missing = await tool.handler({ repo_url: VALID.repo_url });
+    const blank = await tool.handler({ goal: "   ", repo_url: VALID.repo_url });
+
+    for (const res of [missing, blank]) {
+      expect(res.isError).toBe(true);
+      expect(res.content.error).toBe("invalid_goal");
+    }
+    expect(services.agentRepo.findById).not.toHaveBeenCalled();
+  });
+
+  it("rejects anything that isn't an https github.com URL", async () => {
+    const { tool, services } = makeTool();
+    const bad = [
+      undefined,
+      "",
+      "  ",
+      "not a url",
+      "http://github.com/acme/tool", // plaintext
+      "https://gitlab.com/acme/tool", // wrong host
+      "https://github.com.evil.example/acme/tool", // suffix spoof
+      "ftp://github.com/acme/tool",
+    ];
+
+    for (const repo_url of bad) {
+      const res = await tool.handler({ goal: VALID.goal, repo_url });
+      expect(res.isError, `expected ${String(repo_url)} to be rejected`).toBe(true);
+      expect(res.content.error).toBe("invalid_repo_url");
+    }
+    expect(services.taskRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("accepts github.com subdomains and trims surrounding whitespace", async () => {
+    const { tool, services } = makeTool();
+
+    const res = await tool.handler({
+      goal: "  extract the tables  ",
+      repo_url: "  https://www.github.com/acme/pdf-tools  ",
+    });
+
+    expect(res.isError).toBeFalsy();
+    expect(vi.mocked(services.repoRunRepo.create).mock.calls[0]?.[0]).toMatchObject({
+      goal: "extract the tables",
+      repo_url: "https://www.github.com/acme/pdf-tools",
+    });
+  });
+
+  it("errors when the calling agent no longer exists", async () => {
+    const services = makeServices();
+    vi.mocked(services.agentRepo.findById).mockResolvedValue(undefined);
+    const { tool } = makeTool(services);
+
+    const res = await tool.handler(VALID);
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("agent_not_found");
+    expect(services.taskRepo.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("use_repo happy path", () => {
+  it("creates a container task, dispatches the session, then inserts the repo_run", async () => {
+    const { tool, services } = makeTool();
+
+    const res = await tool.handler(VALID);
+
+    expect(res.isError).toBeFalsy();
+    const taskInput = vi.mocked(services.taskRepo.create).mock.calls[0]?.[0];
+    expect(taskInput).toMatchObject({
+      title: "extract the tables",
+      description: "extract the tables",
+      assignee_id: AGENT,
+      creator_id: AGENT,
+      creator_type: "agent",
+      priority: "medium",
+    });
+
+    const dispatchInput = vi.mocked(services.dispatchService.dispatchTask).mock.calls[0]?.[0];
+    expect(dispatchInput).toMatchObject({
+      agentId: AGENT,
+      type: "run_repo",
+      intent: "extract the tables",
+      reason: { kind: "fresh" },
+    });
+
+    // The FK on repo_run.session_id means the session must exist first:
+    // the pre-minted id is what ties the two inserts together.
+    const runInput = vi.mocked(services.repoRunRepo.create).mock.calls[0]?.[0];
+    expect(runInput?.session_id).toBe(dispatchInput?.sessionIdOverride);
+    expect(runInput).toMatchObject({
+      agent_id: AGENT,
+      repo_url: VALID.repo_url,
+      status: "pending",
+    });
+
+    expect(res.content).toMatchObject({
+      repo_run_id: runInput?.id,
+      session_id: runInput?.session_id,
+      task_id: taskInput?.id,
+      status: "pending",
+      watch_url: `/capabilities/runs/${runInput?.id}`,
+    });
+  });
+
+  it("mints fresh ids on every call", async () => {
+    const { tool } = makeTool();
+
+    const first = await tool.handler(VALID);
+    const second = await tool.handler(VALID);
+
+    expect(first.content.repo_run_id).not.toBe(second.content.repo_run_id);
+    expect(first.content.session_id).not.toBe(second.content.session_id);
+  });
+
+  it("collapses whitespace and truncates a long goal into the task title", async () => {
+    const { tool, services } = makeTool();
+
+    await tool.handler({ ...VALID, goal: `${"a".repeat(200)}\n\n  b` });
+
+    const title = vi.mocked(services.taskRepo.create).mock.calls[0]?.[0].title as string;
+    expect(title).toHaveLength(78); // 77 chars + the ellipsis
+    expect(title.endsWith("…")).toBe(true);
+  });
+
+  it("keeps a short goal as the title verbatim", async () => {
+    const { tool, services } = makeTool();
+
+    await tool.handler({ ...VALID, goal: "  pull   the  audio track " });
+
+    expect(vi.mocked(services.taskRepo.create).mock.calls[0]?.[0].title).toBe(
+      "pull the audio track",
+    );
+  });
+
+  it("echoes the optional input download hints back to the caller", async () => {
+    const { tool } = makeTool();
+
+    const res = await tool.handler({
+      ...VALID,
+      input_url: "  https://example.com/report.pdf  ",
+      input_filename: "  report.pdf  ",
+    });
+
+    expect(res.content.input_url).toBe("https://example.com/report.pdf");
+    expect(res.content.input_filename).toBe("report.pdf");
+  });
+
+  it("leaves the input hints undefined when they aren't strings", async () => {
+    const { tool } = makeTool();
+
+    const res = await tool.handler({ ...VALID, input_url: 42, input_filename: null });
+
+    expect(res.content.input_url).toBeUndefined();
+    expect(res.content.input_filename).toBeUndefined();
+  });
+});
+
+describe("use_repo limit parsing", () => {
+  it("passes sane limits through untouched", async () => {
+    const { tool } = makeTool();
+
+    const res = await tool.handler({
+      ...VALID,
+      limits: { wall_clock_minutes: 15, max_install_attempts: 3, disk_mb: 4096 },
+    });
+
+    expect(res.content.limits).toEqual({
+      wall_clock_minutes: 15,
+      max_install_attempts: 3,
+      disk_mb: 4096,
+    });
+  });
+
+  it("clamps oversized limits to the ceilings", async () => {
+    const { tool } = makeTool();
+
+    const res = await tool.handler({
+      ...VALID,
+      limits: { wall_clock_minutes: 9999, max_install_attempts: 99, disk_mb: 999_999 },
+    });
+
+    expect(res.content.limits).toEqual({
+      wall_clock_minutes: 60,
+      max_install_attempts: 5,
+      disk_mb: 10_000,
+    });
+  });
+
+  it("floors fractional counts so the sandbox runner gets integers", async () => {
+    const { tool } = makeTool();
+
+    const res = await tool.handler({
+      ...VALID,
+      limits: { max_install_attempts: 2.9, disk_mb: 1024.7 },
+    });
+
+    expect(res.content.limits).toEqual({ max_install_attempts: 2, disk_mb: 1024 });
+  });
+
+  it("drops non-positive and non-numeric limits rather than passing junk down", async () => {
+    const { tool } = makeTool();
+
+    const res = await tool.handler({
+      ...VALID,
+      limits: { wall_clock_minutes: 0, max_install_attempts: -1, disk_mb: "2048" },
+    });
+
+    expect(res.content.limits).toEqual({});
+  });
+
+  it("treats a missing or non-object `limits` as no limits", async () => {
+    const { tool } = makeTool();
+
+    const omitted = await tool.handler(VALID);
+    const wrongType = await tool.handler({ ...VALID, limits: "20 minutes" });
+    const nulled = await tool.handler({ ...VALID, limits: null });
+
+    for (const res of [omitted, wrongType, nulled]) {
+      expect(res.content.limits).toEqual({});
+    }
+  });
+});
+
+describe("use_repo failure handling", () => {
+  it("surfaces a dispatch failure without attempting the repo_run insert", async () => {
+    const services = makeServices();
+    vi.mocked(services.dispatchService.dispatchTask).mockRejectedValue(
+      new Error("no runtime bound"),
+    );
+    const { tool } = makeTool(services);
+
+    const res = await tool.handler(VALID);
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "dispatch_failed",
+      message: "no runtime bound",
+    });
+    expect(services.repoRunRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the orphaned-session case when the repo_run insert fails", async () => {
+    const services = makeServices();
+    vi.mocked(services.repoRunRepo.create).mockRejectedValue(new Error("duplicate key"));
+    const { tool } = makeTool(services);
+
+    const res = await tool.handler(VALID);
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "repo_run_create_failed",
+      message: "duplicate key",
+    });
+  });
+
+  it("stringifies a non-Error rejection instead of reporting an empty message", async () => {
+    const services = makeServices();
+    vi.mocked(services.dispatchService.dispatchTask).mockRejectedValue("socket hang up");
+    const { tool } = makeTool(services);
+
+    const res = await tool.handler(VALID);
+
+    expect(res.content.message).toBe("socket hang up");
+  });
+});

--- a/packages/api/src/tools/watch.test.ts
+++ b/packages/api/src/tools/watch.test.ts
@@ -1,0 +1,203 @@
+/**
+ * `watch_tasks` + `unwatch` MCP tools — unit tests with a fake
+ * WatchService.
+ *
+ * The tools are thin adapters, so what's worth pinning is exactly the
+ * part that isn't the service: the input coercion an LLM caller will
+ * get wrong (a bare string instead of an array, a nonsense `mode`, a
+ * blank `reason`), the missing-session guard, and the error-class →
+ * tool-error-code mapping — an agent branches on those codes, so a
+ * WatchAuthError degrading to a generic `watch_error` would be a real
+ * behaviour change.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  WatchAuthError,
+  WatchNotFoundError,
+  WatchValidationError,
+  type WatchService,
+} from "@beevibe/core/services/watch-service";
+import { buildWatchTools, type WatchToolContext } from "./watch.js";
+
+const AGENT = "agent_watcher001";
+const SESSION = "sess_watcher0001";
+
+function makeService(): WatchService {
+  return {
+    watchTasks: vi.fn(async () => ({ watchId: "twatch_1", firedImmediately: false })),
+    unwatch: vi.fn(async () => undefined),
+  } as unknown as WatchService;
+}
+
+function makeTools(ctx: Partial<WatchToolContext> = {}, watchService = makeService()) {
+  const [watchTasks, unwatch] = buildWatchTools(
+    { agentId: AGENT, sessionId: SESSION, ...ctx },
+    { watchService },
+  );
+  return { watchTasks: watchTasks!, unwatch: unwatch!, watchService };
+}
+
+describe("buildWatchTools", () => {
+  it("returns watch_tasks and unwatch, in that order", () => {
+    const { watchTasks, unwatch } = makeTools();
+
+    expect(watchTasks.name).toBe("watch_tasks");
+    expect(unwatch.name).toBe("unwatch");
+  });
+
+  it("advertises the mode enum the service accepts", () => {
+    const { watchTasks } = makeTools();
+    const props = watchTasks.schema.properties as Record<string, { enum?: string[] }>;
+
+    expect(props.mode?.enum).toEqual(["all", "any"]);
+    expect(watchTasks.schema.required).toEqual(["task_ids"]);
+  });
+});
+
+describe("watch_tasks", () => {
+  it("registers the watch and reports the service's result", async () => {
+    const { watchTasks, watchService } = makeTools();
+    vi.mocked(watchService.watchTasks).mockResolvedValue({
+      watchId: "twatch_abc",
+      firedImmediately: true,
+    });
+
+    const res = await watchTasks.handler({
+      task_ids: ["task_a", "task_b"],
+      mode: "any",
+      reason: "  waiting on the migration  ",
+    });
+
+    expect(res.isError).toBeFalsy();
+    expect(res.content).toEqual({ watch_id: "twatch_abc", fired_immediately: true });
+    expect(watchService.watchTasks).toHaveBeenCalledWith({
+      callerAgentId: AGENT,
+      callerSessionId: SESSION,
+      taskIds: ["task_a", "task_b"],
+      mode: "any",
+      reason: "waiting on the migration",
+    });
+  });
+
+  it("defaults to mode 'all' when the caller omits it or sends something unknown", async () => {
+    const { watchTasks, watchService } = makeTools();
+
+    await watchTasks.handler({ task_ids: ["task_a"] });
+    await watchTasks.handler({ task_ids: ["task_a"], mode: "sometimes" });
+    await watchTasks.handler({ task_ids: ["task_a"], mode: 7 });
+
+    for (const call of vi.mocked(watchService.watchTasks).mock.calls) {
+      expect(call[0].mode).toBe("all");
+    }
+  });
+
+  it("drops a blank or non-string reason rather than forwarding it", async () => {
+    const { watchTasks, watchService } = makeTools();
+
+    await watchTasks.handler({ task_ids: ["task_a"], reason: "   " });
+    await watchTasks.handler({ task_ids: ["task_a"], reason: 42 });
+
+    for (const call of vi.mocked(watchService.watchTasks).mock.calls) {
+      expect(call[0].reason).toBeUndefined();
+    }
+  });
+
+  it("filters non-string entries out of task_ids", async () => {
+    const { watchTasks, watchService } = makeTools();
+
+    await watchTasks.handler({ task_ids: ["task_a", 7, null, "task_b"] });
+
+    expect(vi.mocked(watchService.watchTasks).mock.calls[0]?.[0].taskIds).toEqual([
+      "task_a",
+      "task_b",
+    ]);
+  });
+
+  it("rejects task_ids that is missing, not an array, or empty after filtering", async () => {
+    const { watchTasks, watchService } = makeTools();
+
+    const cases = [{}, { task_ids: "task_a" }, { task_ids: [] }, { task_ids: [1, 2] }];
+    for (const input of cases) {
+      const res = await watchTasks.handler(input);
+      expect(res.isError).toBe(true);
+      expect(res.content.error).toBe("watch_validation");
+      expect(res.content.message).toContain("non-empty array");
+    }
+    expect(watchService.watchTasks).not.toHaveBeenCalled();
+  });
+
+  it("refuses to register a watch outside a session context", async () => {
+    const { watchTasks, watchService } = makeTools({ sessionId: undefined });
+
+    const res = await watchTasks.handler({ task_ids: ["task_a"] });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("watch_validation");
+    expect(res.content.message).toContain("session context");
+    expect(watchService.watchTasks).not.toHaveBeenCalled();
+  });
+
+  it("maps each WatchService error class to its own tool error code", async () => {
+    const cases = [
+      [new WatchAuthError("not your task"), "watch_auth", "not your task"],
+      [new WatchValidationError("too many tasks"), "watch_validation", "too many tasks"],
+      [
+        new WatchNotFoundError("twatch_gone"),
+        "watch_not_found",
+        "task_watch twatch_gone not found",
+      ],
+      [new Error("pool timeout"), "watch_error", "pool timeout"],
+      ["raw string blowup", "watch_error", "raw string blowup"],
+    ] as const;
+
+    for (const [thrown, code, message] of cases) {
+      const { watchTasks, watchService } = makeTools();
+      vi.mocked(watchService.watchTasks).mockRejectedValue(thrown);
+
+      const res = await watchTasks.handler({ task_ids: ["task_a"] });
+
+      expect(res.isError).toBe(true);
+      expect(res.content).toEqual({ error: code, message });
+    }
+  });
+});
+
+describe("unwatch", () => {
+  it("cancels the watch for the calling agent", async () => {
+    const { unwatch, watchService } = makeTools();
+
+    const res = await unwatch.handler({ watch_id: "twatch_abc" });
+
+    expect(res.isError).toBeFalsy();
+    expect(res.content).toEqual({ ok: true });
+    expect(watchService.unwatch).toHaveBeenCalledWith({
+      callerAgentId: AGENT,
+      watchId: "twatch_abc",
+    });
+  });
+
+  it("rejects a missing, blank, or non-string watch_id", async () => {
+    const { unwatch, watchService } = makeTools();
+
+    for (const input of [{}, { watch_id: "" }, { watch_id: 12 }]) {
+      const res = await unwatch.handler(input);
+      expect(res.isError).toBe(true);
+      expect(res.content.error).toBe("watch_validation");
+    }
+    expect(watchService.unwatch).not.toHaveBeenCalled();
+  });
+
+  it("maps a service throw through the same error mapping", async () => {
+    const { unwatch, watchService } = makeTools();
+    vi.mocked(watchService.unwatch).mockRejectedValue(
+      new WatchAuthError("watch belongs to another agent"),
+    );
+
+    const res = await unwatch.handler({ watch_id: "twatch_abc" });
+
+    expect(res.content).toEqual({
+      error: "watch_auth",
+      message: "watch belongs to another agent",
+    });
+  });
+});

--- a/packages/core/src/adapters/postgres/agent-provision-event-repo.test.ts
+++ b/packages/core/src/adapters/postgres/agent-provision-event-repo.test.ts
@@ -1,0 +1,165 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_RUNTIME_CONFIG } from "../../domain/agent.js";
+import { agentId, agentProvisionEventId, personId } from "../../domain/ids.js";
+import { createTestPool, truncateAll } from "../../test-helpers.js";
+import type { Pool } from "./client.js";
+import { PostgresAgentProvisionEventRepository } from "./agent-provision-event-repo.js";
+import { PostgresAgentRepository } from "./agent-repo.js";
+import { PostgresPersonRepository } from "./person-repo.js";
+
+/**
+ * `agent_provision_event` is the audit trail behind
+ * `create_subordinate_agent`. Its write side is live and accumulating
+ * rows, and `countByParentSince` is what enforces the per-parent spawn
+ * cap — a window query that silently counting wrong would either let a
+ * runaway parent spawn without limit or lock out a legitimate one.
+ * These tests pin the roundtrip, the time window, and the read halves
+ * the audit panel will consume.
+ */
+describe("PostgresAgentProvisionEventRepository", () => {
+  let pool: Pool;
+  let events: PostgresAgentProvisionEventRepository;
+  let agents: PostgresAgentRepository;
+  let persons: PostgresPersonRepository;
+
+  let owner: string;
+  let parent: string;
+  let child: string;
+
+  beforeAll(() => {
+    pool = createTestPool();
+    events = new PostgresAgentProvisionEventRepository(pool);
+    agents = new PostgresAgentRepository(pool);
+    persons = new PostgresPersonRepository(pool);
+  });
+
+  beforeEach(async () => {
+    await truncateAll(pool);
+    const person = await persons.create({ id: personId(), name: "Owner" });
+    owner = person.id;
+    const p = await agents.create({
+      id: agentId(),
+      name: "Parent",
+      owner_id: owner,
+      hierarchy_level: "team",
+      runtime_config: DEFAULT_RUNTIME_CONFIG,
+    });
+    parent = p.id;
+    const c = await agents.create({
+      id: agentId(),
+      name: "Child",
+      owner_id: owner,
+      hierarchy_level: "ic",
+      runtime_config: DEFAULT_RUNTIME_CONFIG,
+    });
+    child = c.id;
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  async function seedEvent(overrides: { parent?: string; createdAt?: Date } = {}) {
+    return events.create({
+      id: agentProvisionEventId(),
+      parent_agent_id: overrides.parent ?? parent,
+      child_agent_id: child,
+      owner_person_id: owner,
+      child_name: "Child",
+      persona: "A careful reviewer.",
+      domain: "code-review",
+      ...(overrides.createdAt ? { created_at: overrides.createdAt } : {}),
+    });
+  }
+
+  it("create returns the persisted row with every field intact", async () => {
+    const created = await seedEvent();
+
+    expect(created).toMatchObject({
+      parent_agent_id: parent,
+      child_agent_id: child,
+      owner_person_id: owner,
+      child_name: "Child",
+      persona: "A careful reviewer.",
+      domain: "code-review",
+    });
+    expect(created.id).toMatch(/^ape_/);
+    expect(created.created_at).toBeInstanceOf(Date);
+  });
+
+  it("defaults created_at to now when the caller omits it", async () => {
+    const before = Date.now();
+    const created = await seedEvent();
+
+    // A second of slack absorbs clock skew between the test process and
+    // the database server.
+    expect(created.created_at.getTime()).toBeGreaterThanOrEqual(before - 1_000);
+    expect(created.created_at.getTime()).toBeLessThanOrEqual(Date.now() + 1_000);
+  });
+
+  it("honours an explicit created_at so backfills keep their timestamps", async () => {
+    const stamped = new Date("2026-03-04T05:06:07.000Z");
+
+    const created = await seedEvent({ createdAt: stamped });
+
+    expect(created.created_at.toISOString()).toBe(stamped.toISOString());
+  });
+
+  describe("countByParentSince", () => {
+    it("counts only events inside the window", async () => {
+      const now = Date.now();
+      await seedEvent({ createdAt: new Date(now - 30 * 1000) }); // inside
+      await seedEvent({ createdAt: new Date(now - 90 * 1000) }); // outside
+      await seedEvent({ createdAt: new Date(now - 10 * 1000) }); // inside
+
+      expect(await events.countByParentSince(parent, 60)).toBe(2);
+      expect(await events.countByParentSince(parent, 3600)).toBe(3);
+    });
+
+    it("scopes the count to one parent", async () => {
+      const other = await agents.create({
+        id: agentId(),
+        name: "Other parent",
+        owner_id: owner,
+        hierarchy_level: "team",
+        runtime_config: DEFAULT_RUNTIME_CONFIG,
+      });
+      await seedEvent();
+      await seedEvent({ parent: other.id });
+
+      expect(await events.countByParentSince(parent, 3600)).toBe(1);
+      expect(await events.countByParentSince(other.id, 3600)).toBe(1);
+    });
+
+    it("returns 0 for a parent that never spawned anything", async () => {
+      expect(await events.countByParentSince(parent, 86_400)).toBe(0);
+    });
+  });
+
+  describe("listByParent", () => {
+    it("returns the parent's events newest first", async () => {
+      const now = Date.now();
+      const oldest = await seedEvent({ createdAt: new Date(now - 3_000) });
+      const middle = await seedEvent({ createdAt: new Date(now - 2_000) });
+      const newest = await seedEvent({ createdAt: new Date(now - 1_000) });
+
+      const listed = await events.listByParent(parent);
+
+      expect(listed.map((e) => e.id)).toEqual([newest.id, middle.id, oldest.id]);
+    });
+
+    it("caps at the supplied limit, and at 50 by default", async () => {
+      const now = Date.now();
+      for (let i = 0; i < 3; i++) {
+        await seedEvent({ createdAt: new Date(now - i * 1_000) });
+      }
+
+      expect(await events.listByParent(parent, 2)).toHaveLength(2);
+      expect(await events.listByParent(parent)).toHaveLength(3);
+    });
+
+    it("returns an empty list for an unknown parent", async () => {
+      expect(await events.listByParent("agent_nosuchagent")).toEqual([]);
+    });
+  });
+});

--- a/packages/core/src/adapters/postgres/promotion-event-repo.test.ts
+++ b/packages/core/src/adapters/postgres/promotion-event-repo.test.ts
@@ -1,0 +1,204 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_RUNTIME_CONFIG } from "../../domain/agent.js";
+import {
+  agentId,
+  factId,
+  personId,
+  promotionEventId,
+  sessionId,
+} from "../../domain/ids.js";
+import { createTestPool, truncateAll } from "../../test-helpers.js";
+import type { Pool } from "./client.js";
+import { PostgresAgentRepository } from "./agent-repo.js";
+import { PostgresMemoryFactRepository } from "./memory-fact-repo.js";
+import { PostgresMemoryPromotionEventRepository } from "./promotion-event-repo.js";
+import { PostgresPersonRepository } from "./person-repo.js";
+
+/** memory_fact.embedding is NOT NULL VECTOR(1536); any unit vector will do. */
+function unitVector(axis: number, dims = 1536): number[] {
+  const v = new Array<number>(dims).fill(0);
+  v[axis] = 1;
+  return v;
+}
+
+/**
+ * The M8.D promotion audit log. `bootstrap.ts` doesn't yet construct
+ * this adapter, so nothing exercised it — but the port, the MemoryAgent
+ * branch that writes through it and the `/promotions` read view all
+ * exist, and finishing that wiring is easier with the SQL pinned.
+ *
+ * The interesting parts are the two COALESCE defaults on insert
+ * (`source_session_ids`, `rejected`) and `listByOwner`, which reaches
+ * the owner through a join on the origin agent rather than the fact.
+ */
+describe("PostgresMemoryPromotionEventRepository", () => {
+  let pool: Pool;
+  let promotions: PostgresMemoryPromotionEventRepository;
+  let facts: PostgresMemoryFactRepository;
+  let agents: PostgresAgentRepository;
+  let persons: PostgresPersonRepository;
+
+  let owner: string;
+  let agent: string;
+  let fact: string;
+
+  beforeAll(() => {
+    pool = createTestPool();
+    promotions = new PostgresMemoryPromotionEventRepository(pool);
+    facts = new PostgresMemoryFactRepository(pool);
+    agents = new PostgresAgentRepository(pool);
+    persons = new PostgresPersonRepository(pool);
+  });
+
+  beforeEach(async () => {
+    await truncateAll(pool);
+    const person = await persons.create({ id: personId(), name: "Owner" });
+    owner = person.id;
+    const a = await agents.create({
+      id: agentId(),
+      name: "Origin",
+      owner_id: owner,
+      hierarchy_level: "ic",
+      runtime_config: DEFAULT_RUNTIME_CONFIG,
+    });
+    agent = a.id;
+    const f = await facts.create({
+      id: factId(),
+      agent_id: agent,
+      scope: "ic",
+      fact_type: "pattern",
+      content: "The deploy script needs a clean lockfile.",
+      embedding: unitVector(0),
+      source_chain_ids: [sessionId()],
+      confidence: 1,
+      valid_from: new Date("2026-01-01T00:00:00Z"),
+      tags: [],
+    });
+    fact = f.id;
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  function newEvent(overrides: Record<string, unknown> = {}) {
+    return {
+      id: promotionEventId(),
+      fact_id: fact,
+      from_scope: "ic" as const,
+      to_scope: "team" as const,
+      origin_agent_id: agent,
+      promoter_reason: "Two other agents hit the same lockfile problem.",
+      source_session_ids: ["sess_aaaaaaaaaaaa"],
+      rejected: false,
+      ...overrides,
+    };
+  }
+
+  it("create → findById roundtrips every column", async () => {
+    const created = await promotions.create(newEvent());
+
+    expect(created).toMatchObject({
+      fact_id: fact,
+      from_scope: "ic",
+      to_scope: "team",
+      origin_agent_id: agent,
+      promoter_reason: "Two other agents hit the same lockfile problem.",
+      source_session_ids: ["sess_aaaaaaaaaaaa"],
+      rejected: false,
+    });
+    expect(created.created_at).toBeInstanceOf(Date);
+
+    const found = await promotions.findById(created.id);
+    expect(found).toEqual(created);
+  });
+
+  it("records a null from_scope for a fact that had no prior scope", async () => {
+    const created = await promotions.create(newEvent({ from_scope: null }));
+
+    expect(created.from_scope).toBeNull();
+    expect((await promotions.findById(created.id))?.from_scope).toBeNull();
+  });
+
+  it("records a rejection as a first-class event", async () => {
+    const created = await promotions.create(
+      newEvent({ rejected: true, promoter_reason: "Too specific to one repo." }),
+    );
+
+    expect(created.rejected).toBe(true);
+    expect(created.promoter_reason).toBe("Too specific to one repo.");
+  });
+
+  it("defaults source_session_ids to an empty array and rejected to false", async () => {
+    const created = await promotions.create(
+      newEvent({ source_session_ids: undefined, rejected: undefined }) as Parameters<
+        typeof promotions.create
+      >[0],
+    );
+
+    expect(created.source_session_ids).toEqual([]);
+    expect(created.rejected).toBe(false);
+  });
+
+  it("findById returns undefined for an unknown id", async () => {
+    expect(await promotions.findById("mpe_nosuchevent")).toBeUndefined();
+  });
+
+  describe("listByOwner", () => {
+    it("returns the owner's events newest first, capped by limit", async () => {
+      const first = await promotions.create(newEvent());
+      const second = await promotions.create(newEvent());
+      const third = await promotions.create(newEvent());
+      // created_at defaults to now() at insert time, so insertion order
+      // is chronological — but ties are possible within a millisecond.
+      // Assert on set membership for the capped call and on the full
+      // ordering only through the ids we know are distinct rows.
+      const all = await promotions.listByOwner(owner, 10);
+
+      expect(all).toHaveLength(3);
+      expect(new Set(all.map((e) => e.id))).toEqual(
+        new Set([first.id, second.id, third.id]),
+      );
+      expect(await promotions.listByOwner(owner, 2)).toHaveLength(2);
+    });
+
+    it("orders by created_at descending", async () => {
+      const now = Date.now();
+      const ids: string[] = [];
+      for (let i = 0; i < 3; i++) {
+        const created = await promotions.create(newEvent());
+        await pool.query(`UPDATE memory_promotion_event SET created_at = $1 WHERE id = $2`, [
+          new Date(now - i * 60_000),
+          created.id,
+        ]);
+        ids.push(created.id);
+      }
+
+      const listed = await promotions.listByOwner(owner, 10);
+
+      expect(listed.map((e) => e.id)).toEqual(ids);
+    });
+
+    it("excludes events whose origin agent belongs to a different owner", async () => {
+      const stranger = await persons.create({ id: personId(), name: "Stranger" });
+      const strangerAgent = await agents.create({
+        id: agentId(),
+        name: "Stranger's agent",
+        owner_id: stranger.id,
+        hierarchy_level: "ic",
+        runtime_config: DEFAULT_RUNTIME_CONFIG,
+      });
+      const mine = await promotions.create(newEvent());
+      await promotions.create(newEvent({ origin_agent_id: strangerAgent.id }));
+
+      const listed = await promotions.listByOwner(owner, 10);
+
+      expect(listed.map((e) => e.id)).toEqual([mine.id]);
+      expect(await promotions.listByOwner(stranger.id, 10)).toHaveLength(1);
+    });
+
+    it("returns an empty list for an owner with no promotions", async () => {
+      expect(await promotions.listByOwner("person_nobody", 10)).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## What

Six new test suites over the least-covered code that actually matters. **No source changes — tests only.**

## How the targets were picked

Ran a v8 coverage sweep with `--coverage.all` (so files with no test file at all show up as 0% instead of being absent from the report), against a real Postgres so the DB-gated suites contributed rather than aborting report generation. That put the packages at:

| Package | Lines before |
| --- | --- |
| `@beevibe/api` | **74.62%** |
| `@beevibe/scheduler` | 65.94% |
| `@beevibe/daemon` | 80.41% |
| `@beevibe/core` | 90.93% |

Then ranked the per-file gaps by uncovered lines crossed with product criticality and six-month churn (`git log --since=6.months --name-only`). The composition roots (`bootstrap.ts`, `main.ts`) dominate the raw uncovered-line count in every package but are pure wiring — skipped in favour of files with real branching.

## What each suite covers

| File | Lines before → after | Why this one |
| --- | --- | --- |
| `api/src/routes/chat.ts` | **26.9% → 100%** | The human chat surface, and the 5th-most-modified source file in the repo. `chat-internals.test.ts` already pinned the pure helpers; the four handlers around them had nothing. |
| `api/src/tools/use-repo.ts` | **32.0% → 100%** | Had no test file at all. |
| `api/src/tools/watch.ts` | **46.3% → 100%** | Had no test file at all. |
| `api/src/tools/session-search.ts` | **64.7% → 100%** | Had no test file at all. |
| `core/…/agent-provision-event-repo.ts` | **0% → 100%** | Entirely unexercised SQL. |
| `core/…/promotion-event-repo.ts` | **0% → 100%** | Entirely unexercised SQL. |

### `routes/chat.ts` — 43 tests

The branching that was uncovered is the branching that costs money or loses data: idempotent replay of a retried `POST` (403 on a cross-caller session id, 409 while in flight, 200 replay of a finished turn — each replay avoided is one Claude Code subprocess not spawned), both rate-limiter ceilings including the slot actually being released on the error paths, the daemon-offline 503 vs. the null-runtime fallthrough, the resolver 504 vs. a generic 500, and the `onboarding_completed_at` flip firing only on a first *successful* turn and never failing the response when the write throws.

Also pins the read side: chain selection via `?c=`, the empty-state-not-404 for an unknown conversation, `in_flight_session_id`, and all four `runtime_mismatch` outcomes.

### `tools/use-repo.ts` — 19 tests

Two things worth pinning beyond the happy path. The insert ordering is load-bearing — `repo_run.session_id` has an FK to `session.id`, so the test asserts the pre-minted id ties the dispatch and the `repo_run` insert together, and that a dispatch failure stops before the `repo_run` insert. And the limit clamps (`disk_mb` ≤ 10000, `wall_clock_minutes` ≤ 60, fractional counts floored) are the only guard between a hallucinated `disk_mb: 999999` and the sandbox runner.

The `repo_url` validation gets a small hostile-input table, including the suffix spoof `https://github.com.evil.example/…` that a naive `includes("github.com")` would let through.

### `tools/watch.ts` — 12 tests

Mostly the error-class → tool-error-code mapping (`WatchAuthError` → `watch_auth`, etc.), since agents branch on those codes and a silent degrade to the catch-all `watch_error` would be a real behaviour change. Plus the input coercion an LLM caller gets wrong: `task_ids` as a bare string, a nonsense `mode`, a whitespace-only `reason`.

### `tools/session-search.ts` — 18 tests

The tool's own logic is `inferRequest` — four calling shapes pulled out of one loose bag of keys with a documented precedence (scroll > read > discover > browse). Getting that wrong silently answers a different question than the agent asked, so the full shape table is pinned, including the cross-bundle `SessionSearchError` recognition by `name` that the src/-vs-dist/ comment in the source calls out.

### The two core repos — 18 tests

Both are audit trails `CLAUDE.md` explicitly flags as *unfinished wiring, not dead code*. `countByParentSince` is what enforces the per-parent spawn cap, so its window boundary and per-parent scoping are pinned directly; `promotion-event-repo` gets its two `COALESCE` insert defaults and the `listByOwner` join through `origin_agent_id → agent.owner_id` (including the cross-owner exclusion).

## Result

| Package | Lines before | Lines after |
| --- | --- | --- |
| `@beevibe/api` | 74.62% | **81.27%** |
| `@beevibe/core` | 90.93% | **92.53%** |

145 new tests. Full `@beevibe/api` (1018 passed) and `@beevibe/core` (877 passed) suites green against a local Postgres 16 + pgvector; `pnpm typecheck` and `pnpm lint` clean across all 9 tasks. The provider-key-gated adapter suites (OpenAI/Anthropic/codex) were excluded from the local run for lack of keys — they're untouched by this change and CI has the secrets.

## Still uncovered, deliberately

Named here so the next sweep doesn't have to rediscover them: `api/src/bootstrap.ts` (0.3%), `api/src/routes/mcp.ts` (0.9%), `scheduler/src/bootstrap.ts` + `main.ts` (0%), `daemon/src/main.ts` + `start.ts` (0%). All composition roots and process entry points. `api/src/tools/hierarchy.ts` (71.3%) and `api/src/mesh/server.ts` (43.6%) are the largest remaining gaps with real logic in them — good candidates for a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMTMpNyhyW9cY8N88PQf8q)_