### PR TITLE
refactor(web): unify three clusters of near-duplicate UI abstractions

### DIFF
--- a/packages/web/app/(authed)/memory/eval/eval-client.tsx
+++ b/packages/web/app/(authed)/memory/eval/eval-client.tsx
@@ -19,6 +19,7 @@ import type {
   ScopeTypeRow,
   WeeklyArchivalRow,
 } from "@/lib/api/types";
+import { StatTable } from "./stat-table";
 
 const FACT_TYPES = ["belief", "pattern", "gotcha", "preference", "decision"] as const;
 type FactType = (typeof FACT_TYPES)[number];
@@ -332,47 +333,48 @@ function Legend() {
 // ─────────────────────────────────────────────────────────────────────────
 
 function ScopeTypeSection({ rows }: { rows: ScopeTypeRow[] }) {
-  // Pivot to scope × fact_type matrix.
+  // Pivot to a scope × fact_type matrix. The three scopes are always
+  // rendered, present in the data or not, so this table has no empty
+  // state to reach.
   const scopes: Array<"ic" | "team" | "org"> = ["ic", "team", "org"];
   const byScope: Record<string, Record<string, number>> = {};
   for (const r of rows) {
     byScope[r.scope] = byScope[r.scope] ?? {};
     byScope[r.scope]![r.fact_type] = r.writes;
   }
+  const pivoted = scopes.map((scope) => {
+    const counts = byScope[scope] ?? {};
+    return {
+      scope,
+      counts,
+      total: Object.values(counts).reduce((a, b) => a + b, 0),
+    };
+  });
+
   return (
     <Card title="Archival writes · scope × fact_type">
-      <table className="w-full text-xs">
-        <thead className="text-muted-foreground text-[10px] uppercase tracking-wider">
-          <tr className="border-b border-border/40">
-            <th className="text-left py-1.5">Scope</th>
-            {FACT_TYPES.map((ft) => (
-              <th key={ft} className="text-right py-1.5">
-                {ft}
-              </th>
-            ))}
-            <th className="text-right py-1.5">Total</th>
-          </tr>
-        </thead>
-        <tbody className="tabular-nums">
-          {scopes.map((scope) => {
-            const row = byScope[scope] ?? {};
-            const total = Object.values(row).reduce((a, b) => a + b, 0);
-            return (
-              <tr key={scope} className="border-b border-border/20 last:border-0">
-                <td className="py-1.5 text-foreground">{scope}</td>
-                {FACT_TYPES.map((ft) => (
-                  <td key={ft} className="text-right py-1.5">
-                    {row[ft] ? fmt(row[ft]!) : "—"}
-                  </td>
-                ))}
-                <td className="text-right py-1.5 font-semibold">
-                  {total ? fmt(total) : "—"}
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+      <StatTable
+        rows={pivoted}
+        rowKey={(r) => r.scope}
+        empty={null}
+        columns={[
+          { header: "Scope", cell: (r) => r.scope, cellClassName: "text-foreground" },
+          // One column per fact_type — the case the column list buys us:
+          // a hand-written <thead> cannot be spread from a constant.
+          ...FACT_TYPES.map((ft) => ({
+            header: ft,
+            align: "right" as const,
+            cell: (r: { counts: Record<string, number> }) =>
+              r.counts[ft] ? fmt(r.counts[ft]!) : "—",
+          })),
+          {
+            header: "Total",
+            align: "right",
+            cell: (r) => (r.total ? fmt(r.total) : "—"),
+            cellClassName: "font-semibold",
+          },
+        ]}
+      />
     </Card>
   );
 }
@@ -384,39 +386,23 @@ function ScopeTypeSection({ rows }: { rows: ScopeTypeRow[] }) {
 function TopAgentsTable({ rows }: { rows: AgentActivityRow[] }) {
   return (
     <Card title="Top writers · 30d" subtitle="by archival count">
-      {rows.length === 0 ? (
-        <EmptyHint>No agents wrote archival in the last 30 days.</EmptyHint>
-      ) : (
-        <table className="w-full text-xs">
-          <thead className="text-muted-foreground text-[10px] uppercase tracking-wider">
-            <tr className="border-b border-border/40">
-              <th className="text-left py-1.5">Agent</th>
-              <th className="text-left py-1.5">Tier</th>
-              <th className="text-right py-1.5">Writes</th>
-              <th className="text-right py-1.5">Types</th>
-              <th className="text-right py-1.5">Last</th>
-            </tr>
-          </thead>
-          <tbody className="tabular-nums">
-            {rows.map((r) => (
-              <tr key={r.agent_id} className="border-b border-border/20 last:border-0">
-                <td className="py-1.5 text-foreground truncate max-w-[160px]">
-                  <Link
-                    href={`/agents/${r.agent_id}`}
-                    className="hover:underline"
-                  >
-                    {r.name}
-                  </Link>
-                </td>
-                <td className="py-1.5 text-muted-foreground">{r.tier}</td>
-                <td className="text-right py-1.5">{fmt(r.writes_30d)}</td>
-                <td className="text-right py-1.5">{r.type_variety}</td>
-                <td className="text-right py-1.5 text-muted-foreground">{r.last_write}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
+      <StatTable
+        rows={rows}
+        rowKey={(r) => r.agent_id}
+        empty="No agents wrote archival in the last 30 days."
+        columns={[
+          { header: "Agent", cell: agentLink, cellClassName: "text-foreground truncate max-w-[160px]" },
+          { header: "Tier", cell: (r) => r.tier, cellClassName: "text-muted-foreground" },
+          { header: "Writes", align: "right", cell: (r) => fmt(r.writes_30d) },
+          { header: "Types", align: "right", cell: (r) => r.type_variety },
+          {
+            header: "Last",
+            align: "right",
+            cell: (r) => r.last_write,
+            cellClassName: "text-muted-foreground",
+          },
+        ]}
+      />
     </Card>
   );
 }
@@ -424,39 +410,27 @@ function TopAgentsTable({ rows }: { rows: AgentActivityRow[] }) {
 function DormantAgentsTable({ rows }: { rows: DormantAgentRow[] }) {
   return (
     <Card title="Dormant · 0 writes in 30d" subtitle="newest agents first">
-      {rows.length === 0 ? (
-        <EmptyHint>All agents wrote archival in the last 30 days.</EmptyHint>
-      ) : (
-        <table className="w-full text-xs">
-          <thead className="text-muted-foreground text-[10px] uppercase tracking-wider">
-            <tr className="border-b border-border/40">
-              <th className="text-left py-1.5">Agent</th>
-              <th className="text-left py-1.5">Tier</th>
-              <th className="text-right py-1.5">Last write</th>
-              <th className="text-right py-1.5">Created</th>
-            </tr>
-          </thead>
-          <tbody className="tabular-nums">
-            {rows.map((r) => (
-              <tr key={r.agent_id} className="border-b border-border/20 last:border-0">
-                <td className="py-1.5 text-foreground truncate max-w-[160px]">
-                  <Link
-                    href={`/agents/${r.agent_id}`}
-                    className="hover:underline"
-                  >
-                    {r.name}
-                  </Link>
-                </td>
-                <td className="py-1.5 text-muted-foreground">{r.tier}</td>
-                <td className="text-right py-1.5 text-muted-foreground">
-                  {r.last_write_ever ?? "never"}
-                </td>
-                <td className="text-right py-1.5 text-muted-foreground">{r.agent_created}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
+      <StatTable
+        rows={rows}
+        rowKey={(r) => r.agent_id}
+        empty="All agents wrote archival in the last 30 days."
+        columns={[
+          { header: "Agent", cell: agentLink, cellClassName: "text-foreground truncate max-w-[160px]" },
+          { header: "Tier", cell: (r) => r.tier, cellClassName: "text-muted-foreground" },
+          {
+            header: "Last write",
+            align: "right",
+            cell: (r) => r.last_write_ever ?? "never",
+            cellClassName: "text-muted-foreground",
+          },
+          {
+            header: "Created",
+            align: "right",
+            cell: (r) => r.agent_created,
+            cellClassName: "text-muted-foreground",
+          },
+        ]}
+      />
     </Card>
   );
 }
@@ -471,41 +445,25 @@ function CoreSnapshotTable({ rows }: { rows: CoreSnapshotRow[] }) {
       title="Core memory · current state"
       subtitle="snapshot proxies (undercount churn)"
     >
-      {rows.length === 0 ? (
-        <EmptyHint>No core memory blocks exist yet.</EmptyHint>
-      ) : (
-        <table className="w-full text-xs">
-          <thead className="text-muted-foreground text-[10px] uppercase tracking-wider">
-            <tr className="border-b border-border/40">
-              <th className="text-left py-1.5">Tier</th>
-              <th className="text-left py-1.5">Block</th>
-              <th className="text-right py-1.5">Blocks</th>
-              <th className="text-right py-1.5">Non-empty</th>
-              <th className="text-right py-1.5">Ever updated</th>
-              <th className="text-right py-1.5">Updated 30d</th>
-              <th className="text-right py-1.5">Avg chars</th>
-            </tr>
-          </thead>
-          <tbody className="tabular-nums">
-            {rows.map((r) => (
-              <tr
-                key={`${r.tier}:${r.block_name}`}
-                className="border-b border-border/20 last:border-0"
-              >
-                <td className="py-1.5 text-muted-foreground">{r.tier}</td>
-                <td className="py-1.5 text-foreground">{r.block_name}</td>
-                <td className="text-right py-1.5">{fmt(r.blocks)}</td>
-                <td className="text-right py-1.5">{fmt(r.non_empty)}</td>
-                <td className="text-right py-1.5">{fmt(r.ever_updated)}</td>
-                <td className="text-right py-1.5">{fmt(r.updated_30d)}</td>
-                <td className="text-right py-1.5 text-muted-foreground">
-                  {fmt(r.avg_chars)}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
+      <StatTable
+        rows={rows}
+        rowKey={(r) => `${r.tier}:${r.block_name}`}
+        empty="No core memory blocks exist yet."
+        columns={[
+          { header: "Tier", cell: (r) => r.tier, cellClassName: "text-muted-foreground" },
+          { header: "Block", cell: (r) => r.block_name, cellClassName: "text-foreground" },
+          { header: "Blocks", align: "right", cell: (r) => fmt(r.blocks) },
+          { header: "Non-empty", align: "right", cell: (r) => fmt(r.non_empty) },
+          { header: "Ever updated", align: "right", cell: (r) => fmt(r.ever_updated) },
+          { header: "Updated 30d", align: "right", cell: (r) => fmt(r.updated_30d) },
+          {
+            header: "Avg chars",
+            align: "right",
+            cell: (r) => fmt(r.avg_chars),
+            cellClassName: "text-muted-foreground",
+          },
+        ]}
+      />
     </Card>
   );
 }
@@ -516,38 +474,23 @@ function RatioTable({ rows }: { rows: AgentRatioRow[] }) {
       title="Archival ÷ core · per agent (30d)"
       subtitle="high ratio = bias toward archival, never touches core"
     >
-      {rows.length === 0 ? (
-        <EmptyHint>No memory writes in the last 30 days.</EmptyHint>
-      ) : (
-        <table className="w-full text-xs">
-          <thead className="text-muted-foreground text-[10px] uppercase tracking-wider">
-            <tr className="border-b border-border/40">
-              <th className="text-left py-1.5">Agent</th>
-              <th className="text-left py-1.5">Tier</th>
-              <th className="text-right py-1.5">Archival</th>
-              <th className="text-right py-1.5">Core touched</th>
-              <th className="text-right py-1.5">Ratio</th>
-            </tr>
-          </thead>
-          <tbody className="tabular-nums">
-            {rows.map((r) => (
-              <tr key={r.agent_id} className="border-b border-border/20 last:border-0">
-                <td className="py-1.5 text-foreground truncate max-w-[200px]">
-                  <Link href={`/agents/${r.agent_id}`} className="hover:underline">
-                    {r.name}
-                  </Link>
-                </td>
-                <td className="py-1.5 text-muted-foreground">{r.tier}</td>
-                <td className="text-right py-1.5">{fmt(r.archival_30d)}</td>
-                <td className="text-right py-1.5">{fmt(r.core_touched_30d)}</td>
-                <td className="text-right py-1.5 font-semibold">
-                  {r.ratio === null ? "—" : r.ratio}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
+      <StatTable
+        rows={rows}
+        rowKey={(r) => r.agent_id}
+        empty="No memory writes in the last 30 days."
+        columns={[
+          { header: "Agent", cell: agentLink, cellClassName: "text-foreground truncate max-w-[200px]" },
+          { header: "Tier", cell: (r) => r.tier, cellClassName: "text-muted-foreground" },
+          { header: "Archival", align: "right", cell: (r) => fmt(r.archival_30d) },
+          { header: "Core touched", align: "right", cell: (r) => fmt(r.core_touched_30d) },
+          {
+            header: "Ratio",
+            align: "right",
+            cell: (r) => (r.ratio === null ? "—" : r.ratio),
+            cellClassName: "font-semibold",
+          },
+        ]}
+      />
     </Card>
   );
 }
@@ -586,32 +529,28 @@ function BeforeAfterPanel({ data }: { data: BeforeAfterData }) {
           <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-2">
             fact_type mix
           </div>
-          <table className="w-full text-xs tabular-nums">
-            <thead className="text-muted-foreground text-[10px] uppercase tracking-wider">
-              <tr className="border-b border-border/40">
-                <th className="text-left py-1.5">Type</th>
-                <th className="text-right py-1.5">pre</th>
-                <th className="text-right py-1.5">post</th>
-                <th className="text-right py-1.5">pre %</th>
-                <th className="text-right py-1.5">post %</th>
-              </tr>
-            </thead>
-            <tbody>
-              {data.by_type.map((r) => (
-                <tr key={r.fact_type} className="border-b border-border/20 last:border-0">
-                  <td className="py-1.5 text-foreground">{r.fact_type}</td>
-                  <td className="text-right py-1.5">{fmt(r.pre)}</td>
-                  <td className="text-right py-1.5">{fmt(r.post)}</td>
-                  <td className="text-right py-1.5 text-muted-foreground">
-                    {r.pre_pct === null ? "—" : `${r.pre_pct}%`}
-                  </td>
-                  <td className="text-right py-1.5 text-muted-foreground">
-                    {r.post_pct === null ? "—" : `${r.post_pct}%`}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <StatTable
+            rows={data.by_type}
+            rowKey={(r) => r.fact_type}
+            empty="No writes on either side of the boundary."
+            columns={[
+              { header: "Type", cell: (r) => r.fact_type, cellClassName: "text-foreground" },
+              { header: "pre", align: "right", cell: (r) => fmt(r.pre) },
+              { header: "post", align: "right", cell: (r) => fmt(r.post) },
+              {
+                header: "pre %",
+                align: "right",
+                cell: (r) => (r.pre_pct === null ? "—" : `${r.pre_pct}%`),
+                cellClassName: "text-muted-foreground",
+              },
+              {
+                header: "post %",
+                align: "right",
+                cell: (r) => (r.post_pct === null ? "—" : `${r.post_pct}%`),
+                cellClassName: "text-muted-foreground",
+              },
+            ]}
+          />
         </div>
       </div>
     </Card>
@@ -646,11 +585,16 @@ function Card({
   );
 }
 
-function EmptyHint({ children }: { children: React.ReactNode }) {
+/**
+ * Agent-name cell, shared by the three tables keyed on an agent. The
+ * truncation width differs per table and stays on the column's
+ * `cellClassName`; the link itself is the same everywhere.
+ */
+function agentLink(row: { agent_id: string; name: string }): React.ReactNode {
   return (
-    <div className="text-xs text-muted-foreground py-4 text-center">
-      {children}
-    </div>
+    <Link href={`/agents/${row.agent_id}`} className="hover:underline">
+      {row.name}
+    </Link>
   );
 }
 

--- a/packages/web/app/(authed)/memory/eval/stat-table.test.tsx
+++ b/packages/web/app/(authed)/memory/eval/stat-table.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StatTable } from "./stat-table";
+
+interface Row {
+  id: string;
+  name: string;
+  writes: number;
+}
+
+const ROWS: Row[] = [
+  { id: "a", name: "Ada", writes: 1234 },
+  { id: "b", name: "Grace", writes: 7 },
+];
+
+const COLUMNS = [
+  { header: "Agent", cell: (r: Row) => r.name },
+  { header: "Writes", align: "right" as const, cell: (r: Row) => r.writes },
+];
+
+describe("StatTable", () => {
+  it("renders one header per column and one row per item", () => {
+    render(<StatTable rows={ROWS} columns={COLUMNS} rowKey={(r) => r.id} empty="none" />);
+    expect(screen.getByRole("columnheader", { name: "Agent" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Writes" })).toBeInTheDocument();
+    expect(screen.getAllByRole("row")).toHaveLength(3); // header + 2 body rows
+    expect(screen.getByText("Grace")).toBeInTheDocument();
+  });
+
+  it("right-aligns both the header and the cells of a right column", () => {
+    render(<StatTable rows={ROWS} columns={COLUMNS} rowKey={(r) => r.id} empty="none" />);
+    expect(screen.getByRole("columnheader", { name: "Writes" }).className).toContain(
+      "text-right",
+    );
+    expect(screen.getByText("1234").className).toContain("text-right");
+  });
+
+  it("shows the empty node instead of a table when there are no rows", () => {
+    render(
+      <StatTable rows={[]} columns={COLUMNS} rowKey={(r) => r.id} empty="Nothing yet." />,
+    );
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    expect(screen.getByText("Nothing yet.")).toBeInTheDocument();
+  });
+
+  it("appends per-column cell classes on top of the shared padding", () => {
+    render(
+      <StatTable
+        rows={ROWS}
+        columns={[
+          { header: "Agent", cell: (r: Row) => r.name, cellClassName: "font-semibold" },
+        ]}
+        rowKey={(r) => r.id}
+        empty="none"
+      />,
+    );
+    const cell = screen.getByText("Ada");
+    expect(cell.className).toContain("font-semibold");
+    expect(cell.className).toContain("py-1.5");
+  });
+});

--- a/packages/web/app/(authed)/memory/eval/stat-table.tsx
+++ b/packages/web/app/(authed)/memory/eval/stat-table.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * The read-only stats table this page renders five times over five
+ * different row types.
+ *
+ * Each copy was the same thirty lines — the same `thead` tint, the same
+ * `border-b border-border/40` header rule, the same
+ * `border-b border-border/20 last:border-0` body rule, the same
+ * `py-1.5` cell padding — with only the column headers and the cell
+ * expressions differing. Describing a table as a column list makes the
+ * per-table code the part that is actually per-table, and means a change
+ * to the row rules lands on all five at once instead of four out of
+ * five.
+ *
+ * Deliberately local to this page. The idiom does not appear anywhere
+ * else in the app (`memory-client` and `agents-list-view` are the only
+ * other `<thead>`s in the tree and both style their rows differently),
+ * so promoting it to `components/` would be inventing a design-system
+ * table on the strength of a single page.
+ */
+export interface StatColumn<T> {
+  header: string;
+  /** Numeric columns are right-aligned; the default is left. */
+  align?: "left" | "right";
+  cell: (row: T) => ReactNode;
+  /** Extra `<td>` classes — muted tone, truncation width, emphasis. */
+  cellClassName?: string;
+}
+
+export function StatTable<T>({
+  rows,
+  columns,
+  rowKey,
+  empty,
+}: {
+  rows: readonly T[];
+  columns: ReadonlyArray<StatColumn<T>>;
+  rowKey: (row: T) => string;
+  /** Shown in place of the table when there is nothing to list. */
+  empty: ReactNode;
+}) {
+  if (rows.length === 0) {
+    return <div className="text-xs text-muted-foreground py-4 text-center">{empty}</div>;
+  }
+  return (
+    <table className="w-full text-xs">
+      <thead className="text-muted-foreground text-[10px] uppercase tracking-wider">
+        <tr className="border-b border-border/40">
+          {columns.map((col) => (
+            <th
+              key={col.header}
+              className={cn("py-1.5", col.align === "right" ? "text-right" : "text-left")}
+            >
+              {col.header}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody className="tabular-nums">
+        {rows.map((row) => (
+          <tr key={rowKey(row)} className="border-b border-border/20 last:border-0">
+            {columns.map((col) => (
+              <td
+                key={col.header}
+                className={cn(
+                  "py-1.5",
+                  col.align === "right" && "text-right",
+                  col.cellClassName,
+                )}
+              >
+                {col.cell(row)}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/packages/web/app/(authed)/rooms/[id]/room-detail-client.tsx
+++ b/packages/web/app/(authed)/rooms/[id]/room-detail-client.tsx
@@ -17,7 +17,7 @@ import { isApiConfigured } from "@/lib/api/config";
 import { api, type RoomDetail, type RoomMemberDetail, type RoomMessage } from "@/lib/api/client";
 import { ApiError, describeError } from "@/lib/api/http";
 import { queryKeys } from "@/lib/hooks/keys";
-import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
+import { InlineError, ShareLinkBox, TextInput } from "@/components/form/field";
 import { ModalOverlay } from "@/components/modal-overlay";
 import { ChatMarkdown } from "@/components/chat/markdown";
 import { ToolStepList } from "@/components/chat/tool-step-list";
@@ -275,7 +275,6 @@ function InviteDialog({ roomId, onClose }: { roomId: string; onClose: () => void
   const [error, setError] = useState<string | null>(null);
   /** When the invitee doesn't have an account yet, surface a share link they can use to sign up + auto-join. */
   const [shareLink, setShareLink] = useState<string | null>(null);
-  const { copied, copy } = useCopyToClipboard();
 
   const invite = useMutation({
     mutationFn: () => api.rooms.invite(roomId, { email: email.trim() }),
@@ -317,43 +316,26 @@ function InviteDialog({ roomId, onClose }: { roomId: string; onClose: () => void
           Enter the invitee&apos;s email. If they already have a beevibe account they&apos;re
           added immediately. If not, you&apos;ll get a sign-up link to share.
         </p>
-        <input
+        <TextInput
           type="email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           autoFocus
           placeholder="alice@example.com"
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
           disabled={invite.isPending}
         />
-        {error ? (
-          <div className="mt-2 text-xs text-status-failed flex items-start gap-1.5">
-            <AlertTriangle className="h-3 w-3 mt-0.5 shrink-0" />
-            <span>{error}</span>
-          </div>
-        ) : null}
+        <InlineError message={error} className="mt-2" />
         {shareLink ? (
-          <div className="mt-3 rounded border border-border bg-muted/40 p-3">
-            <div className="text-[11px] text-muted-foreground mb-1.5">
-              No account for that email yet. Send them this link — they&apos;ll sign up and
-              land in this room.
-            </div>
-            <div className="flex items-center gap-1.5">
-              <input
-                readOnly
-                value={shareLink}
-                className="flex-1 rounded border border-border bg-background px-2 py-1.5 text-[11px] font-mono"
-                onFocus={(e) => e.currentTarget.select()}
-              />
-              <button
-                type="button"
-                onClick={() => void copy(shareLink ?? "")}
-                className="h-7 px-2.5 rounded text-[11px] font-medium border border-border hover:bg-secondary transition-colors cursor-pointer shrink-0"
-              >
-                {copied ? "Copied" : "Copy"}
-              </button>
-            </div>
-          </div>
+          <ShareLinkBox
+            className="mt-3"
+            hint={
+              <>
+                No account for that email yet. Send them this link — they&apos;ll sign up
+                and land in this room.
+              </>
+            }
+            link={shareLink}
+          />
         ) : null}
         <div className="mt-4 flex items-center justify-end gap-2">
           <button

--- a/packages/web/app/(authed)/rooms/rooms-list-client.tsx
+++ b/packages/web/app/(authed)/rooms/rooms-list-client.tsx
@@ -8,6 +8,7 @@ import { AlertTriangle, Loader2, MessageCircleMore, Plus, Users } from "lucide-r
 import { api, type Room } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
 import { queryKeys } from "@/lib/hooks/keys";
+import { InlineError, TextField } from "@/components/form/field";
 import { Skeleton } from "@/components/skeleton";
 import { EmptyState } from "@/components/empty-state";
 import { formatRelativeTime, shortId } from "@/lib/format";
@@ -70,16 +71,13 @@ export function RoomsListClient() {
           className="mb-6 flex items-end gap-2 bg-card border border-border rounded-lg p-3"
         >
           <div className="flex-1">
-            <label htmlFor="room-name" className="block text-xs font-medium text-foreground mb-1.5">
-              Create a new room
-            </label>
-            <input
+            <TextField
               id="room-name"
+              label="Create a new room"
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="e.g. Plan the M9 launch"
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
               disabled={create.isPending}
             />
           </div>
@@ -92,12 +90,7 @@ export function RoomsListClient() {
             Create
           </button>
         </form>
-        {error ? (
-          <div className="mb-4 flex items-start gap-1.5 text-xs text-status-failed">
-            <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>{error}</span>
-          </div>
-        ) : null}
+        <InlineError message={error} className="mb-4" />
 
         <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-2 font-medium">
           Your rooms

--- a/packages/web/app/(authed)/sessions/[sid]/chat-session-detail-client.tsx
+++ b/packages/web/app/(authed)/sessions/[sid]/chat-session-detail-client.tsx
@@ -5,13 +5,12 @@ import { ArrowLeft, ChevronRight, Terminal, Wrench } from "lucide-react";
 import { useConversation } from "@/lib/hooks/use-sessions";
 import { DetailGate } from "@/components/detail/detail-gate";
 import { EmptyState } from "@/components/empty-state";
-import { Skeleton } from "@/components/skeleton";
-import { SessionStatusPill } from "@/components/detail/status-pill";
-import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
-import { FooterField } from "@/components/detail/footer-field";
 import { ChatMarkdown } from "@/components/chat/markdown";
-import { HierChip } from "@/components/hier-chip";
-import { Avatar } from "@/components/avatar";
+import {
+  SessionDetailSkeleton,
+  SessionIdentityHeader,
+  SessionMetaFooter,
+} from "@/components/sessions/session-detail-chrome";
 import { UsagePanel } from "@/components/sessions/usage-panel";
 import type {
   ConversationDisplay,
@@ -41,13 +40,7 @@ export function ChatSessionDetailClient({ sessionShortId }: { sessionShortId: st
       noun="session"
       id={sessionShortId}
       query={query}
-      skeleton={
-        <>
-          <Skeleton className="h-14 w-full mb-6" />
-          <Skeleton className="h-32 w-full mb-5 rounded-lg" />
-          <Skeleton className="h-64 w-full rounded-lg" />
-        </>
-      }
+      skeleton={<SessionDetailSkeleton />}
     >
       {(conversation) =>
         // Task-typed sessions belong on the task-scoped detail page; redirect
@@ -91,37 +84,22 @@ function ConversationBody({ conversation }: { conversation: ConversationDisplay 
 
   return (
     <>
-      <header className="mb-6">
-        <div className="flex items-start gap-3">
-          <Avatar
-            initial={conversation.agent_label.charAt(0).toUpperCase()}
-            kind={conversation.agent_hierarchy}
-            label={conversation.agent_label}
-            size={40}
-            presence={conversation.status === "running" ? "running" : "idle"}
-          />
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 mb-1">
-              <h1 className="text-base font-semibold tracking-tight leading-tight">
-                {multiTurn ? "Conversation" : "One turn"}
-              </h1>
-              <SessionStatusPill status={conversation.status} />
-            </div>
-            <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <span className="text-foreground/85">{conversation.agent_label}</span>
-              <HierChip hier={conversation.agent_hierarchy} />
-              {multiTurn ? (
-                <>
-                  <span className="text-muted-foreground/50">·</span>
-                  <span className="tabular-nums">{turns.length} turns</span>
-                </>
-              ) : null}
-              <span className="text-muted-foreground/50">·</span>
-              <span className="text-foreground/70">{conversation.type}</span>
-            </div>
-          </div>
-        </div>
-      </header>
+      <SessionIdentityHeader
+        agentLabel={conversation.agent_label}
+        agentHierarchy={conversation.agent_hierarchy}
+        status={conversation.status}
+        title={multiTurn ? "Conversation" : "One turn"}
+        meta={[
+          multiTurn ? (
+            <span key="turns" className="tabular-nums">
+              {turns.length} turns
+            </span>
+          ) : null,
+          <span key="type" className="text-foreground/70">
+            {conversation.type}
+          </span>,
+        ]}
+      />
 
       <div className="space-y-6">
         {turns.map((turn) => (
@@ -131,22 +109,13 @@ function ConversationBody({ conversation }: { conversation: ConversationDisplay 
 
       {usage ? <UsagePanel usage={usage} /> : null}
 
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
-        <FooterField label="Conversation ID">
-          <ClickToCopyId id={conversation.conversation_id} />
-        </FooterField>
-        {lastTurn?.cli_session ? (
-          <FooterField label="CLI session" truncate>
-            <span className="font-mono">{lastTurn.cli_session}</span>
-          </FooterField>
-        ) : null}
-        {lastTurn?.worktree ? (
-          <FooterField label="Worktree" truncate>
-            <span className="font-mono">{lastTurn.worktree}</span>
-          </FooterField>
-        ) : null}
-        <FooterField label="Type">{conversation.type}</FooterField>
-      </footer>
+      <SessionMetaFooter
+        idLabel="Conversation ID"
+        id={conversation.conversation_id}
+        cliSession={lastTurn?.cli_session}
+        worktree={lastTurn?.worktree}
+        type={conversation.type}
+      />
     </>
   );
 }

--- a/packages/web/app/(authed)/tasks/[id]/sessions/[sid]/session-detail-client.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/sessions/[sid]/session-detail-client.tsx
@@ -3,15 +3,14 @@
 import Link from "next/link";
 import { ChevronRight, Terminal } from "lucide-react";
 import { useSession } from "@/lib/hooks/use-sessions";
-import { Avatar } from "@/components/avatar";
-import { HierChip } from "@/components/hier-chip";
-import { SessionStatusPill } from "@/components/detail/status-pill";
-import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { DetailGate } from "@/components/detail/detail-gate";
-import { FooterField } from "@/components/detail/footer-field";
 import { BriefingComposer } from "@/components/sessions/briefing-composer";
+import {
+  SessionDetailSkeleton,
+  SessionIdentityHeader,
+  SessionMetaFooter,
+} from "@/components/sessions/session-detail-chrome";
 import { Transcript } from "@/components/sessions/transcript";
-import { Skeleton } from "@/components/skeleton";
 import { formatIntent, shortId } from "@/lib/format";
 import type { SessionDisplay } from "@/lib/types/sessions";
 
@@ -36,13 +35,7 @@ export function SessionDetailClient({ taskId, sessionShortId }: Props) {
       noun="session"
       id={sessionShortId}
       query={query}
-      skeleton={
-        <>
-          <Skeleton className="h-14 w-full mb-6" />
-          <Skeleton className="h-32 w-full mb-5 rounded-lg" />
-          <Skeleton className="h-64 w-full rounded-lg" />
-        </>
-      }
+      skeleton={<SessionDetailSkeleton />}
     >
       {(session) => <SessionDetailBody session={session} taskId={taskId} />}
     </DetailGate>
@@ -87,50 +80,29 @@ function SessionDetailBody({ session, taskId: _taskId }: { session: SessionDispl
   // running session orphaned in the daemon-spawn path.
   return (
     <>
-      <header className="mb-6">
-        <div className="flex items-start gap-3">
-          <Avatar
-            initial={session.agent_label.charAt(0).toUpperCase()}
-            kind={session.agent_hierarchy}
-            label={session.agent_label}
-            size={40}
-            presence={session.status === "running" ? "running" : "idle"}
-          />
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 mb-1">
-              <h1 className="text-base font-semibold leading-tight truncate">{formatIntent(session.intent)}</h1>
-              <SessionStatusPill status={session.status} />
-            </div>
-            <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <span className="text-foreground/85">{session.agent_label}</span>
-              <HierChip hier={session.agent_hierarchy} />
-              <span className="text-muted-foreground/50">·</span>
-              <span className="tabular-nums">{session.duration_label}</span>
-            </div>
-          </div>
-        </div>
-      </header>
+      <SessionIdentityHeader
+        agentLabel={session.agent_label}
+        agentHierarchy={session.agent_hierarchy}
+        status={session.status}
+        title={formatIntent(session.intent)}
+        meta={[
+          <span key="duration" className="tabular-nums">
+            {session.duration_label}
+          </span>,
+        ]}
+      />
 
       <BriefingComposer briefing={session.briefing} />
 
       <Transcript entries={session.transcript} ask_threads={session.ask_threads} />
 
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
-        <FooterField label="Session ID">
-          <ClickToCopyId id={session.id} />
-        </FooterField>
-        {session.cli_session ? (
-          <FooterField label="CLI session" truncate>
-            <span className="font-mono">{session.cli_session}</span>
-          </FooterField>
-        ) : null}
-        {session.worktree ? (
-          <FooterField label="Worktree" truncate>
-            <span className="font-mono">{session.worktree}</span>
-          </FooterField>
-        ) : null}
-        <FooterField label="Type">{session.type}</FooterField>
-      </footer>
+      <SessionMetaFooter
+        idLabel="Session ID"
+        id={session.id}
+        cliSession={session.cli_session}
+        worktree={session.worktree}
+        type={session.type}
+      />
     </>
   );
 }

--- a/packages/web/app/sign-in/sign-in-client.tsx
+++ b/packages/web/app/sign-in/sign-in-client.tsx
@@ -3,8 +3,9 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { AlertTriangle, KeyRound, Loader2, LogIn } from "lucide-react";
+import { KeyRound, Loader2, LogIn } from "lucide-react";
 import { SIGNIN_NO_PASSWORD_SET } from "@beevibe/core/auth/constants";
+import { InlineError, TextField } from "@/components/form/field";
 import { api } from "@/lib/api/client";
 import { asApiError } from "@/lib/api/http";
 import {
@@ -139,11 +140,9 @@ export function SignInClient() {
 
         {mode === "password" ? (
           <>
-            <label className="block text-xs font-medium text-foreground mb-1.5" htmlFor="email">
-              Email
-            </label>
-            <input
+            <TextField
               id="email"
+              label="Email"
               type="email"
               autoComplete="email"
               inputMode="email"
@@ -151,50 +150,38 @@ export function SignInClient() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="alice@example.com"
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
               disabled={submitting}
             />
 
-            <label className="block text-xs font-medium text-foreground mb-1.5 mt-3" htmlFor="password">
-              Password
-            </label>
-            <input
+            <TextField
               id="password"
+              label="Password"
+              labelClassName="mt-3"
               type="password"
               autoComplete="current-password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               placeholder="••••••••"
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
               disabled={submitting}
             />
           </>
         ) : (
-          <>
-            <label className="block text-xs font-medium text-foreground mb-1.5" htmlFor="key">
-              User API key
-            </label>
-            <input
-              id="key"
-              type="password"
-              autoComplete="off"
-              autoFocus
-              spellCheck={false}
-              value={keyDraft}
-              onChange={(e) => setKeyDraft(e.target.value)}
-              placeholder="bv_u_..."
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-ring"
-              disabled={submitting}
-            />
-          </>
+          <TextField
+            id="key"
+            label="User API key"
+            type="password"
+            autoComplete="off"
+            autoFocus
+            spellCheck={false}
+            value={keyDraft}
+            onChange={(e) => setKeyDraft(e.target.value)}
+            placeholder="bv_u_..."
+            className="font-mono"
+            disabled={submitting}
+          />
         )}
 
-        {error ? (
-          <div className="mt-3 flex items-start gap-1.5 text-xs text-status-failed">
-            <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>{error}</span>
-          </div>
-        ) : null}
+        <InlineError message={error} className="mt-3" />
 
         <button
           type="submit"

--- a/packages/web/app/sign-up/sign-up-client.tsx
+++ b/packages/web/app/sign-up/sign-up-client.tsx
@@ -3,8 +3,9 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { AlertTriangle, Loader2, Sparkles, UserPlus } from "lucide-react";
+import { Loader2, Sparkles, UserPlus } from "lucide-react";
 import { PASSWORD_MIN_LENGTH } from "@beevibe/core/auth/constants";
+import { InlineError, TextField } from "@/components/form/field";
 import { api } from "@/lib/api/client";
 import { asApiError } from "@/lib/api/http";
 import { getUserKey, isApiConfigured, setUserKey } from "@/lib/api/config";
@@ -104,57 +105,45 @@ export function SignUpClient() {
           </p>
         </header>
 
-        <label className="block text-xs font-medium text-foreground mb-1.5" htmlFor="name">
-          Name
-        </label>
-        <input
+        <TextField
           id="name"
+          label="Name"
           type="text"
           autoComplete="name"
           autoFocus
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="Alice"
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
           disabled={submitting}
         />
 
-        <label className="block text-xs font-medium text-foreground mb-1.5 mt-3" htmlFor="email">
-          Email
-        </label>
-        <input
+        <TextField
           id="email"
+          label="Email"
+          labelClassName="mt-3"
           type="email"
           autoComplete="email"
           inputMode="email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           placeholder="alice@example.com"
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
           disabled={submitting}
         />
 
-        <label className="block text-xs font-medium text-foreground mb-1.5 mt-3" htmlFor="password">
-          Password
-        </label>
-        <input
+        <TextField
           id="password"
+          label="Password"
+          labelClassName="mt-3"
           type="password"
           autoComplete="new-password"
           minLength={PASSWORD_MIN_LENGTH}
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           placeholder={`at least ${PASSWORD_MIN_LENGTH} characters`}
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
           disabled={submitting}
         />
 
-        {error ? (
-          <div className="mt-3 flex items-start gap-1.5 text-xs text-status-failed">
-            <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>{error}</span>
-          </div>
-        ) : null}
+        <InlineError message={error} className="mt-3" />
 
         <button
           type="submit"

--- a/packages/web/components/form/field.test.tsx
+++ b/packages/web/components/form/field.test.tsx
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { InlineError, ShareLinkBox, TextField, TextInput } from "./field";
+
+describe("TextField", () => {
+  it("associates the label with the input via id", () => {
+    render(<TextField id="email" label="Email" type="email" />);
+    expect(screen.getByLabelText("Email")).toHaveAttribute("type", "email");
+  });
+
+  it("merges caller classes onto the shared input styling instead of replacing it", () => {
+    // The key field adds `font-mono`; it must not lose the border/padding
+    // that every other field in the app has.
+    render(<TextField id="key" label="User API key" className="font-mono" />);
+    const input = screen.getByLabelText("User API key");
+    expect(input.className).toContain("font-mono");
+    expect(input.className).toContain("border-border");
+  });
+
+  it("forwards arbitrary input props", () => {
+    render(<TextField id="pw" label="Password" minLength={8} disabled />);
+    const input = screen.getByLabelText("Password");
+    expect(input).toBeDisabled();
+    expect(input).toHaveAttribute("minlength", "8");
+  });
+});
+
+describe("TextInput", () => {
+  it("renders an unlabeled input carrying the shared styling", () => {
+    render(<TextInput placeholder="alice@example.com" />);
+    const input = screen.getByPlaceholderText("alice@example.com");
+    expect(input.className).toContain("border-border");
+  });
+});
+
+describe("InlineError", () => {
+  it("renders nothing when there is no message", () => {
+    // Callers rely on this to drop their `{error ? … : null}` wrapper —
+    // null, undefined and "" all have to collapse to nothing.
+    const { container: a } = render(<InlineError message={null} />);
+    expect(a).toBeEmptyDOMElement();
+    const { container: b } = render(<InlineError message="" />);
+    expect(b).toBeEmptyDOMElement();
+  });
+
+  it("renders the message and honours caller spacing", () => {
+    const { container } = render(<InlineError message="Nope" className="mt-3" />);
+    expect(screen.getByText("Nope")).toBeInTheDocument();
+    expect(container.firstElementChild?.className).toContain("mt-3");
+  });
+});
+
+describe("ShareLinkBox", () => {
+  // `navigator.clipboard` is getter-only under happy-dom, so it has to be
+  // redefined rather than assigned — same shape as the hook's own test.
+  afterEach(() => Reflect.deleteProperty(navigator, "clipboard"));
+
+  it("shows the link read-only and copies it on click", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+      writable: true,
+    });
+
+    render(<ShareLinkBox hint="Send them this link:" link="https://x.test/sign-up" />);
+    const field = screen.getByDisplayValue("https://x.test/sign-up");
+    expect(field).toHaveAttribute("readonly");
+
+    await userEvent.click(screen.getByRole("button", { name: "Copy" }));
+    expect(writeText).toHaveBeenCalledWith("https://x.test/sign-up");
+    expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument();
+  });
+});

--- a/packages/web/components/form/field.tsx
+++ b/packages/web/components/form/field.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import type { InputHTMLAttributes, ReactNode } from "react";
+import { AlertTriangle } from "lucide-react";
+import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
+import { cn } from "@/lib/utils";
+
+/**
+ * The three form primitives the auth and invite surfaces had each spelled
+ * out by hand: a labeled text input, an inline error row, and a
+ * copyable share-link box.
+ *
+ * They were duplicated across five files — `sign-in`, `sign-up`,
+ * `rooms-list`, the room `InviteDialog` and the user-widget
+ * `InviteTeammateDialog` — and the duplication was in the *class
+ * strings*, which is the worst kind: an 80-character Tailwind literal
+ * repeated nine times renders identically until someone tweaks one copy,
+ * and then two inputs on adjacent screens quietly stop matching. There
+ * is no type error and no test failure to catch that.
+ */
+
+const INPUT_CLASS =
+  "w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring";
+
+/**
+ * A bare text input carrying the shared styling. All props forward, so
+ * callers keep setting `type`, `autoComplete`, `autoFocus`, `minLength`,
+ * `disabled` etc. directly; `className` is merged rather than replaced,
+ * for the one caller that adds `font-mono` to the key field.
+ *
+ * Use {@link TextField} instead wherever there is a visible label — this
+ * is for the two invite dialogs, where a heading and a paragraph of
+ * explanatory copy already stand in for one.
+ */
+export function TextInput({
+  className,
+  ...inputProps
+}: InputHTMLAttributes<HTMLInputElement>) {
+  return <input className={cn(INPUT_CLASS, className)} {...inputProps} />;
+}
+
+/**
+ * {@link TextInput} with its label. `id` wires the two together, so it
+ * is required rather than optional.
+ *
+ * `labelClassName` exists for the same reason `InlineError` takes a
+ * `className`: these fields stack, and the second and subsequent ones in
+ * a stack carry a `mt-3` on the *label*. That is the caller's layout
+ * decision, not the field's.
+ */
+export function TextField({
+  id,
+  label,
+  labelClassName,
+  ...inputProps
+}: {
+  id: string;
+  label: string;
+  labelClassName?: string;
+} & InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <>
+      <label
+        className={cn("block text-xs font-medium text-foreground mb-1.5", labelClassName)}
+        htmlFor={id}
+      >
+        {label}
+      </label>
+      <TextInput id={id} {...inputProps} />
+    </>
+  );
+}
+
+/**
+ * Inline validation / request error, with the warning glyph.
+ *
+ * Renders nothing for a null message so callers can drop the
+ * `{error ? … : null}` ternary that wrapped every copy.
+ *
+ * `className` carries the caller's spacing, which is the one thing that
+ * legitimately differs between sites (`mt-3` under a form field, `mb-4`
+ * above a list). It is not baked in, because a shared component that
+ * imposes its own margins is a component every caller has to fight.
+ */
+export function InlineError({
+  message,
+  className,
+}: {
+  message: string | null | undefined;
+  className?: string;
+}) {
+  if (!message) return null;
+  return (
+    <div className={cn("flex items-start gap-1.5 text-xs text-status-failed", className)}>
+      <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+      <span>{message}</span>
+    </div>
+  );
+}
+
+/**
+ * A read-only URL with a Copy button, under a line of explanatory text.
+ *
+ * Both invite dialogs land here when the invitee has no account yet:
+ * "we can't add them directly, so here's a link to send them." The
+ * input is focus-to-select as well as click-to-copy, because the copy
+ * button needs a clipboard permission the user may have denied.
+ */
+export function ShareLinkBox({
+  hint,
+  link,
+  className,
+}: {
+  hint: ReactNode;
+  link: string;
+  className?: string;
+}) {
+  const { copied, copy } = useCopyToClipboard();
+  return (
+    <div className={cn("rounded border border-border bg-muted/40 p-3", className)}>
+      <div className="text-[11px] text-muted-foreground mb-1.5">{hint}</div>
+      <div className="flex items-center gap-1.5">
+        <input
+          readOnly
+          value={link}
+          className="flex-1 rounded border border-border bg-background px-2 py-1.5 text-[11px] font-mono"
+          onFocus={(e) => e.currentTarget.select()}
+        />
+        <button
+          type="button"
+          onClick={() => void copy(link)}
+          className="h-7 px-2.5 rounded text-[11px] font-medium border border-border hover:bg-secondary transition-colors cursor-pointer shrink-0"
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/sessions/session-detail-chrome.test.tsx
+++ b/packages/web/components/sessions/session-detail-chrome.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  SessionIdentityHeader,
+  SessionMetaFooter,
+} from "./session-detail-chrome";
+
+describe("SessionIdentityHeader", () => {
+  it("renders the title, agent label and hierarchy chip", () => {
+    render(
+      <SessionIdentityHeader
+        agentLabel="Ada"
+        agentHierarchy="ic"
+        status="succeeded"
+        title="One turn"
+      />,
+    );
+    expect(screen.getByRole("heading", { name: "One turn" })).toBeInTheDocument();
+    expect(screen.getByText("Ada")).toBeInTheDocument();
+    expect(screen.getByText("ic")).toBeInTheDocument();
+  });
+
+  it("dot-separates each meta item and drops the null ones", () => {
+    // The separator belongs to the item, not to the row — a conditional
+    // meta entry that renders `null` must not leave a stray "·" behind.
+    const { container } = render(
+      <SessionIdentityHeader
+        agentLabel="Ada"
+        agentHierarchy="team"
+        status="running"
+        title="Conversation"
+        meta={[null, <span key="t">chat</span>]}
+      />,
+    );
+    expect(screen.getByText("chat")).toBeInTheDocument();
+    expect(container.querySelectorAll("span.text-muted-foreground\\/50")).toHaveLength(1);
+  });
+});
+
+describe("SessionMetaFooter", () => {
+  it("labels the id field per-page and always renders the type", () => {
+    render(
+      <SessionMetaFooter idLabel="Conversation ID" id="sess_abc123" type="chat" />,
+    );
+    expect(screen.getByText("Conversation ID")).toBeInTheDocument();
+    expect(screen.getByText("Type")).toBeInTheDocument();
+    expect(screen.getByText("chat")).toBeInTheDocument();
+  });
+
+  it("omits CLI session and worktree when the session never spawned a process", () => {
+    render(<SessionMetaFooter idLabel="Session ID" id="sess_abc123" type="task" />);
+    expect(screen.queryByText("CLI session")).not.toBeInTheDocument();
+    expect(screen.queryByText("Worktree")).not.toBeInTheDocument();
+  });
+
+  it("renders CLI session and worktree when present", () => {
+    render(
+      <SessionMetaFooter
+        idLabel="Session ID"
+        id="sess_abc123"
+        cliSession="cli-99"
+        worktree="/tmp/wt"
+        type="task"
+      />,
+    );
+    expect(screen.getByText("cli-99")).toBeInTheDocument();
+    expect(screen.getByText("/tmp/wt")).toBeInTheDocument();
+  });
+});

--- a/packages/web/components/sessions/session-detail-chrome.tsx
+++ b/packages/web/components/sessions/session-detail-chrome.tsx
@@ -1,0 +1,139 @@
+import { Fragment, type ReactNode } from "react";
+import type { HierarchyLevel, SessionStatus } from "@beevibe/core";
+import { Avatar } from "@/components/avatar";
+import { HierChip } from "@/components/hier-chip";
+import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
+import { FooterField } from "@/components/detail/footer-field";
+import { SessionStatusPill } from "@/components/detail/status-pill";
+import { Skeleton } from "@/components/skeleton";
+
+/**
+ * The chrome shared by the two session detail pages —
+ * `/sessions/[sid]` (a chat conversation) and
+ * `/tasks/[id]/sessions/[sid]` (a task-spawned session).
+ *
+ * The two pages render genuinely different bodies (a turn-by-turn chat
+ * thread vs. a briefing + tool transcript), but they wrap that body in
+ * the same identity header, the same metadata footer, and the same
+ * loading skeleton — all three were maintained as parallel copies.
+ *
+ * The footer is the one that matters most: it is the "which process
+ * produced this" affordance (CLI session id, worktree path) that
+ * operators use to correlate a session with a daemon log, and it must
+ * read identically no matter which of the two pages you reached the
+ * session from. Two copies meant two chances for those fields to drift
+ * apart in wording or ordering.
+ */
+
+/**
+ * Avatar + title + status pill, over a meta line of
+ * `agent name · hierarchy · …`.
+ *
+ * `meta` holds the page-specific tail of that line — turn count and
+ * session type on the chat page, elapsed duration on the task page.
+ * Entries are rendered dot-separated, and `null` entries are dropped,
+ * so a caller can pass a conditional item inline without also having to
+ * manage the separator that precedes it.
+ */
+export function SessionIdentityHeader({
+  agentLabel,
+  agentHierarchy,
+  status,
+  title,
+  meta = [],
+}: {
+  agentLabel: string;
+  agentHierarchy: HierarchyLevel;
+  status: SessionStatus;
+  title: ReactNode;
+  meta?: Array<ReactNode | null>;
+}) {
+  return (
+    <header className="mb-6">
+      <div className="flex items-start gap-3">
+        <Avatar
+          initial={agentLabel.charAt(0).toUpperCase()}
+          kind={agentHierarchy}
+          label={agentLabel}
+          size={40}
+          presence={status === "running" ? "running" : "idle"}
+        />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <h1 className="text-base font-semibold tracking-tight leading-tight truncate">
+              {title}
+            </h1>
+            <SessionStatusPill status={status} />
+          </div>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span className="text-foreground/85">{agentLabel}</span>
+            <HierChip hier={agentHierarchy} />
+            {meta.map((item, i) =>
+              item == null ? null : (
+                // A Fragment, not a wrapper element: the separator and
+                // the item must stay direct children of the flex row so
+                // they pick up its `gap-2`. Index keys are safe — `meta`
+                // is a fixed-shape literal at each call site, never a
+                // reordered list.
+                <Fragment key={i}>
+                  <span className="text-muted-foreground/50">·</span>
+                  {item}
+                </Fragment>
+              ),
+            )}
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+/**
+ * The four-field process-provenance footer. `cliSession` and `worktree`
+ * are omitted rather than rendered empty when the session never got as
+ * far as spawning a process.
+ */
+export function SessionMetaFooter({
+  idLabel,
+  id,
+  cliSession,
+  worktree,
+  type,
+}: {
+  /** "Session ID" on the task page, "Conversation ID" on the chat page. */
+  idLabel: string;
+  id: string;
+  cliSession?: string | null;
+  worktree?: string | null;
+  type: string;
+}) {
+  return (
+    <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      <FooterField label={idLabel}>
+        <ClickToCopyId id={id} />
+      </FooterField>
+      {cliSession ? (
+        <FooterField label="CLI session" truncate>
+          <span className="font-mono">{cliSession}</span>
+        </FooterField>
+      ) : null}
+      {worktree ? (
+        <FooterField label="Worktree" truncate>
+          <span className="font-mono">{worktree}</span>
+        </FooterField>
+      ) : null}
+      <FooterField label="Type">{type}</FooterField>
+    </footer>
+  );
+}
+
+/** `DetailGate`'s `skeleton` for both session pages: header, panel, transcript. */
+export function SessionDetailSkeleton() {
+  return (
+    <>
+      <Skeleton className="h-14 w-full mb-6" />
+      <Skeleton className="h-32 w-full mb-5 rounded-lg" />
+      <Skeleton className="h-64 w-full rounded-lg" />
+    </>
+  );
+}

--- a/packages/web/components/user-widget.tsx
+++ b/packages/web/components/user-widget.tsx
@@ -14,7 +14,7 @@ import {
 } from "lucide-react";
 import { useMe } from "@/lib/hooks/use-me";
 import { useDismissOnOutside } from "@/lib/hooks/use-dismiss";
-import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
+import { ShareLinkBox, TextInput } from "@/components/form/field";
 import { ModalOverlay } from "@/components/modal-overlay";
 import { clearUserKey } from "@/lib/api/config";
 import { cn } from "@/lib/utils";
@@ -148,7 +148,6 @@ function MenuItem({
 
 function InviteTeammateDialog({ onClose }: { onClose: () => void }) {
   const [email, setEmail] = useState("");
-  const { copied, copy } = useCopyToClipboard();
   const trimmed = email.trim().toLowerCase();
   const valid = EMAIL_RE.test(trimmed);
   const origin = typeof window !== "undefined" ? window.location.origin : "";
@@ -164,35 +163,15 @@ function InviteTeammateDialog({ onClose }: { onClose: () => void }) {
           Share a sign-up link. When they sign up, they get their own team
           agent — then you can pull them into rooms with you.
         </p>
-        <input
+        <TextInput
           type="email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           autoFocus
           placeholder="alice@example.com"
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
         />
         {shareLink ? (
-          <div className="mt-3 rounded border border-border bg-muted/40 p-3">
-            <div className="text-[11px] text-muted-foreground mb-1.5">
-              Send them this link:
-            </div>
-            <div className="flex items-center gap-1.5">
-              <input
-                readOnly
-                value={shareLink}
-                className="flex-1 rounded border border-border bg-background px-2 py-1.5 text-[11px] font-mono"
-                onFocus={(e) => e.currentTarget.select()}
-              />
-              <button
-                type="button"
-                onClick={() => void copy(shareLink)}
-                className="h-7 px-2.5 rounded text-[11px] font-medium border border-border hover:bg-secondary transition-colors cursor-pointer shrink-0"
-              >
-                {copied ? "Copied" : "Copy"}
-              </button>
-            </div>
-          </div>
+          <ShareLinkBox className="mt-3" hint="Send them this link:" link={shareLink} />
         ) : null}
         <div className="mt-4 flex items-center justify-end gap-2">
           <button


### PR DESCRIPTION
Swept the monorepo for near-duplicate abstractions and unified the three clusters that survived scrutiny. All three are in `packages/web` — the backend is already well factored (see "Where the duplication isn't" below).

Three independent clusters, one commit each, reviewable in isolation.

---

### 1. `c067c84` — one session-detail chrome for both session pages

`/sessions/[sid]` (chat conversation) and `/tasks/[id]/sessions/[sid]` (task-spawned session) render genuinely different bodies, but wrapped them in three hand-copied parallel blocks: the avatar/title/status header, the metadata footer, and the `DetailGate` loading skeleton.

The footer is the one with teeth. It's the "which process produced this" affordance — CLI session id, worktree path — that operators use to correlate a session with a daemon log, and it has to read identically no matter which page you reached the session from. Two copies meant two chances for those fields to drift in wording or order.

New `components/sessions/session-detail-chrome.tsx`: `SessionIdentityHeader` (page-specific meta comes in as a dot-separated list, null entries dropped so a conditional item doesn't strand its separator), `SessionMetaFooter`, `SessionDetailSkeleton`.

One deliberate normalization: the two `<h1>`s disagreed on `tracking-tight` (chat only) vs `truncate` (task only). The shared header carries both — `truncate` is a no-op on the chat page's fixed titles, `tracking-tight` is a sub-pixel change on the task page.

### 2. `3a81a6e` — shared form primitives for the auth + invite surfaces

Five files — `sign-in`, `sign-up`, `rooms-list`, the room `InviteDialog`, the user-widget `InviteTeammateDialog` — had each hand-written the same three pieces of a form. The duplication lived in the **class strings**, which is the failure mode with no safety net: an 80-character Tailwind literal repeated nine times renders identically until somebody tweaks one copy, and then two inputs on adjacent screens quietly stop matching. No type error, no failing test.

New `components/form/field.tsx`:

| | replaces |
|---|---|
| `TextInput` | 9 copies of the input class string |
| `TextField` | `TextInput` + its `htmlFor`-wired label |
| `InlineError` | 4 copies of the AlertTriangle + message row |
| `ShareLinkBox` | 2 copies × 25 lines of the read-only URL + Copy button |

`TextInput` exists separately from `TextField` on purpose: the two invite dialogs have unlabeled inputs (a heading and explanatory paragraph stand in), and forcing a label on them would have been a visual change, not a refactor.

One normalization: the room dialog's error glyph was `h-3 w-3` where the other three were `h-3.5 w-3.5`; it now matches.

### 3. `403c402` — describe the memory-eval tables as column lists

The memory-eval page rendered six read-only stats tables over six row types, each the same thirty lines of markup — same `thead` tint, same header rule, same body rule, same cell padding — differing only in headers and cell expressions. This file flags against itself more than any other in the tree.

New `stat-table.tsx` next to the page: `StatTable` takes `rows`, a `columns` list of `{header, align, cell, cellClassName}`, a `rowKey`, and an `empty` node. Each table is now its column list and nothing else.

The scope × fact_type pivot is the case that pays for the shape — its columns are generated from the `FACT_TYPES` constant, which a hand-written `<thead>` can't be spread from, so it had that constant mapped in two places.

Kept **local to the page**, not promoted to `components/`. The `<thead>` idiom appears nowhere else in the app (`memory-client` and `agents-list-view` are the only other tables and both style rows differently), so hoisting it would be inventing a design-system table on the strength of one page.

---

### Where the duplication isn't

Worth recording, since the obvious candidates all came up clean — the repo has been swept before:

- **The three CLI runtime adapters** (claude-code / codex / opencode) already share `adapters/runtime-common.ts`. The remaining per-adapter `stream-json.ts` parsers are genuinely different event schemas.
- **The Postgres repositories** already share `pg-helpers.ts` (`findRowById`, `updateRowById`, `buildPatchClause`).
- **The Express routes** already share `routes/http-errors.ts` (`requireParam`, `loadOwned`, `makeErrorHandler`).
- **The three `format.ts` modules** (core / api-views / web-lib) are already one implementation in `@beevibe/core/domain/format` with thin re-exports.
- **The error boundaries** (`app/error.tsx`, `global-error.tsx`, `rooms/[id]/error.tsx`) look similar but diverge deliberately — `global-error` must be inline-styled with its own `html`/`body`, and the room one shows a stack on purpose. Only the `useEffect(console.error)` preamble is shared. Left alone.

One small backend item found but **not** taken, to keep this PR single-purpose: `Math.min(Math.max(1, filter.limit ?? D), MAX)` is spelled out identically in `views/inbox.ts`, `views/memory.ts` and `views/promotions.ts`, with a fourth variant as `clampInt` in `views/memory-activity.ts` and ad-hoc clamps in `routes/view.ts`. Worth a `clampLimit` helper, but it's three lines a site and touches a different package — happy to open it separately if wanted.

### Verification

Run against `packages/web`:

- `tsc --noEmit` — clean
- `next lint` — 0 errors (the 2 remaining `import/no-duplicates` warnings are pre-existing in `lib/types/dashboard.ts`, untouched here)
- `vitest run` — 27 files, 219 tests pass (baseline was 24 files / 203; the 16 new tests cover the three extracted modules)
- `next build` — succeeds; every touched route compiles

No behavior changes beyond the two cosmetic normalizations called out above.

### A note on scope

The task asked for one PR per cluster. This session is pinned to a single designated branch, so it's one PR with three independent commits instead — each commit is self-contained and can be dropped or cherry-picked without touching the others.