### PR TITLE
test: cover the three untested MCP tools (32-65% → 100% lines)

### DIFF
--- a/packages/api/src/tools/session-search.test.ts
+++ b/packages/api/src/tools/session-search.test.ts
@@ -1,0 +1,434 @@
+import { describe, expect, it, vi } from "vitest";
+import type { HierarchyLevel, SessionSearchRequest } from "@beevibe/core";
+import {
+  SessionSearchError,
+  type SessionSearchService,
+} from "@beevibe/core/services/session-search";
+import {
+  createSessionSearchTool,
+  type SessionSearchToolContext,
+} from "./session-search.js";
+
+/**
+ * session_search has four calling shapes (discover / scroll / read /
+ * browse) that the agent selects *implicitly*, by which arguments it
+ * passes. There is no `kind` parameter on the wire — this handler infers
+ * it, and the precedence between the shapes is the whole contract:
+ *
+ *   session_id + around_message_id  → scroll   (wins over query)
+ *   session_id alone                → read
+ *   query alone                     → discover
+ *   nothing                         → browse
+ *
+ * Get the precedence wrong and the agent silently gets a different
+ * search than it asked for, with no error to notice. That is what most
+ * of these tests pin.
+ *
+ * The service is faked: its scope resolution and FTS need Postgres and
+ * are covered by core's own suite.
+ */
+
+const AGENT_ID = "agent_caller";
+const SESSION_ID = "sess_current";
+
+function fakeService(
+  impl?: (
+    req: SessionSearchRequest,
+    ctx: unknown,
+  ) => unknown | Promise<unknown>,
+): SessionSearchService {
+  return {
+    search: vi.fn(async (req: SessionSearchRequest, ctx: unknown) =>
+      impl ? await impl(req, ctx) : { kind: req.kind, results: [] },
+    ),
+  } as unknown as SessionSearchService;
+}
+
+function tool(
+  ctx: Partial<SessionSearchToolContext> = {},
+  service: SessionSearchService = fakeService(),
+) {
+  const t = createSessionSearchTool(
+    {
+      agentId: AGENT_ID,
+      hierarchyLevel: "ic" as HierarchyLevel,
+      sessionId: SESSION_ID,
+      ...ctx,
+    },
+    { sessionSearch: service },
+  );
+  return { handler: t.handler, definition: t, service };
+}
+
+/** The request the handler inferred from a given raw tool input. */
+async function inferred(
+  input: Record<string, unknown>,
+): Promise<SessionSearchRequest> {
+  const { handler, service } = tool();
+  await handler(input);
+  const call = (service.search as ReturnType<typeof vi.fn>).mock.calls[0];
+  if (!call) throw new Error("sessionSearch.search was never called");
+  return call[0] as SessionSearchRequest;
+}
+
+describe("createSessionSearchTool", () => {
+  it("advertises a schema with no required fields — browse takes no args", () => {
+    const { definition } = tool();
+
+    expect(definition.name).toBe("session_search");
+    expect(definition.schema.required).toBeUndefined();
+  });
+
+  it("constrains the filter enums to the domain's own constants", () => {
+    const { definition } = tool();
+    const { filters } = definition.schema.properties as {
+      filters: {
+        properties: {
+          session_type: { enum: string[] };
+          status: { enum: string[] };
+        };
+      };
+    };
+
+    expect(filters.properties.session_type.enum).toContain("task");
+    expect(filters.properties.session_type.enum).toContain("run_repo");
+    expect(filters.properties.status.enum).toContain("failed");
+  });
+
+  it("documents all four calling shapes in the agent-facing description", () => {
+    const { definition } = tool();
+
+    for (const shape of ["DISCOVERY", "SCROLL", "READ", "BROWSE"]) {
+      expect(definition.description).toContain(shape);
+    }
+  });
+});
+
+describe("shape inference", () => {
+  it("infers browse from no arguments", async () => {
+    expect(await inferred({})).toEqual({
+      kind: "browse",
+      limit: undefined,
+      filters: undefined,
+    });
+  });
+
+  it("infers discover from a bare query", async () => {
+    const req = await inferred({ query: "auth refactor" });
+
+    expect(req.kind).toBe("discover");
+    expect(req).toMatchObject({ query: "auth refactor" });
+  });
+
+  it("infers read from a bare session_id", async () => {
+    expect(await inferred({ session_id: "sess_past" })).toEqual({
+      kind: "read",
+      session_id: "sess_past",
+    });
+  });
+
+  it("infers scroll from session_id + around_message_id", async () => {
+    expect(
+      await inferred({ session_id: "sess_past", around_message_id: "evt_9" }),
+    ).toEqual({
+      kind: "scroll",
+      session_id: "sess_past",
+      around_message_id: "evt_9",
+      window: undefined,
+    });
+  });
+
+  it("lets scroll win over a query passed alongside it", async () => {
+    // Documented: "Ignored when session_id + around_message_id are set."
+    const req = await inferred({
+      query: "auth refactor",
+      session_id: "sess_past",
+      around_message_id: "evt_9",
+    });
+
+    expect(req.kind).toBe("scroll");
+    expect(req).not.toHaveProperty("query");
+  });
+
+  it("lets read win over a query when only session_id is set", async () => {
+    const req = await inferred({ query: "auth refactor", session_id: "sess_past" });
+
+    expect(req.kind).toBe("read");
+  });
+
+  it("falls back to discover when around_message_id is set without session_id", async () => {
+    // A dangling anchor can't identify a conversation, so it is ignored
+    // rather than producing an unanswerable scroll.
+    const req = await inferred({ query: "auth", around_message_id: "evt_9" });
+
+    expect(req.kind).toBe("discover");
+  });
+
+  it("falls back to browse when around_message_id is the only argument", async () => {
+    expect((await inferred({ around_message_id: "evt_9" })).kind).toBe("browse");
+  });
+
+  it("accepts the synthetic user-turn anchor id format", async () => {
+    const req = await inferred({
+      session_id: "sess_past",
+      around_message_id: "intent:sess_past",
+    });
+
+    expect(req).toMatchObject({
+      kind: "scroll",
+      around_message_id: "intent:sess_past",
+    });
+  });
+});
+
+describe("argument coercion", () => {
+  it.each([
+    ["whitespace-only", "   "],
+    ["empty", ""],
+    ["a number", 7],
+    ["null", null],
+  ])("treats %s session_id as absent", async (_label, session_id) => {
+    expect((await inferred({ session_id })).kind).toBe("browse");
+  });
+
+  it.each([
+    ["whitespace-only", "   "],
+    ["empty", ""],
+    ["a number", 7],
+  ])("treats %s query as absent", async (_label, query) => {
+    expect((await inferred({ query })).kind).toBe("browse");
+  });
+
+  it("treats a whitespace-only anchor as absent, degrading scroll to read", async () => {
+    expect(await inferred({ session_id: "sess_past", around_message_id: "  " })).toEqual({
+      kind: "read",
+      session_id: "sess_past",
+    });
+  });
+
+  it("trims the query, session_id and anchor before dispatching", async () => {
+    const req = await inferred({
+      session_id: "  sess_past  ",
+      around_message_id: "  evt_9  ",
+    });
+
+    expect(req).toMatchObject({
+      session_id: "sess_past",
+      around_message_id: "evt_9",
+    });
+  });
+
+  it("trims a discover query", async () => {
+    expect(await inferred({ query: "  auth refactor  " })).toMatchObject({
+      query: "auth refactor",
+    });
+  });
+
+  it("passes numeric limit and window through untouched — clamping is the service's job", async () => {
+    const discover = await inferred({ query: "auth", limit: 99 });
+    expect(discover).toMatchObject({ limit: 99 });
+
+    const scroll = await inferred({
+      session_id: "sess_past",
+      around_message_id: "evt_9",
+      window: 100,
+    });
+    expect(scroll).toMatchObject({ window: 100 });
+  });
+
+  it("drops a non-numeric limit rather than forwarding a bad type", async () => {
+    expect(await inferred({ query: "auth", limit: "3" })).toMatchObject({
+      limit: undefined,
+    });
+  });
+
+  it("drops a non-numeric window", async () => {
+    expect(
+      await inferred({
+        session_id: "sess_past",
+        around_message_id: "evt_9",
+        window: "10",
+      }),
+    ).toMatchObject({ window: undefined });
+  });
+
+  it.each([["newest"], ["oldest"]])("forwards the %s sort", async (sort) => {
+    expect(await inferred({ query: "auth", sort })).toMatchObject({ sort });
+  });
+
+  it("drops an unrecognised sort value", async () => {
+    expect(await inferred({ query: "auth", sort: "relevance" })).toMatchObject({
+      sort: undefined,
+    });
+  });
+
+  it("forwards filters on the discover shape", async () => {
+    const filters = { status: "failed", session_type: "task" };
+    expect(await inferred({ query: "auth", filters })).toMatchObject({ filters });
+  });
+
+  it("forwards filters on the browse shape", async () => {
+    const filters = { agent_id: "agent_sub" };
+    expect(await inferred({ filters })).toMatchObject({ filters });
+  });
+
+  it.each([
+    ["null", null],
+    ["a string", "status:failed"],
+  ])("drops %s filters", async (_label, filters) => {
+    expect(await inferred({ query: "auth", filters })).toMatchObject({
+      filters: undefined,
+    });
+  });
+});
+
+describe("caller context", () => {
+  it("passes the caller's agent id, tier and current session to the service", async () => {
+    const { handler, service } = tool({ hierarchyLevel: "org" as HierarchyLevel });
+
+    await handler({ query: "auth" });
+
+    expect(service.search).toHaveBeenCalledWith(expect.anything(), {
+      callerAgentId: AGENT_ID,
+      hierarchyLevel: "org",
+      currentSessionId: SESSION_ID,
+    });
+  });
+
+  it.each([["ic"], ["team"], ["org"]])(
+    "forwards the %s tier verbatim — scope resolution belongs to the service",
+    async (level) => {
+      const { handler, service } = tool({
+        hierarchyLevel: level as HierarchyLevel,
+      });
+
+      await handler({});
+
+      expect(service.search).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ hierarchyLevel: level }),
+      );
+    },
+  );
+});
+
+describe("results and failures", () => {
+  it("returns the service payload unwrapped on success", async () => {
+    const payload = { kind: "discover", results: [{ session: { id: "sess_1" } }] };
+    const { handler } = tool({}, fakeService(() => payload));
+
+    const res = await handler({ query: "auth" });
+
+    expect(res.isError).toBeUndefined();
+    expect(res.content).toBe(payload);
+  });
+
+  it("maps a null result onto not_found_or_forbidden", async () => {
+    // The service collapses three distinct cases to null on purpose:
+    // out-of-scope session, unknown anchor, anchor in the live
+    // conversation. The tool must not leak which.
+    const { handler } = tool({}, fakeService(() => null));
+
+    const res = await handler({ session_id: "sess_other" });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("not_found_or_forbidden");
+    expect(res.content.message).toContain("not in your scope");
+  });
+
+  it.each([
+    ["forbidden_agent_filter"],
+    ["missing_query"],
+    ["missing_args"],
+  ])("surfaces the %s code from a SessionSearchError", async (code) => {
+    const { handler } = tool(
+      {},
+      fakeService(() => {
+        throw new SessionSearchError(
+          code as "forbidden_agent_filter" | "missing_query" | "missing_args",
+          `rejected: ${code}`,
+        );
+      }),
+    );
+
+    const res = await handler({ query: "auth" });
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({ error: code, message: `rejected: ${code}` });
+  });
+
+  it("recognises a structurally-identical error from another bundle by name", async () => {
+    // api consumes @beevibe/core from dist/; a script consuming src/
+    // produces a different class object for the same error. The handler
+    // matches on `name` too so the code still reaches the agent.
+    const foreign = new Error("agent_id outside your scope");
+    foreign.name = "SessionSearchError";
+    (foreign as Error & { code: string }).code = "forbidden_agent_filter";
+
+    const { handler } = tool(
+      {},
+      fakeService(() => {
+        throw foreign;
+      }),
+    );
+
+    const res = await handler({ query: "auth" });
+
+    expect(res.content).toEqual({
+      error: "forbidden_agent_filter",
+      message: "agent_id outside your scope",
+    });
+  });
+
+  it("wraps an unrelated Error as internal_error", async () => {
+    const { handler } = tool(
+      {},
+      fakeService(() => {
+        throw new Error("connection terminated");
+      }),
+    );
+
+    const res = await handler({ query: "auth" });
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "internal_error",
+      message: "connection terminated",
+    });
+  });
+
+  it("stringifies a non-Error throw", async () => {
+    const { handler } = tool(
+      {},
+      fakeService(() => {
+        throw "statement timeout";
+      }),
+    );
+
+    const res = await handler({ query: "auth" });
+
+    expect(res.content).toEqual({
+      error: "internal_error",
+      message: "statement timeout",
+    });
+  });
+
+  it("does not treat a same-named non-SessionSearchError code as a code", async () => {
+    // An Error named SessionSearchError but with no `code` still takes
+    // the coded branch — assert the shape so the fallback is visible.
+    const nameless = new Error("odd");
+    nameless.name = "SessionSearchError";
+
+    const { handler } = tool(
+      {},
+      fakeService(() => {
+        throw nameless;
+      }),
+    );
+
+    const res = await handler({ query: "auth" });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.message).toBe("odd");
+  });
+});

--- a/packages/api/src/tools/use-repo.test.ts
+++ b/packages/api/src/tools/use-repo.test.ts
@@ -1,0 +1,505 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  RepoRunRepository,
+  Task,
+  TaskRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import { createUseRepoTool, type UseRepoServices } from "./use-repo.js";
+
+/**
+ * use_repo hands an arbitrary GitHub repo to a child agent inside a
+ * fresh Docker sandbox. The handler itself does no sandbox work — it
+ * validates, creates a container task, dispatches, and inserts the
+ * repo_run row.
+ *
+ * Two things make it worth pinning down:
+ *
+ *   • It is an untrusted-input boundary. `repo_url` comes from an LLM
+ *     that may have hallucinated it, and `limits` is agent-supplied.
+ *     Both get clamped here or not at all.
+ *
+ *   • The write order is load-bearing. `repo_run.session_id` has an FK
+ *     to `session.id`, so dispatch (which creates the session row) must
+ *     land before the repo_run insert, and the pre-minted session id
+ *     must be the *same* one on both sides. A regression there is an
+ *     FK violation in production and invisible in a unit test that only
+ *     checks the return value.
+ */
+
+const AGENT_ID = "agent_caller";
+const REPO_URL = "https://github.com/acme/pdf-tools";
+
+function fakeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: AGENT_ID,
+    owner_id: "person_owner",
+    hierarchy_level: "ic",
+    ...overrides,
+  } as Agent;
+}
+
+/** Pass `{ agent: undefined }` for the caller-not-found case — an
+ *  omitted argument still yields a valid agent. */
+function fakeAgentRepo(
+  opts: { agent?: Agent } = { agent: fakeAgent() },
+): AgentRepository {
+  return {
+    findById: vi.fn(async () => opts.agent),
+  } as unknown as AgentRepository;
+}
+
+function fakeTaskRepo(): TaskRepository {
+  return {
+    create: vi.fn(async (input: { id: string }) => ({ ...input }) as Task),
+  } as unknown as TaskRepository;
+}
+
+function fakeRepoRunRepo(opts: { throws?: Error } = {}): RepoRunRepository {
+  return {
+    create: vi.fn(async (input: Record<string, unknown>) => {
+      if (opts.throws) throw opts.throws;
+      return input;
+    }),
+  } as unknown as RepoRunRepository;
+}
+
+function fakeDispatchService(opts: { throws?: unknown } = {}): DispatchService {
+  return {
+    dispatchTask: vi.fn(async () => {
+      if (opts.throws) throw opts.throws;
+      return { sessionId: "ignored" };
+    }),
+  } as unknown as DispatchService;
+}
+
+function services(overrides: Partial<UseRepoServices> = {}): UseRepoServices {
+  return {
+    agentRepo: fakeAgentRepo(),
+    taskRepo: fakeTaskRepo(),
+    repoRunRepo: fakeRepoRunRepo(),
+    dispatchService: fakeDispatchService(),
+    ...overrides,
+  };
+}
+
+function tool(svc: UseRepoServices = services()) {
+  return {
+    handler: createUseRepoTool({ agentId: AGENT_ID }, svc).handler,
+    svc,
+  };
+}
+
+function call(
+  input: Record<string, unknown> = {},
+  svc: UseRepoServices = services(),
+) {
+  const t = tool(svc);
+  return t.handler({ goal: "extract tables", repo_url: REPO_URL, ...input });
+}
+
+function mockOf(fn: unknown): ReturnType<typeof vi.fn> {
+  return fn as ReturnType<typeof vi.fn>;
+}
+
+/** The single row handed to taskRepo.create. */
+function createdTask(svc: UseRepoServices): { title: string; description: string } {
+  const call = mockOf(svc.taskRepo.create).mock.calls[0];
+  if (!call) throw new Error("taskRepo.create was never called");
+  return call[0] as { title: string; description: string };
+}
+
+/** Order in which two mocks were first invoked, relative to each other. */
+function firstCallOrder(fn: unknown): number {
+  const order = mockOf(fn).mock.invocationCallOrder[0];
+  if (order === undefined) throw new Error("mock was never called");
+  return order;
+}
+
+describe("createUseRepoTool", () => {
+  it("exposes goal + repo_url as the required schema fields", () => {
+    const t = createUseRepoTool({ agentId: AGENT_ID }, services());
+
+    expect(t.name).toBe("use_repo");
+    expect(t.schema.required).toEqual(["goal", "repo_url"]);
+    expect(t.schema.additionalProperties).toBe(false);
+  });
+});
+
+describe("use_repo happy path", () => {
+  it("creates the container task, dispatches, then inserts the repo_run", async () => {
+    const svc = services();
+    const res = await call({ goal: "Extract the tables as JSON" }, svc);
+
+    expect(res.isError).toBeUndefined();
+    expect(svc.taskRepo.create).toHaveBeenCalledTimes(1);
+    expect(svc.dispatchService.dispatchTask).toHaveBeenCalledTimes(1);
+    expect(svc.repoRunRepo.create).toHaveBeenCalledTimes(1);
+
+    // The FK ordering the module comment calls out: the session row has
+    // to exist before repo_run references it.
+    expect(firstCallOrder(svc.dispatchService.dispatchTask)).toBeLessThan(
+      firstCallOrder(svc.repoRunRepo.create),
+    );
+  });
+
+  it("returns freshly minted, correctly prefixed ids and a watch url", async () => {
+    const res = await call();
+
+    expect(res.content.repo_run_id).toMatch(/^repo_/);
+    expect(res.content.session_id).toMatch(/^sess_/);
+    expect(res.content.task_id).toMatch(/^task_/);
+    expect(res.content.status).toBe("pending");
+    expect(res.content.watch_url).toBe(
+      `/capabilities/runs/${res.content.repo_run_id}`,
+    );
+    expect(res.content.note).toContain("poll");
+  });
+
+  it("dispatches a run_repo session under the pre-minted session id", async () => {
+    const svc = services();
+    const res = await call({ goal: "Rip the audio" }, svc);
+
+    expect(svc.dispatchService.dispatchTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: AGENT_ID,
+        type: "run_repo",
+        intent: "Rip the audio",
+        reason: { kind: "fresh" },
+        sessionIdOverride: res.content.session_id,
+      }),
+    );
+  });
+
+  it("writes the repo_run against that same session and task", async () => {
+    const svc = services();
+    const res = await call({ goal: "Rip the audio" }, svc);
+
+    expect(svc.repoRunRepo.create).toHaveBeenCalledWith({
+      id: res.content.repo_run_id,
+      session_id: res.content.session_id,
+      task_id: res.content.task_id,
+      agent_id: AGENT_ID,
+      goal: "Rip the audio",
+      repo_url: REPO_URL,
+      status: "pending",
+    });
+  });
+
+  it("pins the container task to the resolved agent as both creator and assignee", async () => {
+    const svc = services();
+    await call({ goal: "Extract tables" }, svc);
+
+    expect(svc.taskRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assignee_id: AGENT_ID,
+        creator_id: AGENT_ID,
+        creator_type: "agent",
+        priority: "medium",
+        description: "Extract tables",
+      }),
+    );
+  });
+
+  it("uses the resolved agent's id, not the raw context id", async () => {
+    // findById is the authority; if the repo returns a different row the
+    // task and repo_run should follow it.
+    const svc = services({
+      agentRepo: fakeAgentRepo({ agent: fakeAgent({ id: "agent_resolved" }) }),
+    });
+    await call({}, svc);
+
+    expect(svc.taskRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ assignee_id: "agent_resolved" }),
+    );
+    expect(svc.repoRunRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ agent_id: "agent_resolved" }),
+    );
+  });
+
+  it("trims surrounding whitespace off goal and repo_url", async () => {
+    const svc = services();
+    await call({ goal: "  extract tables  ", repo_url: `  ${REPO_URL}  ` }, svc);
+
+    expect(svc.repoRunRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ goal: "extract tables", repo_url: REPO_URL }),
+    );
+  });
+});
+
+describe("use_repo container task title", () => {
+  it("collapses runs of whitespace so the inbox row stays scannable", async () => {
+    const svc = services();
+    await call({ goal: "extract\n\n  the   tables" }, svc);
+
+    expect(svc.taskRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "extract the tables" }),
+    );
+  });
+
+  it("keeps a title of exactly 80 chars intact", async () => {
+    const goal = "x".repeat(80);
+    const svc = services();
+    await call({ goal }, svc);
+
+    const { title } = createdTask(svc);
+    expect(title).toBe(goal);
+    expect(title).toHaveLength(80);
+  });
+
+  it("truncates a longer title to 77 chars plus an ellipsis", async () => {
+    const goal = "y".repeat(200);
+    const svc = services();
+    await call({ goal }, svc);
+
+    const { title } = createdTask(svc);
+    expect(title).toBe("y".repeat(77) + "…");
+    expect(title).toHaveLength(78);
+  });
+
+  it("truncates the title but stores the full goal as the description", async () => {
+    const goal = "z".repeat(120);
+    const svc = services();
+    await call({ goal }, svc);
+
+    const created = createdTask(svc);
+    expect(created.description).toBe(goal);
+    expect(created.title).not.toBe(goal);
+  });
+});
+
+describe("use_repo input validation", () => {
+  it.each([
+    ["missing", undefined],
+    ["empty", ""],
+    ["whitespace-only", "   "],
+    ["non-string", 42],
+  ])("rejects a %s goal", async (_label, goal) => {
+    const svc = services();
+    const res = await call({ goal }, svc);
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("invalid_goal");
+    expect(svc.taskRepo.create).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["a non-GitHub host", "https://gitlab.com/acme/repo"],
+    ["plain http", "http://github.com/acme/repo"],
+    ["an unparseable url", "not a url"],
+    ["an empty string", ""],
+    ["a lookalike host", "https://github.com.evil.test/acme/repo"],
+    ["a suffix-only lookalike", "https://notgithub.com/acme/repo"],
+    ["an ssh remote", "git@github.com:acme/repo.git"],
+  ])("rejects %s", async (_label, repo_url) => {
+    const svc = services();
+    const res = await call({ repo_url }, svc);
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("invalid_repo_url");
+    expect(svc.taskRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-string repo_url", async () => {
+    const res = await call({ repo_url: { url: REPO_URL } });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("invalid_repo_url");
+  });
+
+  it.each([
+    ["a subdomain of github.com", "https://gist.github.com/acme/abc123"],
+    ["an uppercase host", "https://GitHub.com/acme/repo"],
+    ["a url with a query string", "https://github.com/acme/repo?tab=readme"],
+  ])("accepts %s", async (_label, repo_url) => {
+    const res = await call({ repo_url });
+
+    expect(res.isError).toBeUndefined();
+  });
+
+  it("checks the goal before the repo_url", async () => {
+    const res = await call({ goal: "", repo_url: "https://gitlab.com/x/y" });
+
+    expect(res.content.error).toBe("invalid_goal");
+  });
+
+  it("validates input before looking the agent up", async () => {
+    const svc = services();
+    await call({ goal: "" }, svc);
+
+    expect(svc.agentRepo.findById).not.toHaveBeenCalled();
+  });
+});
+
+describe("use_repo limits clamping", () => {
+  it("passes through in-range limits unchanged", async () => {
+    const res = await call({
+      limits: { wall_clock_minutes: 15, max_install_attempts: 3, disk_mb: 1024 },
+    });
+
+    expect(res.content.limits).toEqual({
+      wall_clock_minutes: 15,
+      max_install_attempts: 3,
+      disk_mb: 1024,
+    });
+  });
+
+  it("clamps each limit to its documented ceiling", async () => {
+    const res = await call({
+      limits: {
+        wall_clock_minutes: 600,
+        max_install_attempts: 99,
+        disk_mb: 500_000,
+      },
+    });
+
+    expect(res.content.limits).toEqual({
+      wall_clock_minutes: 60,
+      max_install_attempts: 5,
+      disk_mb: 10_000,
+    });
+  });
+
+  it("floors fractional attempt and disk values", async () => {
+    const res = await call({
+      limits: { max_install_attempts: 2.9, disk_mb: 512.7 },
+    });
+
+    expect(res.content.limits).toEqual({
+      max_install_attempts: 2,
+      disk_mb: 512,
+    });
+  });
+
+  it.each([
+    ["zero", 0],
+    ["negative", -5],
+    ["a string", "20"],
+    ["null", null],
+  ])("drops %s limit values rather than clamping them", async (_label, value) => {
+    const res = await call({
+      limits: {
+        wall_clock_minutes: value,
+        max_install_attempts: value,
+        disk_mb: value,
+      },
+    });
+
+    expect(res.content.limits).toEqual({});
+  });
+
+  it.each([
+    ["omitted", undefined],
+    ["null", null],
+    ["a string", "generous"],
+    ["a number", 5],
+  ])("treats %s limits as no limits", async (_label, limits) => {
+    const res = await call({ limits });
+
+    expect(res.content.limits).toEqual({});
+  });
+
+  it("keeps the valid half of a partly-bogus limits object", async () => {
+    const res = await call({
+      limits: { wall_clock_minutes: 10, disk_mb: -1 },
+    });
+
+    expect(res.content.limits).toEqual({ wall_clock_minutes: 10 });
+  });
+});
+
+describe("use_repo optional input file", () => {
+  it("echoes a trimmed input_url and input_filename", async () => {
+    const res = await call({
+      input_url: "  https://example.test/report.pdf  ",
+      input_filename: "  report.pdf  ",
+    });
+
+    expect(res.content.input_url).toBe("https://example.test/report.pdf");
+    expect(res.content.input_filename).toBe("report.pdf");
+  });
+
+  it("leaves both undefined when not supplied", async () => {
+    const res = await call();
+
+    expect(res.content.input_url).toBeUndefined();
+    expect(res.content.input_filename).toBeUndefined();
+  });
+
+  it("ignores non-string values", async () => {
+    const res = await call({ input_url: 12, input_filename: false });
+
+    expect(res.content.input_url).toBeUndefined();
+    expect(res.content.input_filename).toBeUndefined();
+  });
+});
+
+describe("use_repo failure paths", () => {
+  it("reports agent_not_found and writes nothing when the caller is unknown", async () => {
+    const svc = services({ agentRepo: fakeAgentRepo({ agent: undefined }) });
+    const res = await call({}, svc);
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("agent_not_found");
+    expect(svc.taskRepo.create).not.toHaveBeenCalled();
+    expect(svc.dispatchService.dispatchTask).not.toHaveBeenCalled();
+    expect(svc.repoRunRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("reports dispatch_failed and skips the repo_run insert", async () => {
+    // No session row landed, so inserting repo_run would violate the FK.
+    const svc = services({
+      dispatchService: fakeDispatchService({ throws: new Error("no daemon online") }),
+    });
+    const res = await call({}, svc);
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "dispatch_failed",
+      message: "no daemon online",
+    });
+    expect(svc.repoRunRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("stringifies a non-Error dispatch throw", async () => {
+    const svc = services({
+      dispatchService: fakeDispatchService({ throws: "runtime unavailable" }),
+    });
+    const res = await call({}, svc);
+
+    expect(res.content).toEqual({
+      error: "dispatch_failed",
+      message: "runtime unavailable",
+    });
+  });
+
+  it("surfaces repo_run_create_failed so the agent doesn't wait on an orphan session", async () => {
+    const svc = services({
+      repoRunRepo: fakeRepoRunRepo({ throws: new Error("duplicate key") }),
+    });
+    const res = await call({}, svc);
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "repo_run_create_failed",
+      message: "duplicate key",
+    });
+  });
+
+  it("lets a container-task failure propagate rather than swallowing it", async () => {
+    // There is no try/catch around taskRepo.create — an unexpected
+    // failure there should surface as a thrown error, not a success
+    // envelope with a missing task_id.
+    const svc = services({
+      taskRepo: {
+        create: vi.fn(async () => {
+          throw new Error("task insert failed");
+        }),
+      } as unknown as TaskRepository,
+    });
+
+    await expect(call({}, svc)).rejects.toThrow("task insert failed");
+  });
+});

--- a/packages/api/src/tools/watch.test.ts
+++ b/packages/api/src/tools/watch.test.ts
@@ -1,0 +1,346 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  WatchAuthError,
+  WatchNotFoundError,
+  WatchValidationError,
+  type WatchService,
+} from "@beevibe/core/services/watch-service";
+import { buildWatchTools, type WatchToolContext } from "./watch.js";
+import type { AgentTool } from "./types.js";
+
+/**
+ * watch_tasks + unwatch are deliberately thin: WatchService owns the
+ * auth check, the insert, the already-terminal race and the unwatch
+ * state machine. What lives *here* is the part the service never sees —
+ * coercing untyped MCP input into a typed call, and mapping the
+ * service's error classes back onto the wire's stable error codes.
+ *
+ * So these tests pin two things:
+ *   1. what reaches WatchService (defaults applied, junk dropped)
+ *   2. what the agent sees when the service throws
+ *
+ * The service itself is faked throughout — its own behaviour is covered
+ * by core's watch-service tests, which need a real Postgres.
+ */
+
+const AGENT_ID = "agent_caller";
+const SESSION_ID = "sess_current";
+
+function fakeWatchService(
+  overrides: Partial<Record<"watchTasks" | "unwatch", unknown>> = {},
+): WatchService {
+  return {
+    watchTasks: vi.fn(async () => ({
+      watchId: "tw_1",
+      firedImmediately: false,
+    })),
+    unwatch: vi.fn(async () => undefined),
+    ...overrides,
+  } as unknown as WatchService;
+}
+
+function tools(
+  ctx: Partial<WatchToolContext> = {},
+  service: WatchService = fakeWatchService(),
+): { watch: AgentTool; unwatch: AgentTool; service: WatchService } {
+  const built = buildWatchTools(
+    { agentId: AGENT_ID, sessionId: SESSION_ID, ...ctx },
+    { watchService: service },
+  );
+  const watch = built.find((t) => t.name === "watch_tasks");
+  const unwatch = built.find((t) => t.name === "unwatch");
+  if (!watch || !unwatch) throw new Error("expected both watch tools");
+  return { watch, unwatch, service };
+}
+
+describe("buildWatchTools", () => {
+  it("returns watch_tasks and unwatch, both with a task_ids/watch_id schema", () => {
+    const { watch, unwatch } = tools();
+
+    expect(watch.schema.required).toEqual(["task_ids"]);
+    expect(unwatch.schema.required).toEqual(["watch_id"]);
+    // The descriptions are the agent-facing contract, so a non-trivial
+    // one is part of the surface, not decoration.
+    expect(watch.description).toContain("watch");
+    expect(unwatch.description.length).toBeGreaterThan(0);
+  });
+
+  it("advertises exactly the modes the domain defines", () => {
+    const { watch } = tools();
+    const props = watch.schema.properties as {
+      mode: { enum: string[] };
+    };
+    expect(props.mode.enum).toEqual(["all", "any"]);
+  });
+});
+
+describe("watch_tasks", () => {
+  it("forwards caller identity, task ids, mode and reason to the service", async () => {
+    const { watch, service } = tools();
+
+    const res = await watch.handler({
+      task_ids: ["task_a", "task_b"],
+      mode: "any",
+      reason: "  need the build result  ",
+    });
+
+    expect(service.watchTasks).toHaveBeenCalledWith({
+      callerAgentId: AGENT_ID,
+      callerSessionId: SESSION_ID,
+      taskIds: ["task_a", "task_b"],
+      mode: "any",
+      reason: "need the build result",
+    });
+    expect(res.isError).toBeUndefined();
+    expect(res.content).toEqual({ watch_id: "tw_1", fired_immediately: false });
+  });
+
+  it("defaults mode to 'all' when omitted", async () => {
+    const { watch, service } = tools();
+
+    await watch.handler({ task_ids: ["task_a"] });
+
+    expect(service.watchTasks).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "all" }),
+    );
+  });
+
+  it("defaults mode to 'all' when the value is not a known mode", async () => {
+    const { watch, service } = tools();
+
+    await watch.handler({ task_ids: ["task_a"], mode: "eventually" });
+
+    expect(service.watchTasks).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "all" }),
+    );
+  });
+
+  it("drops a whitespace-only reason rather than forwarding it", async () => {
+    const { watch, service } = tools();
+
+    await watch.handler({ task_ids: ["task_a"], reason: "   " });
+
+    expect(service.watchTasks).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: undefined }),
+    );
+  });
+
+  it("drops a non-string reason", async () => {
+    const { watch, service } = tools();
+
+    await watch.handler({ task_ids: ["task_a"], reason: 42 });
+
+    expect(service.watchTasks).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: undefined }),
+    );
+  });
+
+  it("filters non-string entries out of task_ids", async () => {
+    const { watch, service } = tools();
+
+    await watch.handler({ task_ids: ["task_a", 7, null, "task_b"] });
+
+    expect(service.watchTasks).toHaveBeenCalledWith(
+      expect.objectContaining({ taskIds: ["task_a", "task_b"] }),
+    );
+  });
+
+  it("reports fired_immediately when the condition was already met", async () => {
+    const service = fakeWatchService({
+      watchTasks: vi.fn(async () => ({ watchId: "tw_9", firedImmediately: true })),
+    });
+    const { watch } = tools({}, service);
+
+    const res = await watch.handler({ task_ids: ["task_done"] });
+
+    expect(res.content).toEqual({ watch_id: "tw_9", fired_immediately: true });
+  });
+
+  it("rejects an empty task_ids array without calling the service", async () => {
+    const { watch, service } = tools();
+
+    const res = await watch.handler({ task_ids: [] });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("watch_validation");
+    expect(service.watchTasks).not.toHaveBeenCalled();
+  });
+
+  it("rejects task_ids that contain no strings at all", async () => {
+    const { watch, service } = tools();
+
+    const res = await watch.handler({ task_ids: [1, 2, 3] });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("watch_validation");
+    expect(service.watchTasks).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-array task_ids", async () => {
+    const { watch, service } = tools();
+
+    const res = await watch.handler({ task_ids: "task_a" });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("watch_validation");
+    expect(service.watchTasks).not.toHaveBeenCalled();
+  });
+
+  it("refuses to register a watch outside a session context", async () => {
+    // Without a session id there is no waiter to re-invoke, so the
+    // watch would fire into nowhere. Caught before the service call.
+    const { watch, service } = tools({ sessionId: undefined });
+
+    const res = await watch.handler({ task_ids: ["task_a"] });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("watch_validation");
+    expect(res.content.message).toContain("session context");
+    expect(service.watchTasks).not.toHaveBeenCalled();
+  });
+
+  it("validates task_ids before the missing-session check", async () => {
+    // Both are invalid here; the array check is the one that reports,
+    // which keeps the message pointed at the argument the agent passed.
+    const { watch } = tools({ sessionId: undefined });
+
+    const res = await watch.handler({ task_ids: [] });
+
+    expect(res.content.message).toContain("non-empty array");
+  });
+});
+
+describe("watch_tasks error mapping", () => {
+  it.each([
+    ["watch_auth", new WatchAuthError("not your task")],
+    ["watch_validation", new WatchValidationError("bad mode")],
+    ["watch_not_found", new WatchNotFoundError("tw_missing")],
+  ])("maps a %s failure onto its stable code", async (code, thrown) => {
+    const service = fakeWatchService({
+      watchTasks: vi.fn(async () => {
+        throw thrown;
+      }),
+    });
+    const { watch } = tools({}, service);
+
+    const res = await watch.handler({ task_ids: ["task_a"] });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe(code);
+    expect(res.content.message).toBe((thrown as Error).message);
+  });
+
+  it("maps an unrecognised Error onto the generic watch_error code", async () => {
+    const service = fakeWatchService({
+      watchTasks: vi.fn(async () => {
+        throw new Error("connection reset");
+      }),
+    });
+    const { watch } = tools({}, service);
+
+    const res = await watch.handler({ task_ids: ["task_a"] });
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "watch_error",
+      message: "connection reset",
+    });
+  });
+
+  it("stringifies a non-Error throw", async () => {
+    const service = fakeWatchService({
+      watchTasks: vi.fn(async () => {
+        throw "pool exhausted";
+      }),
+    });
+    const { watch } = tools({}, service);
+
+    const res = await watch.handler({ task_ids: ["task_a"] });
+
+    expect(res.content).toEqual({
+      error: "watch_error",
+      message: "pool exhausted",
+    });
+  });
+});
+
+describe("unwatch", () => {
+  it("cancels the watch and reports ok", async () => {
+    const { unwatch, service } = tools();
+
+    const res = await unwatch.handler({ watch_id: "tw_1" });
+
+    expect(service.unwatch).toHaveBeenCalledWith({
+      callerAgentId: AGENT_ID,
+      watchId: "tw_1",
+    });
+    expect(res.isError).toBeUndefined();
+    expect(res.content).toEqual({ ok: true });
+  });
+
+  it("rejects a missing watch_id without calling the service", async () => {
+    const { unwatch, service } = tools();
+
+    const res = await unwatch.handler({});
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("watch_validation");
+    expect(service.unwatch).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty-string watch_id", async () => {
+    const { unwatch, service } = tools();
+
+    const res = await unwatch.handler({ watch_id: "" });
+
+    expect(res.isError).toBe(true);
+    expect(service.unwatch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-string watch_id", async () => {
+    const { unwatch, service } = tools();
+
+    const res = await unwatch.handler({ watch_id: { id: "tw_1" } });
+
+    expect(res.isError).toBe(true);
+    expect(service.unwatch).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an auth failure with the watch_auth code", async () => {
+    const service = fakeWatchService({
+      unwatch: vi.fn(async () => {
+        throw new WatchAuthError("watch belongs to another agent");
+      }),
+    });
+    const { unwatch } = tools({}, service);
+
+    const res = await unwatch.handler({ watch_id: "tw_other" });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("watch_auth");
+  });
+
+  it("surfaces a not-found failure with the watch_not_found code", async () => {
+    const service = fakeWatchService({
+      unwatch: vi.fn(async () => {
+        throw new WatchNotFoundError("tw_gone");
+      }),
+    });
+    const { unwatch } = tools({}, service);
+
+    const res = await unwatch.handler({ watch_id: "tw_gone" });
+
+    expect(res.content.error).toBe("watch_not_found");
+  });
+
+  it("does not need a session context — only the caller agent", async () => {
+    // unwatch identifies the row by id, so unlike watch_tasks it stays
+    // usable outside a session.
+    const { unwatch, service } = tools({ sessionId: undefined });
+
+    const res = await unwatch.handler({ watch_id: "tw_1" });
+
+    expect(res.content).toEqual({ ok: true });
+    expect(service.unwatch).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

A coverage sweep across all five packages found three agent-facing MCP tools in `packages/api/src/tools/` with **no test file at all**. Whatever coverage they had came incidentally from other suites importing them.

| File | Before | After |
| --- | --- | --- |
| `tools/use-repo.ts` | 32.0% | **100%** |
| `tools/watch.ts` | 46.3% | **100%** |
| `tools/session-search.ts` | 64.7% | **100%** |

**120 new tests, 277 newly covered lines.** All three are pure handler logic over faked services, so they need neither Postgres nor provider keys — they run green in a bare sandbox and in CI alike.

## How these were picked

Ran v8 coverage per package, excluding the DB- and key-gated suites (per `CLAUDE.md`, an unhandled error in those aborts report generation entirely). Non-gated line coverage by package:

```
core       94.5%      api        73.8%      daemon     80.4%
scheduler  47.0%      sandbox    75.1%
```

Ranking the gaps by uncovered lines, the largest were composition roots (`bootstrap.ts`, `main.ts`, `server.ts`), barrel `index.ts` files, and the `sandbox/src/scripts/*` manual dev utilities — all low-value or explicitly load-bearing-but-untestable per the repo's own dead-code notes. The `tools/*` handlers were the biggest genuine gap: product-critical, agent-facing, and cleanly testable behind their service interfaces.

## What the tests pin, beyond line count

**`use_repo` is an untrusted-input boundary.** `repo_url` arrives from an LLM that may have hallucinated it, and `limits` is agent-supplied — both get clamped here or not at all. Covers host validation (lookalike hosts `github.com.evil.test` and `notgithub.com`, plain `http`, ssh remotes, subdomains that *should* pass like `gist.github.com`) and every limit ceiling.

It also asserts the **load-bearing write order**: `repo_run.session_id` has an FK to `session.id`, so `dispatchTask` (which creates the session row) must land before the `repo_run` insert, under the same pre-minted session id. A regression there is an FK violation in production and completely invisible to a test that only checks the return value.

**`session_search` infers its four calling shapes implicitly** from which arguments are present — there is no `kind` on the wire. The precedence is the entire contract:

```
session_id + around_message_id  → scroll   (wins over query)
session_id alone                → read
query alone                     → discover
nothing                         → browse
```

Get it wrong and the agent silently receives a different search than it asked for, with no error to notice. Every edge is covered, including a dangling anchor with no `session_id`, and the cross-bundle `SessionSearchError` match-by-name (api consumes core from `dist/`, scripts consume `src/`, so `instanceof` alone isn't enough).

**`watch.ts` is a deliberately thin adapter** over `WatchService`, so the tests focus on the part the service never sees: input coercion (mode defaulting, non-strings filtered out of `task_ids`, whitespace-only reasons dropped) and the mapping from its three error classes onto the wire's stable codes.

## Verification

- `npx tsc -p packages/api/tsconfig.json --noEmit` — clean
- `eslint` on the three new files — clean
- Full `@beevibe/api` suite: **940 passed** (820 before + 120 new). The 9 failing files are the pre-existing DB/key-gated suites documented in `CLAUDE.md` — unchanged in count and identity.

Per `CLAUDE.md`, `@vitest/coverage-v8` was installed for the sweep and **not** committed; `package.json` and `pnpm-lock.yaml` are untouched. This PR adds three files and changes nothing else.

---
_Generated by [Claude Code](https://claude.ai/code/session_014BuLSJp7L9WZ38FjBrkR4B)_