### PR TITLE
chore(core): drop the never-wired RuntimeConfig.timeout_ms field

### DIFF
--- a/packages/core/src/domain/agent.ts
+++ b/packages/core/src/domain/agent.ts
@@ -26,7 +26,6 @@ export interface RuntimeConfig {
    */
   model?: string;
   max_turns?: number;
-  timeout_ms?: number;
   system_prompt_addition?: string;
 }
 


### PR DESCRIPTION
Static + dynamic dead-code sweep. The repo is close to clean after #285 — this PR removes the single verified finding, and records the audit so the next sweep doesn't re-derive it.

## The change

`RuntimeConfig.timeout_ms` (`packages/core/src/domain/agent.ts`) is declared on the agent's persisted `runtime_config` shape and **never read or written anywhere** — no reader, no writer, no migration default, no test.

What makes it dead rather than pending work is that its four siblings on the same interface are all wired end-to-end:

| Field | Wired through |
| --- | --- |
| `type` | `adapters/postgres/agent-repo.ts`, `runtime/router.ts` |
| `model` | `runtime/router.ts` → `claude-code/runtime.ts` |
| `max_turns` | `runtime/router.ts:623` → `claude-code/runtime.ts:94` |
| `system_prompt_addition` | `runtime/router.ts:613`, `tools/instructions.ts:46` |
| `timeout_ms` | **nothing** |

There is no port, no service branch, and no read side for it — so it does not fall in the "unfinished wiring, not dead code" category CLAUDE.md protects. (`PostgresMemoryPromotionEventRepository` does fall in that category — it keeps its port, service branch, tests and read-side view — and is deliberately left alone here.)

The only other `timeout_ms` in the repo is unrelated: `routes/chat.ts:711` puts it in a 504 response body, not in a `RuntimeConfig`.

Dropping an optional field is behavior-preserving at runtime: nothing consults it, and `runtime_config` is a JSONB column read through a cast, so any stored row that happens to carry the key still round-trips.

## What the sweep covered and cleared

Everything below came back clean, or resolved to a documented keep:

| Check | Result |
| --- | --- |
| `tsc --noUnusedLocals --noUnusedParameters` (6 packages) | clean |
| `tsc --allowUnreachableCode false` (TS7027, 6 packages) | clean |
| `knip` unused **values** (12 hits) | all 12 used inside their own file — redundant `export`, not dead |
| `knip` unused **types** (107 hits) | same — all used in their declaring file |
| By-name export sweep, 850 symbols (knip's core-barrel blind spot) | only `PostgresMemoryPromotionEventRepository` — documented keep |
| Uncalled class methods, 441 candidates | none (`invalidBody`, `registerToolsOnServer` are live; rest was SQL-in-template and `useEffect` noise) |
| Unread `Deps`/`Config`/`Options` interface fields, 358 candidates | **`RuntimeConfig.timeout_ms`** — this PR. Other 3 hits read at their own call sites |
| `depcheck` + `knip` dependencies | all documented false positives (`node-pg-migrate`, `zod`, `prettier`, `postcss`, `autoprefixer`) |
| Orphan modules | only `packages/sandbox/src/scripts/*` (documented dev utilities) and Next.js framework entries (`layout.tsx`, `error.tsx`, …) |
| Unused `queryKeys` leaves / `api.*` client methods | only `workProducts.all` and `chat.all` — **already removed by open PR #304**, not duplicated here |
| Unused `public/` assets, commented-out code, domain union members, unread env vars | none |
| Coverage (`@vitest/coverage-v8`, `--coverage.all`) | 0% files are barrels, type-only domain files, and DB-gated adapters — a sandbox artifact, not dead code. Provider installed for the sweep and **not committed**, per CLAUDE.md |

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm build` — 9/9 workspace tasks pass
- `@beevibe/core`: 595 tests pass
- `@beevibe/api`: 820 tests pass

Remaining failures are the documented `DATABASE_URL_TEST`-gated suites (no Postgres in this sandbox) and match the CLAUDE.md baseline — unrelated to this change. The two `import/no-duplicates` lint warnings in `web/lib/types/dashboard.ts` are pre-existing and in a file this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMvxRxswDPaNY9qxbSyVTC

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMvxRxswDPaNY9qxbSyVTC)_