### PR TITLE
refactor(web): unify the list-page load-state ladder behind a ListGate

### DIFF
--- a/packages/web/app/(authed)/agents/agents-client.tsx
+++ b/packages/web/app/(authed)/agents/agents-client.tsx
@@ -6,6 +6,11 @@ import { AlertTriangle, Bot, LayoutGrid, List, Maximize2, Minus, Plus } from "lu
 import type { PanZoomTransform } from "@/lib/hooks/use-pan-zoom";
 import { useAgentNetwork } from "@/lib/hooks/use-agent-network";
 import { isApiConfigured } from "@/lib/api/config";
+import {
+  apiNotConfiguredState,
+  fetchFailedTitle,
+  FETCH_FAILED_HINT,
+} from "@/lib/api-state-copy";
 import { EmptyState } from "@/components/empty-state";
 import { TeamOrbit } from "@/components/team-orbit";
 import { AgentDetailPanel } from "@/components/agents/agent-detail-panel";
@@ -99,13 +104,13 @@ export function AgentsClient() {
 
       <div className="relative flex-1 overflow-hidden">
       {!isApiConfigured ? (
-        <CenteredShell
-          icon={Bot}
-          title="API not configured"
-          description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load agents."
-        />
+        <CenteredShell icon={Bot} {...apiNotConfiguredState("agents")} />
       ) : isError ? (
-        <CenteredShell icon={AlertTriangle} title="Couldn't load the network" />
+        <CenteredShell
+          icon={AlertTriangle}
+          title={fetchFailedTitle("the network")}
+          description={FETCH_FAILED_HINT}
+        />
       ) : view === "list" ? (
         <AgentsListView
           agents={selfAgents}

--- a/packages/web/app/(authed)/dashboard/dashboard-client.test.tsx
+++ b/packages/web/app/(authed)/dashboard/dashboard-client.test.tsx
@@ -76,17 +76,20 @@ afterEach(() => {
 });
 
 describe("DashboardClient", () => {
+  // Both messages now come from `ListGate`, which derives them from the
+  // `noun` — hence the shared wording rather than this page's old bespoke
+  // "Dashboard not connected" / "Check that the MCP server is reachable."
   it("renders the not-configured empty state and never fetches", () => {
     apiState.isApiConfigured = false;
     renderHome();
-    expect(screen.getByText("Dashboard not connected")).toBeInTheDocument();
+    expect(screen.getByText("API not configured")).toBeInTheDocument();
     expect(summaryMock).not.toHaveBeenCalled();
   });
 
   it("renders the error empty state when fetch fails", async () => {
     summaryMock.mockRejectedValue(new Error("boom"));
     renderHome();
-    expect(await screen.findByText("Couldn't load dashboard")).toBeInTheDocument();
+    expect(await screen.findByText("Couldn't load the dashboard")).toBeInTheDocument();
   });
 
   it("renders the Metrics header + KPIs + breakdown + fleet when data is loaded", async () => {

--- a/packages/web/app/(authed)/dashboard/dashboard-client.tsx
+++ b/packages/web/app/(authed)/dashboard/dashboard-client.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { AlertTriangle, LayoutDashboard } from "lucide-react";
+import { LayoutDashboard } from "lucide-react";
 import { useDashboard } from "@/lib/hooks/use-dashboard";
-import { isApiConfigured } from "@/lib/api/config";
-import { EmptyState } from "@/components/empty-state";
+import { ListGate } from "@/components/list-gate";
 import { Skeleton } from "@/components/skeleton";
 import { KpiTileSkeleton } from "@/components/skeletons";
 import { KpiTile } from "@/components/home/kpi-tile";
@@ -14,64 +13,35 @@ import { DashboardUsageSection } from "@/components/home/usage-section";
 import type { DashboardDisplay } from "@/lib/types/dashboard";
 
 export function DashboardClient() {
-  const { data, isLoading, isError } = useDashboard();
+  const query = useDashboard();
 
   return (
     <div className="flex-1 overflow-auto">
       <div className="max-w-6xl mx-auto pt-8 pb-12 px-6">
-        <Body data={data} isLoading={isLoading} isError={isError} />
+        <ListGate
+          query={query}
+          noun="the dashboard"
+          icon={LayoutDashboard}
+          skeleton={
+            <div className="space-y-6">
+              <div className="grid grid-cols-4 gap-6">
+                {[0, 1, 2, 3].map((i) => (
+                  <KpiTileSkeleton key={i} />
+                ))}
+              </div>
+              <Skeleton className="h-32 rounded-lg" />
+              <Skeleton className="h-48 rounded-lg" />
+            </div>
+          }
+        >
+          {(data) => <DashboardContent data={data} />}
+        </ListGate>
       </div>
     </div>
   );
 }
 
-function Body({
-  data,
-  isLoading,
-  isError,
-}: {
-  data: DashboardDisplay | undefined;
-  isLoading: boolean;
-  isError: boolean;
-}) {
-  if (!isApiConfigured) {
-    return (
-      <div className="rounded-lg border border-dashed border-border">
-        <EmptyState
-          icon={LayoutDashboard}
-          title="Dashboard not connected"
-          description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load KPIs and fleet status."
-        />
-      </div>
-    );
-  }
-
-  if (isError) {
-    return (
-      <div className="rounded-lg border border-dashed border-border">
-        <EmptyState
-          icon={AlertTriangle}
-          title="Couldn't load dashboard"
-          description="Check that the MCP server is reachable."
-        />
-      </div>
-    );
-  }
-
-  if (isLoading || !data) {
-    return (
-      <div className="space-y-6">
-        <div className="grid grid-cols-4 gap-6">
-          {[0, 1, 2, 3].map((i) => (
-            <KpiTileSkeleton key={i} />
-          ))}
-        </div>
-        <Skeleton className="h-32 rounded-lg" />
-        <Skeleton className="h-48 rounded-lg" />
-      </div>
-    );
-  }
-
+function DashboardContent({ data }: { data: DashboardDisplay }) {
   // /agents (the Home tab) is the front door now — that's where the
   // orbit lives. /dashboard is the "Metrics" sub-page under
   // Observability: KPIs, status, fleet, trend. Items needing decisions

--- a/packages/web/app/(authed)/memory/memory-client.tsx
+++ b/packages/web/app/(authed)/memory/memory-client.tsx
@@ -27,6 +27,11 @@ import { RichTextRender } from "@/components/rich-text";
 import { useMemoryFactCounts, useMemoryFacts } from "@/lib/hooks/use-memory";
 import { useSlashFocus } from "@/lib/hooks/use-slash-focus";
 import { isApiConfigured } from "@/lib/api/config";
+import {
+  apiNotConfiguredState,
+  fetchFailedTitle,
+  FETCH_FAILED_HINT,
+} from "@/lib/api-state-copy";
 import { api } from "@/lib/api/client";
 import { queryKeys } from "@/lib/hooks/keys";
 import { formatRelativeTime } from "@/lib/format";
@@ -136,15 +141,14 @@ function Body({
   isError: boolean;
   hasQuery: boolean;
 }) {
+  // Copy comes from the shared helpers (the same two `ListGate` and
+  // `DetailGate` use); only the table-row container is this page's own.
   if (!isApiConfigured) {
+    const copy = apiNotConfiguredState("memory");
     return (
       <tr>
         <td colSpan={6}>
-          <EmptyState
-            icon={Sparkles}
-            title="No facts learned yet"
-            description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load memory."
-          />
+          <EmptyState icon={Sparkles} title={copy.title} description={copy.description} />
         </td>
       </tr>
     );
@@ -154,7 +158,11 @@ function Body({
     return (
       <tr>
         <td colSpan={6}>
-          <EmptyState icon={AlertTriangle} title="Couldn't load memory" />
+          <EmptyState
+            icon={AlertTriangle}
+            title={fetchFailedTitle("memory")}
+            description={FETCH_FAILED_HINT}
+          />
         </td>
       </tr>
     );

--- a/packages/web/app/(authed)/mesh/mesh-client.tsx
+++ b/packages/web/app/(authed)/mesh/mesh-client.tsx
@@ -1,21 +1,20 @@
 "use client";
 
 import { useState } from "react";
-import { AlertTriangle, Info, Network } from "lucide-react";
-import { EmptyState } from "@/components/empty-state";
+import { Info, Network } from "lucide-react";
 import { Skeleton } from "@/components/skeleton";
 import { MeshAskSkeleton } from "@/components/skeletons";
+import { ListGate } from "@/components/list-gate";
 import { MeshActivityFeed } from "@/components/mesh/activity-feed";
 import { MeshGraphStatic } from "@/components/mesh/graph-static";
 import { ChainBudget } from "@/components/mesh/chain-budget";
 import { MeshWindowPills } from "@/components/mesh/window-pills";
 import { useMeshOverview } from "@/lib/hooks/use-mesh";
-import { isApiConfigured } from "@/lib/api/config";
 import type { MeshDisplay, MeshHover, MeshWindow } from "@/lib/types/mesh";
 
 export function MeshClient() {
   const [meshWindow, setMeshWindow] = useState<MeshWindow>("24h");
-  const { data, isLoading, isError } = useMeshOverview({ window: meshWindow });
+  const query = useMeshOverview({ window: meshWindow });
 
   return (
     <div className="flex-1 overflow-auto">
@@ -32,7 +31,25 @@ export function MeshClient() {
           <MeshWindowPills value={meshWindow} onChange={setMeshWindow} />
         </div>
 
-        <Body data={data} isLoading={isLoading} isError={isError} />
+        <ListGate
+          query={query}
+          noun="mesh activity"
+          icon={Network}
+          skeleton={
+            <div className="grid grid-cols-5 gap-6">
+              <div className="col-span-3 space-y-2">
+                {[0, 1, 2].map((i) => (
+                  <MeshAskSkeleton key={i} />
+                ))}
+              </div>
+              <div className="col-span-2">
+                <Skeleton className="h-[480px] rounded-lg" />
+              </div>
+            </div>
+          }
+        >
+          {(data) => <MeshContent data={data} />}
+        </ListGate>
 
         <div className="mt-10 text-xs text-muted-foreground flex items-start gap-2 max-w-2xl">
           <Info className="h-3.5 w-3.5 shrink-0 mt-0.5" />
@@ -45,54 +62,6 @@ export function MeshClient() {
       </div>
     </div>
   );
-}
-
-function Body({
-  data,
-  isLoading,
-  isError,
-}: {
-  data: MeshDisplay | undefined;
-  isLoading: boolean;
-  isError: boolean;
-}) {
-  if (!isApiConfigured) {
-    return (
-      <div className="rounded-lg border border-dashed border-border">
-        <EmptyState
-          icon={Network}
-          title="No mesh asks yet"
-          description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load mesh activity."
-        />
-      </div>
-    );
-  }
-
-  if (isError) {
-    return (
-      <div className="rounded-lg border border-dashed border-border">
-        <EmptyState icon={AlertTriangle} title="Couldn't load mesh activity" />
-      </div>
-    );
-  }
-
-  if (isLoading) {
-    return (
-      <div className="grid grid-cols-5 gap-6">
-        <div className="col-span-3 space-y-2">
-          {[0, 1, 2].map((i) => (
-            <MeshAskSkeleton key={i} />
-          ))}
-        </div>
-        <div className="col-span-2">
-          <Skeleton className="h-[480px] rounded-lg" />
-        </div>
-      </div>
-    );
-  }
-
-  if (!data) return null;
-  return <MeshContent data={data} />;
 }
 
 function MeshContent({ data }: { data: MeshDisplay }) {

--- a/packages/web/app/(authed)/promotions/promotions-client.tsx
+++ b/packages/web/app/(authed)/promotions/promotions-client.tsx
@@ -1,15 +1,13 @@
 "use client";
 
-import { AlertTriangle, Info, TrendingUp, type LucideIcon } from "lucide-react";
-import { EmptyState } from "@/components/empty-state";
+import { Info, TrendingUp } from "lucide-react";
 import { PromotionEventSkeleton } from "@/components/skeletons";
+import { ListGate } from "@/components/list-gate";
 import { PromotionEventRow } from "@/components/promotions/event-row";
 import { usePromotions } from "@/lib/hooks/use-promotions";
-import { isApiConfigured } from "@/lib/api/config";
-import type { PromotionEvent } from "@/lib/types/promotion-events";
 
 export function PromotionsClient() {
-  const { data, isLoading, isError } = usePromotions();
+  const query = usePromotions();
 
   return (
     <div className="flex-1 overflow-auto">
@@ -26,7 +24,31 @@ export function PromotionsClient() {
           </div>
         </div>
 
-        <Body data={data} isLoading={isLoading} isError={isError} />
+        <ListGate
+          query={query}
+          noun="promotion events"
+          icon={TrendingUp}
+          empty={{
+            title: "No promotions yet",
+            description:
+              "Promotion decisions appear here as agents accumulate facts across sessions.",
+          }}
+          skeleton={
+            <div className="pl-8 space-y-3">
+              {[0, 1, 2].map((i) => (
+                <PromotionEventSkeleton key={i} />
+              ))}
+            </div>
+          }
+        >
+          {(events) => (
+            <div className="pl-8 border-l border-border">
+              {events.map((event) => (
+                <PromotionEventRow key={event.id} event={event} />
+              ))}
+            </div>
+          )}
+        </ListGate>
 
         <div className="mt-10 text-xs text-muted-foreground flex items-start gap-2 max-w-2xl">
           <Info className="h-3.5 w-3.5 shrink-0 mt-0.5" />
@@ -42,62 +64,3 @@ export function PromotionsClient() {
   );
 }
 
-function Body({
-  data,
-  isLoading,
-  isError,
-}: {
-  data: PromotionEvent[] | undefined;
-  isLoading: boolean;
-  isError: boolean;
-}) {
-  if (!isApiConfigured) {
-    return (
-      <EmptyWrapper
-        icon={TrendingUp}
-        title="No promotions yet"
-        description="Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load promotion events."
-      />
-    );
-  }
-
-  if (isError) {
-    return <EmptyWrapper icon={AlertTriangle} title="Couldn't load promotions" />;
-  }
-
-  if (isLoading) {
-    return (
-      <div className="pl-8 space-y-3">
-        {[0, 1, 2].map((i) => (
-          <PromotionEventSkeleton key={i} />
-        ))}
-      </div>
-    );
-  }
-
-  if (!data || data.length === 0) {
-    return (
-      <EmptyWrapper
-        icon={TrendingUp}
-        title="No promotions yet"
-        description="Promotion decisions appear here as agents accumulate facts across sessions."
-      />
-    );
-  }
-
-  return (
-    <div className="pl-8 border-l border-border">
-      {data.map((event) => (
-        <PromotionEventRow key={event.id} event={event} />
-      ))}
-    </div>
-  );
-}
-
-function EmptyWrapper(props: { icon: LucideIcon; title: string; description?: string }) {
-  return (
-    <div className="rounded-lg border border-dashed border-border">
-      <EmptyState {...props} />
-    </div>
-  );
-}

--- a/packages/web/app/(authed)/rooms/rooms-list-client.tsx
+++ b/packages/web/app/(authed)/rooms/rooms-list-client.tsx
@@ -7,6 +7,11 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, Loader2, MessageCircleMore, Plus, Users } from "lucide-react";
 import { api, type Room } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
+import {
+  apiNotConfiguredState,
+  fetchFailedTitle,
+  FETCH_FAILED_HINT,
+} from "@/lib/api-state-copy";
 import { queryKeys } from "@/lib/hooks/keys";
 import { Skeleton } from "@/components/skeleton";
 import { EmptyState } from "@/components/empty-state";
@@ -42,12 +47,13 @@ export function RoomsListClient() {
   };
 
   if (!isApiConfigured) {
+    const copy = apiNotConfiguredState("rooms");
     return (
       <div className="p-6">
         <EmptyState
           icon={MessageCircleMore}
-          title="Web isn't configured"
-          description="Set NEXT_PUBLIC_BV_API_URL and run the api server."
+          title={copy.title}
+          description={copy.description}
         />
       </div>
     );
@@ -111,8 +117,8 @@ export function RoomsListClient() {
         ) : isError ? (
           <EmptyState
             icon={AlertTriangle}
-            title="Couldn't load rooms"
-            description="Check that the api server is reachable."
+            title={fetchFailedTitle("rooms")}
+            description={FETCH_FAILED_HINT}
           />
         ) : (data?.rooms ?? []).length === 0 ? (
           <EmptyState

--- a/packages/web/app/(authed)/runtimes/runtimes-client.tsx
+++ b/packages/web/app/(authed)/runtimes/runtimes-client.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  AlertTriangle,
   Cpu,
   HardDrive,
   Plus,
@@ -24,7 +23,7 @@ import { queryKeys } from "@/lib/hooks/keys";
 import { formatRelativeTime } from "@/lib/format";
 import { CommandBlock } from "@/components/command-block";
 import { DaemonInstallInstructions } from "@/components/daemon-install";
-import { EmptyState } from "@/components/empty-state";
+import { ListGate } from "@/components/list-gate";
 import { Skeleton } from "@/components/skeleton";
 import { cn } from "@/lib/utils";
 
@@ -54,70 +53,34 @@ export function RuntimesClient() {
         </div>
 
         <div className="max-w-3xl mx-auto">
-          <Body
-            data={query.data}
-            isLoading={query.isLoading}
-            isError={query.isError}
-            error={query.error}
-          />
+          <ListGate
+            query={query}
+            noun="runtimes"
+            icon={Terminal}
+            errorDescription={describeError(query.error)}
+            skeleton={
+              <div className="space-y-3">
+                <Skeleton className="h-32 w-full rounded-lg" />
+                <Skeleton className="h-32 w-full rounded-lg" />
+              </div>
+            }
+          >
+            {(data) =>
+              data.daemons.length === 0 ? (
+                <NoDaemonsState />
+              ) : (
+                <div className="space-y-3">
+                  {data.daemons.map((d) => (
+                    <DaemonCard key={d.id} daemon={d} />
+                  ))}
+                  <SyncNewCli />
+                  <AddAnotherMachine />
+                </div>
+              )
+            }
+          </ListGate>
         </div>
       </div>
-    </div>
-  );
-}
-
-function Body({
-  data,
-  isLoading,
-  isError,
-  error,
-}: {
-  data: RuntimesListResponse | undefined;
-  isLoading: boolean;
-  isError: boolean;
-  error: unknown;
-}) {
-  if (!isApiConfigured) {
-    return (
-      <div className="rounded-lg border border-dashed border-border">
-        <EmptyState
-          icon={Terminal}
-          title="API not configured"
-          description="Set NEXT_PUBLIC_BV_API_URL and run the API server to load this page."
-        />
-      </div>
-    );
-  }
-  if (isLoading) {
-    return (
-      <div className="space-y-3">
-        <Skeleton className="h-32 w-full rounded-lg" />
-        <Skeleton className="h-32 w-full rounded-lg" />
-      </div>
-    );
-  }
-  if (isError) {
-    return (
-      <div className="rounded-lg border border-dashed border-border">
-        <EmptyState
-          icon={AlertTriangle}
-          title="Couldn't load runtimes"
-          description={describeError(error)}
-        />
-      </div>
-    );
-  }
-  const daemons = data?.daemons ?? [];
-  if (daemons.length === 0) {
-    return <NoDaemonsState />;
-  }
-  return (
-    <div className="space-y-3">
-      {daemons.map((d) => (
-        <DaemonCard key={d.id} daemon={d} />
-      ))}
-      <SyncNewCli />
-      <AddAnotherMachine />
     </div>
   );
 }

--- a/packages/web/app/(authed)/tasks/tasks-client.test.tsx
+++ b/packages/web/app/(authed)/tasks/tasks-client.test.tsx
@@ -72,9 +72,12 @@ describe("TasksClient — empty-state branches", () => {
     apiState.isApiConfigured = false;
     renderClient();
 
-    expect(await screen.findByText("No tasks yet")).toBeInTheDocument();
+    // Copy now comes from the shared `apiNotConfiguredState` helper, so this
+    // branch says "API not configured" / "run the API server" like every
+    // other page rather than this page's old "No tasks yet" / "MCP server".
+    expect(await screen.findByText("API not configured")).toBeInTheDocument();
     expect(
-      screen.getByText(/Set NEXT_PUBLIC_BV_API_URL and run the MCP server/i),
+      screen.getByText(/Set NEXT_PUBLIC_BV_API_URL and run the API server/i),
     ).toBeInTheDocument();
     expect(listMock).not.toHaveBeenCalled();
   });

--- a/packages/web/app/(authed)/tasks/tasks-client.tsx
+++ b/packages/web/app/(authed)/tasks/tasks-client.tsx
@@ -9,6 +9,11 @@ import { EmptyState } from "@/components/empty-state";
 import { TaskDetailPanel } from "@/components/tasks/task-detail-panel";
 import { useTasks } from "@/lib/hooks/use-tasks";
 import { isApiConfigured } from "@/lib/api/config";
+import {
+  apiNotConfiguredState,
+  fetchFailedTitle,
+  FETCH_FAILED_HINT,
+} from "@/lib/api-state-copy";
 import { countArchivedTasks, groupTasks } from "@/lib/tasks-grouping";
 
 interface EmptyMessage {
@@ -129,17 +134,12 @@ function pickEmptyMessage(state: {
   if (state.isError) {
     return {
       icon: AlertTriangle,
-      title: "Couldn't load tasks",
-      description:
-        "The API is configured but unreachable. Check that the MCP server is running.",
+      title: fetchFailedTitle("tasks"),
+      description: FETCH_FAILED_HINT,
     };
   }
   if (!state.isApiConfigured) {
-    return {
-      icon: ListChecks,
-      title: "No tasks yet",
-      description: "Set NEXT_PUBLIC_BV_API_URL and run the MCP server to load tasks.",
-    };
+    return { icon: ListChecks, ...apiNotConfiguredState("tasks") };
   }
   // Suppress the empty state while ANY fetch is in flight — including a
   // background refetch where `data === []` is cached. Without this guard,

--- a/packages/web/components/detail/detail-gate.tsx
+++ b/packages/web/components/detail/detail-gate.tsx
@@ -5,6 +5,7 @@ import { AlertTriangle, type LucideIcon } from "lucide-react";
 import { isApiConfigured } from "@/lib/api/config";
 import { DetailShell } from "./detail-shell";
 import { EmptyState } from "@/components/empty-state";
+import { apiNotConfiguredState, fetchFailedTitle } from "@/lib/api-state-copy";
 
 interface Props<T> {
   /**
@@ -44,13 +45,10 @@ interface Props<T> {
  */
 export function DetailGate<T>({ nav, icon, noun, id, query, skeleton, children }: Props<T>) {
   if (!isApiConfigured) {
+    const copy = apiNotConfiguredState(`this ${noun}`);
     return (
       <DetailShell nav={nav}>
-        <EmptyState
-          icon={icon}
-          title="API not configured"
-          description={`Set NEXT_PUBLIC_BV_API_URL and run the API server to load this ${noun}.`}
-        />
+        <EmptyState icon={icon} title={copy.title} description={copy.description} />
       </DetailShell>
     );
   }
@@ -65,7 +63,10 @@ export function DetailGate<T>({ nav, icon, noun, id, query, skeleton, children }
       <DetailShell nav={nav}>
         <EmptyState
           icon={AlertTriangle}
-          title={`Couldn't load ${noun}`}
+          title={fetchFailedTitle(noun)}
+          // Bespoke rather than the shared hint: a detail page knows which
+          // row it failed on, and echoing the id makes the failure
+          // identifiable in a way "check the server" isn't.
           description={`${Noun} ${id} could not be fetched. Check the API server logs.`}
         />
       </DetailShell>

--- a/packages/web/components/list-gate.test.tsx
+++ b/packages/web/components/list-gate.test.tsx
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const apiState = { isApiConfigured: true };
+
+vi.mock("@/lib/api/config", () => ({
+  get isApiConfigured() {
+    return apiState.isApiConfigured;
+  },
+}));
+
+import { ListGate } from "./list-gate";
+
+interface Row {
+  name: string;
+}
+
+type Query = { data: Row[] | undefined; isLoading: boolean; isError: boolean };
+
+function renderGate(query: Query, extra: { empty?: { title: string } } = {}) {
+  return render(
+    <ListGate
+      query={query}
+      noun="promotion events"
+      skeleton={<div data-testid="skeleton" />}
+      empty={extra.empty}
+    >
+      {(rows) => <div data-testid="body">{rows.map((r) => r.name).join(",")}</div>}
+    </ListGate>,
+  );
+}
+
+const loaded: Query = {
+  data: [{ name: "Design doc" }],
+  isLoading: false,
+  isError: false,
+};
+
+describe("ListGate", () => {
+  beforeEach(() => {
+    apiState.isApiConfigured = true;
+  });
+
+  it("renders the body once the rows are in hand", () => {
+    renderGate(loaded);
+    expect(screen.getByTestId("body")).toHaveTextContent("Design doc");
+    expect(screen.queryByTestId("skeleton")).toBeNull();
+  });
+
+  it("renders the skeleton while loading, never the body", () => {
+    renderGate({ data: undefined, isLoading: true, isError: false });
+    expect(screen.getByTestId("skeleton")).toBeInTheDocument();
+    expect(screen.queryByTestId("body")).toBeNull();
+  });
+
+  // Same precedence as DetailGate: an unconfigured API is the reason the
+  // fetch failed, so saying "couldn't load" first would misdiagnose it.
+  it("reports an unconfigured API before it reports a failed fetch", () => {
+    apiState.isApiConfigured = false;
+    renderGate({ data: undefined, isLoading: false, isError: true });
+    expect(screen.getByText("API not configured")).toBeInTheDocument();
+    expect(screen.queryByText(/Couldn't load/)).toBeNull();
+  });
+
+  it("derives both messages from the noun", () => {
+    apiState.isApiConfigured = false;
+    renderGate({ data: undefined, isLoading: false, isError: false });
+    expect(
+      screen.getByText(/run the API server to load promotion events\./),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to the shared reachability hint on a failed fetch", () => {
+    renderGate({ data: undefined, isLoading: false, isError: true });
+    expect(screen.getByText("Couldn't load promotion events")).toBeInTheDocument();
+    expect(screen.getByText("Check that the API server is reachable.")).toBeInTheDocument();
+  });
+
+  it("renders the empty state for a settled-but-empty list", () => {
+    renderGate({ data: [], isLoading: false, isError: false }, { empty: { title: "None yet" } });
+    expect(screen.getByText("None yet")).toBeInTheDocument();
+    expect(screen.queryByTestId("body")).toBeNull();
+  });
+
+  // A page whose content component draws its own empty state omits `empty`;
+  // the gate must then render nothing rather than an untitled EmptyState.
+  it("renders nothing when the list is empty and no empty copy was given", () => {
+    const { container } = renderGate({ data: [], isLoading: false, isError: false });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  // A query can settle without erroring and still hand back nothing. That
+  // must not reach the body callback, which assumes data.
+  it("treats settled-but-undefined as empty, not as body", () => {
+    renderGate(
+      { data: undefined, isLoading: false, isError: false },
+      { empty: { title: "None yet" } },
+    );
+    expect(screen.getByText("None yet")).toBeInTheDocument();
+    expect(screen.queryByTestId("body")).toBeNull();
+  });
+
+  it("honors a custom isEmpty for payloads that wrap the list", () => {
+    render(
+      <ListGate
+        query={{ data: { rows: [] }, isLoading: false, isError: false }}
+        noun="runtimes"
+        skeleton={<div />}
+        isEmpty={(d) => d.rows.length === 0}
+        empty={{ title: "None yet" }}
+      >
+        {() => <div data-testid="body" />}
+      </ListGate>,
+    );
+    expect(screen.getByText("None yet")).toBeInTheDocument();
+    expect(screen.queryByTestId("body")).toBeNull();
+  });
+});

--- a/packages/web/components/list-gate.tsx
+++ b/packages/web/components/list-gate.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { AlertTriangle, type LucideIcon } from "lucide-react";
+import { isApiConfigured } from "@/lib/api/config";
+import { EmptyState } from "@/components/empty-state";
+import {
+  apiNotConfiguredState,
+  fetchFailedTitle,
+  FETCH_FAILED_HINT,
+} from "@/lib/api-state-copy";
+
+interface Props<T> {
+  /** The react-query result driving the page. */
+  query: { data: T | undefined; isLoading: boolean; isError: boolean };
+  /**
+   * Lowercase noun phrase for what the page lists, read after "to load" and
+   * after "Couldn't load" — "mesh activity", "promotion events", "runtimes".
+   */
+  noun: string;
+  /** Icon for the not-configured and empty states. The error state is always AlertTriangle. */
+  icon?: LucideIcon;
+  /**
+   * Loading placeholder. Per-page rather than generic: the skeleton mirrors
+   * the layout it stands in for, so a shared one would jump on hydration.
+   * Rendered bare — `wrapper` applies only to the three EmptyState branches.
+   */
+  skeleton: ReactNode;
+  /**
+   * Copy for "the fetch succeeded and there is nothing in it". Omit to render
+   * nothing in that case (a page whose content component draws its own empty
+   * state).
+   */
+  empty?: { title: string; description?: string };
+  /**
+   * Whether loaded data counts as empty. Defaults to "an array with no
+   * elements" — pages whose payload wraps the list (`{ asks }`, `{ daemons }`)
+   * pass their own predicate.
+   */
+  isEmpty?: (data: T) => boolean;
+  /** Overrides {@link FETCH_FAILED_HINT} when the page can say something sharper. */
+  errorDescription?: string;
+  /**
+   * Container for the three placeholder states. Defaults to the dashed-border
+   * box the list pages already share; pages that place their states somewhere
+   * structurally different (a table row, a centered overlay) pass their own.
+   */
+  wrapper?: (node: ReactNode) => ReactNode;
+  /** Rendered once the fetch succeeded and produced something to show. */
+  children: (data: T) => ReactNode;
+}
+
+function defaultWrapper(node: ReactNode): ReactNode {
+  return <div className="rounded-lg border border-dashed border-border">{node}</div>;
+}
+
+function defaultIsEmpty(data: unknown): boolean {
+  return Array.isArray(data) && data.length === 0;
+}
+
+/**
+ * The load-state ladder every list page opens with — API not configured,
+ * still loading, fetch failed, nothing to show — and the shared copy for the
+ * first and third of those.
+ *
+ * This is the list-side counterpart to `DetailGate`. That component fixed the
+ * same duplication for detail pages; the eight list pages kept hand-rolling
+ * the ladder, and their copy drifted exactly the way the detail pages' had
+ * (see `lib/api-state-copy.ts` for the catalogue). Both gates now derive
+ * their wording from the same two helpers, so a page cannot invent a fourth
+ * name for the api server.
+ *
+ * Branch order matches `DetailGate`: not-configured before loading before
+ * error. Several list pages had checked error before loading; with
+ * react-query those two are never simultaneously true, so the order is a
+ * consistency choice rather than a behavior change.
+ */
+export function ListGate<T>({
+  query,
+  noun,
+  icon,
+  skeleton,
+  empty,
+  isEmpty = defaultIsEmpty,
+  errorDescription,
+  wrapper = defaultWrapper,
+  children,
+}: Props<T>) {
+  if (!isApiConfigured) {
+    const copy = apiNotConfiguredState(noun);
+    return wrapper(
+      <EmptyState icon={icon} title={copy.title} description={copy.description} />,
+    );
+  }
+
+  if (query.isLoading) return skeleton;
+
+  if (query.isError) {
+    return wrapper(
+      <EmptyState
+        icon={AlertTriangle}
+        title={fetchFailedTitle(noun)}
+        description={errorDescription ?? FETCH_FAILED_HINT}
+      />,
+    );
+  }
+
+  // A query can settle without erroring and still hand back nothing. Treat
+  // that as empty rather than handing `undefined` to the content component.
+  if (!query.data || isEmpty(query.data)) {
+    if (!empty) return null;
+    return wrapper(
+      <EmptyState icon={icon} title={empty.title} description={empty.description} />,
+    );
+  }
+
+  return children(query.data);
+}

--- a/packages/web/lib/api-state-copy.ts
+++ b/packages/web/lib/api-state-copy.ts
@@ -1,0 +1,55 @@
+/**
+ * The two sentences every data-backed page shows when it has nothing to
+ * render: "the browser was never pointed at an api server" and "the fetch
+ * failed."
+ *
+ * `DetailGate` already derived these for the seven detail pages, and its doc
+ * comment records why: written by hand per page, the copy drifts. That drift
+ * came back on the list side, where no equivalent existed. One process was
+ * called three different things depending on which page you happened to be
+ * looking at —
+ *
+ *   - "run the MCP server"  — mesh, promotions, dashboard, memory, agents, tasks
+ *   - "run the API server"  — runtimes, DetailGate
+ *   - "run the api server"  — rooms
+ *
+ * — and the fetch-failure hint was present on some pages, absent on others,
+ * and named a different process again where it did appear.
+ *
+ * "API server" is the spelling `DetailGate` had already standardized on
+ * across seven pages, so it wins here rather than the more common "MCP
+ * server": the MCP server is one router mounted inside the api process, not
+ * the thing the user has to start.
+ *
+ * Both helpers return `EmptyState` props rather than rendered nodes — the
+ * container differs per page (dashed-border box, table row, centered
+ * overlay) and that difference is deliberate layout, not drift.
+ */
+
+export interface ApiStateCopy {
+  title: string;
+  description: string;
+}
+
+/**
+ * `noun` is the thing the page would have shown, as a lowercase noun phrase
+ * that reads after "to load": `"mesh activity"`, `"promotion events"`,
+ * `"this task"`. Detail pages pass `` `this ${noun}` ``.
+ */
+export function apiNotConfiguredState(noun: string): ApiStateCopy {
+  return {
+    title: "API not configured",
+    description: `Set NEXT_PUBLIC_BV_API_URL and run the API server to load ${noun}.`,
+  };
+}
+
+/** Title for the "the fetch failed" state: "Couldn't load mesh activity". */
+export function fetchFailedTitle(noun: string): string {
+  return `Couldn't load ${noun}`;
+}
+
+/**
+ * Default hint under {@link fetchFailedTitle}. Pages with something more
+ * specific to say (a server-supplied error message) pass their own instead.
+ */
+export const FETCH_FAILED_HINT = "Check that the API server is reachable.";


### PR DESCRIPTION
## What

`DetailGate` already factored out the "API not configured / loading / fetch failed" preamble for the seven **detail** pages, and its doc comment records why:

> Written out by hand on each page before this existed, which is why the copy had drifted: the same condition variously said "run the API server", "run the api server" and "run the MCP server" (one process, three names).

The eight **list** pages never got an equivalent, so they each hand-rolled the same ladder — and the drift came back exactly as that comment predicted.

## The drift this fixes

One process, three names, depending on which page you were looking at:

| Spelling | Pages |
| --- | --- |
| "run the **MCP** server" | mesh, promotions, dashboard, memory, agents, tasks |
| "run the **API** server" | runtimes, `DetailGate` |
| "run the **api** server" | rooms |

The fetch-failure hint had drifted too — present on some pages, absent on others, and naming a different process again where it did appear ("Check that the MCP server is reachable." vs "Check that the api server is reachable." vs nothing).

## Changes

- **`lib/api-state-copy.ts`** (new) — one definition of both sentences. `DetailGate` now derives its wording from it too, so the two gates can't disagree.
- **`components/list-gate.tsx`** (new) — the list-side counterpart to `DetailGate`, plus nine tests mirroring that component's suite.
- **Converted** the four pages that fit the ladder cleanly: `mesh`, `promotions`, `dashboard`, `runtimes`.
- **Copy-only** for the four with bespoke containers — `memory` (table row), `rooms` (inline ternary), `agents` (centered overlay), `tasks` (message object). These keep their layout and just call the shared helpers, since their containers are deliberate layout rather than drift.

Net **-109 lines** across the converted pages.

### Why "API server" won

It's what `DetailGate` had already standardized on across seven pages, so it's the majority spelling in the codebase even though "MCP server" appears on more list pages. It's also the accurate one: the MCP server is a router mounted inside the api process, not something the user starts separately.

## User-visible changes

Deliberate, and the reason two tests needed updating:

- `/dashboard` unconfigured: "Dashboard not connected" → "API not configured"
- `/tasks` unconfigured: "No tasks yet" → "API not configured"
- `/dashboard` error: "Couldn't load dashboard" → "Couldn't load the dashboard"
- Error states that previously showed no hint now show "Check that the API server is reachable."

One behavioral note worth a reviewer's eye: `dashboard` previously rendered its skeleton for `isLoading || !data`, so a settled-but-empty response would show the skeleton forever. `ListGate` treats settled-but-empty as empty and renders nothing. The endpoint returns an object or throws, so this state isn't reachable in practice, but it is a real difference rather than a pure refactor.

Branch ordering was normalized to `DetailGate`'s (not-configured → loading → error); several list pages checked error before loading. With react-query those two are never simultaneously true, so this is a consistency choice, not a behavior change.

## Verification

Run from `packages/web` (Turbo strips proxy env vars, per CLAUDE.md):

- `npx tsc --noEmit` — clean
- `npx vitest run` — **212 passed** (was 203; +9 new `ListGate` tests)
- `npx next lint` — no new warnings (the two `lib/types/dashboard.ts` `import/no-duplicates` warnings are pre-existing and untouched)
- `npx next build` — succeeds

Only `packages/web` is touched, so the DB- and key-gated suites in `core`/`api`/`scheduler` are unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJ9P3ncFHiiZJeZpqLaRBW)_