### PR TITLE
test: cover the chat route and the three untested MCP tools

### DIFF
--- a/packages/api/src/routes/chat.test.ts
+++ b/packages/api/src/routes/chat.test.ts
@@ -1,0 +1,947 @@
+/**
+ * /chat REST surface — unit tests with vitest fakes (no DB, no CLI).
+ *
+ * `chat-internals.test.ts` already pins the pure helpers
+ * (`groupIntoConversations`, `chainToMessages`, `failureMessageFor`).
+ * This suite covers the four route handlers those helpers feed, which
+ * is where the branchy behaviour lives: the human gate, the
+ * no-primary-agent shape each route returns, the idempotent-replay
+ * ladder on POST, the rate limiter, the daemon-offline 503, and the
+ * 504 timeout.
+ *
+ * The router is a closure over eight ports, so a bag of `vi.fn()` fakes
+ * plus a stub auth middleware reaches every branch. `ChatResolver` and
+ * `ChatRateLimiter` are the two real collaborators: the resolver is a
+ * plain in-memory Map (registering and resolving from the test is
+ * simpler than faking it), and the limiter is constructed with an
+ * injected clock so the sliding window is deterministic.
+ *
+ * `dispatchService.dispatchTask` is faked throughout — the real one
+ * inserts a session row and picks a runtime, neither of which this
+ * layer's contract depends on beyond `{ session, runtime_id }`.
+ */
+import express, { json } from "express";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SYSTEM_WAKE_INTENT_CLOSE, SYSTEM_WAKE_INTENT_OPEN } from "@beevibe/core";
+import type {
+  Agent,
+  AgentRepository,
+  Person,
+  PersonRepository,
+  Runtime,
+  RuntimeRepository,
+  Session,
+  SessionRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import { runtimeMissingError } from "@beevibe/core/adapters/runtime-registry";
+import { ChatResolver } from "../runtime/chat-resolver.js";
+import type { DaemonHub } from "../runtime/hub.js";
+import { ChatRateLimiter } from "./chat-rate-limit.js";
+import { createChatRouter } from "./chat.js";
+
+const PERSON = "person_alice";
+const AGENT = "agent_team";
+// The route only accepts a caller-supplied session id matching
+// /^sess_[A-Za-z0-9]{12}$/ — anything else falls through to the run path.
+const VALID_SID = "sess_abcdef123456";
+
+// ── Fixtures ─────────────────────────────────────────────────────────────
+
+function fakeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: AGENT,
+    name: "Hive",
+    owner_id: PERSON,
+    hierarchy_level: "team",
+    runtime_config: { type: "claude" },
+    created_at: new Date("2026-01-01"),
+    updated_at: new Date("2026-01-01"),
+    ...overrides,
+  } as Agent;
+}
+
+function fakePerson(overrides: Partial<Person> = {}): Person {
+  return {
+    id: PERSON,
+    email: "alice@example.com",
+    onboarding_completed_at: new Date("2026-01-01"),
+    created_at: new Date("2026-01-01"),
+    updated_at: new Date("2026-01-01"),
+    ...overrides,
+  } as Person;
+}
+
+function fakeSession(overrides: Partial<Session> & Pick<Session, "id">): Session {
+  return {
+    agent_id: AGENT,
+    type: "chat",
+    status: "succeeded",
+    intent: "hello",
+    created_at: new Date("2026-06-01T10:00:00Z"),
+    ...overrides,
+  } as Session;
+}
+
+function fakeRuntime(overrides: Partial<Runtime> = {}): Runtime {
+  return {
+    id: "rt_1",
+    daemon_id: "daemon_1",
+    cli: "claude",
+    capabilities: {},
+    created_at: new Date("2026-01-01"),
+    ...overrides,
+  } as Runtime;
+}
+
+// ── Ports ────────────────────────────────────────────────────────────────
+
+function makePorts() {
+  const agentRepo = {
+    findTopLevelForOwner: vi.fn().mockResolvedValue(fakeAgent()),
+  };
+  const personRepo = {
+    findById: vi.fn().mockResolvedValue(fakePerson()),
+    update: vi.fn().mockResolvedValue(fakePerson()),
+  };
+  const runtimeRepo = { findById: vi.fn().mockResolvedValue(undefined) };
+  const sessionRepo = {
+    findById: vi.fn().mockResolvedValue(undefined),
+    listChatForAgent: vi.fn().mockResolvedValue([]),
+    softDeleteChatChain: vi.fn().mockResolvedValue(0),
+  };
+  const dispatchService = {
+    dispatchTask: vi
+      .fn()
+      .mockResolvedValue({ session: fakeSession({ id: VALID_SID }), runtime_id: null }),
+  };
+  const hub = { isOnline: vi.fn().mockReturnValue(true) };
+  return { agentRepo, personRepo, runtimeRepo, sessionRepo, dispatchService, hub };
+}
+
+type Ports = ReturnType<typeof makePorts>;
+
+/**
+ * Stand-in for `createAuthMiddleware`. The real one resolves a bv_ token
+ * against Postgres; `requireHuman` only reads `caller.source`.
+ */
+function stubAuth(source: "human" | "agent" | "none") {
+  return (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    if (source === "human") {
+      req.caller = {
+        source: "human",
+        agentId: AGENT,
+        hierarchyLevel: "team",
+        personId: PERSON,
+      };
+    } else if (source === "agent") {
+      req.caller = { source: "agent", agentId: AGENT, hierarchyLevel: "ic" };
+    }
+    next();
+  };
+}
+
+function makeApp(
+  ports: Ports,
+  opts: {
+    source?: "human" | "agent" | "none";
+    chatResolver?: ChatResolver;
+    rateLimiter?: ChatRateLimiter;
+  } = {},
+) {
+  const chatResolver = opts.chatResolver ?? new ChatResolver();
+  const app = express();
+  app.use(json());
+  app.use(
+    "/chat",
+    createChatRouter({
+      authMiddleware: stubAuth(opts.source ?? "human"),
+      agentRepo: ports.agentRepo as unknown as AgentRepository,
+      personRepo: ports.personRepo as unknown as PersonRepository,
+      runtimeRepo: ports.runtimeRepo as unknown as RuntimeRepository,
+      sessionRepo: ports.sessionRepo as unknown as SessionRepository,
+      dispatchService: ports.dispatchService as unknown as DispatchService,
+      chatResolver,
+      hub: ports.hub as unknown as DaemonHub,
+      ...(opts.rateLimiter ? { rateLimiter: opts.rateLimiter } : {}),
+    }),
+  );
+  return { app, chatResolver };
+}
+
+/**
+ * POST a turn and resolve the underlying chat session on the next tick.
+ * The route awaits `chatResolver.register(...)`, which only settles when
+ * /runtime/done fires — here the test plays that part.
+ */
+async function postAndResolve(
+  ports: Ports,
+  body: Record<string, unknown>,
+  final: Partial<Session> & Pick<Session, "id">,
+  opts: Parameters<typeof makeApp>[1] = {},
+) {
+  const { app, chatResolver } = makeApp(ports, opts);
+  // `resolve` is a no-op returning false until the handler registers,
+  // so polling is simpler than racing the await.
+  const tick = setInterval(() => {
+    if (chatResolver.resolve(final.id, fakeSession(final))) clearInterval(tick);
+  }, 5);
+  try {
+    return await request(app).post("/chat").send(body);
+  } finally {
+    clearInterval(tick);
+  }
+}
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── GET /chat/conversations ──────────────────────────────────────────────
+
+describe("GET /chat/conversations", () => {
+  it("403s a non-human caller", async () => {
+    for (const source of ["agent", "none"] as const) {
+      const res = await request(makeApp(makePorts(), { source }).app).get("/chat/conversations");
+      expect(res.status).toBe(403);
+    }
+  });
+
+  it("returns an empty list when the caller has no primary agent", async () => {
+    const ports = makePorts();
+    ports.agentRepo.findTopLevelForOwner.mockResolvedValue(undefined);
+
+    const res = await request(makeApp(ports).app).get("/chat/conversations");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, conversations: [] });
+    expect(ports.sessionRepo.listChatForAgent).not.toHaveBeenCalled();
+  });
+
+  it("summarizes each chain with its title, turn count and last preview", async () => {
+    const ports = makePorts();
+    ports.sessionRepo.listChatForAgent.mockResolvedValue([
+      fakeSession({
+        id: "sess_head",
+        intent: "ship the linter",
+        result_summary: "on it",
+        created_at: new Date("2026-06-01T10:00:00Z"),
+      }),
+      fakeSession({
+        id: "sess_tail",
+        prior_session_id: "sess_head",
+        intent: "and the formatter",
+        result_summary: "done — formatter wired up",
+        created_at: new Date("2026-06-01T10:05:00Z"),
+      }),
+    ]);
+
+    const res = await request(makeApp(ports).app).get("/chat/conversations");
+    expect(res.status).toBe(200);
+    expect(res.body.conversations).toEqual([
+      {
+        head_id: "sess_head",
+        title: "ship the linter",
+        turn_count: 2,
+        last_at: "2026-06-01T10:05:00.000Z",
+        last_preview: "done — formatter wired up",
+      },
+    ]);
+  });
+
+  it("truncates a long title to CHAT_THREAD_TITLE_MAX", async () => {
+    const ports = makePorts();
+    ports.sessionRepo.listChatForAgent.mockResolvedValue([
+      fakeSession({ id: "sess_head", intent: "z".repeat(200) }),
+    ]);
+
+    const { title } = (await request(makeApp(ports).app).get("/chat/conversations")).body
+      .conversations[0];
+    expect(title.length).toBeLessThanOrEqual(80);
+  });
+
+  it("collapses whitespace and ellipsizes an over-long preview", async () => {
+    const ports = makePorts();
+    ports.sessionRepo.listChatForAgent.mockResolvedValue([
+      fakeSession({ id: "sess_head", result_summary: "a\n\n  b " + "c".repeat(300) }),
+    ]);
+
+    const { last_preview } = (await request(makeApp(ports).app).get("/chat/conversations")).body
+      .conversations[0];
+    expect(last_preview).toHaveLength(140);
+    expect(last_preview.startsWith("a b ")).toBe(true);
+    expect(last_preview.endsWith("…")).toBe(true);
+  });
+
+  it("previews the error, then the intent, when there is no summary", async () => {
+    const ports = makePorts();
+    ports.sessionRepo.listChatForAgent.mockResolvedValue([
+      fakeSession({ id: "sess_a", intent: "one", error: "boom", created_at: new Date(2) }),
+      fakeSession({ id: "sess_b", intent: "two", created_at: new Date(1) }),
+    ]);
+
+    const byHead = Object.fromEntries(
+      (await request(makeApp(ports).app).get("/chat/conversations")).body.conversations.map(
+        (c: { head_id: string; last_preview: string }) => [c.head_id, c.last_preview],
+      ),
+    );
+    expect(byHead).toEqual({ sess_a: "boom", sess_b: "two" });
+  });
+
+  it("caps the response at 50 conversations even when more come back", async () => {
+    const ports = makePorts();
+    ports.sessionRepo.listChatForAgent.mockResolvedValue(
+      Array.from({ length: 60 }, (_, i) =>
+        fakeSession({ id: `sess_${i}`, created_at: new Date(1_700_000_000_000 + i * 1000) }),
+      ),
+    );
+
+    const res = await request(makeApp(ports).app).get("/chat/conversations");
+    expect(res.body.conversations).toHaveLength(50);
+    // Newest first, so the cut drops the oldest.
+    expect(res.body.conversations[0].head_id).toBe("sess_59");
+    expect(ports.sessionRepo.listChatForAgent).toHaveBeenCalledWith(AGENT, 400);
+  });
+});
+
+// ── DELETE /chat/conversations/:headId ───────────────────────────────────
+
+describe("DELETE /chat/conversations/:headId", () => {
+  it("403s a non-human caller", async () => {
+    const res = await request(makeApp(makePorts(), { source: "agent" }).app).delete(
+      "/chat/conversations/sess_head",
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("soft-deletes the chain scoped to the caller's agent", async () => {
+    const ports = makePorts();
+    ports.sessionRepo.softDeleteChatChain.mockResolvedValue(3);
+
+    const res = await request(makeApp(ports).app).delete("/chat/conversations/sess_head");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, deleted: 3 });
+    expect(ports.sessionRepo.softDeleteChatChain).toHaveBeenCalledWith("sess_head", AGENT);
+  });
+
+  it("is idempotent — re-deleting reports 0 rather than 404ing", async () => {
+    const ports = makePorts();
+    ports.sessionRepo.softDeleteChatChain.mockResolvedValue(0);
+
+    const res = await request(makeApp(ports).app).delete("/chat/conversations/sess_head");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, deleted: 0 });
+  });
+
+  it("404s when the caller has no primary agent", async () => {
+    const ports = makePorts();
+    ports.agentRepo.findTopLevelForOwner.mockResolvedValue(undefined);
+
+    const res = await request(makeApp(ports).app).delete("/chat/conversations/sess_head");
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("agent_not_found");
+  });
+
+  it("500s with a request id when the repo throws", async () => {
+    const ports = makePorts();
+    ports.sessionRepo.softDeleteChatChain.mockRejectedValue(new Error("deadlock detected"));
+
+    const res = await request(makeApp(ports).app).delete("/chat/conversations/sess_head");
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("internal_error");
+    expect(res.body.request_id).toMatch(/^req_/);
+    // The detail stays server-side.
+    expect(JSON.stringify(res.body)).not.toContain("deadlock");
+  });
+});
+
+// ── GET /chat ────────────────────────────────────────────────────────────
+
+describe("GET /chat", () => {
+  it("403s a non-human caller", async () => {
+    const res = await request(makeApp(makePorts(), { source: "agent" }).app).get("/chat");
+    expect(res.status).toBe(403);
+  });
+
+  it("returns a null agent and empty history when none is provisioned", async () => {
+    const ports = makePorts();
+    ports.agentRepo.findTopLevelForOwner.mockResolvedValue(undefined);
+
+    const res = await request(makeApp(ports).app).get("/chat");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      agent: null,
+      messages: [],
+      prior_session_id: null,
+      conversation_id: null,
+    });
+  });
+
+  it("returns the most recent chain by default", async () => {
+    const ports = makePorts();
+    ports.sessionRepo.listChatForAgent.mockResolvedValue([
+      fakeSession({
+        id: "sess_old",
+        intent: "old thread",
+        result_summary: "old reply",
+        created_at: new Date("2026-06-01T09:00:00Z"),
+      }),
+      fakeSession({
+        id: "sess_new",
+        intent: "new thread",
+        result_summary: "new reply",
+        created_at: new Date("2026-06-01T10:00:00Z"),
+      }),
+    ]);
+
+    const res = await request(makeApp(ports).app).get("/chat");
+    expect(res.body.conversation_id).toBe("sess_new");
+    expect(res.body.prior_session_id).toBe("sess_new");
+    expect(res.body.agent).toEqual({ id: AGENT, name: "Hive", hierarchy: "team" });
+    expect(res.body.messages.map((m: { content: string }) => m.content)).toEqual([
+      "new thread",
+      "new reply",
+    ]);
+  });
+
+  it("selects a specific chain via ?c=", async () => {
+    const ports = makePorts();
+    ports.sessionRepo.listChatForAgent.mockResolvedValue([
+      fakeSession({ id: "sess_old", intent: "old", created_at: new Date("2026-06-01T09:00:00Z") }),
+      fakeSession({ id: "sess_new", intent: "new", created_at: new Date("2026-06-01T10:00:00Z") }),
+    ]);
+
+    const res = await request(makeApp(ports).app).get("/chat").query({ c: "sess_old" });
+    expect(res.body.conversation_id).toBe("sess_old");
+    expect(res.body.messages[0].content).toBe("old");
+  });
+
+  it("returns an empty chain — not a 404 — for an unknown ?c=", async () => {
+    // The chat UI renders its empty state off this; a 404 would surface
+    // as an error toast instead.
+    const ports = makePorts();
+    ports.sessionRepo.listChatForAgent.mockResolvedValue([fakeSession({ id: "sess_a" })]);
+
+    const res = await request(makeApp(ports).app).get("/chat").query({ c: "sess_nope" });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      agent: { id: AGENT, name: "Hive", hierarchy: "team" },
+      messages: [],
+      prior_session_id: null,
+      conversation_id: null,
+    });
+  });
+
+  it("returns an empty chain when the agent has no chat sessions at all", async () => {
+    const res = await request(makeApp(makePorts()).app).get("/chat");
+    expect(res.status).toBe(200);
+    expect(res.body.messages).toEqual([]);
+    expect(res.body.conversation_id).toBeNull();
+  });
+
+  it("truncates a long chain to the last 25 sessions", async () => {
+    const ports = makePorts();
+    const sessions = Array.from({ length: 40 }, (_, i) =>
+      fakeSession({
+        id: `sess_${i}`,
+        ...(i > 0 ? { prior_session_id: `sess_${i - 1}` } : {}),
+        intent: `turn ${i}`,
+        result_summary: `reply ${i}`,
+        created_at: new Date(1_700_000_000_000 + i * 1000),
+      }),
+    );
+    ports.sessionRepo.listChatForAgent.mockResolvedValue(sessions);
+
+    const res = await request(makeApp(ports).app).get("/chat");
+    // HISTORY_LIMIT is 50 messages ≈ 25 sessions × 2 messages.
+    expect(res.body.messages).toHaveLength(50);
+    expect(res.body.messages[0].content).toBe("turn 15");
+    // prior_session_id still points at the true tail, not the window's.
+    expect(res.body.prior_session_id).toBe("sess_39");
+    expect(res.body.conversation_id).toBe("sess_0");
+  });
+
+  it("flags an in-flight tail session so the UI can resume its indicator", async () => {
+    const ports = makePorts();
+    ports.sessionRepo.listChatForAgent.mockResolvedValue([
+      fakeSession({ id: "sess_a", status: "running", intent: "thinking?" }),
+    ]);
+
+    const res = await request(makeApp(ports).app).get("/chat");
+    expect(res.body.in_flight_session_id).toBe("sess_a");
+  });
+
+  it("omits in_flight_session_id once the tail is terminal", async () => {
+    const ports = makePorts();
+    ports.sessionRepo.listChatForAgent.mockResolvedValue([
+      fakeSession({ id: "sess_a", status: "succeeded", result_summary: "done" }),
+    ]);
+
+    const res = await request(makeApp(ports).app).get("/chat");
+    expect(res.body.in_flight_session_id).toBeUndefined();
+  });
+
+  it("renders a system-wake turn as a system message with the summary only", async () => {
+    const ports = makePorts();
+    ports.sessionRepo.listChatForAgent.mockResolvedValue([
+      fakeSession({
+        id: "sess_wake",
+        intent: `${SYSTEM_WAKE_INTENT_OPEN}task_1 finished\n\nDecide next steps.${SYSTEM_WAKE_INTENT_CLOSE}`,
+        result_summary: "picking it up",
+      }),
+    ]);
+
+    const res = await request(makeApp(ports).app).get("/chat");
+    expect(res.body.messages[0]).toEqual({
+      id: "w_sess_wake",
+      role: "system",
+      content: "task_1 finished",
+      session_id: "sess_wake",
+    });
+  });
+
+  it("reports a runtime mismatch when the chain is pinned to another CLI", async () => {
+    const ports = makePorts();
+    ports.sessionRepo.listChatForAgent.mockResolvedValue([
+      fakeSession({ id: "sess_a", runtime_id: "rt_codex", result_summary: "ok" }),
+    ]);
+    ports.runtimeRepo.findById.mockResolvedValue(fakeRuntime({ id: "rt_codex", cli: "codex" }));
+
+    const res = await request(makeApp(ports).app).get("/chat");
+    expect(res.body.runtime_mismatch).toEqual({ pinned_cli: "codex", current_cli: "claude" });
+    expect(ports.runtimeRepo.findById).toHaveBeenCalledWith("rt_codex");
+  });
+
+  it.each([
+    ["the tail has no runtime_id", { runtime_id: undefined }, undefined],
+    ["the runtime row is gone", { runtime_id: "rt_x" }, undefined],
+    ["the pinned CLI matches", { runtime_id: "rt_x" }, fakeRuntime({ cli: "claude" })],
+    ["the pinned CLI is unrecognized", { runtime_id: "rt_x" }, fakeRuntime({ cli: "cursor" })],
+  ])("omits runtime_mismatch when %s", async (_label, sessionOverrides, runtime) => {
+    const ports = makePorts();
+    ports.sessionRepo.listChatForAgent.mockResolvedValue([
+      fakeSession({ id: "sess_a", result_summary: "ok", ...sessionOverrides }),
+    ]);
+    ports.runtimeRepo.findById.mockResolvedValue(runtime);
+
+    const res = await request(makeApp(ports).app).get("/chat");
+    expect(res.body.runtime_mismatch).toBeUndefined();
+  });
+
+  it("renders a failed turn with the rewritten runtime-missing message", async () => {
+    const ports = makePorts();
+    ports.sessionRepo.listChatForAgent.mockResolvedValue([
+      fakeSession({
+        id: "sess_a",
+        status: "failed",
+        intent: "do the thing",
+        error: runtimeMissingError("codex"),
+      }),
+    ]);
+
+    const res = await request(makeApp(ports).app).get("/chat");
+    expect(res.body.messages[1].content).toMatch(/pinned to the codex runtime/);
+  });
+});
+
+// ── POST /chat ───────────────────────────────────────────────────────────
+
+describe("POST /chat — validation and preconditions", () => {
+  it("403s a non-human caller", async () => {
+    const res = await request(makeApp(makePorts(), { source: "agent" }).app)
+      .post("/chat")
+      .send({ message: "hi" });
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    ["an empty body", {}],
+    ["a blank message", { message: "   " }],
+    ["a non-string message", { message: 42 }],
+  ])("400s on %s", async (_label, body) => {
+    const ports = makePorts();
+    const res = await request(makeApp(ports).app).post("/chat").send(body);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("message_required");
+    expect(ports.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("404s when no team or org agent is provisioned", async () => {
+    const ports = makePorts();
+    ports.agentRepo.findTopLevelForOwner.mockResolvedValue(undefined);
+
+    const res = await request(makeApp(ports).app).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("no_primary_agent");
+  });
+});
+
+describe("POST /chat — dispatch", () => {
+  it("dispatches a fresh chat turn and returns the resolved response", async () => {
+    const ports = makePorts();
+    const res = await postAndResolve(
+      ports,
+      { message: "  ship the linter  " },
+      { id: VALID_SID, status: "succeeded", result_summary: "shipped" },
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      agent: { id: AGENT, name: "Hive", hierarchy: "team" },
+      session_id: VALID_SID,
+      response: "shipped",
+      status: "succeeded",
+      view_refs: [],
+    });
+    expect(res.body.replayed).toBeUndefined();
+    expect(ports.dispatchService.dispatchTask).toHaveBeenCalledWith({
+      agentId: AGENT,
+      intent: "ship the linter",
+      reason: { kind: "fresh" },
+      type: "chat",
+      sessionIdOverride: undefined,
+    });
+  });
+
+  it("sends a chat_continuation reason when prior_session_id is passed", async () => {
+    const ports = makePorts();
+    await postAndResolve(
+      ports,
+      { message: "and the formatter", prior_session_id: "sess_prior" },
+      { id: VALID_SID },
+    );
+
+    expect(ports.dispatchService.dispatchTask.mock.calls[0]![0].reason).toEqual({
+      kind: "chat_continuation",
+      prior_session_id: "sess_prior",
+    });
+  });
+
+  it("passes a well-formed caller session id through as the override", async () => {
+    const ports = makePorts();
+    await postAndResolve(ports, { message: "hi", session_id: VALID_SID }, { id: VALID_SID });
+
+    expect(ports.dispatchService.dispatchTask.mock.calls[0]![0].sessionIdOverride).toBe(VALID_SID);
+  });
+
+  it.each(["sess_short", "notasession", "sess_abcdef12345!", 7])(
+    "ignores a malformed session_id (%s) instead of overriding",
+    async (session_id) => {
+      const ports = makePorts();
+      await postAndResolve(ports, { message: "hi", session_id }, { id: VALID_SID });
+
+      expect(ports.dispatchService.dispatchTask.mock.calls[0]![0].sessionIdOverride).toBeUndefined();
+      expect(ports.sessionRepo.findById).not.toHaveBeenCalled();
+    },
+  );
+
+  it("500s and releases the rate slot when dispatch throws", async () => {
+    const ports = makePorts();
+    ports.dispatchService.dispatchTask.mockRejectedValue(new Error("no runtime"));
+    // maxConcurrent defaults to 1, so a leaked slot would 429 the retry.
+    const { app } = makeApp(ports);
+
+    const first = await request(app).post("/chat").send({ message: "hi" });
+    expect(first.status).toBe(500);
+    expect(first.body.error).toBe("internal_error");
+
+    const second = await request(app).post("/chat").send({ message: "hi" });
+    expect(second.status).toBe(500);
+  });
+
+  it("503s and releases the slot when the bound daemon is offline", async () => {
+    const ports = makePorts();
+    ports.dispatchService.dispatchTask.mockResolvedValue({
+      session: fakeSession({ id: VALID_SID }),
+      runtime_id: "rt_1",
+    });
+    ports.hub.isOnline.mockReturnValue(false);
+    const { app } = makeApp(ports);
+
+    const res = await request(app).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe("agent_offline");
+    expect(ports.hub.isOnline).toHaveBeenCalledWith("rt_1");
+
+    // Slot released — a retry gets past the limiter to the same 503.
+    expect((await request(app).post("/chat").send({ message: "hi" })).status).toBe(503);
+  });
+
+  it("does not consult the hub for a null-runtime agent — the executor claims it", async () => {
+    const ports = makePorts();
+    const res = await postAndResolve(ports, { message: "hi" }, { id: VALID_SID });
+
+    expect(ports.hub.isOnline).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+  });
+
+  it("504s when the turn outlives the resolver timeout", async () => {
+    // register()'s own timer rejects; no CLI or clock faking needed —
+    // a resolver whose entry is dropped rejects on the next tick.
+    const ports = makePorts();
+    const chatResolver = new ChatResolver();
+    vi.spyOn(chatResolver, "register").mockRejectedValue(
+      new Error("chat resolver timeout (90000ms) for sess_x"),
+    );
+
+    const res = await request(makeApp(ports, { chatResolver }).app)
+      .post("/chat")
+      .send({ message: "hi" });
+
+    expect(res.status).toBe(504);
+    expect(res.body).toMatchObject({ error: "chat_turn_timeout", timeout_ms: 90_000 });
+  });
+
+  it("500s on a non-timeout resolver rejection", async () => {
+    const ports = makePorts();
+    const chatResolver = new ChatResolver();
+    vi.spyOn(chatResolver, "register").mockRejectedValue(new Error("connection lost"));
+
+    const res = await request(makeApp(ports, { chatResolver }).app)
+      .post("/chat")
+      .send({ message: "hi" });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("internal_error");
+  });
+
+  it("maps a failed turn onto the friendlier failure message", async () => {
+    const ports = makePorts();
+    const res = await postAndResolve(
+      ports,
+      { message: "hi" },
+      { id: VALID_SID, status: "failed", error: "CLI exited with code 1" },
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("failed");
+    // The bare exit line is useless; the daemon-log pointer replaces it.
+    expect(res.body.response).toMatch(/beevibe-daemon start/);
+  });
+});
+
+describe("POST /chat — onboarding flip", () => {
+  it("stamps onboarding_completed_at on the first successful turn", async () => {
+    const ports = makePorts();
+    ports.personRepo.findById.mockResolvedValue(
+      fakePerson({ onboarding_completed_at: undefined }),
+    );
+
+    await postAndResolve(ports, { message: "hi" }, { id: VALID_SID, status: "succeeded" });
+
+    expect(ports.personRepo.update).toHaveBeenCalledWith(PERSON, {
+      onboarding_completed_at: expect.any(Date),
+    });
+  });
+
+  it("leaves the flag alone when the turn failed", async () => {
+    const ports = makePorts();
+    ports.personRepo.findById.mockResolvedValue(
+      fakePerson({ onboarding_completed_at: undefined }),
+    );
+
+    await postAndResolve(ports, { message: "hi" }, { id: VALID_SID, status: "failed" });
+    expect(ports.personRepo.update).not.toHaveBeenCalled();
+  });
+
+  it("skips the write for an already-onboarded person", async () => {
+    const ports = makePorts();
+    await postAndResolve(ports, { message: "hi" }, { id: VALID_SID, status: "succeeded" });
+    expect(ports.personRepo.update).not.toHaveBeenCalled();
+  });
+
+  it("still 200s when the flip write rejects — it is fire-and-forget", async () => {
+    const ports = makePorts();
+    ports.personRepo.findById.mockResolvedValue(
+      fakePerson({ onboarding_completed_at: undefined }),
+    );
+    ports.personRepo.update.mockRejectedValue(new Error("write conflict"));
+
+    const res = await postAndResolve(
+      ports,
+      { message: "hi" },
+      { id: VALID_SID, status: "succeeded", result_summary: "ok" },
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.response).toBe("ok");
+  });
+});
+
+describe("POST /chat — idempotent replay", () => {
+  it("replays a succeeded session without dispatching again", async () => {
+    const ports = makePorts();
+    ports.sessionRepo.findById.mockResolvedValue(
+      fakeSession({ id: VALID_SID, type: "chat", status: "succeeded", result_summary: "cached" }),
+    );
+
+    const res = await request(makeApp(ports).app)
+      .post("/chat")
+      .send({ message: "hi", session_id: VALID_SID });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      replayed: true,
+      response: "cached",
+      status: "succeeded",
+      session_id: VALID_SID,
+    });
+    expect(ports.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("replays a failed session with the failure message", async () => {
+    const ports = makePorts();
+    ports.sessionRepo.findById.mockResolvedValue(
+      fakeSession({ id: VALID_SID, type: "chat", status: "failed", error: "disk full" }),
+    );
+
+    const res = await request(makeApp(ports).app)
+      .post("/chat")
+      .send({ message: "hi", session_id: VALID_SID });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ replayed: true, status: "failed", response: "disk full" });
+  });
+
+  it("409s while the session is still running", async () => {
+    const ports = makePorts();
+    ports.sessionRepo.findById.mockResolvedValue(
+      fakeSession({ id: VALID_SID, type: "chat", status: "running" }),
+    );
+
+    const res = await request(makeApp(ports).app)
+      .post("/chat")
+      .send({ message: "hi", session_id: VALID_SID });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe("session_in_flight");
+    expect(ports.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("403s when the session id belongs to a different agent", async () => {
+    const ports = makePorts();
+    ports.sessionRepo.findById.mockResolvedValue(
+      fakeSession({ id: VALID_SID, type: "chat", agent_id: "agent_someone_else" }),
+    );
+
+    const res = await request(makeApp(ports).app)
+      .post("/chat")
+      .send({ message: "hi", session_id: VALID_SID });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("session_belongs_to_other_caller");
+  });
+
+  it("runs the turn when the pending row exists but hasn't started", async () => {
+    // `pending` is neither terminal nor running — fall through and
+    // dispatch under the same id.
+    const ports = makePorts();
+    ports.sessionRepo.findById.mockResolvedValue(
+      fakeSession({ id: VALID_SID, type: "chat", status: "pending" }),
+    );
+
+    const res = await postAndResolve(
+      ports,
+      { message: "hi", session_id: VALID_SID },
+      { id: VALID_SID, result_summary: "fresh" },
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.replayed).toBeUndefined();
+    expect(ports.dispatchService.dispatchTask).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["the row does not exist", undefined],
+    ["the row is not a chat session", fakeSession({ id: VALID_SID, type: "task" })],
+  ])("falls through to the run path when %s", async (_label, existing) => {
+    const ports = makePorts();
+    ports.sessionRepo.findById.mockResolvedValue(existing);
+
+    const res = await postAndResolve(
+      ports,
+      { message: "hi", session_id: VALID_SID },
+      { id: VALID_SID, result_summary: "ran" },
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.response).toBe("ran");
+    expect(ports.dispatchService.dispatchTask).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("POST /chat — rate limiting", () => {
+  it("429s a concurrent second turn from the same person", async () => {
+    const ports = makePorts();
+    // Same app across both requests so they share one limiter instance.
+    const { app, chatResolver } = makeApp(ports);
+
+    // Kick the first turn off without awaiting it — supertest's Test is
+    // lazy, so `.end()` is what actually fires the request. It parks on
+    // the resolver, holding the single concurrent slot.
+    const first = request(app).post("/chat").send({ message: "first" });
+    const firstDone = new Promise<void>((done) => first.end(() => done()));
+    await vi.waitFor(() => expect(ports.dispatchService.dispatchTask).toHaveBeenCalled());
+
+    const res = await request(app).post("/chat").send({ message: "second" });
+    expect(res.status).toBe(429);
+    expect(res.body.error).toBe("turn_in_flight");
+    expect(res.body.retry_after_ms).toBeGreaterThan(0);
+    expect(res.headers["retry-after"]).toBeDefined();
+
+    // Let the parked turn finish rather than leaving it pending for the
+    // route's full 90s timeout.
+    chatResolver.resolve(VALID_SID, fakeSession({ id: VALID_SID }));
+    await firstDone;
+  });
+
+  it("429s with rate_limited once the sliding window is full", async () => {
+    let now = 1_000_000;
+    const rateLimiter = new ChatRateLimiter({
+      maxConcurrent: 5,
+      maxPerWindow: 2,
+      windowMs: 60_000,
+      now: () => now,
+    });
+    const ports = makePorts();
+
+    for (let i = 0; i < 2; i++) {
+      const ok = await postAndResolve(ports, { message: `turn ${i}` }, { id: VALID_SID }, {
+        rateLimiter,
+      });
+      expect(ok.status).toBe(200);
+    }
+
+    const res = await request(makeApp(ports, { rateLimiter }).app)
+      .post("/chat")
+      .send({ message: "third" });
+    expect(res.status).toBe(429);
+    expect(res.body.error).toBe("rate_limited");
+
+    // Past the window, the same caller is admitted again.
+    now += 60_001;
+    const after = await postAndResolve(ports, { message: "fourth" }, { id: VALID_SID }, {
+      rateLimiter,
+    });
+    expect(after.status).toBe(200);
+  });
+
+  it("never reaches dispatch when the limiter refuses", async () => {
+    const rateLimiter = new ChatRateLimiter({ maxPerWindow: 0 });
+    const ports = makePorts();
+
+    const res = await request(makeApp(ports, { rateLimiter }).app)
+      .post("/chat")
+      .send({ message: "hi" });
+
+    expect(res.status).toBe(429);
+    expect(ports.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/tools/session-search.test.ts
+++ b/packages/api/src/tools/session-search.test.ts
@@ -1,0 +1,257 @@
+/**
+ * session_search MCP tool — unit tests with a fake SessionSearchService.
+ *
+ * The tool's real work is `inferRequest`: it turns the loose,
+ * four-shapes-in-one-signature MCP input into one of the four typed
+ * `SessionSearchRequest` variants. The shape ladder is order-sensitive
+ * (scroll beats read beats discover beats browse), and the whole thing
+ * is reachable only through the handler, so these tests drive the
+ * handler and assert on what the service was handed.
+ *
+ * The service is faked — its scoping and FTS behaviour belong to
+ * `core/src/services/session-search.test.ts`, which needs a real
+ * Postgres. What's left here is the mapping plus two failure surfaces:
+ * the `null` return (out of scope / bad anchor) and the
+ * SessionSearchError code passthrough, including the name-matched
+ * branch that exists for cross-bundle (src vs dist) imports.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { SessionSearchError } from "@beevibe/core/services/session-search";
+import type { SessionSearchService } from "@beevibe/core/services/session-search";
+import { createSessionSearchTool, type SessionSearchToolContext } from "./session-search.js";
+
+const CTX: SessionSearchToolContext = {
+  agentId: "agent_team",
+  hierarchyLevel: "team",
+  sessionId: "sess_current0001",
+};
+
+function makeService(result: unknown = { kind: "browse", sessions: [] }) {
+  return {
+    search: vi.fn().mockResolvedValue(result),
+  } as unknown as SessionSearchService & { search: ReturnType<typeof vi.fn> };
+}
+
+function build(service = makeService(), ctx: Partial<SessionSearchToolContext> = {}) {
+  return { tool: createSessionSearchTool({ ...CTX, ...ctx }, { sessionSearch: service }), service };
+}
+
+/** Drive the handler and hand back the request the service received. */
+async function requestFor(input: Record<string, unknown>) {
+  const { tool, service } = build();
+  await tool.handler(input);
+  return service.search.mock.calls[0]![0];
+}
+
+describe("createSessionSearchTool", () => {
+  it("exposes the session_search name and a thick agent-facing description", () => {
+    const { tool } = build();
+    expect(tool.name).toBe("session_search");
+    // The description is the contract; it has to spell out all four shapes.
+    for (const shape of ["DISCOVERY", "SCROLL", "READ", "BROWSE"]) {
+      expect(tool.description).toContain(shape);
+    }
+  });
+
+  it("passes the caller context through on every call", async () => {
+    const { tool, service } = build();
+    await tool.handler({ query: "auth refactor" });
+
+    expect(service.search.mock.calls[0]![1]).toEqual({
+      callerAgentId: "agent_team",
+      hierarchyLevel: "team",
+      currentSessionId: "sess_current0001",
+    });
+  });
+});
+
+describe("session_search — shape inference", () => {
+  it("infers scroll when session_id and around_message_id are both set", async () => {
+    expect(
+      await requestFor({
+        session_id: "sess_a",
+        around_message_id: "evt_1",
+        window: 10,
+      }),
+    ).toEqual({
+      kind: "scroll",
+      session_id: "sess_a",
+      around_message_id: "evt_1",
+      window: 10,
+    });
+  });
+
+  it("leaves window undefined on scroll when it isn't a number — the service clamps", async () => {
+    expect(
+      await requestFor({ session_id: "sess_a", around_message_id: "evt_1", window: "10" }),
+    ).toMatchObject({ kind: "scroll", window: undefined });
+  });
+
+  it("infers read from a bare session_id", async () => {
+    expect(await requestFor({ session_id: "sess_a" })).toEqual({
+      kind: "read",
+      session_id: "sess_a",
+    });
+  });
+
+  it("falls back to read when the anchor is present but blank", async () => {
+    expect(await requestFor({ session_id: "sess_a", around_message_id: "   " })).toEqual({
+      kind: "read",
+      session_id: "sess_a",
+    });
+  });
+
+  it("infers discover from a query, carrying limit, sort and filters", async () => {
+    expect(
+      await requestFor({
+        query: "auth refactor",
+        limit: 3,
+        sort: "oldest",
+        filters: { type: "chat", status: "failed" },
+      }),
+    ).toEqual({
+      kind: "discover",
+      query: "auth refactor",
+      limit: 3,
+      sort: "oldest",
+      filters: { type: "chat", status: "failed" },
+    });
+  });
+
+  it("drops an unrecognized sort rather than passing it down", async () => {
+    expect(await requestFor({ query: "auth", sort: "relevance" })).toMatchObject({
+      kind: "discover",
+      sort: undefined,
+    });
+  });
+
+  it("infers browse when nothing identifying is passed", async () => {
+    expect(await requestFor({})).toEqual({
+      kind: "browse",
+      limit: undefined,
+      filters: undefined,
+    });
+  });
+
+  it("keeps limit and filters on the browse shape", async () => {
+    expect(await requestFor({ limit: 5, filters: { agent_id: "agent_ic" } })).toEqual({
+      kind: "browse",
+      limit: 5,
+      filters: { agent_id: "agent_ic" },
+    });
+  });
+
+  it("prefers scroll over discover when a query is passed alongside an anchor", async () => {
+    // Ambiguous input from the agent — the ladder resolves it, and this
+    // pins which way.
+    expect(
+      await requestFor({ session_id: "sess_a", around_message_id: "evt_1", query: "auth" }),
+    ).toMatchObject({ kind: "scroll" });
+  });
+
+  it("prefers read over discover when a query is passed alongside a session_id", async () => {
+    expect(await requestFor({ session_id: "sess_a", query: "auth" })).toMatchObject({
+      kind: "read",
+    });
+  });
+
+  it.each([
+    ["blank strings", { session_id: "  ", query: "  " }],
+    ["non-strings", { session_id: 1, around_message_id: 2, query: 3 }],
+    ["null filters", { filters: null }],
+  ])("treats %s as browse", async (_label, input) => {
+    expect(await requestFor(input)).toMatchObject({ kind: "browse" });
+  });
+
+  it("trims the identifying strings before handing them to the service", async () => {
+    expect(await requestFor({ session_id: "  sess_a  ", around_message_id: " evt_1 " })).toEqual({
+      kind: "scroll",
+      session_id: "sess_a",
+      around_message_id: "evt_1",
+      window: undefined,
+    });
+    expect(await requestFor({ query: "  auth refactor  " })).toMatchObject({
+      query: "auth refactor",
+    });
+  });
+});
+
+describe("session_search — results and failures", () => {
+  it("returns the service result verbatim on success", async () => {
+    const result = { kind: "discover", results: [{ session: { id: "sess_a" } }] };
+    const { tool } = build(makeService(result));
+
+    const res = await tool.handler({ query: "auth" });
+    expect(res.isError).toBeUndefined();
+    expect(res.content).toEqual(result);
+  });
+
+  it("maps a null result onto not_found_or_forbidden", async () => {
+    // The service returns null for three distinct causes; the tool
+    // deliberately collapses them into one message so a probing agent
+    // can't distinguish "doesn't exist" from "not yours".
+    const { tool } = build(makeService(null));
+
+    const res = await tool.handler({ session_id: "sess_someone_else" });
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("not_found_or_forbidden");
+    expect(res.content.message).toMatch(/not in your scope/);
+  });
+
+  it.each(["forbidden_agent_filter", "missing_query", "missing_args"] as const)(
+    "passes a SessionSearchError's %s code straight through",
+    async (code) => {
+      const service = makeService();
+      service.search.mockRejectedValue(new SessionSearchError(code, `bad: ${code}`));
+      const { tool } = build(service);
+
+      const res = await tool.handler({ query: "auth" });
+      expect(res.isError).toBe(true);
+      expect(res.content).toEqual({ error: code, message: `bad: ${code}` });
+    },
+  );
+
+  it("recognizes a SessionSearchError by name across bundle boundaries", async () => {
+    // An integration script consuming core's src/ while the api consumes
+    // dist/ throws a structurally identical but not `instanceof`-equal
+    // error. The name check is what keeps the code from degrading to
+    // internal_error.
+    class ForeignSessionSearchError extends Error {
+      code = "missing_query";
+      constructor() {
+        super("query is required");
+        this.name = "SessionSearchError";
+      }
+    }
+    const service = makeService();
+    service.search.mockRejectedValue(new ForeignSessionSearchError());
+    const { tool } = build(service);
+
+    const res = await tool.handler({ query: "auth" });
+    expect(res.content).toEqual({ error: "missing_query", message: "query is required" });
+  });
+
+  it("wraps an unexpected throw as internal_error", async () => {
+    const service = makeService();
+    service.search.mockRejectedValue(new Error("connection terminated"));
+    const { tool } = build(service);
+
+    const res = await tool.handler({ query: "auth" });
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "internal_error",
+      message: "connection terminated",
+    });
+  });
+
+  it("stringifies a non-Error throw", async () => {
+    const service = makeService();
+    service.search.mockRejectedValue("nope");
+    const { tool } = build(service);
+
+    expect((await tool.handler({})).content).toEqual({
+      error: "internal_error",
+      message: "nope",
+    });
+  });
+});

--- a/packages/api/src/tools/use-repo.test.ts
+++ b/packages/api/src/tools/use-repo.test.ts
@@ -1,0 +1,360 @@
+/**
+ * use_repo MCP tool — unit tests with vitest fakes (no DB, no Docker).
+ *
+ * The handler is a four-step sequence with a validation gate in front:
+ * validate goal + repo_url, resolve the calling agent, create the
+ * container task, dispatch the sandbox session, then insert the
+ * repo_run row. Order matters — `repo_run.session_id` FKs to
+ * `session.id`, so the dispatch has to land first. These tests pin that
+ * ordering explicitly, because a future refactor that swaps the two
+ * calls would still pass every per-step assertion.
+ *
+ * The two failure paths after the task insert (dispatch throws,
+ * repo_run insert throws) each leave a different amount of debris
+ * behind, and the tool reports a distinct code for each so the agent
+ * can tell "nothing started" from "started but orphaned". Both are
+ * covered below.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  RepoRunRepository,
+  Task,
+  TaskRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import { createUseRepoTool } from "./use-repo.js";
+
+const AGENT = "agent_ic";
+
+function fakeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: AGENT,
+    name: "Scout",
+    owner_id: "person_1",
+    hierarchy_level: "ic",
+    runtime_config: { type: "claude" },
+    created_at: new Date("2026-01-01"),
+    updated_at: new Date("2026-01-01"),
+    ...overrides,
+  } as Agent;
+}
+
+function makeServices(overrides: Record<string, unknown> = {}) {
+  const agentRepo = { findById: vi.fn().mockResolvedValue(fakeAgent()) };
+  // The real repo echoes the row back with its generated columns filled
+  // in; the tool only reads `.id`, which it minted itself.
+  const taskRepo = { create: vi.fn().mockImplementation(async (t: Task) => t) };
+  const repoRunRepo = { create: vi.fn().mockResolvedValue(undefined) };
+  const dispatchService = {
+    dispatchTask: vi.fn().mockResolvedValue({ session: { id: "sess_x" }, runtime_id: "rt_1" }),
+  };
+  return {
+    agentRepo: agentRepo as unknown as AgentRepository,
+    taskRepo: taskRepo as unknown as TaskRepository,
+    repoRunRepo: repoRunRepo as unknown as RepoRunRepository,
+    dispatchService: dispatchService as unknown as DispatchService,
+    ...overrides,
+    // Handles kept unwrapped for assertions.
+    _agentRepo: agentRepo,
+    _taskRepo: taskRepo,
+    _repoRunRepo: repoRunRepo,
+    _dispatch: dispatchService,
+  };
+}
+
+function build(services = makeServices()) {
+  const tool = createUseRepoTool({ agentId: AGENT }, services);
+  return { tool, services };
+}
+
+const GOOD = {
+  goal: "Extract the tables from this PDF as JSON",
+  repo_url: "https://github.com/jsvine/pdfplumber",
+};
+
+describe("createUseRepoTool", () => {
+  it("exposes the use_repo name and requires goal + repo_url", () => {
+    const { tool } = build();
+    expect(tool.name).toBe("use_repo");
+    expect((tool.schema as { required: string[] }).required).toEqual(["goal", "repo_url"]);
+    expect((tool.schema as { additionalProperties: boolean }).additionalProperties).toBe(false);
+  });
+});
+
+describe("use_repo — input validation", () => {
+  it.each([
+    ["missing goal", { repo_url: GOOD.repo_url }],
+    ["blank goal", { goal: "   ", repo_url: GOOD.repo_url }],
+    ["non-string goal", { goal: 12, repo_url: GOOD.repo_url }],
+  ])("rejects %s with invalid_goal", async (_label, input) => {
+    const { tool, services } = build();
+    const res = await tool.handler(input);
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("invalid_goal");
+    expect(services._agentRepo.findById).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["missing repo_url", {}],
+    ["a non-GitHub host", { repo_url: "https://gitlab.com/acme/tool" }],
+    ["plain http", { repo_url: "http://github.com/acme/tool" }],
+    ["a lookalike host", { repo_url: "https://notgithub.com/acme/tool" }],
+    ["an unparseable string", { repo_url: "not a url" }],
+    ["a non-string", { repo_url: 42 }],
+  ])("rejects %s with invalid_repo_url", async (_label, extra) => {
+    const { tool, services } = build();
+    const res = await tool.handler({ goal: GOOD.goal, ...extra });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("invalid_repo_url");
+    expect(services._taskRepo.create).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "https://github.com/acme/tool",
+    "https://www.github.com/acme/tool",
+    "https://GITHUB.COM/acme/tool",
+  ])("accepts %s", async (repo_url) => {
+    const { tool } = build();
+    const res = await tool.handler({ goal: GOOD.goal, repo_url });
+    expect(res.isError).toBeUndefined();
+  });
+
+  it("404s when the calling agent row is gone", async () => {
+    const services = makeServices();
+    services._agentRepo.findById.mockResolvedValue(undefined);
+    const { tool } = build(services);
+
+    const res = await tool.handler(GOOD);
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "agent_not_found",
+      message: "calling agent not found",
+    });
+    expect(services._taskRepo.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("use_repo — happy path", () => {
+  it("creates the container task pinned to the calling agent", async () => {
+    const { tool, services } = build();
+    await tool.handler(GOOD);
+
+    const task = services._taskRepo.create.mock.calls[0]![0];
+    expect(task).toMatchObject({
+      title: GOOD.goal,
+      description: GOOD.goal,
+      priority: "medium",
+      assignee_id: AGENT,
+      creator_id: AGENT,
+      creator_type: "agent",
+    });
+    expect(task.id).toMatch(/^task_/);
+  });
+
+  it("truncates a long goal into an 80-char container task title", async () => {
+    const { tool, services } = build();
+    const goal = "x".repeat(200);
+    await tool.handler({ ...GOOD, goal });
+
+    const { title, description } = services._taskRepo.create.mock.calls[0]![0];
+    expect(title).toHaveLength(78); // 77 chars + the ellipsis
+    expect(title.endsWith("…")).toBe(true);
+    // The full goal still reaches the child agent via description.
+    expect(description).toBe(goal);
+  });
+
+  it("collapses whitespace in the title but not the dispatched goal", async () => {
+    const { tool, services } = build();
+    await tool.handler({ ...GOOD, goal: "  extract\n\n  the   tables  " });
+
+    expect(services._taskRepo.create.mock.calls[0]![0].title).toBe("extract the tables");
+    expect(services._dispatch.dispatchTask.mock.calls[0]![0].intent).toBe(
+      "extract\n\n  the   tables",
+    );
+  });
+
+  it("dispatches a run_repo session under a pre-minted session id", async () => {
+    const { tool, services } = build();
+    const res = await tool.handler(GOOD);
+
+    const dispatched = services._dispatch.dispatchTask.mock.calls[0]![0];
+    expect(dispatched).toMatchObject({
+      agentId: AGENT,
+      type: "run_repo",
+      intent: GOOD.goal,
+      reason: { kind: "fresh" },
+    });
+    // The container task built one step earlier is handed to the
+    // dispatch verbatim, so the sandbox session hangs off the same row
+    // the work_product will later land on.
+    expect(dispatched.task).toBe(services._taskRepo.create.mock.calls[0]![0]);
+    // The tool mints the session id itself so repo_run can reference it;
+    // the response has to echo the same one back.
+    expect(dispatched.sessionIdOverride).toBe(res.content.session_id);
+  });
+
+  it("inserts the repo_run AFTER the dispatch — repo_run.session_id FKs to session.id", async () => {
+    const order: string[] = [];
+    const services = makeServices();
+    services._dispatch.dispatchTask.mockImplementation(async () => {
+      order.push("dispatch");
+      return { session: { id: "sess_x" }, runtime_id: "rt_1" };
+    });
+    services._repoRunRepo.create.mockImplementation(async () => {
+      order.push("repo_run");
+    });
+    const { tool } = build(services);
+
+    await tool.handler(GOOD);
+    expect(order).toEqual(["dispatch", "repo_run"]);
+  });
+
+  it("writes a pending repo_run tying session, task and repo together", async () => {
+    const { tool, services } = build();
+    const res = await tool.handler(GOOD);
+
+    expect(services._repoRunRepo.create).toHaveBeenCalledWith({
+      id: res.content.repo_run_id,
+      session_id: res.content.session_id,
+      task_id: services._taskRepo.create.mock.calls[0]![0].id,
+      agent_id: AGENT,
+      goal: GOOD.goal,
+      repo_url: GOOD.repo_url,
+      status: "pending",
+    });
+  });
+
+  it("returns the ids, the watch url and a poll hint", async () => {
+    const { tool } = build();
+    const res = await tool.handler(GOOD);
+
+    expect(res.isError).toBeUndefined();
+    expect(res.content.repo_run_id).toMatch(/^repo_/);
+    expect(res.content.session_id).toMatch(/^sess_/);
+    expect(res.content.task_id).toMatch(/^task_/);
+    expect(res.content.status).toBe("pending");
+    expect(res.content.watch_url).toBe(`/capabilities/runs/${res.content.repo_run_id}`);
+    expect(res.content.note).toMatch(/poll/i);
+  });
+
+  it("trims and echoes input_url and input_filename", async () => {
+    const { tool } = build();
+    const res = await tool.handler({
+      ...GOOD,
+      input_url: "  https://example.com/a.pdf  ",
+      input_filename: "  a.pdf  ",
+    });
+
+    expect(res.content.input_url).toBe("https://example.com/a.pdf");
+    expect(res.content.input_filename).toBe("a.pdf");
+  });
+
+  it("leaves input_url and input_filename undefined when absent or non-string", async () => {
+    const { tool } = build();
+    const res = await tool.handler({ ...GOOD, input_url: 5 });
+
+    expect(res.content.input_url).toBeUndefined();
+    expect(res.content.input_filename).toBeUndefined();
+  });
+});
+
+describe("use_repo — limits parsing", () => {
+  async function limitsFor(limits: unknown): Promise<Record<string, unknown>> {
+    const { tool } = build();
+    const res = await tool.handler({ ...GOOD, limits });
+    return res.content.limits as Record<string, unknown>;
+  }
+
+  it("passes through in-range values", async () => {
+    expect(
+      await limitsFor({ wall_clock_minutes: 10, max_install_attempts: 3, disk_mb: 1024 }),
+    ).toEqual({ wall_clock_minutes: 10, max_install_attempts: 3, disk_mb: 1024 });
+  });
+
+  it("clamps each value to its ceiling", async () => {
+    expect(
+      await limitsFor({ wall_clock_minutes: 999, max_install_attempts: 99, disk_mb: 999_999 }),
+    ).toEqual({ wall_clock_minutes: 60, max_install_attempts: 5, disk_mb: 10_000 });
+  });
+
+  it("floors the integer-valued limits but not wall clock", async () => {
+    expect(
+      await limitsFor({ wall_clock_minutes: 2.5, max_install_attempts: 2.9, disk_mb: 512.7 }),
+    ).toEqual({ wall_clock_minutes: 2.5, max_install_attempts: 2, disk_mb: 512 });
+  });
+
+  it.each([
+    ["zero", { wall_clock_minutes: 0, max_install_attempts: 0, disk_mb: 0 }],
+    ["negative", { wall_clock_minutes: -1, max_install_attempts: -1, disk_mb: -1 }],
+    ["non-numeric", { wall_clock_minutes: "10", max_install_attempts: null, disk_mb: [] }],
+  ])("drops %s values so the sandbox default applies", async (_label, limits) => {
+    expect(await limitsFor(limits)).toEqual({});
+  });
+
+  it.each([
+    ["omitted", undefined],
+    ["null", null],
+    ["a non-object", "20m"],
+  ])("returns {} when limits is %s", async (_label, limits) => {
+    expect(await limitsFor(limits)).toEqual({});
+  });
+});
+
+describe("use_repo — failure after the task insert", () => {
+  it("reports dispatch_failed and never inserts the repo_run", async () => {
+    const services = makeServices();
+    services._dispatch.dispatchTask.mockRejectedValue(new Error("no runtime bound"));
+    const { tool } = build(services);
+
+    const res = await tool.handler(GOOD);
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "dispatch_failed",
+      message: "no runtime bound",
+    });
+    expect(services._repoRunRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("stringifies a non-Error dispatch throw", async () => {
+    const services = makeServices();
+    services._dispatch.dispatchTask.mockRejectedValue("kaboom");
+    const { tool } = build(services);
+
+    expect((await tool.handler(GOOD)).content).toEqual({
+      error: "dispatch_failed",
+      message: "kaboom",
+    });
+  });
+
+  it("reports repo_run_create_failed — the session row is already orphaned", async () => {
+    // The session landed but has no repo_run to compose a payload from.
+    // composeDispatchPayload self-recovers by failing the session; the
+    // agent still needs to hear about it rather than wait on a run that
+    // will never start.
+    const services = makeServices();
+    services._repoRunRepo.create.mockRejectedValue(new Error("duplicate key"));
+    const { tool } = build(services);
+
+    const res = await tool.handler(GOOD);
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "repo_run_create_failed",
+      message: "duplicate key",
+    });
+    expect(services._dispatch.dispatchTask).toHaveBeenCalledTimes(1);
+  });
+
+  it("stringifies a non-Error repo_run throw", async () => {
+    const services = makeServices();
+    services._repoRunRepo.create.mockRejectedValue({ code: "23505" });
+    const { tool } = build(services);
+
+    expect((await tool.handler(GOOD)).content).toMatchObject({
+      error: "repo_run_create_failed",
+    });
+  });
+});

--- a/packages/api/src/tools/watch.test.ts
+++ b/packages/api/src/tools/watch.test.ts
@@ -1,0 +1,252 @@
+/**
+ * watch_tasks + unwatch MCP tools — unit tests with a fake WatchService.
+ *
+ * Both tools are thin adapters: they coerce loose MCP input into the
+ * service's typed arguments and map the service's four error classes
+ * onto stable `error` codes. The service itself is exercised by
+ * `core/src/services/watch-service.test.ts` against a real DB, so the
+ * fake here only has to record what it was handed and throw on demand.
+ *
+ * What these tests pin is the adapter contract the agent sees: the
+ * input coercion (non-string entries dropped, mode defaulting, reason
+ * trimming), the session-context precondition, and the error-code
+ * mapping — none of which the service-level suite covers.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  WatchAuthError,
+  WatchNotFoundError,
+  WatchValidationError,
+  type WatchService,
+} from "@beevibe/core/services/watch-service";
+import { buildWatchTools, type WatchToolContext } from "./watch.js";
+import type { AgentTool } from "./types.js";
+
+const AGENT = "agent_team";
+const SESSION = "sess_caller00001";
+
+function makeService(overrides: Partial<WatchService> = {}) {
+  return {
+    watchTasks: vi.fn().mockResolvedValue({ watchId: "twatch_1", firedImmediately: false }),
+    unwatch: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as WatchService & {
+    watchTasks: ReturnType<typeof vi.fn>;
+    unwatch: ReturnType<typeof vi.fn>;
+  };
+}
+
+function build(
+  ctx: Partial<WatchToolContext> = {},
+  service = makeService(),
+): { watch: AgentTool; unwatch: AgentTool; service: typeof service } {
+  const tools = buildWatchTools(
+    { agentId: AGENT, sessionId: SESSION, ...ctx },
+    { watchService: service },
+  );
+  const watch = tools.find((t) => t.name === "watch_tasks")!;
+  const unwatch = tools.find((t) => t.name === "unwatch")!;
+  return { watch, unwatch, service };
+}
+
+describe("buildWatchTools", () => {
+  it("returns watch_tasks and unwatch, in that order", () => {
+    const tools = buildWatchTools(
+      { agentId: AGENT, sessionId: SESSION },
+      { watchService: makeService() },
+    );
+    expect(tools.map((t) => t.name)).toEqual(["watch_tasks", "unwatch"]);
+  });
+
+  it("advertises the three watch modes on the schema enum", () => {
+    const { watch } = build();
+    const schema = watch.schema as {
+      properties: { mode: { enum: string[] }; task_ids: { minItems: number } };
+      required: string[];
+    };
+    // The enum is the agent-facing contract; "all" and "any" are the
+    // two documented in the description.
+    expect(schema.properties.mode.enum).toContain("all");
+    expect(schema.properties.mode.enum).toContain("any");
+    expect(schema.properties.task_ids.minItems).toBe(1);
+    expect(schema.required).toEqual(["task_ids"]);
+  });
+});
+
+describe("watch_tasks", () => {
+  it("passes task ids through and returns the service's watch id", async () => {
+    const { watch, service } = build();
+    const res = await watch.handler({ task_ids: ["task_a", "task_b"], mode: "any" });
+
+    expect(res.isError).toBeUndefined();
+    expect(res.content).toEqual({ watch_id: "twatch_1", fired_immediately: false });
+    expect(service.watchTasks).toHaveBeenCalledWith({
+      callerAgentId: AGENT,
+      callerSessionId: SESSION,
+      taskIds: ["task_a", "task_b"],
+      mode: "any",
+      reason: undefined,
+    });
+  });
+
+  it("surfaces fired_immediately when the condition was already met", async () => {
+    const service = makeService({
+      watchTasks: vi.fn().mockResolvedValue({ watchId: "twatch_9", firedImmediately: true }),
+    } as Partial<WatchService>);
+    const { watch } = build({}, service);
+
+    const res = await watch.handler({ task_ids: ["task_a"] });
+    expect(res.content).toEqual({ watch_id: "twatch_9", fired_immediately: true });
+  });
+
+  it("defaults mode to 'all' when omitted or not a known mode", async () => {
+    const { watch, service } = build();
+
+    await watch.handler({ task_ids: ["task_a"] });
+    expect(service.watchTasks.mock.calls[0]![0].mode).toBe("all");
+
+    await watch.handler({ task_ids: ["task_a"], mode: "eventually" });
+    expect(service.watchTasks.mock.calls[1]![0].mode).toBe("all");
+
+    await watch.handler({ task_ids: ["task_a"], mode: 7 });
+    expect(service.watchTasks.mock.calls[2]![0].mode).toBe("all");
+  });
+
+  it("trims reason, and drops it when blank", async () => {
+    const { watch, service } = build();
+
+    await watch.handler({ task_ids: ["task_a"], reason: "  need the diff  " });
+    expect(service.watchTasks.mock.calls[0]![0].reason).toBe("need the diff");
+
+    await watch.handler({ task_ids: ["task_a"], reason: "   " });
+    expect(service.watchTasks.mock.calls[1]![0].reason).toBeUndefined();
+
+    await watch.handler({ task_ids: ["task_a"], reason: 42 });
+    expect(service.watchTasks.mock.calls[2]![0].reason).toBeUndefined();
+  });
+
+  it("filters non-string entries out of task_ids", async () => {
+    const { watch, service } = build();
+    await watch.handler({ task_ids: ["task_a", 5, null, "task_b", { id: "x" }] });
+
+    expect(service.watchTasks.mock.calls[0]![0].taskIds).toEqual(["task_a", "task_b"]);
+  });
+
+  it("rejects a missing, non-array, or all-non-string task_ids", async () => {
+    const { watch, service } = build();
+
+    for (const input of [{}, { task_ids: "task_a" }, { task_ids: [] }, { task_ids: [1, 2] }]) {
+      const res = await watch.handler(input);
+      expect(res.isError).toBe(true);
+      expect(res.content.error).toBe("watch_validation");
+      expect(res.content.message).toMatch(/non-empty array of strings/);
+    }
+    expect(service.watchTasks).not.toHaveBeenCalled();
+  });
+
+  it("rejects the call when there is no session context", async () => {
+    // The MCP transport binds sessionId per session; without it the
+    // service has no waiter to wake, so the tool refuses rather than
+    // registering an unwakeable watch.
+    const { watch, service } = build({ sessionId: undefined });
+    const res = await watch.handler({ task_ids: ["task_a"] });
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "watch_validation",
+      message: "watch_tasks must be called inside a session context",
+    });
+    expect(service.watchTasks).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["WatchAuthError", new WatchAuthError("not your session"), "watch_auth", "not your session"],
+    [
+      "WatchValidationError",
+      new WatchValidationError("task_ids must be non-empty"),
+      "watch_validation",
+      "task_ids must be non-empty",
+    ],
+    [
+      "WatchNotFoundError",
+      new WatchNotFoundError("twatch_missing"),
+      "watch_not_found",
+      "task_watch twatch_missing not found",
+    ],
+    ["plain Error", new Error("pg down"), "watch_error", "pg down"],
+  ])("maps a thrown %s onto its error code", async (_label, thrown, code, message) => {
+    const service = makeService({
+      watchTasks: vi.fn().mockRejectedValue(thrown),
+    } as Partial<WatchService>);
+    const { watch } = build({}, service);
+
+    const res = await watch.handler({ task_ids: ["task_a"] });
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({ error: code, message });
+  });
+
+  it("stringifies a non-Error throw", async () => {
+    const service = makeService({
+      watchTasks: vi.fn().mockRejectedValue("boom"),
+    } as Partial<WatchService>);
+    const { watch } = build({}, service);
+
+    const res = await watch.handler({ task_ids: ["task_a"] });
+    expect(res.content).toEqual({ error: "watch_error", message: "boom" });
+  });
+});
+
+describe("unwatch", () => {
+  it("cancels the watch and returns ok", async () => {
+    const { unwatch, service } = build();
+    const res = await unwatch.handler({ watch_id: "twatch_1" });
+
+    expect(res.isError).toBeUndefined();
+    expect(res.content).toEqual({ ok: true });
+    expect(service.unwatch).toHaveBeenCalledWith({
+      callerAgentId: AGENT,
+      watchId: "twatch_1",
+    });
+  });
+
+  it("rejects a missing or non-string watch_id", async () => {
+    const { unwatch, service } = build();
+
+    for (const input of [{}, { watch_id: "" }, { watch_id: 12 }]) {
+      const res = await unwatch.handler(input);
+      expect(res.isError).toBe(true);
+      expect(res.content).toEqual({
+        error: "watch_validation",
+        message: "watch_id must be a non-empty string",
+      });
+    }
+    expect(service.unwatch).not.toHaveBeenCalled();
+  });
+
+  it("maps a thrown WatchNotFoundError onto watch_not_found", async () => {
+    const service = makeService({
+      unwatch: vi.fn().mockRejectedValue(new WatchNotFoundError("twatch_gone")),
+    } as Partial<WatchService>);
+    const { unwatch } = build({}, service);
+
+    const res = await unwatch.handler({ watch_id: "twatch_gone" });
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "watch_not_found",
+      message: "task_watch twatch_gone not found",
+    });
+  });
+
+  it("maps a thrown WatchAuthError onto watch_auth", async () => {
+    const service = makeService({
+      unwatch: vi.fn().mockRejectedValue(new WatchAuthError("watch does not belong to caller")),
+    } as Partial<WatchService>);
+    const { unwatch } = build({}, service);
+
+    const res = await unwatch.handler({ watch_id: "twatch_other" });
+    expect(res.content).toEqual({
+      error: "watch_auth",
+      message: "watch does not belong to caller",
+    });
+  });
+});


### PR DESCRIPTION
## What this covers

A coverage sweep across the monorepo (v8, `--coverage.all`) ranked source files by missed lines. Discounting the postgres adapters — whose suites only *look* uncovered because they need a database this sandbox doesn't have — these four came out on top:

| File | Lines before | Missed | Test file before? |
| --- | --- | --- | --- |
| `api/src/routes/chat.ts` | 26.9% | 320 | helpers only |
| `api/src/tools/use-repo.ts` | 32.0% | 123 | none |
| `api/src/tools/session-search.ts` | 64.7% | 82 | none |
| `api/src/tools/watch.ts` | 46.3% | 72 | none |

`chat.ts` is also the 5th most-modified source file in the last six months, which is what broke the tie against the similarly-uncovered `tools/hierarchy.ts` and `mesh/server.ts`.

All four are now at **100% lines**; `chat.ts` reaches 93% branches.

| Package | Before | After |
| --- | --- | --- |
| `@beevibe/api` lines | 64.53% | **71.17%** |
| `@beevibe/api` functions | 83.63% | **88.78%** |

138 new tests. **No production code changed.**

## What the tests actually pin

**`routes/chat.test.ts`** (60 tests) — `chat-internals.test.ts` already covers the pure helpers (`groupIntoConversations`, `chainToMessages`, `failureMessageFor`), so this suite takes the four route handlers those helpers feed, which is where the branching lives:

- the human gate and the distinct no-primary-agent shape each of the four routes returns
- `GET /chat`: chain selection via `?c=`, the empty-chain-not-404 contract the UI's empty state depends on, the 25-session history window (with `prior_session_id` still pointing at the true tail, not the window's), the in-flight tail flag, `<system-wake>` turns rendering as `system` messages, and all five runtime-mismatch branches
- `POST /chat`: the replay ladder (403 wrong owner → 409 running → 200 replayed → fall through for `pending`), both rate-limiter refusal modes with a deterministic injected clock, the daemon-offline 503, and the 504 timeout
- the onboarding flip, including that a rejected fire-and-forget write still 200s

Both post-dispatch failure paths assert the rate slot is **released** by re-issuing the request and expecting to reach the same error rather than a 429 — a leaked `release()` would wedge the caller out of chat entirely, and no per-branch assertion would catch it.

**The three tool suites** fake their service and pin the adapter contract the agent sees — input coercion, the error-code mapping, and for `use_repo` the dispatch-before-`repo_run` ordering that its FK depends on (asserted on call order, not just per-step, since a refactor swapping the two would otherwise still pass).

## Test plan

- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors; the 4 remaining warnings are pre-existing in files this PR doesn't touch
- `packages/api` full suite: **958 passed**, 9 files failing

The 9 failures are the pre-existing DB-gated suites (no Postgres in this sandbox, per `CLAUDE.md`) and are byte-identical before and after this change. CI has Postgres, so they should pass there.

---
_Generated by [Claude Code](https://claude.ai/code/session_013r2dYBQ4pGmkAHiv5vXAH6)_