### PR TITLE
chore: drop five unread type fields found by a static + dynamic sweep

### DIFF
--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -96,7 +96,6 @@ export interface AgentDisplay
   /** Reserved for future memory-merge telemetry. */
   merge_events?: number;
   specialization?: string;
-  themes?: string[];
   /** CLI tool the agent uses — derived from `runtime_config.type`. */
   runtime?: string;
   /**

--- a/packages/core/src/adapters/claude-code/stream-json.ts
+++ b/packages/core/src/adapters/claude-code/stream-json.ts
@@ -46,8 +46,6 @@ export interface StreamJsonMessage {
   session_id?: string;
   cost_usd?: number;
   total_cost_usd?: number;
-  duration_ms?: number;
-  num_turns?: number;
   usage?: {
     input_tokens?: number;
     output_tokens?: number;

--- a/packages/core/src/ports/runtime.ts
+++ b/packages/core/src/ports/runtime.ts
@@ -199,7 +199,6 @@ export interface RuntimeResult {
 /** Result of `healthCheck()`. */
 export interface RuntimeHealth {
   healthy: boolean;
-  latency_ms?: number;
   error?: string;
 }
 

--- a/packages/daemon/src/update.ts
+++ b/packages/daemon/src/update.ts
@@ -53,9 +53,10 @@ const PLATFORM_ASSETS: Record<string, string> = {
   "linux-arm64": "beevibe-daemon-linux-arm64",
 };
 
+// Only `tag_name` is read: the download URL is built by convention from
+// PLATFORM_ASSETS + the tag, not from the response's `assets` array.
 interface GitHubRelease {
   tag_name: string;
-  assets: Array<{ name: string; browser_download_url: string }>;
 }
 
 function currentVersion(): string | undefined {


### PR DESCRIPTION
Follow-up dead-code sweep after #285 / #291. Export-, dependency- and module-level dead code is now clean, so this pass targets what `knip` structurally cannot see: it never checks class or interface **members**, so a declared field with no producer and no consumer stays invisible to it.

Net diff is 4 files, `+2 −5`.

## Removed

Each verified to have zero writers and zero readers across `packages/`, `scripts/`, `migrations/` and `skills/`.

| Field | Why it's dead |
| --- | --- |
| `StreamJsonMessage.duration_ms`, `.num_turns` (`claude-code/stream-json.ts`) | Every other field of the parser's input type is consumed in the same file. These two are read nowhere and appear in no fixture. |
| `RuntimeHealth.latency_ms` (`core/ports/runtime.ts`) | The sole producer, `cliVersionHealthCheck`, only ever returns `{healthy}` or `{healthy, error}`. The sole consumer, `GET /health/runtime` in `routes/me.ts`, reads `.healthy`. |
| `AgentDisplay.themes` (`api/views/types.ts`) | No SQL projection populates it and no web component reads it — unlike its live neighbours `specialization` / `sessions_count` / `facts_learned`. |
| `GitHubRelease.assets` (`daemon/update.ts`) | The updater builds its download URL by convention from `PLATFORM_ASSETS` + the tag, so it never touches the response's `assets` array. The cast otherwise implied a contract the code does not depend on. |

## Overlap with #310 — deliberately not included here

The sweep also flagged **`RuntimeConfig.timeout_ms`**, a config knob nothing honored: its siblings (`max_turns`, `model`, `system_prompt_addition`) are all plumbed through to the CLI, but `timeout_ms` was never written by any route and never read by any runtime.

It is **left to #310**, which already removes that exact line with a byte-identical diff (same blob hashes, `d6f56877` → `577a90ab`). This PR originally included it; I dropped it once I found the overlap. Landing the same deletion twice buys nothing and risks exactly the merge-order breakage #291 had to clean up after #285 and #286 landed 66 seconds apart, each green against its own base.

## Deliberately kept

Two flagged fields are unfinished wiring rather than dead code — removing them would make finishing the feature harder, which is the call CLAUDE.md already documents for this category:

- **`MemoryFactDisplay.promotion_origin_scope`** — the deferred half of the `"promoted"` `MergeOrigin` variant. `views/memory.ts:108` says so in a comment ("needs an explicit signal that core doesn't currently surface — defer"), and the promotions feature it belongs to is built end to end (`views/promotions.ts` → `routes/view.ts` → `/promotions` page).
- **`AgentDisplay.merge_events`** — explicitly marked *"Reserved for future memory-merge telemetry."*

The line drawn here: remove a field with no producer, no consumer **and** no in-code marker of deferred intent; keep it when the codebase records that the gap is intentional.

## Checks that came back clean

No action was needed from any of these — recording them so the next sweep doesn't redo the work:

- `--noUnusedLocals` / `--noUnusedParameters` and `--allowUnreachableCode false` over all five TS packages.
- `eslint` — 0 errors (only pre-existing `import/no-duplicates` and `import/no-named-as-default` warnings).
- A name-by-name grep of all **603 exported values** and **517 exported types**, discounting the declaring file and pure barrel re-export lines. Every remaining "unused export" hit is a symbol used *within its own file* — a redundant `export`, not dead code.
- A v8 coverage pass; the only 0%-covered files were the Docker- and key-gated suites excluded from the run, so it surfaced no dead modules.
- `knip` and `depcheck`: every remaining hit is a false positive already tabulated in CLAUDE.md (`node-pg-migrate`, `zod`, `prettier`, `postcss`/`autoprefixer`, the manual dev/ops scripts, and applied migration files).

## Verification

`typecheck`, `lint` and `build` are clean across all packages — `@beevibe/web` was built directly with `next build` to sidestep the documented Turbo env-mode font-proxy issue.

Test failures are an **identical set before and after** the change (confirmed by stashing): 20 core files / 7 tests, all Postgres- or provider-key-gated, matching CLAUDE.md's bare-sandbox baseline. `api` (820 passed), `scheduler` (10), `daemon` (156), `sandbox` (109) and `web` (203) report **zero failing tests**.