### PR TITLE
refactor: unify four duplicated wire-contract types

### DIFF
--- a/packages/api/src/routes/runtimes.ts
+++ b/packages/api/src/routes/runtimes.ts
@@ -24,6 +24,11 @@ import type {
 } from "@beevibe/core";
 import { requireHuman } from "../auth/middleware.js";
 import type { DaemonHub } from "../runtime/hub.js";
+import type {
+  DaemonPanelEntry,
+  RuntimePanelEntry,
+  RuntimesListResponse,
+} from "../views/types.js";
 import { loadOwned, requireParam } from "./http-errors.js";
 
 export interface RuntimesRoutesDeps {
@@ -33,30 +38,12 @@ export interface RuntimesRoutesDeps {
   hub: DaemonHub;
 }
 
-export interface RuntimePanelEntry {
-  id: string;
-  cli: string;
-  cli_version: string | null;
-  last_heartbeat: string | null;
-  /** True iff a daemon WS client subscribed to this runtime is connected. */
-  online: boolean;
-  capabilities: Record<string, unknown>;
-  created_at: string;
-}
-
-export interface DaemonPanelEntry {
-  id: string;
-  device_name: string;
-  external_id: string;
-  last_seen_at: string | null;
-  created_at: string;
-  runtimes: RuntimePanelEntry[];
-}
-
-export interface RuntimesListResponse {
-  ok: true;
-  daemons: DaemonPanelEntry[];
-}
+/**
+ * The panel DTOs live in `views/types.ts` — the one module web imports
+ * (`@beevibe/api/views/types`), so the projection below and the UI that
+ * renders it read a single declaration. Re-exported for existing importers.
+ */
+export type { DaemonPanelEntry, RuntimePanelEntry, RuntimesListResponse };
 
 function projectRuntime(r: Runtime, online: boolean): RuntimePanelEntry {
   return {

--- a/packages/api/src/tools/find-repo.ts
+++ b/packages/api/src/tools/find-repo.ts
@@ -40,6 +40,7 @@ import type {
   LearnedSkillRepository,
 } from "@beevibe/core";
 import type { AgentTool, AgentToolResult } from "./types.js";
+import type { FindRepoCandidate, FindRepoSource } from "../views/types.js";
 
 /**
  * Data layer URLs — all live in the public `beevibe-ai/beevibe-capabilities`
@@ -93,31 +94,13 @@ const FIND_REPO_SCHEMA = {
   additionalProperties: false,
 } as const;
 
-export type CandidateSource = "learned" | "community" | "trending" | "github";
-
-export interface FindRepoCandidate {
-  repo_url: string;
-  score: number;
-  /** Highest-precedence source (learned > community > trending > github). */
-  source: CandidateSource;
-  /** Every source that contributed to the score. Useful for debugging. */
-  sources: CandidateSource[];
-  /** Human-readable explanation of why this candidate scored. */
-  reason: string;
-  /** GitHub stars when available (best-effort enrich). */
-  stars?: number;
-  /** GitHub description when available. */
-  description?: string;
-  /** Programming language inferred from GitHub. */
-  language?: string;
-  /** Hydrated learned_skill row when source includes "learned". */
-  learned_skill?: {
-    id: string;
-    name: string;
-    goal_pattern: string;
-    invocation: string;
-  };
-}
+/**
+ * The candidate shape lives in `views/types.ts` — the one module web imports
+ * (`@beevibe/api/views/types`), so the scoring below and the capabilities
+ * page that renders it read a single declaration. Re-exported for existing
+ * importers; `FindRepoSource` was previously spelled `CandidateSource` here.
+ */
+export type { FindRepoCandidate, FindRepoSource };
 
 export interface FindRepoContext {
   agentId: string;
@@ -672,7 +655,7 @@ function isFilteredOutContent(description: string | null | undefined): boolean {
   return FILTERED_DESCRIPTION_PATTERN.test(description);
 }
 
-function pickPrimarySource(sources: CandidateSource[]): CandidateSource {
+function pickPrimarySource(sources: FindRepoSource[]): FindRepoSource {
   // Trust order: learned > trending > community > github. The user's
   // explicit preference is "prefer trendy ones", so trending wins the
   // label when a candidate has both trending velocity and community

--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -26,6 +26,7 @@ import type {
   SessionEventKind,
   SessionStatus,
   SessionType,
+  WorkProductType,
 } from "@beevibe/core";
 
 /**
@@ -791,6 +792,99 @@ export interface AgentNetwork {
   self: AgentDisplay[];
   /** Other people's agents the caller co-exists with via shared rooms. */
   peers: AgentPeerOwner[];
+}
+
+// ── Runtimes panel — daemons and their CLIs ─────────────────────────────────
+//
+// Emitted by `GET /runtimes` (`routes/runtimes.ts`, which projects rows with
+// `satisfies RuntimesListResponse`). Absent values are sent as explicit
+// `null`, not omitted — the projection normalizes `undefined` away — so these
+// fields are nullable rather than optional.
+
+export interface RuntimePanelEntry {
+  id: string;
+  cli: string;
+  cli_version: string | null;
+  /** ISO last_heartbeat, or null when the runtime has never beat. */
+  last_heartbeat: string | null;
+  /** True iff a daemon WS client subscribed to this runtime is connected. */
+  online: boolean;
+  capabilities: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface DaemonPanelEntry {
+  id: string;
+  device_name: string;
+  external_id: string;
+  /** ISO last_seen_at — when the daemon last hit /runtime/heartbeat. */
+  last_seen_at: string | null;
+  created_at: string;
+  runtimes: RuntimePanelEntry[];
+}
+
+export interface RuntimesListResponse {
+  ok: true;
+  daemons: DaemonPanelEntry[];
+}
+
+// ── Work products — single deliverable detail ───────────────────────────────
+
+export interface WorkProductDetail {
+  id: string;
+  task_id: string;
+  task_short_id: string;
+  task_title: string;
+  agent_id: string;
+  agent_label: string;
+  type: WorkProductType;
+  title: string;
+  summary?: string;
+  url?: string;
+  provider?: string;
+  external_id?: string;
+  /**
+   * Full deliverable content. Sourced from `work_product.body` when set;
+   * otherwise falls back to reading a `file://` URL from disk. Truncated
+   * to 256 KB.
+   */
+  body?: string;
+  /** True when `url` is file:// — UI uses this to suppress an unclickable link. */
+  url_is_local: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+// ── find_repo — candidate repos the discovery tool ranks ────────────────────
+//
+// Returned inside the `find_repo` tool envelope and surfaced verbatim by the
+// capabilities page. Declared here rather than in `tools/find-repo.ts` so the
+// server that scores candidates and the UI that renders them share one shape.
+
+export type FindRepoSource = "learned" | "community" | "trending" | "github";
+
+export interface FindRepoCandidate {
+  repo_url: string;
+  score: number;
+  /** Highest-precedence source (learned > community > trending > github). */
+  source: FindRepoSource;
+  /** Every source that contributed to the score. Useful for debugging. */
+  sources: FindRepoSource[];
+  /** Human-readable explanation of why this candidate scored. */
+  reason: string;
+  /** GitHub stars when available (best-effort enrich). */
+  stars?: number;
+  /** GitHub description when available. */
+  description?: string;
+  /** Programming language inferred from GitHub. */
+  language?: string;
+  /** Hydrated learned_skill row when source includes "learned". */
+  learned_skill?: {
+    id: string;
+    name: string;
+    goal_pattern: string;
+    invocation: string;
+  };
 }
 
 // ── Re-exports of ambient types that web imports alongside the DTOs ─────────

--- a/packages/api/src/views/work-product.ts
+++ b/packages/api/src/views/work-product.ts
@@ -12,31 +12,14 @@ import { fileURLToPath } from "node:url";
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import type { WorkProductType } from "@beevibe/core";
 import { deriveShortId } from "./format.js";
+import type { WorkProductDetail } from "./types.js";
 
-export interface WorkProductDetail {
-  id: string;
-  task_id: string;
-  task_short_id: string;
-  task_title: string;
-  agent_id: string;
-  agent_label: string;
-  type: WorkProductType;
-  title: string;
-  summary?: string;
-  url?: string;
-  provider?: string;
-  external_id?: string;
-  /**
-   * Full deliverable content. Sourced from `work_product.body` when set;
-   * otherwise falls back to reading a `file://` URL from disk. Truncated
-   * to 256 KB.
-   */
-  body?: string;
-  /** True when `url` is file:// — UI uses this to suppress an unclickable link. */
-  url_is_local: boolean;
-  created_at: string;
-  updated_at: string;
-}
+/**
+ * Declared in `./types.js` alongside the other read-side DTOs — that's the
+ * module web imports (`@beevibe/api/views/types`), so the loader below and
+ * the detail page read one declaration. Re-exported for existing importers.
+ */
+export type { WorkProductDetail };
 
 const SQL = /* sql */ `
 SELECT

--- a/packages/web/app/welcome/welcome-client.tsx
+++ b/packages/web/app/welcome/welcome-client.tsx
@@ -21,6 +21,7 @@ import { api, type RuntimesListResponse } from "@/lib/api/client";
 import { DaemonInstallInstructions } from "@/components/daemon-install";
 import { queryKeys } from "@/lib/hooks/keys";
 import { useMe } from "@/lib/hooks/use-me";
+import { toRuntimeOptions, type RuntimeOption } from "@/lib/runtime-options";
 import { cn } from "@/lib/utils";
 
 type Step = "intro" | "install" | "pick" | "ready";
@@ -262,19 +263,7 @@ function PickRuntimeStep({
     refetchInterval: 3_000,
   });
 
-  const allRuntimes = useMemo(
-    () =>
-      (query.data?.daemons ?? []).flatMap((d) =>
-        d.runtimes.map((r) => ({
-          id: r.id,
-          cli: r.cli,
-          cli_version: r.cli_version,
-          online: r.online,
-          device: d.device_name ?? d.external_id,
-        })),
-      ),
-    [query.data],
-  );
+  const allRuntimes = useMemo(() => toRuntimeOptions(query.data), [query.data]);
 
   const [selected, setSelected] = useState<string | null>(null);
   // Auto-select the first online runtime to make the happy path one-click.
@@ -359,13 +348,7 @@ function RuntimeCard({
   selected,
   onSelect,
 }: {
-  runtime: {
-    id: string;
-    cli: string;
-    cli_version?: string;
-    online: boolean;
-    device: string;
-  };
+  runtime: RuntimeOption;
   selected: boolean;
   onSelect: () => void;
 }) {

--- a/packages/web/components/agents/pickers/runtime-picker.tsx
+++ b/packages/web/components/agents/pickers/runtime-picker.tsx
@@ -18,35 +18,11 @@ import {
   useAgentSettingMutation,
 } from "@/components/agents/pickers/picker-card";
 import type { AgentDisplay } from "@/lib/api/types";
-
-type RuntimeOption = {
-  id: string;
-  cli: string;
-  cli_version?: string;
-  online: boolean;
-  device: string;
-};
-
-type DaemonGroup = {
-  device: string;
-  runtimes: RuntimeOption[];
-};
-
-function groupRuntimesByDaemon(
-  data: RuntimesListResponse | undefined,
-): DaemonGroup[] {
-  if (!data) return [];
-  return data.daemons.map((d) => ({
-    device: d.device_name ?? d.external_id,
-    runtimes: d.runtimes.map((r) => ({
-      id: r.id,
-      cli: r.cli,
-      cli_version: r.cli_version,
-      online: r.online,
-      device: d.device_name ?? d.external_id,
-    })),
-  }));
-}
+import {
+  groupRuntimesByDaemon,
+  type DaemonGroup,
+  type RuntimeOption,
+} from "@/lib/runtime-options";
 
 function flattenRuntimes(groups: DaemonGroup[]): RuntimeOption[] {
   return groups.flatMap((g) => g.runtimes);

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -42,6 +42,30 @@ import type { InboxItem } from "@/lib/types/inbox";
 import type { EscalationReviewDetail } from "@/lib/types/escalations";
 import type { NegotiationReviewDetail } from "@/lib/types/negotiations";
 import type { Lifecycle } from "@/lib/tasks-grouping";
+import type {
+  DaemonPanelEntry,
+  RuntimePanelEntry,
+  RuntimesListResponse,
+} from "@/lib/types/runtimes";
+import type { WorkProductDetail } from "@/lib/types/work-products";
+import type { FindRepoCandidate, FindRepoSource } from "@/lib/types/find-repo";
+import type { ReferencedRepo } from "@/lib/types/referenced-repos";
+/**
+ * Response shapes owned by the server. `@beevibe/api/views/types` (and, for
+ * `ReferencedRepo`, the core service that computes it) is the single
+ * declaration; these are type-only re-exports, erased at build, so nothing
+ * from those packages reaches the browser bundle. Re-exported here because
+ * the pages below import their types from the api client.
+ */
+export type {
+  DaemonPanelEntry,
+  FindRepoCandidate,
+  FindRepoSource,
+  ReferencedRepo,
+  RuntimePanelEntry,
+  RuntimesListResponse,
+  WorkProductDetail,
+};
 
 export type TaskView = "all" | "mine";
 
@@ -185,61 +209,6 @@ export interface RoomDetail {
   messages: RoomMessage[];
   /** Agents currently working on a turn for this room. May be omitted by older server builds. */
   typing?: RoomTypingIndicator[];
-}
-
-export interface WorkProductDetail {
-  id: string;
-  task_id: string;
-  task_short_id: string;
-  task_title: string;
-  agent_id: string;
-  agent_label: string;
-  type:
-    | "pull_request"
-    | "branch"
-    | "commit"
-    | "document"
-    | "analysis"
-    | "report"
-    | "design"
-    | "artifact"
-    | "preview";
-  title: string;
-  summary?: string;
-  url?: string;
-  provider?: string;
-  external_id?: string;
-  /** Inlined file contents when url is file://. Render as markdown. */
-  body?: string;
-  url_is_local: boolean;
-  created_at: string;
-  updated_at: string;
-}
-
-export interface RuntimePanelEntry {
-  id: string;
-  cli: string;
-  cli_version?: string;
-  /** True when a live WebSocket from this runtime is connected. */
-  online: boolean;
-  /** ISO last_heartbeat timestamp; absent when the runtime has never beat. */
-  last_heartbeat?: string;
-}
-
-export interface DaemonPanelEntry {
-  id: string;
-  device_name?: string;
-  external_id: string;
-  /** ISO created_at. */
-  created_at: string;
-  /** ISO last_seen_at — when the daemon last hit /runtime/heartbeat. */
-  last_seen_at?: string;
-  runtimes: RuntimePanelEntry[];
-}
-
-export interface RuntimesListResponse {
-  ok: true;
-  daemons: DaemonPanelEntry[];
 }
 
 export interface SignupInput {
@@ -693,39 +662,5 @@ export const api = {
       }>("/capabilities/use", { method: "POST", body: input }),
   },
 } as const;
-
-export interface ReferencedRepo {
-  owner: string;
-  name: string;
-  url: string;
-  occurrences: number;
-  already_saved: boolean;
-}
-
-/**
- * Mirrors the candidate shape that `packages/api/src/tools/find-repo.ts`
- * returns. Duplicating the type rather than importing it avoids
- * pulling the whole api package into the web bundle — the shape is
- * small + stable enough that a UI-side copy is cheaper than the
- * cross-package coupling.
- */
-export type FindRepoSource = "learned" | "community" | "trending" | "github";
-
-export interface FindRepoCandidate {
-  repo_url: string;
-  score: number;
-  source: FindRepoSource;
-  sources: FindRepoSource[];
-  reason: string;
-  stars?: number;
-  description?: string;
-  language?: string;
-  learned_skill?: {
-    id: string;
-    name: string;
-    goal_pattern: string;
-    invocation: string;
-  };
-}
 
 export type Api = typeof api;

--- a/packages/web/lib/runtime-options.ts
+++ b/packages/web/lib/runtime-options.ts
@@ -1,0 +1,49 @@
+/**
+ * Flattened runtime rows for the two surfaces that let a user pick a CLI:
+ * the agent-settings runtime picker and the welcome walkthrough. Both turn
+ * `GET /runtimes` into the same "<device> · <cli> <version>" option, so the
+ * shape and the flattening live here instead of being re-derived per file.
+ *
+ * `device` comes from the daemon's `device_name`, which is `NOT NULL` in the
+ * schema — the old `?? external_id` fallbacks were unreachable.
+ */
+
+import type { RuntimesListResponse } from "@/lib/types/runtimes";
+
+export interface RuntimeOption {
+  id: string;
+  cli: string;
+  cli_version: string | null;
+  online: boolean;
+  /** The daemon's device name — the machine this runtime runs on. */
+  device: string;
+}
+
+export interface DaemonGroup {
+  device: string;
+  runtimes: RuntimeOption[];
+}
+
+/** One group per daemon, preserving the server's ordering. */
+export function groupRuntimesByDaemon(
+  data: RuntimesListResponse | undefined,
+): DaemonGroup[] {
+  if (!data) return [];
+  return data.daemons.map((d) => ({
+    device: d.device_name,
+    runtimes: d.runtimes.map((r) => ({
+      id: r.id,
+      cli: r.cli,
+      cli_version: r.cli_version,
+      online: r.online,
+      device: d.device_name,
+    })),
+  }));
+}
+
+/** Every runtime across every daemon, flattened. */
+export function toRuntimeOptions(
+  data: RuntimesListResponse | undefined,
+): RuntimeOption[] {
+  return groupRuntimesByDaemon(data).flatMap((g) => g.runtimes);
+}

--- a/packages/web/lib/types/find-repo.ts
+++ b/packages/web/lib/types/find-repo.ts
@@ -1,0 +1,1 @@
+export type { FindRepoCandidate, FindRepoSource } from "@beevibe/api/views/types";

--- a/packages/web/lib/types/referenced-repos.ts
+++ b/packages/web/lib/types/referenced-repos.ts
@@ -1,0 +1,1 @@
+export type { ReferencedRepo } from "@beevibe/core/services/referenced-repos";

--- a/packages/web/lib/types/runtimes.ts
+++ b/packages/web/lib/types/runtimes.ts
@@ -1,0 +1,5 @@
+export type {
+  DaemonPanelEntry,
+  RuntimePanelEntry,
+  RuntimesListResponse,
+} from "@beevibe/api/views/types";

--- a/packages/web/lib/types/work-products.ts
+++ b/packages/web/lib/types/work-products.ts
@@ -1,0 +1,1 @@
+export type { WorkProductDetail } from "@beevibe/api/views/types";


### PR DESCRIPTION
## What

Four API response shapes were declared **twice** — once on the server and once as a hand-copied mirror inside the web bundle — so the two copies could (and in one case already did) drift apart. This unifies them behind the repo's existing single-source-of-truth pattern.

The repo already established the fix: read-side DTOs live in `packages/api/src/views/types.ts`, and web re-exports them through `@beevibe/api/views/types` via thin `web/lib/types/*` files (so the backend owns the contract and web bends to it). These four types had simply never been pulled into that pattern.

## The clusters

| Type | Was | Now |
| --- | --- | --- |
| `RuntimePanelEntry` / `DaemonPanelEntry` / `RuntimesListResponse` | declared in `routes/runtimes.ts` **and** re-declared in `web/lib/api/client.ts` — **already diverged** | canonical in `views/types.ts`; both sides read it |
| `WorkProductDetail` | `views/work-product.ts` + a literal-union copy in `client.ts` | canonical in `views/types.ts`, `type` sourced from core's `WorkProductType` |
| `FindRepoCandidate` / `FindRepoSource` | `tools/find-repo.ts` (as `CandidateSource`) + a copy in `client.ts` whose own comment admitted the duplication | canonical in `views/types.ts`; `CandidateSource` renamed to `FindRepoSource` |
| `ReferencedRepo` | core service `referenced-repos.ts` + a copy in `client.ts` | web re-exports core's declaration |

### The divergence was a live type lie

The web copy of the runtimes panel had drifted from the server it describes: `cli_version` / `last_heartbeat` / `last_seen_at` were typed `?: string` where the server sends `string | null`, and `device_name` was optional where the DB column is `NOT NULL`. Unifying the copies surfaced two compile errors that had been masked — both now fixed, and the dead `?? external_id` fallbacks removed.

### Bonus: a 5th and 6th copy on the web side

The two runtime-picker surfaces (agent-settings picker + welcome walkthrough) each re-derived the same flattened runtime-option shape and mapping. Extracted once to `web/lib/runtime-options.ts`.

## Approach

Canonical declarations move to `views/types.ts`; the server modules that previously owned them re-export for their existing importers, so no call sites break. All web-side re-exports are **type-only**, so nothing new reaches the browser bundle.

## Validation

- `pnpm typecheck` — green across all 9 packages
- `pnpm lint` — 0 errors (only pre-existing `import/no-duplicates` warnings)
- `next build` (web, direct — Turbo strips the proxy CA per CLAUDE.md) — clean, confirming the re-exports are fully erased
- `pnpm --filter @beevibe/web test` — 203 pass
- DB- and key-gated suites fail only on missing Postgres / provider keys, exactly as documented in CLAUDE.md — none in touched files

Net **−59 lines**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EzGG8nTuRFXijMyiuveS24)_