### PR TITLE
test(api): make the tautological dashboard fan-out test able to fail

### DIFF
--- a/packages/api/src/views/dashboard.test.ts
+++ b/packages/api/src/views/dashboard.test.ts
@@ -254,27 +254,35 @@ describe("getDashboardSummary", () => {
     });
   });
 
-  it("fires all 7 queries in parallel (single Promise.all)", async () => {
-    const calls: number[] = [];
-    let next = 0;
+  it("issues every query before awaiting any (Promise.all, not sequential awaits)", async () => {
+    // Hold every query open on one gate, then count how many were issued
+    // while all of them were still unresolved. Under Promise.all that is
+    // the full fan-out; under sequential awaits it is 1, because query
+    // N+1 is not issued until query N settles.
+    let release: () => void = () => {};
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
     const query = vi.fn(async (sql: unknown) => {
-      const i = next++;
-      calls.push(i);
-      // First-issued query resolves last to prove they were issued together,
-      // not awaited sequentially.
-      await new Promise((r) => setTimeout(r, i === 0 ? 10 : 0));
+      await gate;
       const sqlText = String(sql);
       if (sqlText.includes("FROM days") && sqlText.includes("active_sessions")) return { rows: makeKpiTrendRows() };
       if (sqlText.includes("FROM days")) return { rows: makeTrendRows() };
-      if (sqlText.includes("FROM agent")) return { rows: [] };
-      if (sqlText.includes("blocked', 'failed'")) return { rows: [] };
-      if (sqlText.includes("usage IS NOT NULL")) return { rows: [] };
       return { rows: [] };
     });
     const pool = { query } as unknown as Pool;
-    await getDashboardSummary(pool);
-    expect(calls).toEqual([0, 1, 2, 3, 4, 5, 6]);
-    expect(query).toHaveBeenCalledTimes(7);
+
+    const pending = getDashboardSummary(pool);
+    await Promise.resolve(); // let the synchronous fan-out run
+    const issuedBeforeAnySettled = query.mock.calls.length;
+    release();
+    await pending;
+
+    // Not hard-coded to today's 7: adding a query is fine, awaiting one
+    // sequentially is not. The lower bound keeps a future single-query
+    // rewrite from passing vacuously.
+    expect(issuedBeforeAnySettled).toBe(query.mock.calls.length);
+    expect(issuedBeforeAnySettled).toBeGreaterThan(1);
   });
 });
 


### PR DESCRIPTION
## Summary

A scheduled sweep of the test suite for tests that are no longer useful — skipped/disabled without reason, tests for removed/refactored features, and tests with no assertions or that only pin implementation details. The suite is in good shape; this PR fixes the one test that could never fail.

## The finding: a test that can't fail

`packages/api/src/views/dashboard.test.ts` had a test titled **"fires all 7 queries in parallel (single Promise.all)"**. Its only assertions were that seven queries ran and that they were *issued* in order `[0,1,2,3,4,5,6]`:

```js
expect(calls).toEqual([0, 1, 2, 3, 4, 5, 6]);
expect(query).toHaveBeenCalledTimes(7);
```

But a sequential `await pool.query(...)` chain issues those same seven queries in that exact order and returns the same result — so the test passed whether or not the production code was actually parallel. The comment claimed "First-issued query resolves last to prove they were issued together," but nothing asserted on *resolution* order, so that setup did no work.

**Verified:** rewriting `getDashboardSummary` to seven sequential `await`s left the old test green. It was a no-op guard on the parallelism it advertised.

## The fix

Replaced it with a test that holds every query open on a single gate and counts how many were issued *before any settled*:

- Under `Promise.all`, that count is the full fan-out.
- Under sequential awaits, it is 1 — query N+1 isn't issued until query N settles.

Also dropped the hard-coded `7` for a `> 1` lower bound, so adding or removing a dashboard query no longer forces a test edit, while a regression to sequential awaits is still caught.

**Verified:** the new test fails (`received 1, expected 7`) against a sequential-await implementation and passes against the current `Promise.all`.

## What was checked and deliberately left alone

- **Skipped/gated tests** (`describe.skip`, `it.skipIf`, `describe.skipIf`) are all environment gates — Docker e2e, live-provider-key integration, Windows-only `spawn` — each with a clear opt-in env var and rationale. Not dead; kept.
- **No feature-removal orphans:** e.g. the `TaskView "mine"` filter the web `keys.test.ts` exercises is still live in `packages/api/src/views/tasks.ts`.
- **`toHaveBeenCalledTimes(n)` counts** in `memory-activity` / `dashboard` map to real behavior branches (always-on queries vs. the before/after split), not brittle implementation details.
- **The two same-named `parseAllowedOrigins` cases in `cors.test.ts`** test different inputs (trailing comma vs. double comma) — both meaningful.
- No assertion-free tests, no tautological subject-equals-subject assertions found anywhere else.

## Test plan

- `pnpm typecheck` — clean
- `pnpm lint` — clean (only the pre-existing `import/no-duplicates` warning in web)
- `vitest run packages/api/src/views/dashboard.test.ts` — 21 pass
- Confirmed the new test is a real guard by flipping the SUT to sequential awaits (fails) and back (passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ufwe28KTm5npRetVD1Jt8J)_