### PR TITLE
fix: restore the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,10 +184,10 @@ marks. Forks and derivative works are welcome under names that are not
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=beevibe-ai%2Fbeevibe&type=date&legend=bottom-right">
+<a href="https://star-history.dera.page/#beevibe-ai/beevibe&type=date&legend=bottom-right">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=beevibe-ai/beevibe&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=beevibe-ai/beevibe&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=beevibe-ai/beevibe&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=beevibe-ai/beevibe&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=beevibe-ai/beevibe&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=beevibe-ai/beevibe&type=date&legend=top-left" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart in the README was broken because the upstream provider's stargazer API is no longer available. Point it at the star-history.dera.page fork, which uses a different data source that requires no API token, so the chart renders again.