### PR TITLE
refactor(web): unify the five id-detail query hooks behind one factory

### DIFF
--- a/packages/web/lib/hooks/detail-query.ts
+++ b/packages/web/lib/hooks/detail-query.ts
@@ -1,0 +1,38 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import { type ReadOptions } from "@/lib/api/client";
+import { isApiConfigured } from "@/lib/api/config";
+
+/**
+ * The "fetch one entity by id" query shape, in one place.
+ *
+ * Five hooks — `useAgent`, `useSession`, `useTask`, `useEscalation`,
+ * `useNegotiation` — were byte-identical bar the resource name: take an
+ * optional id, key on `detail(id)` when present and fall back to the
+ * resource's `all` key when not, fetch via `api.<resource>.get(id, {signal})`,
+ * and stay disabled until both the api is configured and an id exists. The
+ * `id ? … : all` branch, the `id as string` cast (safe only because
+ * `enabled` gates on `!!id`), and the `enabled` guard were spelled out at
+ * every site — five chances to let one drift (e.g. forget the `!!id` guard
+ * and fire a request for `/agent/undefined`).
+ *
+ * `detailKey` / `allKey` come from `queryKeys`, and `fetcher` is the
+ * matching `api.<resource>.get`; the result type `T` is inferred from the
+ * fetcher, so each hook keeps its exact return shape with no consumer
+ * changes.
+ *
+ * Hooks with extra per-resource options (e.g. `useConversation`'s
+ * `staleTime`) keep their own `useQuery` call — this covers only the plain
+ * detail shape.
+ */
+export function useDetailQuery<T>(
+  id: string | undefined,
+  detailKey: (id: string) => readonly unknown[],
+  allKey: readonly unknown[],
+  fetcher: (id: string, opts: ReadOptions) => Promise<T>,
+): UseQueryResult<T> {
+  return useQuery<T>({
+    queryKey: id ? detailKey(id) : allKey,
+    queryFn: ({ signal }) => fetcher(id as string, { signal }),
+    enabled: isApiConfigured && !!id,
+  });
+}

--- a/packages/web/lib/hooks/use-agents.ts
+++ b/packages/web/lib/hooks/use-agents.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
+import { useDetailQuery } from "./detail-query";
 import { queryKeys } from "./keys";
 
 export function useAgents() {
@@ -12,9 +13,5 @@ export function useAgents() {
 }
 
 export function useAgent(id: string | undefined) {
-  return useQuery({
-    queryKey: id ? queryKeys.agents.detail(id) : queryKeys.agents.all,
-    queryFn: ({ signal }) => api.agents.get(id as string, { signal }),
-    enabled: isApiConfigured && !!id,
-  });
+  return useDetailQuery(id, queryKeys.agents.detail, queryKeys.agents.all, api.agents.get);
 }

--- a/packages/web/lib/hooks/use-escalations.ts
+++ b/packages/web/lib/hooks/use-escalations.ts
@@ -1,12 +1,12 @@
-import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
-import { isApiConfigured } from "@/lib/api/config";
+import { useDetailQuery } from "./detail-query";
 import { queryKeys } from "./keys";
 
 export function useEscalation(id: string | undefined) {
-  return useQuery({
-    queryKey: id ? queryKeys.escalations.detail(id) : queryKeys.escalations.all,
-    queryFn: ({ signal }) => api.escalations.get(id as string, { signal }),
-    enabled: isApiConfigured && !!id,
-  });
+  return useDetailQuery(
+    id,
+    queryKeys.escalations.detail,
+    queryKeys.escalations.all,
+    api.escalations.get,
+  );
 }

--- a/packages/web/lib/hooks/use-negotiations.ts
+++ b/packages/web/lib/hooks/use-negotiations.ts
@@ -1,12 +1,12 @@
-import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
-import { isApiConfigured } from "@/lib/api/config";
+import { useDetailQuery } from "./detail-query";
 import { queryKeys } from "./keys";
 
 export function useNegotiation(id: string | undefined) {
-  return useQuery({
-    queryKey: id ? queryKeys.negotiations.detail(id) : queryKeys.negotiations.all,
-    queryFn: ({ signal }) => api.negotiations.get(id as string, { signal }),
-    enabled: isApiConfigured && !!id,
-  });
+  return useDetailQuery(
+    id,
+    queryKeys.negotiations.detail,
+    queryKeys.negotiations.all,
+    api.negotiations.get,
+  );
 }

--- a/packages/web/lib/hooks/use-sessions.ts
+++ b/packages/web/lib/hooks/use-sessions.ts
@@ -1,14 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
+import { useDetailQuery } from "./detail-query";
 import { queryKeys } from "./keys";
 
 export function useSession(shortId: string | undefined) {
-  return useQuery({
-    queryKey: shortId ? queryKeys.sessions.detail(shortId) : queryKeys.sessions.all,
-    queryFn: ({ signal }) => api.sessions.get(shortId as string, { signal }),
-    enabled: isApiConfigured && !!shortId,
-  });
+  return useDetailQuery(
+    shortId,
+    queryKeys.sessions.detail,
+    queryKeys.sessions.all,
+    api.sessions.get,
+  );
 }
 
 /**

--- a/packages/web/lib/hooks/use-tasks.ts
+++ b/packages/web/lib/hooks/use-tasks.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { api, type TaskListFilter } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
+import { useDetailQuery } from "./detail-query";
 import { queryKeys } from "./keys";
 
 export function useTasks(filter: TaskListFilter = {}) {
@@ -23,9 +24,5 @@ export function useTasks(filter: TaskListFilter = {}) {
 }
 
 export function useTask(id: string | undefined) {
-  return useQuery({
-    queryKey: id ? queryKeys.tasks.detail(id) : queryKeys.tasks.all,
-    queryFn: ({ signal }) => api.tasks.get(id as string, { signal }),
-    enabled: isApiConfigured && !!id,
-  });
+  return useDetailQuery(id, queryKeys.tasks.detail, queryKeys.tasks.all, api.tasks.get);
 }


### PR DESCRIPTION
## What

`useAgent`, `useSession`, `useTask`, `useEscalation` and `useNegotiation` were byte-identical bar the resource name — the same "fetch one entity by optional id" React Query shape copied five times:

```ts
useQuery({
  queryKey: id ? queryKeys.X.detail(id) : queryKeys.X.all,
  queryFn: ({ signal }) => api.X.get(id as string, { signal }),
  enabled: isApiConfigured && !!id,
});
```

Each site re-spelled the `id ? … : all` branch, the `id as string` cast (sound only because `enabled` gates on `!!id`), and the `enabled` guard. Five copies is five chances to let one drift — e.g. drop the `!!id` guard and fire a request for `/agent/undefined`.

## Change

Extract the shape into a single `useDetailQuery(id, detailKey, allKey, fetcher)` in `lib/hooks/detail-query.ts`. `detailKey`/`allKey` come from `queryKeys`; `fetcher` is the matching `api.<resource>.get`. The result type `T` is inferred from the fetcher, so **every hook keeps its exact return shape and there are no consumer changes** — the public hook signatures (`useAgent(id)`, `useTask(id)`, …) are unchanged.

`useConversation` deliberately keeps its own `useQuery` call: it carries an extra `staleTime` and isn't the plain detail shape. Same rationale for the list hooks (`useAgents`, `useTasks`) which vary in `select`/`refetchOnMount`.

Net: `+25 / −29` across 5 hooks, plus the new 39-line helper (mostly the doc comment explaining the drift risk it removes).

## Testing

- `pnpm typecheck` — clean (all 9 packages)
- `next lint` on the changed files — no warnings or errors
- `vitest run` in `@beevibe/web` — 203 tests pass (24 files), including the existing `use-tasks` / `use-task-mutations` suites that exercise these hooks

## Notes for reviewers

This was the single cleanest N-way duplicate the dedup sweep turned up; the codebase already factors most shared shapes (`runtime-common.ts`, `pg-helpers.ts`, `http-errors.ts`, `domain/format.ts`). Other near-duplicate candidates I looked at were left alone as deliberate divergences rather than accidental copies — e.g. the two `errMsg` helpers (`routes/me.ts` truncates to one line / 200 chars, `tools/find-repo.ts` doesn't) and the several limit-clamp variants (`views/*` pass-through-then-clamp vs. `inbox`/`activity` reject-to-fallback have genuinely different contracts). Happy to follow up on any of those in a separate PR if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzvbMWK5KVo5R6KrqvWouj)_