### PR TITLE
test(daemon): cover the CLI entry, start orchestration and logger (80% → 99.9% lines)

### DIFF
--- a/packages/daemon/src/claimer.test.ts
+++ b/packages/daemon/src/claimer.test.ts
@@ -141,6 +141,50 @@ describe("Claimer ws ping watchdog", () => {
       vi.useRealTimers();
     }
   });
+
+  it("terminates when ping() itself throws on a dead socket", async () => {
+    vi.useFakeTimers();
+    const { claimer, sockets } = startClaimerWithFakeWs();
+    try {
+      sockets[0]!.fire("open");
+      // `ws.ping()` on an already-destroyed socket throws synchronously;
+      // the watchdog has to fall through to terminate or the daemon is
+      // left phantom-connected with no `close` ever arriving.
+      sockets[0]!.ping.mockImplementation(() => {
+        throw new Error("WebSocket is not open: readyState 3 (CLOSED)");
+      });
+
+      vi.advanceTimersByTime(1_000);
+
+      expect(sockets[0]!.ping).toHaveBeenCalledTimes(1);
+      expect(sockets[0]!.terminate).toHaveBeenCalledTimes(1);
+
+      // The synthetic close from terminate() still drives the reconnect.
+      vi.advanceTimersByTime(20);
+      expect(sockets).toHaveLength(2);
+    } finally {
+      await claimer.stop();
+      vi.useRealTimers();
+    }
+  });
+
+  it("stop() cancels a reconnect that was already scheduled", async () => {
+    vi.useFakeTimers();
+    const { claimer, sockets } = startClaimerWithFakeWs();
+    try {
+      sockets[0]!.fire("open");
+      // Drop the socket so a backoff timer is armed, then stop before it
+      // fires: the pending timer must be cleared, not merely ignored.
+      sockets[0]!.fire("close");
+
+      await claimer.stop();
+      vi.advanceTimersByTime(1_000);
+
+      expect(sockets).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("Claimer.pollRuntime resilience", () => {

--- a/packages/daemon/src/logger.test.ts
+++ b/packages/daemon/src/logger.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { error, log, warn } from "./logger.js";
+
+const ISO = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("daemon logger", () => {
+  it.each([
+    ["log", log, "log"],
+    ["warn", warn, "warn"],
+    ["error", error, "error"],
+  ] as const)(
+    "%s stamps an ISO timestamp and forwards every argument to console.%s",
+    (_name, fn, method) => {
+      const spy = vi.spyOn(console, method).mockImplementation(() => undefined);
+
+      fn("[daemon]", "started", { id: 1 });
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      const [stamp, ...rest] = spy.mock.calls[0]!;
+      expect(stamp).toMatch(ISO);
+      expect(rest).toEqual(["[daemon]", "started", { id: 1 }]);
+    },
+  );
+
+  it("keeps the three levels on their own console channels", () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const errorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    log("a");
+    warn("b");
+    error("c");
+
+    expect(logSpy.mock.calls[0]!.slice(1)).toEqual(["a"]);
+    expect(warnSpy.mock.calls[0]!.slice(1)).toEqual(["b"]);
+    expect(errorSpy.mock.calls[0]!.slice(1)).toEqual(["c"]);
+  });
+
+  it("emits only the timestamp when called with no arguments", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    log();
+
+    expect(spy.mock.calls[0]!).toHaveLength(1);
+    expect(spy.mock.calls[0]![0]).toMatch(ISO);
+  });
+});

--- a/packages/daemon/src/main.test.ts
+++ b/packages/daemon/src/main.test.ts
@@ -1,0 +1,328 @@
+/**
+ * `beevibe-daemon` CLI entry coverage.
+ *
+ * main.ts fires `main()` at import time, so each case re-imports the
+ * module with a fresh `process.argv` after `vi.resetModules()`. The
+ * module body doesn't await that call, so `runCli` drains the queue
+ * before returning.
+ *
+ * `process.exit` is stubbed as a *recorder* rather than a thrower: a
+ * throwing stub would escape main's own `.catch` (which itself calls
+ * `process.exit`) as an unhandled rejection. The trade-off is that code
+ * after an `exit()` still runs here, which the real CLI never does — so
+ * assertions check the exit code and the operator-facing message, not
+ * what the doomed continuation went on to do.
+ */
+
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import { CONFIG_ROOT_ENV } from "./config.js";
+
+const {
+  runSetupMock,
+  runStartMock,
+  runSyncMock,
+  runUpdateMock,
+  logMock,
+  errorMock,
+  isDevBuildMock,
+} = vi.hoisted(() => ({
+  runSetupMock: vi.fn(),
+  runStartMock: vi.fn(),
+  runSyncMock: vi.fn(),
+  runUpdateMock: vi.fn(),
+  logMock: vi.fn(),
+  errorMock: vi.fn(),
+  isDevBuildMock: vi.fn(),
+}));
+
+vi.mock("./setup.js", () => ({ runSetup: runSetupMock }));
+vi.mock("./start.js", () => ({ runStart: runStartMock }));
+vi.mock("./sync.js", () => ({ runSync: runSyncMock }));
+vi.mock("./update.js", () => ({ runUpdate: runUpdateMock }));
+vi.mock("./logger.js", () => ({
+  log: logMock,
+  warn: vi.fn(),
+  error: errorMock,
+}));
+vi.mock("./config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./config.js")>();
+  return { ...actual, isDevBuild: isDevBuildMock };
+});
+
+const REGISTERED = {
+  daemon_id: "dmn_1",
+  runtimes: [
+    { id: "rt_claude", cli: "claude" },
+    { id: "rt_codex", cli: "codex" },
+  ],
+};
+
+let exitMock: MockInstance<typeof process.exit>;
+let argv: string[];
+
+/** Stub argv, re-import main.ts (which self-executes) and drain the queue. */
+async function runCli(...args: string[]): Promise<void> {
+  process.argv = ["node", "/usr/local/bin/beevibe-daemon", ...args];
+  vi.resetModules();
+  await import("./main.js");
+  // Two macrotask turns: one for the awaited command, one for main's
+  // trailing `.catch` to settle on the rejection paths.
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+/** Everything the CLI printed, joined — help text is one multi-line call. */
+function printed(): string {
+  return logMock.mock.calls.map((call) => call.join(" ")).join("\n");
+}
+
+beforeEach(() => {
+  argv = process.argv;
+  delete process.env[CONFIG_ROOT_ENV];
+  runSetupMock.mockReset().mockResolvedValue(REGISTERED);
+  runStartMock.mockReset().mockResolvedValue(undefined);
+  runSyncMock.mockReset().mockResolvedValue({ added: [] });
+  runUpdateMock.mockReset().mockResolvedValue(undefined);
+  logMock.mockReset();
+  errorMock.mockReset();
+  isDevBuildMock.mockReset().mockReturnValue(true);
+  exitMock = vi
+    .spyOn(process, "exit")
+    .mockImplementation((() => undefined) as never);
+});
+
+afterEach(() => {
+  process.argv = argv;
+  delete process.env[CONFIG_ROOT_ENV];
+  vi.restoreAllMocks();
+});
+
+describe("help", () => {
+  it.each([[], ["--help"], ["-h"]])(
+    "prints usage for %j without touching a command",
+    async (...args) => {
+      await runCli(...args);
+
+      expect(printed()).toContain("Usage: beevibe-daemon <command> [flags]");
+      expect(printed()).toContain("  setup    Register this machine");
+      expect(exitMock).not.toHaveBeenCalled();
+      expect(runStartMock).not.toHaveBeenCalled();
+      expect(runSetupMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("documents the dev-only config-root knob and its env var", async () => {
+    await runCli("--help");
+
+    expect(printed()).toContain("--config-root <path>");
+    expect(printed()).toContain(CONFIG_ROOT_ENV);
+  });
+
+  it("rejects an unknown command with exit 2 and the usage block", async () => {
+    await runCli("strat");
+
+    expect(errorMock).toHaveBeenCalledWith("Unknown command: strat");
+    expect(printed()).toContain("Usage: beevibe-daemon <command> [flags]");
+    expect(exitMock).toHaveBeenCalledWith(2);
+  });
+});
+
+describe("setup", () => {
+  it("forwards every long flag and reports where the config landed", async () => {
+    await runCli(
+      "setup",
+      "--api",
+      "http://api.test",
+      "--user-token",
+      "bv_u_human",
+      "--device-name",
+      "workbench",
+      "--external-id",
+      "machine-7",
+      "--config-root",
+      "/tmp/root-a",
+    );
+
+    expect(runSetupMock).toHaveBeenCalledWith({
+      apiUrl: "http://api.test",
+      userToken: "bv_u_human",
+      deviceName: "workbench",
+      externalId: "machine-7",
+      configRoot: "/tmp/root-a",
+    });
+    expect(printed()).toContain("Registered as dmn_1");
+    expect(printed()).toContain("Runtimes: claude (rt_claude), codex (rt_codex)");
+    expect(printed()).toContain(
+      `Config saved to ${join("/tmp/root-a", "config.json")}`,
+    );
+  });
+
+  it("accepts the -a / -t short forms and leaves the optional flags unset", async () => {
+    await runCli("setup", "-a", "http://api.test", "-t", "bv_u_human");
+
+    expect(runSetupMock).toHaveBeenCalledWith({
+      apiUrl: "http://api.test",
+      userToken: "bv_u_human",
+      deviceName: undefined,
+      externalId: undefined,
+      configRoot: undefined,
+    });
+    expect(exitMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["--api alone", ["setup", "--api", "http://api.test"]],
+    ["--user-token alone", ["setup", "--user-token", "bv_u_human"]],
+    ["no flags at all", ["setup"]],
+  ])("exits 2 when %s is supplied", async (_label, args) => {
+    await runCli(...args);
+
+    expect(errorMock).toHaveBeenCalledWith(
+      "setup requires --api and --user-token",
+    );
+    expect(exitMock).toHaveBeenCalledWith(2);
+  });
+
+  it("treats a value-less trailing flag as absent rather than eating the next arg", async () => {
+    await runCli("setup", "--user-token", "bv_u_human", "--api");
+
+    expect(errorMock).toHaveBeenCalledWith(
+      "setup requires --api and --user-token",
+    );
+    expect(exitMock).toHaveBeenCalledWith(2);
+  });
+});
+
+describe("start", () => {
+  it("runs with no config-root override by default", async () => {
+    await runCli("start");
+
+    expect(runStartMock).toHaveBeenCalledWith({ configRoot: undefined });
+  });
+
+  it("passes --config-root through", async () => {
+    await runCli("start", "--config-root", "/tmp/root-b");
+
+    expect(runStartMock).toHaveBeenCalledWith({ configRoot: "/tmp/root-b" });
+  });
+});
+
+describe("sync", () => {
+  it("says nothing was found when the detector adds no runtime", async () => {
+    await runCli("sync");
+
+    expect(runSyncMock).toHaveBeenCalledWith({ configRoot: undefined });
+    expect(printed()).toContain("No new CLIs detected.");
+    expect(printed()).not.toContain("Restart the daemon");
+  });
+
+  it("lists the added runtimes and tells the operator to restart", async () => {
+    runSyncMock.mockResolvedValue({
+      added: [
+        { id: "rt_codex", cli: "codex" },
+        { id: "rt_opencode", cli: "opencode" },
+      ],
+    });
+
+    await runCli("sync", "--config-root", "/tmp/root-c");
+
+    expect(runSyncMock).toHaveBeenCalledWith({ configRoot: "/tmp/root-c" });
+    expect(printed()).toContain(
+      "Added 2 runtime(s): codex (rt_codex), opencode (rt_opencode).",
+    );
+    expect(printed()).toContain("Restart the daemon to pick up the new runtime(s).");
+  });
+});
+
+describe("update", () => {
+  it("prompts by default", async () => {
+    await runCli("update");
+
+    expect(runUpdateMock).toHaveBeenCalledWith({ skipPrompt: false });
+  });
+
+  it.each(["--yes", "-y"])("skips the prompt with %s", async (flag) => {
+    await runCli("update", flag);
+
+    expect(runUpdateMock).toHaveBeenCalledWith({ skipPrompt: true });
+  });
+});
+
+describe("config-root resolution", () => {
+  it("falls back to the env var when the flag is absent", async () => {
+    process.env[CONFIG_ROOT_ENV] = "/tmp/from-env";
+
+    await runCli("start");
+
+    expect(runStartMock).toHaveBeenCalledWith({ configRoot: "/tmp/from-env" });
+  });
+
+  it("prefers the flag over the env var", async () => {
+    process.env[CONFIG_ROOT_ENV] = "/tmp/from-env";
+
+    await runCli("start", "--config-root", "/tmp/from-flag");
+
+    expect(runStartMock).toHaveBeenCalledWith({ configRoot: "/tmp/from-flag" });
+  });
+
+  it("treats an empty env var as unset", async () => {
+    process.env[CONFIG_ROOT_ENV] = "";
+
+    await runCli("start");
+
+    expect(runStartMock).toHaveBeenCalledWith({ configRoot: undefined });
+    expect(exitMock).not.toHaveBeenCalled();
+  });
+
+  it("never consults the dev gate when neither knob is set", async () => {
+    await runCli("start");
+
+    expect(isDevBuildMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects the flag in a compiled build, naming the flag", async () => {
+    isDevBuildMock.mockReturnValue(false);
+
+    await runCli("start", "--config-root", "/tmp/from-flag");
+
+    expect(exitMock).toHaveBeenCalledWith(2);
+    const message = String(errorMock.mock.calls[0]![0]);
+    expect(message).toContain("--config-root is a dev-only knob");
+    expect(message).toContain("pnpm dev");
+  });
+
+  it("rejects the env var in a compiled build, naming the env var", async () => {
+    isDevBuildMock.mockReturnValue(false);
+    process.env[CONFIG_ROOT_ENV] = "/tmp/from-env";
+
+    await runCli("start");
+
+    expect(exitMock).toHaveBeenCalledWith(2);
+    expect(String(errorMock.mock.calls[0]![0])).toContain(
+      `${CONFIG_ROOT_ENV} is a dev-only knob`,
+    );
+  });
+});
+
+describe("top-level failure handling", () => {
+  it("prints the stack and exits 1 when a command rejects with an Error", async () => {
+    const boom = new Error("no daemon config found");
+    runStartMock.mockRejectedValue(boom);
+
+    await runCli("start");
+
+    expect(errorMock).toHaveBeenCalledWith(boom.stack);
+    expect(exitMock).toHaveBeenCalledWith(1);
+  });
+
+  it("stringifies a non-Error rejection", async () => {
+    runSyncMock.mockRejectedValue("socket hang up");
+
+    await runCli("sync");
+
+    expect(errorMock).toHaveBeenCalledWith("socket hang up");
+    expect(exitMock).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/daemon/src/start.test.ts
+++ b/packages/daemon/src/start.test.ts
@@ -1,0 +1,342 @@
+/**
+ * `beevibe-daemon start` orchestration coverage.
+ *
+ * `runStart` deliberately never resolves — it ends on a promise that is
+ * only broken by `process.exit` from a signal handler. So every case
+ * kicks it off without awaiting and waits on the observable side effect
+ * (the claimer starting, or the throw on a missing config).
+ */
+
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import { runStart } from "./start.js";
+
+const {
+  loadConfigMock,
+  getConfigRootMock,
+  syncSkillsCacheMock,
+  apiClientMock,
+  claimerMock,
+  claimerStartMock,
+  claimerStopMock,
+  supervisorMock,
+  workspaceManagerMock,
+  runtimeRegistryMock,
+  createDefaultRuntimeRegistryMock,
+  logMock,
+  warnMock,
+} = vi.hoisted(() => {
+  const claimerStartMock = vi.fn();
+  const claimerStopMock = vi.fn(async () => undefined);
+  const runtimeRegistryMock = { registry: true };
+  return {
+    loadConfigMock: vi.fn(),
+    getConfigRootMock: vi.fn(),
+    syncSkillsCacheMock: vi.fn(),
+    apiClientMock: vi.fn(),
+    claimerMock: vi.fn((_config: unknown) => ({
+      start: claimerStartMock,
+      stop: claimerStopMock,
+    })),
+    claimerStartMock,
+    claimerStopMock,
+    supervisorMock: vi.fn(),
+    workspaceManagerMock: vi.fn(),
+    runtimeRegistryMock,
+    createDefaultRuntimeRegistryMock: vi.fn(() => runtimeRegistryMock),
+    logMock: vi.fn(),
+    warnMock: vi.fn(),
+  };
+});
+
+vi.mock("./config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./config.js")>();
+  return {
+    ...actual,
+    loadConfig: loadConfigMock,
+    getConfigRoot: getConfigRootMock,
+  };
+});
+vi.mock("./skills-cache.js", () => ({ syncSkillsCache: syncSkillsCacheMock }));
+vi.mock("./api-client.js", () => ({ ApiClient: apiClientMock }));
+vi.mock("./claimer.js", () => ({ Claimer: claimerMock }));
+vi.mock("./supervisor.js", () => ({ Supervisor: supervisorMock }));
+vi.mock("./logger.js", () => ({
+  log: logMock,
+  warn: warnMock,
+  error: vi.fn(),
+}));
+vi.mock("@beevibe/core/adapters/local-workspace", () => ({
+  LocalWorkspaceManager: workspaceManagerMock,
+}));
+vi.mock("@beevibe/core/adapters/runtime-registry", () => ({
+  createDefaultRuntimeRegistry: createDefaultRuntimeRegistryMock,
+}));
+
+const CONFIG = {
+  api_url: "http://api.test",
+  external_id: "machine-7",
+  daemon_id: "dmn_1",
+  daemon_token: "bv_d_secret",
+  runtimes: [
+    { id: "rt_claude", cli: "claude" },
+    { id: "rt_codex", cli: "codex" },
+  ],
+};
+
+const SIGNALS = ["SIGINT", "SIGTERM", "unhandledRejection"] as const;
+
+// `process.listeners`/`removeListener` are typed per-signal; the set
+// below mixes a signal-like event in, so go through the plain emitter.
+const emitter = process as NodeJS.EventEmitter;
+
+type Listener = (...args: unknown[]) => void;
+
+let exitMock: MockInstance<typeof process.exit>;
+let priorListeners: Map<string, Listener[]>;
+let workspaceRoot: string | undefined;
+
+/** Start the daemon and wait until the claim loop is running. */
+async function start(configRoot?: string): Promise<void> {
+  // Floating on purpose: runStart only settles via process.exit.
+  void runStart(configRoot === undefined ? {} : { configRoot });
+  await vi.waitFor(() => expect(claimerStartMock).toHaveBeenCalled());
+}
+
+/** Args the LocalWorkspaceManager was constructed with. */
+function workspaceOptions(): Record<string, unknown> {
+  return workspaceManagerMock.mock.calls[0]![0] as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  priorListeners = new Map(
+    SIGNALS.map(
+      (signal) => [signal, emitter.listeners(signal) as Listener[]] as const,
+    ),
+  );
+  workspaceRoot = process.env.WORKSPACE_ROOT;
+  delete process.env.WORKSPACE_ROOT;
+
+  loadConfigMock.mockReset().mockReturnValue(CONFIG);
+  getConfigRootMock.mockReset().mockReturnValue("/home/test/.beevibe");
+  syncSkillsCacheMock.mockReset().mockResolvedValue("/home/test/.beevibe/skills");
+  apiClientMock.mockReset();
+  claimerMock.mockClear();
+  claimerStartMock.mockReset();
+  claimerStopMock.mockReset().mockResolvedValue(undefined);
+  supervisorMock.mockReset();
+  workspaceManagerMock.mockReset();
+  createDefaultRuntimeRegistryMock.mockClear();
+  logMock.mockReset();
+  warnMock.mockReset();
+  exitMock = vi
+    .spyOn(process, "exit")
+    .mockImplementation((() => undefined) as never);
+});
+
+afterEach(() => {
+  // runStart installs signal + unhandledRejection handlers on the shared
+  // process object; strip anything this test added so the next file
+  // doesn't inherit them.
+  for (const signal of SIGNALS) {
+    const before = priorListeners.get(signal) ?? [];
+    for (const listener of emitter.listeners(signal) as Listener[]) {
+      if (!before.includes(listener)) {
+        emitter.removeListener(signal, listener);
+      }
+    }
+  }
+  if (workspaceRoot === undefined) delete process.env.WORKSPACE_ROOT;
+  else process.env.WORKSPACE_ROOT = workspaceRoot;
+  vi.restoreAllMocks();
+});
+
+describe("config gate", () => {
+  it("refuses to start without a config, pointing at the setup command", async () => {
+    loadConfigMock.mockReturnValue(undefined);
+
+    await expect(runStart()).rejects.toThrow(
+      /No daemon config found\. Run `beevibe-daemon setup --api <url> --user-token <bv_u_…>` first\./,
+    );
+    expect(claimerStartMock).not.toHaveBeenCalled();
+    expect(syncSkillsCacheMock).not.toHaveBeenCalled();
+  });
+
+  it("reads the config from the requested root", async () => {
+    await start("/tmp/root-a");
+
+    expect(loadConfigMock).toHaveBeenCalledWith("/tmp/root-a");
+  });
+});
+
+describe("wiring", () => {
+  it("authenticates the api client with the stored url and daemon token", async () => {
+    await start();
+
+    expect(apiClientMock).toHaveBeenCalledWith({
+      apiUrl: "http://api.test",
+      daemonToken: "bv_d_secret",
+    });
+  });
+
+  it("points the workspace manager at the api's /mcp endpoint", async () => {
+    await start();
+
+    expect(workspaceOptions().mcpServerUrl).toBe("http://api.test/mcp");
+    expect(workspaceOptions().runtimeRegistry).toBe(runtimeRegistryMock);
+    expect(createDefaultRuntimeRegistryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("subscribes the claimer to every registered runtime id", async () => {
+    await start();
+
+    const claimerConfig = claimerMock.mock.calls[0]![0] as {
+      runtimeIds: string[];
+      runtimeRegistry: unknown;
+      api: unknown;
+      supervisor: unknown;
+      workspaceManager: unknown;
+    };
+    expect(claimerConfig.runtimeIds).toEqual(["rt_claude", "rt_codex"]);
+    expect(claimerConfig.runtimeRegistry).toBe(runtimeRegistryMock);
+    expect(claimerConfig.api).toBeInstanceOf(apiClientMock);
+    expect(claimerConfig.supervisor).toBeInstanceOf(supervisorMock);
+    expect(claimerConfig.workspaceManager).toBeInstanceOf(workspaceManagerMock);
+  });
+
+  it("logs the daemon id, api url and runtime count once running", async () => {
+    await start();
+
+    expect(logMock).toHaveBeenCalledWith(
+      "[daemon] started (dmn_1 → http://api.test, 2 runtime(s))",
+    );
+  });
+});
+
+describe("skills cache", () => {
+  it("hands the synced bundle to the workspace manager", async () => {
+    await start("/tmp/root-a");
+
+    expect(syncSkillsCacheMock).toHaveBeenCalledWith(
+      expect.any(apiClientMock),
+      "/tmp/root-a",
+    );
+    expect(workspaceOptions().skillsSourceDir).toBe("/home/test/.beevibe/skills");
+  });
+
+  it("keeps starting on a sync failure, falling back to an empty source", async () => {
+    syncSkillsCacheMock.mockRejectedValue(new Error("502 from /skills"));
+
+    await start();
+
+    expect(warnMock).toHaveBeenCalledWith(
+      "[daemon] skills sync failed; continuing without skills:",
+      "502 from /skills",
+    );
+    expect(workspaceOptions().skillsSourceDir).toBe("/dev/null");
+  });
+
+  it("stringifies a non-Error sync failure", async () => {
+    syncSkillsCacheMock.mockRejectedValue("ENOTFOUND api.test");
+
+    await start();
+
+    expect(warnMock).toHaveBeenCalledWith(
+      "[daemon] skills sync failed; continuing without skills:",
+      "ENOTFOUND api.test",
+    );
+  });
+});
+
+describe("workspace root", () => {
+  it("defaults to <configRoot>/workspaces", async () => {
+    getConfigRootMock.mockReturnValue("/tmp/root-a");
+
+    await start("/tmp/root-a");
+
+    expect(getConfigRootMock).toHaveBeenCalledWith("/tmp/root-a");
+    expect(workspaceOptions().workspaceRoot).toBe(
+      join("/tmp/root-a", "workspaces"),
+    );
+  });
+
+  it("lets WORKSPACE_ROOT win for CI and bespoke layouts", async () => {
+    process.env.WORKSPACE_ROOT = "/mnt/ci/workspaces";
+
+    await start();
+
+    expect(workspaceOptions().workspaceRoot).toBe("/mnt/ci/workspaces");
+  });
+
+  it("treats an empty WORKSPACE_ROOT as unset", async () => {
+    process.env.WORKSPACE_ROOT = "";
+    getConfigRootMock.mockReturnValue("/home/test/.beevibe");
+
+    await start();
+
+    expect(workspaceOptions().workspaceRoot).toBe(
+      join("/home/test/.beevibe", "workspaces"),
+    );
+  });
+});
+
+describe("shutdown", () => {
+  it.each(["SIGINT", "SIGTERM"] as const)(
+    "stops the claim loop and exits 0 on %s",
+    async (signal) => {
+      await start();
+
+      process.emit(signal);
+      await vi.waitFor(() => expect(exitMock).toHaveBeenCalled());
+
+      expect(logMock).toHaveBeenCalledWith(
+        `[daemon] received ${signal}; stopping`,
+      );
+      expect(claimerStopMock).toHaveBeenCalledTimes(1);
+      expect(exitMock).toHaveBeenCalledWith(0);
+    },
+  );
+
+  it("ignores a second signal so shutdown never runs twice", async () => {
+    await start();
+
+    process.emit("SIGTERM");
+    await vi.waitFor(() => expect(claimerStopMock).toHaveBeenCalled());
+    process.emit("SIGINT");
+    process.emit("SIGTERM");
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(claimerStopMock).toHaveBeenCalledTimes(1);
+    expect(exitMock).toHaveBeenCalledTimes(1);
+    expect(logMock).not.toHaveBeenCalledWith(
+      "[daemon] received SIGINT; stopping",
+    );
+  });
+});
+
+describe("unhandled rejections", () => {
+  it("logs and keeps the self-healing claim loop alive", async () => {
+    await start();
+
+    process.emit("unhandledRejection", new Error("fetch failed"), Promise.resolve());
+
+    expect(warnMock).toHaveBeenCalledWith(
+      "[daemon] unhandledRejection (continuing):",
+      "fetch failed",
+    );
+    expect(exitMock).not.toHaveBeenCalled();
+    expect(claimerStopMock).not.toHaveBeenCalled();
+  });
+
+  it("stringifies a non-Error rejection reason", async () => {
+    await start();
+
+    process.emit("unhandledRejection", "socket hang up", Promise.resolve());
+
+    expect(warnMock).toHaveBeenCalledWith(
+      "[daemon] unhandledRejection (continuing):",
+      "socket hang up",
+    );
+  });
+});

--- a/packages/daemon/src/supervisor.test.ts
+++ b/packages/daemon/src/supervisor.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
-import { Supervisor } from "./supervisor.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_MAX_CONCURRENT, Supervisor } from "./supervisor.js";
+
+const ENV = "BEEVIBE_DAEMON_MAX_CONCURRENT";
 
 describe("Supervisor", () => {
   it("respects maxConcurrent: hasCapacity flips to false at the cap", () => {
@@ -47,4 +49,56 @@ describe("Supervisor", () => {
     expect(abortCount).toBe(3);
     expect(s.inFlight()).toBe(0);
   });
+});
+
+describe("Supervisor default cap from the environment", () => {
+  let previous: string | undefined;
+
+  /** Fill the supervisor and report the cap it actually enforced. */
+  function effectiveCap(): number {
+    const s = new Supervisor();
+    let n = 0;
+    while (s.hasCapacity()) {
+      s.start(`sess_${n}`);
+      n += 1;
+      if (n > DEFAULT_MAX_CONCURRENT * 2) throw new Error("cap never reached");
+    }
+    return n;
+  }
+
+  beforeEach(() => {
+    previous = process.env[ENV];
+  });
+
+  afterEach(() => {
+    if (previous === undefined) delete process.env[ENV];
+    else process.env[ENV] = previous;
+  });
+
+  it("defaults to DEFAULT_MAX_CONCURRENT when the env var is unset", () => {
+    delete process.env[ENV];
+
+    expect(effectiveCap()).toBe(DEFAULT_MAX_CONCURRENT);
+  });
+
+  it("honors a valid override", () => {
+    process.env[ENV] = "3";
+
+    expect(effectiveCap()).toBe(3);
+  });
+
+  it("parses a trailing-garbage value down to its leading integer", () => {
+    process.env[ENV] = "4 workers";
+
+    expect(effectiveCap()).toBe(4);
+  });
+
+  it.each(["", "many", "0", "-2", "NaN"])(
+    "falls back to the default for the unusable value %j",
+    (raw) => {
+      process.env[ENV] = raw;
+
+      expect(effectiveCap()).toBe(DEFAULT_MAX_CONCURRENT);
+    },
+  );
 });


### PR DESCRIPTION
## What

A coverage sweep across every package found the **daemon's entire process entrypoint** untested. `main.ts` (the `beevibe-daemon` CLI) and `start.ts` (the claim-loop orchestration) were both at **0% lines**; `logger.ts` sat at 55%. This PR adds focused unit tests. **No production code changed.**

| Module | Before | After (lines) |
| --- | ---: | ---: |
| `src/main.ts` | 0% | 100% |
| `src/start.ts` | 0% | 98.4% |
| `src/logger.ts` | 55.5% | 100% |
| `src/supervisor.ts` | 82.0% | 100% |
| `src/claimer.ts` | 97.2% | 100% |

Package total: **80.41% → 99.90% lines** (branches 90.6% → 93.0%). The single remaining uncovered line is `start.ts`'s deliberate never-resolving hold-open promise.

## Why these

Every daemon install runs exactly this path on every launch, and it's the one part of the product that executes on a user's own machine. A regression in flag parsing, in the dev-only config-root gate (which is a *security-ish* boundary — it must refuse the knob in compiled builds), or in the SIGINT/SIGTERM shutdown ships with nothing to catch it. None of it needs Postgres or provider keys, so it all runs in plain CI.

No open PR touches these files — the other in-flight coverage work (#307, #309, #312, #316) is all api-side tools/routes and web `lib/`.

## Tests added

- **`main.test.ts`** (26 cases) — help/usage output, each subcommand's dispatch and flag forwarding in both long and short forms, a value-less trailing flag not eating the next arg, `setup`'s missing-flag exit 2, `sync`'s added-vs-nothing branches, `update --yes/-y`, config-root flag-over-env precedence with empty strings treated as unset, the compiled-build rejection of both the flag and the env var, and the top-level `Error` / non-`Error` failure handler.
- **`start.test.ts`** (17 cases) — the no-config refusal, api-client + workspace-manager + claimer wiring, a skills-cache failure falling back to an empty source rather than aborting startup, `WORKSPACE_ROOT` vs `<configRoot>/workspaces`, SIGINT/SIGTERM shutdown with its double-signal guard, and the `unhandledRejection` safety net that keeps the self-healing claim loop alive.
- **`logger.test.ts`** — ISO stamping, argument passthrough and channel routing for all three levels.
- **`supervisor.test.ts`** (extended) — the `BEEVIBE_DAEMON_MAX_CONCURRENT` parse ladder: valid override, leading-integer parse, and the empty / non-numeric / zero / negative fallbacks.
- **`claimer.test.ts`** (extended) — `ping()` throwing on an already-dead socket falling through to `terminate()`, and `stop()` clearing a reconnect timer that was already armed.

Two mechanics worth calling out for review:

- `main.ts` fires `main()` at import time, so each case re-imports it after `vi.resetModules()` with a fresh `process.argv`.
- `process.exit` is stubbed as a **recorder**, not a thrower — a throwing stub would escape `main`'s own `.catch` (which itself calls `process.exit`) as an unhandled rejection. Assertions therefore check the exit code and the operator-facing message, not what the doomed continuation went on to do. Both trade-offs are documented in the file headers.

`start.test.ts` snapshots and restores `process`'s signal / `unhandledRejection` listeners so nothing leaks into the next test file.

## Verification

- `turbo typecheck --filter=@beevibe/daemon` — clean
- `turbo lint --filter=@beevibe/daemon` — clean (3 pre-existing `WebSocket` default-import warnings, untouched)
- Full `@beevibe/daemon` suite — **214 passing**, e2e suite skipped as usual
- **Mutation-checked**: flipping the config-root flag/env precedence, dropping the `-y` alias, changing the `/mcp` URL, and relaxing the `n < 1` concurrency guard each fail these tests — they are not change detectors.

`@vitest/coverage-v8` was installed only for the local sweep and is intentionally **not** committed, per the repo's coverage guidance in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kf6PL2q4xoxxJQhhJkat8M)_