### PR TITLE
chore: remove five dead type fields found by a static + dynamic sweep

### DIFF
--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -93,10 +93,7 @@ export interface AgentDisplay
   hierarchy: HierarchyLevel;
   sessions_count?: number;
   facts_learned?: number;
-  /** Reserved for future memory-merge telemetry. */
-  merge_events?: number;
   specialization?: string;
-  themes?: string[];
   /** CLI tool the agent uses — derived from `runtime_config.type`. */
   runtime?: string;
   /**
@@ -404,7 +401,6 @@ export interface MemoryFactDisplay {
   source_session_count: number;
   created_at: Date;
   merge_origin?: MergeOrigin;
-  promotion_origin_scope?: MemoryScope;
 }
 
 /**

--- a/packages/core/src/domain/agent.ts
+++ b/packages/core/src/domain/agent.ts
@@ -26,7 +26,6 @@ export interface RuntimeConfig {
    */
   model?: string;
   max_turns?: number;
-  timeout_ms?: number;
   system_prompt_addition?: string;
 }
 

--- a/packages/core/src/ports/runtime.ts
+++ b/packages/core/src/ports/runtime.ts
@@ -199,7 +199,6 @@ export interface RuntimeResult {
 /** Result of `healthCheck()`. */
 export interface RuntimeHealth {
   healthy: boolean;
-  latency_ms?: number;
   error?: string;
 }
 


### PR DESCRIPTION
## What this is

A full dead-code sweep of the monorepo. After #285 and #291 the tree is essentially clean — every tool-reported hit is either a documented false positive or a redundant `export` keyword on a symbol used inside its own file.

The sweep did surface one category **no tool in the toolbox covers**: interface fields that nothing ever writes and nothing ever reads. knip only reasons about exported *symbols*, never about members inside a type, so these were invisible to every previous pass.

## What was removed

Five fields, verified by grepping every write and read site across the monorepo:

| Field | Why it's dead |
| --- | --- |
| `AgentDisplay.merge_events` | Marked *"reserved for future memory-merge telemetry"*. `toAgentDisplay` — the sole builder — never sets it; no consumer reads it. |
| `AgentDisplay.themes` | Never populated, never read. |
| `MemoryFactDisplay.promotion_origin_scope` | The memory view builds `merge_origin` but never this field, and nothing reads it. |
| `RuntimeConfig.timeout_ms` | A **persisted per-agent knob nothing honors**. Its siblings `model` / `max_turns` are threaded through `AgentSession`, `runtime/router.ts` and the CLI adapters; `timeout_ms` is read nowhere, so setting it silently did nothing. |
| `RuntimeHealth.latency_ms` | None of the three `healthCheck()` implementations set it, and the one caller (`GET /health/runtime`) doesn't read it. |

Net: 6 deletions, 0 insertions.

## What was deliberately left alone

Not everything unread is dead, so these stay:

- **`StreamJsonMessage.duration_ms` / `num_turns`** — unread, but they describe the Claude Code CLI's real stream-json wire format alongside the rest of that interface. Dropping them would make a field the CLI actually emits untypeable.
- **`LlmResponse.stop_reason` / `LlmStructuredResponse.stop_reason`** — both provider adapters populate these. Write-only, not dead.
- **`PostgresMemoryPromotionEventRepository`, `GET /activity`, `packages/sandbox/src/scripts/*`, `node-pg-migrate`, `zod`, `postcss`, `autoprefixer`, `prettier`, `migrations/*`** — the known false positives and unfinished-wiring entries documented in CLAUDE.md.

## Sweep coverage

Static: `tsc --noUnusedLocals --noUnusedParameters` and `tsc --allowUnreachableCode false` across all five TS packages (both clean); knip; a by-name export sweep over every package — including `packages/web`, whose code lives outside `src/` and which the standard sweep recipe misses; an orphan-file scan; a class-method sweep (the category that found the dead repo methods in #285); and a web API-client method sweep.

Dynamic: `depcheck` per package, and v8 coverage with `--coverage.all`. Coverage's 0% files turned out to be the Postgres adapters excluded as DB-gated, not dead code.

Two false positives worth recording, both caught only by reading the code:

- `api.sessions.tree` looked uncalled — it's invoked as `api.sessions\n  .tree(...)`, split across lines in `chat-stream.ts`.
- `BEEVIBE_MCP_SERVER_URL` looked unread — it's read through the typed `env.ts` accessor, not `process.env`.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm build` — clean, 9/9 tasks.
- Test counts **byte-identical before and after** (confirmed by stashing and re-running): core `7 failed | 609 passed`, api `820 passed | 0 failed`. The residual failures are the Postgres- and API-key-gated suites documented in CLAUDE.md as expected in a sandbox without Docker or provider keys.
- Suites directly covering the changed types all pass: `agent-display`, `memory`, `agent-network`, `me`, `view` (217 tests) and the three runtime adapters + `agent-session` (94 tests).
- The `@vitest/coverage-v8` provider installed for the sweep was reverted, not committed, per CLAUDE.md.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HD7EMRxhuyEdvbXjkzd7ek)_