### PR TITLE
test: drop six tests that only exercised the type system

### DIFF
--- a/packages/core/src/adapters/runtime-registry.test.ts
+++ b/packages/core/src/adapters/runtime-registry.test.ts
@@ -6,27 +6,16 @@ import {
 } from "./runtime-registry.js";
 
 describe("createDefaultRuntimeRegistry", () => {
-  it("registers claude-code", () => {
-    const registry = createDefaultRuntimeRegistry();
-    expect(registry["claude"]).toBeDefined();
-    expect(registry["claude"]!.type).toBe("claude");
-  });
-
-  it("registers opencode", () => {
-    const registry = createDefaultRuntimeRegistry();
-    expect(registry["opencode"]).toBeDefined();
-    expect(registry["opencode"]!.type).toBe("opencode");
-  });
-
-  it("registers codex", () => {
-    const registry = createDefaultRuntimeRegistry();
-    expect(registry["codex"]).toBeDefined();
-    expect(registry["codex"]!.type).toBe("codex");
-  });
-
+  // The exact key set is asserted from the composition root
+  // (`composition.test.ts` — "registers the three CLI runtimes"); this file
+  // only guards the per-entry `type === key` invariant, which is what a typo
+  // in a new runtime adapter would silently break.
   it("every registry value's .type matches its registry key (sanity check against typos)", () => {
     const registry = createDefaultRuntimeRegistry();
-    for (const [key, runtime] of Object.entries(registry)) {
+    const entries = Object.entries(registry);
+    // Guard against an empty registry masquerading as "all types match".
+    expect(entries.length).toBeGreaterThan(0);
+    for (const [key, runtime] of entries) {
       expect(runtime.type).toBe(key);
     }
   });

--- a/packages/core/src/services/task-service.test.ts
+++ b/packages/core/src/services/task-service.test.ts
@@ -596,31 +596,10 @@ describe("TaskService.createWorkProduct + listWorkProducts", () => {
   });
 
 
-  it("updateWorkProduct forwards the mutable patch to the repo", async () => {
-    vi.mocked(workProductRepo.update).mockImplementation(async (id, patch) =>
-      makeWorkProduct({ id, ...patch }),
-    );
-
-    const out = await service.updateWorkProduct("wp_1", {
-      summary: "now merged",
-      url: "https://example.test/pr/42",
-    });
-
-    expect(workProductRepo.update).toHaveBeenCalledWith("wp_1", {
-      summary: "now merged",
-      url: "https://example.test/pr/42",
-    });
-    expect(out.summary).toBe("now merged");
-  });
-
-  it("updateWorkProduct surfaces the repo's not-found error", async () => {
-    vi.mocked(workProductRepo.update).mockRejectedValue(
-      new Error("work_product wp_missing not found"),
-    );
-    await expect(
-      service.updateWorkProduct("wp_missing", { summary: "x" }),
-    ).rejects.toThrow(/work_product wp_missing not found/);
-  });
+  // `updateWorkProduct` is a single-line pass-through to
+  // `workProductRepo.update(id, patch)` — no shaping, no error mapping. The
+  // two tests that used to sit here asserted only that a mock forwards its
+  // args and that a rejected promise stays rejected, so they were dropped.
 });
 
 describe("TaskService.checkAndCompleteParent", () => {

--- a/packages/web/lib/mesh-display.test.ts
+++ b/packages/web/lib/mesh-display.test.ts
@@ -143,16 +143,8 @@ describe("overviewToDisplay — graph layout", () => {
   });
 });
 
-describe("overviewToDisplay — summary passthrough", () => {
-  it("forwards summary counts unchanged", () => {
-    const overview: MeshOverview = {
-      ...emptyOverview(),
-      summary: { asks_24h: 12, in_flight: 3, edge_count: 7 },
-    };
-    expect(overviewToDisplay(overview).summary).toEqual({
-      asks_24h: 12,
-      in_flight: 3,
-      edge_count: 7,
-    });
-  });
-});
+// `summary` is a shallow spread from the overview onto the display object;
+// asserting `.toEqual` on it only re-derived the source literal. A test worth
+// having here would guard the detachment (that a later mutation on the source
+// summary doesn't reach the display) — but no caller depends on that, and
+// there's no bug pattern the test would catch, so the block was dropped.


### PR DESCRIPTION
## Summary

Follow-up sweep after #261 / #265 / #270 / #284 / #291. Those PRs caught most of the low-signal tests; this picks up the six that survived scrutiny.

- **`TaskService.updateWorkProduct` (2 tests, `packages/core/src/services/task-service.test.ts`)** — the method is `return this.deps.workProductRepo.update(id, patch)`. Asserting the mock got those exact args, or that a rejected promise stays rejected, tests nothing but TS's `Parameters` type.
- **`createDefaultRuntimeRegistry` (3 per-CLI `registers <cli>` tests, `packages/core/src/adapters/runtime-registry.test.ts`)** — strictly dominated by the same file's `.type === key` sanity check and by `composition.test.ts`'s exact key-set assertion. Kept the sanity check; added a `>0` guard so an empty registry can't masquerade as "all types match".
- **`overviewToDisplay — summary passthrough` (1 test, `packages/web/lib/mesh-display.test.ts`)** — the subject-under-test is `summary: { ...overview.summary }`, and `.toEqual` doesn't even guard the one thing a spread does (detachment).

Each removal leaves a short comment where the test used to live, so a future contributor doesn't re-add the same tautology.

Nothing turned up as a test for a symbol removed by the recent dead-code sweeps (#285/#283/#279) — those cleanups landed cleanly. Left in place:

- `describe.skipIf(!HAS_LIVE_API_KEYS)` / `describe.skipIf(!RUN)` gates
- `it.skipIf(process.platform === "win32")` platform skips
- `packages/{sandbox,daemon}` e2e `describe.skip` behind `ENABLED` flags
- Pass-through-looking tests that actually guard argument shaping (`hierarchy.test.ts` work-product tool tests) or key mappings (`dispatch.test.ts`)
- `queryKeys.*.all` root-tuple test — borderline but the literals do act as a documentation gate for react-query invalidation cascades

## Test plan

- [x] `pnpm --filter @beevibe/core --filter @beevibe/web typecheck` clean
- [x] `vitest run` passes on all three affected files (47 tests in core, 6 tests in web mesh-display)
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoonHK8FNWfYCom9q2Q79Y)_