### PR TITLE
chore: drop lone dead assignment left after the #285 sweep

### DIFF
--- a/packages/core/src/process-lifecycle.test.ts
+++ b/packages/core/src/process-lifecycle.test.ts
@@ -94,7 +94,9 @@ describe("installShutdownHandlers", () => {
   });
 
   it("handles SIGINT and SIGTERM alike", async () => {
-    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    // Stub process.exit so the handler doesn't take the test runner down;
+    // the assertion is on shutdown, not on the exit call itself.
+    vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     const shutdown = vi.fn().mockResolvedValue(undefined);
 


### PR DESCRIPTION
## Summary

- Removes the one real piece of dead code a monorepo-wide static + dynamic sweep still turned up on top of #285: an unused `const exit =` binding for a `vi.spyOn(process, "exit")` in `packages/core/src/process-lifecycle.test.ts`'s "handles SIGINT and SIGTERM alike" test. The spy call itself is still needed (so the handler doesn't take the test runner down), but the reference was never used — the assertion here is on `shutdown`, not on `exit`. Adds a one-line comment so the next reader doesn't re-add the capture "just in case".

## What the sweep looked at

- `tsc --noEmit --noUnusedLocals --noUnusedParameters` across `api / core / daemon / scheduler / sandbox` — clean.
- `tsc --noEmit --allowUnreachableCode false` across the same — clean.
- `knip@5` — its 12 unused-export flags all resolve to symbols used within their own file (the `export` keyword is redundant, not the symbol; `CLAUDE.md` is explicit about leaving those alone). Its unused-file and unused-dependency flags are all the false positives already catalogued in `CLAUDE.md` (migrations, sandbox dev scripts, `node-pg-migrate`, `zod` as an MCP peer, `postcss`/`autoprefixer` from `postcss.config.js`, `prettier`).
- `depcheck` per package — same catalogued false positives.
- Name-grep sweep across every `export function|class|const` in `packages/core/src/**` (knip's barrel blind spot) — one hit, `PostgresMemoryPromotionEventRepository`, which `CLAUDE.md` documents as unfinished wiring rather than dead code.
- `git grep` for every `export function|class|const` in `api / daemon / scheduler / sandbox / web` — zero unreferenced symbols.
- Unimported-file scan across all package `src/` trees — zero.
- `pnpm -w lint` — one real dead-code warning, the one this PR fixes.

The recent #285 sweep really did clean out the codebase; this is what remained.

## Test plan

- [x] `pnpm --filter @beevibe/core lint` — clean (was 1 warning).
- [x] `pnpm --filter @beevibe/core exec vitest run src/process-lifecycle.test.ts` — 11 tests pass.
- [ ] CI green on the PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_011bWqF6ECrRgoFL4hfNVyNR)_