### PR TITLE
test: drop tests that can't fail, make the parallelism test actually test parallelism

### DIFF
--- a/packages/api/src/views/dashboard.test.ts
+++ b/packages/api/src/views/dashboard.test.ts
@@ -255,14 +255,18 @@ describe("getDashboardSummary", () => {
   });
 
   it("fires all 7 queries in parallel (single Promise.all)", async () => {
-    const calls: number[] = [];
-    let next = 0;
+    // Peak concurrency is the only observable that separates the two
+    // shapes: `Promise.all` issues all 7 before any resolves (peak 7),
+    // a sequential `await` chain never has more than 1 outstanding.
+    // Issue *order* does not — it's 0..6 either way — so asserting on
+    // it would pass on a sequentialised implementation.
+    let inFlight = 0;
+    let peakInFlight = 0;
     const query = vi.fn(async (sql: unknown) => {
-      const i = next++;
-      calls.push(i);
-      // First-issued query resolves last to prove they were issued together,
-      // not awaited sequentially.
-      await new Promise((r) => setTimeout(r, i === 0 ? 10 : 0));
+      inFlight += 1;
+      peakInFlight = Math.max(peakInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 0));
+      inFlight -= 1;
       const sqlText = String(sql);
       if (sqlText.includes("FROM days") && sqlText.includes("active_sessions")) return { rows: makeKpiTrendRows() };
       if (sqlText.includes("FROM days")) return { rows: makeTrendRows() };
@@ -273,7 +277,7 @@ describe("getDashboardSummary", () => {
     });
     const pool = { query } as unknown as Pool;
     await getDashboardSummary(pool);
-    expect(calls).toEqual([0, 1, 2, 3, 4, 5, 6]);
+    expect(peakInFlight).toBe(7);
     expect(query).toHaveBeenCalledTimes(7);
   });
 });

--- a/packages/api/src/views/format.test.ts
+++ b/packages/api/src/views/format.test.ts
@@ -11,24 +11,11 @@ import { computeCacheHitRatio, formatRelativeShort } from "./format.js";
 describe("formatRelativeShort", () => {
   const now = new Date("2026-04-30T12:00:00Z");
 
-  it("returns 'just now' under 60s", () => {
-    expect(formatRelativeShort(new Date(now.getTime() - 30_000), now)).toBe("just now");
-  });
-
-  it("uses minute granularity under an hour", () => {
-    expect(formatRelativeShort(new Date(now.getTime() - 5 * 60_000), now)).toBe("5m");
-  });
-
-  it("uses hour granularity under a day", () => {
-    expect(formatRelativeShort(new Date(now.getTime() - 3 * 3600_000), now)).toBe("3h");
-  });
-
-  it("uses day granularity under a month", () => {
-    expect(formatRelativeShort(new Date(now.getTime() - 4 * 86400_000), now)).toBe("4d");
-  });
-
-  // The whole point of the api-local wrapper: the web renders "2m ago",
-  // the wire carries the bare "2m". Same ladder, no suffix.
+  // `formatRelativeShort` is a one-line delegation to core's
+  // `formatRelative`, whose own suite already walks every threshold in
+  // the ladder. The only thing this wrapper adds — and so the only
+  // thing worth asserting here — is that it passes no suffix: the web
+  // renders "2m ago", the wire carries the bare "2m".
   it("emits the bare label with no ' ago' suffix", () => {
     expect(formatRelativeShort(new Date(now.getTime() - 2 * 60_000), now)).toBe("2m");
   });

--- a/packages/core/src/adapters/runtime-registry.test.ts
+++ b/packages/core/src/adapters/runtime-registry.test.ts
@@ -6,22 +6,16 @@ import {
 } from "./runtime-registry.js";
 
 describe("createDefaultRuntimeRegistry", () => {
-  it("registers claude-code", () => {
-    const registry = createDefaultRuntimeRegistry();
-    expect(registry["claude"]).toBeDefined();
-    expect(registry["claude"]!.type).toBe("claude");
-  });
-
-  it("registers opencode", () => {
-    const registry = createDefaultRuntimeRegistry();
-    expect(registry["opencode"]).toBeDefined();
-    expect(registry["opencode"]!.type).toBe("opencode");
-  });
-
-  it("registers codex", () => {
-    const registry = createDefaultRuntimeRegistry();
-    expect(registry["codex"]).toBeDefined();
-    expect(registry["codex"]!.type).toBe("codex");
+  // Asserting the whole key set at once, rather than one `it` per CLI,
+  // is what actually pins the registry: a per-CLI test can't fail on a
+  // *missing* fourth runtime, and the typo check below passes on an
+  // empty registry.
+  it("registers exactly the three supported CLIs", () => {
+    expect(Object.keys(createDefaultRuntimeRegistry()).sort()).toEqual([
+      "claude",
+      "codex",
+      "opencode",
+    ]);
   });
 
   it("every registry value's .type matches its registry key (sanity check against typos)", () => {

--- a/packages/web/lib/hooks/keys.test.ts
+++ b/packages/web/lib/hooks/keys.test.ts
@@ -25,10 +25,4 @@ describe("queryKeys", () => {
     const b = queryKeys.tasks.list({ view: "mine" });
     expect(a).not.toEqual(b);
   });
-
-  it("structural equality across separate calls with the same arg shape", () => {
-    const a = queryKeys.tasks.list({ view: "mine" });
-    const b = queryKeys.tasks.list({ view: "mine" });
-    expect(a).toEqual(b);
-  });
 });


### PR DESCRIPTION
A sweep of the suite for tests that are no longer useful: skipped/disabled without a reason, orphaned by removed code, assertion-free, or testing implementation detail rather than behaviour.

## What came back clean

- **Gated suites all have a current, documented reason.** `RUN_CLAUDE_SMOKE` (ci.yml's "Not included in CI" block + CONTRIBUTING.md), `BEEVIBE_E2E_DOCKER` and `BEEVIBE_E2E_MULTI_INSTANCE` (invocation documented in each file's docstring), and the `HAS_LIVE_API_KEYS`-gated `/mcp` integration suite. The remaining `skipIf`s are `process.platform === "win32"` guards. Nothing is stale.
- **No orphaned tests.** No test file imports a module that no longer exists, and `pnpm typecheck` is clean — nothing left over from the #285 dead-code sweep.
- **No assertion-free tests.** Every `it`/`test` body in the repo reaches an `expect`. #261 and #270 got the last of them.

## What did turn up

### `packages/api/src/views/dashboard.test.ts` — a test that could not fail

`it("fires all 7 queries in parallel (single Promise.all)")` asserted the *issue order* of the seven queries:

```js
expect(calls).toEqual([0, 1, 2, 3, 4, 5, 6]);
```

That order is `0..6` whether the queries are issued together or awaited one at a time, so the assertion carried no information about the property in its name. Verified by mutation — sequentialising `getDashboardSummary` into an `await` chain left all 21 tests in the file passing.

Rewritten to assert peak concurrency, the one observable that separates the two shapes (`Promise.all` → 7 outstanding, an `await` chain → never more than 1). Re-verified against the same mutation: the test now reports `expected 1 to be 7`, and passes against the real implementation.

### `packages/api/src/views/format.test.ts` — duplicated ladder coverage

`formatRelativeShort` is a one-line delegation to core's `formatRelative`. Four of its five tests walked the just-now / minute / hour / day rungs, each already covered by `domain/format.test.ts`'s "walks every threshold in the ladder". The file's own header comment says it should cover only "the two things that are actually this package's" — the four had drifted from that. Kept the suffix test, which is the only behaviour the wrapper adds.

### `packages/core/src/adapters/runtime-registry.test.ts` — three tests that pinned nothing

Three near-identical `it`s asserting one CLI each. None can fail on a *missing* runtime, and the "every value's `.type` matches its key" test below them passes on an empty registry — so nothing actually pinned the key set. Folded into one assertion on the whole set, which does.

### `packages/web/lib/hooks/keys.test.ts` — a tautology

`it("structural equality across separate calls with the same arg shape")` called a pure function twice with the same object literal and compared the results. It tests `toEqual`, not `queryKeys`.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean (the two `import/no-duplicates` warnings in `web/lib/types/dashboard.ts` are pre-existing and untouched here)
- `@beevibe/web` — 24 files, 202/202 pass
- `@beevibe/api` — 816 tests pass, 0 test failures; the 9 failing files are the DB-gated suites
- `@beevibe/core` — 607 pass, 7 fail, all of them the `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` provider-key failures documented in CLAUDE.md

No production code changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KuNNyShpK8zf55kSh6FM7v)_