### PR TITLE
test(api): cover the four under-tested MCP tool modules (32–65% → 100%)

### DIFF
--- a/packages/api/src/tools/mesh.test.ts
+++ b/packages/api/src/tools/mesh.test.ts
@@ -1,14 +1,28 @@
 /**
- * Mesh tool assembly tests — IC vs team tier gating.
+ * Mesh tool tests — tier gating plus per-handler behavior.
  *
- * Per-tool handler behavior is covered indirectly by the m6/m7 e2e scripts
- * (mesh flows require live Postgres + spawned CLI subprocesses). This file
- * locks the static tier inventory — the exact tool *names* each tier gets,
- * so future skill-loader work can rely on the surface being stable.
+ * The end-to-end mesh flows (real spawns, real blocking round-trips) are
+ * exercised by the m6/m7 e2e scripts, which need live Postgres and CLI
+ * subprocesses. What's tested here is everything the tool layer itself
+ * owns: the static tier inventory, the argument coercion and guards each
+ * handler applies before it reaches MeshServer, the projection of the
+ * server's responses back onto the agent-facing envelope, and the
+ * CodedMeshError pass-through that keeps `max_rounds_exceeded` and
+ * friends machine-readable.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { ResolvedCaller } from "@beevibe/core/auth";
+import type { AgentRepository, TaskRepository } from "@beevibe/core";
+import type { EscalationService } from "@beevibe/core/services/escalation-service";
+import type { TaskService } from "@beevibe/core/services/task-service";
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import type { MeshServer } from "../mesh/server.js";
+import {
+  CannotNegotiateWithIcError,
+  MeshMaxRoundsError,
+} from "../mesh/types.js";
 import { buildIcMeshTools, buildTeamMeshTools, type MeshToolServices } from "./mesh.js";
+import type { AgentTool } from "./types.js";
 
 // Fake services — the assembly itself doesn't invoke handlers, so the
 // dependencies just need to be the right shape.
@@ -45,5 +59,684 @@ describe("buildTeamMeshTools", () => {
       "respond_ask",
       "respond_negotiate",
     ]);
+  });
+});
+
+// ── Handler harness ──────────────────────────────────────────────────────
+
+interface MeshStubs {
+  sendAsk: ReturnType<typeof vi.fn>;
+  respondAsk: ReturnType<typeof vi.fn>;
+  sendNegotiate: ReturnType<typeof vi.fn>;
+  respondNegotiate: ReturnType<typeof vi.fn>;
+  reportBlocker: ReturnType<typeof vi.fn>;
+  unblockOnEscalate: ReturnType<typeof vi.fn>;
+}
+
+interface Harness {
+  tools: AgentTool[];
+  mesh: MeshStubs;
+  findParent: ReturnType<typeof vi.fn>;
+  markBlocked: ReturnType<typeof vi.fn>;
+  createEscalation: ReturnType<typeof vi.fn>;
+  query: ReturnType<typeof vi.fn>;
+}
+
+function harness(
+  overrides: Partial<{
+    sendAsk: () => Promise<unknown>;
+    respondAsk: () => void;
+    sendNegotiate: () => Promise<unknown>;
+    respondNegotiate: () => Promise<unknown>;
+    reportBlocker: () => void;
+    parent: { id: string } | undefined;
+    markBlocked: () => Promise<unknown>;
+    createEscalation: () => Promise<unknown>;
+  }> = {},
+): Harness {
+  const mesh: MeshStubs = {
+    sendAsk: vi.fn(
+      overrides.sendAsk ??
+        (async () => ({
+          request_id: "req_1",
+          from_agent_id: "agent_target",
+          answer: "yes, feasible",
+        })),
+    ),
+    respondAsk: vi.fn(overrides.respondAsk ?? (() => undefined)),
+    sendNegotiate: vi.fn(
+      overrides.sendNegotiate ??
+        (async () => ({
+          negotiation_id: "neg_1",
+          from_agent_id: "agent_peer",
+          decision: "counter",
+          message: "how about Tuesday",
+          counter_proposal: "ship Tuesday",
+        })),
+    ),
+    respondNegotiate: vi.fn(overrides.respondNegotiate ?? (async () => null)),
+    reportBlocker: vi.fn(overrides.reportBlocker ?? (() => undefined)),
+    unblockOnEscalate: vi.fn(),
+  };
+
+  const findParent = vi.fn(async () =>
+    "parent" in overrides ? overrides.parent : { id: "agent_parent" },
+  );
+  const markBlocked = vi.fn(overrides.markBlocked ?? (async () => undefined));
+  const createEscalation = vi.fn(
+    overrides.createEscalation ??
+      (async () => ({
+        id: "esc_1",
+        status: "open",
+        negotiation_id: "neg_1",
+      })),
+  );
+  const query = vi.fn(async () => ({ rows: [] }));
+
+  const services = {
+    mesh: mesh as unknown as MeshServer,
+    agentRepo: { findParent } as unknown as AgentRepository,
+    taskRepo: {} as unknown as TaskRepository,
+    taskService: { markBlocked } as unknown as TaskService,
+    escalationService: { create: createEscalation } as unknown as EscalationService,
+    pool: { query } as unknown as Pool,
+  };
+
+  return {
+    tools: buildTeamMeshTools(fakeCtx, services),
+    mesh,
+    findParent,
+    markBlocked,
+    createEscalation,
+    query,
+  };
+}
+
+function pick(h: Harness, name: string): AgentTool {
+  const t = h.tools.find((x) => x.name === name);
+  if (!t) throw new Error(`tool ${name} missing`);
+  return t;
+}
+
+// ── ask ──────────────────────────────────────────────────────────────────
+
+describe("ask handler", () => {
+  it("forwards the caller as sender and projects only the wire fields", async () => {
+    const h = harness();
+    const result = await pick(h, "ask").handler({
+      target_agent_id: "agent_target",
+      question: "is X feasible?",
+    });
+
+    const [requestId, from, to, question] = h.mesh.sendAsk.mock.calls[0] ?? [];
+    expect(requestId).toMatch(/^[0-9a-f-]{36}$/);
+    expect([from, to, question]).toEqual([
+      "agent_x",
+      "agent_target",
+      "is X feasible?",
+    ]);
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({
+      request_id: "req_1",
+      from_agent_id: "agent_target",
+      answer: "yes, feasible",
+    });
+  });
+
+  it("mints a fresh request id per call", async () => {
+    const h = harness();
+    const t = pick(h, "ask");
+    await t.handler({ target_agent_id: "a", question: "q" });
+    await t.handler({ target_agent_id: "a", question: "q" });
+
+    expect(h.mesh.sendAsk.mock.calls[0]?.[0]).not.toBe(
+      h.mesh.sendAsk.mock.calls[1]?.[0],
+    );
+  });
+
+  it.each([
+    ["target_agent_id", { question: "q" }],
+    ["question", { target_agent_id: "agent_target" }],
+    ["both", {}],
+  ])("rejects a call missing %s", async (_label, input) => {
+    const h = harness();
+    const result = await pick(h, "ask").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "target_agent_id and question required",
+    });
+    expect(h.mesh.sendAsk).not.toHaveBeenCalled();
+  });
+
+  it("preserves a CodedMeshError's code and meta", async () => {
+    const h = harness({
+      sendAsk: async () => {
+        throw new CannotNegotiateWithIcError({ agentId: "agent_ic" });
+      },
+    });
+    const result = await pick(h, "ask").handler({
+      target_agent_id: "agent_ic",
+      question: "q",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "CANNOT_NEGOTIATE_WITH_IC",
+      agentId: "agent_ic",
+    });
+  });
+
+  it("degrades a plain throw to the catch-all envelope", async () => {
+    const h = harness({
+      sendAsk: async () => {
+        throw new Error("target offline");
+      },
+    });
+    const result = await pick(h, "ask").handler({
+      target_agent_id: "agent_target",
+      question: "q",
+    });
+
+    expect(result.content).toEqual({ error: "target offline" });
+  });
+});
+
+// ── respond_ask ──────────────────────────────────────────────────────────
+
+describe("respond_ask handler", () => {
+  it("stamps the responder as the caller and echoes the request id", async () => {
+    const h = harness();
+    const result = await pick(h, "respond_ask").handler({
+      request_id: "req_1",
+      answer: "yes",
+    });
+
+    expect(h.mesh.respondAsk).toHaveBeenCalledWith("req_1", {
+      request_id: "req_1",
+      from_agent_id: "agent_x",
+      answer: "yes",
+    });
+    expect(result.content).toEqual({ responded: true, request_id: "req_1" });
+  });
+
+  it.each([
+    ["request_id", { answer: "yes" }],
+    ["answer", { request_id: "req_1" }],
+  ])("rejects a call missing %s", async (_label, input) => {
+    const h = harness();
+    const result = await pick(h, "respond_ask").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "request_id and answer required" });
+    expect(h.mesh.respondAsk).not.toHaveBeenCalled();
+  });
+
+  it("envelopes a throw from the unblock path", async () => {
+    const h = harness({
+      respondAsk: () => {
+        throw new Error("no waiter registered");
+      },
+    });
+    const result = await pick(h, "respond_ask").handler({
+      request_id: "req_1",
+      answer: "yes",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "no waiter registered" });
+  });
+});
+
+// ── negotiate ────────────────────────────────────────────────────────────
+
+describe("negotiate handler", () => {
+  it("passes the caller's session id as initiator metadata", async () => {
+    const h = harness();
+    await pick(h, "negotiate").handler({
+      peer_id: "agent_peer",
+      proposal: "ship Monday",
+      task_id: "task_1",
+    });
+
+    expect(h.mesh.sendNegotiate).toHaveBeenCalledWith(
+      "agent_x",
+      "agent_peer",
+      "ship Monday",
+      { taskId: "task_1", initiatorSessionId: "ses_x" },
+    );
+  });
+
+  it.each([
+    ["absent", {}],
+    ["an empty string", { task_id: "" }],
+    ["a non-string", { task_id: 5 }],
+  ])("sends taskId undefined when task_id is %s", async (_label, extra) => {
+    const h = harness();
+    await pick(h, "negotiate").handler({
+      peer_id: "agent_peer",
+      proposal: "p",
+      ...extra,
+    });
+
+    expect(h.mesh.sendNegotiate.mock.calls[0]?.[3]).toMatchObject({
+      taskId: undefined,
+    });
+  });
+
+  it("projects a counter response with its counter_proposal", async () => {
+    const h = harness();
+    const result = await pick(h, "negotiate").handler({
+      peer_id: "agent_peer",
+      proposal: "ship Monday",
+    });
+
+    expect(result.content).toEqual({
+      negotiation_id: "neg_1",
+      from_agent_id: "agent_peer",
+      decision: "counter",
+      message: "how about Tuesday",
+      counter_proposal: "ship Tuesday",
+    });
+  });
+
+  it("projects the escalated sentinel through its own branch", async () => {
+    const h = harness({
+      sendNegotiate: async () => ({
+        decision: "escalated",
+        escalation_id: "esc_9",
+        negotiation_id: "neg_1",
+        message: "peer escalated",
+      }),
+    });
+    const result = await pick(h, "negotiate").handler({
+      peer_id: "agent_peer",
+      proposal: "p",
+    });
+
+    expect(result.content).toEqual({
+      decision: "escalated",
+      escalation_id: "esc_9",
+      negotiation_id: "neg_1",
+      message: "peer escalated",
+    });
+  });
+
+  it.each([
+    ["peer_id", { proposal: "p" }],
+    ["proposal", { peer_id: "agent_peer" }],
+  ])("rejects a call missing %s", async (_label, input) => {
+    const h = harness();
+    const result = await pick(h, "negotiate").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "peer_id and proposal required" });
+    expect(h.mesh.sendNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("surfaces cannot_negotiate_with_ic with its meta intact", async () => {
+    const h = harness({
+      sendNegotiate: async () => {
+        throw new CannotNegotiateWithIcError({ agentId: "agent_ic" });
+      },
+    });
+    const result = await pick(h, "negotiate").handler({
+      peer_id: "agent_ic",
+      proposal: "p",
+    });
+
+    expect(result.content).toMatchObject({
+      error: "CANNOT_NEGOTIATE_WITH_IC",
+      agentId: "agent_ic",
+    });
+  });
+});
+
+// ── respond_negotiate ────────────────────────────────────────────────────
+
+const COUNTER_INPUT = {
+  negotiation_id: "neg_1",
+  decision: "counter",
+  message: "not quite",
+  counter_proposal: "ship Wednesday",
+};
+
+describe("respond_negotiate handler", () => {
+  it("reports terminal when the server returns null (accept/reject)", async () => {
+    const h = harness({ respondNegotiate: async () => null });
+    const result = await pick(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "accept",
+      message: "agreed",
+    });
+
+    expect(h.mesh.respondNegotiate).toHaveBeenCalledWith(
+      "neg_1",
+      {
+        negotiation_id: "neg_1",
+        from_agent_id: "agent_x",
+        decision: "accept",
+        message: "agreed",
+        counter_proposal: undefined,
+      },
+      "ses_x",
+    );
+    expect(result.content).toEqual({
+      negotiation_id: "neg_1",
+      decision: "accept",
+      terminal: true,
+    });
+  });
+
+  it("projects the peer's continuation when the round goes on", async () => {
+    const h = harness({
+      respondNegotiate: async () => ({
+        negotiation_id: "neg_1",
+        from_agent_id: "agent_peer",
+        decision: "counter",
+        message: "Thursday then",
+        counter_proposal: "ship Thursday",
+      }),
+    });
+    const result = await pick(h, "respond_negotiate").handler(COUNTER_INPUT);
+
+    expect(result.content).toMatchObject({
+      from_agent_id: "agent_peer",
+      counter_proposal: "ship Thursday",
+    });
+  });
+
+  it("projects an escalated sentinel returned to the responder", async () => {
+    const h = harness({
+      respondNegotiate: async () => ({
+        decision: "escalated",
+        escalation_id: "esc_9",
+        negotiation_id: "neg_1",
+        message: "peer escalated",
+      }),
+    });
+    const result = await pick(h, "respond_negotiate").handler(COUNTER_INPUT);
+
+    expect(result.content).toMatchObject({
+      decision: "escalated",
+      escalation_id: "esc_9",
+    });
+  });
+
+  it("forwards counter_proposal on the counter path", async () => {
+    const h = harness();
+    await pick(h, "respond_negotiate").handler(COUNTER_INPUT);
+
+    expect(h.mesh.respondNegotiate.mock.calls[0]?.[1]).toMatchObject({
+      decision: "counter",
+      counter_proposal: "ship Wednesday",
+    });
+  });
+
+  it.each([
+    ["negotiation_id", { decision: "accept", message: "ok" }],
+    ["message", { negotiation_id: "neg_1", decision: "accept" }],
+  ])("rejects a call missing %s", async (_label, input) => {
+    const h = harness();
+    const result = await pick(h, "respond_negotiate").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "negotiation_id and message required",
+    });
+    expect(h.mesh.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it.each([["approve"], [""], ["escalated"]])(
+    "rejects decision %j",
+    async (decision) => {
+      const h = harness();
+      const result = await pick(h, "respond_negotiate").handler({
+        negotiation_id: "neg_1",
+        decision,
+        message: "m",
+      });
+
+      expect(result.isError).toBe(true);
+      expect(String(result.content.error)).toContain(
+        "decision must be one of: counter, accept, reject",
+      );
+      expect(h.mesh.respondNegotiate).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects decision='counter' with no counter_proposal", async () => {
+    const h = harness();
+    const result = await pick(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "not quite",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "counter_proposal required when decision='counter'",
+    });
+    expect(h.mesh.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("keeps max_rounds_exceeded machine-readable for the escalate hand-off", async () => {
+    const h = harness({
+      respondNegotiate: async () => {
+        throw new MeshMaxRoundsError({
+          negotiationId: "neg_1",
+          rounds_completed: 5,
+          max_rounds: 5,
+        });
+      },
+    });
+    const result = await pick(h, "respond_negotiate").handler(COUNTER_INPUT);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "MAX_ROUNDS_EXCEEDED",
+      negotiationId: "neg_1",
+      rounds_completed: 5,
+      max_rounds: 5,
+    });
+    expect(String(result.content.message)).toContain("escalate_to_humans");
+  });
+});
+
+// ── report_blocker ───────────────────────────────────────────────────────
+
+describe("report_blocker handler", () => {
+  it("marks the task blocked, then spawns the parent", async () => {
+    const h = harness();
+    const result = await pick(h, "report_blocker").handler({
+      task_id: "task_1",
+      description: "the API key is missing",
+    });
+
+    expect(h.findParent).toHaveBeenCalledWith("agent_x");
+    expect(h.markBlocked).toHaveBeenCalledWith(
+      "task_1",
+      "agent_x",
+      "the API key is missing",
+    );
+    expect(h.mesh.reportBlocker).toHaveBeenCalledWith(
+      "agent_parent",
+      "agent_x",
+      "task_1",
+      "the API key is missing",
+    );
+    expect(result.content).toEqual({
+      reported: true,
+      parent_agent_id: "agent_parent",
+      task_id: "task_1",
+    });
+  });
+
+  it.each([
+    ["task_id", { description: "d" }],
+    ["description", { task_id: "task_1" }],
+  ])("rejects a call missing %s", async (_label, input) => {
+    const h = harness();
+    const result = await pick(h, "report_blocker").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "task_id and description required" });
+    expect(h.findParent).not.toHaveBeenCalled();
+  });
+
+  it("refuses for a top-level agent and leaves the task untouched", async () => {
+    const h = harness({ parent: undefined });
+    const result = await pick(h, "report_blocker").handler({
+      task_id: "task_1",
+      description: "stuck",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "no_parent_to_block" });
+    expect(String(result.content.message)).toContain("escalate_to_humans");
+    expect(h.markBlocked).not.toHaveBeenCalled();
+    expect(h.mesh.reportBlocker).not.toHaveBeenCalled();
+  });
+
+  it("does not spawn the parent when marking the task blocked fails", async () => {
+    const h = harness({
+      markBlocked: async () => {
+        throw new Error("task not found");
+      },
+    });
+    const result = await pick(h, "report_blocker").handler({
+      task_id: "task_gone",
+      description: "stuck",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "task not found" });
+    expect(h.mesh.reportBlocker).not.toHaveBeenCalled();
+  });
+});
+
+// ── escalate_to_humans ───────────────────────────────────────────────────
+
+const ESCALATE_INPUT = {
+  negotiation_id: "neg_1",
+  summary: "We're stuck on the ship date.",
+  proposals: [{ title: "Ship Monday", description: "cut scope" }],
+  open_questions: ["Is the customer demo fixed?"],
+};
+
+describe("escalate_to_humans handler", () => {
+  it("creates the escalation, unblocks the peer, then notifies", async () => {
+    const h = harness();
+    const result = await pick(h, "escalate_to_humans").handler(ESCALATE_INPUT);
+
+    expect(h.createEscalation).toHaveBeenCalledWith({
+      negotiationId: "neg_1",
+      callerAgentId: "agent_x",
+      summary: "We're stuck on the ship date.",
+      proposals: ESCALATE_INPUT.proposals,
+      openQuestions: ESCALATE_INPUT.open_questions,
+    });
+    expect(h.mesh.unblockOnEscalate).toHaveBeenCalledWith("neg_1", "esc_1");
+    expect(h.query).toHaveBeenCalledWith(
+      expect.stringContaining("pg_notify('escalation_created'"),
+      ["esc_1"],
+    );
+    expect(result.content).toEqual({
+      escalation_id: "esc_1",
+      status: "open",
+      negotiation_id: "neg_1",
+    });
+  });
+
+  it.each([
+    ["not arrays", { proposals: "one", open_questions: "two" }],
+    ["absent", {}],
+  ])("sends undefined when proposals/open_questions are %s", async (_l, extra) => {
+    const h = harness();
+    await pick(h, "escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "s",
+      ...extra,
+    });
+
+    expect(h.createEscalation.mock.calls[0]?.[0]).toMatchObject({
+      proposals: undefined,
+      openQuestions: undefined,
+    });
+  });
+
+  it("drops non-string entries from open_questions", async () => {
+    const h = harness();
+    await pick(h, "escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "s",
+      open_questions: ["real question", 42, null],
+    });
+
+    expect(h.createEscalation.mock.calls[0]?.[0]).toMatchObject({
+      openQuestions: ["real question"],
+    });
+  });
+
+  it.each([
+    ["negotiation_id", { summary: "s" }],
+    ["summary", { negotiation_id: "neg_1" }],
+  ])("rejects a call missing %s", async (_label, input) => {
+    const h = harness();
+    const result = await pick(h, "escalate_to_humans").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "negotiation_id and summary required",
+    });
+    expect(h.createEscalation).not.toHaveBeenCalled();
+  });
+
+  it("neither unblocks nor notifies when the escalation insert fails", async () => {
+    const h = harness({
+      createEscalation: async () => {
+        throw new Error("negotiation neg_1 already has an escalation");
+      },
+    });
+    const result = await pick(h, "escalate_to_humans").handler(ESCALATE_INPUT);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "negotiation neg_1 already has an escalation",
+    });
+    expect(h.mesh.unblockOnEscalate).not.toHaveBeenCalled();
+    expect(h.query).not.toHaveBeenCalled();
+  });
+});
+
+// ── IC tier handlers ─────────────────────────────────────────────────────
+
+describe("IC tier handlers are wired to the same context", () => {
+  it("respond_ask from an IC still stamps the IC as responder", async () => {
+    const mesh = { respondAsk: vi.fn() } as unknown as MeshServer;
+    const icCaller: ResolvedCaller = {
+      agentId: "agent_ic",
+      source: "agent",
+      hierarchyLevel: "ic",
+    };
+    const tools = buildIcMeshTools(
+      { caller: icCaller, beevibeSid: "ses_ic" },
+      { mesh } as unknown as MeshToolServices,
+    );
+    const respondAsk = tools.find((t) => t.name === "respond_ask");
+
+    const result = await respondAsk?.handler({
+      request_id: "req_1",
+      answer: "here's what I know",
+    });
+
+    expect(
+      (mesh as unknown as { respondAsk: ReturnType<typeof vi.fn> }).respondAsk,
+    ).toHaveBeenCalledWith("req_1", {
+      request_id: "req_1",
+      from_agent_id: "agent_ic",
+      answer: "here's what I know",
+    });
+    expect(result?.content).toEqual({ responded: true, request_id: "req_1" });
   });
 });

--- a/packages/api/src/tools/session-search.test.ts
+++ b/packages/api/src/tools/session-search.test.ts
@@ -1,0 +1,337 @@
+/**
+ * session_search tool tests.
+ *
+ * The whole point of this adapter is shape inference: one flat tool
+ * input has to become one of four typed SessionSearchRequests, and the
+ * precedence between them (scroll beats read beats discover beats
+ * browse) is the contract the tool description promises the agent. That
+ * gets exhaustive coverage here, along with the two failure envelopes —
+ * the `null` return (out of scope / bad anchor) and the SessionSearchError
+ * projection, including the by-name match that keeps working when core is
+ * consumed from src/ on one side and dist/ on the other.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { SessionSearchRequest } from "@beevibe/core";
+import {
+  SessionSearchError,
+  type SessionSearchService,
+} from "@beevibe/core/services/session-search";
+import {
+  createSessionSearchTool,
+  type SessionSearchToolContext,
+} from "./session-search.js";
+
+const CTX: SessionSearchToolContext = {
+  agentId: "agent_caller",
+  hierarchyLevel: "team",
+  sessionId: "ses_current",
+};
+
+/** Same arity as SessionSearchService.search, so `mock.calls` stays typed. */
+type SearchStub = (
+  req: SessionSearchRequest,
+  scope: {
+    callerAgentId: string;
+    hierarchyLevel: string;
+    currentSessionId: string;
+  },
+) => Promise<unknown>;
+
+function harness(
+  search: SearchStub = async () => ({ kind: "browse", sessions: [] }),
+  ctx: SessionSearchToolContext = CTX,
+) {
+  const spy = vi.fn(search);
+  const tool = createSessionSearchTool(ctx, {
+    sessionSearch: { search: spy } as unknown as SessionSearchService,
+  });
+  return { tool, spy };
+}
+
+function requestFrom(spy: ReturnType<typeof vi.fn>): SessionSearchRequest {
+  return spy.mock.calls[0]?.[0] as SessionSearchRequest;
+}
+
+describe("session_search tool descriptor", () => {
+  it("is named session_search and documents the four calling shapes", () => {
+    const { tool } = harness();
+    expect(tool.name).toBe("session_search");
+    for (const shape of ["DISCOVERY", "SCROLL", "READ", "BROWSE"]) {
+      expect(tool.description).toContain(shape);
+    }
+  });
+
+  it("takes no required fields, so the bare browse call is valid", () => {
+    const { tool } = harness();
+    expect(tool.schema.required).toBeUndefined();
+  });
+});
+
+describe("caller scope", () => {
+  it("passes the caller's agent id, tier and active session to the service", async () => {
+    const { tool, spy } = harness();
+    await tool.handler({});
+
+    expect(spy.mock.calls[0]?.[1]).toEqual({
+      callerAgentId: "agent_caller",
+      hierarchyLevel: "team",
+      currentSessionId: "ses_current",
+    });
+  });
+
+  it("forwards an ic caller's tier unchanged", async () => {
+    const { tool, spy } = harness(undefined, { ...CTX, hierarchyLevel: "ic" });
+    await tool.handler({});
+
+    expect(spy.mock.calls[0]?.[1]).toMatchObject({ hierarchyLevel: "ic" });
+  });
+});
+
+describe("shape inference", () => {
+  it("infers browse from an empty input", async () => {
+    const { tool, spy } = harness();
+    await tool.handler({});
+
+    expect(requestFrom(spy)).toEqual({
+      kind: "browse",
+      limit: undefined,
+      filters: undefined,
+    });
+  });
+
+  it("infers browse with a limit when only limit is given", async () => {
+    const { tool, spy } = harness();
+    await tool.handler({ limit: 7 });
+
+    expect(requestFrom(spy)).toMatchObject({ kind: "browse", limit: 7 });
+  });
+
+  it("infers discover from a query", async () => {
+    const { tool, spy } = harness();
+    await tool.handler({ query: "  auth refactor  ", limit: 3, sort: "newest" });
+
+    expect(requestFrom(spy)).toEqual({
+      kind: "discover",
+      query: "auth refactor",
+      limit: 3,
+      sort: "newest",
+      filters: undefined,
+    });
+  });
+
+  it("infers read from a bare session_id", async () => {
+    const { tool, spy } = harness();
+    await tool.handler({ session_id: "  ses_old  " });
+
+    expect(requestFrom(spy)).toEqual({ kind: "read", session_id: "ses_old" });
+  });
+
+  it("infers scroll from session_id + around_message_id", async () => {
+    const { tool, spy } = harness();
+    await tool.handler({
+      session_id: "  ses_old  ",
+      around_message_id: "  evt_9  ",
+      window: 10,
+    });
+
+    expect(requestFrom(spy)).toEqual({
+      kind: "scroll",
+      session_id: "ses_old",
+      around_message_id: "evt_9",
+      window: 10,
+    });
+  });
+
+  it("lets scroll win over a query supplied alongside it", async () => {
+    const { tool, spy } = harness();
+    await tool.handler({
+      session_id: "ses_old",
+      around_message_id: "evt_9",
+      query: "ignored",
+    });
+
+    expect(requestFrom(spy)).toMatchObject({ kind: "scroll" });
+  });
+
+  it("lets read win over a query supplied alongside it", async () => {
+    const { tool, spy } = harness();
+    await tool.handler({ session_id: "ses_old", query: "ignored" });
+
+    expect(requestFrom(spy)).toMatchObject({ kind: "read" });
+  });
+
+  it("falls back to discover when the anchor is blank but a query is present", async () => {
+    const { tool, spy } = harness();
+    await tool.handler({ around_message_id: "   ", query: "auth" });
+
+    expect(requestFrom(spy)).toMatchObject({ kind: "discover", query: "auth" });
+  });
+
+  it.each([
+    ["whitespace-only", "   "],
+    ["empty", ""],
+    ["a non-string", 12],
+  ])("treats %s session_id as absent", async (_label, session_id) => {
+    const { tool, spy } = harness();
+    await tool.handler({ session_id });
+
+    expect(requestFrom(spy)).toMatchObject({ kind: "browse" });
+  });
+
+  it.each([
+    ["whitespace-only", "   "],
+    ["a non-string", 12],
+  ])("treats %s query as absent", async (_label, query) => {
+    const { tool, spy } = harness();
+    await tool.handler({ query });
+
+    expect(requestFrom(spy)).toMatchObject({ kind: "browse" });
+  });
+
+  it("drops a non-numeric window rather than passing it through", async () => {
+    const { tool, spy } = harness();
+    await tool.handler({
+      session_id: "ses_old",
+      around_message_id: "evt_9",
+      window: "10",
+    });
+
+    expect(requestFrom(spy)).toMatchObject({ window: undefined });
+  });
+
+  it.each([
+    ["a bogus value", "closest"],
+    ["a non-string", 1],
+  ])("drops %s for sort", async (_label, sort) => {
+    const { tool, spy } = harness();
+    await tool.handler({ query: "auth", sort });
+
+    expect(requestFrom(spy)).toMatchObject({ sort: undefined });
+  });
+
+  it("keeps 'oldest' as a valid sort", async () => {
+    const { tool, spy } = harness();
+    await tool.handler({ query: "auth", sort: "oldest" });
+
+    expect(requestFrom(spy)).toMatchObject({ sort: "oldest" });
+  });
+});
+
+describe("filters", () => {
+  it("passes a filters object through to discover", async () => {
+    const { tool, spy } = harness();
+    const filters = { session_type: "task", status: "failed" };
+    await tool.handler({ query: "auth", filters });
+
+    expect(requestFrom(spy)).toMatchObject({ filters });
+  });
+
+  it("passes a filters object through to browse", async () => {
+    const { tool, spy } = harness();
+    const filters = { agent_id: "agent_sub" };
+    await tool.handler({ filters });
+
+    expect(requestFrom(spy)).toMatchObject({ kind: "browse", filters });
+  });
+
+  it.each([
+    ["null", null],
+    ["a string", "status:failed"],
+    ["absent", undefined],
+  ])("treats %s filters as undefined", async (_label, filters) => {
+    const { tool, spy } = harness();
+    await tool.handler({ query: "auth", filters });
+
+    expect(requestFrom(spy)).toMatchObject({ filters: undefined });
+  });
+});
+
+describe("result handling", () => {
+  it("returns the service payload verbatim on success", async () => {
+    const payload = { kind: "read", session: { id: "ses_old" }, messages: [] };
+    const { tool } = harness(async () => payload);
+
+    const result = await tool.handler({ session_id: "ses_old" });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toBe(payload);
+  });
+
+  it("maps a null result onto not_found_or_forbidden", async () => {
+    const { tool } = harness(async () => null);
+
+    const result = await tool.handler({
+      session_id: "ses_other",
+      around_message_id: "evt_1",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "not_found_or_forbidden" });
+    expect(String(result.content.message)).toContain("not in your scope");
+  });
+
+  it.each([
+    "forbidden_agent_filter",
+    "missing_query",
+    "missing_args",
+  ] as const)("projects SessionSearchError code %s", async (code) => {
+    const { tool } = harness(async () => {
+      throw new SessionSearchError(code, `bad: ${code}`);
+    });
+
+    const result = await tool.handler({ query: "auth" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: code, message: `bad: ${code}` });
+  });
+
+  it("projects a cross-bundle SessionSearchError matched by name", async () => {
+    // Same class from a different module instance: instanceof fails, so
+    // the name check is what keeps the structured code from degrading.
+    class ForeignSessionSearchError extends Error {
+      code = "forbidden_agent_filter";
+      constructor(message: string) {
+        super(message);
+        this.name = "SessionSearchError";
+      }
+    }
+    const { tool } = harness(async () => {
+      throw new ForeignSessionSearchError("out of scope");
+    });
+
+    const result = await tool.handler({ query: "auth" });
+
+    expect(result.content).toEqual({
+      error: "forbidden_agent_filter",
+      message: "out of scope",
+    });
+  });
+
+  it("wraps an unexpected Error as internal_error", async () => {
+    const { tool } = harness(async () => {
+      throw new Error("connection terminated");
+    });
+
+    const result = await tool.handler({});
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "internal_error",
+      message: "connection terminated",
+    });
+  });
+
+  it("stringifies a non-Error throw", async () => {
+    const { tool } = harness(async () => {
+      throw "pool exhausted";
+    });
+
+    const result = await tool.handler({});
+
+    expect(result.content).toEqual({
+      error: "internal_error",
+      message: "pool exhausted",
+    });
+  });
+});

--- a/packages/api/src/tools/use-repo.test.ts
+++ b/packages/api/src/tools/use-repo.test.ts
@@ -1,0 +1,434 @@
+/**
+ * use_repo tool tests.
+ *
+ * The handler is a five-step sequence — validate, resolve the agent,
+ * create the container task, dispatch, insert the repo_run — and every
+ * step has a distinct failure envelope the calling agent branches on.
+ * The ordering constraint documented in the module (session row before
+ * repo_run, because repo_run.session_id has an FK to session.id) is
+ * load-bearing, so it gets its own assertion rather than being implied
+ * by the happy path.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  RepoRunRepository,
+  Task,
+  TaskRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import { createUseRepoTool, type UseRepoServices } from "./use-repo.js";
+
+const AGENT: Agent = {
+  id: "agent_caller",
+  name: "Caller",
+  owner_id: "person_1",
+  hierarchy_level: "ic",
+  runtime_config: {} as Agent["runtime_config"],
+  created_at: new Date("2026-01-01T00:00:00Z"),
+  updated_at: new Date("2026-01-01T00:00:00Z"),
+};
+
+interface Harness {
+  services: UseRepoServices;
+  calls: string[];
+  created: Array<Record<string, unknown>>;
+  dispatched: Array<Record<string, unknown>>;
+  repoRuns: Array<Record<string, unknown>>;
+}
+
+function harness(
+  overrides: {
+    agent?: Agent | undefined;
+    dispatch?: () => Promise<unknown>;
+    createRepoRun?: () => Promise<unknown>;
+  } = {},
+): Harness {
+  const calls: string[] = [];
+  const created: Array<Record<string, unknown>> = [];
+  const dispatched: Array<Record<string, unknown>> = [];
+  const repoRuns: Array<Record<string, unknown>> = [];
+
+  const agentRepo = {
+    findById: vi.fn(async () => {
+      calls.push("findById");
+      return "agent" in overrides ? overrides.agent : AGENT;
+    }),
+  } as unknown as AgentRepository;
+
+  const taskRepo = {
+    create: vi.fn(async (input: Record<string, unknown>) => {
+      calls.push("taskRepo.create");
+      created.push(input);
+      return { ...input, status: "pending" } as unknown as Task;
+    }),
+  } as unknown as TaskRepository;
+
+  const repoRunRepo = {
+    create: vi.fn(async (input: Record<string, unknown>) => {
+      calls.push("repoRunRepo.create");
+      repoRuns.push(input);
+      if (overrides.createRepoRun) return overrides.createRepoRun();
+      return input;
+    }),
+  } as unknown as RepoRunRepository;
+
+  const dispatchService = {
+    dispatchTask: vi.fn(async (input: Record<string, unknown>) => {
+      calls.push("dispatchTask");
+      dispatched.push(input);
+      if (overrides.dispatch) return overrides.dispatch();
+      return {};
+    }),
+  } as unknown as DispatchService;
+
+  return {
+    services: { agentRepo, taskRepo, repoRunRepo, dispatchService },
+    calls,
+    created,
+    dispatched,
+    repoRuns,
+  };
+}
+
+function tool(h: Harness) {
+  return createUseRepoTool({ agentId: "agent_caller" }, h.services);
+}
+
+const GOOD_INPUT = {
+  goal: "Extract the tables from this PDF as JSON",
+  repo_url: "https://github.com/acme/pdfplumber",
+};
+
+describe("use_repo tool descriptor", () => {
+  it("exposes goal + repo_url as the required schema fields", () => {
+    const t = tool(harness());
+    expect(t.name).toBe("use_repo");
+    expect(t.schema.required).toEqual(["goal", "repo_url"]);
+  });
+});
+
+describe("use_repo input validation", () => {
+  it("rejects a missing goal before touching any service", async () => {
+    const h = harness();
+    const result = await tool(h).handler({ repo_url: GOOD_INPUT.repo_url });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "invalid_goal" });
+    expect(h.calls).toEqual([]);
+  });
+
+  it("rejects a whitespace-only goal", async () => {
+    const h = harness();
+    const result = await tool(h).handler({ ...GOOD_INPUT, goal: "   " });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "invalid_goal" });
+    expect(h.calls).toEqual([]);
+  });
+
+  it.each([
+    ["a non-GitHub host", "https://gitlab.com/acme/tool"],
+    ["plain http", "http://github.com/acme/tool"],
+    ["an unparseable string", "not a url"],
+    ["a lookalike host", "https://notgithub.com/acme/tool"],
+    ["an empty string", ""],
+    ["a non-string", 42],
+  ])("rejects %s as repo_url", async (_label, repo_url) => {
+    const h = harness();
+    const result = await tool(h).handler({ ...GOOD_INPUT, repo_url });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "invalid_repo_url" });
+    expect(h.calls).toEqual([]);
+  });
+
+  it.each([
+    ["the bare host", "https://github.com/acme/tool"],
+    ["a subdomain", "https://www.github.com/acme/tool"],
+  ])("accepts %s", async (_label, repo_url) => {
+    const h = harness();
+    const result = await tool(h).handler({ ...GOOD_INPUT, repo_url });
+
+    expect(result.isError).toBeFalsy();
+    expect(h.repoRuns[0]).toMatchObject({ repo_url });
+  });
+
+  it("returns agent_not_found when the caller no longer exists", async () => {
+    const h = harness({ agent: undefined });
+    const result = await tool(h).handler(GOOD_INPUT);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "agent_not_found" });
+    // Bailed before the container task was created.
+    expect(h.calls).toEqual(["findById"]);
+  });
+});
+
+describe("use_repo happy path", () => {
+  it("returns the minted ids plus a watch url", async () => {
+    const h = harness();
+    const result = await tool(h).handler(GOOD_INPUT);
+
+    expect(result.isError).toBeFalsy();
+    const content = result.content as Record<string, string>;
+    expect(content.status).toBe("pending");
+    expect(content.repo_run_id).toBeTruthy();
+    expect(content.session_id).toBeTruthy();
+    expect(content.task_id).toBeTruthy();
+    expect(content.watch_url).toBe(`/capabilities/runs/${content.repo_run_id}`);
+    expect(content.note).toContain("Sandbox run started");
+  });
+
+  it("creates the session row before the repo_run row (FK ordering)", async () => {
+    const h = harness();
+    await tool(h).handler(GOOD_INPUT);
+
+    expect(h.calls).toEqual([
+      "findById",
+      "taskRepo.create",
+      "dispatchTask",
+      "repoRunRepo.create",
+    ]);
+  });
+
+  it("pins the container task to the resolved agent on both sides", async () => {
+    const h = harness();
+    await tool(h).handler(GOOD_INPUT);
+
+    expect(h.created[0]).toMatchObject({
+      title: GOOD_INPUT.goal,
+      description: GOOD_INPUT.goal,
+      priority: "medium",
+      assignee_id: "agent_caller",
+      creator_id: "agent_caller",
+      creator_type: "agent",
+    });
+  });
+
+  it("dispatches a run_repo session under the pre-minted session id", async () => {
+    const h = harness();
+    const result = await tool(h).handler(GOOD_INPUT);
+
+    const sessionId = (result.content as Record<string, string>).session_id;
+    expect(h.dispatched[0]).toMatchObject({
+      agentId: "agent_caller",
+      type: "run_repo",
+      intent: GOOD_INPUT.goal,
+      reason: { kind: "fresh" },
+      sessionIdOverride: sessionId,
+    });
+  });
+
+  it("hands the repo_run the same session and task ids it returns", async () => {
+    const h = harness();
+    const result = await tool(h).handler(GOOD_INPUT);
+    const content = result.content as Record<string, string>;
+
+    expect(h.repoRuns[0]).toMatchObject({
+      id: content.repo_run_id,
+      session_id: content.session_id,
+      task_id: content.task_id,
+      agent_id: "agent_caller",
+      goal: GOOD_INPUT.goal,
+      repo_url: GOOD_INPUT.repo_url,
+      status: "pending",
+    });
+  });
+
+  it("trims goal and repo_url before they reach the repos", async () => {
+    const h = harness();
+    await tool(h).handler({
+      goal: "  do the thing  ",
+      repo_url: `  ${GOOD_INPUT.repo_url}  `,
+    });
+
+    expect(h.repoRuns[0]).toMatchObject({
+      goal: "do the thing",
+      repo_url: GOOD_INPUT.repo_url,
+    });
+  });
+
+  it("elides an over-long goal into an 80-char container task title", async () => {
+    const h = harness();
+    const goal = "x".repeat(200);
+    await tool(h).handler({ ...GOOD_INPUT, goal });
+
+    const title = h.created[0]?.title as string;
+    expect(title).toHaveLength(78); // 77 chars + the ellipsis
+    expect(title.endsWith("…")).toBe(true);
+    // The full goal still reaches the description and the repo_run.
+    expect(h.created[0]?.description).toBe(goal);
+    expect(h.repoRuns[0]?.goal).toBe(goal);
+  });
+
+  it("collapses internal whitespace in the container task title", async () => {
+    const h = harness();
+    await tool(h).handler({ ...GOOD_INPUT, goal: "extract\n\n  the   tables" });
+
+    expect(h.created[0]?.title).toBe("extract the tables");
+  });
+
+  it("passes optional input_url + input_filename back to the caller", async () => {
+    const h = harness();
+    const result = await tool(h).handler({
+      ...GOOD_INPUT,
+      input_url: "  https://example.com/report.pdf  ",
+      input_filename: "  report.pdf  ",
+    });
+
+    expect(result.content).toMatchObject({
+      input_url: "https://example.com/report.pdf",
+      input_filename: "report.pdf",
+    });
+  });
+
+  it("omits input fields entirely when they are not strings", async () => {
+    const h = harness();
+    const result = await tool(h).handler({ ...GOOD_INPUT, input_url: 42 });
+
+    expect(result.content.input_url).toBeUndefined();
+    expect(result.content.input_filename).toBeUndefined();
+  });
+});
+
+describe("use_repo limit parsing", () => {
+  it("returns an empty object when limits is absent", async () => {
+    const h = harness();
+    const result = await tool(h).handler(GOOD_INPUT);
+    expect(result.content.limits).toEqual({});
+  });
+
+  it.each([
+    ["null", null],
+    ["a string", "20"],
+  ])("returns an empty object when limits is %s", async (_label, limits) => {
+    const h = harness();
+    const result = await tool(h).handler({ ...GOOD_INPUT, limits });
+    expect(result.content.limits).toEqual({});
+  });
+
+  it("passes through in-range limits untouched", async () => {
+    const h = harness();
+    const result = await tool(h).handler({
+      ...GOOD_INPUT,
+      limits: { wall_clock_minutes: 15, max_install_attempts: 3, disk_mb: 4096 },
+    });
+
+    expect(result.content.limits).toEqual({
+      wall_clock_minutes: 15,
+      max_install_attempts: 3,
+      disk_mb: 4096,
+    });
+  });
+
+  it("clamps each limit to its ceiling", async () => {
+    const h = harness();
+    const result = await tool(h).handler({
+      ...GOOD_INPUT,
+      limits: {
+        wall_clock_minutes: 999,
+        max_install_attempts: 50,
+        disk_mb: 1_000_000,
+      },
+    });
+
+    expect(result.content.limits).toEqual({
+      wall_clock_minutes: 60,
+      max_install_attempts: 5,
+      disk_mb: 10_000,
+    });
+  });
+
+  it("floors fractional attempt + disk values", async () => {
+    const h = harness();
+    const result = await tool(h).handler({
+      ...GOOD_INPUT,
+      limits: { max_install_attempts: 2.9, disk_mb: 512.7 },
+    });
+
+    expect(result.content.limits).toEqual({
+      max_install_attempts: 2,
+      disk_mb: 512,
+    });
+  });
+
+  it.each([
+    ["zero", 0],
+    ["negative", -5],
+    ["a non-number", "10"],
+  ])("drops %s limit values", async (_label, value) => {
+    const h = harness();
+    const result = await tool(h).handler({
+      ...GOOD_INPUT,
+      limits: {
+        wall_clock_minutes: value,
+        max_install_attempts: value,
+        disk_mb: value,
+      },
+    });
+
+    expect(result.content.limits).toEqual({});
+  });
+});
+
+describe("use_repo failure envelopes", () => {
+  it("reports dispatch_failed and never inserts a repo_run", async () => {
+    const h = harness({
+      dispatch: async () => {
+        throw new Error("no daemon online");
+      },
+    });
+    const result = await tool(h).handler(GOOD_INPUT);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "dispatch_failed",
+      message: "no daemon online",
+    });
+    expect(h.calls).not.toContain("repoRunRepo.create");
+  });
+
+  it("stringifies a non-Error dispatch throw", async () => {
+    const h = harness({
+      dispatch: async () => {
+        throw "capacity";
+      },
+    });
+    const result = await tool(h).handler(GOOD_INPUT);
+
+    expect(result.content).toMatchObject({
+      error: "dispatch_failed",
+      message: "capacity",
+    });
+  });
+
+  it("surfaces repo_run_create_failed rather than silently orphaning the session", async () => {
+    const h = harness({
+      createRepoRun: async () => {
+        throw new Error("duplicate key");
+      },
+    });
+    const result = await tool(h).handler(GOOD_INPUT);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "repo_run_create_failed",
+      message: "duplicate key",
+    });
+  });
+
+  it("stringifies a non-Error repo_run throw", async () => {
+    const h = harness({
+      createRepoRun: async () => {
+        throw { code: 23503 };
+      },
+    });
+    const result = await tool(h).handler(GOOD_INPUT);
+
+    expect(result.content).toMatchObject({ error: "repo_run_create_failed" });
+    expect(String(result.content.message)).toContain("object");
+  });
+});

--- a/packages/api/src/tools/watch.test.ts
+++ b/packages/api/src/tools/watch.test.ts
@@ -1,0 +1,276 @@
+/**
+ * watch_tasks + unwatch tool tests.
+ *
+ * Both tools are thin adapters over WatchService — the interesting
+ * surface is what the adapter does *before* delegating (input coercion,
+ * mode defaulting, the missing-session guard) and how it maps the
+ * service's typed errors onto stable `error` codes the agent branches
+ * on. Service behavior itself is covered by watch-service's own suite.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  WatchAuthError,
+  WatchNotFoundError,
+  WatchValidationError,
+  type WatchService,
+} from "@beevibe/core/services/watch-service";
+import { buildWatchTools, type WatchToolContext } from "./watch.js";
+import type { AgentTool } from "./types.js";
+
+interface Harness {
+  tools: AgentTool[];
+  watchTasks: ReturnType<typeof vi.fn>;
+  unwatch: ReturnType<typeof vi.fn>;
+}
+
+function harness(
+  overrides: {
+    ctx?: Partial<WatchToolContext>;
+    watchTasks?: () => Promise<unknown>;
+    unwatch?: () => Promise<unknown>;
+  } = {},
+): Harness {
+  const watchTasks = vi.fn(
+    overrides.watchTasks ??
+      (async () => ({ watchId: "tw_1", firedImmediately: false })),
+  );
+  const unwatch = vi.fn(overrides.unwatch ?? (async () => undefined));
+  const watchService = { watchTasks, unwatch } as unknown as WatchService;
+
+  const ctx: WatchToolContext = {
+    agentId: "agent_caller",
+    sessionId: "ses_caller",
+    ...overrides.ctx,
+  };
+
+  return { tools: buildWatchTools(ctx, { watchService }), watchTasks, unwatch };
+}
+
+function watchTasksTool(h: Harness): AgentTool {
+  const t = h.tools.find((x) => x.name === "watch_tasks");
+  if (!t) throw new Error("watch_tasks tool missing");
+  return t;
+}
+
+function unwatchTool(h: Harness): AgentTool {
+  const t = h.tools.find((x) => x.name === "unwatch");
+  if (!t) throw new Error("unwatch tool missing");
+  return t;
+}
+
+describe("buildWatchTools", () => {
+  it("returns watch_tasks and unwatch in that order", () => {
+    expect(harness().tools.map((t) => t.name)).toEqual([
+      "watch_tasks",
+      "unwatch",
+    ]);
+  });
+
+  it("advertises both watch modes in the schema enum", () => {
+    const schema = watchTasksTool(harness()).schema as {
+      properties: { mode: { enum: string[] } };
+      required: string[];
+    };
+    expect(schema.properties.mode.enum).toEqual(["all", "any"]);
+    expect(schema.required).toEqual(["task_ids"]);
+  });
+});
+
+describe("watch_tasks", () => {
+  it("forwards caller identity, ids, mode and reason to the service", async () => {
+    const h = harness();
+    const result = await watchTasksTool(h).handler({
+      task_ids: ["task_a", "task_b"],
+      mode: "any",
+      reason: "  need the first result  ",
+    });
+
+    expect(h.watchTasks).toHaveBeenCalledWith({
+      callerAgentId: "agent_caller",
+      callerSessionId: "ses_caller",
+      taskIds: ["task_a", "task_b"],
+      mode: "any",
+      reason: "need the first result",
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({
+      watch_id: "tw_1",
+      fired_immediately: false,
+    });
+  });
+
+  it("surfaces firedImmediately from the already-terminal race path", async () => {
+    const h = harness({
+      watchTasks: async () => ({ watchId: "tw_2", firedImmediately: true }),
+    });
+    const result = await watchTasksTool(h).handler({ task_ids: ["task_a"] });
+
+    expect(result.content).toEqual({
+      watch_id: "tw_2",
+      fired_immediately: true,
+    });
+  });
+
+  it("defaults mode to 'all' when omitted", async () => {
+    const h = harness();
+    await watchTasksTool(h).handler({ task_ids: ["task_a"] });
+
+    expect(h.watchTasks.mock.calls[0]?.[0]).toMatchObject({ mode: "all" });
+  });
+
+  it.each([
+    ["an unknown string", "first"],
+    ["a non-string", 1],
+    ["null", null],
+  ])("defaults mode to 'all' for %s", async (_label, mode) => {
+    const h = harness();
+    await watchTasksTool(h).handler({ task_ids: ["task_a"], mode });
+
+    expect(h.watchTasks.mock.calls[0]?.[0]).toMatchObject({ mode: "all" });
+  });
+
+  it.each([
+    ["whitespace-only", "   "],
+    ["empty", ""],
+    ["a non-string", 7],
+  ])("drops %s reason instead of forwarding it", async (_label, reason) => {
+    const h = harness();
+    await watchTasksTool(h).handler({ task_ids: ["task_a"], reason });
+
+    expect(h.watchTasks.mock.calls[0]?.[0]).toMatchObject({
+      reason: undefined,
+    });
+  });
+
+  it("filters non-string entries out of task_ids", async () => {
+    const h = harness();
+    await watchTasksTool(h).handler({
+      task_ids: ["task_a", 42, null, "task_b"],
+    });
+
+    expect(h.watchTasks.mock.calls[0]?.[0]).toMatchObject({
+      taskIds: ["task_a", "task_b"],
+    });
+  });
+
+  it.each([
+    ["an empty array", []],
+    ["an array with no strings left", [1, null]],
+    ["a non-array", "task_a"],
+    ["undefined", undefined],
+  ])("rejects %s task_ids without calling the service", async (_l, task_ids) => {
+    const h = harness();
+    const result = await watchTasksTool(h).handler({ task_ids });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "watch_validation" });
+    expect(h.watchTasks).not.toHaveBeenCalled();
+  });
+
+  it("refuses to register a watch outside a session context", async () => {
+    const h = harness({ ctx: { sessionId: undefined } });
+    const result = await watchTasksTool(h).handler({ task_ids: ["task_a"] });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "watch_validation",
+      message: "watch_tasks must be called inside a session context",
+    });
+    expect(h.watchTasks).not.toHaveBeenCalled();
+  });
+});
+
+describe("unwatch", () => {
+  it("delegates to the service and reports ok", async () => {
+    const h = harness();
+    const result = await unwatchTool(h).handler({ watch_id: "tw_1" });
+
+    expect(h.unwatch).toHaveBeenCalledWith({
+      callerAgentId: "agent_caller",
+      watchId: "tw_1",
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({ ok: true });
+  });
+
+  it.each([
+    ["an empty string", ""],
+    ["a non-string", 5],
+    ["undefined", undefined],
+  ])("rejects %s watch_id without calling the service", async (_l, watch_id) => {
+    const h = harness();
+    const result = await unwatchTool(h).handler({ watch_id });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "watch_validation" });
+    expect(h.unwatch).not.toHaveBeenCalled();
+  });
+
+  it("still reports ok when the watch is already gone (idempotent)", async () => {
+    const h = harness({ unwatch: async () => undefined });
+    const result = await unwatchTool(h).handler({ watch_id: "tw_gone" });
+
+    expect(result.content).toEqual({ ok: true });
+  });
+});
+
+describe("service error mapping", () => {
+  const cases: Array<[string, unknown, string, string]> = [
+    [
+      "WatchAuthError",
+      new WatchAuthError("task task_a is not in your chain"),
+      "watch_auth",
+      "task task_a is not in your chain",
+    ],
+    [
+      "WatchValidationError",
+      new WatchValidationError("task_ids must be non-empty"),
+      "watch_validation",
+      "task_ids must be non-empty",
+    ],
+    [
+      "WatchNotFoundError",
+      new WatchNotFoundError("tw_missing"),
+      "watch_not_found",
+      "task_watch tw_missing not found",
+    ],
+    [
+      "a plain Error",
+      new Error("connection terminated"),
+      "watch_error",
+      "connection terminated",
+    ],
+    ["a thrown string", "boom", "watch_error", "boom"],
+  ];
+
+  it.each(cases)(
+    "maps %s out of watch_tasks",
+    async (_label, thrown, code, message) => {
+      const h = harness({
+        watchTasks: async () => {
+          throw thrown;
+        },
+      });
+      const result = await watchTasksTool(h).handler({ task_ids: ["task_a"] });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual({ error: code, message });
+    },
+  );
+
+  it.each(cases)(
+    "maps %s out of unwatch",
+    async (_label, thrown, code, message) => {
+      const h = harness({
+        unwatch: async () => {
+          throw thrown;
+        },
+      });
+      const result = await unwatchTool(h).handler({ watch_id: "tw_1" });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual({ error: code, message });
+    },
+  );
+});


### PR DESCRIPTION
## Why these four

A coverage sweep across the monorepo put `@beevibe/api` lowest of the five packages at **74.62% lines**:

| Package | Lines before |
| --- | --- |
| `@beevibe/core` | 90.05% |
| `@beevibe/daemon` | 80.41% |
| `@beevibe/sandbox` | 75.11% |
| **`@beevibe/api`** | **74.62%** |
| `@beevibe/scheduler` | 65.94% |

Ranking every file by uncovered lines and setting aside entrypoints (`bootstrap.ts`, `main.ts`, `start.ts`), dev/ops scripts, and the live-provider adapters that need real API keys, the worst-covered cluster was `packages/api/src/tools/` — the MCP surface agents actually call. `use-repo.ts`, `watch.ts`, and `session-search.ts` had **no test file at all**; `mesh.ts` had one that locked the tier inventory and explicitly deferred handler behavior to the m6/m7 e2e scripts, which need live Postgres and spawned CLI subprocesses. `hierarchy.ts` and `chat.ts` also churn (4–5 commits in 6 months) but are large enough to want their own passes.

## What's covered

Every one of these modules is a closure over injected services, so the handlers test as plain functions against fakes — no DB, no network. The tests assert what the tool layer itself owns: argument coercion, the guards that run *before* any service call, and the projection of results and thrown errors onto the envelopes agents branch on.

**`use-repo.test.ts`** (32.04% → 100%) — the five-step sequence and its five distinct failure envelopes (`invalid_goal`, `invalid_repo_url`, `agent_not_found`, `dispatch_failed`, `repo_run_create_failed`), limit clamping and flooring, GitHub URL validation including the `notgithub.com` lookalike and plain-http rejection, and title elision. The FK ordering the module documents in a comment — session row before the `repo_run` insert — is asserted as an explicit call sequence rather than left implied by the happy path.

**`watch.test.ts`** (46.26% → 100%) — mode defaulting to `all` for anything not in the enum, non-string filtering out of `task_ids`, the missing-session guard, and the full `WatchService` error → error-code map (`watch_auth` / `watch_validation` / `watch_not_found` / `watch_error`) exercised across both tools.

**`session-search.test.ts`** (64.65% → 100%) — shape inference for all four calling shapes plus their precedence (scroll beats read beats discover beats browse), the `null` → `not_found_or_forbidden` map, and the by-name `SessionSearchError` match that keeps the structured code intact when core is consumed from `src/` on one side and `dist/` on the other.

**`mesh.test.ts`** (45.93% → 100%) — all six handlers, appended below the existing tier-inventory tests. Includes the two orderings that matter for consistency: a failed `markBlocked` must not spawn the parent, and a failed escalation insert must neither unblock the peer nor emit `pg_notify`.

## Result

147 new assertions. All four modules reach **100% statements, branches, functions and lines**:

| Module | Lines | Branches | Functions |
| --- | --- | --- | --- |
| `tools/use-repo.ts` | 32.04% → 100% | → 100% | 20% → 100% |
| `tools/watch.ts` | 46.26% → 100% | → 100% | 42.85% → 100% |
| `tools/session-search.ts` | 64.65% → 100% | → 100% | 33.33% → 100% |
| `tools/mesh.ts` | 45.93% → 100% | → 100% | 50% → 100% |
| **`@beevibe/api` total** | **74.62% → 79.78%** | 85.06% → 86.24% | 85.95% → 90.90% |

## Validation

**No source files changed** — tests only.

- `packages/api` suite: 1071 passed, 4 skipped, 0 failed (56 files) — run against a real Postgres 16 with both databases migrated, so the DB-gated suites executed rather than erroring out.
- `turbo run typecheck` — 9/9 successful.
- `turbo run lint` — 9/9 successful (the one `@beevibe/web` `import/no-duplicates` warning is pre-existing on `main`).

Coverage was measured with `@vitest/coverage-v8@2.1.9` installed ad hoc per `CLAUDE.md`; the `package.json` / `pnpm-lock.yaml` change was reverted and is not part of this diff.


---
_Generated by [Claude Code](https://claude.ai/code/session_015T5vWMpkrjZamjCF1REvC7)_