### PR TITLE
refactor: unify four clusters of near-duplicate error/input handling

### DIFF
--- a/packages/api/src/bootstrap.ts
+++ b/packages/api/src/bootstrap.ts
@@ -36,6 +36,7 @@ import { SessionSearchService } from "@beevibe/core/services/session-search";
 import { DaemonOrphanReaper } from "@beevibe/core/services/orphan-reaper";
 import { buildPostDispatchHook } from "@beevibe/core/services/post-dispatch";
 import type { Session } from "@beevibe/core";
+import { errorMessage } from "@beevibe/core";
 import { MeshServer } from "./mesh/server.js";
 import { BeevibeApiServer } from "./server.js";
 import { SessionCache } from "./session-cache.js";
@@ -443,10 +444,7 @@ export async function bootstrap(cfg: BootstrapConfig): Promise<BootstrapResult> 
         try {
           await taskRepo.update(session.task_id, { status: "review" });
         } catch (err) {
-          console.warn(
-            "[onSessionComplete] run_repo task→review failed:",
-            err instanceof Error ? err.message : String(err),
-          );
+          console.warn("[onSessionComplete] run_repo task→review failed:", errorMessage(err));
         }
       }
       // Auto-retry-then-fail for task sessions whose agent exited

--- a/packages/api/src/routes/capabilities.ts
+++ b/packages/api/src/routes/capabilities.ts
@@ -28,6 +28,7 @@ import type {
 import { getReferencedRepos } from "@beevibe/core/services/referenced-repos";
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
 import { requireHuman } from "../auth/middleware.js";
+import { operationFailed } from "./http-errors.js";
 import { createUseRepoTool } from "../tools/use-repo.js";
 
 export interface CapabilitiesRouterDeps {
@@ -86,8 +87,7 @@ export function createCapabilitiesRouter(deps: CapabilitiesRouterDeps): Router {
       });
       res.status(200).json({ repos });
     } catch (err) {
-      console.error("[capabilities/referenced-repos]", err);
-      res.status(500).json({ error: "scan_failed" });
+      operationFailed(res, err, "capabilities/referenced-repos", "scan_failed");
     }
   });
 
@@ -135,8 +135,7 @@ export function createCapabilitiesRouter(deps: CapabilitiesRouterDeps): Router {
       }
       res.status(202).json(result.content);
     } catch (err) {
-      console.error("[capabilities/use]", err);
-      res.status(500).json({ error: "use_failed" });
+      operationFailed(res, err, "capabilities/use", "use_failed");
     }
   });
 

--- a/packages/api/src/routes/chat.ts
+++ b/packages/api/src/routes/chat.ts
@@ -24,6 +24,7 @@
 import { randomUUID } from "node:crypto";
 import { Router, type RequestHandler, type Response } from "express";
 import {
+  errorMessage,
   SYSTEM_WAKE_INTENT_CLOSE,
   SYSTEM_WAKE_INTENT_OPEN,
   isInFlightSessionStatus,
@@ -679,10 +680,7 @@ export function createChatRouter(deps: ChatRoutesDeps): Router {
         deps.personRepo
           .update(req.caller.personId, { onboarding_completed_at: new Date() })
           .catch((err: unknown) =>
-            console.error(
-              "[chat route] onboarding_completed_at flip failed:",
-              err instanceof Error ? err.message : String(err),
-            ),
+            console.error("[chat route] onboarding_completed_at flip failed:", errorMessage(err)),
           );
       }
 

--- a/packages/api/src/routes/escalation.ts
+++ b/packages/api/src/routes/escalation.ts
@@ -18,6 +18,7 @@
  */
 
 import { Router, type RequestHandler, type Response } from "express";
+import { errorMessage } from "@beevibe/core";
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import {
   type EscalationService,
@@ -104,7 +105,7 @@ function handleEscalationError(err: unknown, res: Response): void {
   console.error("[escalation route]", err);
   res.status(500).json({
     error: "internal_error",
-    message: err instanceof Error ? err.message : String(err),
+    message: errorMessage(err),
   });
 }
 

--- a/packages/api/src/routes/find-repo.ts
+++ b/packages/api/src/routes/find-repo.ts
@@ -16,6 +16,7 @@ import type {
   LearnedSkillRepository,
 } from "@beevibe/core";
 import { requireHuman } from "../auth/middleware.js";
+import { operationFailed } from "./http-errors.js";
 import { createFindRepoTool } from "../tools/find-repo.js";
 
 export interface FindRepoRouterDeps {
@@ -68,8 +69,7 @@ export function createFindRepoRouter(deps: FindRepoRouterDeps): Router {
       }
       res.status(200).json(result.content);
     } catch (err) {
-      console.error("[find-repo/search]", err);
-      res.status(500).json({ error: "search_failed" });
+      operationFailed(res, err, "find-repo/search", "search_failed");
     }
   });
 

--- a/packages/api/src/routes/http-errors.test.ts
+++ b/packages/api/src/routes/http-errors.test.ts
@@ -3,6 +3,7 @@ import type { Request, Response } from "express";
 import {
   invalidBody,
   loadOwned,
+  operationFailed,
   requireNullableString,
   requireParam,
 } from "./http-errors.js";
@@ -217,5 +218,28 @@ describe("requireNullableString", () => {
     expect(res.body).toMatchObject({
       message: "expected { runtime_id: string | null }",
     });
+  });
+});
+
+describe("operationFailed", () => {
+  it("logs the raw error under the router/operation tag", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const err = new Error("ENOENT: /var/artifacts/secret.txt");
+
+    operationFailed(fakeRes(), err, "repo-runs/artifact", "artifact_failed");
+
+    expect(spy).toHaveBeenCalledWith("[repo-runs/artifact]", err);
+    spy.mockRestore();
+  });
+
+  it("answers 500 with the code alone — never the error's own message", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = fakeRes();
+
+    operationFailed(res, new Error("ENOENT: /var/artifacts/secret.txt"), "x/y", "get_failed");
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: "get_failed" });
+    spy.mockRestore();
   });
 });

--- a/packages/api/src/routes/http-errors.ts
+++ b/packages/api/src/routes/http-errors.ts
@@ -151,3 +151,33 @@ export function makeErrorHandler(
     });
   };
 }
+
+/**
+ * The *other* 500 — the one that names the operation that failed instead
+ * of reflecting the error's own message.
+ *
+ * `capabilities`, `find-repo`, `learned-skills` and `repo-runs` end ten
+ * handlers with the identical three lines: log the raw error with a
+ * `[router/operation]` tag, then answer `{ error: "<verb>_failed" }` and
+ * nothing else. That envelope is deliberately terser than
+ * {@link makeErrorHandler}'s — these endpoints reach GitHub, the
+ * filesystem and the capability registry, so an `err.message` reflected
+ * to the client can carry a path or a token-bearing URL. Keeping both
+ * builders side by side is the point: a handler author picks the
+ * disclosure they want rather than rediscovering the terse shape by
+ * copying whichever neighbour they happened to read.
+ *
+ * `tag` is the `router/operation` pair without brackets; `code` is the
+ * wire-visible failure code, which stays per-call-site because the
+ * existing codes are already per-operation (`scan_failed`, `get_failed`,
+ * `cancel_failed`, …) and clients may branch on them.
+ */
+export function operationFailed(
+  res: Response,
+  err: unknown,
+  tag: string,
+  code: string,
+): void {
+  console.error(`[${tag}]`, err);
+  res.status(500).json({ error: code });
+}

--- a/packages/api/src/routes/http-errors.ts
+++ b/packages/api/src/routes/http-errors.ts
@@ -1,4 +1,5 @@
 import type { Request, Response } from "express";
+import { errorMessage } from "@beevibe/core";
 
 /**
  * Read a required route param, 400-ing when Express hands back an empty
@@ -146,7 +147,7 @@ export function makeErrorHandler(
     console.error(context ? `[${tag}: ${context}]` : `[${tag}]`, err);
     res.status(500).json({
       error: "internal_error",
-      message: err instanceof Error ? err.message : String(err),
+      message: errorMessage(err),
     });
   };
 }

--- a/packages/api/src/routes/learned-skills.ts
+++ b/packages/api/src/routes/learned-skills.ts
@@ -11,6 +11,7 @@ import { writeFile, mkdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { Router, type RequestHandler, type Response } from "express";
 import {
+  errorMessage,
   learnedSkillId as newLearnedSkillId,
   type LearnedSkillRepository,
   type RepoRun,
@@ -233,7 +234,7 @@ export function createLearnedSkillsRouter(deps: LearnedSkillsRouterDeps): Router
       console.error("[learned-skills/publish]", err);
       res.status(500).json({
         error: "publish_failed",
-        message: err instanceof Error ? err.message : String(err),
+        message: errorMessage(err),
       });
     }
   });

--- a/packages/api/src/routes/learned-skills.ts
+++ b/packages/api/src/routes/learned-skills.ts
@@ -20,7 +20,7 @@ import {
 } from "@beevibe/core";
 import { requireHuman } from "../auth/middleware.js";
 import { readArtifactBody } from "../views/work-product.js";
-import { invalidBody, loadOwned, requireParam } from "./http-errors.js";
+import { invalidBody, loadOwned, operationFailed, requireParam } from "./http-errors.js";
 
 export interface LearnedSkillsRouterDeps {
   authMiddleware: RequestHandler;
@@ -64,8 +64,7 @@ export function createLearnedSkillsRouter(deps: LearnedSkillsRouterDeps): Router
       const skills = await deps.learnedSkillRepo.listByOwner(req.caller!.personId);
       res.status(200).json({ skills });
     } catch (err) {
-      console.error("[learned-skills/list]", err);
-      res.status(500).json({ error: "list_failed" });
+      operationFailed(res, err, "learned-skills/list", "list_failed");
     }
   });
 
@@ -142,8 +141,7 @@ export function createLearnedSkillsRouter(deps: LearnedSkillsRouterDeps): Router
 
       res.status(201).json({ skill });
     } catch (err) {
-      console.error("[learned-skills/create]", err);
-      res.status(500).json({ error: "create_failed" });
+      operationFailed(res, err, "learned-skills/create", "create_failed");
     }
   });
 
@@ -158,8 +156,7 @@ export function createLearnedSkillsRouter(deps: LearnedSkillsRouterDeps): Router
       await deps.learnedSkillRepo.delete(id);
       res.status(204).send();
     } catch (err) {
-      console.error("[learned-skills/delete]", err);
-      res.status(500).json({ error: "delete_failed" });
+      operationFailed(res, err, "learned-skills/delete", "delete_failed");
     }
   });
 

--- a/packages/api/src/routes/mcp.ts
+++ b/packages/api/src/routes/mcp.ts
@@ -24,7 +24,7 @@ import type {
   WorkProductRepository,
 } from "@beevibe/core";
 import type { Pool } from "@beevibe/core/adapters/postgres";
-import { sessionId as makeBeevibeSid } from "@beevibe/core";
+import { errorMessage, sessionId as makeBeevibeSid } from "@beevibe/core";
 import type { TaskService } from "@beevibe/core/services/task-service";
 import type { EscalationService } from "@beevibe/core/services/escalation-service";
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
@@ -362,7 +362,7 @@ function registerToolsOnServer(server: McpLowLevelServer, tools: AgentTool[]): v
         isError: result.isError ?? false,
       };
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = errorMessage(err);
       return {
         content: [{ type: "text" as const, text: JSON.stringify({ error: message }) }],
         isError: true,

--- a/packages/api/src/routes/negotiation.ts
+++ b/packages/api/src/routes/negotiation.ts
@@ -9,6 +9,7 @@
  */
 
 import { Router, type RequestHandler } from "express";
+import { errorMessage } from "@beevibe/core";
 import {
   type NegotiationService,
   NegotiationNotFoundError,
@@ -40,7 +41,7 @@ export function createNegotiationRouter(deps: NegotiationRoutesDeps): Router {
       console.error("[negotiation route]", err);
       res.status(500).json({
         error: "internal_error",
-        message: err instanceof Error ? err.message : String(err),
+        message: errorMessage(err),
       });
     }
   });

--- a/packages/api/src/routes/repo-runs.ts
+++ b/packages/api/src/routes/repo-runs.ts
@@ -19,7 +19,7 @@ import type {
   SessionEventRepository,
 } from "@beevibe/core";
 import { requireHuman } from "../auth/middleware.js";
-import { requireParam } from "./http-errors.js";
+import { operationFailed, requireParam } from "./http-errors.js";
 
 export interface RepoRunsRouterDeps {
   authMiddleware: RequestHandler;
@@ -67,8 +67,7 @@ export function createRepoRunsRouter(deps: RepoRunsRouterDeps): Router {
       const runs = await deps.repoRunRepo.listRecent({ limit: 50 });
       res.status(200).json({ runs });
     } catch (err) {
-      console.error("[repo-runs/list]", err);
-      res.status(500).json({ error: "list_failed" });
+      operationFailed(res, err, "repo-runs/list", "list_failed");
     }
   });
 
@@ -101,8 +100,7 @@ export function createRepoRunsRouter(deps: RepoRunsRouterDeps): Router {
       }
       res.status(200).json({ run: { ...run, transcript } });
     } catch (err) {
-      console.error("[repo-runs/get]", err);
-      res.status(500).json({ error: "get_failed" });
+      operationFailed(res, err, "repo-runs/get", "get_failed");
     }
   });
 
@@ -133,8 +131,7 @@ export function createRepoRunsRouter(deps: RepoRunsRouterDeps): Router {
       });
       res.status(200).json({ run: updated });
     } catch (err) {
-      console.error("[repo-runs/cancel]", err);
-      res.status(500).json({ error: "cancel_failed" });
+      operationFailed(res, err, "repo-runs/cancel", "cancel_failed");
     }
   });
 
@@ -187,8 +184,7 @@ export function createRepoRunsRouter(deps: RepoRunsRouterDeps): Router {
         task_id: run.task_id,
       });
     } catch (err) {
-      console.error("[repo-runs/artifact]", err);
-      res.status(500).json({ error: "artifact_failed" });
+      operationFailed(res, err, "repo-runs/artifact", "artifact_failed");
     }
   });
 

--- a/packages/api/src/routes/task.ts
+++ b/packages/api/src/routes/task.ts
@@ -19,6 +19,7 @@
 import { Router, type RequestHandler, type Response } from "express";
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import {
+  errorMessage,
   TASK_PRIORITIES,
   isInFlightSessionStatus,
   taskId,
@@ -111,7 +112,7 @@ async function recordCapabilityOutcome(
     }
   } catch (err) {
     // Outcome recording is best-effort — don't fail the review action.
-    console.warn("[task route] capability outcome recording failed:", err instanceof Error ? err.message : String(err));
+    console.warn("[task route] capability outcome recording failed:", errorMessage(err));
   }
 }
 
@@ -127,7 +128,7 @@ function handleServiceError(err: unknown, res: Response): void {
   console.error("[task route]", err);
   res.status(500).json({
     error: "internal_error",
-    message: err instanceof Error ? err.message : String(err),
+    message: errorMessage(err),
   });
 }
 

--- a/packages/api/src/runtime/hub.ts
+++ b/packages/api/src/runtime/hub.ts
@@ -16,7 +16,7 @@
  *     10 concern (pg_notify('runtime_wakeup', json) + per-instance hubs).
  */
 
-import { RUNTIME_HEARTBEAT_INTERVAL_MS } from "@beevibe/core";
+import { errorMessage, RUNTIME_HEARTBEAT_INTERVAL_MS } from "@beevibe/core";
 
 export type DaemonPushPayload =
   | { type: "task_available"; runtime_id: string; session_id: string }
@@ -187,7 +187,7 @@ export class DaemonHub {
     } catch (err) {
       console.warn("[hub] send failed; unregistering client", {
         daemonId: client.daemonId,
-        err: err instanceof Error ? err.message : String(err),
+        err: errorMessage(err),
       });
       this.unregister(client);
     }

--- a/packages/api/src/runtime/router.ts
+++ b/packages/api/src/runtime/router.ts
@@ -3,6 +3,7 @@ import { promises as fs } from "node:fs";
 import { join, relative } from "node:path";
 import { Router, type RequestHandler } from "express";
 import {
+  errorMessage,
   daemonId as newDaemonId,
   runtimeId as newRuntimeId,
   sessionEventId as newSessionEventId,
@@ -315,10 +316,7 @@ export function createRuntimeRouter(deps: RuntimeRouterDeps): Router {
             ended_at: new Date(),
           });
         } catch (err) {
-          console.warn(
-            "[runtime/done] repo_run update failed:",
-            err instanceof Error ? err.message : String(err),
-          );
+          console.warn("[runtime/done] repo_run update failed:", errorMessage(err));
         }
 
         // Write one work_product per exported artifact, attached to the
@@ -346,7 +344,7 @@ export function createRuntimeRouter(deps: RuntimeRouterDeps): Router {
             } catch (err) {
               console.warn(
                 `[runtime/done] work_product create failed for ${artifact.filename}:`,
-                err instanceof Error ? err.message : String(err),
+                errorMessage(err),
               );
             }
           }
@@ -360,10 +358,7 @@ export function createRuntimeRouter(deps: RuntimeRouterDeps): Router {
         // Fire-and-forget; resolver/post-dispatch errors must not fail the
         // daemon's request.
         Promise.resolve(deps.onSessionComplete(updated)).catch((err: unknown) =>
-          console.warn(
-            "[runtime/done] onSessionComplete failed:",
-            err instanceof Error ? err.message : String(err),
-          ),
+          console.warn("[runtime/done] onSessionComplete failed:", errorMessage(err)),
         );
       }
       res.status(204).send();
@@ -565,10 +560,7 @@ async function composeDispatchPayload(
   try {
     await deps.sessionRepo.update(session.id, { briefing: briefing.snapshot });
   } catch (err) {
-    console.warn(
-      "[runtime/claim] briefing snapshot persist failed:",
-      err instanceof Error ? err.message : String(err),
-    );
+    console.warn("[runtime/claim] briefing snapshot persist failed:", errorMessage(err));
   }
 
   // Capability Network: run_repo dispatches carry the orchestrator
@@ -595,10 +587,7 @@ async function composeDispatchPayload(
     try {
       await deps.repoRunRepo.update(repoRun.id, { status: "running" });
     } catch (err) {
-      console.warn(
-        "[runtime/claim] repo_run status flip failed:",
-        err instanceof Error ? err.message : String(err),
-      );
+      console.warn("[runtime/claim] repo_run status flip failed:", errorMessage(err));
     }
   }
 

--- a/packages/api/src/runtime/ws-server.ts
+++ b/packages/api/src/runtime/ws-server.ts
@@ -17,6 +17,7 @@ import { WebSocket, WebSocketServer } from "ws";
 import type { LookupApiKeyDeps } from "@beevibe/core/auth";
 import { lookupApiKey } from "@beevibe/core/auth";
 import type { RuntimeRepository, SessionRepository } from "@beevibe/core";
+import { errorMessage } from "@beevibe/core";
 import type { DaemonClient, DaemonHub, DaemonPushPayload } from "./hub.js";
 
 export const RUNTIME_WS_PATH = "/runtime/ws";
@@ -195,7 +196,7 @@ export class RuntimeWsServer {
       }
     } catch (err) {
       console.warn("[runtime/ws] replay-pending failed", {
-        err: err instanceof Error ? err.message : String(err),
+        err: errorMessage(err),
       });
     }
   }
@@ -208,7 +209,7 @@ export class RuntimeWsServer {
         } catch (err) {
           console.warn("[runtime/ws] heartbeat on connect failed", {
             runtimeId: rid,
-            err: err instanceof Error ? err.message : String(err),
+            err: errorMessage(err),
           });
         }
       }),

--- a/packages/api/src/tools/errors.test.ts
+++ b/packages/api/src/tools/errors.test.ts
@@ -4,7 +4,7 @@ import {
   MeshCapacityError,
   MeshMaxRoundsError,
 } from "../mesh/types.js";
-import { toolError, toolErrorFromThrown } from "./errors.js";
+import { toolError, toolErrorFromThrown, toolFailure } from "./errors.js";
 
 describe("toolError", () => {
   it("puts the code in `error` and the human text in `message`", () => {
@@ -17,6 +17,22 @@ describe("toolError", () => {
   it("merges structured context alongside code and message", () => {
     expect(toolError("watch_validation", "bad mode", { mode: "nope" })).toEqual({
       content: { error: "watch_validation", message: "bad mode", mode: "nope" },
+      isError: true,
+    });
+  });
+});
+
+describe("toolFailure", () => {
+  it("puts the whole string in `error`, with no `message` alongside", () => {
+    expect(toolFailure("task_id and title required")).toEqual({
+      content: { error: "task_id and title required" },
+      isError: true,
+    });
+  });
+
+  it("merges structured context alongside it", () => {
+    expect(toolFailure("task_not_found", { task_id: "task_1" })).toEqual({
+      content: { error: "task_not_found", task_id: "task_1" },
       isError: true,
     });
   });

--- a/packages/api/src/tools/errors.ts
+++ b/packages/api/src/tools/errors.ts
@@ -17,6 +17,7 @@
  * branch on `error` for the coded tools.
  */
 
+import { errorMessage } from "@beevibe/core";
 import { CodedMeshError } from "../mesh/types.js";
 import type { AgentToolResult } from "./types.js";
 
@@ -53,7 +54,7 @@ export function toolErrorFromThrown(
   }
   return {
     content: {
-      error: err instanceof Error ? err.message : String(err),
+      error: errorMessage(err),
       ...extra,
     },
     isError: true,

--- a/packages/api/src/tools/errors.ts
+++ b/packages/api/src/tools/errors.ts
@@ -8,13 +8,21 @@
  *   - `{ error: <code>, message: <human text> }` — a known, named
  *     failure the calling agent can branch on. `watch.ts` had this as a
  *     private `errResult`; most other modules wrote the literal inline.
- *   - `{ error: <message> }` — the catch-all for an unexpected throw.
+ *     {@link toolError}.
+ *   - `{ error: <message> }` — the catch-all for an unexpected throw,
+ *     and the shape the argument guards answer with.
  *     `mesh.ts` and `hierarchy.ts` each had a private `asError` for it.
+ *     {@link toolFailure} / {@link toolErrorFromThrown}.
  *
  * Note the catch-all puts the human message in `error`, where the coded
  * shape puts a stable code there. That is the existing wire contract on
  * both paths, preserved here rather than harmonized — agents already
  * branch on `error` for the coded tools.
+ *
+ * These two builders are the only way the tool modules should construct
+ * a failure. Fifty-six inline copies of the literal came before them,
+ * and an inline copy is one `isError: true` away from an MCP result that
+ * reads as success.
  */
 
 import { errorMessage } from "@beevibe/core";
@@ -32,6 +40,28 @@ export function toolError(
   extra: Record<string, unknown> = {},
 ): AgentToolResult {
   return { content: { error: code, message, ...extra }, isError: true };
+}
+
+/**
+ * The single-field failure: whatever string you pass lands in `error`,
+ * with no `message` alongside it. Same wire shape
+ * {@link toolErrorFromThrown} produces for an unexpected throw.
+ *
+ * This is the envelope the argument-validation guards in `hierarchy.ts`
+ * and `mesh.ts` use — about thirty copies of the same four-line object
+ * literal, written inline. What goes in that one field is not uniform
+ * (most sites pass prose like `"task_id and title required"`, a couple
+ * pass a bare code like `"task_not_found"`), and both are already on the
+ * wire, so this factors out the shape and leaves the convention alone.
+ *
+ * Prefer {@link toolError} for anything new that a caller might branch
+ * on. Reach for this one to match a call site that is already uncoded.
+ */
+export function toolFailure(
+  message: string,
+  extra: Record<string, unknown> = {},
+): AgentToolResult {
+  return { content: { error: message, ...extra }, isError: true };
 }
 
 /**

--- a/packages/api/src/tools/find-repo.ts
+++ b/packages/api/src/tools/find-repo.ts
@@ -39,6 +39,7 @@ import type {
   EmbeddingService,
   LearnedSkillRepository,
 } from "@beevibe/core";
+import { errorMessage } from "@beevibe/core";
 import type { AgentTool, AgentToolResult } from "./types.js";
 
 /**
@@ -340,7 +341,7 @@ async function findRepoHandler(
   try {
     goalVec = await services.embeddings.embed(goal);
   } catch (err) {
-    notes.push(`embedding goal failed (semantic tiers skipped): ${errMsg(err)}`);
+    notes.push(`embedding goal failed (semantic tiers skipped): ${errorMessage(err)}`);
   }
 
   // ── Tier 2: Local learned skills (highest priority signal) ────────
@@ -364,7 +365,7 @@ async function findRepoHandler(
       };
     }
   } catch (err) {
-    notes.push(`learned skill lookup failed: ${errMsg(err)}`);
+    notes.push(`learned skill lookup failed: ${errorMessage(err)}`);
   }
 
   // ── Tier 1: Community registry (best-effort, may 404) ─────────────
@@ -390,7 +391,7 @@ async function findRepoHandler(
         notes.push("community registry unavailable (proceeding without Tier 1)");
       }
     } catch (err) {
-      notes.push(`community registry error: ${errMsg(err)}`);
+      notes.push(`community registry error: ${errorMessage(err)}`);
     }
   }
 
@@ -423,7 +424,7 @@ async function findRepoHandler(
       }
     }
   } catch (err) {
-    notes.push(`GitHub search failed: ${errMsg(err)}`);
+    notes.push(`GitHub search failed: ${errorMessage(err)}`);
   }
 
   // ── Tier 5: GitHub trending (snapshot lookup, no per-candidate I/O) ─
@@ -480,7 +481,7 @@ async function findRepoHandler(
         if (entry.language) c.language = entry.language;
       }
     } catch (err) {
-      notes.push(`trending lookup failed: ${errMsg(err)}`);
+      notes.push(`trending lookup failed: ${errorMessage(err)}`);
     }
   }
 
@@ -698,10 +699,6 @@ function formatReason(c: FindRepoCandidate): string {
     parts.push(`${c.stars.toLocaleString()} stars on GitHub`);
   }
   return parts.join("; ") || "no signal";
-}
-
-function errMsg(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
 }
 
 /* ─── GitHub search ──────────────────────────────────────────────── */

--- a/packages/api/src/tools/find-repo.ts
+++ b/packages/api/src/tools/find-repo.ts
@@ -40,6 +40,8 @@ import type {
   LearnedSkillRepository,
 } from "@beevibe/core";
 import { errorMessage } from "@beevibe/core";
+import { toolError } from "./errors.js";
+import { optionalNumber, optionalString } from "./input.js";
 import type { AgentTool, AgentToolResult } from "./types.js";
 
 /**
@@ -311,23 +313,17 @@ async function findRepoHandler(
   trending: TrendingClient,
   githubToken: string | undefined,
 ): Promise<AgentToolResult> {
-  const goal = typeof input.goal === "string" ? input.goal.trim() : "";
+  const goal = optionalString(input, "goal", { trim: true }) ?? "";
   if (!goal) {
-    return {
-      content: { error: "invalid_goal", message: "goal must be a non-empty string" },
-      isError: true,
-    };
+    return toolError("invalid_goal", "goal must be a non-empty string");
   }
-  const limitRaw = typeof input.limit === "number" ? input.limit : 5;
+  const limitRaw = optionalNumber(input, "limit", 5);
   const limit = Math.min(10, Math.max(1, Math.floor(limitRaw)));
 
   // Resolve the agent's owner so we can scope learned-skill lookups.
   const agent = await services.agentRepo.findById(ctx.agentId);
   if (!agent) {
-    return {
-      content: { error: "agent_not_found", message: "calling agent not found" },
-      isError: true,
-    };
+    return toolError("agent_not_found", "calling agent not found");
   }
 
   const notes: string[] = [];

--- a/packages/api/src/tools/hierarchy.ts
+++ b/packages/api/src/tools/hierarchy.ts
@@ -52,7 +52,15 @@ import {
   buildIntent,
   type ResumeReason,
 } from "@beevibe/core/services/agent-session";
-import { toolErrorFromThrown } from "./errors.js";
+import { toolError, toolErrorFromThrown, toolFailure } from "./errors.js";
+import {
+  coerceString,
+  enumArg,
+  nonEmptyString,
+  oneOfMessage,
+  optionalObject,
+  optionalString,
+} from "./input.js";
 import type { AgentTool } from "./types.js";
 
 // ── Agent-callable status subsets ─────────────────────────────────────────
@@ -69,7 +77,6 @@ import type { AgentTool } from "./types.js";
 // platform-internal transition, not something the agent declared.
 
 const AGENT_END_STATUSES = ["done", "failed", "blocked"] as const satisfies readonly TaskStatus[];
-type AgentEndStatus = (typeof AGENT_END_STATUSES)[number];
 
 // ── Shared services + context ────────────────────────────────────────────
 
@@ -158,6 +165,26 @@ function projectTask(task: Task | undefined): Record<string, unknown> | null {
   };
 }
 
+/**
+ * The six work-product fields an agent may set, read off a tool input.
+ *
+ * `create_work_product` and `update_work_product` disagree about the
+ * identity fields (create mints them, update refuses to touch them) but
+ * take exactly the same mutable set, and each had spelled it out —
+ * six near-identical `typeof` ternaries, twice. Two copies of a field
+ * list is how a field ends up settable on create and not on update.
+ */
+function mutableWorkProductFields(input: Record<string, unknown>) {
+  return {
+    summary: optionalString(input, "summary"),
+    body: optionalString(input, "body"),
+    url: optionalString(input, "url"),
+    provider: optionalString(input, "provider"),
+    external_id: optionalString(input, "external_id"),
+    metadata: optionalObject(input, "metadata"),
+  };
+}
+
 // ── Shared (IC + team) tools ─────────────────────────────────────────────
 
 function searchContextTool(
@@ -187,9 +214,9 @@ function searchContextTool(
     },
     handler: async (input) => {
       try {
-        const query = String(input.query ?? "").trim();
+        const query = coerceString(input, "query", { trim: true });
         if (!query) {
-          return { content: { error: "query must be a non-empty string" }, isError: true };
+          return toolFailure("query must be a non-empty string");
         }
         const archival = await services.memoryAgent.searchArchival(query);
         return { content: { archival } };
@@ -236,16 +263,11 @@ function updateProgressTool(
     },
     handler: async (input) => {
       try {
-        const taskId = String(input.task_id ?? "");
-        const status = input.status as AgentEndStatus;
-        const summary = String(input.summary ?? "");
-        if (!AGENT_END_STATUSES.includes(status)) {
-          return {
-            content: {
-              error: `status must be one of: ${AGENT_END_STATUSES.join(", ")}`,
-            },
-            isError: true,
-          };
+        const taskId = coerceString(input, "task_id");
+        const status = enumArg(input, "status", AGENT_END_STATUSES);
+        const summary = coerceString(input, "summary");
+        if (!status) {
+          return toolFailure(oneOfMessage("status", AGENT_END_STATUSES));
         }
         const updated = await services.taskService.updateProgress(taskId, status, summary);
         return {
@@ -303,8 +325,8 @@ function getAgentProfileTool(
     },
     handler: async (input) => {
       try {
-        const id = String(input.agent_id ?? "");
-        if (!id) return { content: { error: "agent_id required" }, isError: true };
+        const id = coerceString(input, "agent_id");
+        if (!id) return toolFailure("agent_id required");
         const agent = await services.agentRepo.findById(id);
         return { content: { agent: projectAgent(agent) } };
       } catch (err) {
@@ -333,8 +355,8 @@ function getTaskTool(
     },
     handler: async (input) => {
       try {
-        const id = String(input.task_id ?? "");
-        if (!id) return { content: { error: "task_id required" }, isError: true };
+        const id = coerceString(input, "task_id");
+        if (!id) return toolFailure("task_id required");
         const task = await services.taskRepo.findById(id);
         return { content: { task: projectTask(task) } };
       } catch (err) {
@@ -383,36 +405,22 @@ function createWorkProductTool(
     },
     handler: async (input) => {
       try {
-        const taskId = String(input.task_id ?? "");
-        const type = input.type;
-        const title = String(input.title ?? "");
+        const taskId = coerceString(input, "task_id");
+        const type = enumArg(input, "type", WORK_PRODUCT_TYPES);
+        const title = coerceString(input, "title");
         if (!taskId || !title) {
-          return {
-            content: { error: "task_id and title required" },
-            isError: true,
-          };
+          return toolFailure("task_id and title required");
         }
-        if (!WORK_PRODUCT_TYPES.includes(type as (typeof WORK_PRODUCT_TYPES)[number])) {
-          return {
-            content: { error: `type must be one of: ${WORK_PRODUCT_TYPES.join(", ")}` },
-            isError: true,
-          };
+        if (!type) {
+          return toolFailure(oneOfMessage("type", WORK_PRODUCT_TYPES));
         }
         const wp = await services.taskService.createWorkProduct({
           id: makeWorkProductId(),
           task_id: taskId,
           agent_id: ctx.agentId,
-          type: type as (typeof WORK_PRODUCT_TYPES)[number],
+          type,
           title,
-          summary: typeof input.summary === "string" ? input.summary : undefined,
-          body: typeof input.body === "string" ? input.body : undefined,
-          url: typeof input.url === "string" ? input.url : undefined,
-          provider: typeof input.provider === "string" ? input.provider : undefined,
-          external_id: typeof input.external_id === "string" ? input.external_id : undefined,
-          metadata:
-            input.metadata && typeof input.metadata === "object"
-              ? (input.metadata as Record<string, unknown>)
-              : undefined,
+          ...mutableWorkProductFields(input),
         });
         return {
           content: {
@@ -447,8 +455,8 @@ function listWorkProductsTool(
     },
     handler: async (input) => {
       try {
-        const taskId = String(input.task_id ?? "");
-        if (!taskId) return { content: { error: "task_id required" }, isError: true };
+        const taskId = coerceString(input, "task_id");
+        if (!taskId) return toolFailure("task_id required");
         const wps = await services.taskService.listWorkProducts(taskId);
         return {
           content: {
@@ -491,11 +499,11 @@ function getWorkProductTool(
     },
     handler: async (input) => {
       try {
-        const id = String(input.id ?? "");
-        if (!id) return { content: { error: "id required" }, isError: true };
+        const id = coerceString(input, "id");
+        if (!id) return toolFailure("id required");
         const wp = await services.taskService.getWorkProduct(id);
         if (!wp) {
-          return { content: { error: `work_product ${id} not found` }, isError: true };
+          return toolFailure(`work_product ${id} not found`);
         }
         return {
           content: {
@@ -550,20 +558,12 @@ function updateWorkProductTool(
     },
     handler: async (input) => {
       try {
-        const id = String(input.id ?? "");
-        if (!id) return { content: { error: "id required" }, isError: true };
-        const updated = await services.taskService.updateWorkProduct(id, {
-          summary: typeof input.summary === "string" ? input.summary : undefined,
-          body: typeof input.body === "string" ? input.body : undefined,
-          url: typeof input.url === "string" ? input.url : undefined,
-          provider: typeof input.provider === "string" ? input.provider : undefined,
-          external_id:
-            typeof input.external_id === "string" ? input.external_id : undefined,
-          metadata:
-            input.metadata && typeof input.metadata === "object"
-              ? (input.metadata as Record<string, unknown>)
-              : undefined,
-        });
+        const id = coerceString(input, "id");
+        if (!id) return toolFailure("id required");
+        const updated = await services.taskService.updateWorkProduct(
+          id,
+          mutableWorkProductFields(input),
+        );
         return {
           content: {
             updated: {
@@ -673,48 +673,39 @@ function createTaskTool(
     },
     handler: async (input) => {
       try {
-        const intent = String(input.intent ?? "");
-        const targetId = String(input.agent_id ?? "");
+        const intent = coerceString(input, "intent");
+        const targetId = coerceString(input, "agent_id");
         if (!intent || !targetId) {
-          return {
-            content: { error: "intent and agent_id required" },
-            isError: true,
-          };
+          return toolFailure("intent and agent_id required");
         }
 
         // Authz: assignee must be one of caller's subordinates.
         const subs = await services.agentRepo.findSubordinates(ctx.agentId);
         if (!subs.some((s) => s.id === targetId)) {
-          return {
-            content: {
-              error: "not_subordinate",
-              message: `Cannot assign tasks to ${targetId} — not a direct subordinate of ${ctx.agentId}.`,
-            },
-            isError: true,
-          };
+          return toolError(
+            "not_subordinate",
+            `Cannot assign tasks to ${targetId} — not a direct subordinate of ${ctx.agentId}.`,
+          );
         }
 
         const priority = (input.priority as (typeof TASK_PRIORITIES)[number]) ?? "medium";
         if (!TASK_PRIORITIES.includes(priority)) {
-          return {
-            content: { error: `priority must be one of: ${TASK_PRIORITIES.join(", ")}` },
-            isError: true,
-          };
+          return toolFailure(`priority must be one of: ${TASK_PRIORITIES.join(", ")}`);
         }
 
         const created = await services.taskRepo.create({
           id: makeTaskId(),
           title: intent,
-          description: typeof input.description === "string" ? input.description : undefined,
+          description: optionalString(input, "description"),
           status: "assigned",
           priority,
           assignee_id: targetId,
           creator_id: ctx.agentId,
           creator_type: "agent",
           parent_task_id:
-            typeof input.parent_task_id === "string" ? input.parent_task_id : undefined,
+            optionalString(input, "parent_task_id"),
           repo_url:
-            typeof input.repo_url === "string" && input.repo_url ? input.repo_url : undefined,
+            nonEmptyString(input, "repo_url"),
         });
 
         // Dispatch creates the pending session row + advances task →
@@ -780,20 +771,17 @@ function checkWorkStatusTool(
     },
     handler: async (input) => {
       try {
-        const targetId = String(input.agent_id ?? "");
-        if (!targetId) return { content: { error: "agent_id required" }, isError: true };
+        const targetId = coerceString(input, "agent_id");
+        if (!targetId) return toolFailure("agent_id required");
 
         // Authz: self or direct subordinate.
         if (targetId !== ctx.agentId) {
           const subs = await services.agentRepo.findSubordinates(ctx.agentId);
           if (!subs.some((s) => s.id === targetId)) {
-            return {
-              content: {
-                error: "unauthorized",
-                message: `Can only check work status for self or a direct subordinate.`,
-              },
-              isError: true,
-            };
+            return toolError(
+              "unauthorized",
+              "Can only check work status for self or a direct subordinate.",
+            );
           }
         }
 
@@ -852,36 +840,30 @@ function reviseTaskTool(
     },
     handler: async (input) => {
       try {
-        const taskId = String(input.task_id ?? "");
-        const feedback = String(input.feedback ?? "");
+        const taskId = coerceString(input, "task_id");
+        const feedback = coerceString(input, "feedback");
         if (!taskId || !feedback) {
-          return { content: { error: "task_id and feedback required" }, isError: true };
+          return toolFailure("task_id and feedback required");
         }
 
         const task = await services.taskRepo.findById(taskId);
         if (!task) {
-          return { content: { error: "task_not_found", task_id: taskId }, isError: true };
+          return toolFailure("task_not_found", { task_id: taskId });
         }
         if (!task.assignee_id) {
-          return {
-            content: { error: "task_unassigned", message: "task has no assignee" },
-            isError: true,
-          };
+          return toolError("task_unassigned", "task has no assignee");
         }
 
         // Authz: caller must be the assignee's direct parent.
         const assignee = await services.agentRepo.findById(task.assignee_id);
         if (!assignee) {
-          return { content: { error: "assignee_not_found" }, isError: true };
+          return toolFailure("assignee_not_found");
         }
         if (assignee.parent_agent_id !== ctx.agentId) {
-          return {
-            content: {
-              error: "not_parent",
-              message: `caller ${ctx.agentId} is not the parent of task assignee ${task.assignee_id}`,
-            },
-            isError: true,
-          };
+          return toolError(
+            "not_parent",
+            `caller ${ctx.agentId} is not the parent of task assignee ${task.assignee_id}`,
+          );
         }
 
         const updated = await services.taskService.reviseTask(taskId, feedback, {
@@ -921,7 +903,7 @@ function reviseTaskTool(
         };
       } catch (err) {
         if (err instanceof InvalidTaskTransitionError) {
-          return { content: { error: "invalid_transition", message: err.message }, isError: true };
+          return toolError("invalid_transition", err.message);
         }
         return toolErrorFromThrown(err);
       }
@@ -974,9 +956,9 @@ function addToEscalationTool(
     },
     handler: async (input) => {
       try {
-        const escalationId = String(input.escalation_id ?? "");
+        const escalationId = coerceString(input, "escalation_id");
         if (!escalationId) {
-          return { content: { error: "escalation_id required" }, isError: true };
+          return toolFailure("escalation_id required");
         }
         const proposals = Array.isArray(input.proposals)
           ? (input.proposals as Array<{ title: string; description: string; tradeoffs?: string }>)
@@ -1134,60 +1116,42 @@ function createSubordinateAgentTool(
     handler: async (input) => {
       try {
         if (ctx.hierarchyLevel === "ic") {
-          return {
-            content: {
-              error: "ic_cannot_spawn",
-              message:
-                "Only team/org agents can spawn subordinates; you are an IC.",
-            },
-            isError: true,
-          };
+          return toolError(
+            "ic_cannot_spawn",
+            "Only team/org agents can spawn subordinates; you are an IC.",
+          );
         }
 
-        const name = String(input.name ?? "").trim();
-        const tagLine = String(input.tag_line ?? "").trim();
-        const persona = String(input.persona ?? "").trim();
-        const domain = String(input.domain ?? "").trim();
-        const activeContext = String(input.active_context ?? "").trim();
-        const constraints = String(input.constraints ?? "").trim();
+        const name = coerceString(input, "name", { trim: true });
+        const tagLine = coerceString(input, "tag_line", { trim: true });
+        const persona = coerceString(input, "persona", { trim: true });
+        const domain = coerceString(input, "domain", { trim: true });
+        const activeContext = coerceString(input, "active_context", { trim: true });
+        const constraints = coerceString(input, "constraints", { trim: true });
         if (!name || !tagLine || !persona || !domain) {
-          return {
-            content: {
-              error: "missing_required_fields",
-              message: "name, tag_line, persona, and domain are all required",
-            },
-            isError: true,
-          };
+          return toolError(
+            "missing_required_fields",
+            "name, tag_line, persona, and domain are all required",
+          );
         }
         // Soft-enforce the tag_line limit so the UI's agent card line stays
         // legible. Hard limit is the column char_limit.
         if (tagLine.length > 100) {
-          return {
-            content: {
-              error: "tag_line_too_long",
-              message: "tag_line must be ≤100 chars",
-              actual: tagLine.length,
-            },
-            isError: true,
-          };
+          return toolError("tag_line_too_long", "tag_line must be ≤100 chars", {
+            actual: tagLine.length,
+          });
         }
         if (name.length > 80 || PROVISION_NAME_INVALID_RE.test(name)) {
-          return {
-            content: {
-              error: "invalid_name",
-              message: "name must be 1-80 chars and contain no control characters",
-            },
-            isError: true,
-          };
+          return toolError(
+            "invalid_name",
+            "name must be 1-80 chars and contain no control characters",
+          );
         }
 
         // Resolve the parent (caller) so we can inherit owner_id + runtime config.
         const parent = await services.agentRepo.findById(ctx.agentId);
         if (!parent) {
-          return {
-            content: { error: "parent_not_found", agent_id: ctx.agentId },
-            isError: true,
-          };
+          return toolFailure("parent_not_found", { agent_id: ctx.agentId });
         }
 
         // Phase 9 per-parent daily cap. A runaway team agent could
@@ -1198,17 +1162,12 @@ function createSubordinateAgentTool(
           24 * 60 * 60,
         );
         if (recentSpawns >= SUBORDINATE_DAILY_CAP) {
-          return {
-            content: {
-              error: "subordinate_daily_cap",
-              message:
-                `Parent '${parent.name}' has spawned ${recentSpawns} subordinates in the last 24h ` +
-                `(cap: ${SUBORDINATE_DAILY_CAP}). Reuse an existing specialist or wait for the window to expire.`,
-              cap: SUBORDINATE_DAILY_CAP,
-              count: recentSpawns,
-            },
-            isError: true,
-          };
+          return toolError(
+            "subordinate_daily_cap",
+            `Parent '${parent.name}' has spawned ${recentSpawns} subordinates in the last 24h ` +
+              `(cap: ${SUBORDINATE_DAILY_CAP}). Reuse an existing specialist or wait for the window to expire.`,
+            { cap: SUBORDINATE_DAILY_CAP, count: recentSpawns },
+          );
         }
 
         // Inherit the parent's runtime so all the user's agents share the

--- a/packages/api/src/tools/input.test.ts
+++ b/packages/api/src/tools/input.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+  coerceString,
+  enumArg,
+  nonEmptyString,
+  oneOfMessage,
+  optionalNumber,
+  optionalObject,
+  optionalString,
+} from "./input.js";
+
+describe("coerceString", () => {
+  it("reads a string arg back verbatim", () => {
+    expect(coerceString({ task_id: "task_abc" }, "task_id")).toBe("task_abc");
+  });
+
+  it("returns the empty string for a missing or null arg", () => {
+    expect(coerceString({}, "task_id")).toBe("");
+    expect(coerceString({ task_id: null }, "task_id")).toBe("");
+    expect(coerceString({ task_id: undefined }, "task_id")).toBe("");
+  });
+
+  it("coerces a non-string — the contract that separates it from optionalString", () => {
+    expect(coerceString({ limit: 123 }, "limit")).toBe("123");
+    expect(optionalString({ limit: 123 }, "limit")).toBeUndefined();
+  });
+
+  it("trims only when asked", () => {
+    expect(coerceString({ q: "  hi  " }, "q")).toBe("  hi  ");
+    expect(coerceString({ q: "  hi  " }, "q", { trim: true })).toBe("hi");
+  });
+});
+
+describe("optionalString", () => {
+  it("passes an empty string through", () => {
+    expect(optionalString({ url: "" }, "url")).toBe("");
+  });
+
+  it("trims without turning a blank value into undefined", () => {
+    expect(optionalString({ url: "   " }, "url", { trim: true })).toBe("");
+  });
+
+  it("rejects non-strings", () => {
+    expect(optionalString({ url: 5 }, "url")).toBeUndefined();
+    expect(optionalString({ url: null }, "url")).toBeUndefined();
+    expect(optionalString({}, "url")).toBeUndefined();
+  });
+});
+
+describe("nonEmptyString", () => {
+  it("treats an empty string as absent", () => {
+    expect(nonEmptyString({ reason: "" }, "reason")).toBeUndefined();
+  });
+
+  it("treats a whitespace-only value as absent when trimming", () => {
+    expect(nonEmptyString({ reason: "  " }, "reason", { trim: true })).toBeUndefined();
+    // Without trim it is a non-empty string, so it survives.
+    expect(nonEmptyString({ reason: "  " }, "reason")).toBe("  ");
+  });
+
+  it("returns the trimmed value", () => {
+    expect(nonEmptyString({ reason: " late " }, "reason", { trim: true })).toBe("late");
+  });
+});
+
+describe("optionalNumber", () => {
+  it("returns the number when present", () => {
+    expect(optionalNumber({ limit: 7 }, "limit")).toBe(7);
+  });
+
+  it("returns undefined with no fallback, and the fallback when given", () => {
+    expect(optionalNumber({}, "limit")).toBeUndefined();
+    expect(optionalNumber({}, "limit", 5)).toBe(5);
+  });
+
+  it("does not accept a numeric string", () => {
+    expect(optionalNumber({ limit: "7" }, "limit", 5)).toBe(5);
+  });
+});
+
+describe("optionalObject", () => {
+  it("returns a plain object", () => {
+    expect(optionalObject({ metadata: { pr: 12 } }, "metadata")).toEqual({ pr: 12 });
+  });
+
+  it("rejects an array — the case the two hand-written copies let through", () => {
+    expect(optionalObject({ metadata: [] }, "metadata")).toBeUndefined();
+    expect(optionalObject({ metadata: [1, 2] }, "metadata")).toBeUndefined();
+  });
+
+  it("rejects null and non-objects", () => {
+    expect(optionalObject({ metadata: null }, "metadata")).toBeUndefined();
+    expect(optionalObject({ metadata: "x" }, "metadata")).toBeUndefined();
+    expect(optionalObject({}, "metadata")).toBeUndefined();
+  });
+});
+
+describe("enumArg", () => {
+  const ALLOWED = ["done", "failed", "blocked"] as const;
+
+  it("returns a member of the set", () => {
+    expect(enumArg({ status: "failed" }, "status", ALLOWED)).toBe("failed");
+  });
+
+  it("returns undefined for a non-member, a non-string, and an absent arg", () => {
+    expect(enumArg({ status: "shipped" }, "status", ALLOWED)).toBeUndefined();
+    expect(enumArg({ status: 1 }, "status", ALLOWED)).toBeUndefined();
+    expect(enumArg({}, "status", ALLOWED)).toBeUndefined();
+  });
+});
+
+describe("oneOfMessage", () => {
+  it("renders the rejection prose the guards used to build inline", () => {
+    expect(oneOfMessage("status", ["done", "failed"])).toBe(
+      "status must be one of: done, failed",
+    );
+  });
+});

--- a/packages/api/src/tools/input.ts
+++ b/packages/api/src/tools/input.ts
@@ -1,0 +1,144 @@
+/**
+ * Readers for an MCP tool handler's `input` bag.
+ *
+ * A handler receives `Record<string, unknown>` — the JSON the model sent,
+ * unvalidated. The declared `schema` is advertised to the client but
+ * nothing enforces it server-side, so every handler narrows each field by
+ * hand. Across the ten tool modules that came to ~60 copies of four
+ * idioms, most of them one-liners that a reader could name instead.
+ *
+ * The two string readers exist separately because the tree already had
+ * two *different* contracts and quietly merging them would change what a
+ * malformed call does:
+ *
+ *   - {@link coerceString} is `String(input[key] ?? "")` — the form used
+ *     throughout `hierarchy.ts` and `mesh.ts`. A number `123` reads back
+ *     as `"123"`.
+ *   - {@link optionalString} is a `typeof` check — the form used in
+ *     `find-repo.ts`, `use-repo.ts`, `session-search.ts` and `watch.ts`.
+ *     A number reads back as `undefined`.
+ *
+ * Which one a given argument gets is historical rather than considered,
+ * but the difference is observable (a coerced `"123"` reaches the repo
+ * layer as an id; a rejected one 400s at the guard right below), so this
+ * module names both rather than picking a winner. Naming them is the
+ * first step to being able to pick one.
+ */
+
+/**
+ * Coercing read of a required string arg: `String(input[key] ?? "")`.
+ * Absent, `null` and `undefined` all come back as `""`, which is what the
+ * `if (!x) return toolFailure(...)` guard on the next line tests for.
+ *
+ * `trim` mirrors the `.trim()` that several call sites chain on.
+ */
+export function coerceString(
+  input: Record<string, unknown>,
+  key: string,
+  opts: { trim?: boolean } = {},
+): string {
+  const s = String(input[key] ?? "");
+  return opts.trim ? s.trim() : s;
+}
+
+/**
+ * Strict read of an optional string arg: the value when it really is a
+ * string, `undefined` for anything else. Note an empty string passes —
+ * use {@link nonEmptyString} when `""` should read as absent. `trim`
+ * trims the value but does not turn a blank one into `undefined`.
+ */
+export function optionalString(
+  input: Record<string, unknown>,
+  key: string,
+  opts: { trim?: boolean } = {},
+): string | undefined {
+  const v = input[key];
+  if (typeof v !== "string") return undefined;
+  return opts.trim ? v.trim() : v;
+}
+
+/**
+ * Strict read of an optional string arg that must carry something:
+ * `undefined` for a non-string, an empty string, or (with `trim`) a
+ * whitespace-only one. With `trim` the returned value is trimmed.
+ */
+export function nonEmptyString(
+  input: Record<string, unknown>,
+  key: string,
+  opts: { trim?: boolean } = {},
+): string | undefined {
+  const v = input[key];
+  if (typeof v !== "string") return undefined;
+  const s = opts.trim ? v.trim() : v;
+  return s ? s : undefined;
+}
+
+/**
+ * Strict read of an optional number arg. `fallback` covers the call sites
+ * that want a default rather than `undefined`.
+ */
+export function optionalNumber(
+  input: Record<string, unknown>,
+  key: string,
+): number | undefined;
+export function optionalNumber(
+  input: Record<string, unknown>,
+  key: string,
+  fallback: number,
+): number;
+export function optionalNumber(
+  input: Record<string, unknown>,
+  key: string,
+  fallback?: number,
+): number | undefined {
+  const v = input[key];
+  return typeof v === "number" ? v : fallback;
+}
+
+/**
+ * Strict read of an optional JSON-object arg (a `metadata` / `filters`
+ * blob passed straight through to a jsonb column or a service).
+ *
+ * NOTE: arrays are rejected. The two hand-written copies of this — in
+ * `create_work_product` and `update_work_product` — tested only
+ * `typeof v === "object"`, which is *true for arrays*, so a model that
+ * sent `metadata: []` had it cast to `Record<string, unknown>` and
+ * written to the column. That is the one behavior difference in this
+ * module: such a call now stores no metadata instead of storing a lie.
+ */
+export function optionalObject(
+  input: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | undefined {
+  const v = input[key];
+  if (!v || typeof v !== "object" || Array.isArray(v)) return undefined;
+  return v as Record<string, unknown>;
+}
+
+/**
+ * Read an arg that must be one of a fixed set, `undefined` when it isn't.
+ *
+ * Six handlers spelled out the same `input.x as T` cast followed by an
+ * `ALLOWED.includes(x)` guard — the cast being the part worth deleting,
+ * since it asserts exactly what the next line is about to check.
+ *
+ * The rejection message is {@link oneOfMessage}, but building the error
+ * result stays at the call site: three of the six answer with the coded
+ * `toolError(code, message)` envelope and three with the uncoded
+ * `toolFailure(message)` one, and those codes are already on the wire.
+ */
+export function enumArg<T extends string>(
+  input: Record<string, unknown>,
+  key: string,
+  allowed: readonly T[],
+): T | undefined {
+  const v = input[key];
+  return typeof v === "string" && (allowed as readonly string[]).includes(v)
+    ? (v as T)
+    : undefined;
+}
+
+/** The rejection prose every `enumArg` guard reported, in one place. */
+export function oneOfMessage(key: string, allowed: readonly string[]): string {
+  return `${key} must be one of: ${allowed.join(", ")}`;
+}

--- a/packages/api/src/tools/mesh.ts
+++ b/packages/api/src/tools/mesh.ts
@@ -15,7 +15,8 @@ import type {
   CreateEscalationInput,
 } from "@beevibe/core/services/escalation-service";
 import type { Pool } from "@beevibe/core/adapters/postgres";
-import { toolErrorFromThrown } from "./errors.js";
+import { toolError, toolErrorFromThrown, toolFailure } from "./errors.js";
+import { coerceString, enumArg, nonEmptyString, oneOfMessage, optionalString } from "./input.js";
 import type { AgentTool } from "./types.js";
 import type { McpCaller } from "./assemble.js";
 import type { MeshServer } from "../mesh/server.js";
@@ -95,10 +96,10 @@ function askTool(ctx: MeshToolContext, services: MeshToolServices): AgentTool {
     },
     handler: async (input) => {
       try {
-        const target = String(input.target_agent_id ?? "");
-        const question = String(input.question ?? "");
+        const target = coerceString(input, "target_agent_id");
+        const question = coerceString(input, "question");
         if (!target || !question) {
-          return { content: { error: "target_agent_id and question required" }, isError: true };
+          return toolFailure("target_agent_id and question required");
         }
         const requestId = randomUUID();
         const response = await services.mesh.sendAsk(
@@ -133,10 +134,10 @@ function respondAskTool(ctx: MeshToolContext, services: MeshToolServices): Agent
     },
     handler: async (input) => {
       try {
-        const requestId = String(input.request_id ?? "");
-        const answer = String(input.answer ?? "");
+        const requestId = coerceString(input, "request_id");
+        const answer = coerceString(input, "answer");
         if (!requestId || !answer) {
-          return { content: { error: "request_id and answer required" }, isError: true };
+          return toolFailure("request_id and answer required");
         }
         services.mesh.respondAsk(requestId, {
           request_id: requestId,
@@ -178,12 +179,12 @@ function negotiateTool(ctx: MeshToolContext, services: MeshToolServices): AgentT
     },
     handler: async (input) => {
       try {
-        const peerId = String(input.peer_id ?? "");
-        const proposal = String(input.proposal ?? "");
+        const peerId = coerceString(input, "peer_id");
+        const proposal = coerceString(input, "proposal");
         const taskId =
-          typeof input.task_id === "string" && input.task_id ? input.task_id : undefined;
+          nonEmptyString(input, "task_id");
         if (!peerId || !proposal) {
-          return { content: { error: "peer_id and proposal required" }, isError: true };
+          return toolFailure("peer_id and proposal required");
         }
 
         const response = await services.mesh.sendNegotiate(
@@ -228,26 +229,19 @@ function respondNegotiateTool(ctx: MeshToolContext, services: MeshToolServices):
     },
     handler: async (input) => {
       try {
-        const negId = String(input.negotiation_id ?? "");
-        const decision = input.decision as (typeof NEGOTIATE_DECISIONS)[number];
-        const message = String(input.message ?? "");
-        const counter =
-          typeof input.counter_proposal === "string" ? input.counter_proposal : undefined;
+        const negId = coerceString(input, "negotiation_id");
+        const decision = enumArg(input, "decision", NEGOTIATE_DECISIONS);
+        const message = coerceString(input, "message");
+        const counter = optionalString(input, "counter_proposal");
 
         if (!negId || !message) {
-          return { content: { error: "negotiation_id and message required" }, isError: true };
+          return toolFailure("negotiation_id and message required");
         }
-        if (!NEGOTIATE_DECISIONS.includes(decision)) {
-          return {
-            content: { error: `decision must be one of: ${NEGOTIATE_DECISIONS.join(", ")}` },
-            isError: true,
-          };
+        if (!decision) {
+          return toolFailure(oneOfMessage("decision", NEGOTIATE_DECISIONS));
         }
         if (decision === "counter" && !counter) {
-          return {
-            content: { error: "counter_proposal required when decision='counter'" },
-            isError: true,
-          };
+          return toolFailure("counter_proposal required when decision='counter'");
         }
 
         // The server computes the round number internally from
@@ -299,26 +293,20 @@ function reportBlockerTool(ctx: MeshToolContext, services: MeshToolServices): Ag
     },
     handler: async (input) => {
       try {
-        const taskId = String(input.task_id ?? "");
-        const description = String(input.description ?? "");
+        const taskId = coerceString(input, "task_id");
+        const description = coerceString(input, "description");
         if (!taskId || !description) {
-          return {
-            content: { error: "task_id and description required" },
-            isError: true,
-          };
+          return toolFailure("task_id and description required");
         }
 
         // Server derives parent from caller's hierarchy. Direct parent only.
         const parent = await services.agentRepo.findParent(ctx.caller.agentId);
         if (!parent) {
-          return {
-            content: {
-              error: "no_parent_to_block",
-              message:
-                "Top-level agents have no parent to report blockers to. Use escalate_to_humans or update_progress('failed') instead.",
-            },
-            isError: true,
-          };
+          return toolError(
+            "no_parent_to_block",
+            "Top-level agents have no parent to report blockers to. Use " +
+              "escalate_to_humans or update_progress('failed') instead.",
+          );
         }
 
         // Mark the task blocked + record the blocker_agent_id + reason.
@@ -392,10 +380,10 @@ function escalateToHumansTool(
     },
     handler: async (input) => {
       try {
-        const negotiationId = String(input.negotiation_id ?? "");
-        const summary = String(input.summary ?? "");
+        const negotiationId = coerceString(input, "negotiation_id");
+        const summary = coerceString(input, "summary");
         if (!negotiationId || !summary) {
-          return { content: { error: "negotiation_id and summary required" }, isError: true };
+          return toolFailure("negotiation_id and summary required");
         }
 
         const proposals = Array.isArray(input.proposals)

--- a/packages/api/src/tools/save-memory.ts
+++ b/packages/api/src/tools/save-memory.ts
@@ -6,6 +6,8 @@ import {
   type FactType,
   type HierarchyLevel,
 } from "@beevibe/core";
+import { toolError } from "./errors.js";
+import { enumArg, nonEmptyString, oneOfMessage } from "./input.js";
 import type { AgentTool } from "./types.js";
 
 /**
@@ -94,22 +96,13 @@ export function createSaveMemoryTool(
       "The most valuable memory makes the next session start already knowing.",
     schema: SAVE_MEMORY_SCHEMA as Record<string, unknown>,
     handler: async (input) => {
-      const content = input.content;
-      const factType = input.fact_type;
-      if (typeof content !== "string" || !content.trim()) {
-        return {
-          content: { error: "invalid_content", message: "content must be a non-empty string" },
-          isError: true,
-        };
+      const content = nonEmptyString(input, "content", { trim: true });
+      const factType = enumArg(input, "fact_type", FACT_TYPES);
+      if (!content) {
+        return toolError("invalid_content", "content must be a non-empty string");
       }
-      if (typeof factType !== "string" || !FACT_TYPES.includes(factType as FactType)) {
-        return {
-          content: {
-            error: "invalid_fact_type",
-            message: `fact_type must be one of: ${FACT_TYPES.join(", ")}`,
-          },
-          isError: true,
-        };
+      if (!factType) {
+        return toolError("invalid_fact_type", oneOfMessage("fact_type", FACT_TYPES));
       }
       const fact = await services.factStore.addOrMerge(
         ctx.agentId,

--- a/packages/api/src/tools/session-search.ts
+++ b/packages/api/src/tools/session-search.ts
@@ -4,6 +4,8 @@ import {
   SessionSearchService,
 } from "@beevibe/core/services/session-search";
 import { errorMessage, SESSION_TYPES, SESSION_STATUSES } from "@beevibe/core";
+import { toolError } from "./errors.js";
+import { nonEmptyString, optionalNumber } from "./input.js";
 import type { AgentTool } from "./types.js";
 
 /**
@@ -192,23 +194,16 @@ function inferRequest(input: Record<string, unknown>): SessionSearchRequest {
       ? (input.filters as SessionSearchRequest extends { filters?: infer F } ? F : never)
       : undefined;
 
-  const sessionId =
-    typeof input.session_id === "string" && input.session_id.trim()
-      ? input.session_id.trim()
-      : null;
-  const anchor =
-    typeof input.around_message_id === "string" && input.around_message_id.trim()
-      ? input.around_message_id.trim()
-      : null;
-  const query =
-    typeof input.query === "string" && input.query.trim() ? input.query.trim() : null;
+  const sessionId = nonEmptyString(input, "session_id", { trim: true }) ?? null;
+  const anchor = nonEmptyString(input, "around_message_id", { trim: true }) ?? null;
+  const query = nonEmptyString(input, "query", { trim: true }) ?? null;
 
   if (sessionId && anchor) {
     return {
       kind: "scroll",
       session_id: sessionId,
       around_message_id: anchor,
-      window: typeof input.window === "number" ? input.window : undefined,
+      window: optionalNumber(input, "window"),
     };
   }
   if (sessionId) {
@@ -218,7 +213,7 @@ function inferRequest(input: Record<string, unknown>): SessionSearchRequest {
     return {
       kind: "discover",
       query,
-      limit: typeof input.limit === "number" ? input.limit : undefined,
+      limit: optionalNumber(input, "limit"),
       sort:
         input.sort === "newest" || input.sort === "oldest"
           ? input.sort
@@ -228,7 +223,7 @@ function inferRequest(input: Record<string, unknown>): SessionSearchRequest {
   }
   return {
     kind: "browse",
-    limit: typeof input.limit === "number" ? input.limit : undefined,
+    limit: optionalNumber(input, "limit"),
     filters,
   };
 }
@@ -250,15 +245,11 @@ export function createSessionSearchTool(
           currentSessionId: ctx.sessionId,
         });
         if (result === null) {
-          return {
-            content: {
-              error: "not_found_or_forbidden",
-              message:
-                "session_id is not in your scope, the anchor message id does not " +
-                "exist, or the anchor lives in your active conversation.",
-            },
-            isError: true,
-          };
+          return toolError(
+            "not_found_or_forbidden",
+            "session_id is not in your scope, the anchor message id does not " +
+              "exist, or the anchor lives in your active conversation.",
+          );
         }
         return { content: result as unknown as Record<string, unknown> };
       } catch (err) {
@@ -270,18 +261,9 @@ export function createSessionSearchTool(
           (err instanceof Error && err.name === "SessionSearchError");
         if (isSessionSearchError) {
           const e = err as SessionSearchError;
-          return {
-            content: { error: e.code, message: e.message },
-            isError: true,
-          };
+          return toolError(e.code, e.message);
         }
-        return {
-          content: {
-            error: "internal_error",
-            message: errorMessage(err),
-          },
-          isError: true,
-        };
+        return toolError("internal_error", errorMessage(err));
       }
     },
   };

--- a/packages/api/src/tools/session-search.ts
+++ b/packages/api/src/tools/session-search.ts
@@ -3,7 +3,7 @@ import {
   SessionSearchError,
   SessionSearchService,
 } from "@beevibe/core/services/session-search";
-import { SESSION_TYPES, SESSION_STATUSES } from "@beevibe/core";
+import { errorMessage, SESSION_TYPES, SESSION_STATUSES } from "@beevibe/core";
 import type { AgentTool } from "./types.js";
 
 /**
@@ -278,7 +278,7 @@ export function createSessionSearchTool(
         return {
           content: {
             error: "internal_error",
-            message: err instanceof Error ? err.message : String(err),
+            message: errorMessage(err),
           },
           isError: true,
         };

--- a/packages/api/src/tools/update-core-memory.ts
+++ b/packages/api/src/tools/update-core-memory.ts
@@ -1,6 +1,6 @@
 import type { CoreMemory, CoreMemoryOperation } from "@beevibe/core/services/memory";
 import type { HierarchyLevel } from "@beevibe/core";
-import { DEFAULT_BLOCK_TEMPLATES } from "@beevibe/core";
+import { errorMessage, DEFAULT_BLOCK_TEMPLATES } from "@beevibe/core";
 import type { AgentTool } from "./types.js";
 
 const OPERATIONS: readonly CoreMemoryOperation[] = ["append", "replace"];
@@ -254,7 +254,7 @@ export function createUpdateCoreMemoryTool(
         return {
           content: {
             error: "update_failed",
-            message: err instanceof Error ? err.message : String(err),
+            message: errorMessage(err),
           },
           isError: true,
         };

--- a/packages/api/src/tools/update-core-memory.ts
+++ b/packages/api/src/tools/update-core-memory.ts
@@ -1,6 +1,8 @@
 import type { CoreMemory, CoreMemoryOperation } from "@beevibe/core/services/memory";
 import type { HierarchyLevel } from "@beevibe/core";
 import { errorMessage, DEFAULT_BLOCK_TEMPLATES } from "@beevibe/core";
+import { toolError } from "./errors.js";
+import { enumArg, nonEmptyString, oneOfMessage, optionalString } from "./input.js";
 import type { AgentTool } from "./types.js";
 
 const OPERATIONS: readonly CoreMemoryOperation[] = ["append", "replace"];
@@ -190,49 +192,27 @@ export function createUpdateCoreMemoryTool(
       "  # in place.",
     schema: schema as Record<string, unknown>,
     handler: async (input) => {
-      const blockName = input.block_name;
-      const operation = input.operation;
-      const content = input.content;
-      const oldContent = input.old_content;
+      const blockName = optionalString(input, "block_name");
+      const operation = enumArg(input, "operation", OPERATIONS);
+      const content = optionalString(input, "content");
+      const oldContent = nonEmptyString(input, "old_content");
 
-      if (typeof blockName !== "string" || !blockName.trim()) {
-        return {
-          content: { error: "invalid_block_name", message: "block_name must be a non-empty string" },
-          isError: true,
-        };
+      // Blank-check but don't trim: the block name is matched against
+      // `tierBlocks` verbatim below, as it was before.
+      if (!blockName?.trim()) {
+        return toolError("invalid_block_name", "block_name must be a non-empty string");
       }
       if (!tierBlocks.includes(blockName)) {
-        return {
-          content: {
-            error: "unknown_block",
-            message: `block_name must be one of: ${tierBlocks.join(", ")}`,
-          },
-          isError: true,
-        };
+        return toolError("unknown_block", oneOfMessage("block_name", tierBlocks));
       }
-      if (typeof operation !== "string" || !OPERATIONS.includes(operation as CoreMemoryOperation)) {
-        return {
-          content: {
-            error: "invalid_operation",
-            message: `operation must be one of: ${OPERATIONS.join(", ")}`,
-          },
-          isError: true,
-        };
+      if (!operation) {
+        return toolError("invalid_operation", oneOfMessage("operation", OPERATIONS));
       }
-      if (typeof content !== "string") {
-        return {
-          content: { error: "invalid_content", message: "content must be a string" },
-          isError: true,
-        };
+      if (content === undefined) {
+        return toolError("invalid_content", "content must be a string");
       }
-      if (operation === "replace" && (typeof oldContent !== "string" || !oldContent)) {
-        return {
-          content: {
-            error: "missing_old_content",
-            message: "operation='replace' requires old_content",
-          },
-          isError: true,
-        };
+      if (operation === "replace" && oldContent === undefined) {
+        return toolError("missing_old_content", "operation='replace' requires old_content");
       }
 
       try {
@@ -251,13 +231,7 @@ export function createUpdateCoreMemoryTool(
           },
         };
       } catch (err) {
-        return {
-          content: {
-            error: "update_failed",
-            message: errorMessage(err),
-          },
-          isError: true,
-        };
+        return toolError("update_failed", errorMessage(err));
       }
     },
   };

--- a/packages/api/src/tools/use-repo.ts
+++ b/packages/api/src/tools/use-repo.ts
@@ -28,6 +28,8 @@ import {
   type TaskRepository,
 } from "@beevibe/core";
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import { toolError } from "./errors.js";
+import { optionalString } from "./input.js";
 import type { AgentTool } from "./types.js";
 
 const USE_REPO_SCHEMA = {
@@ -123,41 +125,24 @@ export function createUseRepoTool(
       "the UI, or read repo_run.status for completion.",
     schema: USE_REPO_SCHEMA as Record<string, unknown>,
     handler: async (input) => {
-      const goal = typeof input.goal === "string" ? input.goal.trim() : "";
-      const repoUrl =
-        typeof input.repo_url === "string" ? input.repo_url.trim() : "";
+      const goal = optionalString(input, "goal", { trim: true }) ?? "";
+      const repoUrl = optionalString(input, "repo_url", { trim: true }) ?? "";
       if (!goal) {
-        return {
-          content: { error: "invalid_goal", message: "goal must be a non-empty string" },
-          isError: true,
-        };
+        return toolError("invalid_goal", "goal must be a non-empty string");
       }
       if (!repoUrl || !isLikelyGithubUrl(repoUrl)) {
-        return {
-          content: {
-            error: "invalid_repo_url",
-            message: "repo_url must be a GitHub HTTPS URL",
-          },
-          isError: true,
-        };
+        return toolError("invalid_repo_url", "repo_url must be a GitHub HTTPS URL");
       }
 
-      const inputUrl =
-        typeof input.input_url === "string" ? input.input_url.trim() : undefined;
-      const inputFilename =
-        typeof input.input_filename === "string"
-          ? input.input_filename.trim()
-          : undefined;
+      const inputUrl = optionalString(input, "input_url", { trim: true });
+      const inputFilename = optionalString(input, "input_filename", { trim: true });
       const limits = parseLimits(input.limits);
 
       // Look the agent up so we can pin the container task's creator
       // to the actual agent id and confirm the caller exists.
       const agent = await services.agentRepo.findById(ctx.agentId);
       if (!agent) {
-        return {
-          content: { error: "agent_not_found", message: "calling agent not found" },
-          isError: true,
-        };
+        return toolError("agent_not_found", "calling agent not found");
       }
 
       // Container task — the artifact has to live somewhere, and
@@ -196,13 +181,7 @@ export function createUseRepoTool(
           sessionIdOverride: sessionIdValue,
         });
       } catch (err) {
-        return {
-          content: {
-            error: "dispatch_failed",
-            message: errorMessage(err),
-          },
-          isError: true,
-        };
+        return toolError("dispatch_failed", errorMessage(err));
       }
 
       try {
@@ -220,13 +199,7 @@ export function createUseRepoTool(
         // session. composeDispatchPayload will find no repo_run and
         // return null, marking the session failed. Self-recovers, but
         // surface the error so the agent doesn't silently wait.
-        return {
-          content: {
-            error: "repo_run_create_failed",
-            message: errorMessage(err),
-          },
-          isError: true,
-        };
+        return toolError("repo_run_create_failed", errorMessage(err));
       }
 
       return {

--- a/packages/api/src/tools/use-repo.ts
+++ b/packages/api/src/tools/use-repo.ts
@@ -19,6 +19,7 @@
  */
 
 import {
+  errorMessage,
   repoRunId as newRepoRunId,
   sessionId as newSessionId,
   taskId as newTaskId,
@@ -198,7 +199,7 @@ export function createUseRepoTool(
         return {
           content: {
             error: "dispatch_failed",
-            message: err instanceof Error ? err.message : String(err),
+            message: errorMessage(err),
           },
           isError: true,
         };
@@ -222,7 +223,7 @@ export function createUseRepoTool(
         return {
           content: {
             error: "repo_run_create_failed",
-            message: err instanceof Error ? err.message : String(err),
+            message: errorMessage(err),
           },
           isError: true,
         };

--- a/packages/api/src/tools/watch.ts
+++ b/packages/api/src/tools/watch.ts
@@ -18,6 +18,7 @@ import {
   type WatchService,
 } from "@beevibe/core/services/watch-service";
 import { toolError } from "./errors.js";
+import { nonEmptyString, optionalString } from "./input.js";
 import type { AgentTool, AgentToolResult } from "./types.js";
 
 export interface WatchToolContext {
@@ -107,10 +108,7 @@ function buildWatchTasksTool(
           );
         }
         const mode: TaskWatchMode = isMode(input.mode) ? input.mode : "all";
-        const reason =
-          typeof input.reason === "string" && input.reason.trim().length > 0
-            ? input.reason.trim()
-            : undefined;
+        const reason = nonEmptyString(input, "reason", { trim: true });
         if (!ctx.sessionId) {
           return toolError(
             "watch_validation",
@@ -161,8 +159,7 @@ function buildUnwatchTool(
     },
     handler: async (input) => {
       try {
-        const watchId =
-          typeof input.watch_id === "string" ? input.watch_id : "";
+        const watchId = optionalString(input, "watch_id") ?? "";
         if (!watchId) {
           return toolError(
             "watch_validation",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,10 @@
       "types": "./dist/domain/index.d.ts",
       "default": "./dist/domain/index.js"
     },
+    "./domain/errors": {
+      "types": "./dist/domain/errors.d.ts",
+      "default": "./dist/domain/errors.js"
+    },
     "./domain/format": {
       "types": "./dist/domain/format.d.ts",
       "default": "./dist/domain/format.js"

--- a/packages/core/src/domain/errors.test.ts
+++ b/packages/core/src/domain/errors.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { errorMessage } from "./errors.js";
+
+describe("errorMessage", () => {
+  it("returns an Error's message without the class-name prefix", () => {
+    // The distinction from bare String(err), which would yield "Error: boom".
+    expect(errorMessage(new Error("boom"))).toBe("boom");
+  });
+
+  it("keeps the message of an Error subclass", () => {
+    class HttpError extends Error {}
+    expect(errorMessage(new HttpError("404 not found"))).toBe("404 not found");
+  });
+
+  it("stringifies a thrown non-Error", () => {
+    expect(errorMessage("plain string throw")).toBe("plain string throw");
+    expect(errorMessage(42)).toBe("42");
+    expect(errorMessage({ code: "E" })).toBe("[object Object]");
+  });
+
+  it("stringifies null and undefined rather than throwing", () => {
+    expect(errorMessage(undefined)).toBe("undefined");
+    expect(errorMessage(null)).toBe("null");
+  });
+});

--- a/packages/core/src/domain/errors.ts
+++ b/packages/core/src/domain/errors.ts
@@ -1,0 +1,31 @@
+/**
+ * The one place that turns an unknown thrown value into a string.
+ *
+ * `catch (err)` gives back `unknown`, and every layer that wants to log
+ * it, put it on the wire, or store it in a column has to narrow it
+ * first. The narrowing was written out longhand — `err instanceof Error
+ * ? err.message : String(err)` — at 39 call sites across `api`,
+ * `daemon`, `sandbox` and `web`, which made it the most-repeated
+ * expression in the tree. Two packages had already noticed and grown a
+ * private helper for it (`errMsg` in `api/src/tools/find-repo.ts`, the
+ * tail of `describeError` in `web/lib/api/http.ts`).
+ *
+ * `String(err)` alone is not a substitute: on an Error it yields
+ * `"Error: boom"` rather than `"boom"`, so the prefix would leak into
+ * error envelopes and log lines that currently carry only the message.
+ * That asymmetry is exactly why the ternary keeps getting written out.
+ *
+ * Pure and dependency-free, so it is safe anywhere — including modules
+ * that end up in the browser bundle. Reach it via
+ * `@beevibe/core/domain/errors` from a client component, for the same
+ * `node:crypto` reason documented on `domain/format.ts`.
+ */
+
+/**
+ * The human-readable message for a caught value: an `Error`'s `message`,
+ * or the value stringified for anything else (a thrown string, a
+ * rejected non-Error, `undefined` from an aborted promise).
+ */
+export function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -17,5 +17,6 @@ export * from "./repo-run.js";
 export * from "./task-watch.js";
 export * from "./session-search.js";
 export * from "./xml.js";
+export * from "./errors.js";
 export * from "./format.js";
 export * from "./github-url.js";

--- a/packages/daemon/src/claimer.ts
+++ b/packages/daemon/src/claimer.ts
@@ -12,7 +12,7 @@
  */
 
 import WebSocket from "ws";
-import { RUNTIME_HEARTBEAT_INTERVAL_MS, type RuntimeRegistry } from "@beevibe/core";
+import { errorMessage, RUNTIME_HEARTBEAT_INTERVAL_MS, type RuntimeRegistry } from "@beevibe/core";
 import type { LocalWorkspaceManager } from "@beevibe/core/adapters/local-workspace";
 import type { ApiClient } from "./api-client.js";
 import { error, log, warn } from "./logger.js";
@@ -205,10 +205,7 @@ export class Claimer {
         runtime_ids: this.cfg.runtimeIds,
       });
     } catch (err) {
-      warn(
-        "[daemon] heartbeat failed:",
-        err instanceof Error ? err.message : String(err),
-      );
+      warn("[daemon] heartbeat failed:", errorMessage(err));
     }
   }
 
@@ -234,10 +231,7 @@ export class Claimer {
       try {
         payload = await this.cfg.api.claim<DispatchPayload>(runtimeId);
       } catch (err) {
-        warn(
-          `[daemon] claim failed for runtime=${runtimeId}:`,
-          err instanceof Error ? err.message : String(err),
-        );
+        warn(`[daemon] claim failed for runtime=${runtimeId}:`, errorMessage(err));
         return;
       }
       if (!payload) return;
@@ -258,10 +252,7 @@ export class Claimer {
         ctrl.signal,
       )
         .catch((err: unknown) =>
-          error(
-            `[daemon] dispatch ${payload.session_id} failed:`,
-            err instanceof Error ? err.message : String(err),
-          ),
+          error(`[daemon] dispatch ${payload.session_id} failed:`, errorMessage(err)),
         )
         .finally(() => this.cfg.supervisor.finish(payload.session_id));
     }

--- a/packages/daemon/src/config.ts
+++ b/packages/daemon/src/config.ts
@@ -8,6 +8,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { errorMessage } from "@beevibe/core";
 
 export interface DaemonConfig {
   /** Beevibe API base URL (e.g. http://localhost:3000). */
@@ -63,11 +64,7 @@ export function loadConfig(configRoot?: string): DaemonConfig | undefined {
   try {
     return JSON.parse(readFileSync(path, "utf8")) as DaemonConfig;
   } catch (err) {
-    throw new Error(
-      `Daemon config at ${path} is malformed: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-    );
+    throw new Error(`Daemon config at ${path} is malformed: ${errorMessage(err)}`);
   }
 }
 

--- a/packages/daemon/src/event-batcher.ts
+++ b/packages/daemon/src/event-batcher.ts
@@ -18,6 +18,7 @@
  */
 
 import type { SessionEventKind } from "@beevibe/core";
+import { errorMessage } from "@beevibe/core";
 import type { ApiClient } from "./api-client.js";
 import { warn } from "./logger.js";
 
@@ -69,10 +70,7 @@ export function createEventBatcher(opts: {
     try {
       await opts.api.post("/runtime/events", { events });
     } catch (err) {
-      warn(
-        `${opts.tag} /runtime/events POST failed; events dropped:`,
-        err instanceof Error ? err.message : String(err),
-      );
+      warn(`${opts.tag} /runtime/events POST failed; events dropped:`, errorMessage(err));
     }
   };
 

--- a/packages/daemon/src/repo-runs.ts
+++ b/packages/daemon/src/repo-runs.ts
@@ -18,11 +18,11 @@ import type {
   SessionEventKind,
   TerminalSessionStatus,
 } from "@beevibe/core";
-import { errorMessage } from "@beevibe/core";
 import { runRepoAgent, type TranscriptEvent } from "@beevibe/sandbox/orchestrator";
 import type { ApiClient } from "./api-client.js";
 import { createEventBatcher } from "./event-batcher.js";
-import { error, log } from "./logger.js";
+import { reportDone } from "./runtime-done.js";
+import { log } from "./logger.js";
 import type { DispatchPayload, RunRepoArtifact } from "./spawner.js";
 
 export interface RunRepoDeps {
@@ -158,22 +158,11 @@ export async function runRepoDispatch(
     },
   };
 
-  if (status === "succeeded") {
-    log(
-      `[daemon/repo-run] sess=${payload.session_id} succeeded artifacts=${artifacts.length}`,
-    );
-  } else {
-    error(
-      `[daemon/repo-run] sess=${payload.session_id} status=${status}` +
-        (result.error ? `\n  error:\n    ${result.error.split("\n").join("\n    ")}` : ""),
-    );
-  }
-
-  try {
-    await deps.api.post("/runtime/done", done);
-  } catch (err) {
-    error("[daemon/repo-run] /runtime/done POST failed:", errorMessage(err));
-  }
+  await reportDone(deps.api, done, {
+    tag: "daemon/repo-run",
+    succeeded: `succeeded artifacts=${artifacts.length}`,
+    errorDetail: result.error,
+  });
 }
 
 /**

--- a/packages/daemon/src/repo-runs.ts
+++ b/packages/daemon/src/repo-runs.ts
@@ -18,6 +18,7 @@ import type {
   SessionEventKind,
   TerminalSessionStatus,
 } from "@beevibe/core";
+import { errorMessage } from "@beevibe/core";
 import { runRepoAgent, type TranscriptEvent } from "@beevibe/sandbox/orchestrator";
 import type { ApiClient } from "./api-client.js";
 import { createEventBatcher } from "./event-batcher.js";
@@ -171,10 +172,7 @@ export async function runRepoDispatch(
   try {
     await deps.api.post("/runtime/done", done);
   } catch (err) {
-    error(
-      "[daemon/repo-run] /runtime/done POST failed:",
-      err instanceof Error ? err.message : String(err),
-    );
+    error("[daemon/repo-run] /runtime/done POST failed:", errorMessage(err));
   }
 }
 

--- a/packages/daemon/src/runtime-done.test.ts
+++ b/packages/daemon/src/runtime-done.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiClient } from "./api-client.js";
+import { reportDone } from "./runtime-done.js";
+
+function makeApi(post = vi.fn(async () => ({ status: 204, body: undefined }))) {
+  return { api: { post } as unknown as ApiClient, post };
+}
+
+/** Everything the logger passed after its leading timestamp argument. */
+function logged(spy: ReturnType<typeof vi.spyOn>, call = 0): unknown[] {
+  return (spy.mock.calls[call] ?? []).slice(1);
+}
+
+describe("reportDone", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("logs one success line and posts the body verbatim", async () => {
+    const { api, post } = makeApi();
+    const done = { session_id: "sess_1", status: "succeeded" as const, exit_code: 0 };
+
+    await reportDone(api, done, { tag: "daemon/spawn", succeeded: "exit=0" });
+
+    expect(logged(logSpy)).toEqual(["[daemon/spawn] sess=sess_1 exit=0"]);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(post).toHaveBeenCalledWith("/runtime/done", done);
+  });
+
+  it("reports a non-success through error(), with the status and the extra field", async () => {
+    const { api } = makeApi();
+
+    await reportDone(
+      api,
+      { session_id: "sess_2", status: "failed" },
+      { tag: "daemon/spawn", succeeded: "exit=0", failed: "exit=127" },
+    );
+
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(logged(errorSpy)).toEqual(["[daemon/spawn] sess=sess_2 status=failed exit=127"]);
+  });
+
+  it("indents a multi-line diagnostic under an error: label", async () => {
+    const { api } = makeApi();
+
+    await reportDone(
+      api,
+      { session_id: "sess_3", status: "failed" },
+      {
+        tag: "daemon/repo-run",
+        succeeded: "ok",
+        errorDetail: "boom\n  at frame",
+      },
+    );
+
+    expect(logged(errorSpy)).toEqual([
+      "[daemon/repo-run] sess=sess_3 status=failed\n  error:\n    boom\n      at frame",
+    ]);
+  });
+
+  it("omits the error block entirely when there is no diagnostic", async () => {
+    const { api } = makeApi();
+
+    await reportDone(
+      api,
+      { session_id: "sess_4", status: "cancelled" },
+      { tag: "daemon/spawn", succeeded: "exit=0" },
+    );
+
+    expect(logged(errorSpy)).toEqual(["[daemon/spawn] sess=sess_4 status=cancelled"]);
+  });
+
+  it("swallows a failed POST — the run it describes is already over", async () => {
+    const post = vi.fn(async () => {
+      throw new Error("connection reset");
+    });
+    const { api } = makeApi(post as unknown as ReturnType<typeof makeApi>["post"]);
+
+    await expect(
+      reportDone(
+        api,
+        { session_id: "sess_5", status: "succeeded" },
+        { tag: "daemon/spawn", succeeded: "exit=0" },
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(logged(errorSpy)).toEqual([
+      "[daemon/spawn] /runtime/done POST failed:",
+      "connection reset",
+    ]);
+  });
+});

--- a/packages/daemon/src/runtime-done.ts
+++ b/packages/daemon/src/runtime-done.ts
@@ -1,0 +1,73 @@
+/**
+ * The last thing every dispatch does: log its outcome and POST
+ * `/runtime/done`.
+ *
+ * `spawner.ts` (a CLI runtime session) and `repo-runs.ts` (a sandboxed
+ * repo run) build genuinely different bodies, but ended the same way —
+ * a one-line success log, an `error()` on anything else carrying the
+ * status and an indented multi-line error block, then a POST whose own
+ * failure is logged and swallowed. Two copies of the tail, and the tail
+ * is where the swallow lives: a `throw` out of the POST would take down
+ * a run that has already finished.
+ */
+
+import { errorMessage, type TerminalSessionStatus } from "@beevibe/core";
+import type { ApiClient } from "./api-client.js";
+import { error, log } from "./logger.js";
+
+/** The subset of a `/runtime/done` body this module reads. */
+interface DoneOutcome {
+  session_id: string;
+  status: TerminalSessionStatus;
+}
+
+export interface ReportDoneOptions {
+  /** Log prefix without brackets, e.g. `daemon/spawn`. */
+  tag: string;
+  /** Tail of the success line, after `sess=<id>`. */
+  succeeded: string;
+  /** Extra `key=value` on the failure line, after `status=<status>`. */
+  failed?: string;
+  /**
+   * Multi-line diagnostic, rendered indented under an `error:` label.
+   * Omitted when there is nothing to say.
+   */
+  errorDetail?: string;
+}
+
+/**
+ * Log the terminal outcome and report it to the api.
+ *
+ * Never throws: a failed POST is logged and dropped, because the run it
+ * describes is already over and the api reconciles orphaned sessions on
+ * its own.
+ */
+export async function reportDone(
+  api: Pick<ApiClient, "post">,
+  done: DoneOutcome,
+  opts: ReportDoneOptions,
+): Promise<void> {
+  const prefix = `[${opts.tag}] sess=${done.session_id}`;
+  if (done.status === "succeeded") {
+    log(`${prefix} ${opts.succeeded}`);
+  } else {
+    const suffix = opts.failed ? ` ${opts.failed}` : "";
+    error(`${prefix} status=${done.status}${suffix}${indentDetail(opts.errorDetail)}`);
+  }
+
+  try {
+    await api.post("/runtime/done", done);
+  } catch (err) {
+    error(`[${opts.tag}] /runtime/done POST failed:`, errorMessage(err));
+  }
+}
+
+/**
+ * Render a diagnostic as an indented block under the failure line, so a
+ * multi-line stack trace stays visually attached to the run it belongs
+ * to rather than interleaving with other runs' output.
+ */
+function indentDetail(detail: string | undefined): string {
+  if (!detail) return "";
+  return `\n  error:\n    ${detail.split("\n").join("\n    ")}`;
+}

--- a/packages/daemon/src/spawner.ts
+++ b/packages/daemon/src/spawner.ts
@@ -26,11 +26,11 @@ import type {
   RuntimeResult,
   TerminalSessionStatus,
 } from "@beevibe/core";
-import { errorMessage } from "@beevibe/core";
 import type { LocalWorkspaceManager } from "@beevibe/core/adapters/local-workspace";
 import type { ApiClient } from "./api-client.js";
 import { createEventBatcher } from "./event-batcher.js";
-import { error, log } from "./logger.js";
+import { reportDone } from "./runtime-done.js";
+import { log } from "./logger.js";
 import { runRepoDispatch } from "./repo-runs.js";
 
 export type {
@@ -159,18 +159,10 @@ export async function runDispatch(
     usage: result?.usage,
   };
 
-  if (status === "succeeded") {
-    log(`[daemon/spawn] sess=${payload.session_id} exit=0`);
-  } else {
-    error(
-      `[daemon/spawn] sess=${payload.session_id} status=${status} exit=${done.exit_code}` +
-        (errorDetail ? `\n  error:\n    ${errorDetail.split("\n").join("\n    ")}` : ""),
-    );
-  }
-
-  try {
-    await deps.api.post("/runtime/done", done);
-  } catch (err) {
-    error("[daemon/spawner] /runtime/done POST failed:", errorMessage(err));
-  }
+  await reportDone(deps.api, done, {
+    tag: "daemon/spawn",
+    succeeded: "exit=0",
+    failed: `exit=${done.exit_code}`,
+    errorDetail,
+  });
 }

--- a/packages/daemon/src/spawner.ts
+++ b/packages/daemon/src/spawner.ts
@@ -26,6 +26,7 @@ import type {
   RuntimeResult,
   TerminalSessionStatus,
 } from "@beevibe/core";
+import { errorMessage } from "@beevibe/core";
 import type { LocalWorkspaceManager } from "@beevibe/core/adapters/local-workspace";
 import type { ApiClient } from "./api-client.js";
 import { createEventBatcher } from "./event-batcher.js";
@@ -170,9 +171,6 @@ export async function runDispatch(
   try {
     await deps.api.post("/runtime/done", done);
   } catch (err) {
-    error(
-      "[daemon/spawner] /runtime/done POST failed:",
-      err instanceof Error ? err.message : String(err),
-    );
+    error("[daemon/spawner] /runtime/done POST failed:", errorMessage(err));
   }
 }

--- a/packages/daemon/src/start.ts
+++ b/packages/daemon/src/start.ts
@@ -4,6 +4,7 @@
  */
 
 import { join } from "node:path";
+import { errorMessage } from "@beevibe/core";
 import { LocalWorkspaceManager } from "@beevibe/core/adapters/local-workspace";
 import { createDefaultRuntimeRegistry } from "@beevibe/core/adapters/runtime-registry";
 import { ApiClient } from "./api-client.js";
@@ -36,10 +37,7 @@ export async function runStart(options: StartOptions = {}): Promise<void> {
   // LocalWorkspaceManager.ensureWorkspace.
   const skillsSourceDir = await syncSkillsCache(api, options.configRoot).catch(
     (err: unknown) => {
-      warn(
-        "[daemon] skills sync failed; continuing without skills:",
-        err instanceof Error ? err.message : String(err),
-      );
+      warn("[daemon] skills sync failed; continuing without skills:", errorMessage(err));
       return undefined;
     },
   );
@@ -87,10 +85,7 @@ export async function runStart(options: StartOptions = {}): Promise<void> {
   // self-healing, so logging and continuing is the right behavior under
   // Node 20+'s default `--unhandled-rejections=throw`.
   process.on("unhandledRejection", (reason) => {
-    warn(
-      "[daemon] unhandledRejection (continuing):",
-      reason instanceof Error ? reason.message : String(reason),
-    );
+    warn("[daemon] unhandledRejection (continuing):", errorMessage(reason));
   });
 
   // Hold the process open. The `setInterval` in claimer keeps the event

--- a/packages/daemon/src/update.ts
+++ b/packages/daemon/src/update.ts
@@ -27,6 +27,7 @@ import { join } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { createInterface } from "node:readline/promises";
+import { errorMessage } from "@beevibe/core";
 import { error, log } from "./logger.js";
 
 // Baked in by `bun build --compile --define BEEVIBE_DAEMON_VERSION="…"`
@@ -220,7 +221,7 @@ export async function runUpdate(opts: { skipPrompt?: boolean } = {}): Promise<vo
     try {
       renameSync(stagingPath, process.execPath);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
+      const msg = errorMessage(err);
       error(`Failed to replace ${process.execPath}: ${msg}`);
       error(`The new binary is at ${stagingPath} — install manually if needed.`);
       // Don't clean up the stagingDir if we leave the new binary behind


### PR DESCRIPTION
Swept the monorepo for near-duplicate abstractions. The obvious candidates are gone — prior sweeps (#257, #259, #263, #266, #271, #276, #277, #279, #281, #283) took the CLI runtime adapters, the Postgres repositories, the three `format.ts` modules and the wire-contract types, and `jscpd` at `--min-lines 7 --min-tokens 40` now finds **three** token-level clones in the whole tree, all of them already claimed by open PRs (#306, #308).

What's left is structural: the same *shape* written out by hand with different names, which a token-level clone detector can't see. Four clusters, three commits, each independent.

---

## 1. `errorMessage(err)` — 39 copies, 6 packages · `b9c7ae5`

`catch (err)` yields `unknown`, so every layer that logs it, puts it on the wire, or stores it in a column narrows it first — longhand:

```ts
err instanceof Error ? err.message : String(err)
```

**39 call sites** across `api`, `daemon`, `sandbox` and `web`. It is the most-repeated expression in the tree, and two packages had already noticed and grown a private helper for it: `errMsg` in `api/src/tools/find-repo.ts`, and the tail of `describeError` in `web/lib/api/http.ts`.

Now one `errorMessage()` in `@beevibe/core`'s domain layer, with a `@beevibe/core/domain/errors` subpath for client-bundled callers (same `node:crypto` reasoning as the existing `domain/format` subpath). `find-repo`'s private `errMsg` goes away.

`String(err)` alone is not a substitute — on an `Error` it yields `"Error: boom"` rather than `"boom"` — which is exactly why the ternary kept getting rewritten instead of simplified away.

**Deliberately left alone.** `packages/sandbox` (4 sites) has no `@beevibe/core` dependency; it is the trust-boundary package and is kept dependency-light on purpose, so adding a dep on core (pg + openai + anthropic SDKs) to share one line would be a bad trade. `web/lib/api/http.ts` (1 site) already has the abstraction locally as `describeError`, whose `ApiError`-aware branches are the interesting part; pulling a new core runtime import into the client bundle to replace its one-line fallback isn't worth it.

## 2. The MCP tool layer — ~116 copies · `ec587b0`

The ten modules under `packages/api/src/tools/` each hand-rolled the same two things.

**The error envelope — 56 inline copies.** `tools/errors.ts` already existed with `toolError(code, message)`, but only four modules imported it and even those wrote most of their failures out longhand:

```ts
return {
  content: { error: "invalid_repo_url", message: "…" },
  isError: true,
};
```

Every one is now `toolError(...)` or, for the sites whose wire shape is the uncoded single-field one, a new `toolFailure(text)` next to it. Both shapes were already *documented* in that module — the second just had no builder. Nothing on the wire changes.

This is duplication with no safety net: an inline copy is one missing `isError: true` away from an MCP result that reads as success.

**Argument reading — new `tools/input.ts`.** ~60 copies of four idioms for narrowing `Record<string, unknown>`, now `coerceString` / `optionalString` / `nonEmptyString` / `optionalNumber` / `optionalObject` / `enumArg` / `oneOfMessage`.

The two string readers stay separate on purpose, and this is the interesting find: `hierarchy.ts` and `mesh.ts` read arguments with `String(input.x ?? "")`, which turns a numeric `123` into `"123"`; the other four modules use a `typeof` check, which turns it into `undefined`. Which contract a given argument gets is historical rather than considered, but the difference is observable, so this names both rather than picking a winner behind the reader's back. Naming them is the first step to being able to pick one.

`enumArg` replaces the `input.x as T` cast that six handlers wrote immediately above the `ALLOWED.includes(x)` guard checking that very assertion.

Also folds the six mutable work-product fields — spelled out identically in `create_work_product` and `update_work_product` — into one `mutableWorkProductFields(input)`, so a field can't become settable on create but not on update.

### ⚠️ One behavior change, deliberate

`optionalObject` **rejects arrays.** The two hand-written `metadata` reads tested only `typeof v === "object"`, which is true for arrays, so `metadata: []` was cast to `Record<string, unknown>` and written to the jsonb column. Such a call now stores no metadata instead of storing a lie.

### Not taken (kept the PR single-purpose)

- `session-search.ts`'s `filters` read needs a conditional-type cast, so a `Record<string, unknown>` reader doesn't fit it.
- `create_task`'s `priority` bakes a default into the same expression as its guard, so `enumArg` would silently turn an invalid priority into `"medium"` instead of rejecting it.
- The **22 handlers** that wrap their whole body in `try { … } catch (err) { return toolErrorFromThrown(err); }` are a real cluster with a real correctness argument, but hoisting them into a wrapper reindents most of `hierarchy.ts`. Worth its own PR.

## 3. `reportDone` — the daemon's dispatch tail, twice · `b6b9bbc`

`spawner.ts` (a CLI runtime session) and `repo-runs.ts` (a sandboxed repo run) build genuinely different `/runtime/done` bodies, but ended identically: one success log line, an `error()` on anything else carrying `status=` plus a multi-line diagnostic indented under an `error:` label, then a POST whose own failure is logged and swallowed.

The swallow is the part worth having once — a throw out of that POST would take down a run that has already finished, and the only thing keeping that from happening was each copy remembering the try/catch.

One log-string change: the POST-failure line in `spawner.ts` was tagged `[daemon/spawner]` where its own status lines used `[daemon/spawn]`. Both now read `[daemon/spawn]`. Nothing parses these.

## 4. `operationFailed` — the api's *other* 500 · `b6b9bbc`

Ten handlers across `capabilities`, `find-repo`, `learned-skills` and `repo-runs` ended with the same three lines: log the raw error under a `[router/operation]` tag, answer `{ error: "<verb>_failed" }`, nothing else.

That envelope is deliberately terser than `makeErrorHandler`'s, which reflects `err.message` back to the client — these four routers reach GitHub, the filesystem and the capability registry, where a message can carry a path or a token-bearing URL. Putting the terse builder next to the verbose one in `routes/http-errors.ts` is most of the value: a handler author now picks the disclosure they want instead of rediscovering the shape by copying whichever neighbour they read first.

`learned-skills`' `publish_failed` keeps its own hand-written 500 — it's the one site in that group that does return a `message`.

---

## Where the duplication isn't

Recorded because these are the obvious next places to look and they came up clean:

| Candidate | Verdict |
| --- | --- |
| The three CLI runtime adapters' `stream-json.ts` | Genuinely different provider event schemas. The shared lifecycle already lives in `adapters/runtime-common.ts`. |
| `AnthropicLlmProvider` / `OpenAILlmProvider` | Structurally parallel, but only the ~8-line constructor is actually shared; the rest is SDK-shaped and must differ. Parallel structure is the adapter pattern working, not duplication. |
| `MeshServer.sendAsk` / `.sendNegotiate` / `.respondNegotiate` | Same silhouette, different protocols (one-shot vs. multi-round with a row + round insert). |
| The Postgres repositories | Already share `pg-helpers.ts`. |
| The view-layer `limit` clamps | Overlaps open #324's `parseIntQuery`; left alone to avoid a conflict. |

## Verification

- `pnpm typecheck` — green, 9/9 packages.
- `pnpm lint` — **0 errors** (the remaining warnings are pre-existing: `WebSocket` default-import naming in daemon, `import/no-duplicates` in test files, one unused local in core).
- `npx tsc --noEmit --noUnusedLocals --noUnusedParameters` on the api and daemon tsconfigs — clean. It surfaced one alias (`AgentEndStatus`) that `enumArg` made dead; removed.
- `next build` (web, direct — Turbo strips the proxy CA per `CLAUDE.md`) — clean.

Tests, against the branch point:

| Package | Before | After |
| --- | --- | --- |
| `@beevibe/core` | 609 pass · 7 fail | **613 pass** · 7 fail |
| `@beevibe/api` | 820 pass · 9 files fail | **843 pass** · 9 files fail |
| `@beevibe/daemon` | 156 pass | **161 pass** |
| `@beevibe/scheduler` | 10 pass | 10 pass |
| `@beevibe/web` | 203 pass | 203 pass |
| `@beevibe/sandbox` | 109 pass | 109 pass |

**Zero regressions; +32 new tests** covering `errorMessage`, `tools/input.ts`, `toolFailure`, `reportDone` and `operationFailed`. Every remaining failure locally is a documented no-Postgres / no-provider-key suite per `CLAUDE.md`'s environmental-failure table — none in a file this PR touches. CI, which has Postgres and keys, is green on all three checks.

## A note on scope

The task asked for one PR per cluster. This session is pinned to a single designated branch, so it's one PR with three independent commits instead — each is self-contained and can be dropped or cherry-picked without touching the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsKNfcpPLDe8m9ajTvjBgh