### PR TITLE
chore: remove dead code found by a static + dynamic sweep

### DIFF
--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -93,10 +93,7 @@ export interface AgentDisplay
   hierarchy: HierarchyLevel;
   sessions_count?: number;
   facts_learned?: number;
-  /** Reserved for future memory-merge telemetry. */
-  merge_events?: number;
   specialization?: string;
-  themes?: string[];
   /** CLI tool the agent uses — derived from `runtime_config.type`. */
   runtime?: string;
   /**
@@ -404,7 +401,6 @@ export interface MemoryFactDisplay {
   source_session_count: number;
   created_at: Date;
   merge_origin?: MergeOrigin;
-  promotion_origin_scope?: MemoryScope;
 }
 
 /**

--- a/packages/core/src/adapters/runtime-common.ts
+++ b/packages/core/src/adapters/runtime-common.ts
@@ -39,7 +39,7 @@ export function parseNdjsonLine<T>(line: string): T | null {
  * richer superset — extra `name`/`persona` and single-key branches — and
  * intentionally keeps its own implementation.)
  */
-export const PREFERRED_TOOL_INPUT_FIELDS = [
+const PREFERRED_TOOL_INPUT_FIELDS = [
   "file_path",
   "path",
   "command",
@@ -53,16 +53,13 @@ export const PREFERRED_TOOL_INPUT_FIELDS = [
 /**
  * Pull the most informative string field out of a tool-call input payload,
  * truncated to 200 chars. Falls back to the raw JSON when no preferred field
- * is present. `fields` defaults to {@link PREFERRED_TOOL_INPUT_FIELDS}.
+ * is present. Probes {@link PREFERRED_TOOL_INPUT_FIELDS} in order.
  */
-export function describeToolInput(
-  input: unknown,
-  fields: readonly string[] = PREFERRED_TOOL_INPUT_FIELDS,
-): string {
+export function describeToolInput(input: unknown): string {
   if (typeof input === "string") return input.slice(0, 200);
   if (!input || typeof input !== "object" || Array.isArray(input)) return "";
   const obj = input as Record<string, unknown>;
-  for (const key of fields) {
+  for (const key of PREFERRED_TOOL_INPUT_FIELDS) {
     const v = obj[key];
     if (typeof v === "string" && v.length > 0) return v.slice(0, 200);
   }

--- a/packages/core/src/ports/runtime.ts
+++ b/packages/core/src/ports/runtime.ts
@@ -199,7 +199,6 @@ export interface RuntimeResult {
 /** Result of `healthCheck()`. */
 export interface RuntimeHealth {
   healthy: boolean;
-  latency_ms?: number;
   error?: string;
 }
 

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -119,19 +119,6 @@
   }
 }
 
-.timeline-rail {
-  position: relative;
-}
-.timeline-rail::before {
-  content: "";
-  position: absolute;
-  left: 11px;
-  top: 8px;
-  bottom: 8px;
-  width: 1px;
-  background: hsl(var(--border));
-}
-
 /* Pearl button — sidebar New chat CTA. Adapted from Uiverse.io by
    marcelodolza, recolored to the app's honey primary. The .wrap
    pseudo-elements render the glossy top cap and rising under-glow. */
@@ -268,10 +255,9 @@
    material instead of solid blocks against shiny pearls.
 
    Use `.glass-surface` for popovers, composers, peek panels — anything
-   that hosts content. Use `.glass-bubble-agent` / `.glass-bubble-user`
-   for chat message bubbles. All three need a non-solid backdrop behind
-   them to read correctly; the chat surface's gradient + the sidebar's
-   `bg-card` both qualify. */
+   that hosts content. Use `.glass-bubble-user` for chat message bubbles.
+   Both need a non-solid backdrop behind them to read correctly; the chat
+   surface's gradient + the sidebar's `bg-card` both qualify. */
 .glass-surface {
   background-color: hsl(var(--card) / 0.55);
   /* Apple Liquid Glass cues: heavy blur picks up backdrop variation, the
@@ -296,21 +282,6 @@
   .dark .glass-surface { background-color: hsl(var(--card) / 0.92); }
 }
 
-/* Agent message — neutral translucent bubble. Drops the solid
-   bg-secondary block in favor of a frosted variant that lets the
-   gradient backdrop bleed through. */
-.glass-bubble-agent {
-  background-color: hsl(var(--secondary) / 0.5);
-  backdrop-filter: blur(20px) saturate(180%);
-  -webkit-backdrop-filter: blur(20px) saturate(180%);
-  color: hsl(var(--foreground));
-  box-shadow: inset 0 1px 0 hsl(0 0% 100% / 0.06);
-}
-.dark .glass-bubble-agent {
-  background-color: hsl(var(--secondary) / 0.4);
-  box-shadow: inset 0 1px 0 hsl(0 0% 100% / 0.05);
-}
-
 /* User message — replaces the saturated bg-primary yellow with a low-
    opacity tint + brand-colored border. Brand reads as accent instead
    of dominating the column; short prompts stop looking like billboards. */
@@ -329,7 +300,6 @@
 }
 
 @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
-  .glass-bubble-agent { background-color: hsl(var(--secondary) / 0.9); }
   .glass-bubble-user { background-color: hsl(var(--primary) / 0.22); }
 }
 
@@ -843,7 +813,6 @@
 
 @media (prefers-reduced-motion: reduce) {
   .animate-pulse-breathe,
-  .animate-spin-slow,
   .animate-row-flash {
     animation: none !important;
   }

--- a/packages/web/lib/types/mesh.ts
+++ b/packages/web/lib/types/mesh.ts
@@ -10,21 +10,12 @@ export interface MeshAsk {
   id: string;
   caller: string;
   target: string;
-  intermediate?: string;
-  arrow?: "right" | "up";
   type: "ask" | "negotiate" | "blocker";
-  type_label?: string;
   status: "in_flight" | "succeeded" | "blocked";
   duration_label: string;
   intent: RichText;
-  response?: { agent: string; content: RichText };
   chain_depth: string;
-  chain_depth_color?: "review";
-  source_session?: string;
   source_task_short_id?: string;
-  source_task_age?: string;
-  awaiting_label?: string;
-  awaiting_task_short_id?: string;
 }
 
 export interface ChainBudgetRow {

--- a/packages/web/tailwind.config.ts
+++ b/packages/web/tailwind.config.ts
@@ -79,9 +79,6 @@ const config: Config = {
           "0%, 100%": { opacity: "1", transform: "scale(1)" },
           "50%": { opacity: "0.55", transform: "scale(0.92)" },
         },
-        "spin-slow": {
-          to: { transform: "rotate(360deg)" },
-        },
         "row-flash": {
           "0%": { backgroundColor: "hsl(48 96% 53% / 0.16)" },
           "100%": { backgroundColor: "transparent" },
@@ -96,7 +93,6 @@ const config: Config = {
       },
       animation: {
         "pulse-breathe": "pulse-breathe 2s ease-in-out infinite",
-        "spin-slow": "spin-slow 2.5s linear infinite",
         "row-flash": "row-flash 1200ms ease-out",
         "step-pop": "step-pop 260ms ease-out",
       },


### PR DESCRIPTION
Third dead-code pass over the repo, using the sweeps documented in `CLAUDE.md`.

## What was run

| Sweep | Result |
| --- | --- |
| `tsc --noUnusedLocals --noUnusedParameters` (6 packages) | clean |
| `tsc --allowUnreachableCode false` (TS7027, 6 packages) | clean |
| `turbo lint` / `turbo typecheck` | clean |
| `knip` | only the false positives already catalogued in `CLAUDE.md` |
| `depcheck` (root + per package) | same false positives (`node-pg-migrate`, `zod`, `postcss`/`autoprefixer`, `prettier`) |
| By-name grep of all 676 exported symbols | 1 hit — `PostgresMemoryPromotionEventRepository`, documented as unfinished wiring, kept |
| Import-graph orphan-file scan | 7 hits, all documented entry points (codex/opencode barrels, sandbox bins, manual scripts) |
| Never-called class-method scan (309 methods) | 1 hit — `AgentProvisionEventRepository.listByParent`, documented audit-trail read half, kept |
| Per-member scan of all 2794 interface fields | the findings below |
| CSS class / keyframe usage scan | the findings below |
| `vitest --coverage` (v8, `--coverage.all`) on core | 90–100% on real logic; every 0% file is either type-only or a DB-gated postgres adapter. No dead-code signal. |

The symbol- and file-level sweeps came back empty — #285 and #291 already cleared those. What was left is field- and rule-level dead weight.

## What was removed

**Phantom fields on the mesh display DTO** — `packages/web/lib/types/mesh.ts`

`MeshAsk` declared nine optional fields (`intermediate`, `arrow`, `type_label`, `response`, `chain_depth_color`, `source_session`, `source_task_age`, `awaiting_label`, `awaiting_task_short_id`) that its only producer (`askToDisplay` in `lib/mesh-display.ts`) never sets and its only consumer (`components/mesh/activity-feed.tsx`) never reads. The backend `MeshAskData` has no corresponding columns either, so nothing could ever populate them.

**Never-populated view fields** — `packages/api/src/views/types.ts`

`AgentDisplay.merge_events` (marked "reserved for future telemetry"), `AgentDisplay.themes`, and `MemoryFactDisplay.promotion_origin_scope` each appear exactly once in the monorepo: their own declaration. No SQL aliases them, no mapper writes them, no page reads them.

**Never-populated port field** — `packages/core/src/ports/runtime.ts`

`RuntimeHealth.latency_ms` is set by none of the three runtime adapters (claude-code, codex and opencode all return through `cliVersionHealthCheck`) and read by no caller.

**Dead parameter** — `packages/core/src/adapters/runtime-common.ts`

`describeToolInput(input, fields)` — both call sites (the codex and opencode stream parsers) pass one argument, so the override branch never ran. Inlined the default and dropped the now-file-local `PREFERRED_TOOL_INPUT_FIELDS` export.

**Dead CSS** — `packages/web/app/globals.css`, `packages/web/tailwind.config.ts`

`.timeline-rail` (+ `::before`), `.glass-bubble-agent` (+ its `.dark` and `@supports` variants), and the `spin-slow` keyframe/animation pair with its `prefers-reduced-motion` opt-out. None of the three class names is ever emitted as a `className`; `.glass-bubble-agent` was added in #226 alongside `.glass-bubble-user` and never applied.

## Deliberately left in place

- Everything in the `CLAUDE.md` false-positive table, plus `PostgresMemoryPromotionEventRepository` and the uncalled audit-trail read methods (unfinished wiring, not dead code).
- `StreamJsonMessage.duration_ms` / `num_turns` and the web-side `TrendingSnapshot.fetched_at` — never read, but they mirror external wire formats (the Claude Code CLI's stream-json and the trending snapshot JSON) rather than internal contracts, so they document a real payload.
- `MeshAsk.intent` and `MeshAsk.chain_depth` — the mapper does populate them and a test does assert `chain_depth`, even though no component renders them yet. Dropping those is a product call, not a cleanup.

## Verification

- `turbo typecheck`, `turbo lint`, `turbo build` — 9/9 tasks clean.
- `next build` for `@beevibe/web` — clean (built directly, per the Turbo strict-env-mode note in `CLAUDE.md`).
- Tests: web 203/203, daemon 156/156, sandbox 109/109, api 820 passing, scheduler 10 passing. The only failures are the DB- and API-key-gated suites (`DATABASE_URL_TEST env var is required`, `OPENAI_API_KEY missing`, `ANTHROPIC_API_KEY missing`) documented as the bare-sandbox baseline.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XubS792G3LEP8fBRsukJhR)_