### PR TITLE
test: correct two stale claims about the suite; no dead tests to remove

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,10 @@ jobs:
 
     # Bind to the `production` GitHub Environment so the step below can
     # read `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` from environment
-    # secrets. These keys gate the live embedding + LLM integration tests
-    # (no describe.skipIf — missing keys fail the suite loudly, per design).
+    # secrets. These keys gate the live embedding + LLM integration tests,
+    # which fail loudly rather than skip when a key is missing. They also
+    # gate routes/mcp.test.ts, the one describe.skipIf'd suite — supplying
+    # them here is what makes it run in CI at all.
     environment: production
 
     # Postgres 16 with the pgvector extension preinstalled. Matches the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,8 +105,12 @@ DATABASE_URL=postgresql://beevibe:beevibe@localhost:5433/beevibe
 ## Running tests
 
 `pnpm test` is **not** hermetic — integration tests need a real Postgres
-and the adapter tests make live provider calls. There is no
-`describe.skipIf`: missing prerequisites fail loudly by design.
+and the adapter tests make live provider calls. Missing prerequisites
+fail loudly by design rather than silently skipping. The one exception is
+`packages/api/src/routes/mcp.test.ts`, which is `describe.skipIf`-gated on
+both provider keys — CI supplies them, so it runs there, but a keyless
+local run skips it silently. (The opt-in e2e/smoke suites and the
+`it.skipIf(win32)` platform gates skip by design; see below.)
 
 ```bash
 docker compose up -d --wait postgres

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,8 +83,16 @@ pnpm sync-core-memory   # re-sync core memory block descriptions
 
 `pnpm test` is **not** hermetic. The integration tests talk to a real
 Postgres, and the embedding/LLM adapter tests make live provider calls —
-by design, there is no `describe.skipIf`, so missing prerequisites fail
-the suite loudly rather than silently skipping.
+by design, missing prerequisites fail the suite loudly rather than
+silently skipping. One suite is deliberately gated instead:
+`packages/api/src/routes/mcp.test.ts` is `describe.skipIf`'d on both
+provider keys, so it runs in CI (which supplies them) but skips on a
+keyless local run.
+
+Separately, the opt-in e2e/smoke suites (`BEEVIBE_E2E_DOCKER`,
+`BEEVIBE_E2E_MULTI_INSTANCE`, `RUN_CLAUDE_SMOKE`) and the
+`it.skipIf(process.platform === "win32")` gates skip unless you enable
+them — each carries its enable instructions in its own file header.
 
 Prerequisites:
 

--- a/packages/web/lib/api/client.test.ts
+++ b/packages/web/lib/api/client.test.ts
@@ -92,7 +92,10 @@ describe("api client (reads)", () => {
     });
   });
 
-  describe("deferred surfaces (paths set; backend not yet shipped)", () => {
+  // All three shipped: `view.ts` serves GET /promotion, /mesh and
+  // /dashboard, and use-promotions / use-mesh / use-dashboard consume
+  // them. These stay to pin the paths and query shapes the hooks rely on.
+  describe("dashboard, mesh and promotion surfaces", () => {
     it("promotions.list() hits /promotion", async () => {
       await api.promotions.list();
       expect(fetchJsonMock).toHaveBeenCalledWith("/promotion", { signal: undefined });


### PR DESCRIPTION
## What this is

A sweep of the whole test suite (160 files) for dead weight, against four criteria: tests skipped/disabled without a clear reason, tests for removed or significantly refactored features, tests with no assertions or that only pin implementation details, and orphaned test files.

**It came back essentially clean.** #284, #285, #286 and #291 already took what was there. No test is removed here.

What the sweep *did* turn up was two places where the suite's own documentation has drifted from what the suite actually does — both of which would send the next person chasing a ghost. That's what this PR fixes.

## Changes

**1. `packages/web/lib/api/client.test.ts` — stale block label**

The promotions/mesh/dashboard client tests sit under `describe("deferred surfaces (paths set; backend not yet shipped)")`. All three shipped:

- `packages/api/src/routes/view.ts` serves `GET /promotion` (:516), `/mesh` (:504) and `/dashboard` (:462), each with its own coverage in `view.test.ts`
- `use-promotions.ts`, `use-mesh.ts` and `use-dashboard.ts` call the three client surfaces from live React Query hooks

The tests themselves are still worth having — they pin the paths and query shapes those hooks depend on — so this renames the block and records why it stays, rather than dropping it.

**2. `CLAUDE.md`, `CONTRIBUTING.md`, `.github/workflows/ci.yml` — the "no `describe.skipIf`" claim**

All three state there is no `describe.skipIf` and that missing prerequisites fail loudly. That holds for the DB- and provider-key-gated adapter suites, but not for `packages/api/src/routes/mcp.test.ts`, which is `describe.skipIf(!HAS_LIVE_API_KEYS)`-gated and skips silently without keys.

CI supplies both keys through the `production` environment, so it does run there. The claim is wrong only for a keyless local run — which is exactly the situation where someone would rely on it and quietly get less coverage than they think. Corrected in all three, with a pointer to the opt-in e2e/smoke gates and the `win32` platform gates alongside.

## Deliberately left alone

| Thing | Why |
| --- | --- |
| `docker.e2e.test.ts`, `multi-instance.e2e.test.ts`, `smoke.test.ts` | Opt-in by env flag; each documents its enable command in its own file header, and `ci.yml` explains the smoke exclusion. Working as designed. |
| `it.skipIf(process.platform === "win32")` in `spawn.test.ts` / `manager.test.ts` | POSIX-specific behavior, correctly gated. |
| `views/activity.test.ts`, `views/promotions.test.ts` | Their subjects have no in-repo caller, but CLAUDE.md already records both as kept-on-purpose (documented public endpoint; unfinished wiring). Not a test-cleanup call. |
| `runtime-registry.test.ts` per-runtime cases | Mildly redundant with the same file's key/type sanity check and `composition.test.ts`'s exact-key-set assertion. Cheap, readable, and removing them is churn without benefit. |
| `dashboard.test.ts` SQL-text assertions | White-box, but they pin a real regression (the chat-churn gauge oscillation) with the rationale in-comment. |

## What the sweep checked and found nothing on

- Zero orphaned test files — every test file's subject module exists and is imported in production
- Zero tests with fewer assertions than test cases; zero empty or commented-out test bodies
- Zero `TODO`/`FIXME`-marked stale tests
- Zero leftover `vi.fn()` stubs for methods removed by #285/#291 (`findByOwnerId`, `listMemberPersonIds`, `areAgentsCoMembers` have no references left anywhere)
- No cross-file duplicate coverage — `api/views/format.test.ts` even carries an explicit comment on why it doesn't re-test its core re-exports

## Verification

No test behavior changes.

| Package | Result |
| --- | --- |
| `@beevibe/web` | 24 files / 203 tests pass; `typecheck` + `lint` clean |
| `@beevibe/daemon` | 156 pass, 2 skipped (env-gated e2e) |
| `@beevibe/sandbox` | 109 pass, 1 skipped (env-gated e2e) |
| `@beevibe/core`, `@beevibe/scheduler` | Match the documented bare-sandbox baseline (no Docker, no provider keys) |

`ci.yml` re-validated as YAML. The pre-existing Prettier warnings on `CLAUDE.md` / `CONTRIBUTING.md` are unchanged by this diff (confirmed against a clean tree).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ce1gqrxnsqQ3ZzyLp9YcnE)_