### PR TITLE
refactor(web): unify duplicated detail-page chrome and auth-form markup

### DIFF
--- a/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
+++ b/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
@@ -22,6 +22,7 @@ import { ReviewPolicyPicker } from "@/components/agents/pickers/review-policy-pi
 import { Skeleton } from "@/components/skeleton";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { DetailGate } from "@/components/detail/detail-gate";
+import { DetailFooter } from "@/components/detail/detail-footer";
 import { FooterField } from "@/components/detail/footer-field";
 import { Metric } from "@/components/detail/metric";
 import { cn } from "@/lib/utils";
@@ -278,7 +279,7 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
         ) : null}
       </div>
 
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      <DetailFooter>
         <FooterField label="ID">
           <ClickToCopyId id={agent.id} />
         </FooterField>
@@ -294,7 +295,7 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
             {new Date(agent.archived_at).toLocaleString()}
           </FooterField>
         ) : null}
-      </footer>
+      </DetailFooter>
     </>
   );
 }

--- a/packages/web/app/(authed)/agents/[id]/loading.tsx
+++ b/packages/web/app/(authed)/agents/[id]/loading.tsx
@@ -1,93 +1,92 @@
+import { DetailShell } from "@/components/detail/detail-shell";
 import { Skeleton } from "@/components/skeleton";
 
 export default function AgentDetailLoading() {
   return (
-    <div className="flex-1 overflow-auto">
-      <div className="max-w-5xl mx-auto px-6 py-8">
-        <Skeleton className="h-4 w-20 mb-3" />
+    <DetailShell>
+      <Skeleton className="h-4 w-20 mb-3" />
 
-        <header className="mb-6">
-          <div className="flex items-start gap-4">
-            <Skeleton className="h-14 w-14 rounded-full shrink-0" />
-            <div className="flex-1 min-w-0 space-y-2">
-              <div className="flex items-center gap-2">
-                <Skeleton className="h-6 w-40 rounded" />
-                <Skeleton className="h-5 w-10 rounded" />
-                <Skeleton className="h-5 w-20 rounded" />
-              </div>
-              <Skeleton className="h-4 w-72" />
+      <header className="mb-6">
+        <div className="flex items-start gap-4">
+          <Skeleton className="h-14 w-14 rounded-full shrink-0" />
+          <div className="flex-1 min-w-0 space-y-2">
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-6 w-40 rounded" />
+              <Skeleton className="h-5 w-10 rounded" />
+              <Skeleton className="h-5 w-20 rounded" />
             </div>
-            <Skeleton className="h-8 w-24 rounded shrink-0" />
+            <Skeleton className="h-4 w-72" />
           </div>
-
-          <div className="grid grid-cols-4 gap-x-8 mt-6 pt-6 border-t border-border">
-            {[0, 1, 2, 3].map((i) => (
-              <div key={i}>
-                <Skeleton className="h-3 w-20 mb-2" />
-                <Skeleton className="h-7 w-12" />
-              </div>
-            ))}
-          </div>
-        </header>
-
-        <div className="grid grid-cols-3 gap-6">
-          <div className="col-span-2 space-y-5">
-            <section>
-              <Skeleton className="h-4 w-40 mb-3" />
-              <div className="space-y-3">
-                {[0, 1, 2].map((i) => (
-                  <div key={i} className="rounded-lg border border-border bg-card p-4">
-                    <div className="flex items-start gap-3">
-                      <Skeleton className="h-12 w-12 rounded-full shrink-0" />
-                      <div className="flex-1 min-w-0 space-y-2">
-                        <div className="flex items-center gap-2">
-                          <Skeleton className="h-3 w-16" />
-                          <Skeleton className="h-3 w-32" />
-                        </div>
-                        <Skeleton className="h-3 w-full" />
-                        <Skeleton className="h-3 w-5/6" />
-                        <Skeleton className="h-3 w-3/4" />
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </section>
-
-            <section>
-              <Skeleton className="h-4 w-44 mb-3" />
-              <div className="space-y-2">
-                {[0, 1, 2, 3].map((i) => (
-                  <div
-                    key={i}
-                    className="rounded-lg border border-border bg-card p-3 flex items-start gap-3"
-                  >
-                    <div className="flex flex-col gap-1">
-                      <Skeleton className="h-5 w-16 rounded" />
-                      <Skeleton className="h-3 w-8 rounded" />
-                    </div>
-                    <div className="flex-1 space-y-1.5">
-                      <Skeleton className="h-3 w-full" />
-                      <Skeleton className="h-3 w-4/5" />
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </section>
-          </div>
-
-          <aside className="col-span-1 space-y-4">
-            <section className="rounded-lg border border-border bg-card p-4">
-              <Skeleton className="h-3 w-24 mb-3" />
-              <Skeleton className="h-4 w-full mb-2" />
-              <Skeleton className="h-3 w-32" />
-            </section>
-            <section className="rounded-lg border border-dashed border-border p-4">
-              <Skeleton className="h-3 w-32 mx-auto" />
-            </section>
-          </aside>
+          <Skeleton className="h-8 w-24 rounded shrink-0" />
         </div>
+
+        <div className="grid grid-cols-4 gap-x-8 mt-6 pt-6 border-t border-border">
+          {[0, 1, 2, 3].map((i) => (
+            <div key={i}>
+              <Skeleton className="h-3 w-20 mb-2" />
+              <Skeleton className="h-7 w-12" />
+            </div>
+          ))}
+        </div>
+      </header>
+
+      <div className="grid grid-cols-3 gap-6">
+        <div className="col-span-2 space-y-5">
+          <section>
+            <Skeleton className="h-4 w-40 mb-3" />
+            <div className="space-y-3">
+              {[0, 1, 2].map((i) => (
+                <div key={i} className="rounded-lg border border-border bg-card p-4">
+                  <div className="flex items-start gap-3">
+                    <Skeleton className="h-12 w-12 rounded-full shrink-0" />
+                    <div className="flex-1 min-w-0 space-y-2">
+                      <div className="flex items-center gap-2">
+                        <Skeleton className="h-3 w-16" />
+                        <Skeleton className="h-3 w-32" />
+                      </div>
+                      <Skeleton className="h-3 w-full" />
+                      <Skeleton className="h-3 w-5/6" />
+                      <Skeleton className="h-3 w-3/4" />
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <Skeleton className="h-4 w-44 mb-3" />
+            <div className="space-y-2">
+              {[0, 1, 2, 3].map((i) => (
+                <div
+                  key={i}
+                  className="rounded-lg border border-border bg-card p-3 flex items-start gap-3"
+                >
+                  <div className="flex flex-col gap-1">
+                    <Skeleton className="h-5 w-16 rounded" />
+                    <Skeleton className="h-3 w-8 rounded" />
+                  </div>
+                  <div className="flex-1 space-y-1.5">
+                    <Skeleton className="h-3 w-full" />
+                    <Skeleton className="h-3 w-4/5" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+        </div>
+
+        <aside className="col-span-1 space-y-4">
+          <section className="rounded-lg border border-border bg-card p-4">
+            <Skeleton className="h-3 w-24 mb-3" />
+            <Skeleton className="h-4 w-full mb-2" />
+            <Skeleton className="h-3 w-32" />
+          </section>
+          <section className="rounded-lg border border-dashed border-border p-4">
+            <Skeleton className="h-3 w-32 mx-auto" />
+          </section>
+        </aside>
       </div>
-    </div>
+    </DetailShell>
   );
 }

--- a/packages/web/app/(authed)/escalations/[id]/escalation-detail-client.tsx
+++ b/packages/web/app/(authed)/escalations/[id]/escalation-detail-client.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useState, type ReactNode } from "react";
 import { Info, Scale } from "lucide-react";
 import { MeshBackLink } from "@/components/detail/mesh-back-link";
@@ -9,9 +8,11 @@ import { useResolveEscalation } from "@/lib/hooks/use-escalation-mutations";
 import { ChatMarkdown } from "@/components/chat/markdown";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { DetailGate } from "@/components/detail/detail-gate";
+import { DetailFooter } from "@/components/detail/detail-footer";
 import { FooterField } from "@/components/detail/footer-field";
 import { Skeleton } from "@/components/skeleton";
 import { EscalationStatusPill } from "@/components/detail/status-pill";
+import { MonoLink } from "@/components/detail/mono-link";
 import { MutationError } from "@/components/mutation-error";
 import { formatRelativeTime } from "@/lib/format";
 import type { EscalationResolveInput } from "@/lib/api/client";
@@ -110,21 +111,19 @@ function EscalationDetailLoaded({ esc }: { esc: EscalationReviewDetail }) {
 
       {esc.status === "pending" ? <ResolveForm esc={esc} /> : <ResolvedView esc={esc} />}
 
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      <DetailFooter>
         <FooterField label="ID">
           <ClickToCopyId id={esc.id} />
         </FooterField>
         <FooterField label="Negotiation">
-          <Link href="/mesh" className="font-mono hover:text-foreground transition-colors">
-            {esc.negotiation_id}
-          </Link>
+          <MonoLink href="/mesh">{esc.negotiation_id}</MonoLink>
         </FooterField>
         <FooterField label="Escalated by">{esc.escalated_by_role}</FooterField>
         <FooterField label="Created">{formatRelativeTime(esc.created_at)}</FooterField>
         {esc.resolved_at ? (
           <FooterField label="Resolved">{formatRelativeTime(esc.resolved_at)}</FooterField>
         ) : null}
-      </footer>
+      </DetailFooter>
     </>
   );
 }

--- a/packages/web/app/(authed)/escalations/[id]/loading.tsx
+++ b/packages/web/app/(authed)/escalations/[id]/loading.tsx
@@ -1,21 +1,20 @@
+import { DetailShell } from "@/components/detail/detail-shell";
 import { Skeleton } from "@/components/skeleton";
 
 export default function EscalationDetailLoading() {
   return (
-    <div className="flex-1 overflow-auto">
-      <div className="max-w-5xl mx-auto px-6 py-8">
-        <Skeleton className="h-4 w-16 mb-3" />
-        <div className="flex items-start justify-between gap-6 mb-4">
-          <Skeleton className="h-7 w-40" />
-          <Skeleton className="h-6 w-20 rounded" />
-        </div>
-        <Skeleton className="h-24 w-full rounded-lg mb-6" />
-        <div className="grid grid-cols-2 gap-4 mb-6">
-          <Skeleton className="h-48 w-full rounded-lg" />
-          <Skeleton className="h-48 w-full rounded-lg" />
-        </div>
-        <Skeleton className="h-56 w-full rounded-lg" />
+    <DetailShell>
+      <Skeleton className="h-4 w-16 mb-3" />
+      <div className="flex items-start justify-between gap-6 mb-4">
+        <Skeleton className="h-7 w-40" />
+        <Skeleton className="h-6 w-20 rounded" />
       </div>
-    </div>
+      <Skeleton className="h-24 w-full rounded-lg mb-6" />
+      <div className="grid grid-cols-2 gap-4 mb-6">
+        <Skeleton className="h-48 w-full rounded-lg" />
+        <Skeleton className="h-48 w-full rounded-lg" />
+      </div>
+      <Skeleton className="h-56 w-full rounded-lg" />
+    </DetailShell>
   );
 }

--- a/packages/web/app/(authed)/negotiations/[id]/loading.tsx
+++ b/packages/web/app/(authed)/negotiations/[id]/loading.tsx
@@ -1,20 +1,19 @@
+import { DetailShell } from "@/components/detail/detail-shell";
 import { Skeleton } from "@/components/skeleton";
 
 export default function NegotiationDetailLoading() {
   return (
-    <div className="flex-1 overflow-auto">
-      <div className="max-w-5xl mx-auto px-6 py-8">
-        <Skeleton className="h-4 w-16 mb-3" />
-        <div className="flex items-start justify-between gap-6 mb-4">
-          <Skeleton className="h-7 w-40" />
-          <Skeleton className="h-6 w-20 rounded" />
-        </div>
-        <div className="space-y-3">
-          <Skeleton className="h-32 w-full rounded-lg" />
-          <Skeleton className="h-32 w-full rounded-lg" />
-          <Skeleton className="h-32 w-full rounded-lg" />
-        </div>
+    <DetailShell>
+      <Skeleton className="h-4 w-16 mb-3" />
+      <div className="flex items-start justify-between gap-6 mb-4">
+        <Skeleton className="h-7 w-40" />
+        <Skeleton className="h-6 w-20 rounded" />
       </div>
-    </div>
+      <div className="space-y-3">
+        <Skeleton className="h-32 w-full rounded-lg" />
+        <Skeleton className="h-32 w-full rounded-lg" />
+        <Skeleton className="h-32 w-full rounded-lg" />
+      </div>
+    </DetailShell>
   );
 }

--- a/packages/web/app/(authed)/negotiations/[id]/negotiation-detail-client.tsx
+++ b/packages/web/app/(authed)/negotiations/[id]/negotiation-detail-client.tsx
@@ -7,8 +7,10 @@ import { useNegotiation } from "@/lib/hooks/use-negotiations";
 import { ChatMarkdown } from "@/components/chat/markdown";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { DetailGate } from "@/components/detail/detail-gate";
+import { DetailFooter } from "@/components/detail/detail-footer";
 import { FooterField } from "@/components/detail/footer-field";
 import { NegotiationStatusPill } from "@/components/detail/status-pill";
+import { MonoLink } from "@/components/detail/mono-link";
 import { Skeleton } from "@/components/skeleton";
 import { formatRelativeTime } from "@/lib/format";
 import type {
@@ -120,18 +122,13 @@ function NegotiationDetailLoaded({ neg }: { neg: NegotiationReviewDetail }) {
         )}
       </section>
 
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      <DetailFooter>
         <FooterField label="ID">
           <ClickToCopyId id={neg.id} />
         </FooterField>
         {neg.task_id ? (
           <FooterField label="Task">
-            <Link
-              href={`/tasks/${neg.task_id}`}
-              className="font-mono hover:text-foreground transition-colors"
-            >
-              {neg.task_id}
-            </Link>
+            <MonoLink href={`/tasks/${neg.task_id}`}>{neg.task_id}</MonoLink>
           </FooterField>
         ) : null}
         <FooterField label="Rounds">
@@ -141,7 +138,7 @@ function NegotiationDetailLoaded({ neg }: { neg: NegotiationReviewDetail }) {
         {neg.updated_at !== neg.created_at ? (
           <FooterField label="Updated">{formatRelativeTime(neg.updated_at)}</FooterField>
         ) : null}
-      </footer>
+      </DetailFooter>
     </>
   );
 }

--- a/packages/web/app/(authed)/rooms/[id]/room-detail-client.tsx
+++ b/packages/web/app/(authed)/rooms/[id]/room-detail-client.tsx
@@ -17,7 +17,7 @@ import { isApiConfigured } from "@/lib/api/config";
 import { api, type RoomDetail, type RoomMemberDetail, type RoomMessage } from "@/lib/api/client";
 import { ApiError, describeError } from "@/lib/api/http";
 import { queryKeys } from "@/lib/hooks/keys";
-import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
+import { ShareLinkBox } from "@/components/share-link-box";
 import { ModalOverlay } from "@/components/modal-overlay";
 import { ChatMarkdown } from "@/components/chat/markdown";
 import { ToolStepList } from "@/components/chat/tool-step-list";
@@ -275,7 +275,6 @@ function InviteDialog({ roomId, onClose }: { roomId: string; onClose: () => void
   const [error, setError] = useState<string | null>(null);
   /** When the invitee doesn't have an account yet, surface a share link they can use to sign up + auto-join. */
   const [shareLink, setShareLink] = useState<string | null>(null);
-  const { copied, copy } = useCopyToClipboard();
 
   const invite = useMutation({
     mutationFn: () => api.rooms.invite(roomId, { email: email.trim() }),
@@ -333,27 +332,15 @@ function InviteDialog({ roomId, onClose }: { roomId: string; onClose: () => void
           </div>
         ) : null}
         {shareLink ? (
-          <div className="mt-3 rounded border border-border bg-muted/40 p-3">
-            <div className="text-[11px] text-muted-foreground mb-1.5">
-              No account for that email yet. Send them this link — they&apos;ll sign up and
-              land in this room.
-            </div>
-            <div className="flex items-center gap-1.5">
-              <input
-                readOnly
-                value={shareLink}
-                className="flex-1 rounded border border-border bg-background px-2 py-1.5 text-[11px] font-mono"
-                onFocus={(e) => e.currentTarget.select()}
-              />
-              <button
-                type="button"
-                onClick={() => void copy(shareLink ?? "")}
-                className="h-7 px-2.5 rounded text-[11px] font-medium border border-border hover:bg-secondary transition-colors cursor-pointer shrink-0"
-              >
-                {copied ? "Copied" : "Copy"}
-              </button>
-            </div>
-          </div>
+          <ShareLinkBox
+            blurb={
+              <>
+                No account for that email yet. Send them this link — they&apos;ll sign up and
+                land in this room.
+              </>
+            }
+            link={shareLink}
+          />
         ) : null}
         <div className="mt-4 flex items-center justify-end gap-2">
           <button

--- a/packages/web/app/(authed)/sessions/[sid]/chat-session-detail-client.tsx
+++ b/packages/web/app/(authed)/sessions/[sid]/chat-session-detail-client.tsx
@@ -8,6 +8,7 @@ import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
 import { SessionStatusPill } from "@/components/detail/status-pill";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
+import { DetailFooter } from "@/components/detail/detail-footer";
 import { FooterField } from "@/components/detail/footer-field";
 import { ChatMarkdown } from "@/components/chat/markdown";
 import { HierChip } from "@/components/hier-chip";
@@ -131,7 +132,7 @@ function ConversationBody({ conversation }: { conversation: ConversationDisplay 
 
       {usage ? <UsagePanel usage={usage} /> : null}
 
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      <DetailFooter>
         <FooterField label="Conversation ID">
           <ClickToCopyId id={conversation.conversation_id} />
         </FooterField>
@@ -146,7 +147,7 @@ function ConversationBody({ conversation }: { conversation: ConversationDisplay 
           </FooterField>
         ) : null}
         <FooterField label="Type">{conversation.type}</FooterField>
-      </footer>
+      </DetailFooter>
     </>
   );
 }

--- a/packages/web/app/(authed)/tasks/[id]/loading.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/loading.tsx
@@ -1,64 +1,63 @@
+import { DetailShell } from "@/components/detail/detail-shell";
 import { Skeleton } from "@/components/skeleton";
 
 export default function TaskDetailLoading() {
   return (
-    <div className="flex-1 overflow-auto">
-      <div className="max-w-5xl mx-auto px-6 py-8">
-        <Skeleton className="h-4 w-16 mb-3" />
+    <DetailShell>
+      <Skeleton className="h-4 w-16 mb-3" />
 
-        <div className="flex items-start justify-between gap-6 mb-1.5">
-          <Skeleton className="h-8 flex-1 max-w-2xl" />
-          <div className="flex items-center gap-1.5 mt-1.5">
-            <Skeleton className="h-6 w-20 rounded" />
-            <Skeleton className="h-6 w-12 rounded" />
-          </div>
-        </div>
-
-        <Skeleton className="h-4 w-2/3 mb-5" />
-
-        <div className="flex justify-end gap-2 mb-6">
-          <Skeleton className="h-9 w-20 rounded" />
-          <Skeleton className="h-9 w-32 rounded" />
-          <Skeleton className="h-9 w-24 rounded" />
-        </div>
-
-        <div className="border-b border-border mb-6">
-          <div className="flex items-center gap-1 -mb-px py-2">
-            <Skeleton className="h-5 w-16 rounded" />
-            <Skeleton className="h-5 w-20 rounded ml-3" />
-            <Skeleton className="h-5 w-24 rounded ml-3" />
-          </div>
-        </div>
-
-        <div className="grid grid-cols-3 gap-6">
-          <div className="col-span-2 space-y-5">
-            <section className="rounded-lg border border-border bg-card p-5">
-              <Skeleton className="h-3 w-20 mb-3" />
-              <Skeleton className="h-4 w-full mb-2" />
-              <Skeleton className="h-4 w-5/6 mb-2" />
-              <Skeleton className="h-4 w-4/6" />
-            </section>
-            <section className="rounded-lg border border-border bg-card p-5">
-              <Skeleton className="h-3 w-24 mb-3" />
-              <Skeleton className="h-4 w-full mb-2" />
-              <Skeleton className="h-4 w-3/4" />
-            </section>
-          </div>
-          <aside className="col-span-1 space-y-4">
-            <section className="rounded-lg border border-border bg-card p-4">
-              <Skeleton className="h-3 w-24 mb-3" />
-              <div className="flex items-center justify-between mb-2">
-                <Skeleton className="h-4 w-20" />
-                <Skeleton className="h-5 w-16 rounded" />
-              </div>
-              <Skeleton className="h-3 w-32" />
-            </section>
-            <section className="rounded-lg border border-dashed border-border p-4">
-              <Skeleton className="h-3 w-24 mx-auto" />
-            </section>
-          </aside>
+      <div className="flex items-start justify-between gap-6 mb-1.5">
+        <Skeleton className="h-8 flex-1 max-w-2xl" />
+        <div className="flex items-center gap-1.5 mt-1.5">
+          <Skeleton className="h-6 w-20 rounded" />
+          <Skeleton className="h-6 w-12 rounded" />
         </div>
       </div>
-    </div>
+
+      <Skeleton className="h-4 w-2/3 mb-5" />
+
+      <div className="flex justify-end gap-2 mb-6">
+        <Skeleton className="h-9 w-20 rounded" />
+        <Skeleton className="h-9 w-32 rounded" />
+        <Skeleton className="h-9 w-24 rounded" />
+      </div>
+
+      <div className="border-b border-border mb-6">
+        <div className="flex items-center gap-1 -mb-px py-2">
+          <Skeleton className="h-5 w-16 rounded" />
+          <Skeleton className="h-5 w-20 rounded ml-3" />
+          <Skeleton className="h-5 w-24 rounded ml-3" />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-6">
+        <div className="col-span-2 space-y-5">
+          <section className="rounded-lg border border-border bg-card p-5">
+            <Skeleton className="h-3 w-20 mb-3" />
+            <Skeleton className="h-4 w-full mb-2" />
+            <Skeleton className="h-4 w-5/6 mb-2" />
+            <Skeleton className="h-4 w-4/6" />
+          </section>
+          <section className="rounded-lg border border-border bg-card p-5">
+            <Skeleton className="h-3 w-24 mb-3" />
+            <Skeleton className="h-4 w-full mb-2" />
+            <Skeleton className="h-4 w-3/4" />
+          </section>
+        </div>
+        <aside className="col-span-1 space-y-4">
+          <section className="rounded-lg border border-border bg-card p-4">
+            <Skeleton className="h-3 w-24 mb-3" />
+            <div className="flex items-center justify-between mb-2">
+              <Skeleton className="h-4 w-20" />
+              <Skeleton className="h-5 w-16 rounded" />
+            </div>
+            <Skeleton className="h-3 w-32" />
+          </section>
+          <section className="rounded-lg border border-dashed border-border p-4">
+            <Skeleton className="h-3 w-24 mx-auto" />
+          </section>
+        </aside>
+      </div>
+    </DetailShell>
   );
 }

--- a/packages/web/app/(authed)/tasks/[id]/sessions/[sid]/loading.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/sessions/[sid]/loading.tsx
@@ -1,78 +1,77 @@
+import { DetailShell } from "@/components/detail/detail-shell";
 import { Skeleton } from "@/components/skeleton";
 
 export default function SessionDetailLoading() {
   return (
-    <div className="flex-1 overflow-auto">
-      <div className="max-w-5xl mx-auto px-6 py-8">
-        <div className="flex items-center gap-1.5 mb-4">
-          <Skeleton className="h-3 w-12" />
-          <Skeleton className="h-3 w-3" />
-          <Skeleton className="h-3 w-40" />
-          <Skeleton className="h-3 w-3" />
-          <Skeleton className="h-3 w-24" />
-        </div>
-
-        <header className="mb-6">
-          <div className="flex items-start gap-3">
-            <Skeleton className="h-10 w-10 rounded-full shrink-0" />
-            <div className="flex-1 min-w-0 space-y-2">
-              <div className="flex items-center gap-2">
-                <Skeleton className="h-5 w-72 rounded" />
-                <Skeleton className="h-5 w-20 rounded" />
-              </div>
-              <Skeleton className="h-4 w-96" />
-            </div>
-            <div className="flex items-center gap-1 shrink-0">
-              <Skeleton className="h-8 w-20 rounded" />
-              <Skeleton className="h-8 w-8 rounded" />
-            </div>
-          </div>
-        </header>
-
-        <section className="rounded-lg border border-border bg-card overflow-hidden mb-5">
-          <div className="px-4 py-3 flex items-center justify-between">
-            <div className="flex items-center gap-2.5">
-              <Skeleton className="h-4 w-4 rounded" />
-              <Skeleton className="h-4 w-16" />
-              <Skeleton className="h-3 w-64" />
-            </div>
-            <Skeleton className="h-3 w-48" />
-          </div>
-          <div className="border-t border-border p-4 space-y-4">
-            <div>
-              <Skeleton className="h-3 w-32 mb-2" />
-              <div className="ml-5 space-y-1.5">
-                <Skeleton className="h-3 w-full" />
-                <Skeleton className="h-3 w-5/6" />
-                <Skeleton className="h-3 w-4/6" />
-              </div>
-            </div>
-            <div>
-              <Skeleton className="h-3 w-32 mb-2" />
-              <div className="ml-5 space-y-2">
-                <Skeleton className="h-3 w-full" />
-                <Skeleton className="h-3 w-5/6" />
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <section className="rounded-lg border border-border bg-card p-5">
-          <Skeleton className="h-3 w-24 mb-4" />
-          <div className="space-y-3">
-            {[0, 1, 2, 3].map((i) => (
-              <div key={i} className="flex items-start gap-3 px-3 py-2 -mx-3">
-                <Skeleton className="h-4 w-4 rounded shrink-0 mt-0.5" />
-                <div className="flex-1 space-y-1">
-                  <Skeleton className="h-3 w-20" />
-                  <Skeleton className="h-3 w-full" />
-                  <Skeleton className="h-3 w-3/4" />
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
+    <DetailShell>
+      <div className="flex items-center gap-1.5 mb-4">
+        <Skeleton className="h-3 w-12" />
+        <Skeleton className="h-3 w-3" />
+        <Skeleton className="h-3 w-40" />
+        <Skeleton className="h-3 w-3" />
+        <Skeleton className="h-3 w-24" />
       </div>
-    </div>
+
+      <header className="mb-6">
+        <div className="flex items-start gap-3">
+          <Skeleton className="h-10 w-10 rounded-full shrink-0" />
+          <div className="flex-1 min-w-0 space-y-2">
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-5 w-72 rounded" />
+              <Skeleton className="h-5 w-20 rounded" />
+            </div>
+            <Skeleton className="h-4 w-96" />
+          </div>
+          <div className="flex items-center gap-1 shrink-0">
+            <Skeleton className="h-8 w-20 rounded" />
+            <Skeleton className="h-8 w-8 rounded" />
+          </div>
+        </div>
+      </header>
+
+      <section className="rounded-lg border border-border bg-card overflow-hidden mb-5">
+        <div className="px-4 py-3 flex items-center justify-between">
+          <div className="flex items-center gap-2.5">
+            <Skeleton className="h-4 w-4 rounded" />
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-3 w-64" />
+          </div>
+          <Skeleton className="h-3 w-48" />
+        </div>
+        <div className="border-t border-border p-4 space-y-4">
+          <div>
+            <Skeleton className="h-3 w-32 mb-2" />
+            <div className="ml-5 space-y-1.5">
+              <Skeleton className="h-3 w-full" />
+              <Skeleton className="h-3 w-5/6" />
+              <Skeleton className="h-3 w-4/6" />
+            </div>
+          </div>
+          <div>
+            <Skeleton className="h-3 w-32 mb-2" />
+            <div className="ml-5 space-y-2">
+              <Skeleton className="h-3 w-full" />
+              <Skeleton className="h-3 w-5/6" />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-border bg-card p-5">
+        <Skeleton className="h-3 w-24 mb-4" />
+        <div className="space-y-3">
+          {[0, 1, 2, 3].map((i) => (
+            <div key={i} className="flex items-start gap-3 px-3 py-2 -mx-3">
+              <Skeleton className="h-4 w-4 rounded shrink-0 mt-0.5" />
+              <div className="flex-1 space-y-1">
+                <Skeleton className="h-3 w-20" />
+                <Skeleton className="h-3 w-full" />
+                <Skeleton className="h-3 w-3/4" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </DetailShell>
   );
 }

--- a/packages/web/app/(authed)/tasks/[id]/sessions/[sid]/session-detail-client.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/sessions/[sid]/session-detail-client.tsx
@@ -8,6 +8,7 @@ import { HierChip } from "@/components/hier-chip";
 import { SessionStatusPill } from "@/components/detail/status-pill";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { DetailGate } from "@/components/detail/detail-gate";
+import { DetailFooter } from "@/components/detail/detail-footer";
 import { FooterField } from "@/components/detail/footer-field";
 import { BriefingComposer } from "@/components/sessions/briefing-composer";
 import { Transcript } from "@/components/sessions/transcript";
@@ -115,7 +116,7 @@ function SessionDetailBody({ session, taskId: _taskId }: { session: SessionDispl
 
       <Transcript entries={session.transcript} ask_threads={session.ask_threads} />
 
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      <DetailFooter>
         <FooterField label="Session ID">
           <ClickToCopyId id={session.id} />
         </FooterField>
@@ -130,7 +131,7 @@ function SessionDetailBody({ session, taskId: _taskId }: { session: SessionDispl
           </FooterField>
         ) : null}
         <FooterField label="Type">{session.type}</FooterField>
-      </footer>
+      </DetailFooter>
     </>
   );
 }

--- a/packages/web/app/(authed)/tasks/[id]/task-detail-client.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/task-detail-client.tsx
@@ -25,7 +25,9 @@ import { TaskStatusPill, SessionStatusPill } from "@/components/detail/status-pi
 import { ChatMarkdown } from "@/components/chat/markdown";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { DetailGate } from "@/components/detail/detail-gate";
+import { DetailFooter } from "@/components/detail/detail-footer";
 import { FooterField } from "@/components/detail/footer-field";
+import { MonoLink } from "@/components/detail/mono-link";
 import { HierChip } from "@/components/hier-chip";
 import { Skeleton } from "@/components/skeleton";
 import { richTextToMarkdown } from "@/components/rich-text";
@@ -293,7 +295,7 @@ function TaskDetailLoaded({ task }: { task: TaskDetail }) {
         </aside>
       </div>
 
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      <DetailFooter>
         <FooterField label="ID">
           <ClickToCopyId id={task.id} />
         </FooterField>
@@ -308,15 +310,12 @@ function TaskDetailLoaded({ task }: { task: TaskDetail }) {
         ) : null}
         {task.parent_task_id ? (
           <FooterField label="Parent">
-            <Link
-              href={`/tasks/${task.parent_task_id}`}
-              className="font-mono hover:text-foreground transition-colors"
-            >
+            <MonoLink href={`/tasks/${task.parent_task_id}`}>
               {shortId(task.parent_task_id)}
-            </Link>
+            </MonoLink>
           </FooterField>
         ) : null}
-      </footer>
+      </DetailFooter>
     </>
   );
 }

--- a/packages/web/app/(authed)/work-products/[id]/work-product-detail-client.tsx
+++ b/packages/web/app/(authed)/work-products/[id]/work-product-detail-client.tsx
@@ -16,7 +16,9 @@ import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
 import { ChatMarkdown } from "@/components/chat/markdown";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
+import { DetailFooter } from "@/components/detail/detail-footer";
 import { FooterField } from "@/components/detail/footer-field";
+import { MonoLink } from "@/components/detail/mono-link";
 import { formatRelativeTime, shortId } from "@/lib/format";
 
 export function WorkProductDetailClient({ workProductId }: { workProductId: string }) {
@@ -125,17 +127,12 @@ function Body({ wp }: { wp: WorkProductDetail }) {
         />
       )}
 
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      <DetailFooter>
         <FooterField label="ID">
           <ClickToCopyId id={wp.id} />
         </FooterField>
         <FooterField label="Task" truncate>
-          <Link
-            href={`/tasks/${wp.task_id}`}
-            className="font-mono hover:text-foreground transition-colors"
-          >
-            {shortId(wp.task_id)}
-          </Link>
+          <MonoLink href={`/tasks/${wp.task_id}`}>{shortId(wp.task_id)}</MonoLink>
         </FooterField>
         {wp.url ? (
           <FooterField label={wp.url_is_local ? "Stored at (host)" : "URL"} truncate>
@@ -143,7 +140,7 @@ function Body({ wp }: { wp: WorkProductDetail }) {
           </FooterField>
         ) : null}
         {wp.provider ? <FooterField label="Provider">{wp.provider}</FooterField> : null}
-      </footer>
+      </DetailFooter>
     </>
   );
 }

--- a/packages/web/app/sign-in/sign-in-client.tsx
+++ b/packages/web/app/sign-in/sign-in-client.tsx
@@ -3,10 +3,11 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { AlertTriangle, KeyRound, Loader2, LogIn } from "lucide-react";
+import { KeyRound, LogIn } from "lucide-react";
 import { SIGNIN_NO_PASSWORD_SET } from "@beevibe/core/auth/constants";
 import { api } from "@/lib/api/client";
 import { asApiError } from "@/lib/api/http";
+import { AuthCard, AuthError, AuthField, AuthSubmitButton } from "@/components/auth/auth-form";
 import {
   getUserKey,
   isApiConfigured,
@@ -114,133 +115,99 @@ export function SignInClient() {
   };
 
   return (
-    <main className="min-h-screen flex items-center justify-center px-6 bg-background">
-      <form
-        onSubmit={mode === "password" ? submitPassword : submitKey}
-        className="w-full max-w-sm bg-card border border-border rounded-lg p-6 shadow-sm"
-      >
-        <header className="mb-5">
-          <div className="inline-flex items-center justify-center h-10 w-10 rounded-md bg-primary text-primary-foreground mb-3">
-            {mode === "password" ? (
-              <LogIn className="h-5 w-5" />
-            ) : (
-              <KeyRound className="h-5 w-5" />
-            )}
-          </div>
-          <h1 className="text-lg font-semibold tracking-tight">Sign in to beevibe</h1>
-          <p className="mt-1 text-xs text-muted-foreground leading-relaxed">
-            {mode === "password" ? (
-              <>Email + password. Your <span className="font-mono">bv_u_</span> key is generated server-side and never leaves the browser after.</>
-            ) : (
-              <>Paste your <span className="font-mono">bv_u_</span> key — for legacy accounts or CLI-provisioned users.</>
-            )}
-          </p>
-        </header>
-
-        {mode === "password" ? (
-          <>
-            <label className="block text-xs font-medium text-foreground mb-1.5" htmlFor="email">
-              Email
-            </label>
-            <input
-              id="email"
-              type="email"
-              autoComplete="email"
-              inputMode="email"
-              autoFocus
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="alice@example.com"
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-              disabled={submitting}
-            />
-
-            <label className="block text-xs font-medium text-foreground mb-1.5 mt-3" htmlFor="password">
-              Password
-            </label>
-            <input
-              id="password"
-              type="password"
-              autoComplete="current-password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="••••••••"
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-              disabled={submitting}
-            />
-          </>
+    <AuthCard
+      icon={mode === "password" ? LogIn : KeyRound}
+      title="Sign in to beevibe"
+      description={
+        mode === "password" ? (
+          <>Email + password. Your <span className="font-mono">bv_u_</span> key is generated server-side and never leaves the browser after.</>
         ) : (
-          <>
-            <label className="block text-xs font-medium text-foreground mb-1.5" htmlFor="key">
-              User API key
-            </label>
-            <input
-              id="key"
-              type="password"
-              autoComplete="off"
-              autoFocus
-              spellCheck={false}
-              value={keyDraft}
-              onChange={(e) => setKeyDraft(e.target.value)}
-              placeholder="bv_u_..."
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-ring"
-              disabled={submitting}
-            />
-          </>
-        )}
-
-        {error ? (
-          <div className="mt-3 flex items-start gap-1.5 text-xs text-status-failed">
-            <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>{error}</span>
-          </div>
-        ) : null}
-
-        <button
-          type="submit"
-          disabled={
-            submitting ||
-            (mode === "password"
-              ? email.trim().length === 0 || password.length === 0
-              : keyDraft.trim().length === 0)
-          }
-          className="mt-5 w-full inline-flex items-center justify-center gap-1.5 h-9 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {submitting ? (
-            <>
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              {mode === "password" ? "Signing in…" : "Verifying…"}
-            </>
-          ) : (
-            <>
-              <LogIn className="h-3.5 w-3.5" />
-              Sign in
-            </>
-          )}
-        </button>
-
-        <button
-          type="button"
-          onClick={() => {
-            setMode((m) => (m === "password" ? "key" : "password"));
-            setError(null);
-          }}
-          disabled={submitting}
-          className="mt-3 w-full text-[11px] text-muted-foreground hover:text-foreground transition-colors cursor-pointer disabled:opacity-50"
-        >
-          {mode === "password"
-            ? "Or sign in with your bv_u_ key"
-            : "Or sign in with email + password"}
-        </button>
-
-        <footer className="mt-5 pt-4 border-t border-border/60 text-[11px] text-muted-foreground leading-relaxed">
+          <>Paste your <span className="font-mono">bv_u_</span> key — for legacy accounts or CLI-provisioned users.</>
+        )
+      }
+      onSubmit={mode === "password" ? submitPassword : submitKey}
+      footer={
+        <>
           New here?{" "}
           <Link href="/sign-up" className="text-foreground/80 hover:underline">
             Sign up
           </Link>{" "}
           — takes about 5 seconds.
-        </footer>
-      </form>
-    </main>
+        </>
+      }
+    >
+      {mode === "password" ? (
+        <>
+          <AuthField
+            first
+            id="email"
+            label="Email"
+            type="email"
+            autoComplete="email"
+            inputMode="email"
+            autoFocus
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="alice@example.com"
+            disabled={submitting}
+          />
+
+          <AuthField
+            id="password"
+            label="Password"
+            type="password"
+            autoComplete="current-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="••••••••"
+            disabled={submitting}
+          />
+        </>
+      ) : (
+        <AuthField
+          first
+          id="key"
+          label="User API key"
+          type="password"
+          autoComplete="off"
+          autoFocus
+          spellCheck={false}
+          value={keyDraft}
+          onChange={(e) => setKeyDraft(e.target.value)}
+          placeholder="bv_u_..."
+          className="font-mono"
+          disabled={submitting}
+        />
+      )}
+
+      <AuthError message={error} />
+
+      <AuthSubmitButton
+        icon={LogIn}
+        label="Sign in"
+        pendingLabel={mode === "password" ? "Signing in…" : "Verifying…"}
+        pending={submitting}
+        disabled={
+          submitting ||
+          (mode === "password"
+            ? email.trim().length === 0 || password.length === 0
+            : keyDraft.trim().length === 0)
+        }
+      />
+
+      <button
+        type="button"
+        onClick={() => {
+          setMode((m) => (m === "password" ? "key" : "password"));
+          setError(null);
+        }}
+        disabled={submitting}
+        className="mt-3 w-full text-[11px] text-muted-foreground hover:text-foreground transition-colors cursor-pointer disabled:opacity-50"
+      >
+        {mode === "password"
+          ? "Or sign in with your bv_u_ key"
+          : "Or sign in with email + password"}
+      </button>
+    </AuthCard>
   );
 }

--- a/packages/web/app/sign-up/sign-up-client.tsx
+++ b/packages/web/app/sign-up/sign-up-client.tsx
@@ -3,11 +3,12 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { AlertTriangle, Loader2, Sparkles, UserPlus } from "lucide-react";
+import { Sparkles, UserPlus } from "lucide-react";
 import { PASSWORD_MIN_LENGTH } from "@beevibe/core/auth/constants";
 import { api } from "@/lib/api/client";
 import { asApiError } from "@/lib/api/http";
 import { getUserKey, isApiConfigured, setUserKey } from "@/lib/api/config";
+import { AuthCard, AuthError, AuthField, AuthSubmitButton } from "@/components/auth/auth-form";
 
 /**
  * Self-serve signup. Visitor enters name + email; the api mints them a
@@ -88,105 +89,77 @@ export function SignUpClient() {
   };
 
   return (
-    <main className="min-h-screen flex items-center justify-center px-6 bg-background">
-      <form
-        onSubmit={submit}
-        className="w-full max-w-sm bg-card border border-border rounded-lg p-6 shadow-sm"
-      >
-        <header className="mb-5">
-          <div className="inline-flex items-center justify-center h-10 w-10 rounded-md bg-primary text-primary-foreground mb-3">
-            <UserPlus className="h-5 w-5" />
-          </div>
-          <h1 className="text-lg font-semibold tracking-tight">Sign up for beevibe</h1>
-          <p className="mt-1 text-xs text-muted-foreground leading-relaxed">
-            We&apos;ll mint you a personal team agent. Your key stays in your browser only — you
-            can come back and sign in with the same email later.
-          </p>
-        </header>
-
-        <label className="block text-xs font-medium text-foreground mb-1.5" htmlFor="name">
-          Name
-        </label>
-        <input
-          id="name"
-          type="text"
-          autoComplete="name"
-          autoFocus
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Alice"
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-          disabled={submitting}
-        />
-
-        <label className="block text-xs font-medium text-foreground mb-1.5 mt-3" htmlFor="email">
-          Email
-        </label>
-        <input
-          id="email"
-          type="email"
-          autoComplete="email"
-          inputMode="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          placeholder="alice@example.com"
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-          disabled={submitting}
-        />
-
-        <label className="block text-xs font-medium text-foreground mb-1.5 mt-3" htmlFor="password">
-          Password
-        </label>
-        <input
-          id="password"
-          type="password"
-          autoComplete="new-password"
-          minLength={PASSWORD_MIN_LENGTH}
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          placeholder={`at least ${PASSWORD_MIN_LENGTH} characters`}
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-          disabled={submitting}
-        />
-
-        {error ? (
-          <div className="mt-3 flex items-start gap-1.5 text-xs text-status-failed">
-            <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>{error}</span>
-          </div>
-        ) : null}
-
-        <button
-          type="submit"
-          disabled={
-            submitting ||
-            name.trim().length === 0 ||
-            email.trim().length === 0 ||
-            password.length < PASSWORD_MIN_LENGTH
-          }
-          className="mt-5 w-full inline-flex items-center justify-center gap-1.5 h-9 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {submitting ? (
-            <>
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              Provisioning…
-            </>
-          ) : (
-            <>
-              <Sparkles className="h-3.5 w-3.5" />
-              Create my team agent
-            </>
-          )}
-        </button>
-
-        <footer className="mt-5 pt-4 border-t border-border/60 text-[11px] text-muted-foreground leading-relaxed">
+    <AuthCard
+      icon={UserPlus}
+      title="Sign up for beevibe"
+      description={
+        <>
+          We&apos;ll mint you a personal team agent. Your key stays in your browser only — you
+          can come back and sign in with the same email later.
+        </>
+      }
+      onSubmit={submit}
+      footer={
+        <>
           Already have a key?{" "}
           <Link href="/sign-in" className="text-foreground/80 hover:underline">
             Sign in
           </Link>{" "}
           instead.
-        </footer>
-      </form>
-    </main>
+        </>
+      }
+    >
+      <AuthField
+        first
+        id="name"
+        label="Name"
+        type="text"
+        autoComplete="name"
+        autoFocus
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Alice"
+        disabled={submitting}
+      />
+
+      <AuthField
+        id="email"
+        label="Email"
+        type="email"
+        autoComplete="email"
+        inputMode="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="alice@example.com"
+        disabled={submitting}
+      />
+
+      <AuthField
+        id="password"
+        label="Password"
+        type="password"
+        autoComplete="new-password"
+        minLength={PASSWORD_MIN_LENGTH}
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder={`at least ${PASSWORD_MIN_LENGTH} characters`}
+        disabled={submitting}
+      />
+
+      <AuthError message={error} />
+
+      <AuthSubmitButton
+        icon={Sparkles}
+        label="Create my team agent"
+        pendingLabel="Provisioning…"
+        pending={submitting}
+        disabled={
+          submitting ||
+          name.trim().length === 0 ||
+          email.trim().length === 0 ||
+          password.length < PASSWORD_MIN_LENGTH
+        }
+      />
+    </AuthCard>
   );
 }

--- a/packages/web/components/auth/auth-form.test.tsx
+++ b/packages/web/components/auth/auth-form.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { LogIn } from "lucide-react";
+
+import { AuthCard, AuthError, AuthField, AuthSubmitButton } from "./auth-form";
+
+describe("AuthField", () => {
+  it("wires the label to the input", () => {
+    render(<AuthField first id="email" label="Email" type="email" />);
+    expect(screen.getByLabelText("Email")).toBeTruthy();
+  });
+
+  it("stacks fields with a top margin on every one but the first", () => {
+    const { container } = render(
+      <>
+        <AuthField first id="a" label="First" />
+        <AuthField id="b" label="Second" />
+      </>,
+    );
+    const [first, second] = Array.from(container.querySelectorAll("label"));
+    expect(first?.className).not.toContain("mt-3");
+    expect(second?.className).toContain("mt-3");
+  });
+
+  it("merges a caller's class onto the shared input styling", () => {
+    render(<AuthField first id="key" label="User API key" className="font-mono" />);
+    const input = screen.getByLabelText("User API key");
+    expect(input.className).toContain("font-mono");
+    expect(input.className).toContain("border-border");
+  });
+});
+
+describe("AuthError", () => {
+  it("renders nothing without a message", () => {
+    const { container } = render(<AuthError message={null} />);
+    expect(container.textContent).toBe("");
+  });
+
+  it("shows the message when there is one", () => {
+    render(<AuthError message="Email or password is incorrect." />);
+    expect(screen.getByText("Email or password is incorrect.")).toBeTruthy();
+  });
+});
+
+describe("AuthSubmitButton", () => {
+  it("swaps to the pending label while in flight", () => {
+    const { rerender } = render(
+      <AuthSubmitButton
+        icon={LogIn}
+        label="Sign in"
+        pendingLabel="Signing in…"
+        pending={false}
+        disabled={false}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Sign in" })).toBeTruthy();
+
+    rerender(
+      <AuthSubmitButton
+        icon={LogIn}
+        label="Sign in"
+        pendingLabel="Signing in…"
+        pending
+        disabled
+      />,
+    );
+    const button = screen.getByRole("button") as HTMLButtonElement;
+    expect(button.textContent).toContain("Signing in…");
+    expect(button.disabled).toBe(true);
+  });
+});
+
+describe("AuthCard", () => {
+  it("submits the form the fields live in", async () => {
+    const onSubmit = vi.fn((e: React.FormEvent) => e.preventDefault());
+    render(
+      <AuthCard
+        icon={LogIn}
+        title="Sign in to beevibe"
+        description="Email + password."
+        onSubmit={onSubmit}
+        footer={<span>New here?</span>}
+      >
+        <AuthField first id="email" label="Email" />
+        <AuthSubmitButton
+          icon={LogIn}
+          label="Sign in"
+          pendingLabel="Signing in…"
+          pending={false}
+          disabled={false}
+        />
+      </AuthCard>,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Sign in" }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("New here?")).toBeTruthy();
+  });
+});

--- a/packages/web/components/auth/auth-form.tsx
+++ b/packages/web/components/auth/auth-form.tsx
@@ -1,0 +1,139 @@
+import type { InputHTMLAttributes, ReactNode } from "react";
+import { AlertTriangle, Loader2, type LucideIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * The primitives the two unauthenticated pages — `/sign-in` and `/sign-up` —
+ * are both built out of.
+ *
+ * The pages differ in what they submit (password vs. key vs. provisioning)
+ * but not at all in how they look: the same centred card, the same labelled
+ * input, the same warning-triangle error line, the same full-width submit
+ * button with a spinner. Each was written out by hand twice, which is how
+ * the two ended up one Tailwind class apart in places. The state, the
+ * validation and the submit handlers stay on the pages — only the chrome
+ * lives here.
+ */
+
+const INPUT_CLASS =
+  "w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring";
+
+/**
+ * Centred card wrapping a form, with the icon badge / title / blurb header
+ * both pages open with. `footer` is the "New here? Sign up" cross-link.
+ */
+export function AuthCard({
+  icon: Icon,
+  title,
+  description,
+  onSubmit,
+  footer,
+  children,
+}: {
+  icon: LucideIcon;
+  title: string;
+  description: ReactNode;
+  onSubmit: (e: React.FormEvent) => void;
+  footer: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <main className="min-h-screen flex items-center justify-center px-6 bg-background">
+      <form
+        onSubmit={onSubmit}
+        className="w-full max-w-sm bg-card border border-border rounded-lg p-6 shadow-sm"
+      >
+        <header className="mb-5">
+          <div className="inline-flex items-center justify-center h-10 w-10 rounded-md bg-primary text-primary-foreground mb-3">
+            <Icon className="h-5 w-5" />
+          </div>
+          <h1 className="text-lg font-semibold tracking-tight">{title}</h1>
+          <p className="mt-1 text-xs text-muted-foreground leading-relaxed">{description}</p>
+        </header>
+
+        {children}
+
+        <footer className="mt-5 pt-4 border-t border-border/60 text-[11px] text-muted-foreground leading-relaxed">
+          {footer}
+        </footer>
+      </form>
+    </main>
+  );
+}
+
+/**
+ * A labelled input. `first` drops the top margin — fields are stacked, so
+ * every one but the first sits `mt-3` below its predecessor.
+ */
+export function AuthField({
+  id,
+  label,
+  first,
+  className,
+  ...input
+}: {
+  id: string;
+  label: string;
+  first?: boolean;
+} & InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <>
+      <label
+        className={cn("block text-xs font-medium text-foreground mb-1.5", !first && "mt-3")}
+        htmlFor={id}
+      >
+        {label}
+      </label>
+      <input id={id} className={cn(INPUT_CLASS, className)} {...input} />
+    </>
+  );
+}
+
+/** The inline failure line under the fields. Renders nothing when `message` is null. */
+export function AuthError({ message }: { message: string | null }) {
+  if (!message) return null;
+  return (
+    <div className="mt-3 flex items-start gap-1.5 text-xs text-status-failed">
+      <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+      <span>{message}</span>
+    </div>
+  );
+}
+
+/**
+ * Full-width submit button that swaps its icon + label for a spinner while
+ * the request is in flight.
+ */
+export function AuthSubmitButton({
+  icon: Icon,
+  label,
+  pendingLabel,
+  pending,
+  disabled,
+}: {
+  icon: LucideIcon;
+  label: string;
+  pendingLabel: string;
+  pending: boolean;
+  disabled: boolean;
+}) {
+  return (
+    <button
+      type="submit"
+      disabled={disabled}
+      className="mt-5 w-full inline-flex items-center justify-center gap-1.5 h-9 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      {pending ? (
+        <>
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          {pendingLabel}
+        </>
+      ) : (
+        <>
+          <Icon className="h-3.5 w-3.5" />
+          {label}
+        </>
+      )}
+    </button>
+  );
+}

--- a/packages/web/components/detail/detail-footer.tsx
+++ b/packages/web/components/detail/detail-footer.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+
+/**
+ * The metadata strip every detail page closes with — a responsive grid of
+ * {@link FooterField}s above a hairline rule.
+ *
+ * All seven detail pages (task, agent, session, chat session, work product,
+ * escalation, negotiation) had spelled the same nine-class `<footer>` out by
+ * hand. The *fields* differ per page and stay at the call site; only the
+ * container is shared, so a spacing or column-count change lands everywhere
+ * instead of in whichever six pages someone remembered to update.
+ */
+export function DetailFooter({ children }: { children: ReactNode }) {
+  return (
+    <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      {children}
+    </footer>
+  );
+}

--- a/packages/web/components/detail/mono-link.tsx
+++ b/packages/web/components/detail/mono-link.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+/**
+ * A monospaced link to another entity — the id-shaped cross-reference that
+ * shows up in detail footers and side panels ("Parent: task_a1b2c3").
+ *
+ * Five call sites wrote the identical `font-mono hover:text-foreground
+ * transition-colors` triple inline. `ClickToCopyId` deliberately keeps its
+ * own class list: it is a button with an icon and extra layout classes, not
+ * a navigation link.
+ */
+export function MonoLink({ href, children }: { href: string; children: ReactNode }) {
+  return (
+    <Link href={href} className="font-mono hover:text-foreground transition-colors">
+      {children}
+    </Link>
+  );
+}

--- a/packages/web/components/share-link-box.test.tsx
+++ b/packages/web/components/share-link-box.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ShareLinkBox } from "./share-link-box";
+
+const LINK = "https://beevibe.test/sign-up?email=alice%40example.com";
+
+describe("ShareLinkBox", () => {
+  it("renders the link read-only so it can't be edited into something else", () => {
+    render(<ShareLinkBox blurb="Send them this link:" link={LINK} />);
+    const field = screen.getByDisplayValue(LINK) as HTMLInputElement;
+    expect(field.readOnly).toBe(true);
+    expect(screen.getByText("Send them this link:")).toBeTruthy();
+  });
+
+  it("copies the link and flashes the confirmation", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } });
+
+    render(<ShareLinkBox blurb="Send them this link:" link={LINK} />);
+    await userEvent.click(screen.getByRole("button", { name: "Copy" }));
+
+    expect(writeText).toHaveBeenCalledWith(LINK);
+    expect(await screen.findByRole("button", { name: "Copied" })).toBeTruthy();
+    vi.unstubAllGlobals();
+  });
+
+  it("leaves the field selectable when the clipboard API is unavailable", async () => {
+    vi.stubGlobal("navigator", { ...navigator, clipboard: undefined });
+
+    render(<ShareLinkBox blurb="Send them this link:" link={LINK} />);
+    await userEvent.click(screen.getByRole("button", { name: "Copy" }));
+
+    // No clipboard write is possible, so the button must not claim success —
+    // manual select-and-copy stays the fallback.
+    expect(screen.getByRole("button", { name: "Copy" })).toBeTruthy();
+    vi.unstubAllGlobals();
+  });
+});

--- a/packages/web/components/share-link-box.tsx
+++ b/packages/web/components/share-link-box.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
+
+/**
+ * The read-only URL field with a Copy button that both invite dialogs show
+ * once they have a sign-up link to hand over — `UserWidget`'s "Invite a
+ * teammate" and the room detail page's "Invite to room".
+ *
+ * The two had the same twenty lines of markup and their own copy of the
+ * `useCopyToClipboard` wiring; only the sentence above the field differed,
+ * so that is the one thing left as a prop. Owning the hook here also means
+ * neither dialog carries copy state it uses nowhere else.
+ *
+ * The input stays focusable and select-on-focus: `copy` is a no-op on
+ * non-secure origins, so manual selection has to keep working.
+ */
+export function ShareLinkBox({ blurb, link }: { blurb: ReactNode; link: string }) {
+  const { copied, copy } = useCopyToClipboard();
+
+  return (
+    <div className="mt-3 rounded border border-border bg-muted/40 p-3">
+      <div className="text-[11px] text-muted-foreground mb-1.5">{blurb}</div>
+      <div className="flex items-center gap-1.5">
+        <input
+          readOnly
+          value={link}
+          className="flex-1 rounded border border-border bg-background px-2 py-1.5 text-[11px] font-mono"
+          onFocus={(e) => e.currentTarget.select()}
+        />
+        <button
+          type="button"
+          onClick={() => void copy(link)}
+          className="h-7 px-2.5 rounded text-[11px] font-medium border border-border hover:bg-secondary transition-colors cursor-pointer shrink-0"
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/tasks/task-detail-panel.tsx
+++ b/packages/web/components/tasks/task-detail-panel.tsx
@@ -7,6 +7,7 @@ import { ChatMarkdown } from "@/components/chat/markdown";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { PanelFooterField, PeekPanel } from "@/components/detail/peek-panel";
 import { TaskStatusPill, SessionStatusPill } from "@/components/detail/status-pill";
+import { MonoLink } from "@/components/detail/mono-link";
 import { EmptyState } from "@/components/empty-state";
 import { HierChip } from "@/components/hier-chip";
 import { Skeleton } from "@/components/skeleton";
@@ -209,12 +210,9 @@ function PanelLoaded({ task }: { task: TaskDetail }) {
         ) : null}
         {task.parent_task_id ? (
           <PanelFooterField label="Parent">
-            <Link
-              href={`/tasks/${task.parent_task_id}`}
-              className="font-mono hover:text-foreground transition-colors"
-            >
+            <MonoLink href={`/tasks/${task.parent_task_id}`}>
               {shortId(task.parent_task_id)}
-            </Link>
+            </MonoLink>
           </PanelFooterField>
         ) : null}
       </footer>

--- a/packages/web/components/user-widget.tsx
+++ b/packages/web/components/user-widget.tsx
@@ -14,7 +14,7 @@ import {
 } from "lucide-react";
 import { useMe } from "@/lib/hooks/use-me";
 import { useDismissOnOutside } from "@/lib/hooks/use-dismiss";
-import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
+import { ShareLinkBox } from "@/components/share-link-box";
 import { ModalOverlay } from "@/components/modal-overlay";
 import { clearUserKey } from "@/lib/api/config";
 import { cn } from "@/lib/utils";
@@ -148,7 +148,6 @@ function MenuItem({
 
 function InviteTeammateDialog({ onClose }: { onClose: () => void }) {
   const [email, setEmail] = useState("");
-  const { copied, copy } = useCopyToClipboard();
   const trimmed = email.trim().toLowerCase();
   const valid = EMAIL_RE.test(trimmed);
   const origin = typeof window !== "undefined" ? window.location.origin : "";
@@ -173,26 +172,7 @@ function InviteTeammateDialog({ onClose }: { onClose: () => void }) {
           className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
         />
         {shareLink ? (
-          <div className="mt-3 rounded border border-border bg-muted/40 p-3">
-            <div className="text-[11px] text-muted-foreground mb-1.5">
-              Send them this link:
-            </div>
-            <div className="flex items-center gap-1.5">
-              <input
-                readOnly
-                value={shareLink}
-                className="flex-1 rounded border border-border bg-background px-2 py-1.5 text-[11px] font-mono"
-                onFocus={(e) => e.currentTarget.select()}
-              />
-              <button
-                type="button"
-                onClick={() => void copy(shareLink)}
-                className="h-7 px-2.5 rounded text-[11px] font-medium border border-border hover:bg-secondary transition-colors cursor-pointer shrink-0"
-              >
-                {copied ? "Copied" : "Copy"}
-              </button>
-            </div>
-          </div>
+          <ShareLinkBox blurb="Send them this link:" link={shareLink} />
         ) : null}
         <div className="mt-4 flex items-center justify-end gap-2">
           <button


### PR DESCRIPTION
Sweep for near-duplicate abstractions across the monorepo. `packages/core` and `packages/api` have already been through this (`adapters/runtime-common.ts`, `routes/http-errors.ts`, and their doc comments record what was merged and what deliberately wasn't) — `packages/web` had not, and it held the largest remaining clusters.

Every change here is chrome only: no state moved, no data flow changed, no visual difference.

## What was unified

| Extraction | Call sites | What was duplicated |
| --- | --- | --- |
| `components/detail/detail-footer.tsx` | 7 | All seven detail pages (task, agent, session, chat session, work product, escalation, negotiation) spelled out the same nine-class `<footer>` metadata grid. The fields differ per page and stay at the call site; only the container moved. |
| `components/detail/mono-link.tsx` | 5 | The id-shaped cross-reference link (`Parent: task_a1b2c3`) repeated `font-mono hover:text-foreground transition-colors` inline. `ClickToCopyId` keeps its own class list — it's a button with an icon, not a navigation link. |
| `DetailShell` (existing) | 5 | The five `loading.tsx` skeletons re-implemented `DetailShell`'s two nested divs by hand rather than importing it, so the page shell and its loading state could drift apart. |
| `components/auth/auth-form.tsx` | 2 | `/sign-in` and `/sign-up` are the same centred card, the same labelled input, the same warning-triangle error line and the same spinner submit button — written out twice, and already one Tailwind class apart in places. Split into `AuthCard` / `AuthField` / `AuthError` / `AuthSubmitButton`. State, validation and submit handlers stay on the pages. |
| `components/share-link-box.tsx` | 2 | Both invite dialogs (`UserWidget` → "Invite a teammate", room detail → "Invite to room") had the same twenty lines of read-only-URL-plus-Copy markup and their own `useCopyToClipboard` wiring. `use-copy-to-clipboard.ts`'s own doc comment already named this pair. Only the sentence above the field differed, so that stayed a prop. |

Net: 17 files touched, 412 insertions / 517 deletions.

## Deliberately not merged

- **`app/error.tsx` / `global-error.tsx` / `rooms/[id]/error.tsx`** — share only the props signature and a `useEffect(console.error)`. `global-error` replaces `<html>`/`<body>` so it must be inline-styled with no Tailwind, and the room boundary renders a stack trace the others don't. Three genuinely different renderings.
- **The per-page `DetailGate` skeletons** — the first `<Skeleton>` line matches across four pages but the rest doesn't, and `DetailGate`'s doc explains why they're per-page: a generic skeleton would jump on hydration.
- **`anthropic/llm-provider.ts` / `openai/llm-provider.ts`** — structurally parallel but the bodies are SDK-specific. Only the five-line "resolve API key from config or env, throw if missing" constructor preamble is actually shared; not worth an indirection.
- **`api/views/tasks.ts`'s `TaskListRow` vs `postgres/row-types.ts`'s `TaskRow`** — the same eighteen columns, but the view narrows to domain unions (`TaskStatus`) where the row type stays `string`. Merging them would change what each layer asserts, which is a decision rather than a cleanup.

## Also found, not in this PR

Two clusters worth their own change, kept out to keep this one reviewable:

1. **`ClaudeCodeRuntime` / `CodexRuntime` / `OpenCodeRuntime` `execute()`** (`packages/core/src/adapters/*/runtime.ts`) — after the arg-building diverges, all three end with the same ~25 lines: accumulate events, `createStdoutLineReader`, `runCliProcess` with identical options, `flush`, `warnIfTruncated`, `aborted → cancelledResult`, `finalizeCliResult(parse(...))`. A generic `runCliRuntimeSession<E>(...)` in `runtime-common.ts` parameterised by tag / command / args / env / `parseLine` / `extractSteps` / `buildResult` would absorb it; codex additionally needs a post-exit hook for its `--output-last-message` file.
2. **Transcript assembly in the three `stream-json.ts` parsers** — each builds `[assistant] …` / `[tool_call] …` / `[tool_result from X] …` lines with its own 200-char slice and newline-collapse. A small shared builder would stop the wire format drifting per runtime. Related: `claude-code/stream-json.ts` keeps a private `describeToolInput` that is a superset of `runtime-common.ts`'s — the shared one already takes a `fields` list, so the two could converge on it plus the extra branches.

## Verification

`packages/web`: `typecheck` clean, `lint` clean (one pre-existing `import/no-duplicates` warning in untouched `lib/types/dashboard.ts`), `next build` succeeds, **213 tests pass** (203 before, plus 10 new).

New tests cover the two extractions that carry behavior rather than just markup: `ShareLinkBox` (read-only field, copy flash, clipboard-unavailable fallback) and the auth primitives (label wiring, stacking margin, class merge, pending swap, form submit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsKCPg7zkaNdhmgbEgJ85t

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsKCPg7zkaNdhmgbEgJ85t)_