### PR TITLE
chore(web): drop the unused `Api` type export

### DIFF
--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -727,5 +727,3 @@ export interface FindRepoCandidate {
     invocation: string;
   };
 }
-
-export type Api = typeof api;


### PR DESCRIPTION
## What

Removes `export type Api = typeof api;` from `packages/web/lib/api/client.ts` — the only genuine dead-code finding from a full static + dynamic sweep of the monorepo.

```diff
-
-export type Api = typeof api;
```

## Why

The type has no consumer anywhere in the repo: nothing imports it, no barrel re-exports it, and neither the web app, the API package, nor any script references it. The only other matches for the bare word `Api` are the `X-GitHub-Api-Version` header literals in `learned-skills.ts` / `find-repo.ts` and a prose line in `packages/daemon/README.md`.

Two independent methods agree it is dead: knip flagged it, and a by-name `git grep` sweep (the method CLAUDE.md prescribes, since knip is blind to symbols behind `@beevibe/core` subpath barrels) found zero surviving references.

## How it was found

| Analysis | Result |
| --- | --- |
| `knip` | 7 unused files, 2 unused deps, 12 unused exports, 107 unused types — all false positives (see below) except `Api` |
| `depcheck` (root + per package) | `prettier`, `typescript`, `node-pg-migrate`, `zod`, `autoprefixer`, `postcss` — all in CLAUDE.md's documented table |
| `tsc --noUnusedLocals --noUnusedParameters` (6 packages) | clean |
| `tsc --allowUnreachableCode false` (TS7027) | clean |
| By-name sweep of `export function\|class\|const\|let` | every hit used within its own declaring file |
| By-name sweep of `export type\|interface\|enum` | no fully dead types |
| Class-method sweep for uncalled methods | no dead methods |
| Module-import graph (all packages incl. web) | orphans are only `main.ts` entrypoints, sandbox bins, and Next.js App Router convention files |
| v8 coverage — core 84.7%, api 64.9%, daemon 80.4% | no 0%-covered module that wasn't a barrel, a type-only file, or a CLI entrypoint |

## Why nothing else was removed

Everything else the tools surfaced fell into one of two buckets:

1. **Already documented in `CLAUDE.md`'s false-positive table** — `node-pg-migrate` (deploy migrations), `zod` (MCP SDK peer dep), `postcss`/`autoprefixer`, `prettier`, `migrations/*.js`, the manual dev/ops scripts, `OwnerLookup.singleOwnerSet`/`.meshOwners`, the core subpath exports, and the "dead in-repo, but not ours to delete" entries (`PostgresMemoryPromotionEventRepository`, `SkillOutcomeRepository.listBySkill`/`.statsForSkill`, `AgentProvisionEventRepository.listByParent`, `GET /activity`).
2. **Symbols used inside their own file** — `RUNTIME_WS_PATH`, `STREAM_TYPE`, `BLOCK_TYPE`, `MODEL_PRESETS`, `splitWakeReason`, the `DEFAULT_*` constants, and the ~107 DI `*Deps` interfaces. There the `export` keyword is redundant, not the code dead; per CLAUDE.md these are left alone.

`scripts/test-watch-tasks.sh` is unreferenced by any config, but its own header documents it as a manual DB-level E2E smoke that guards against migration drift the vitest suite can't catch — same call as the documented manual utilities, so it stays.

The sweep also confirms CLAUDE.md's false-positive table is still accurate after #285.

## Validation

- `pnpm typecheck` — 9/9 pass
- `pnpm lint` — 9/9 pass (4 pre-existing `import/no-duplicates` warnings, untouched)
- `pnpm --filter @beevibe/web exec next build` — succeeds (direct build per CLAUDE.md; `pnpm build` fails on web behind the proxy for the documented Turbo strict-env/Google Fonts reason, on `main` as well)
- `packages/web` vitest — 24 files, 203 tests pass

The coverage provider used for the dynamic pass was installed temporarily and is **not** committed; `pnpm-lock.yaml` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDRTHpFpz6j5aCfKkoKP2x

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDRTHpFpz6j5aCfKkoKP2x)_