### PR TITLE
refactor: unify near-duplicate abstractions in the CLI runtimes and the web UI

### DIFF
--- a/packages/core/src/adapters/claude-code/runtime.ts
+++ b/packages/core/src/adapters/claude-code/runtime.ts
@@ -9,17 +9,10 @@ import type {
 import {
   cancelledResult,
   cliVersionHealthCheck,
-  createStdoutLineReader,
   finalizeCliResult,
-  warnIfTruncated,
+  runCliStream,
 } from "../runtime-common.js";
-import { runCliProcess } from "./spawn.js";
-import {
-  extractStepEvents,
-  parseClaudeMessages,
-  parseStreamJsonLine,
-  type StreamJsonMessage,
-} from "./stream-json.js";
+import { extractStepEvents, parseClaudeMessages, parseStreamJsonLine } from "./stream-json.js";
 
 /**
  * Claude Code CLI subprocess runtime.
@@ -103,39 +96,19 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     for (const key of ANTHROPIC_AUTH_VARS) delete env[key];
     if (context.env) Object.assign(env, context.env);
 
-    // Parse messages incrementally during streaming so we don't re-parse
-    // the entire stdout after close. A line buffer handles chunk boundaries
-    // (a single JSON message can arrive split across multiple chunks).
-    const messages: StreamJsonMessage[] = [];
-    const handleLine = (line: string): void => {
-      const msg = parseStreamJsonLine(line);
-      if (!msg) return;
-      messages.push(msg);
-      if (context.onStep) {
-        for (const step of extractStepEvents(msg)) {
-          context.onStep(step);
-        }
-      }
-    };
-    const stdout = createStdoutLineReader(handleLine);
-
-    const result = await runCliProcess({
+    // Messages are parsed incrementally during streaming (see runCliStream)
+    // so we don't re-parse the entire stdout after close.
+    const { events: messages, result } = await runCliStream({
+      runtimeTag: "ClaudeCodeRuntime",
       command: this.config.command ?? "claude",
       args,
       cwd,
       env,
       stdin: context.intent,
-      abortSignal: context.abort_signal,
-      onSpawn: ({ pid, process_group_id }) => {
-        context.onSpawn?.({ process_pid: pid, process_group_id });
-      },
-      onLog: stdout.onLog,
+      context,
+      parseLine: parseStreamJsonLine,
+      extractSteps: extractStepEvents,
     });
-
-    // Flush any final partial line (stream without trailing \n)
-    stdout.flush();
-
-    warnIfTruncated("ClaudeCodeRuntime", result);
 
     if (result.aborted) return cancelledResult(result);
 

--- a/packages/core/src/adapters/claude-code/stream-json.ts
+++ b/packages/core/src/adapters/claude-code/stream-json.ts
@@ -1,5 +1,11 @@
 import type { RuntimeResult, RuntimeStep } from "../../ports/runtime.js";
-import { parseNdjsonLine } from "../runtime-common.js";
+import {
+  assistantLine,
+  inlineSnippet,
+  parseNdjsonLine,
+  toolCallLine,
+  toolResultLine,
+} from "../runtime-common.js";
 
 /**
  * Parser for Claude Code's `--output-format stream-json` output. Each line
@@ -214,36 +220,27 @@ export function parseClaudeMessages(
     if (msg.type === STREAM_TYPE.Assistant && msg.message) {
       const content = msg.message.content;
       if (typeof content === "string") {
-        transcriptParts.push(`[assistant] ${content}\n`);
+        transcriptParts.push(assistantLine(content));
         output = content;
       } else if (Array.isArray(content)) {
         const texts: string[] = [];
         for (const block of content) {
           if (block.type === BLOCK_TYPE.Text && typeof block.text === "string") {
-            transcriptParts.push(`[assistant] ${block.text}\n`);
+            transcriptParts.push(assistantLine(block.text));
             texts.push(block.text);
           } else if (block.type === BLOCK_TYPE.ToolUse) {
-            transcriptParts.push(`[tool_call] ${block.name ?? "unknown"}\n`);
+            transcriptParts.push(toolCallLine(block.name ?? "unknown"));
           }
           // Skip thinking blocks + signatures — they bloat the transcript.
         }
         if (texts.length > 0) output = texts.join("\n");
       }
     } else if (msg.type === STREAM_TYPE.ToolUse) {
-      transcriptParts.push(`[tool_call] ${msg.name ?? "unknown"}\n`);
+      transcriptParts.push(toolCallLine(msg.name ?? "unknown"));
     } else if (msg.type === STREAM_TYPE.ToolResult) {
       const toolName = msg.tool_use_id ? toolUseNames.get(msg.tool_use_id) : undefined;
-      const resultContent =
-        typeof msg.content === "string" ? msg.content.slice(0, 200).replace(/\n/g, " ") : "";
-      if (toolName) {
-        transcriptParts.push(
-          resultContent
-            ? `[tool_result from ${toolName}] ${resultContent}\n`
-            : `[tool_result from ${toolName}]\n`,
-        );
-      } else {
-        transcriptParts.push("[tool_result]\n");
-      }
+      const resultContent = typeof msg.content === "string" ? inlineSnippet(msg.content) : "";
+      transcriptParts.push(toolResultLine(toolName, resultContent));
     } else if (msg.type === STREAM_TYPE.Result) {
       sessionId = msg.session_id;
       costUsd = msg.total_cost_usd ?? msg.cost_usd;

--- a/packages/core/src/adapters/codex/runtime.ts
+++ b/packages/core/src/adapters/codex/runtime.ts
@@ -8,21 +8,18 @@ import type {
   RuntimeWorkspaceContext,
   Workspace,
 } from "../../ports/runtime.js";
-import { runCliProcess } from "../claude-code/spawn.js";
 import { MCP_TOOL_TIMEOUT_MS } from "../local-workspace/manager.js";
 import {
   cancelledResult,
   cliVersionHealthCheck,
   composePrompt,
-  createStdoutLineReader,
   finalizeCliResult,
-  warnIfTruncated,
+  runCliStream,
 } from "../runtime-common.js";
 import {
   extractCodexStepEvents,
   parseCodexEventLine,
   parseCodexEvents,
-  type CodexEvent,
 } from "./stream-json.js";
 
 export interface CodexRuntimeConfig {
@@ -120,32 +117,16 @@ export class CodexRuntime implements AgentRuntime {
     if (context.env) Object.assign(env, context.env);
     if (prepared) env.BEEVIBE_AGENT_API_KEY = prepared.agentApiKey;
 
-    const events: CodexEvent[] = [];
-    const handleLine = (line: string): void => {
-      const evt = parseCodexEventLine(line);
-      if (!evt) return;
-      events.push(evt);
-      if (!context.onStep) return;
-      for (const step of extractCodexStepEvents(evt)) {
-        context.onStep(step);
-      }
-    };
-    const stdout = createStdoutLineReader(handleLine);
-
-    const result = await runCliProcess({
+    const { events, result } = await runCliStream({
+      runtimeTag: "CodexRuntime",
       command: this.config.command ?? "codex",
       args,
       cwd: context.workspace.path,
       env,
-      abortSignal: context.abort_signal,
-      onSpawn: ({ pid, process_group_id }) => {
-        context.onSpawn?.({ process_pid: pid, process_group_id });
-      },
-      onLog: stdout.onLog,
+      context,
+      parseLine: parseCodexEventLine,
+      extractSteps: extractCodexStepEvents,
     });
-    stdout.flush();
-
-    warnIfTruncated("CodexRuntime", result);
 
     if (result.aborted) {
       removeIfExists(lastMessagePath);

--- a/packages/core/src/adapters/codex/stream-json.ts
+++ b/packages/core/src/adapters/codex/stream-json.ts
@@ -1,6 +1,15 @@
 import type { RuntimeResult, RuntimeStep } from "../../ports/runtime.js";
 import { bareCliExitMessage } from "../claude-code/stream-json.js";
-import { describeToolInput, parseNdjsonLine } from "../runtime-common.js";
+import {
+  assistantLine,
+  describeToolInput,
+  errorLine,
+  inlineSnippet,
+  parseNdjsonLine,
+  toolCallLine,
+  toolResultLine,
+  TRANSCRIPT_SNIPPET_CHARS,
+} from "../runtime-common.js";
 
 /**
  * Parser for `codex exec --json` output.
@@ -210,29 +219,27 @@ export function parseCodexEvents(
         break;
       case CODEX_EVENT_TYPE.Error:
         topLevelError = evt.message ?? topLevelError;
-        if (evt.message) transcriptParts.push(`[error] ${evt.message}\n`);
+        if (evt.message) transcriptParts.push(errorLine(evt.message));
         break;
       case CODEX_EVENT_TYPE.ItemCompleted: {
         const item = evt.item;
         if (!item || !item.type) break;
         if (item.type === CODEX_ITEM_TYPE.AgentMessage && item.text) {
           assistantText = item.text;
-          transcriptParts.push(`[assistant] ${item.text}\n`);
+          transcriptParts.push(assistantLine(item.text));
         } else if (item.type === CODEX_ITEM_TYPE.McpToolCall) {
           const tool = item.tool ?? "unknown";
-          transcriptParts.push(`[tool_call] ${tool}\n`);
+          transcriptParts.push(toolCallLine(tool));
           const resultSummary = summarizeMcpResult(item.result);
           if (resultSummary || item.error?.message) {
-            transcriptParts.push(
-              `[tool_result from ${tool}] ${item.error?.message ?? resultSummary}\n`,
-            );
+            transcriptParts.push(toolResultLine(tool, item.error?.message ?? resultSummary));
           }
         } else if (item.type === CODEX_ITEM_TYPE.CommandExecution) {
-          transcriptParts.push(`[tool_call] shell ${(item.command ?? "").slice(0, 200)}\n`);
+          transcriptParts.push(
+            toolCallLine("shell", (item.command ?? "").slice(0, TRANSCRIPT_SNIPPET_CHARS)),
+          );
           if (item.aggregated_output) {
-            transcriptParts.push(
-              `[tool_result from shell] ${item.aggregated_output.slice(0, 200).replace(/\n/g, " ")}\n`,
-            );
+            transcriptParts.push(toolResultLine("shell", inlineSnippet(item.aggregated_output)));
           }
         }
         break;
@@ -280,8 +287,8 @@ function summarizeMcpResult(result: { content?: unknown[] } | null | undefined):
   for (const block of result.content) {
     if (block && typeof block === "object" && (block as { type?: unknown }).type === "text") {
       const text = (block as { text?: unknown }).text;
-      if (typeof text === "string") return text.slice(0, 200).replace(/\n/g, " ");
+      if (typeof text === "string") return inlineSnippet(text);
     }
   }
-  return JSON.stringify(result.content).slice(0, 200);
+  return JSON.stringify(result.content).slice(0, TRANSCRIPT_SNIPPET_CHARS);
 }

--- a/packages/core/src/adapters/opencode/runtime.ts
+++ b/packages/core/src/adapters/opencode/runtime.ts
@@ -8,20 +8,17 @@ import type {
   RuntimeWorkspaceContext,
   Workspace,
 } from "../../ports/runtime.js";
-import { runCliProcess } from "../claude-code/spawn.js";
 import {
   cancelledResult,
   cliVersionHealthCheck,
   composePrompt,
-  createStdoutLineReader,
   finalizeCliResult,
-  warnIfTruncated,
+  runCliStream,
 } from "../runtime-common.js";
 import {
   extractOpenCodeStepEvents,
   parseOpenCodeEventLine,
   parseOpenCodeEvents,
-  type OpenCodeEvent,
 } from "./stream-json.js";
 
 export interface OpenCodeRuntimeConfig {
@@ -76,32 +73,16 @@ export class OpenCodeRuntime implements AgentRuntime {
     const env: Record<string, string | undefined> = { ...process.env };
     if (context.env) Object.assign(env, context.env);
 
-    const events: OpenCodeEvent[] = [];
-    const handleLine = (line: string): void => {
-      const evt = parseOpenCodeEventLine(line);
-      if (!evt) return;
-      events.push(evt);
-      if (!context.onStep) return;
-      for (const step of extractOpenCodeStepEvents(evt)) {
-        context.onStep(step);
-      }
-    };
-    const stdout = createStdoutLineReader(handleLine);
-
-    const result = await runCliProcess({
+    const { events, result } = await runCliStream({
+      runtimeTag: "OpenCodeRuntime",
       command: this.config.command ?? "opencode",
       args,
       cwd: context.workspace.path,
       env,
-      abortSignal: context.abort_signal,
-      onSpawn: ({ pid, process_group_id }) => {
-        context.onSpawn?.({ process_pid: pid, process_group_id });
-      },
-      onLog: stdout.onLog,
+      context,
+      parseLine: parseOpenCodeEventLine,
+      extractSteps: extractOpenCodeStepEvents,
     });
-    stdout.flush();
-
-    warnIfTruncated("OpenCodeRuntime", result);
 
     if (result.aborted) return cancelledResult(result);
 

--- a/packages/core/src/adapters/opencode/stream-json.ts
+++ b/packages/core/src/adapters/opencode/stream-json.ts
@@ -1,7 +1,15 @@
 import type { SessionUsage } from "../../domain/session.js";
 import type { RuntimeResult, RuntimeStep } from "../../ports/runtime.js";
 import { bareCliExitMessage } from "../claude-code/stream-json.js";
-import { describeToolInput, parseNdjsonLine } from "../runtime-common.js";
+import {
+  assistantLine,
+  describeToolInput,
+  errorLine,
+  inlineSnippet,
+  parseNdjsonLine,
+  toolCallLine,
+  toolResultLine,
+} from "../runtime-common.js";
 
 /**
  * Parser for `opencode run --format json` output.
@@ -172,7 +180,7 @@ export function parseOpenCodeEvents(
         const text = evt.part?.text;
         if (text) {
           assistantTexts.push(text);
-          transcriptParts.push(`[assistant] ${text}\n`);
+          transcriptParts.push(assistantLine(text));
         }
         break;
       }
@@ -182,20 +190,16 @@ export function parseOpenCodeEvents(
         const tool = part.tool ?? "unknown";
         const status = part.state?.status;
         if (status === OPENCODE_TOOL_STATUS.Completed || status === OPENCODE_TOOL_STATUS.Error) {
-          const detail = (part.state?.error ?? part.state?.output ?? "")
-            .slice(0, 200)
-            .replace(/\n/g, " ");
-          transcriptParts.push(
-            detail ? `[tool_result from ${tool}] ${detail}\n` : `[tool_result from ${tool}]\n`,
-          );
+          const detail = inlineSnippet(part.state?.error ?? part.state?.output ?? "");
+          transcriptParts.push(toolResultLine(tool, detail));
         } else {
-          transcriptParts.push(`[tool_call] ${tool}\n`);
+          transcriptParts.push(toolCallLine(tool));
         }
         break;
       }
       case OPENCODE_EVENT_TYPE.Error:
         errorMessage = evt.error?.message ?? evt.result?.error?.message ?? errorMessage;
-        if (errorMessage) transcriptParts.push(`[error] ${errorMessage}\n`);
+        if (errorMessage) transcriptParts.push(errorLine(errorMessage));
         break;
       default:
         break;

--- a/packages/core/src/adapters/runtime-common.test.ts
+++ b/packages/core/src/adapters/runtime-common.test.ts
@@ -1,10 +1,17 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { CliProcessResult } from "./claude-code/spawn.js";
-import type { RuntimeResult } from "../ports/runtime.js";
+import type { CliProcessOptions, CliProcessResult } from "./claude-code/spawn.js";
+import * as spawnModule from "./claude-code/spawn.js";
+import type { RuntimeContext, RuntimeResult, RuntimeStep } from "../ports/runtime.js";
 import {
+  assistantLine,
   cancelledResult,
   createStdoutLineReader,
+  errorLine,
   finalizeCliResult,
+  inlineSnippet,
+  runCliStream,
+  toolCallLine,
+  toolResultLine,
   warnIfTruncated,
 } from "./runtime-common.js";
 
@@ -145,5 +152,170 @@ describe("finalizeCliResult", () => {
   it("omits stderr on failure when the CLI wrote nothing", () => {
     const failed: RuntimeResult = { status: "failed", output: "" };
     expect(finalizeCliResult(failed, cliResult({ stderr: "", exitCode: 1 })).stderr).toBeUndefined();
+  });
+});
+
+describe("runCliStream", () => {
+  interface Evt {
+    n: number;
+  }
+
+  function ctx(overrides: Partial<RuntimeContext> = {}): RuntimeContext {
+    return {
+      intent: "do a thing",
+      workspace: { path: "/tmp/beevibe-stream-test" },
+      system_prompt_append: "",
+      ...overrides,
+    };
+  }
+
+  function stream(
+    context: RuntimeContext,
+    opts: { extractSteps?: (e: Evt) => RuntimeStep[] } = {},
+  ) {
+    return runCliStream<Evt>({
+      runtimeTag: "TestRuntime",
+      command: "fake-cli",
+      args: ["--json"],
+      cwd: context.workspace.path,
+      context,
+      parseLine: (line) => {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith("{")) return null;
+        return JSON.parse(trimmed) as Evt;
+      },
+      extractSteps: opts.extractSteps ?? (() => []),
+    });
+  }
+
+  /** Mock `runCliProcess`, replaying `stdout` through `onLog` in `chunks`. */
+  function mockCli(chunks: string[], overrides: Partial<CliProcessResult> = {}) {
+    let seen: CliProcessOptions | undefined;
+    const spy = vi.spyOn(spawnModule, "runCliProcess").mockImplementation(async (options) => {
+      seen = options;
+      const result = cliResult(overrides);
+      if (result.pid !== null) {
+        options.onSpawn?.({
+          pid: result.pid,
+          process_group_id: result.process_group_id ?? result.pid,
+        });
+      }
+      for (const chunk of chunks) options.onLog?.("stdout", chunk);
+      return result;
+    });
+    return { spy, options: () => seen };
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("collects parsed events in arrival order and skips unparseable lines", async () => {
+    mockCli(['{"n":1}\nnot json\n{"n":2}\n']);
+    const { events, result } = await stream(ctx());
+    expect(events).toEqual([{ n: 1 }, { n: 2 }]);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("reassembles an event split across stdout chunks", async () => {
+    mockCli(['{"n', '":7}\n']);
+    const { events } = await stream(ctx());
+    expect(events).toEqual([{ n: 7 }]);
+  });
+
+  it("flushes a trailing line the stream never terminated with a newline", async () => {
+    mockCli(['{"n":1}\n{"n":2}']);
+    const { events } = await stream(ctx());
+    expect(events).toEqual([{ n: 1 }, { n: 2 }]);
+  });
+
+  it("forwards each event's steps to context.onStep", async () => {
+    mockCli(['{"n":1}\n{"n":2}\n']);
+    const steps: RuntimeStep[] = [];
+    await stream(ctx({ onStep: (s) => steps.push(s) }), {
+      extractSteps: (e) => [{ kind: "agent", description: `step ${e.n}`, timestamp: "t" }],
+    });
+    expect(steps.map((s) => s.description)).toEqual(["step 1", "step 2"]);
+  });
+
+  it("skips step extraction entirely when the caller wants no live steps", async () => {
+    mockCli(['{"n":1}\n']);
+    const extractSteps = vi.fn(() => []);
+    const { events } = await stream(ctx(), { extractSteps });
+    expect(events).toHaveLength(1);
+    expect(extractSteps).not.toHaveBeenCalled();
+  });
+
+  it("relays spawn metadata through context.onSpawn", async () => {
+    mockCli([]);
+    const onSpawn = vi.fn();
+    await stream(ctx({ onSpawn }));
+    expect(onSpawn).toHaveBeenCalledWith({ process_pid: 4242, process_group_id: 4242 });
+  });
+
+  it("passes command, args, cwd, env, stdin and the abort signal to the spawner", async () => {
+    const { options } = mockCli([]);
+    const controller = new AbortController();
+    await runCliStream<Evt>({
+      runtimeTag: "TestRuntime",
+      command: "fake-cli",
+      args: ["--json"],
+      cwd: "/ws",
+      env: { FOO: "bar" },
+      stdin: "the intent",
+      context: ctx({ abort_signal: controller.signal }),
+      parseLine: () => null,
+      extractSteps: () => [],
+    });
+    expect(options()).toMatchObject({
+      command: "fake-cli",
+      args: ["--json"],
+      cwd: "/ws",
+      env: { FOO: "bar" },
+      stdin: "the intent",
+      abortSignal: controller.signal,
+    });
+  });
+
+  it("warns with the runtime tag when stdout was capped", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockCli(['{"n":1}\n'], { truncated: true });
+    await stream(ctx());
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("[TestRuntime]"));
+  });
+});
+
+describe("transcript line builders", () => {
+  it("truncates and flattens a payload onto one line", () => {
+    expect(inlineSnippet("line one\nline two")).toBe("line one line two");
+    expect(inlineSnippet("x".repeat(500))).toHaveLength(200);
+    expect(inlineSnippet("abcdef", 3)).toBe("abc");
+  });
+
+  it("tags assistant text", () => {
+    expect(assistantLine("hello")).toBe("[assistant] hello\n");
+  });
+
+  it("renders a tool call with and without an argument summary", () => {
+    expect(toolCallLine("Read")).toBe("[tool_call] Read\n");
+    expect(toolCallLine("shell", "pnpm test")).toBe("[tool_call] shell pnpm test\n");
+    // An empty detail collapses to the bare form rather than leaving a
+    // trailing space.
+    expect(toolCallLine("shell", "")).toBe("[tool_call] shell\n");
+  });
+
+  it("attributes a tool result to its tool", () => {
+    expect(toolResultLine("Read", "file contents")).toBe("[tool_result from Read] file contents\n");
+    expect(toolResultLine("Read")).toBe("[tool_result from Read]\n");
+    expect(toolResultLine("Read", "")).toBe("[tool_result from Read]\n");
+  });
+
+  it("degrades to the opaque form — dropping detail — when the tool is unknown", () => {
+    expect(toolResultLine(undefined)).toBe("[tool_result]\n");
+    expect(toolResultLine(undefined, "orphaned payload")).toBe("[tool_result]\n");
+  });
+
+  it("tags a run-level error", () => {
+    expect(errorLine("rate limited")).toBe("[error] rate limited\n");
   });
 });

--- a/packages/core/src/adapters/runtime-common.ts
+++ b/packages/core/src/adapters/runtime-common.ts
@@ -1,5 +1,10 @@
 import { tmpdir } from "node:os";
-import type { RuntimeContext, RuntimeHealth, RuntimeResult } from "../ports/runtime.js";
+import type {
+  RuntimeContext,
+  RuntimeHealth,
+  RuntimeResult,
+  RuntimeStep,
+} from "../ports/runtime.js";
 import { type CliProcessResult, runCliProcess } from "./claude-code/spawn.js";
 
 /**
@@ -67,6 +72,64 @@ export function describeToolInput(
     if (typeof v === "string" && v.length > 0) return v.slice(0, 200);
   }
   return JSON.stringify(input).slice(0, 200);
+}
+
+/**
+ * How much of a tool's input or output a transcript line carries. Long
+ * enough to identify the call, short enough that a chatty session doesn't
+ * blow up the persisted transcript (or the summarizer's context).
+ */
+export const TRANSCRIPT_SNIPPET_CHARS = 200;
+
+/**
+ * Collapse a tool payload onto one transcript line: truncate, then flatten
+ * newlines to spaces so a multi-line command output can't fake extra
+ * transcript entries.
+ */
+export function inlineSnippet(text: string, max = TRANSCRIPT_SNIPPET_CHARS): string {
+  return text.slice(0, max).replace(/\n/g, " ");
+}
+
+/*
+ * The persisted-transcript line format.
+ *
+ * `[assistant] …` / `[tool_call] …` / `[tool_result from X] …` / `[error] …`
+ * is a cross-provider contract, not per-adapter cosmetics: the transcript
+ * summarizer and downstream LLM consumers key off these tags, and the web
+ * transcript view renders them. All three parsers had spelled the same
+ * template literals out by hand, which is three places to drift. The
+ * builders below are the single definition.
+ */
+
+/** One assistant text block. */
+export function assistantLine(text: string): string {
+  return `[assistant] ${text}\n`;
+}
+
+/**
+ * One tool invocation. `detail` is an optional already-snippeted argument
+ * summary (codex appends the shell command); omitted or empty renders the
+ * bare `[tool_call] <tool>` form.
+ */
+export function toolCallLine(tool: string, detail?: string): string {
+  return detail ? `[tool_call] ${tool} ${detail}\n` : `[tool_call] ${tool}\n`;
+}
+
+/**
+ * One tool result. An unknown `tool` degrades to the opaque `[tool_result]`
+ * form — and drops `detail` with it, since an unattributed payload is more
+ * confusing to a downstream reader than no payload at all. That case only
+ * arises for Claude Code results whose `tool_use_id` never appeared in an
+ * assistant block.
+ */
+export function toolResultLine(tool: string | undefined, detail?: string): string {
+  if (!tool) return "[tool_result]\n";
+  return detail ? `[tool_result from ${tool}] ${detail}\n` : `[tool_result from ${tool}]\n`;
+}
+
+/** A run-level error event (codex `error` / `turn.failed`, opencode `error`). */
+export function errorLine(message: string): string {
+  return `[error] ${message}\n`;
 }
 
 /**
@@ -166,6 +229,80 @@ export function createStdoutLineReader(handleLine: (line: string) => void): {
 export function warnIfTruncated(runtimeTag: string, result: CliProcessResult): void {
   if (!result.truncated) return;
   console.warn(`[${runtimeTag}] stdout truncated at 4MB — result parsing may be incomplete`);
+}
+
+export interface CliStreamOptions<Event> {
+  /** Log tag for the truncation warning — e.g. `"CodexRuntime"`. */
+  runtimeTag: string;
+  command: string;
+  args: string[];
+  cwd: string;
+  env?: Record<string, string | undefined>;
+  /** Piped to the child's stdin. Only Claude Code uses this (`--print -`). */
+  stdin?: string;
+  /** Supplies `abort_signal`, `onSpawn` and `onStep`. */
+  context: RuntimeContext;
+  /** Provider-specific NDJSON line parser; `null` skips the line. */
+  parseLine: (line: string) => Event | null;
+  /** Provider-specific event → live-transcript steps. */
+  extractSteps: (event: Event) => RuntimeStep[];
+}
+
+export interface CliStreamOutcome<Event> {
+  /** Every event parsed off stdout, in arrival order. */
+  events: Event[];
+  result: CliProcessResult;
+}
+
+/**
+ * Spawn a CLI runtime and collect its NDJSON event stream.
+ *
+ * All three CLI adapters run the identical sequence around their own parser:
+ * accumulate events off a line reader, forward each one's steps to
+ * `context.onStep`, spawn, flush the trailing partial line, then warn if
+ * stdout hit the capture cap. Only the event schema and what happens *after*
+ * the process settles differ, so this owns the streaming half and hands back
+ * the raw events — each adapter still decides how to turn them into a
+ * `RuntimeResult` (codex, for one, also has an `--output-last-message` file
+ * to read and clean up on both the aborted and the completed path).
+ *
+ * Steps are forwarded as they parse, so the live transcript keeps updating
+ * while the process runs; `events` is only used once it settles.
+ */
+export async function runCliStream<Event>(
+  opts: CliStreamOptions<Event>,
+): Promise<CliStreamOutcome<Event>> {
+  const { context } = opts;
+  const events: Event[] = [];
+
+  const stdout = createStdoutLineReader((line) => {
+    const event = opts.parseLine(line);
+    if (!event) return;
+    events.push(event);
+    if (!context.onStep) return;
+    for (const step of opts.extractSteps(event)) {
+      context.onStep(step);
+    }
+  });
+
+  const result = await runCliProcess({
+    command: opts.command,
+    args: opts.args,
+    cwd: opts.cwd,
+    env: opts.env,
+    stdin: opts.stdin,
+    abortSignal: context.abort_signal,
+    onSpawn: ({ pid, process_group_id }) => {
+      context.onSpawn?.({ process_pid: pid, process_group_id });
+    },
+    onLog: stdout.onLog,
+  });
+
+  // Emit any final line the stream ended without a newline after.
+  stdout.flush();
+  warnIfTruncated(opts.runtimeTag, result);
+
+  return { events, result };
 }
 
 /**

--- a/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
+++ b/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
@@ -23,6 +23,7 @@ import { Skeleton } from "@/components/skeleton";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { DetailGate } from "@/components/detail/detail-gate";
 import { FooterField } from "@/components/detail/footer-field";
+import { DetailFooter } from "@/components/detail/detail-footer";
 import { Metric } from "@/components/detail/metric";
 import { cn } from "@/lib/utils";
 import type { AgentDetail } from "@/lib/api/types";
@@ -278,7 +279,7 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
         ) : null}
       </div>
 
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      <DetailFooter>
         <FooterField label="ID">
           <ClickToCopyId id={agent.id} />
         </FooterField>
@@ -294,7 +295,7 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
             {new Date(agent.archived_at).toLocaleString()}
           </FooterField>
         ) : null}
-      </footer>
+      </DetailFooter>
     </>
   );
 }

--- a/packages/web/app/(authed)/escalations/[id]/escalation-detail-client.tsx
+++ b/packages/web/app/(authed)/escalations/[id]/escalation-detail-client.tsx
@@ -10,6 +10,7 @@ import { ChatMarkdown } from "@/components/chat/markdown";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { DetailGate } from "@/components/detail/detail-gate";
 import { FooterField } from "@/components/detail/footer-field";
+import { DetailFooter } from "@/components/detail/detail-footer";
 import { Skeleton } from "@/components/skeleton";
 import { EscalationStatusPill } from "@/components/detail/status-pill";
 import { MutationError } from "@/components/mutation-error";
@@ -110,7 +111,7 @@ function EscalationDetailLoaded({ esc }: { esc: EscalationReviewDetail }) {
 
       {esc.status === "pending" ? <ResolveForm esc={esc} /> : <ResolvedView esc={esc} />}
 
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      <DetailFooter>
         <FooterField label="ID">
           <ClickToCopyId id={esc.id} />
         </FooterField>
@@ -124,7 +125,7 @@ function EscalationDetailLoaded({ esc }: { esc: EscalationReviewDetail }) {
         {esc.resolved_at ? (
           <FooterField label="Resolved">{formatRelativeTime(esc.resolved_at)}</FooterField>
         ) : null}
-      </footer>
+      </DetailFooter>
     </>
   );
 }

--- a/packages/web/app/(authed)/negotiations/[id]/negotiation-detail-client.tsx
+++ b/packages/web/app/(authed)/negotiations/[id]/negotiation-detail-client.tsx
@@ -8,6 +8,7 @@ import { ChatMarkdown } from "@/components/chat/markdown";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { DetailGate } from "@/components/detail/detail-gate";
 import { FooterField } from "@/components/detail/footer-field";
+import { DetailFooter } from "@/components/detail/detail-footer";
 import { NegotiationStatusPill } from "@/components/detail/status-pill";
 import { Skeleton } from "@/components/skeleton";
 import { formatRelativeTime } from "@/lib/format";
@@ -120,7 +121,7 @@ function NegotiationDetailLoaded({ neg }: { neg: NegotiationReviewDetail }) {
         )}
       </section>
 
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      <DetailFooter>
         <FooterField label="ID">
           <ClickToCopyId id={neg.id} />
         </FooterField>
@@ -141,7 +142,7 @@ function NegotiationDetailLoaded({ neg }: { neg: NegotiationReviewDetail }) {
         {neg.updated_at !== neg.created_at ? (
           <FooterField label="Updated">{formatRelativeTime(neg.updated_at)}</FooterField>
         ) : null}
-      </footer>
+      </DetailFooter>
     </>
   );
 }

--- a/packages/web/app/(authed)/rooms/[id]/room-detail-client.tsx
+++ b/packages/web/app/(authed)/rooms/[id]/room-detail-client.tsx
@@ -17,7 +17,7 @@ import { isApiConfigured } from "@/lib/api/config";
 import { api, type RoomDetail, type RoomMemberDetail, type RoomMessage } from "@/lib/api/client";
 import { ApiError, describeError } from "@/lib/api/http";
 import { queryKeys } from "@/lib/hooks/keys";
-import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
+import { ShareLinkBox } from "@/components/share-link-box";
 import { ModalOverlay } from "@/components/modal-overlay";
 import { ChatMarkdown } from "@/components/chat/markdown";
 import { ToolStepList } from "@/components/chat/tool-step-list";
@@ -275,7 +275,6 @@ function InviteDialog({ roomId, onClose }: { roomId: string; onClose: () => void
   const [error, setError] = useState<string | null>(null);
   /** When the invitee doesn't have an account yet, surface a share link they can use to sign up + auto-join. */
   const [shareLink, setShareLink] = useState<string | null>(null);
-  const { copied, copy } = useCopyToClipboard();
 
   const invite = useMutation({
     mutationFn: () => api.rooms.invite(roomId, { email: email.trim() }),
@@ -333,27 +332,10 @@ function InviteDialog({ roomId, onClose }: { roomId: string; onClose: () => void
           </div>
         ) : null}
         {shareLink ? (
-          <div className="mt-3 rounded border border-border bg-muted/40 p-3">
-            <div className="text-[11px] text-muted-foreground mb-1.5">
-              No account for that email yet. Send them this link — they&apos;ll sign up and
-              land in this room.
-            </div>
-            <div className="flex items-center gap-1.5">
-              <input
-                readOnly
-                value={shareLink}
-                className="flex-1 rounded border border-border bg-background px-2 py-1.5 text-[11px] font-mono"
-                onFocus={(e) => e.currentTarget.select()}
-              />
-              <button
-                type="button"
-                onClick={() => void copy(shareLink ?? "")}
-                className="h-7 px-2.5 rounded text-[11px] font-medium border border-border hover:bg-secondary transition-colors cursor-pointer shrink-0"
-              >
-                {copied ? "Copied" : "Copy"}
-              </button>
-            </div>
-          </div>
+          <ShareLinkBox url={shareLink}>
+            No account for that email yet. Send them this link — they&apos;ll sign up and land
+            in this room.
+          </ShareLinkBox>
         ) : null}
         <div className="mt-4 flex items-center justify-end gap-2">
           <button

--- a/packages/web/app/(authed)/sessions/[sid]/chat-session-detail-client.tsx
+++ b/packages/web/app/(authed)/sessions/[sid]/chat-session-detail-client.tsx
@@ -6,12 +6,14 @@ import { useConversation } from "@/lib/hooks/use-sessions";
 import { DetailGate } from "@/components/detail/detail-gate";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
-import { SessionStatusPill } from "@/components/detail/status-pill";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { FooterField } from "@/components/detail/footer-field";
+import { DetailFooter } from "@/components/detail/detail-footer";
 import { ChatMarkdown } from "@/components/chat/markdown";
-import { HierChip } from "@/components/hier-chip";
-import { Avatar } from "@/components/avatar";
+import {
+  SessionHeader,
+  SessionHeaderDot,
+} from "@/components/sessions/session-header";
 import { UsagePanel } from "@/components/sessions/usage-panel";
 import type {
   ConversationDisplay,
@@ -91,37 +93,21 @@ function ConversationBody({ conversation }: { conversation: ConversationDisplay 
 
   return (
     <>
-      <header className="mb-6">
-        <div className="flex items-start gap-3">
-          <Avatar
-            initial={conversation.agent_label.charAt(0).toUpperCase()}
-            kind={conversation.agent_hierarchy}
-            label={conversation.agent_label}
-            size={40}
-            presence={conversation.status === "running" ? "running" : "idle"}
-          />
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 mb-1">
-              <h1 className="text-base font-semibold tracking-tight leading-tight">
-                {multiTurn ? "Conversation" : "One turn"}
-              </h1>
-              <SessionStatusPill status={conversation.status} />
-            </div>
-            <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <span className="text-foreground/85">{conversation.agent_label}</span>
-              <HierChip hier={conversation.agent_hierarchy} />
-              {multiTurn ? (
-                <>
-                  <span className="text-muted-foreground/50">·</span>
-                  <span className="tabular-nums">{turns.length} turns</span>
-                </>
-              ) : null}
-              <span className="text-muted-foreground/50">·</span>
-              <span className="text-foreground/70">{conversation.type}</span>
-            </div>
-          </div>
-        </div>
-      </header>
+      <SessionHeader
+        agentLabel={conversation.agent_label}
+        agentHierarchy={conversation.agent_hierarchy}
+        status={conversation.status}
+        title={multiTurn ? "Conversation" : "One turn"}
+      >
+        {multiTurn ? (
+          <>
+            <SessionHeaderDot />
+            <span className="tabular-nums">{turns.length} turns</span>
+          </>
+        ) : null}
+        <SessionHeaderDot />
+        <span className="text-foreground/70">{conversation.type}</span>
+      </SessionHeader>
 
       <div className="space-y-6">
         {turns.map((turn) => (
@@ -131,7 +117,7 @@ function ConversationBody({ conversation }: { conversation: ConversationDisplay 
 
       {usage ? <UsagePanel usage={usage} /> : null}
 
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      <DetailFooter>
         <FooterField label="Conversation ID">
           <ClickToCopyId id={conversation.conversation_id} />
         </FooterField>
@@ -146,7 +132,7 @@ function ConversationBody({ conversation }: { conversation: ConversationDisplay 
           </FooterField>
         ) : null}
         <FooterField label="Type">{conversation.type}</FooterField>
-      </footer>
+      </DetailFooter>
     </>
   );
 }

--- a/packages/web/app/(authed)/tasks/[id]/sessions/[sid]/session-detail-client.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/sessions/[sid]/session-detail-client.tsx
@@ -1,18 +1,20 @@
 "use client";
 
-import Link from "next/link";
-import { ChevronRight, Terminal } from "lucide-react";
+import { Terminal } from "lucide-react";
 import { useSession } from "@/lib/hooks/use-sessions";
-import { Avatar } from "@/components/avatar";
-import { HierChip } from "@/components/hier-chip";
-import { SessionStatusPill } from "@/components/detail/status-pill";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { DetailGate } from "@/components/detail/detail-gate";
 import { FooterField } from "@/components/detail/footer-field";
+import { DetailFooter } from "@/components/detail/detail-footer";
+import { TaskBreadcrumbs } from "@/components/detail/task-breadcrumbs";
 import { BriefingComposer } from "@/components/sessions/briefing-composer";
+import {
+  SessionHeader,
+  SessionHeaderDot,
+} from "@/components/sessions/session-header";
 import { Transcript } from "@/components/sessions/transcript";
 import { Skeleton } from "@/components/skeleton";
-import { formatIntent, shortId } from "@/lib/format";
+import { formatIntent } from "@/lib/format";
 import type { SessionDisplay } from "@/lib/types/sessions";
 
 interface Props {
@@ -26,10 +28,11 @@ export function SessionDetailClient({ taskId, sessionShortId }: Props) {
   return (
     <DetailGate
       nav={
-        <Breadcrumbs
+        <TaskBreadcrumbs
           taskId={taskId}
           taskTitle={query.data?.task_title ?? null}
-          sessionShortId={sessionShortId}
+          leaf={sessionShortId}
+          leafMono
         />
       }
       icon={Terminal}
@@ -49,36 +52,6 @@ export function SessionDetailClient({ taskId, sessionShortId }: Props) {
   );
 }
 
-function Breadcrumbs({
-  taskId,
-  taskTitle,
-  sessionShortId,
-}: {
-  taskId: string;
-  taskTitle: string | null;
-  sessionShortId: string;
-}) {
-  return (
-    <nav
-      aria-label="Breadcrumb"
-      className="flex items-center gap-1.5 text-xs text-muted-foreground mb-4"
-    >
-      <Link href="/tasks" className="hover:text-foreground transition-colors">
-        Tasks
-      </Link>
-      <ChevronRight className="h-3 w-3" />
-      <Link
-        href={`/tasks/${taskId}`}
-        className="hover:text-foreground transition-colors max-w-[18rem] truncate"
-      >
-        {taskTitle ?? shortId(taskId)}
-      </Link>
-      <ChevronRight className="h-3 w-3" />
-      <span className="font-mono text-foreground/80">{sessionShortId}</span>
-    </nav>
-  );
-}
-
 function SessionDetailBody({ session, taskId: _taskId }: { session: SessionDisplay; taskId: string }) {
   // Cancel is a task-level action, not a session-level one — moved to
   // the task detail page. The button used to live here but it called
@@ -87,35 +60,22 @@ function SessionDetailBody({ session, taskId: _taskId }: { session: SessionDispl
   // running session orphaned in the daemon-spawn path.
   return (
     <>
-      <header className="mb-6">
-        <div className="flex items-start gap-3">
-          <Avatar
-            initial={session.agent_label.charAt(0).toUpperCase()}
-            kind={session.agent_hierarchy}
-            label={session.agent_label}
-            size={40}
-            presence={session.status === "running" ? "running" : "idle"}
-          />
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 mb-1">
-              <h1 className="text-base font-semibold leading-tight truncate">{formatIntent(session.intent)}</h1>
-              <SessionStatusPill status={session.status} />
-            </div>
-            <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <span className="text-foreground/85">{session.agent_label}</span>
-              <HierChip hier={session.agent_hierarchy} />
-              <span className="text-muted-foreground/50">·</span>
-              <span className="tabular-nums">{session.duration_label}</span>
-            </div>
-          </div>
-        </div>
-      </header>
+      <SessionHeader
+        agentLabel={session.agent_label}
+        agentHierarchy={session.agent_hierarchy}
+        status={session.status}
+        title={formatIntent(session.intent)}
+        truncateTitle
+      >
+        <SessionHeaderDot />
+        <span className="tabular-nums">{session.duration_label}</span>
+      </SessionHeader>
 
       <BriefingComposer briefing={session.briefing} />
 
       <Transcript entries={session.transcript} ask_threads={session.ask_threads} />
 
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      <DetailFooter>
         <FooterField label="Session ID">
           <ClickToCopyId id={session.id} />
         </FooterField>
@@ -130,7 +90,7 @@ function SessionDetailBody({ session, taskId: _taskId }: { session: SessionDispl
           </FooterField>
         ) : null}
         <FooterField label="Type">{session.type}</FooterField>
-      </footer>
+      </DetailFooter>
     </>
   );
 }

--- a/packages/web/app/(authed)/tasks/[id]/task-detail-client.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/task-detail-client.tsx
@@ -26,6 +26,7 @@ import { ChatMarkdown } from "@/components/chat/markdown";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { DetailGate } from "@/components/detail/detail-gate";
 import { FooterField } from "@/components/detail/footer-field";
+import { DetailFooter } from "@/components/detail/detail-footer";
 import { HierChip } from "@/components/hier-chip";
 import { Skeleton } from "@/components/skeleton";
 import { richTextToMarkdown } from "@/components/rich-text";
@@ -293,7 +294,7 @@ function TaskDetailLoaded({ task }: { task: TaskDetail }) {
         </aside>
       </div>
 
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      <DetailFooter>
         <FooterField label="ID">
           <ClickToCopyId id={task.id} />
         </FooterField>
@@ -316,7 +317,7 @@ function TaskDetailLoaded({ task }: { task: TaskDetail }) {
             </Link>
           </FooterField>
         ) : null}
-      </footer>
+      </DetailFooter>
     </>
   );
 }

--- a/packages/web/app/(authed)/work-products/[id]/work-product-detail-client.tsx
+++ b/packages/web/app/(authed)/work-products/[id]/work-product-detail-client.tsx
@@ -2,12 +2,7 @@
 
 import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
-import {
-  ArrowLeft,
-  ChevronRight,
-  ExternalLink,
-  FileText,
-} from "lucide-react";
+import { ArrowLeft, ExternalLink, FileText } from "lucide-react";
 import { api, type WorkProductDetail } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
 import { queryKeys } from "@/lib/hooks/keys";
@@ -17,6 +12,8 @@ import { Skeleton } from "@/components/skeleton";
 import { ChatMarkdown } from "@/components/chat/markdown";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { FooterField } from "@/components/detail/footer-field";
+import { DetailFooter } from "@/components/detail/detail-footer";
+import { TaskBreadcrumbs } from "@/components/detail/task-breadcrumbs";
 import { formatRelativeTime, shortId } from "@/lib/format";
 
 export function WorkProductDetailClient({ workProductId }: { workProductId: string }) {
@@ -31,7 +28,15 @@ export function WorkProductDetailClient({ workProductId }: { workProductId: stri
     <DetailGate
       // The breadcrumb names the parent task, so it can only be drawn once
       // the row is in hand — the pre-data states render without one.
-      nav={query.data ? <Breadcrumbs wp={query.data} /> : undefined}
+      nav={
+        query.data ? (
+          <TaskBreadcrumbs
+            taskId={query.data.task_id}
+            taskTitle={query.data.task_title}
+            leaf={query.data.title}
+          />
+        ) : undefined
+      }
       icon={FileText}
       noun="work product"
       id={workProductId}
@@ -45,25 +50,6 @@ export function WorkProductDetailClient({ workProductId }: { workProductId: stri
     >
       {(wp) => <Body wp={wp} />}
     </DetailGate>
-  );
-}
-
-function Breadcrumbs({ wp }: { wp: WorkProductDetail }) {
-  return (
-    <nav className="flex items-center gap-1.5 text-xs text-muted-foreground mb-4" aria-label="Breadcrumb">
-      <Link href="/tasks" className="hover:text-foreground transition-colors">
-        Tasks
-      </Link>
-      <ChevronRight className="h-3 w-3" />
-      <Link
-        href={`/tasks/${wp.task_id}`}
-        className="hover:text-foreground transition-colors max-w-[18rem] truncate"
-      >
-        {wp.task_title}
-      </Link>
-      <ChevronRight className="h-3 w-3" />
-      <span className="text-foreground/80 truncate max-w-[14rem]">{wp.title}</span>
-    </nav>
   );
 }
 
@@ -125,7 +111,7 @@ function Body({ wp }: { wp: WorkProductDetail }) {
         />
       )}
 
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      <DetailFooter>
         <FooterField label="ID">
           <ClickToCopyId id={wp.id} />
         </FooterField>
@@ -143,7 +129,7 @@ function Body({ wp }: { wp: WorkProductDetail }) {
           </FooterField>
         ) : null}
         {wp.provider ? <FooterField label="Provider">{wp.provider}</FooterField> : null}
-      </footer>
+      </DetailFooter>
     </>
   );
 }

--- a/packages/web/app/sign-in/sign-in-client.tsx
+++ b/packages/web/app/sign-in/sign-in-client.tsx
@@ -3,8 +3,14 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { AlertTriangle, KeyRound, Loader2, LogIn } from "lucide-react";
+import { KeyRound, LogIn } from "lucide-react";
 import { SIGNIN_NO_PASSWORD_SET } from "@beevibe/core/auth/constants";
+import {
+  AuthCard,
+  AuthError,
+  AuthField,
+  AuthSubmitButton,
+} from "@/components/auth/auth-card";
 import { api } from "@/lib/api/client";
 import { asApiError } from "@/lib/api/http";
 import {
@@ -114,133 +120,103 @@ export function SignInClient() {
   };
 
   return (
-    <main className="min-h-screen flex items-center justify-center px-6 bg-background">
-      <form
-        onSubmit={mode === "password" ? submitPassword : submitKey}
-        className="w-full max-w-sm bg-card border border-border rounded-lg p-6 shadow-sm"
-      >
-        <header className="mb-5">
-          <div className="inline-flex items-center justify-center h-10 w-10 rounded-md bg-primary text-primary-foreground mb-3">
-            {mode === "password" ? (
-              <LogIn className="h-5 w-5" />
-            ) : (
-              <KeyRound className="h-5 w-5" />
-            )}
-          </div>
-          <h1 className="text-lg font-semibold tracking-tight">Sign in to beevibe</h1>
-          <p className="mt-1 text-xs text-muted-foreground leading-relaxed">
-            {mode === "password" ? (
-              <>Email + password. Your <span className="font-mono">bv_u_</span> key is generated server-side and never leaves the browser after.</>
-            ) : (
-              <>Paste your <span className="font-mono">bv_u_</span> key — for legacy accounts or CLI-provisioned users.</>
-            )}
-          </p>
-        </header>
-
-        {mode === "password" ? (
+    <AuthCard
+      icon={mode === "password" ? LogIn : KeyRound}
+      title="Sign in to beevibe"
+      blurb={
+        mode === "password" ? (
           <>
-            <label className="block text-xs font-medium text-foreground mb-1.5" htmlFor="email">
-              Email
-            </label>
-            <input
-              id="email"
-              type="email"
-              autoComplete="email"
-              inputMode="email"
-              autoFocus
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="alice@example.com"
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-              disabled={submitting}
-            />
-
-            <label className="block text-xs font-medium text-foreground mb-1.5 mt-3" htmlFor="password">
-              Password
-            </label>
-            <input
-              id="password"
-              type="password"
-              autoComplete="current-password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="••••••••"
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-              disabled={submitting}
-            />
+            Email + password. Your <span className="font-mono">bv_u_</span> key is generated
+            server-side and never leaves the browser after.
           </>
         ) : (
           <>
-            <label className="block text-xs font-medium text-foreground mb-1.5" htmlFor="key">
-              User API key
-            </label>
-            <input
-              id="key"
-              type="password"
-              autoComplete="off"
-              autoFocus
-              spellCheck={false}
-              value={keyDraft}
-              onChange={(e) => setKeyDraft(e.target.value)}
-              placeholder="bv_u_..."
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-ring"
-              disabled={submitting}
-            />
+            Paste your <span className="font-mono">bv_u_</span> key — for legacy accounts or
+            CLI-provisioned users.
           </>
-        )}
-
-        {error ? (
-          <div className="mt-3 flex items-start gap-1.5 text-xs text-status-failed">
-            <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>{error}</span>
-          </div>
-        ) : null}
-
-        <button
-          type="submit"
-          disabled={
-            submitting ||
-            (mode === "password"
-              ? email.trim().length === 0 || password.length === 0
-              : keyDraft.trim().length === 0)
-          }
-          className="mt-5 w-full inline-flex items-center justify-center gap-1.5 h-9 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {submitting ? (
-            <>
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              {mode === "password" ? "Signing in…" : "Verifying…"}
-            </>
-          ) : (
-            <>
-              <LogIn className="h-3.5 w-3.5" />
-              Sign in
-            </>
-          )}
-        </button>
-
-        <button
-          type="button"
-          onClick={() => {
-            setMode((m) => (m === "password" ? "key" : "password"));
-            setError(null);
-          }}
-          disabled={submitting}
-          className="mt-3 w-full text-[11px] text-muted-foreground hover:text-foreground transition-colors cursor-pointer disabled:opacity-50"
-        >
-          {mode === "password"
-            ? "Or sign in with your bv_u_ key"
-            : "Or sign in with email + password"}
-        </button>
-
-        <footer className="mt-5 pt-4 border-t border-border/60 text-[11px] text-muted-foreground leading-relaxed">
+        )
+      }
+      onSubmit={mode === "password" ? submitPassword : submitKey}
+      footer={
+        <>
           New here?{" "}
           <Link href="/sign-up" className="text-foreground/80 hover:underline">
             Sign up
           </Link>{" "}
           — takes about 5 seconds.
-        </footer>
-      </form>
-    </main>
+        </>
+      }
+    >
+      {mode === "password" ? (
+        <>
+          <AuthField
+            id="email"
+            label="Email"
+            type="email"
+            autoComplete="email"
+            inputMode="email"
+            autoFocus
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="alice@example.com"
+            disabled={submitting}
+          />
+          <AuthField
+            id="password"
+            label="Password"
+            spaced
+            type="password"
+            autoComplete="current-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="••••••••"
+            disabled={submitting}
+          />
+        </>
+      ) : (
+        <AuthField
+          id="key"
+          label="User API key"
+          type="password"
+          autoComplete="off"
+          autoFocus
+          spellCheck={false}
+          value={keyDraft}
+          onChange={(e) => setKeyDraft(e.target.value)}
+          placeholder="bv_u_..."
+          className="font-mono"
+          disabled={submitting}
+        />
+      )}
+
+      <AuthError message={error} />
+
+      <AuthSubmitButton
+        icon={LogIn}
+        label="Sign in"
+        pendingLabel={mode === "password" ? "Signing in…" : "Verifying…"}
+        pending={submitting}
+        disabled={
+          submitting ||
+          (mode === "password"
+            ? email.trim().length === 0 || password.length === 0
+            : keyDraft.trim().length === 0)
+        }
+      />
+
+      <button
+        type="button"
+        onClick={() => {
+          setMode((m) => (m === "password" ? "key" : "password"));
+          setError(null);
+        }}
+        disabled={submitting}
+        className="mt-3 w-full text-[11px] text-muted-foreground hover:text-foreground transition-colors cursor-pointer disabled:opacity-50"
+      >
+        {mode === "password"
+          ? "Or sign in with your bv_u_ key"
+          : "Or sign in with email + password"}
+      </button>
+    </AuthCard>
   );
 }

--- a/packages/web/app/sign-up/sign-up-client.tsx
+++ b/packages/web/app/sign-up/sign-up-client.tsx
@@ -3,8 +3,14 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { AlertTriangle, Loader2, Sparkles, UserPlus } from "lucide-react";
+import { Sparkles, UserPlus } from "lucide-react";
 import { PASSWORD_MIN_LENGTH } from "@beevibe/core/auth/constants";
+import {
+  AuthCard,
+  AuthError,
+  AuthField,
+  AuthSubmitButton,
+} from "@/components/auth/auth-card";
 import { api } from "@/lib/api/client";
 import { asApiError } from "@/lib/api/http";
 import { getUserKey, isApiConfigured, setUserKey } from "@/lib/api/config";
@@ -88,105 +94,76 @@ export function SignUpClient() {
   };
 
   return (
-    <main className="min-h-screen flex items-center justify-center px-6 bg-background">
-      <form
-        onSubmit={submit}
-        className="w-full max-w-sm bg-card border border-border rounded-lg p-6 shadow-sm"
-      >
-        <header className="mb-5">
-          <div className="inline-flex items-center justify-center h-10 w-10 rounded-md bg-primary text-primary-foreground mb-3">
-            <UserPlus className="h-5 w-5" />
-          </div>
-          <h1 className="text-lg font-semibold tracking-tight">Sign up for beevibe</h1>
-          <p className="mt-1 text-xs text-muted-foreground leading-relaxed">
-            We&apos;ll mint you a personal team agent. Your key stays in your browser only — you
-            can come back and sign in with the same email later.
-          </p>
-        </header>
-
-        <label className="block text-xs font-medium text-foreground mb-1.5" htmlFor="name">
-          Name
-        </label>
-        <input
-          id="name"
-          type="text"
-          autoComplete="name"
-          autoFocus
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Alice"
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-          disabled={submitting}
-        />
-
-        <label className="block text-xs font-medium text-foreground mb-1.5 mt-3" htmlFor="email">
-          Email
-        </label>
-        <input
-          id="email"
-          type="email"
-          autoComplete="email"
-          inputMode="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          placeholder="alice@example.com"
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-          disabled={submitting}
-        />
-
-        <label className="block text-xs font-medium text-foreground mb-1.5 mt-3" htmlFor="password">
-          Password
-        </label>
-        <input
-          id="password"
-          type="password"
-          autoComplete="new-password"
-          minLength={PASSWORD_MIN_LENGTH}
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          placeholder={`at least ${PASSWORD_MIN_LENGTH} characters`}
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-          disabled={submitting}
-        />
-
-        {error ? (
-          <div className="mt-3 flex items-start gap-1.5 text-xs text-status-failed">
-            <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>{error}</span>
-          </div>
-        ) : null}
-
-        <button
-          type="submit"
-          disabled={
-            submitting ||
-            name.trim().length === 0 ||
-            email.trim().length === 0 ||
-            password.length < PASSWORD_MIN_LENGTH
-          }
-          className="mt-5 w-full inline-flex items-center justify-center gap-1.5 h-9 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {submitting ? (
-            <>
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              Provisioning…
-            </>
-          ) : (
-            <>
-              <Sparkles className="h-3.5 w-3.5" />
-              Create my team agent
-            </>
-          )}
-        </button>
-
-        <footer className="mt-5 pt-4 border-t border-border/60 text-[11px] text-muted-foreground leading-relaxed">
+    <AuthCard
+      icon={UserPlus}
+      title="Sign up for beevibe"
+      blurb={
+        <>
+          We&apos;ll mint you a personal team agent. Your key stays in your browser only — you
+          can come back and sign in with the same email later.
+        </>
+      }
+      onSubmit={submit}
+      footer={
+        <>
           Already have a key?{" "}
           <Link href="/sign-in" className="text-foreground/80 hover:underline">
             Sign in
           </Link>{" "}
           instead.
-        </footer>
-      </form>
-    </main>
+        </>
+      }
+    >
+      <AuthField
+        id="name"
+        label="Name"
+        type="text"
+        autoComplete="name"
+        autoFocus
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Alice"
+        disabled={submitting}
+      />
+      <AuthField
+        id="email"
+        label="Email"
+        spaced
+        type="email"
+        autoComplete="email"
+        inputMode="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="alice@example.com"
+        disabled={submitting}
+      />
+      <AuthField
+        id="password"
+        label="Password"
+        spaced
+        type="password"
+        autoComplete="new-password"
+        minLength={PASSWORD_MIN_LENGTH}
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder={`at least ${PASSWORD_MIN_LENGTH} characters`}
+        disabled={submitting}
+      />
+
+      <AuthError message={error} />
+
+      <AuthSubmitButton
+        icon={Sparkles}
+        label="Create my team agent"
+        pendingLabel="Provisioning…"
+        pending={submitting}
+        disabled={
+          submitting ||
+          name.trim().length === 0 ||
+          email.trim().length === 0 ||
+          password.length < PASSWORD_MIN_LENGTH
+        }
+      />
+    </AuthCard>
   );
 }

--- a/packages/web/components/auth/auth-card.test.tsx
+++ b/packages/web/components/auth/auth-card.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { LogIn, Sparkles } from "lucide-react";
+
+import { AuthCard, AuthError, AuthField, AuthSubmitButton } from "./auth-card";
+
+describe("AuthCard", () => {
+  it("submits the form when the submit button is pressed", async () => {
+    const onSubmit = vi.fn((e: React.FormEvent) => e.preventDefault());
+    render(
+      <AuthCard icon={LogIn} title="Sign in" blurb="blurb" onSubmit={onSubmit} footer="footer">
+        <AuthSubmitButton icon={LogIn} label="Sign in" pendingLabel="…" pending={false} />
+      </AuthCard>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Sign in" }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("AuthField", () => {
+  it("wires the label to its input so clicking the label focuses the field", async () => {
+    render(<AuthField id="email" label="Email" type="email" />);
+    await userEvent.click(screen.getByText("Email"));
+    expect(screen.getByLabelText("Email")).toHaveFocus();
+  });
+
+  it("keeps caller classes alongside the shared field styling", () => {
+    render(<AuthField id="key" label="Key" className="font-mono" />);
+    const input = screen.getByLabelText("Key");
+    expect(input.className).toContain("font-mono");
+    expect(input.className).toContain("bg-background");
+  });
+
+  it("only spaces itself from a field above when asked", () => {
+    const { rerender } = render(<AuthField id="a" label="First" />);
+    expect(screen.getByText("First").className).not.toContain("mt-3");
+    rerender(<AuthField id="a" label="First" spaced />);
+    expect(screen.getByText("First").className).toContain("mt-3");
+  });
+});
+
+describe("AuthError", () => {
+  it("renders nothing when there is no error", () => {
+    const { container } = render(<AuthError message={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the message when there is one", () => {
+    render(<AuthError message="Email or password is incorrect." />);
+    expect(screen.getByText("Email or password is incorrect.")).toBeInTheDocument();
+  });
+});
+
+describe("AuthSubmitButton", () => {
+  it("swaps to the pending label and disables while in flight", () => {
+    render(
+      <AuthSubmitButton
+        icon={Sparkles}
+        label="Create my team agent"
+        pendingLabel="Provisioning…"
+        pending
+        disabled
+      />,
+    );
+    const button = screen.getByRole("button", { name: "Provisioning…" });
+    expect(button).toBeDisabled();
+    expect(screen.queryByText("Create my team agent")).not.toBeInTheDocument();
+  });
+
+  it("can be enabled while showing its idle label", () => {
+    render(
+      <AuthSubmitButton icon={LogIn} label="Sign in" pendingLabel="Signing in…" pending={false} />,
+    );
+    expect(screen.getByRole("button", { name: "Sign in" })).toBeEnabled();
+  });
+});

--- a/packages/web/components/auth/auth-card.tsx
+++ b/packages/web/components/auth/auth-card.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { AlertTriangle, Loader2, type LucideIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * The centered credential card shared by `/sign-in` and `/sign-up`.
+ *
+ * The two pages ask for different things and route differently on success,
+ * but the chrome around that — full-height centered `<main>`, the bordered
+ * card `<form>`, the badge/title/blurb header, the labeled inputs, the
+ * inline error row, the spinner-swapping submit button and the
+ * "already have an account?" footer — was written out twice, verbatim down
+ * to the Tailwind strings. Changing the field styling meant remembering
+ * both files.
+ *
+ * These are presentational only: every page keeps its own state, its own
+ * validation and its own submit handler.
+ */
+
+export function AuthCard({
+  icon: Icon,
+  title,
+  blurb,
+  onSubmit,
+  children,
+  footer,
+}: {
+  icon: LucideIcon;
+  title: string;
+  /** Sub-title prose under the heading. */
+  blurb: ReactNode;
+  onSubmit: (e: React.FormEvent) => void;
+  children: ReactNode;
+  footer: ReactNode;
+}) {
+  return (
+    <main className="min-h-screen flex items-center justify-center px-6 bg-background">
+      <form
+        onSubmit={onSubmit}
+        className="w-full max-w-sm bg-card border border-border rounded-lg p-6 shadow-sm"
+      >
+        <header className="mb-5">
+          <div className="inline-flex items-center justify-center h-10 w-10 rounded-md bg-primary text-primary-foreground mb-3">
+            <Icon className="h-5 w-5" />
+          </div>
+          <h1 className="text-lg font-semibold tracking-tight">{title}</h1>
+          <p className="mt-1 text-xs text-muted-foreground leading-relaxed">{blurb}</p>
+        </header>
+
+        {children}
+
+        <footer className="mt-5 pt-4 border-t border-border/60 text-[11px] text-muted-foreground leading-relaxed">
+          {footer}
+        </footer>
+      </form>
+    </main>
+  );
+}
+
+/**
+ * A labeled text input. `spaced` adds the top margin that separates it from
+ * the field above — the first field in a card leaves it off.
+ */
+export function AuthField({
+  id,
+  label,
+  spaced,
+  className,
+  ...input
+}: {
+  id: string;
+  label: string;
+  spaced?: boolean;
+} & React.InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <>
+      <label
+        className={cn("block text-xs font-medium text-foreground mb-1.5", spaced && "mt-3")}
+        htmlFor={id}
+      >
+        {label}
+      </label>
+      <input
+        id={id}
+        className={cn(
+          "w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring",
+          className,
+        )}
+        {...input}
+      />
+    </>
+  );
+}
+
+/** Inline validation / server-error row. Renders nothing when there's no error. */
+export function AuthError({ message }: { message: string | null }) {
+  if (!message) return null;
+  return (
+    <div className="mt-3 flex items-start gap-1.5 text-xs text-status-failed">
+      <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+      <span>{message}</span>
+    </div>
+  );
+}
+
+/**
+ * Primary submit button. Swaps its icon for a spinner and its label for
+ * `pendingLabel` while the request is in flight.
+ */
+export function AuthSubmitButton({
+  icon: Icon,
+  label,
+  pendingLabel,
+  pending,
+  disabled,
+}: {
+  icon: LucideIcon;
+  label: string;
+  pendingLabel: string;
+  pending: boolean;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="submit"
+      disabled={disabled}
+      className="mt-5 w-full inline-flex items-center justify-center gap-1.5 h-9 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      {pending ? (
+        <>
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          {pendingLabel}
+        </>
+      ) : (
+        <>
+          <Icon className="h-3.5 w-3.5" />
+          {label}
+        </>
+      )}
+    </button>
+  );
+}

--- a/packages/web/components/detail/detail-footer.tsx
+++ b/packages/web/components/detail/detail-footer.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+
+/**
+ * The metadata strip at the bottom of every detail page — a responsive grid
+ * of `<FooterField>`s holding ids, timestamps and cross-links.
+ *
+ * `FooterField` was already shared, but all seven detail pages carried
+ * their own copy of the wrapper's Tailwind string, so the grid, spacing and
+ * rule above it could drift page to page. This is the one definition.
+ */
+export function DetailFooter({ children }: { children: ReactNode }) {
+  return (
+    <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      {children}
+    </footer>
+  );
+}

--- a/packages/web/components/detail/task-breadcrumbs.tsx
+++ b/packages/web/components/detail/task-breadcrumbs.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+import { shortId } from "@/lib/format";
+import { cn } from "@/lib/utils";
+
+/**
+ * `Tasks › <task> › <leaf>` breadcrumb, for the detail pages that hang off
+ * a task — the task-scoped session view and the work-product view. Both had
+ * their own `Breadcrumbs` local component with the same three-crumb markup
+ * and the same chevron/truncation classes.
+ *
+ * `taskTitle` is nullable because the session page draws the trail before
+ * its query resolves; it falls back to the task's short id.
+ */
+export function TaskBreadcrumbs({
+  taskId,
+  taskTitle,
+  leaf,
+  leafMono,
+}: {
+  taskId: string;
+  taskTitle: string | null;
+  /** Final, non-linked crumb — the thing the page is showing. */
+  leaf: string;
+  /** Render the leaf monospaced (ids read better that way than titles). */
+  leafMono?: boolean;
+}) {
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className="flex items-center gap-1.5 text-xs text-muted-foreground mb-4"
+    >
+      <Link href="/tasks" className="hover:text-foreground transition-colors">
+        Tasks
+      </Link>
+      <ChevronRight className="h-3 w-3" />
+      <Link
+        href={`/tasks/${taskId}`}
+        className="hover:text-foreground transition-colors max-w-[18rem] truncate"
+      >
+        {taskTitle ?? shortId(taskId)}
+      </Link>
+      <ChevronRight className="h-3 w-3" />
+      <span
+        className={cn("text-foreground/80", leafMono ? "font-mono" : "truncate max-w-[14rem]")}
+      >
+        {leaf}
+      </span>
+    </nav>
+  );
+}

--- a/packages/web/components/sessions/session-header.tsx
+++ b/packages/web/components/sessions/session-header.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from "react";
+import { Avatar } from "@/components/avatar";
+import { HierChip } from "@/components/hier-chip";
+import { SessionStatusPill } from "@/components/detail/status-pill";
+import { cn } from "@/lib/utils";
+import type { SessionDisplay } from "@/lib/types/sessions";
+
+/**
+ * The identity block at the top of a session detail page: the agent's
+ * avatar (its presence dot driven by the session status), the page title
+ * with its status pill, and a meta row naming the agent and its tier.
+ *
+ * Both session pages — the task-scoped one and the chat-conversation one —
+ * rendered this identically; only the title and the trailing meta items
+ * differ, so those are the props. `children` lands after the `HierChip`,
+ * where each page adds its own facts (turn count and type for a
+ * conversation, elapsed duration for a task session).
+ */
+export function SessionHeader({
+  agentLabel,
+  agentHierarchy,
+  status,
+  title,
+  truncateTitle,
+  children,
+}: {
+  agentLabel: string;
+  agentHierarchy: SessionDisplay["agent_hierarchy"];
+  status: SessionDisplay["status"];
+  title: string;
+  /** Titles derived from a free-text intent need clamping; fixed ones don't. */
+  truncateTitle?: boolean;
+  children?: ReactNode;
+}) {
+  return (
+    <header className="mb-6">
+      <div className="flex items-start gap-3">
+        <Avatar
+          initial={agentLabel.charAt(0).toUpperCase()}
+          kind={agentHierarchy}
+          label={agentLabel}
+          size={40}
+          presence={status === "running" ? "running" : "idle"}
+        />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <h1
+              className={cn(
+                "text-base font-semibold tracking-tight leading-tight",
+                truncateTitle && "truncate",
+              )}
+            >
+              {title}
+            </h1>
+            <SessionStatusPill status={status} />
+          </div>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span className="text-foreground/85">{agentLabel}</span>
+            <HierChip hier={agentHierarchy} />
+            {children}
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+/** Separator between meta items in a {@link SessionHeader}'s meta row. */
+export function SessionHeaderDot() {
+  return <span className="text-muted-foreground/50">·</span>;
+}

--- a/packages/web/components/share-link-box.test.tsx
+++ b/packages/web/components/share-link-box.test.tsx
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ShareLinkBox } from "./share-link-box";
+
+const writeText = vi.fn().mockResolvedValue(undefined);
+
+// `navigator.clipboard` is a getter-only property in jsdom, so it has to be
+// redefined rather than assigned.
+beforeEach(() => {
+  writeText.mockClear();
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+    writable: true,
+  });
+});
+
+afterEach(() => {
+  Reflect.deleteProperty(navigator, "clipboard");
+});
+
+describe("ShareLinkBox", () => {
+  it("shows the url read-only next to its blurb", () => {
+    render(<ShareLinkBox url="https://beevibe.test/sign-up">Send them this link:</ShareLinkBox>);
+    expect(screen.getByText("Send them this link:")).toBeInTheDocument();
+    const input = screen.getByDisplayValue("https://beevibe.test/sign-up");
+    expect(input).toHaveAttribute("readonly");
+  });
+
+  it("copies the url and flips the button label", async () => {
+    render(<ShareLinkBox url="https://beevibe.test/sign-up">blurb</ShareLinkBox>);
+    await userEvent.click(screen.getByRole("button", { name: "Copy" }));
+    expect(writeText).toHaveBeenCalledWith("https://beevibe.test/sign-up");
+    expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument();
+  });
+
+  it("keeps each box's copied state to itself", async () => {
+    render(
+      <>
+        <ShareLinkBox url="https://beevibe.test/one">one</ShareLinkBox>
+        <ShareLinkBox url="https://beevibe.test/two">two</ShareLinkBox>
+      </>,
+    );
+    const [first] = screen.getAllByRole("button", { name: "Copy" });
+    await userEvent.click(first!);
+    expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument();
+    // The second box is untouched — one "Copy" left standing.
+    expect(screen.getAllByRole("button", { name: "Copy" })).toHaveLength(1);
+  });
+});

--- a/packages/web/components/share-link-box.tsx
+++ b/packages/web/components/share-link-box.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
+
+/**
+ * A read-only URL with a copy button, under a line of explanation.
+ *
+ * Both invite flows end here — the "invite a teammate" modal in the user
+ * widget and the room invite modal, when the invitee has no account yet —
+ * and both had spelled out the same select-on-focus input, copy button and
+ * "Copied" toggle. Only the blurb above it differs, so that's the prop.
+ *
+ * Owns its own copy state: nothing outside cares whether the button has
+ * flipped to "Copied", and giving each box its own hook keeps two boxes on
+ * one page from flipping together.
+ */
+export function ShareLinkBox({ url, children }: { url: string; children: ReactNode }) {
+  const { copied, copy } = useCopyToClipboard();
+
+  return (
+    <div className="mt-3 rounded border border-border bg-muted/40 p-3">
+      <div className="text-[11px] text-muted-foreground mb-1.5">{children}</div>
+      <div className="flex items-center gap-1.5">
+        <input
+          readOnly
+          value={url}
+          className="flex-1 rounded border border-border bg-background px-2 py-1.5 text-[11px] font-mono"
+          onFocus={(e) => e.currentTarget.select()}
+        />
+        <button
+          type="button"
+          onClick={() => void copy(url)}
+          className="h-7 px-2.5 rounded text-[11px] font-medium border border-border hover:bg-secondary transition-colors cursor-pointer shrink-0"
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/user-widget.tsx
+++ b/packages/web/components/user-widget.tsx
@@ -14,7 +14,7 @@ import {
 } from "lucide-react";
 import { useMe } from "@/lib/hooks/use-me";
 import { useDismissOnOutside } from "@/lib/hooks/use-dismiss";
-import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
+import { ShareLinkBox } from "@/components/share-link-box";
 import { ModalOverlay } from "@/components/modal-overlay";
 import { clearUserKey } from "@/lib/api/config";
 import { cn } from "@/lib/utils";
@@ -148,7 +148,6 @@ function MenuItem({
 
 function InviteTeammateDialog({ onClose }: { onClose: () => void }) {
   const [email, setEmail] = useState("");
-  const { copied, copy } = useCopyToClipboard();
   const trimmed = email.trim().toLowerCase();
   const valid = EMAIL_RE.test(trimmed);
   const origin = typeof window !== "undefined" ? window.location.origin : "";
@@ -173,26 +172,7 @@ function InviteTeammateDialog({ onClose }: { onClose: () => void }) {
           className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
         />
         {shareLink ? (
-          <div className="mt-3 rounded border border-border bg-muted/40 p-3">
-            <div className="text-[11px] text-muted-foreground mb-1.5">
-              Send them this link:
-            </div>
-            <div className="flex items-center gap-1.5">
-              <input
-                readOnly
-                value={shareLink}
-                className="flex-1 rounded border border-border bg-background px-2 py-1.5 text-[11px] font-mono"
-                onFocus={(e) => e.currentTarget.select()}
-              />
-              <button
-                type="button"
-                onClick={() => void copy(shareLink)}
-                className="h-7 px-2.5 rounded text-[11px] font-medium border border-border hover:bg-secondary transition-colors cursor-pointer shrink-0"
-              >
-                {copied ? "Copied" : "Copy"}
-              </button>
-            </div>
-          </div>
+          <ShareLinkBox url={shareLink}>Send them this link:</ShareLinkBox>
         ) : null}
         <div className="mt-4 flex items-center justify-end gap-2">
           <button


### PR DESCRIPTION
Sweep for near-duplicate abstractions across the monorepo, then merge the
clusters that were safe to merge. Net **−395 lines of duplicated markup and
wiring**, replaced by five shared web components and two shared core helpers
(plus tests for all of them).

Prior passes had already pulled out the obvious shared layers — `runtime-common.ts`,
`pg-helpers.ts`, `routes/http-errors.ts`, `domain/format.ts`, `DetailGate`/`FooterField`
— so what's left here is the second tier: skeletons that were *structurally*
identical but not textually identical, which a clone detector at default
thresholds doesn't surface.

## What changed

### `@beevibe/core` — the three CLI runtime adapters

**`runCliStream`** (`adapters/runtime-common.ts`). `claude-code`, `codex` and
`opencode` each spelled out the same spawn-and-stream sequence around their own
parser: accumulate events off a line reader, forward each one's steps to
`context.onStep`, spawn, flush the trailing partial line, warn if stdout hit the
4MB capture cap. Only the event schema and what happens *after* the process
settles differ, so the new helper owns the streaming half and hands back the raw
events — each adapter still builds its own `RuntimeResult`, and codex keeps its
`--output-last-message` read/cleanup on both the aborted and the completed path.

**Transcript line builders** (same file). `[assistant] …` / `[tool_call] …` /
`[tool_result from X] …` / `[error] …` is a cross-provider contract — the
transcript summarizer and the web transcript view key off those tags — but all
three parsers built the lines from hand-written template literals, and the
"truncate to 200 chars, then flatten newlines" step was open-coded five times.
Now: `assistantLine` / `toolCallLine` / `toolResultLine` / `errorLine` /
`inlineSnippet`.

### `@beevibe/web` — five copy-pasted JSX clusters

| New component | Was duplicated in |
| --- | --- |
| `AuthCard` + `AuthField` / `AuthError` / `AuthSubmitButton` | `/sign-in`, `/sign-up` — byte-identical card shell, header, labeled inputs, error row, spinner-swapping button |
| `DetailFooter` | all **7** detail pages repeated the same 130-char `<footer>` class string |
| `TaskBreadcrumbs` | task-scoped session page + work-product page, each with its own local `Breadcrumbs` |
| `SessionHeader` | task-session + chat-conversation pages — same avatar + title + status pill + meta row |
| `ShareLinkBox` | both invite modals (user widget, room detail) — same select-on-focus URL input + Copy/Copied button |

Each shared piece is presentational only: every page keeps its own state,
validation, queries and submit handlers.

## Behavior changes

Two, both incidental and intentional:

- An empty codex `command` used to render as `[tool_call] shell ` with a
  trailing space; `toolCallLine` collapses that to the bare `[tool_call] shell`.
- The task-session page title picks up the `tracking-tight` that the other six
  detail titles already had.

## Validation

- `pnpm typecheck` — 9/9 tasks clean
- `pnpm lint` — 9/9 tasks clean (only pre-existing `import/no-duplicates`
  warnings in untouched test files)
- `pnpm --filter @beevibe/web exec next build` — clean
- `@beevibe/core` CLI-adapter suites: **187 passed**, up from 151 (36 new tests
  for `runCliStream` and the transcript builders)
- `@beevibe/web`: **214 passed**, up from 203 (11 new tests for `AuthCard` and
  `ShareLinkBox`)
- Remaining `core` / `api` / `scheduler` failures are the documented sandbox
  baseline — no Postgres (`DATABASE_URL_TEST env var is required…`) and no
  provider keys. None are in code this PR touches.

## Findings not acted on

Clusters the sweep surfaced that were deliberately left alone:

- **`describeToolInput` in `claude-code/stream-json.ts`** duplicates the shared
  one in `runtime-common.ts`, but with a richer field list and two extra
  branches. `runtime-common.ts` documents this as a deliberate divergence;
  folding it in would need a callback parameter and would subtly change codex /
  opencode behavior for single-key inputs.
- **`app/error.tsx` vs `app/global-error.tsx`** share only the
  `useEffect(console.error)` prelude. `global-error` replaces the root `<html>`
  and so cannot use Tailwind — the inline styles are load-bearing.
- **`api/bootstrap.ts` vs `scheduler/bootstrap.ts`** already share
  `createMemoryStack` / `createWorkspaceStack`; what's left is each root's own
  repository list, which is genuinely different per binary.
- **`anthropic/llm-provider.ts` vs `openai/llm-provider.ts`** overlap in ~9
  lines of constructor/key-check. Merging would mean an abstract base for two
  SDKs with different response shapes — more indirection than it removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxbUPuqy2HfeS4XcpB9D15

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxbUPuqy2HfeS4XcpB9D15)_