### PR TITLE
chore: remove dead code found by a static + dynamic sweep

### DIFF
--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -404,7 +404,6 @@ export interface MemoryFactDisplay {
   source_session_count: number;
   created_at: Date;
   merge_origin?: MergeOrigin;
-  promotion_origin_scope?: MemoryScope;
 }
 
 /**

--- a/packages/core/src/domain/agent.ts
+++ b/packages/core/src/domain/agent.ts
@@ -26,7 +26,6 @@ export interface RuntimeConfig {
    */
   model?: string;
   max_turns?: number;
-  timeout_ms?: number;
   system_prompt_addition?: string;
 }
 

--- a/packages/core/src/ports/runtime.ts
+++ b/packages/core/src/ports/runtime.ts
@@ -199,7 +199,6 @@ export interface RuntimeResult {
 /** Result of `healthCheck()`. */
 export interface RuntimeHealth {
   healthy: boolean;
-  latency_ms?: number;
   error?: string;
 }
 

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -119,19 +119,6 @@
   }
 }
 
-.timeline-rail {
-  position: relative;
-}
-.timeline-rail::before {
-  content: "";
-  position: absolute;
-  left: 11px;
-  top: 8px;
-  bottom: 8px;
-  width: 1px;
-  background: hsl(var(--border));
-}
-
 /* Pearl button — sidebar New chat CTA. Adapted from Uiverse.io by
    marcelodolza, recolored to the app's honey primary. The .wrap
    pseudo-elements render the glossy top cap and rising under-glow. */
@@ -268,10 +255,10 @@
    material instead of solid blocks against shiny pearls.
 
    Use `.glass-surface` for popovers, composers, peek panels — anything
-   that hosts content. Use `.glass-bubble-agent` / `.glass-bubble-user`
-   for chat message bubbles. All three need a non-solid backdrop behind
-   them to read correctly; the chat surface's gradient + the sidebar's
-   `bg-card` both qualify. */
+   that hosts content. Use `.glass-bubble-user` for the user's chat
+   message bubbles. Both need a non-solid backdrop behind them to read
+   correctly; the chat surface's gradient + the sidebar's `bg-card` both
+   qualify. */
 .glass-surface {
   background-color: hsl(var(--card) / 0.55);
   /* Apple Liquid Glass cues: heavy blur picks up backdrop variation, the
@@ -296,21 +283,6 @@
   .dark .glass-surface { background-color: hsl(var(--card) / 0.92); }
 }
 
-/* Agent message — neutral translucent bubble. Drops the solid
-   bg-secondary block in favor of a frosted variant that lets the
-   gradient backdrop bleed through. */
-.glass-bubble-agent {
-  background-color: hsl(var(--secondary) / 0.5);
-  backdrop-filter: blur(20px) saturate(180%);
-  -webkit-backdrop-filter: blur(20px) saturate(180%);
-  color: hsl(var(--foreground));
-  box-shadow: inset 0 1px 0 hsl(0 0% 100% / 0.06);
-}
-.dark .glass-bubble-agent {
-  background-color: hsl(var(--secondary) / 0.4);
-  box-shadow: inset 0 1px 0 hsl(0 0% 100% / 0.05);
-}
-
 /* User message — replaces the saturated bg-primary yellow with a low-
    opacity tint + brand-colored border. Brand reads as accent instead
    of dominating the column; short prompts stop looking like billboards. */
@@ -329,7 +301,6 @@
 }
 
 @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
-  .glass-bubble-agent { background-color: hsl(var(--secondary) / 0.9); }
   .glass-bubble-user { background-color: hsl(var(--primary) / 0.22); }
 }
 
@@ -843,7 +814,6 @@
 
 @media (prefers-reduced-motion: reduce) {
   .animate-pulse-breathe,
-  .animate-spin-slow,
   .animate-row-flash {
     animation: none !important;
   }

--- a/packages/web/lib/types/mesh.ts
+++ b/packages/web/lib/types/mesh.ts
@@ -10,21 +10,12 @@ export interface MeshAsk {
   id: string;
   caller: string;
   target: string;
-  intermediate?: string;
-  arrow?: "right" | "up";
   type: "ask" | "negotiate" | "blocker";
-  type_label?: string;
   status: "in_flight" | "succeeded" | "blocked";
   duration_label: string;
   intent: RichText;
-  response?: { agent: string; content: RichText };
   chain_depth: string;
-  chain_depth_color?: "review";
-  source_session?: string;
   source_task_short_id?: string;
-  source_task_age?: string;
-  awaiting_label?: string;
-  awaiting_task_short_id?: string;
 }
 
 export interface ChainBudgetRow {

--- a/packages/web/tailwind.config.ts
+++ b/packages/web/tailwind.config.ts
@@ -79,9 +79,6 @@ const config: Config = {
           "0%, 100%": { opacity: "1", transform: "scale(1)" },
           "50%": { opacity: "0.55", transform: "scale(0.92)" },
         },
-        "spin-slow": {
-          to: { transform: "rotate(360deg)" },
-        },
         "row-flash": {
           "0%": { backgroundColor: "hsl(48 96% 53% / 0.16)" },
           "100%": { backgroundColor: "transparent" },
@@ -96,7 +93,6 @@ const config: Config = {
       },
       animation: {
         "pulse-breathe": "pulse-breathe 2s ease-in-out infinite",
-        "spin-slow": "spin-slow 2.5s linear infinite",
         "row-flash": "row-flash 1200ms ease-out",
         "step-pop": "step-pop 260ms ease-out",
       },


### PR DESCRIPTION
## What this is

A full dead-code sweep of the monorepo, and the removals it turned up.

## How the sweep was run

**Static**
- `tsc --noEmit --noUnusedLocals --noUnusedParameters` on all six packages — clean
- `tsc --noEmit --allowUnreachableCode false` (TS7027) on all six — clean
- `pnpm lint` — clean (4 pre-existing warnings, all in test files)
- By-name grep sweep of every `export function|class|const|interface|type|enum` under `packages/*/src/**` and `scripts/*.ts`, discounting the declaring file and pure re-export lines. This is the check that matters here: knip treats each of core's 26 `exports` subpaths as an entry point, so nothing behind a barrel is ever flagged.
- Same sweep over class methods, which the export sweep doesn't reach
- Per-field sweeps of interface members, React props, `globals.css` selectors and custom properties, and `.env.example` keys
- Never-imported-module check across all packages

**Dynamic**
- `depcheck` per package
- v8 coverage (`--coverage.all`) on core and api, with the DB- and key-gated suites excluded so the report actually gets written

## What the sweep found — and mostly didn't

Every symbol-level hit was either a documented false positive from CLAUDE.md's table, or a symbol used within its own file (where the `export` is redundant, not the code dead). Same for the dependency hits: `node-pg-migrate`, `zod`, `postcss`/`autoprefixer`, `prettier`, `typescript` are all load-bearing per the table. The low-coverage files were exactly the ones whose tests are DB-gated in this environment, so they carry no signal.

What was actually dead was field- and style-level:

| Removed | Why |
| --- | --- |
| Nine optional `MeshAsk` fields (`intermediate`, `arrow`, `type_label`, `response`, `chain_depth_color`, `source_session`, `source_task_age`, `awaiting_label`, `awaiting_task_short_id`) | `askToDisplay()` never populates them and no consumer reads them — vestigial surface from an older mesh page. The live feed binds id/caller/target/type/status/duration_label and the task link. Fields the mapper *does* produce are left alone. |
| `RuntimeHealth.latency_ms` | All three runtimes health-check through `cliVersionHealthCheck()`, which only ever returns `healthy` and `error`. Nothing set it, nothing read it. |
| `RuntimeConfig.timeout_ms` | A knob wired to nothing: never written by the runtime/model routes, never threaded into a runtime the way its `max_turns` sibling is. Legacy JSONB rows keep round-tripping any stray key, since the write paths spread the existing config rather than replacing it. |
| `MemoryFactDisplay.promotion_origin_scope` | Never produced by `views/memory.ts` and never read by web, unlike its `merge_origin` sibling. |
| `.timeline-rail` / `.timeline-rail::before`, `.glass-bubble-agent` (three rule blocks incl. dark + no-`backdrop-filter` fallbacks) | No element carries either class. The glass-utilities doc comment still pointed at the agent bubble, so it's reworded. |
| `spin-slow` keyframe + animation in `tailwind.config.ts`, and its entry in the `prefers-reduced-motion` list | `animate-spin-slow` appears in no component. |

Deliberately left in place: the survivors CLAUDE.md already documents (`GET /activity`, the uncalled read halves of live audit trails, `PostgresMemoryPromotionEventRepository`), plus `MeshAsk.intent` / `.chain_depth`, which the mapper does produce even though no component binds them yet.

## Validation

`pnpm typecheck`, `pnpm lint`, and `pnpm --filter @beevibe/web exec next build` all clean. Test suites for core / api / daemon / scheduler / sandbox / web are byte-identical to the pre-change baseline — the remaining failures are the documented no-Postgres / no-provider-key ones. The unused-locals and unreachable-code passes were re-run after the edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BVJyekWvbgTouF2YWn6EFi

---
_Generated by [Claude Code](https://claude.ai/code/session_01BVJyekWvbgTouF2YWn6EFi)_