### PR TITLE
test: drop five zero-signal tests, generalize the query-key invariant

### DIFF
--- a/packages/core/src/adapters/runtime-registry.test.ts
+++ b/packages/core/src/adapters/runtime-registry.test.ts
@@ -6,22 +6,16 @@ import {
 } from "./runtime-registry.js";
 
 describe("createDefaultRuntimeRegistry", () => {
-  it("registers claude-code", () => {
-    const registry = createDefaultRuntimeRegistry();
-    expect(registry["claude"]).toBeDefined();
-    expect(registry["claude"]!.type).toBe("claude");
-  });
-
-  it("registers opencode", () => {
-    const registry = createDefaultRuntimeRegistry();
-    expect(registry["opencode"]).toBeDefined();
-    expect(registry["opencode"]!.type).toBe("opencode");
-  });
-
-  it("registers codex", () => {
-    const registry = createDefaultRuntimeRegistry();
-    expect(registry["codex"]).toBeDefined();
-    expect(registry["codex"]!.type).toBe("codex");
+  // Asserting the whole key set rather than probing three keys one at a
+  // time: this also catches an *extra* entry, which per-key presence
+  // checks can't see. The `.type` half of those probes is covered by the
+  // key/type sanity check below.
+  it("registers exactly the three production CLI runtimes", () => {
+    expect(Object.keys(createDefaultRuntimeRegistry()).sort()).toEqual([
+      "claude",
+      "codex",
+      "opencode",
+    ]);
   });
 
   it("every registry value's .type matches its registry key (sanity check against typos)", () => {

--- a/packages/core/src/composition.test.ts
+++ b/packages/core/src/composition.test.ts
@@ -42,16 +42,6 @@ describe("resolveSkillsSourceDir", () => {
 });
 
 describe("createMemoryStack", () => {
-  it("hands back every service the bootstraps destructure", () => {
-    const stack = createMemoryStack({ ...repos, ...KEYS });
-    expect(stack.embed).toBeDefined();
-    expect(stack.llm).toBeDefined();
-    expect(stack.coreMemory).toBeDefined();
-    expect(stack.factStore).toBeDefined();
-    expect(stack.promoter).toBeDefined();
-    expect(typeof stack.makeMemoryAgent).toBe("function");
-  });
-
   // The factory has to close over the stack's own services rather than
   // rebuild them per agent: SessionCache calls it once per evicted session.
   it("builds a distinct MemoryAgent per id from one shared stack", () => {
@@ -59,7 +49,6 @@ describe("createMemoryStack", () => {
     const a = stack.makeMemoryAgent("agent_1");
     const b = stack.makeMemoryAgent("agent_2");
     expect(a).not.toBe(b);
-    expect(typeof a.prepareBriefing).toBe("function");
   });
 });
 

--- a/packages/core/src/process-lifecycle.test.ts
+++ b/packages/core/src/process-lifecycle.test.ts
@@ -92,17 +92,6 @@ describe("installShutdownHandlers", () => {
     expect(exit).toHaveBeenCalledWith(0);
     expect(logged).toHaveBeenCalledWith("[scheduler] shutdown error:", expect.any(Error));
   });
-
-  it("handles SIGINT and SIGTERM alike", async () => {
-    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
-    vi.spyOn(console, "error").mockImplementation(() => undefined);
-    const shutdown = vi.fn().mockResolvedValue(undefined);
-
-    installShutdownHandlers("api", shutdown);
-    process.emit("SIGINT");
-    process.emit("SIGTERM");
-    await vi.waitFor(() => expect(shutdown).toHaveBeenCalledTimes(2));
-  });
 });
 
 describe("runEntrypoint", () => {

--- a/packages/web/lib/hooks/keys.test.ts
+++ b/packages/web/lib/hooks/keys.test.ts
@@ -1,34 +1,38 @@
 import { describe, expect, it } from "vitest";
 import { queryKeys } from "./keys";
 
+// Every call site invalidates through `queryKeys.<domain>.all` rather than
+// a bare string, so the root's literal spelling is arbitrary. What the app
+// does depend on is that each domain's derived keys start with that
+// domain's own root — that prefix is what makes
+// `invalidateQueries({ queryKey: queryKeys.tasks.all })` cascade to the
+// list and detail slots.
 describe("queryKeys", () => {
-  it("namespaces every domain under a stable root tuple", () => {
-    expect(queryKeys.tasks.all).toEqual(["tasks"]);
-    expect(queryKeys.agents.all).toEqual(["agents"]);
-    expect(queryKeys.sessions.all).toEqual(["sessions"]);
-    expect(queryKeys.memory.all).toEqual(["memory"]);
-    expect(queryKeys.promotions.all).toEqual(["promotions"]);
-    expect(queryKeys.mesh.all).toEqual(["mesh"]);
-    expect(queryKeys.dashboard.all).toEqual(["dashboard"]);
+  it("prefixes every derived key with its own domain root (so invalidation cascades)", () => {
+    for (const [domain, group] of Object.entries(queryKeys)) {
+      const { all, ...derived } = group as Record<string, unknown> & {
+        all: readonly string[];
+      };
+      for (const [name, value] of Object.entries(derived)) {
+        // `historyAll` is a bare prefix tuple; everything else is a builder.
+        const key = typeof value === "function" ? value({}) : value;
+        expect(
+          (key as readonly string[]).slice(0, all.length),
+          `${domain}.${name} must start with ${JSON.stringify(all)}`,
+        ).toEqual([...all]);
+      }
+    }
   });
 
-  it("derives list/detail keys that share the root prefix (so SSE invalidation cascades work)", () => {
-    const taskList = queryKeys.tasks.list({ view: "mine" });
-    const taskDetail = queryKeys.tasks.detail("t_1");
-    expect(taskList[0]).toBe("tasks");
-    expect(taskDetail[0]).toBe("tasks");
-    expect(taskList).not.toEqual(taskDetail);
+  it("separates list from detail within a domain", () => {
+    expect(queryKeys.tasks.list({ view: "mine" })).not.toEqual(
+      queryKeys.tasks.detail("t_1"),
+    );
   });
 
   it("filter args are part of the key (so different filters cache separately)", () => {
     const a = queryKeys.tasks.list({ view: "all" });
     const b = queryKeys.tasks.list({ view: "mine" });
     expect(a).not.toEqual(b);
-  });
-
-  it("structural equality across separate calls with the same arg shape", () => {
-    const a = queryKeys.tasks.list({ view: "mine" });
-    const b = queryKeys.tasks.list({ view: "mine" });
-    expect(a).toEqual(b);
   });
 });


### PR DESCRIPTION
Sweep of all 156 test files for tests that no longer earn their place.

## What came up empty

As in #270 and #284, the structural categories found nothing:

| Checked for | Result |
| --- | --- |
| Skipped / disabled / xfail without a reason | None. Every `.skip` / `.skipIf` in the tree is a **live environment gate** — Docker (`BEEVIBE_E2E_DOCKER`), live API keys, `RUN_CLAUDE_SMOKE`, `BEEVIBE_E2E_MULTI_INSTANCE`, `win32` — each with a documented opt-in header. |
| Tests for removed / refactored features | None. `pnpm typecheck` is clean across all 9 packages, so no test references a deleted API. |
| Tests with no assertions | None (scripted scan over every `it`/`test` body). |
| Orphaned test files | None. The 9 files without an exact sibling are companions (`chat-internals` → `chat.ts`, `shell-quote` → `docker.ts`, `mesh.db` → `mesh.ts`, …). |
| Duplicate test bodies | None (normalized-body comparison across the suite). |

The 269 skipped core tests are the Postgres-gated repository suites, not parked tests.

## What did turn up

**Compile-time-guaranteed assertions** — `packages/core/src/composition.test.ts`

`hands back every service the bootstraps destructure` called `toBeDefined()` on five fields of `MemoryStack` — a declared interface whose every member is a `new X()` in the same function — plus `typeof makeMemoryAgent === "function"` on a member typed as an arrow. Every call site destructuring those fields fails typecheck before this test could run. Same for the trailing `typeof a.prepareBriefing === "function"` in the next test; `expect(a).not.toBe(b)` is the assertion doing real work there (it guards against a memoized factory), so that test stays without the line. This is the #261 pattern — an assertion on a field the interface already pins.

**Already covered by its neighbours** — `packages/core/src/process-lifecycle.test.ts`

`handles SIGINT and SIGTERM alike` installs handlers and emits both signals, asserting only that shutdown ran twice. The two tests above it already emit SIGTERM and SIGINT through the same one-line install and assert the exit code each time, so nothing here can fail while those pass — and despite the title it never checks that the two are treated "alike".

**Three probes where one assertion is stronger** — `packages/core/src/adapters/runtime-registry.test.ts`

`registers claude-code` / `registers opencode` / `registers codex` each asserted presence plus `.type`; the `.type` half is what the following `every registry value's .type matches its registry key` test already sweeps. Collapsed to one assertion on the whole key set, which also catches an **extra** registry entry — something three per-key presence checks structurally cannot see.

**An invariant asserted as a literal mirror** — `packages/web/lib/hooks/keys.test.ts`

`namespaces every domain under a stable root tuple` restated seven root literals from the source, and `structural equality across separate calls with the same arg shape` compared two evaluations of the same pure array literal — a test of `toEqual`, not of the code.

Every consumer invalidates through `queryKeys.<domain>.all`, never a bare string, so the roots' spelling is arbitrary. What the app actually depends on is that each derived key **starts with its own domain root**, or `invalidateQueries({ queryKey: queryKeys.tasks.all })` won't cascade to the list and detail slots. The old suite checked that for `tasks` alone; it now covers **all 16 domains and their 24 derived keys**, and names the offender on failure.

Verified it has teeth by mutating `tasks.detail`'s root to `"task"`:

```
× prefixes every derived key with its own domain root (so invalidation cascades)
  → tasks.detail must start with ["tasks"]: expected [ 'task' ] to deeply equal [ 'tasks' ]
```

## Verification

| Suite | Before | After |
| --- | --- | --- |
| `@beevibe/core` | 609 passed, 7 failed, 269 skipped (885) | 605 passed, 7 failed, 269 skipped (881) |
| `@beevibe/web` | 203 passed (203) | 202 passed (202) |

Those runs are from a sandbox with no Postgres and no provider keys, so the 7 failures and 269 skips are the environment gates documented in `CLAUDE.md` — unchanged by this diff, and none of them in a file this PR touches. CI supplies both, so it exercises those suites for real. `typecheck`, `lint` and `build` are clean across all 9 packages.