### PR TITLE
refactor: unify four near-duplicate abstractions across core and api

### DIFF
--- a/packages/api/src/routes/agent-tool-bridge.ts
+++ b/packages/api/src/routes/agent-tool-bridge.ts
@@ -1,0 +1,58 @@
+/**
+ * Running an MCP agent tool on behalf of a human HTTP caller.
+ *
+ * Two REST endpoints exist only to give the Capabilities UI the same
+ * capability an agent gets over MCP: `/find-repo` wraps the `find_repo`
+ * tool's ranker, and `/capabilities/use` wraps `use_repo`. Both had spelled
+ * out the same bridge inline — `/capabilities`' copy is even commented
+ * "Same pattern as /find-repo".
+ *
+ * The bridge is four steps, and three of them are contract, not plumbing:
+ *
+ *   1. Resolve the caller's primary team agent. The tools are written
+ *      against an agent identity: `find_repo`'s ranker scopes learned-skill
+ *      lookups to the calling agent's owner, and `use_repo`'s container
+ *      task / repo_run / work_product rows are owned by the agent that ran
+ *      it. Substituting the person id would silently change both.
+ *   2. 404 `no_agent` when there is no such agent.
+ *   3. Map the tool's own `isError` result to a 400, passing its structured
+ *      `content` straight through — that content is the tool's error
+ *      envelope and clients read it.
+ *   4. Answer with the tool's `content` on success, at the status the
+ *      endpoint has already published (200 for a search, 202 for a
+ *      kicked-off run).
+ */
+
+import type { Response } from "express";
+import type { AgentRepository } from "@beevibe/core";
+import type { AgentTool } from "../tools/types.js";
+
+export interface RunAsPrimaryAgentOptions {
+  res: Response;
+  personId: string;
+  agentRepo: AgentRepository;
+  /** Builds the tool once the agent identity is known. */
+  makeTool: (agentId: string) => AgentTool;
+  /** Arguments for the tool's handler, already validated by the route. */
+  input: Record<string, unknown>;
+  /** Status for the success branch — 200 for a read, 202 for a kicked-off run. */
+  successStatus: number;
+}
+
+/**
+ * Resolve the caller's primary team agent, run `makeTool`'s tool under that
+ * identity, and answer the request from the tool's own result.
+ *
+ * Responds in every branch. Throws only what the tool handler throws, so
+ * callers keep their existing try/catch and its per-endpoint 500 code.
+ */
+export async function runToolAsPrimaryAgent(opts: RunAsPrimaryAgentOptions): Promise<void> {
+  const agent = await opts.agentRepo.findTopLevelForOwner(opts.personId);
+  if (!agent) {
+    opts.res.status(404).json({ error: "no_agent", message: "Caller has no primary agent." });
+    return;
+  }
+
+  const result = await opts.makeTool(agent.id).handler(opts.input);
+  opts.res.status(result.isError ? 400 : opts.successStatus).json(result.content);
+}

--- a/packages/api/src/routes/capabilities.ts
+++ b/packages/api/src/routes/capabilities.ts
@@ -28,6 +28,7 @@ import type {
 import { getReferencedRepos } from "@beevibe/core/services/referenced-repos";
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
 import { requireHuman } from "../auth/middleware.js";
+import { runToolAsPrimaryAgent } from "./agent-tool-bridge.js";
 import { readStringQuery } from "./http-errors.js";
 import { createUseRepoTool } from "../tools/use-repo.js";
 
@@ -109,32 +110,25 @@ export function createCapabilitiesRouter(deps: CapabilitiesRouterDeps): Router {
     }
 
     try {
-      // Same pattern as /find-repo: resolve caller's primary team agent
-      // and run the use_repo tool under that agent's identity. The
-      // resulting container task + repo_run + work_product are owned by
-      // the team agent, which matches the existing agent-driven flow.
-      const personId = req.caller!.personId;
-      const agent = await deps.agentRepo.findTopLevelForOwner(personId);
-      if (!agent) {
-        res.status(404).json({ error: "no_agent", message: "Caller has no primary agent." });
-        return;
-      }
-
-      const tool = createUseRepoTool(
-        { agentId: agent.id },
-        {
-          agentRepo: deps.agentRepo,
-          taskRepo: deps.taskRepo,
-          repoRunRepo: deps.repoRunRepo,
-          dispatchService: deps.dispatchService,
-        },
-      );
-      const result = await tool.handler({ goal, repo_url: repoUrl });
-      if (result.isError) {
-        res.status(400).json(result.content);
-        return;
-      }
-      res.status(202).json(result.content);
+      // The resulting container task + repo_run + work_product are owned
+      // by the caller's team agent, which matches the agent-driven flow.
+      await runToolAsPrimaryAgent({
+        res,
+        personId: req.caller!.personId,
+        agentRepo: deps.agentRepo,
+        makeTool: (agentId) =>
+          createUseRepoTool(
+            { agentId },
+            {
+              agentRepo: deps.agentRepo,
+              taskRepo: deps.taskRepo,
+              repoRunRepo: deps.repoRunRepo,
+              dispatchService: deps.dispatchService,
+            },
+          ),
+        input: { goal, repo_url: repoUrl },
+        successStatus: 202,
+      });
     } catch (err) {
       console.error("[capabilities/use]", err);
       res.status(500).json({ error: "use_failed" });

--- a/packages/api/src/routes/capabilities.ts
+++ b/packages/api/src/routes/capabilities.ts
@@ -28,6 +28,7 @@ import type {
 import { getReferencedRepos } from "@beevibe/core/services/referenced-repos";
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
 import { requireHuman } from "../auth/middleware.js";
+import { readStringQuery } from "./http-errors.js";
 import { createUseRepoTool } from "../tools/use-repo.js";
 
 export interface CapabilitiesRouterDeps {
@@ -50,7 +51,7 @@ export function createCapabilitiesRouter(deps: CapabilitiesRouterDeps): Router {
   router.get("/referenced-repos", async (req, res) => {
     if (!requireHuman(req, res)) return;
 
-    const taskIdParam = typeof req.query.task_id === "string" ? req.query.task_id.trim() : "";
+    const taskIdParam = readStringQuery(req, "task_id");
     if (!taskIdParam) {
       res.status(400).json({ error: "missing_task_id" });
       return;

--- a/packages/api/src/routes/escalation.ts
+++ b/packages/api/src/routes/escalation.ts
@@ -17,7 +17,7 @@
  * executor picks both up within ≤30s.
  */
 
-import { Router, type RequestHandler, type Response } from "express";
+import { Router, type RequestHandler } from "express";
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import {
   type EscalationService,
@@ -27,7 +27,7 @@ import {
 } from "@beevibe/core/services/escalation-service";
 import { NegotiationNotFoundError } from "@beevibe/core/services/negotiation-service";
 import { requireHuman } from "../auth/middleware.js";
-import { requireParam } from "./http-errors.js";
+import { makeServiceErrorHandler, requireParam } from "./http-errors.js";
 
 export interface EscalationRoutesDeps {
   authMiddleware: RequestHandler;
@@ -88,25 +88,11 @@ function buildSelector(body: unknown):
   };
 }
 
-function handleEscalationError(err: unknown, res: Response): void {
-  if (err instanceof EscalationNotFoundError) {
-    res.status(404).json({ error: "escalation_not_found", message: err.message });
-    return;
-  }
-  if (err instanceof NegotiationNotFoundError) {
-    res.status(404).json({ error: "negotiation_not_found", message: err.message });
-    return;
-  }
-  if (err instanceof EscalationStateError) {
-    res.status(409).json({ error: "invalid_state", message: err.message });
-    return;
-  }
-  console.error("[escalation route]", err);
-  res.status(500).json({
-    error: "internal_error",
-    message: err instanceof Error ? err.message : String(err),
-  });
-}
+const handleEscalationError = makeServiceErrorHandler("escalation route", [
+  { is: EscalationNotFoundError, status: 404, error: "escalation_not_found" },
+  { is: NegotiationNotFoundError, status: 404, error: "negotiation_not_found" },
+  { is: EscalationStateError, status: 409, error: "invalid_state" },
+]);
 
 export function createEscalationRouter(deps: EscalationRoutesDeps): Router {
   const router = Router();

--- a/packages/api/src/routes/find-repo.ts
+++ b/packages/api/src/routes/find-repo.ts
@@ -16,6 +16,7 @@ import type {
   LearnedSkillRepository,
 } from "@beevibe/core";
 import { requireHuman } from "../auth/middleware.js";
+import { readIntQuery, readStringQuery } from "./http-errors.js";
 import { createFindRepoTool } from "../tools/find-repo.js";
 
 export interface FindRepoRouterDeps {
@@ -32,13 +33,17 @@ export function createFindRepoRouter(deps: FindRepoRouterDeps): Router {
   router.get("/", async (req, res) => {
     if (!requireHuman(req, res)) return;
 
-    const goal = typeof req.query.goal === "string" ? req.query.goal.trim() : "";
+    const goal = readStringQuery(req, "goal");
     if (!goal) {
       res.status(400).json({ error: "missing_goal" });
       return;
     }
-    const limitParam = typeof req.query.limit === "string" ? Number(req.query.limit) : 5;
-    const limit = Number.isFinite(limitParam) ? Math.min(10, Math.max(1, Math.floor(limitParam))) : 5;
+    const limit = readIntQuery(req, "limit", {
+      fallback: 5,
+      min: 1,
+      max: 10,
+      onOutOfRange: "clamp",
+    });
 
     try {
       // The ranker scopes learned_skill lookups to the calling agent's

--- a/packages/api/src/routes/find-repo.ts
+++ b/packages/api/src/routes/find-repo.ts
@@ -16,6 +16,7 @@ import type {
   LearnedSkillRepository,
 } from "@beevibe/core";
 import { requireHuman } from "../auth/middleware.js";
+import { runToolAsPrimaryAgent } from "./agent-tool-bridge.js";
 import { readIntQuery, readStringQuery } from "./http-errors.js";
 import { createFindRepoTool } from "../tools/find-repo.js";
 
@@ -47,31 +48,24 @@ export function createFindRepoRouter(deps: FindRepoRouterDeps): Router {
 
     try {
       // The ranker scopes learned_skill lookups to the calling agent's
-      // owner. The HTTP caller is a human (bv_u_), so we resolve their
-      // primary team agent and use its id. If they have no agent at
-      // all, the ranker just gets zero learned-skill matches and the
-      // other 3 tiers still work.
-      const personId = req.caller!.personId;
-      const agent = await deps.agentRepo.findTopLevelForOwner(personId);
-      if (!agent) {
-        res.status(404).json({ error: "no_agent", message: "Caller has no primary agent." });
-        return;
-      }
-
-      const tool = createFindRepoTool(
-        { agentId: agent.id },
-        {
-          agentRepo: deps.agentRepo,
-          learnedSkillRepo: deps.learnedSkillRepo,
-          embeddings: deps.embeddings,
-        },
-      );
-      const result = await tool.handler({ goal, limit });
-      if (result.isError) {
-        res.status(400).json(result.content);
-        return;
-      }
-      res.status(200).json(result.content);
+      // owner. The HTTP caller is a human (bv_u_), so the bridge resolves
+      // their primary team agent and runs the tool under its id.
+      await runToolAsPrimaryAgent({
+        res,
+        personId: req.caller!.personId,
+        agentRepo: deps.agentRepo,
+        makeTool: (agentId) =>
+          createFindRepoTool(
+            { agentId },
+            {
+              agentRepo: deps.agentRepo,
+              learnedSkillRepo: deps.learnedSkillRepo,
+              embeddings: deps.embeddings,
+            },
+          ),
+        input: { goal, limit },
+        successStatus: 200,
+      });
     } catch (err) {
       console.error("[find-repo/search]", err);
       res.status(500).json({ error: "search_failed" });

--- a/packages/api/src/routes/http-errors.test.ts
+++ b/packages/api/src/routes/http-errors.test.ts
@@ -3,6 +3,9 @@ import type { Request, Response } from "express";
 import {
   invalidBody,
   loadOwned,
+  makeServiceErrorHandler,
+  readIntQuery,
+  readStringQuery,
   requireNullableString,
   requireParam,
 } from "./http-errors.js";
@@ -29,6 +32,10 @@ function fakeReq(params: Record<string, unknown>): Request {
 
 function fakeBodyReq(body: unknown): Request {
   return { body } as unknown as Request;
+}
+
+function fakeQueryReq(query: Record<string, unknown>): Request {
+  return { query } as unknown as Request;
 }
 
 describe("requireParam", () => {
@@ -217,5 +224,115 @@ describe("requireNullableString", () => {
     expect(res.body).toMatchObject({
       message: "expected { runtime_id: string | null }",
     });
+  });
+});
+
+describe("makeServiceErrorHandler", () => {
+  class NotFound extends Error {}
+  class BadState extends Error {}
+  class Unrelated extends Error {}
+
+  const handle = makeServiceErrorHandler("test route", [
+    { is: NotFound, status: 404, error: "thing_not_found" },
+    { is: BadState, status: 409, error: "invalid_state" },
+  ]);
+
+  it("maps a listed error to its status and code, keeping the thrown message", () => {
+    const res = fakeRes();
+    handle(new NotFound("no such thing: t_1"), res);
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({ error: "thing_not_found", message: "no such thing: t_1" });
+  });
+
+  it("walks the whole table, not just the first row", () => {
+    const res = fakeRes();
+    handle(new BadState("already closed"), res);
+    expect(res.statusCode).toBe(409);
+    expect(res.body).toEqual({ error: "invalid_state", message: "already closed" });
+  });
+
+  it("falls through to the shared 500 for an unlisted error", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = fakeRes();
+    handle(new Unrelated("connection reset"), res);
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: "internal_error", message: "connection reset" });
+    expect(spy.mock.calls[0]![0]).toBe("[test route]");
+    spy.mockRestore();
+  });
+
+  it("stringifies a non-Error throw on the fallback path", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = fakeRes();
+    handle("just a string", res);
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: "internal_error", message: "just a string" });
+    spy.mockRestore();
+  });
+
+  it("prefers the first matching row when an error subclasses another", () => {
+    // Ordering is the table's contract: escalation lists both of its
+    // not-found errors before the 409, and a subclass must not be
+    // swallowed by a base class listed above it.
+    class Specific extends NotFound {}
+    const ordered = makeServiceErrorHandler("test route", [
+      { is: Specific, status: 410, error: "gone" },
+      { is: NotFound, status: 404, error: "thing_not_found" },
+    ]);
+    const res = fakeRes();
+    ordered(new Specific("x"), res);
+    expect(res.statusCode).toBe(410);
+  });
+});
+
+describe("readIntQuery", () => {
+  it("returns undefined for an absent param when there is no fallback", () => {
+    expect(readIntQuery(fakeQueryReq({}), "limit")).toBeUndefined();
+  });
+
+  it("returns undefined for a non-numeric value when there is no fallback", () => {
+    expect(readIntQuery(fakeQueryReq({ limit: "abc" }), "limit")).toBeUndefined();
+  });
+
+  it("ignores a repeated param, which Express hands back as an array", () => {
+    expect(readIntQuery(fakeQueryReq({ limit: ["1", "2"] }), "limit", { fallback: 7 })).toBe(7);
+  });
+
+  it("uses the fallback when the value is out of range", () => {
+    const req = fakeQueryReq({ limit: "500" });
+    expect(readIntQuery(req, "limit", { fallback: 50, min: 1, max: 200 })).toBe(50);
+  });
+
+  it("passes an in-range value straight through", () => {
+    const req = fakeQueryReq({ limit: "120" });
+    expect(readIntQuery(req, "limit", { fallback: 50, min: 1, max: 200 })).toBe(120);
+  });
+
+  it("clamps to the nearest bound when asked to", () => {
+    const opts = { fallback: 5, min: 1, max: 10, onOutOfRange: "clamp" } as const;
+    expect(readIntQuery(fakeQueryReq({ limit: "50" }), "limit", opts)).toBe(10);
+    expect(readIntQuery(fakeQueryReq({ limit: "0" }), "limit", opts)).toBe(1);
+  });
+
+  it("floors a fractional value in clamp mode, as /find-repo always did", () => {
+    const opts = { fallback: 5, min: 1, max: 10, onOutOfRange: "clamp" } as const;
+    expect(readIntQuery(fakeQueryReq({ limit: "3.7" }), "limit", opts)).toBe(3);
+  });
+
+  it("falls back for a missing param even in clamp mode", () => {
+    const opts = { fallback: 5, min: 1, max: 10, onOutOfRange: "clamp" } as const;
+    expect(readIntQuery(fakeQueryReq({}), "limit", opts)).toBe(5);
+  });
+});
+
+describe("readStringQuery", () => {
+  it("trims the value", () => {
+    expect(readStringQuery(fakeQueryReq({ goal: "  ship it  " }), "goal")).toBe("ship it");
+  });
+
+  it("returns empty string for absent, blank, or repeated params", () => {
+    expect(readStringQuery(fakeQueryReq({}), "goal")).toBe("");
+    expect(readStringQuery(fakeQueryReq({ goal: "   " }), "goal")).toBe("");
+    expect(readStringQuery(fakeQueryReq({ goal: ["a", "b"] }), "goal")).toBe("");
   });
 });

--- a/packages/api/src/routes/http-errors.ts
+++ b/packages/api/src/routes/http-errors.ts
@@ -150,3 +150,114 @@ export function makeErrorHandler(
     });
   };
 }
+
+/**
+ * One row of a service-error → HTTP-response table. `is` is the domain
+ * error class to match with `instanceof`; the response carries `error` as
+ * the stable code and the thrown error's own `message`.
+ */
+export interface ServiceErrorMapping {
+  is: abstract new (...args: never[]) => Error;
+  status: number;
+  error: string;
+}
+
+/**
+ * The catch-block every service-backed router grew its own copy of: walk a
+ * short `instanceof` chain of the domain errors that map to a 4xx, and fall
+ * through to {@link makeErrorHandler}'s 500 for anything unrecognized.
+ *
+ * `task`, `escalation` and `negotiation` each hand-rolled this — three
+ * chains that differed only in their rows, sharing a byte-identical 500
+ * tail. Splitting the table (data) from the walk (behavior) means a new
+ * mapped error is one row rather than another chain, and the unmapped case
+ * can't drift between routers.
+ *
+ * Deliberately NOT applied to `view`'s handlers: those mix domain-error
+ * mapping with per-endpoint 404s of their own and pass a `context` string
+ * through to the log tag, which this signature doesn't take.
+ */
+export function makeServiceErrorHandler(
+  tag: string,
+  mappings: readonly ServiceErrorMapping[],
+): (err: unknown, res: Response) => void {
+  const fallback = makeErrorHandler(tag);
+  return (err, res) => {
+    for (const mapping of mappings) {
+      if (err instanceof mapping.is) {
+        res.status(mapping.status).json({ error: mapping.error, message: err.message });
+        return;
+      }
+    }
+    fallback(err, res);
+  };
+}
+
+/**
+ * Read an integer query param, falling back when it is absent or unusable.
+ *
+ * Seven handlers across `view` and `find-repo` had each written out their
+ * own `typeof req.query.x === "string" ? Number(...) : …` plus a range
+ * check, and the range checks were not written the same way twice. The two
+ * out-of-range policies actually in use both survive here as an explicit
+ * `onOutOfRange` choice rather than an accident of how the ternary was
+ * spelled:
+ *
+ * - `"fallback"` (default) — a value outside [min, max] is discarded and
+ *   `fallback` is used. What `/inbox` (50, ≤200) and `/activity` (20, ≤100)
+ *   already did.
+ * - `"clamp"` — a value outside the range is pulled to the nearest bound
+ *   and floored. What `/find-repo` (5, clamped to [1, 10]) already did.
+ *
+ * With no `fallback` the result is `undefined` for an absent or non-numeric
+ * value, which is how `/promotion` and `/memory/fact` pass "unset" down to
+ * the view layer.
+ */
+export interface IntQueryOptions {
+  fallback?: number;
+  min?: number;
+  max?: number;
+  onOutOfRange?: "fallback" | "clamp";
+}
+
+export function readIntQuery(
+  req: Request,
+  name: string,
+  opts: IntQueryOptions & { fallback: number },
+): number;
+export function readIntQuery(req: Request, name: string, opts?: IntQueryOptions): number | undefined;
+export function readIntQuery(
+  req: Request,
+  name: string,
+  opts: IntQueryOptions = {},
+): number | undefined {
+  const raw = req.query[name];
+  const parsed = typeof raw === "string" ? Number(raw) : NaN;
+  if (!Number.isFinite(parsed)) return opts.fallback;
+
+  const min = opts.min ?? -Infinity;
+  const max = opts.max ?? Infinity;
+  // Clamping callers want an integer index, so floor before the range test
+  // — `?limit=3.7` under [1, 10] is in range and must still come back as 3,
+  // which is what /find-repo's Math.floor(Math.min(...)) already produced.
+  const value = opts.onOutOfRange === "clamp" ? Math.floor(parsed) : parsed;
+  if (value >= min && value <= max) return value;
+
+  return opts.onOutOfRange === "clamp" ? Math.min(max, Math.max(min, value)) : opts.fallback;
+}
+
+/**
+ * Read a trimmed string query param, or `""` when absent, empty, or not a
+ * string — so the caller's next line is a plain `if (!value)` 400.
+ *
+ * Express types a query value as `string | string[] | ParsedQs | …` (a
+ * repeated `?goal=a&goal=b` really does arrive as an array), and
+ * `/find-repo`'s `goal` and `/capabilities`' `task_id` each narrowed it
+ * with the same hand-written ternary before trimming. The other query
+ * params in this package deliberately keep `undefined` for "absent" rather
+ * than folding it into `""`, so they are left alone.
+ */
+export function readStringQuery(req: Request, name: string): string {
+  const raw = req.query[name];
+  return typeof raw === "string" ? raw.trim() : "";
+}

--- a/packages/api/src/routes/negotiation.ts
+++ b/packages/api/src/routes/negotiation.ts
@@ -14,7 +14,11 @@ import {
   NegotiationNotFoundError,
 } from "@beevibe/core/services/negotiation-service";
 import { requireHuman } from "../auth/middleware.js";
-import { requireParam } from "./http-errors.js";
+import { makeServiceErrorHandler, requireParam } from "./http-errors.js";
+
+const handleNegotiationError = makeServiceErrorHandler("negotiation route", [
+  { is: NegotiationNotFoundError, status: 404, error: "negotiation_not_found" },
+]);
 
 export interface NegotiationRoutesDeps {
   authMiddleware: RequestHandler;
@@ -33,15 +37,7 @@ export function createNegotiationRouter(deps: NegotiationRoutesDeps): Router {
       const negotiation = await deps.negotiationService.getReview(id);
       res.json({ ok: true, negotiation });
     } catch (err) {
-      if (err instanceof NegotiationNotFoundError) {
-        res.status(404).json({ error: "negotiation_not_found", message: err.message });
-        return;
-      }
-      console.error("[negotiation route]", err);
-      res.status(500).json({
-        error: "internal_error",
-        message: err instanceof Error ? err.message : String(err),
-      });
+      handleNegotiationError(err, res);
     }
   });
 

--- a/packages/api/src/routes/task.ts
+++ b/packages/api/src/routes/task.ts
@@ -16,7 +16,7 @@
  *     killed).
  */
 
-import { Router, type RequestHandler, type Response } from "express";
+import { Router, type RequestHandler } from "express";
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import {
   TASK_PRIORITIES,
@@ -42,7 +42,7 @@ import { buildIntent, type ResumeReason } from "@beevibe/core/services/agent-ses
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
 import { requireHuman } from "../auth/middleware.js";
 import type { DaemonHub } from "../runtime/hub.js";
-import { requireParam } from "./http-errors.js";
+import { makeServiceErrorHandler, requireParam } from "./http-errors.js";
 
 /** Statuses from which /cancel is legal. Anything non-terminal. */
 const CANCELLABLE_FROM: readonly TaskStatus[] = [
@@ -115,21 +115,10 @@ async function recordCapabilityOutcome(
   }
 }
 
-function handleServiceError(err: unknown, res: Response): void {
-  if (err instanceof TaskNotFoundError) {
-    res.status(404).json({ error: "task_not_found", message: err.message });
-    return;
-  }
-  if (err instanceof InvalidTaskTransitionError) {
-    res.status(409).json({ error: "invalid_transition", message: err.message });
-    return;
-  }
-  console.error("[task route]", err);
-  res.status(500).json({
-    error: "internal_error",
-    message: err instanceof Error ? err.message : String(err),
-  });
-}
+const handleServiceError = makeServiceErrorHandler("task route", [
+  { is: TaskNotFoundError, status: 404, error: "task_not_found" },
+  { is: InvalidTaskTransitionError, status: 409, error: "invalid_transition" },
+]);
 
 function parsePriority(input: unknown): TaskPriority | undefined {
   if (typeof input !== "string") return undefined;

--- a/packages/api/src/routes/view.ts
+++ b/packages/api/src/routes/view.ts
@@ -64,6 +64,7 @@ import {
   invalidBody,
   loadOwned,
   makeErrorHandler,
+  readIntQuery,
   requireNullableString,
   requireParam,
 } from "./http-errors.js";
@@ -515,8 +516,7 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
 
   router.get("/promotion", async (req, res) => {
     if (!requireHuman(req, res)) return;
-    const limitRaw = typeof req.query.limit === "string" ? Number(req.query.limit) : NaN;
-    const limit = Number.isFinite(limitRaw) ? limitRaw : undefined;
+    const limit = readIntQuery(req, "limit");
     try {
       const events = await listPromotions(deps.pool, req.caller.personId, { limit });
       res.json(events);
@@ -532,8 +532,7 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
       scopeParam && SCOPES.has(scopeParam as MemoryScope)
         ? (scopeParam as MemoryScope)
         : undefined;
-    const limitRaw = typeof req.query.limit === "string" ? Number(req.query.limit) : NaN;
-    const limit = Number.isFinite(limitRaw) ? limitRaw : undefined;
+    const limit = readIntQuery(req, "limit");
 
     try {
       const facts = await listMemoryFacts(deps.pool, req.caller.personId, {
@@ -603,8 +602,7 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
   router.get("/inbox", async (req, res) => {
     if (!requireHuman(req, res)) return;
     try {
-      const limitParam = typeof req.query.limit === "string" ? Number(req.query.limit) : 50;
-      const limit = Number.isFinite(limitParam) && limitParam > 0 && limitParam <= 200 ? limitParam : 50;
+      const limit = readIntQuery(req, "limit", { fallback: 50, min: 1, max: 200 });
       const items = await listInbox(deps.pool, req.caller.personId, { limit });
       res.json(items);
     } catch (err) {
@@ -615,12 +613,7 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
   router.get("/activity", async (req, res) => {
     if (!requireHuman(req, res)) return;
     try {
-      const limitParam =
-        typeof req.query.limit === "string" ? Number(req.query.limit) : 20;
-      const limit =
-        Number.isFinite(limitParam) && limitParam > 0 && limitParam <= 100
-          ? limitParam
-          : 20;
+      const limit = readIntQuery(req, "limit", { fallback: 20, min: 1, max: 100 });
       const entries = await listActivity(deps.pool, req.caller.personId, limit);
       res.json(entries);
     } catch (err) {

--- a/packages/api/src/tools/args.test.ts
+++ b/packages/api/src/tools/args.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { requireStringArgs } from "./args.js";
+
+describe("requireStringArgs", () => {
+  it("returns the coerced values when every argument is present", () => {
+    const args = requireStringArgs({ task_id: "t_1", title: "Ship it" }, [
+      "task_id",
+      "title",
+    ]);
+    expect(args.ok).toBe(true);
+    if (!args.ok) return;
+    expect(args.values).toEqual({ task_id: "t_1", title: "Ship it" });
+  });
+
+  it("rejects a missing argument with the message already on the wire", () => {
+    const args = requireStringArgs({}, ["agent_id"]);
+    expect(args.ok).toBe(false);
+    if (args.ok) return;
+    expect(args.result).toEqual({
+      content: { error: "agent_id required" },
+      isError: true,
+    });
+  });
+
+  it("names every required argument, not just the missing one", () => {
+    // The message is what the calling agent sees when its call bounces;
+    // deriving it from the same list as the check is the point.
+    const args = requireStringArgs({ task_id: "t_1" }, ["task_id", "title"]);
+    expect(args.ok).toBe(false);
+    if (args.ok) return;
+    expect(args.result.content).toEqual({ error: "task_id and title required" });
+  });
+
+  it("treats an empty string as missing", () => {
+    expect(requireStringArgs({ id: "" }, ["id"]).ok).toBe(false);
+  });
+
+  it("treats an explicit null as missing", () => {
+    expect(requireStringArgs({ id: null }, ["id"]).ok).toBe(false);
+  });
+
+  it("accepts a whitespace-only value, leaving trimming to the caller", () => {
+    // Same as the hand-written guards: `String("  ")` is truthy, and the
+    // handlers that want a trim apply it after this check.
+    const args = requireStringArgs({ id: "  " }, ["id"]);
+    expect(args.ok).toBe(true);
+  });
+
+  it("coerces a non-string argument rather than rejecting it", () => {
+    const args = requireStringArgs({ id: 42 }, ["id"]);
+    expect(args.ok).toBe(true);
+    if (!args.ok) return;
+    expect(args.values.id).toBe("42");
+  });
+
+  it("rejects when a later argument is the missing one", () => {
+    const args = requireStringArgs({ intent: "do it", agent_id: "" }, [
+      "intent",
+      "agent_id",
+    ]);
+    expect(args.ok).toBe(false);
+    if (args.ok) return;
+    expect(args.result.content).toEqual({ error: "intent and agent_id required" });
+  });
+});

--- a/packages/api/src/tools/args.ts
+++ b/packages/api/src/tools/args.ts
@@ -1,0 +1,63 @@
+/**
+ * Required-argument narrowing for MCP tool handlers.
+ *
+ * Sixteen handlers across `hierarchy.ts` and `mesh.ts` opened with the same
+ * three moves: coerce each required argument with `String(input.x ?? "")`,
+ * test them all for emptiness in one `if`, and return an error whose message
+ * lists the same names again. Written out three times per handler, the list
+ * of names had three chances to disagree with itself — a handler that grows
+ * a fourth required argument gets a new `String(...)` line and a new `||`
+ * clause, but the message stays as it was and the agent is told the wrong
+ * thing about why its call failed.
+ *
+ * `requireStringArgs` derives all three from one list, so they cannot drift.
+ *
+ * The JSON Schema each tool ships already marks these `required`, but MCP
+ * clients are not obliged to enforce it and the schema is advisory on the
+ * wire — the runtime check has to exist regardless.
+ */
+
+import type { AgentToolResult } from "./types.js";
+
+export type RequiredStringArgs<K extends string> = { [P in K]: string };
+
+export type RequireStringArgsResult<K extends string> =
+  | { ok: true; values: RequiredStringArgs<K> }
+  | { ok: false; result: AgentToolResult };
+
+/**
+ * Coerce each named argument to a string and reject the call when any of
+ * them is empty.
+ *
+ * Emptiness, not absence, is the test — matching what the hand-written
+ * guards did. `String(undefined ?? "")` and an explicit `""` are the same
+ * failure, and a whitespace-only value passes here exactly as it did
+ * before (the handlers that want a trim do it themselves, after this).
+ *
+ * The rejection message is `"<a> and <b> required"` — the wording already
+ * on the wire at every call site this replaces. Agents branch on
+ * `content.error`, so it is reproduced verbatim rather than harmonized
+ * into a coded shape.
+ *
+ * ```ts
+ * const args = requireStringArgs(input, ["task_id", "title"]);
+ * if (!args.ok) return args.result;
+ * const { task_id: taskId, title } = args.values;
+ * ```
+ */
+export function requireStringArgs<const K extends string>(
+  input: Record<string, unknown>,
+  keys: readonly K[],
+): RequireStringArgsResult<K> {
+  const values = {} as RequiredStringArgs<K>;
+  for (const key of keys) {
+    values[key] = String(input[key] ?? "");
+  }
+  if (keys.some((key) => !values[key])) {
+    return {
+      ok: false,
+      result: { content: { error: `${keys.join(" and ")} required` }, isError: true },
+    };
+  }
+  return { ok: true, values };
+}

--- a/packages/api/src/tools/hierarchy.ts
+++ b/packages/api/src/tools/hierarchy.ts
@@ -52,6 +52,7 @@ import {
   buildIntent,
   type ResumeReason,
 } from "@beevibe/core/services/agent-session";
+import { requireStringArgs } from "./args.js";
 import { toolErrorFromThrown } from "./errors.js";
 import type { AgentTool } from "./types.js";
 
@@ -303,8 +304,9 @@ function getAgentProfileTool(
     },
     handler: async (input) => {
       try {
-        const id = String(input.agent_id ?? "");
-        if (!id) return { content: { error: "agent_id required" }, isError: true };
+        const args = requireStringArgs(input, ["agent_id"]);
+        if (!args.ok) return args.result;
+        const id = args.values.agent_id;
         const agent = await services.agentRepo.findById(id);
         return { content: { agent: projectAgent(agent) } };
       } catch (err) {
@@ -333,9 +335,9 @@ function getTaskTool(
     },
     handler: async (input) => {
       try {
-        const id = String(input.task_id ?? "");
-        if (!id) return { content: { error: "task_id required" }, isError: true };
-        const task = await services.taskRepo.findById(id);
+        const args = requireStringArgs(input, ["task_id"]);
+        if (!args.ok) return args.result;
+        const task = await services.taskRepo.findById(args.values.task_id);
         return { content: { task: projectTask(task) } };
       } catch (err) {
         return toolErrorFromThrown(err);
@@ -383,15 +385,10 @@ function createWorkProductTool(
     },
     handler: async (input) => {
       try {
-        const taskId = String(input.task_id ?? "");
+        const args = requireStringArgs(input, ["task_id", "title"]);
+        if (!args.ok) return args.result;
+        const { task_id: taskId, title } = args.values;
         const type = input.type;
-        const title = String(input.title ?? "");
-        if (!taskId || !title) {
-          return {
-            content: { error: "task_id and title required" },
-            isError: true,
-          };
-        }
         if (!WORK_PRODUCT_TYPES.includes(type as (typeof WORK_PRODUCT_TYPES)[number])) {
           return {
             content: { error: `type must be one of: ${WORK_PRODUCT_TYPES.join(", ")}` },
@@ -447,9 +444,9 @@ function listWorkProductsTool(
     },
     handler: async (input) => {
       try {
-        const taskId = String(input.task_id ?? "");
-        if (!taskId) return { content: { error: "task_id required" }, isError: true };
-        const wps = await services.taskService.listWorkProducts(taskId);
+        const args = requireStringArgs(input, ["task_id"]);
+        if (!args.ok) return args.result;
+        const wps = await services.taskService.listWorkProducts(args.values.task_id);
         return {
           content: {
             work_products: wps.map((w) => ({
@@ -491,8 +488,9 @@ function getWorkProductTool(
     },
     handler: async (input) => {
       try {
-        const id = String(input.id ?? "");
-        if (!id) return { content: { error: "id required" }, isError: true };
+        const args = requireStringArgs(input, ["id"]);
+        if (!args.ok) return args.result;
+        const id = args.values.id;
         const wp = await services.taskService.getWorkProduct(id);
         if (!wp) {
           return { content: { error: `work_product ${id} not found` }, isError: true };
@@ -550,8 +548,9 @@ function updateWorkProductTool(
     },
     handler: async (input) => {
       try {
-        const id = String(input.id ?? "");
-        if (!id) return { content: { error: "id required" }, isError: true };
+        const args = requireStringArgs(input, ["id"]);
+        if (!args.ok) return args.result;
+        const id = args.values.id;
         const updated = await services.taskService.updateWorkProduct(id, {
           summary: typeof input.summary === "string" ? input.summary : undefined,
           body: typeof input.body === "string" ? input.body : undefined,
@@ -673,14 +672,9 @@ function createTaskTool(
     },
     handler: async (input) => {
       try {
-        const intent = String(input.intent ?? "");
-        const targetId = String(input.agent_id ?? "");
-        if (!intent || !targetId) {
-          return {
-            content: { error: "intent and agent_id required" },
-            isError: true,
-          };
-        }
+        const args = requireStringArgs(input, ["intent", "agent_id"]);
+        if (!args.ok) return args.result;
+        const { intent, agent_id: targetId } = args.values;
 
         // Authz: assignee must be one of caller's subordinates.
         const subs = await services.agentRepo.findSubordinates(ctx.agentId);
@@ -780,8 +774,9 @@ function checkWorkStatusTool(
     },
     handler: async (input) => {
       try {
-        const targetId = String(input.agent_id ?? "");
-        if (!targetId) return { content: { error: "agent_id required" }, isError: true };
+        const args = requireStringArgs(input, ["agent_id"]);
+        if (!args.ok) return args.result;
+        const targetId = args.values.agent_id;
 
         // Authz: self or direct subordinate.
         if (targetId !== ctx.agentId) {
@@ -852,11 +847,9 @@ function reviseTaskTool(
     },
     handler: async (input) => {
       try {
-        const taskId = String(input.task_id ?? "");
-        const feedback = String(input.feedback ?? "");
-        if (!taskId || !feedback) {
-          return { content: { error: "task_id and feedback required" }, isError: true };
-        }
+        const args = requireStringArgs(input, ["task_id", "feedback"]);
+        if (!args.ok) return args.result;
+        const { task_id: taskId, feedback } = args.values;
 
         const task = await services.taskRepo.findById(taskId);
         if (!task) {
@@ -974,10 +967,9 @@ function addToEscalationTool(
     },
     handler: async (input) => {
       try {
-        const escalationId = String(input.escalation_id ?? "");
-        if (!escalationId) {
-          return { content: { error: "escalation_id required" }, isError: true };
-        }
+        const args = requireStringArgs(input, ["escalation_id"]);
+        if (!args.ok) return args.result;
+        const escalationId = args.values.escalation_id;
         const proposals = Array.isArray(input.proposals)
           ? (input.proposals as Array<{ title: string; description: string; tradeoffs?: string }>)
           : undefined;

--- a/packages/api/src/tools/mesh.ts
+++ b/packages/api/src/tools/mesh.ts
@@ -15,6 +15,7 @@ import type {
   CreateEscalationInput,
 } from "@beevibe/core/services/escalation-service";
 import type { Pool } from "@beevibe/core/adapters/postgres";
+import { requireStringArgs } from "./args.js";
 import { toolErrorFromThrown } from "./errors.js";
 import type { AgentTool } from "./types.js";
 import type { McpCaller } from "./assemble.js";
@@ -95,11 +96,9 @@ function askTool(ctx: MeshToolContext, services: MeshToolServices): AgentTool {
     },
     handler: async (input) => {
       try {
-        const target = String(input.target_agent_id ?? "");
-        const question = String(input.question ?? "");
-        if (!target || !question) {
-          return { content: { error: "target_agent_id and question required" }, isError: true };
-        }
+        const args = requireStringArgs(input, ["target_agent_id", "question"]);
+        if (!args.ok) return args.result;
+        const { target_agent_id: target, question } = args.values;
         const requestId = randomUUID();
         const response = await services.mesh.sendAsk(
           requestId,
@@ -133,11 +132,9 @@ function respondAskTool(ctx: MeshToolContext, services: MeshToolServices): Agent
     },
     handler: async (input) => {
       try {
-        const requestId = String(input.request_id ?? "");
-        const answer = String(input.answer ?? "");
-        if (!requestId || !answer) {
-          return { content: { error: "request_id and answer required" }, isError: true };
-        }
+        const args = requireStringArgs(input, ["request_id", "answer"]);
+        if (!args.ok) return args.result;
+        const { request_id: requestId, answer } = args.values;
         services.mesh.respondAsk(requestId, {
           request_id: requestId,
           from_agent_id: ctx.caller.agentId,
@@ -178,13 +175,11 @@ function negotiateTool(ctx: MeshToolContext, services: MeshToolServices): AgentT
     },
     handler: async (input) => {
       try {
-        const peerId = String(input.peer_id ?? "");
-        const proposal = String(input.proposal ?? "");
+        const args = requireStringArgs(input, ["peer_id", "proposal"]);
+        if (!args.ok) return args.result;
+        const { peer_id: peerId, proposal } = args.values;
         const taskId =
           typeof input.task_id === "string" && input.task_id ? input.task_id : undefined;
-        if (!peerId || !proposal) {
-          return { content: { error: "peer_id and proposal required" }, isError: true };
-        }
 
         const response = await services.mesh.sendNegotiate(
           ctx.caller.agentId,
@@ -228,15 +223,13 @@ function respondNegotiateTool(ctx: MeshToolContext, services: MeshToolServices):
     },
     handler: async (input) => {
       try {
-        const negId = String(input.negotiation_id ?? "");
+        const args = requireStringArgs(input, ["negotiation_id", "message"]);
+        if (!args.ok) return args.result;
+        const { negotiation_id: negId, message } = args.values;
         const decision = input.decision as (typeof NEGOTIATE_DECISIONS)[number];
-        const message = String(input.message ?? "");
         const counter =
           typeof input.counter_proposal === "string" ? input.counter_proposal : undefined;
 
-        if (!negId || !message) {
-          return { content: { error: "negotiation_id and message required" }, isError: true };
-        }
         if (!NEGOTIATE_DECISIONS.includes(decision)) {
           return {
             content: { error: `decision must be one of: ${NEGOTIATE_DECISIONS.join(", ")}` },
@@ -299,14 +292,9 @@ function reportBlockerTool(ctx: MeshToolContext, services: MeshToolServices): Ag
     },
     handler: async (input) => {
       try {
-        const taskId = String(input.task_id ?? "");
-        const description = String(input.description ?? "");
-        if (!taskId || !description) {
-          return {
-            content: { error: "task_id and description required" },
-            isError: true,
-          };
-        }
+        const args = requireStringArgs(input, ["task_id", "description"]);
+        if (!args.ok) return args.result;
+        const { task_id: taskId, description } = args.values;
 
         // Server derives parent from caller's hierarchy. Direct parent only.
         const parent = await services.agentRepo.findParent(ctx.caller.agentId);
@@ -392,11 +380,9 @@ function escalateToHumansTool(
     },
     handler: async (input) => {
       try {
-        const negotiationId = String(input.negotiation_id ?? "");
-        const summary = String(input.summary ?? "");
-        if (!negotiationId || !summary) {
-          return { content: { error: "negotiation_id and summary required" }, isError: true };
-        }
+        const args = requireStringArgs(input, ["negotiation_id", "summary"]);
+        if (!args.ok) return args.result;
+        const { negotiation_id: negotiationId, summary } = args.values;
 
         const proposals = Array.isArray(input.proposals)
           ? (input.proposals as CreateEscalationInput["proposals"])

--- a/packages/core/src/adapters/claude-code/runtime.ts
+++ b/packages/core/src/adapters/claude-code/runtime.ts
@@ -6,19 +6,11 @@ import type {
   RuntimeResult,
   Workspace,
 } from "../../ports/runtime.js";
-import {
-  cancelledResult,
-  cliVersionHealthCheck,
-  createStdoutLineReader,
-  finalizeCliResult,
-  warnIfTruncated,
-} from "../runtime-common.js";
-import { runCliProcess } from "./spawn.js";
+import { cliVersionHealthCheck, runCliSession } from "../runtime-common.js";
 import {
   extractStepEvents,
   parseClaudeMessages,
   parseStreamJsonLine,
-  type StreamJsonMessage,
 } from "./stream-json.js";
 
 /**
@@ -103,43 +95,18 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     for (const key of ANTHROPIC_AUTH_VARS) delete env[key];
     if (context.env) Object.assign(env, context.env);
 
-    // Parse messages incrementally during streaming so we don't re-parse
-    // the entire stdout after close. A line buffer handles chunk boundaries
-    // (a single JSON message can arrive split across multiple chunks).
-    const messages: StreamJsonMessage[] = [];
-    const handleLine = (line: string): void => {
-      const msg = parseStreamJsonLine(line);
-      if (!msg) return;
-      messages.push(msg);
-      if (context.onStep) {
-        for (const step of extractStepEvents(msg)) {
-          context.onStep(step);
-        }
-      }
-    };
-    const stdout = createStdoutLineReader(handleLine);
-
-    const result = await runCliProcess({
+    return runCliSession({
+      runtimeTag: "ClaudeCodeRuntime",
       command: this.config.command ?? "claude",
       args,
       cwd,
       env,
       stdin: context.intent,
-      abortSignal: context.abort_signal,
-      onSpawn: ({ pid, process_group_id }) => {
-        context.onSpawn?.({ process_pid: pid, process_group_id });
-      },
-      onLog: stdout.onLog,
+      context,
+      parseLine: parseStreamJsonLine,
+      extractSteps: extractStepEvents,
+      buildResult: (messages, exitCode) => parseClaudeMessages(messages, exitCode),
     });
-
-    // Flush any final partial line (stream without trailing \n)
-    stdout.flush();
-
-    warnIfTruncated("ClaudeCodeRuntime", result);
-
-    if (result.aborted) return cancelledResult(result);
-
-    return finalizeCliResult(parseClaudeMessages(messages, result.exitCode), result);
   }
 
   async healthCheck(): Promise<RuntimeHealth> {

--- a/packages/core/src/adapters/codex/runtime.ts
+++ b/packages/core/src/adapters/codex/runtime.ts
@@ -8,21 +8,16 @@ import type {
   RuntimeWorkspaceContext,
   Workspace,
 } from "../../ports/runtime.js";
-import { runCliProcess } from "../claude-code/spawn.js";
 import { MCP_TOOL_TIMEOUT_MS } from "../local-workspace/manager.js";
 import {
-  cancelledResult,
   cliVersionHealthCheck,
   composePrompt,
-  createStdoutLineReader,
-  finalizeCliResult,
-  warnIfTruncated,
+  runCliSession,
 } from "../runtime-common.js";
 import {
   extractCodexStepEvents,
   parseCodexEventLine,
   parseCodexEvents,
-  type CodexEvent,
 } from "./stream-json.js";
 
 export interface CodexRuntimeConfig {
@@ -120,44 +115,22 @@ export class CodexRuntime implements AgentRuntime {
     if (context.env) Object.assign(env, context.env);
     if (prepared) env.BEEVIBE_AGENT_API_KEY = prepared.agentApiKey;
 
-    const events: CodexEvent[] = [];
-    const handleLine = (line: string): void => {
-      const evt = parseCodexEventLine(line);
-      if (!evt) return;
-      events.push(evt);
-      if (!context.onStep) return;
-      for (const step of extractCodexStepEvents(evt)) {
-        context.onStep(step);
-      }
-    };
-    const stdout = createStdoutLineReader(handleLine);
-
-    const result = await runCliProcess({
+    return runCliSession({
+      runtimeTag: "CodexRuntime",
       command: this.config.command ?? "codex",
       args,
       cwd: context.workspace.path,
       env,
-      abortSignal: context.abort_signal,
-      onSpawn: ({ pid, process_group_id }) => {
-        context.onSpawn?.({ process_pid: pid, process_group_id });
-      },
-      onLog: stdout.onLog,
+      context,
+      parseLine: parseCodexEventLine,
+      extractSteps: extractCodexStepEvents,
+      // Read the `--output-last-message` scratch file here, before
+      // `onSettled` deletes it — codex writes the canonical final
+      // assistant text there rather than into the event stream.
+      buildResult: (events, exitCode) =>
+        parseCodexEvents(events, exitCode, readIfExists(lastMessagePath)),
+      onSettled: () => removeIfExists(lastMessagePath),
     });
-    stdout.flush();
-
-    warnIfTruncated("CodexRuntime", result);
-
-    if (result.aborted) {
-      removeIfExists(lastMessagePath);
-      return cancelledResult(result);
-    }
-
-    const lastMessage = readIfExists(lastMessagePath);
-    removeIfExists(lastMessagePath);
-    return finalizeCliResult(
-      parseCodexEvents(events, result.exitCode, lastMessage),
-      result,
-    );
   }
 
   async healthCheck(): Promise<RuntimeHealth> {

--- a/packages/core/src/adapters/opencode/runtime.ts
+++ b/packages/core/src/adapters/opencode/runtime.ts
@@ -8,20 +8,15 @@ import type {
   RuntimeWorkspaceContext,
   Workspace,
 } from "../../ports/runtime.js";
-import { runCliProcess } from "../claude-code/spawn.js";
 import {
-  cancelledResult,
   cliVersionHealthCheck,
   composePrompt,
-  createStdoutLineReader,
-  finalizeCliResult,
-  warnIfTruncated,
+  runCliSession,
 } from "../runtime-common.js";
 import {
   extractOpenCodeStepEvents,
   parseOpenCodeEventLine,
   parseOpenCodeEvents,
-  type OpenCodeEvent,
 } from "./stream-json.js";
 
 export interface OpenCodeRuntimeConfig {
@@ -76,36 +71,17 @@ export class OpenCodeRuntime implements AgentRuntime {
     const env: Record<string, string | undefined> = { ...process.env };
     if (context.env) Object.assign(env, context.env);
 
-    const events: OpenCodeEvent[] = [];
-    const handleLine = (line: string): void => {
-      const evt = parseOpenCodeEventLine(line);
-      if (!evt) return;
-      events.push(evt);
-      if (!context.onStep) return;
-      for (const step of extractOpenCodeStepEvents(evt)) {
-        context.onStep(step);
-      }
-    };
-    const stdout = createStdoutLineReader(handleLine);
-
-    const result = await runCliProcess({
+    return runCliSession({
+      runtimeTag: "OpenCodeRuntime",
       command: this.config.command ?? "opencode",
       args,
       cwd: context.workspace.path,
       env,
-      abortSignal: context.abort_signal,
-      onSpawn: ({ pid, process_group_id }) => {
-        context.onSpawn?.({ process_pid: pid, process_group_id });
-      },
-      onLog: stdout.onLog,
+      context,
+      parseLine: parseOpenCodeEventLine,
+      extractSteps: extractOpenCodeStepEvents,
+      buildResult: (events, exitCode) => parseOpenCodeEvents(events, exitCode),
     });
-    stdout.flush();
-
-    warnIfTruncated("OpenCodeRuntime", result);
-
-    if (result.aborted) return cancelledResult(result);
-
-    return finalizeCliResult(parseOpenCodeEvents(events, result.exitCode), result);
   }
 
   async healthCheck(): Promise<RuntimeHealth> {

--- a/packages/core/src/adapters/runtime-common.test.ts
+++ b/packages/core/src/adapters/runtime-common.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { CliProcessResult } from "./claude-code/spawn.js";
-import type { RuntimeResult } from "../ports/runtime.js";
+import type { CliProcessOptions, CliProcessResult } from "./claude-code/spawn.js";
+import * as spawnModule from "./claude-code/spawn.js";
+import type { RuntimeContext, RuntimeResult, RuntimeStep } from "../ports/runtime.js";
 import {
   cancelledResult,
   createStdoutLineReader,
   finalizeCliResult,
+  runCliSession,
   warnIfTruncated,
 } from "./runtime-common.js";
 
@@ -145,5 +147,123 @@ describe("finalizeCliResult", () => {
   it("omits stderr on failure when the CLI wrote nothing", () => {
     const failed: RuntimeResult = { status: "failed", output: "" };
     expect(finalizeCliResult(failed, cliResult({ stderr: "", exitCode: 1 })).stderr).toBeUndefined();
+  });
+});
+
+describe("runCliSession", () => {
+  interface Evt {
+    n: number;
+  }
+
+  function ctx(overrides: Partial<RuntimeContext> = {}): RuntimeContext {
+    return {
+      intent: "do a thing",
+      workspace: { path: "/tmp/beevibe-runtime-common-test" },
+      system_prompt_append: "",
+      ...overrides,
+    };
+  }
+
+  function spec(overrides: Partial<Parameters<typeof runCliSession<Evt>>[0]> = {}) {
+    return {
+      runtimeTag: "TestRuntime",
+      command: "fake-cli",
+      args: ["--json"],
+      cwd: "/tmp/beevibe-runtime-common-test",
+      env: {},
+      context: ctx(),
+      parseLine: (line: string): Evt | null =>
+        line.trim() ? ({ n: Number(line) } as Evt) : null,
+      extractSteps: (evt: Evt): RuntimeStep[] => [
+        { kind: "agent", description: `step ${evt.n}`, timestamp: "t" },
+      ],
+      buildResult: (events: Evt[]): RuntimeResult => ({
+        status: "completed",
+        output: events.map((e) => e.n).join(","),
+      }),
+      ...overrides,
+    };
+  }
+
+  function mockRunCli(result: Partial<CliProcessResult>, stdoutChunks: string[] = []) {
+    return vi.spyOn(spawnModule, "runCliProcess").mockImplementation(async (options) => {
+      options.onSpawn?.({ pid: 4242, process_group_id: 4242 });
+      for (const chunk of stdoutChunks) options.onLog?.("stdout", chunk);
+      return cliResult(result);
+    });
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("folds the whole stream, including a final line with no trailing newline", async () => {
+    // The flush() has to happen before buildResult or the last event is
+    // silently dropped — the reason this sequence is shared, not copied.
+    mockRunCli({}, ["1\n2\n", "3"]);
+    const out = await runCliSession<Evt>(spec());
+    expect(out.output).toBe("1,2,3");
+  });
+
+  it("streams each parsed event to context.onStep as it arrives", async () => {
+    mockRunCli({}, ["7\n8\n"]);
+    const steps: RuntimeStep[] = [];
+    await runCliSession<Evt>(spec({ context: ctx({ onStep: (s) => steps.push(s) }) }));
+    expect(steps.map((s) => s.description)).toEqual(["step 7", "step 8"]);
+  });
+
+  it("merges process metadata into the parsed result", async () => {
+    mockRunCli({ exitCode: 0 }, ["1\n"]);
+    const out = await runCliSession<Evt>(spec());
+    expect(out.process_pid).toBe(4242);
+    expect(out.process_group_id).toBe(4242);
+    expect(out.exit_code).toBe(0);
+  });
+
+  it("reports an aborted run as cancelled without folding the events", async () => {
+    // A cancelled session must not surface as a failure just because the
+    // CLI exited non-zero on SIGTERM.
+    mockRunCli({ aborted: true, exitCode: 143 }, ["1\n"]);
+    const buildResult = vi.fn();
+    const out = await runCliSession<Evt>(spec({ buildResult }));
+    expect(out.status).toBe("cancelled");
+    expect(buildResult).not.toHaveBeenCalled();
+  });
+
+  it("runs onSettled after buildResult, so a scratch file is still readable", async () => {
+    mockRunCli({}, ["1\n"]);
+    const order: string[] = [];
+    await runCliSession<Evt>(
+      spec({
+        buildResult: () => {
+          order.push("build");
+          return { status: "completed", output: "" };
+        },
+        onSettled: () => order.push("settled"),
+      }),
+    );
+    expect(order).toEqual(["build", "settled"]);
+  });
+
+  it("still runs onSettled on the aborted path", async () => {
+    mockRunCli({ aborted: true }, []);
+    const onSettled = vi.fn();
+    await runCliSession<Evt>(spec({ onSettled }));
+    expect(onSettled).toHaveBeenCalledOnce();
+  });
+
+  it("passes command, args, cwd, env and stdin straight through", async () => {
+    let seen: CliProcessOptions | undefined;
+    vi.spyOn(spawnModule, "runCliProcess").mockImplementation(async (options) => {
+      seen = options;
+      return cliResult();
+    });
+    await runCliSession<Evt>(
+      spec({ command: "codex", args: ["exec"], env: { A: "1" }, stdin: "hello" }),
+    );
+    expect(seen?.command).toBe("codex");
+    expect(seen?.args).toEqual(["exec"]);
+    expect(seen?.env).toEqual({ A: "1" });
+    expect(seen?.stdin).toBe("hello");
   });
 });

--- a/packages/core/src/adapters/runtime-common.ts
+++ b/packages/core/src/adapters/runtime-common.ts
@@ -1,5 +1,10 @@
 import { tmpdir } from "node:os";
-import type { RuntimeContext, RuntimeHealth, RuntimeResult } from "../ports/runtime.js";
+import type {
+  RuntimeContext,
+  RuntimeHealth,
+  RuntimeResult,
+  RuntimeStep,
+} from "../ports/runtime.js";
 import { type CliProcessResult, runCliProcess } from "./claude-code/spawn.js";
 
 /**
@@ -207,4 +212,90 @@ export function finalizeCliResult(
     exit_code: result.exitCode,
     ...(stderrTail ? { stderr: stderrTail } : {}),
   };
+}
+
+/**
+ * Everything {@link runCliSession} needs to drive one CLI subprocess, minus
+ * the provider-specific event schema (supplied as the three callbacks).
+ */
+export interface CliSessionSpec<Event> {
+  /** Log tag for the truncation warning, e.g. `"CodexRuntime"`. */
+  runtimeTag: string;
+  command: string;
+  args: string[];
+  cwd: string;
+  env: Record<string, string | undefined>;
+  /** Piped to the child's stdin. Only Claude Code feeds the intent this way. */
+  stdin?: string;
+  /** Supplies `abort_signal`, `onSpawn` and `onStep`. */
+  context: RuntimeContext;
+  /** One stdout line → one provider event, or `null` to skip the line. */
+  parseLine: (line: string) => Event | null;
+  /** One event → 0+ live-transcript steps. */
+  extractSteps: (evt: Event) => RuntimeStep[];
+  /** Fold the collected events into a result, once the process has settled. */
+  buildResult: (events: Event[], exitCode: number | null) => RuntimeResult;
+  /**
+   * Best-effort cleanup, run on both the aborted and the settled path.
+   * On the settled path it runs *after* `buildResult`, so a spec whose
+   * result depends on a scratch file (codex's `--output-last-message`) can
+   * read it in `buildResult` and delete it here.
+   */
+  onSettled?: () => void;
+}
+
+/**
+ * Run one CLI subprocess end to end: stream its NDJSON stdout through
+ * `parseLine`, fan each event out to `context.onStep`, then fold everything
+ * into a `RuntimeResult`.
+ *
+ * All three CLI runtimes (claude-code, codex, opencode) had spelled this
+ * sequence out by hand. The steps are ordered for a reason and the ordering
+ * is easy to get subtly wrong when copied: `flush()` has to run before the
+ * events are folded (a stream that ends without a trailing newline drops its
+ * last event otherwise), and the `aborted` check has to come before
+ * `buildResult` (a cancelled session must not be reported as a failure just
+ * because the CLI exited non-zero on SIGTERM).
+ */
+export async function runCliSession<Event>(spec: CliSessionSpec<Event>): Promise<RuntimeResult> {
+  // Parse incrementally during streaming rather than re-reading the whole of
+  // stdout after close. `createStdoutLineReader` handles chunk boundaries — a
+  // single JSON event can arrive split across chunks.
+  const events: Event[] = [];
+  const stdout = createStdoutLineReader((line) => {
+    const evt = spec.parseLine(line);
+    if (!evt) return;
+    events.push(evt);
+    if (!spec.context.onStep) return;
+    for (const step of spec.extractSteps(evt)) {
+      spec.context.onStep(step);
+    }
+  });
+
+  const result = await runCliProcess({
+    command: spec.command,
+    args: spec.args,
+    cwd: spec.cwd,
+    env: spec.env,
+    stdin: spec.stdin,
+    abortSignal: spec.context.abort_signal,
+    onSpawn: ({ pid, process_group_id }) => {
+      spec.context.onSpawn?.({ process_pid: pid, process_group_id });
+    },
+    onLog: stdout.onLog,
+  });
+
+  // Emit any final partial line (stream that ended without a trailing \n).
+  stdout.flush();
+
+  warnIfTruncated(spec.runtimeTag, result);
+
+  if (result.aborted) {
+    spec.onSettled?.();
+    return cancelledResult(result);
+  }
+
+  const parsed = spec.buildResult(events, result.exitCode);
+  spec.onSettled?.();
+  return finalizeCliResult(parsed, result);
 }


### PR DESCRIPTION
Four clusters of near-duplicate code, found by a similarity sweep over every non-test module under `packages/*/src` (brace-balanced function blocks, normalized, compared on 5-gram token shingles). Each is a separate commit; all four are behavior-preserving.

Earlier passes already pulled out the easy shared pieces — `runtime-common.ts`, `pg-helpers.ts`, `routes/http-errors.ts`, `tools/errors.ts`. What is left is the layer above those: the *sequences* that call them, which had been copied rather than shared.

## 1. `runCliSession` — the CLI-runtime `execute()` skeleton (`packages/core`)

`claude-code`, `codex` and `opencode` each spelled out the same sequence: collect an events array off a stdout line reader, spawn via `runCliProcess`, flush, warn on truncation, branch on `aborted`, fold the events, merge process metadata. Only the parse/extract/fold callbacks actually differ.

Two orderings in that sequence are load-bearing and easy to get wrong in a copy:

- `flush()` before the fold, or a stream that ends without a trailing newline drops its last event.
- the `aborted` check before the fold, or a cancelled session reads as a failure on SIGTERM's non-zero exit.

Both are now stated once. Codex's `--output-last-message` scratch file is handled by an `onSettled` hook that runs after `buildResult` on the settled path and on the aborted path too, preserving the existing read-then-delete order.

## 2. `makeServiceErrorHandler` + `readIntQuery` / `readStringQuery` (`packages/api/src/routes`)

`task`, `escalation` and `negotiation` each hand-rolled the same catch block: a short `instanceof` chain of domain errors mapping to a 4xx, then a byte-identical 500 tail. The new factory splits the table (data) from the walk (behavior), so a new mapped error is one row rather than another chain.

Query params had drifted further. Seven handlers across `view` and `find-repo` wrote their own `typeof req.query.x === "string" ? Number(…)` plus a range check, and no two range checks were written the same way. `readIntQuery` keeps both out-of-range policies actually in use as an explicit choice — discard-to-fallback (`/inbox`, `/activity`) and clamp-to-bound (`/find-repo`, which also floors) — rather than leaving it to how each ternary happened to be spelled.

One deliberate behavior change: a fractional limit below 1 (`?limit=0.5`) on `/inbox` and `/activity` now falls back instead of reaching Postgres as a non-integer `LIMIT`, which was a 500. Integer inputs are unaffected.

`view`'s own handlers keep their per-call `handleError` context strings — they mix domain-error mapping with per-endpoint 404s, which the new signature does not model.

## 3. `requireStringArgs` — the MCP tool argument guard (`packages/api/src/tools`)

Sixteen handlers in `hierarchy.ts` and `mesh.ts` opened with the same three moves: coerce each required argument with `String(input.x ?? "")`, test them all for emptiness in one `if`, and return an error whose message lists the same names a third time.

Written out three times per handler, the list had three chances to disagree with itself — a handler that grows a fourth required argument gets a new `String(...)` line and a new `||` clause, but the message stays as it was and the agent is told the wrong thing about why its call failed. All three now derive from one list.

Wire behavior is unchanged: emptiness (not absence) is still the test, a whitespace-only value still passes through, and the rejection message is reproduced verbatim — agents branch on `content.error`. The one guard with different wording (`create_subordinate_agent`'s coded `missing_required_fields`) is left alone.

## 4. `runToolAsPrimaryAgent` — the agent-tool-over-HTTP bridge (`packages/api/src/routes`)

`/find-repo` and `/capabilities/use` exist to give the Capabilities UI what an agent gets over MCP, and both spelled out the same bridge inline — `/capabilities`' copy was commented "Same pattern as /find-repo".

Three of its four steps are contract rather than plumbing: the tools are written against an agent identity (`find_repo`'s ranker scopes learned-skill lookups to the calling agent's owner; `use_repo`'s task, repo_run and work_product rows are owned by the agent that ran it), a caller with no such agent gets `404 no_agent`, and a tool-level `isError` becomes a 400 forwarding the tool's own structured content. Each route keeps its published success status (200 vs 202) and its own try/catch, so `search_failed` / `use_failed` are unchanged.

## Verification

- `pnpm typecheck` and `pnpm lint` clean across all 9 packages (the 4 remaining lint warnings are pre-existing `import/no-duplicates` in test files this PR does not touch).
- `tsc --noUnusedLocals --noUnusedParameters` clean on `core` and `api`.
- `@beevibe/core` runtime suites: 76 pass (69 before, +7 new).
- `@beevibe/api`: 843 pass, 9 files fail — all the documented `DATABASE_URL_TEST` / provider-key environmental failures, none in a file this PR touches.
- `@beevibe/daemon` 156 pass, `@beevibe/scheduler` at its documented no-Postgres baseline.

33 tests added, covering the paths whose only prior coverage was DB-gated: `runCliSession`'s ordering guarantees, `makeServiceErrorHandler`'s table walk and fallback, `readIntQuery`'s two out-of-range policies, and `requireStringArgs`.

## Found but not changed

- The three `stream-json.ts` parsers share an output-selection tail (`failed ? errorMessage || assistantText || bareCliExitMessage(exitCode) : …`) and transcript-line formatting. The event schemas around them are genuinely different, so the shared part is small and entangled — worth a look, not obviously worth a shared helper.
- `daemon/src/repo-runs.ts:mapKind` and `api/src/routes/repo-runs.ts:sessionEventToTranscriptKind` are exact inverses across packages, each documented as the other's reverse. A single bidirectional table in core would make them unable to drift.
- `view.ts` has three near-identical "fetch by id or 404" GET handlers, and `hierarchy.ts` has ~20 tool definitions whose only shared body is the `try`/`catch (err) { return toolErrorFromThrown(err) }` wrapper. Both are same-file repetition with a lower payoff than the four above.
- The `AnthropicLlmProvider` / `OpenAILlmProvider` / `OpenAIEmbeddingService` constructors share an 8-line api-key-or-throw preamble.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDyjmFQaUQeaFHLHycAvXd)_