### PR TITLE
test: cover the MCP tool handlers agents call every session

### DIFF
--- a/packages/api/src/tools/hierarchy.test.ts
+++ b/packages/api/src/tools/hierarchy.test.ts
@@ -11,6 +11,7 @@ import type {
   AgentProvisionEventRepository,
   AgentRepository,
   CoreMemoryBlockRepository,
+  Escalation,
   HierarchyLevel,
   Session,
   Task,
@@ -20,7 +21,10 @@ import type {
   WorkProductRepository,
 } from "@beevibe/core";
 import type { MemoryAgent } from "@beevibe/core/services/memory";
-import type { TaskService } from "@beevibe/core/services/task-service";
+import {
+  InvalidTaskTransitionError,
+  type TaskService,
+} from "@beevibe/core/services/task-service";
 import type { EscalationService } from "@beevibe/core/services/escalation-service";
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
 import type { Pool } from "@beevibe/core/adapters/postgres";
@@ -76,6 +80,23 @@ function fakeWpListItem(
   return { ...rest, body_bytes: 0, ...overrides };
 }
 
+function fakeEscalation(overrides: Partial<Escalation> = {}): Escalation {
+  return {
+    id: "esc_1",
+    negotiation_id: "neg_1",
+    initiator_session_id: "sess_i",
+    counterparty_session_id: "sess_c",
+    summary: "We disagree on the rollout date.",
+    initiator_open_questions: [],
+    counterparty_open_questions: [],
+    escalated_by_role: "initiator",
+    status: "pending",
+    created_at: new Date("2026-04-01"),
+    updated_at: new Date("2026-04-01"),
+    ...overrides,
+  } as Escalation;
+}
+
 function buildServices(overrides: {
   agentRepo?: Partial<AgentRepository>;
   taskRepo?: Partial<TaskRepository>;
@@ -128,7 +149,7 @@ function buildServices(overrides: {
 
   const escalationService = {
     create: vi.fn(),
-    addContribution: vi.fn(async () => ({ id: "esc_1", status: "pending" })),
+    addContribution: vi.fn(async () => fakeEscalation()),
     resolve: vi.fn(),
     ...overrides.escalationService,
   } as unknown as EscalationService;
@@ -155,6 +176,9 @@ function buildServices(overrides: {
   const coreMemoryRepo = {
     findByAgent: vi.fn(async () => []),
     updateContent: vi.fn(async () => undefined),
+    // provisionAgent (create_subordinate_agent) seeds the new IC's blocks
+    // through this before the tool overwrites the identity-bearing ones.
+    initDefaults: vi.fn(async () => []),
   } as unknown as CoreMemoryBlockRepository;
 
   const agentProvisionEventRepo = {
@@ -574,5 +598,502 @@ describe("check_work_status", () => {
     const result = await callTool(tools, "check_work_status", { agent_id: "rando" });
     expect(result.isError).toBe(true);
     expect((result.content as { error: string }).error).toBe("unauthorized");
+  });
+});
+
+describe("revise_task", () => {
+  const blockedTask = () =>
+    fakeTask({ id: "task_b", status: "blocked", assignee_id: "sub_1" });
+
+  function reviseServices(
+    overrides: Parameters<typeof buildServices>[0] = {},
+  ): ReturnType<typeof buildServices> {
+    return buildServices({
+      taskRepo: { findById: vi.fn(async () => blockedTask()) },
+      agentRepo: {
+        findById: vi.fn(async () =>
+          fakeAgent({ id: "sub_1", hierarchy_level: "ic", parent_agent_id: "agent_t" }),
+        ),
+      },
+      taskService: {
+        reviseTask: vi.fn(async () =>
+          fakeTask({
+            id: "task_b",
+            status: "needs_revision",
+            assignee_id: "sub_1",
+            next_dispatch_context: {
+              kind: "revision",
+              feedback: "try the staging creds",
+              from_status: "blocked",
+              source: "parent_agent",
+            },
+          }),
+        ),
+      },
+      ...overrides,
+    });
+  }
+
+  it("revises the subordinate's task and dispatches the revision session", async () => {
+    const services = reviseServices();
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "revise_task", {
+      task_id: "task_b",
+      feedback: "try the staging creds",
+    });
+
+    expect(services.taskService.reviseTask).toHaveBeenCalledWith(
+      "task_b",
+      "try the staging creds",
+      { source: "parent_agent", reviserAgentId: "agent_t" },
+    );
+    expect(services.dispatchService.dispatchTask).toHaveBeenCalledOnce();
+    const dispatched = vi.mocked(services.dispatchService.dispatchTask).mock.calls[0]![0];
+    expect(dispatched).toMatchObject({
+      agentId: "sub_1",
+      type: "task",
+      reason: { kind: "revision", from_status: "blocked" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toMatchObject({
+      revised: true,
+      task_id: "task_b",
+      status: "needs_revision",
+      from_status: "blocked",
+    });
+  });
+
+  it("skips the dispatch when reviseTask left no revision context", async () => {
+    const services = reviseServices({
+      taskService: {
+        reviseTask: vi.fn(async () =>
+          fakeTask({ id: "task_b", status: "needs_revision", assignee_id: "sub_1" }),
+        ),
+      },
+    });
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "revise_task", { task_id: "task_b", feedback: "f" });
+
+    expect(result.isError).toBeFalsy();
+    expect(services.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["no task_id", { feedback: "f" }],
+    ["no feedback", { task_id: "task_b" }],
+  ])("refuses %s", async (_label, input) => {
+    const services = reviseServices();
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "revise_task", input);
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "task_id and feedback required" });
+    expect(services.taskRepo.findById).not.toHaveBeenCalled();
+  });
+
+  it("reports task_not_found for an unknown task", async () => {
+    const services = reviseServices({ taskRepo: { findById: vi.fn(async () => undefined) } });
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "revise_task", { task_id: "nope", feedback: "f" });
+    expect(result.content).toMatchObject({ error: "task_not_found", task_id: "nope" });
+  });
+
+  it("reports task_unassigned when the task has no assignee", async () => {
+    const services = reviseServices({
+      taskRepo: { findById: vi.fn(async () => fakeTask({ assignee_id: undefined })) },
+    });
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "revise_task", { task_id: "task_b", feedback: "f" });
+    expect(result.content).toMatchObject({ error: "task_unassigned" });
+  });
+
+  it("reports assignee_not_found when the assignee row is gone", async () => {
+    const services = reviseServices({ agentRepo: { findById: vi.fn(async () => undefined) } });
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "revise_task", { task_id: "task_b", feedback: "f" });
+    expect(result.content).toMatchObject({ error: "assignee_not_found" });
+  });
+
+  it("refuses a caller who is not the assignee's direct parent", async () => {
+    const services = reviseServices({
+      agentRepo: {
+        findById: vi.fn(async () => fakeAgent({ id: "sub_1", parent_agent_id: "someone_else" })),
+      },
+    });
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "revise_task", { task_id: "task_b", feedback: "f" });
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "not_parent" });
+    expect(services.taskService.reviseTask).not.toHaveBeenCalled();
+  });
+
+  it("maps an InvalidTaskTransitionError to invalid_transition", async () => {
+    const services = reviseServices({
+      taskService: {
+        reviseTask: vi.fn(async () => {
+          throw new InvalidTaskTransitionError("cannot revise a done task");
+        }),
+      },
+    });
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "revise_task", { task_id: "task_b", feedback: "f" });
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "invalid_transition",
+      message: "cannot revise a done task",
+    });
+  });
+
+  it("degrades any other throw to the catch-all envelope", async () => {
+    const services = reviseServices({
+      taskService: {
+        reviseTask: vi.fn(async () => {
+          throw new Error("pool exhausted");
+        }),
+      },
+    });
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "revise_task", { task_id: "task_b", feedback: "f" });
+    expect(result.content).toEqual({ error: "pool exhausted" });
+  });
+});
+
+describe("add_to_escalation", () => {
+  it("adds the caller's contribution and notifies listeners", async () => {
+    const services = buildServices({
+      escalationService: {
+        addContribution: vi.fn(async () =>
+          fakeEscalation({ initiator_submitted_at: new Date("2026-04-01") }),
+        ),
+      },
+    });
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "add_to_escalation", {
+      escalation_id: "esc_1",
+      proposals: [{ title: "Ship behind a flag", description: "gate it" }],
+      open_questions: ["is the customer flexible?", 42],
+    });
+
+    expect(services.escalationService.addContribution).toHaveBeenCalledWith({
+      escalationId: "esc_1",
+      callerAgentId: "agent_t",
+      proposals: [{ title: "Ship behind a flag", description: "gate it" }],
+      // non-string questions are dropped rather than forwarded
+      openQuestions: ["is the customer flexible?"],
+    });
+    expect(services.pool.query).toHaveBeenCalledWith(
+      expect.stringContaining("escalation_updated"),
+      ["esc_1"],
+    );
+    expect(result.content).toEqual({
+      escalation_id: "esc_1",
+      status: "pending",
+      // only one side has submitted
+      both_sides_submitted: false,
+    });
+  });
+
+  it("reports both_sides_submitted once the counterparty has filed too", async () => {
+    const services = buildServices({
+      escalationService: {
+        addContribution: vi.fn(async () =>
+          fakeEscalation({
+            status: "resolved",
+            initiator_submitted_at: new Date("2026-04-01"),
+            counterparty_submitted_at: new Date("2026-04-02"),
+          }),
+        ),
+      },
+    });
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "add_to_escalation", { escalation_id: "esc_1" });
+    expect(result.content).toMatchObject({ both_sides_submitted: true });
+  });
+
+  it("leaves proposals and open_questions undefined when they are not arrays", async () => {
+    const services = buildServices();
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    await callTool(tools, "add_to_escalation", {
+      escalation_id: "esc_1",
+      proposals: "one option",
+      open_questions: "a question",
+    });
+
+    expect(vi.mocked(services.escalationService.addContribution).mock.calls[0]![0]).toMatchObject({
+      proposals: undefined,
+      openQuestions: undefined,
+    });
+  });
+
+  it("refuses a missing escalation_id without calling the service", async () => {
+    const services = buildServices();
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "add_to_escalation", {});
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "escalation_id required" });
+    expect(services.escalationService.addContribution).not.toHaveBeenCalled();
+  });
+
+  it("does not notify when the contribution fails", async () => {
+    const services = buildServices({
+      escalationService: {
+        addContribution: vi.fn(async () => {
+          throw new Error("already submitted");
+        }),
+      },
+    });
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "add_to_escalation", { escalation_id: "esc_1" });
+    expect(result.content).toEqual({ error: "already submitted" });
+    expect(services.pool.query).not.toHaveBeenCalled();
+  });
+});
+
+describe("create_subordinate_agent", () => {
+  const GOOD = {
+    name: "Backend specialist",
+    tag_line: "Owns the API surface",
+    persona: "Pragmatic, test-first.",
+    domain: "Express + Postgres",
+  };
+
+  function spawnServices(
+    overrides: Parameters<typeof buildServices>[0] = {},
+  ): ReturnType<typeof buildServices> {
+    return buildServices({
+      agentRepo: {
+        findById: vi.fn(async () =>
+          fakeAgent({
+            id: "agent_t",
+            name: "Team lead",
+            owner_id: "person_1",
+            runtime_config: { type: "claude", model: "opus" },
+          }),
+        ),
+        create: vi.fn(async (input: Partial<Agent>) => fakeAgent(input)),
+      },
+      ...overrides,
+    });
+  }
+
+  function toolsFor(services: ReturnType<typeof buildServices>): AgentTool[] {
+    return buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+  }
+
+  /** What the tool actually handed provisionAgent, via agentRepo.create. */
+  function createdRow(services: ReturnType<typeof buildServices>) {
+    return vi.mocked(services.agentRepo.create).mock.calls[0]![0];
+  }
+
+  it("provisions the IC under the caller, inheriting owner and runtime", async () => {
+    const services = spawnServices();
+    const result = await callTool(toolsFor(services), "create_subordinate_agent", GOOD);
+
+    expect(result.isError).toBeFalsy();
+    expect(createdRow(services)).toMatchObject({
+      name: GOOD.name,
+      owner_id: "person_1",
+      parent_agent_id: "agent_t",
+      hierarchy_level: "ic",
+    });
+    // Parent's runtime carries over; only the identity line is replaced.
+    expect(createdRow(services).runtime_config).toMatchObject({
+      type: "claude",
+      model: "opus",
+      system_prompt_addition: `You are ${GOOD.name}.`,
+    });
+    expect(result.content).toMatchObject({
+      created: { hierarchy_level: "ic", parent_agent_id: "agent_t" },
+    });
+  });
+
+  it("pins the child to the parent's runtime when the parent has one", async () => {
+    const services = spawnServices({
+      agentRepo: {
+        findById: vi.fn(async () => fakeAgent({ id: "agent_t", preferred_runtime_id: "rt_1" })),
+        create: vi.fn(async (input: Partial<Agent>) => fakeAgent(input)),
+      },
+    });
+    await callTool(toolsFor(services), "create_subordinate_agent", GOOD);
+
+    expect(createdRow(services)).toMatchObject({ preferred_runtime_id: "rt_1" });
+  });
+
+  it("omits preferred_runtime_id when the parent has none", async () => {
+    const services = spawnServices();
+    await callTool(toolsFor(services), "create_subordinate_agent", GOOD);
+
+    expect(createdRow(services)).not.toHaveProperty("preferred_runtime_id");
+  });
+
+  it("seeds only the three required blocks when the optional ones are blank", async () => {
+    const services = spawnServices();
+    await callTool(toolsFor(services), "create_subordinate_agent", GOOD);
+
+    const seeded = vi
+      .mocked(services.coreMemoryRepo.updateContent)
+      .mock.calls.map((c) => c[1])
+      .sort();
+    expect(seeded).toEqual(["domain", "persona", "tag_line"]);
+  });
+
+  it("seeds active_context and constraints when supplied", async () => {
+    const services = spawnServices();
+    await callTool(toolsFor(services), "create_subordinate_agent", {
+      ...GOOD,
+      active_context: "Migrating auth to OIDC",
+      constraints: "No breaking API changes",
+    });
+
+    const seeded = vi
+      .mocked(services.coreMemoryRepo.updateContent)
+      .mock.calls.map((c) => [c[1], c[2]]);
+    expect(seeded).toEqual(
+      expect.arrayContaining([
+        ["active_context", "Migrating auth to OIDC"],
+        ["constraints", "No breaking API changes"],
+      ]),
+    );
+  });
+
+  it("writes the provision audit row", async () => {
+    const services = spawnServices();
+    await callTool(toolsFor(services), "create_subordinate_agent", GOOD);
+
+    expect(vi.mocked(services.agentProvisionEventRepo.create).mock.calls[0]![0]).toMatchObject({
+      parent_agent_id: "agent_t",
+      owner_person_id: "person_1",
+      child_name: GOOD.name,
+      persona: GOOD.persona,
+      domain: GOOD.domain,
+    });
+  });
+
+  it("still succeeds when the audit row fails to write", async () => {
+    const services = spawnServices();
+    vi.mocked(services.agentProvisionEventRepo.create).mockRejectedValueOnce(
+      new Error("audit table locked"),
+    );
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await callTool(toolsFor(services), "create_subordinate_agent", GOOD);
+
+    expect(result.isError).toBeFalsy();
+    expect(logged).toHaveBeenCalled();
+    logged.mockRestore();
+  });
+
+  it("is not offered to ICs at all — the tier gate is in the tool set", () => {
+    const services = spawnServices();
+    const icTools = buildHierarchyTools({ agentId: "agent_i", hierarchyLevel: "ic" }, services);
+    expect(icTools.map((t) => t.name)).not.toContain("create_subordinate_agent");
+  });
+
+  it.each([
+    ["name", { ...GOOD, name: "  " }],
+    ["tag_line", { ...GOOD, tag_line: "" }],
+    ["persona", { ...GOOD, persona: "" }],
+    ["domain", { ...GOOD, domain: "" }],
+  ])("refuses a blank %s", async (_field, input) => {
+    const services = spawnServices();
+    const result = await callTool(toolsFor(services), "create_subordinate_agent", input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "missing_required_fields" });
+    expect(services.agentRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("refuses a tag_line over 100 chars and reports the actual length", async () => {
+    const services = spawnServices();
+    const result = await callTool(toolsFor(services), "create_subordinate_agent", {
+      ...GOOD,
+      tag_line: "x".repeat(101),
+    });
+
+    expect(result.content).toMatchObject({ error: "tag_line_too_long", actual: 101 });
+    expect(services.agentRepo.create).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["over 80 chars", "n".repeat(81)],
+    ["containing a control character", "Backend\u0001specialist"],
+  ])("refuses a name %s", async (_label, name) => {
+    const services = spawnServices();
+    const result = await callTool(toolsFor(services), "create_subordinate_agent", {
+      ...GOOD,
+      name,
+    });
+
+    expect(result.content).toMatchObject({ error: "invalid_name" });
+    expect(services.agentRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("reports parent_not_found when the caller's row is gone", async () => {
+    const services = spawnServices({
+      agentRepo: {
+        findById: vi.fn(async () => undefined),
+        create: vi.fn(async (input: Partial<Agent>) => fakeAgent(input)),
+      },
+    });
+    const result = await callTool(toolsFor(services), "create_subordinate_agent", GOOD);
+
+    expect(result.content).toMatchObject({ error: "parent_not_found", agent_id: "agent_t" });
+  });
+
+  it("counts recent spawns over a 24h window", async () => {
+    const services = spawnServices();
+    await callTool(toolsFor(services), "create_subordinate_agent", GOOD);
+
+    expect(services.agentProvisionEventRepo.countByParentSince).toHaveBeenCalledWith(
+      "agent_t",
+      24 * 60 * 60,
+    );
+  });
+
+  it("enforces the per-parent daily cap", async () => {
+    const services = spawnServices();
+    vi.mocked(services.agentProvisionEventRepo.countByParentSince).mockResolvedValueOnce(8);
+
+    const result = await callTool(toolsFor(services), "create_subordinate_agent", GOOD);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "subordinate_daily_cap",
+      cap: 8,
+      count: 8,
+    });
+    expect(services.agentRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("degrades a provisioning throw to the catch-all envelope", async () => {
+    const services = spawnServices();
+    vi.mocked(services.agentRepo.create).mockRejectedValueOnce(new Error("duplicate name"));
+
+    const result = await callTool(toolsFor(services), "create_subordinate_agent", GOOD);
+    expect(result.content).toEqual({ error: "duplicate name" });
+  });
+
+  it("takes its field descriptions from the IC core-memory block templates", () => {
+    const tool = findTool(toolsFor(spawnServices()), "create_subordinate_agent");
+    const props = tool.schema.properties as Record<string, { description: string }>;
+
+    for (const block of ["tag_line", "persona", "domain"]) {
+      expect(props[block]!.description.length).toBeGreaterThan(0);
+    }
+    expect(tool.schema.required).toEqual(["name", "tag_line", "persona", "domain"]);
   });
 });

--- a/packages/api/src/tools/mesh.test.ts
+++ b/packages/api/src/tools/mesh.test.ts
@@ -1,13 +1,30 @@
 /**
- * Mesh tool assembly tests — IC vs team tier gating.
+ * Mesh tool tests — tier gating plus the per-tool handler contracts.
  *
- * Per-tool handler behavior is covered indirectly by the m6/m7 e2e scripts
- * (mesh flows require live Postgres + spawned CLI subprocesses). This file
- * locks the static tier inventory — the exact tool *names* each tier gets,
- * so future skill-loader work can rely on the surface being stable.
+ * The *flows* (a real spawn, a real block-until-response round trip) need
+ * live Postgres + spawned CLI subprocesses and stay with the m6/m7 e2e
+ * scripts. What is unit-testable, and covered here, is everything the
+ * handler does either side of the MeshServer call: argument coercion and
+ * validation, the projection of each response shape onto the MCP wire
+ * envelope, and the error envelope for a thrown CodedMeshError.
+ *
+ * The first section locks the static tier inventory — the exact tool
+ * *names* each tier gets, so future skill-loader work can rely on the
+ * surface being stable.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { ResolvedCaller } from "@beevibe/core/auth";
+import type { AgentRepository, TaskRepository } from "@beevibe/core";
+import type { EscalationService } from "@beevibe/core/services/escalation-service";
+import type { TaskService } from "@beevibe/core/services/task-service";
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import {
+  CannotNegotiateWithIcError,
+  MeshCapacityError,
+  MeshMaxRoundsError,
+} from "../mesh/types.js";
+import type { MeshServer } from "../mesh/server.js";
+import type { AgentTool } from "./types.js";
 import { buildIcMeshTools, buildTeamMeshTools, type MeshToolServices } from "./mesh.js";
 
 // Fake services — the assembly itself doesn't invoke handlers, so the
@@ -45,5 +62,500 @@ describe("buildTeamMeshTools", () => {
       "respond_ask",
       "respond_negotiate",
     ]);
+  });
+});
+
+// ── Handler harness ──────────────────────────────────────────────────────
+
+interface MeshStubs {
+  sendAsk: ReturnType<typeof vi.fn>;
+  respondAsk: ReturnType<typeof vi.fn>;
+  sendNegotiate: ReturnType<typeof vi.fn>;
+  respondNegotiate: ReturnType<typeof vi.fn>;
+  reportBlocker: ReturnType<typeof vi.fn>;
+  unblockOnEscalate: ReturnType<typeof vi.fn>;
+  findParent: ReturnType<typeof vi.fn>;
+  markBlocked: ReturnType<typeof vi.fn>;
+  createEscalation: ReturnType<typeof vi.fn>;
+  query: ReturnType<typeof vi.fn>;
+}
+
+function harness(): { services: MeshToolServices; stubs: MeshStubs; tool: (n: string) => AgentTool } {
+  const stubs: MeshStubs = {
+    sendAsk: vi.fn(async () => ({
+      request_id: "req_1",
+      from_agent_id: "agent_target",
+      answer: "yes, feasible",
+    })),
+    respondAsk: vi.fn(),
+    sendNegotiate: vi.fn(async () => ({
+      negotiation_id: "neg_1",
+      from_agent_id: "agent_peer",
+      decision: "counter",
+      message: "how about Tuesday",
+      counter_proposal: "ship Tuesday",
+    })),
+    respondNegotiate: vi.fn(async () => null),
+    reportBlocker: vi.fn(),
+    unblockOnEscalate: vi.fn(),
+    findParent: vi.fn(async () => ({ id: "agent_parent" })),
+    markBlocked: vi.fn(async () => undefined),
+    createEscalation: vi.fn(async () => ({
+      id: "esc_1",
+      status: "open",
+      negotiation_id: "neg_1",
+    })),
+    query: vi.fn(async () => ({ rows: [] })),
+  };
+
+  const services = {
+    mesh: {
+      sendAsk: stubs.sendAsk,
+      respondAsk: stubs.respondAsk,
+      sendNegotiate: stubs.sendNegotiate,
+      respondNegotiate: stubs.respondNegotiate,
+      reportBlocker: stubs.reportBlocker,
+      unblockOnEscalate: stubs.unblockOnEscalate,
+    } as unknown as MeshServer,
+    agentRepo: { findParent: stubs.findParent } as unknown as AgentRepository,
+    taskRepo: {} as unknown as TaskRepository,
+    taskService: { markBlocked: stubs.markBlocked } as unknown as TaskService,
+    escalationService: { create: stubs.createEscalation } as unknown as EscalationService,
+    pool: { query: stubs.query } as unknown as Pool,
+  };
+
+  const tools = buildTeamMeshTools(fakeCtx, services);
+  const tool = (name: string): AgentTool => {
+    const found = tools.find((t) => t.name === name);
+    if (!found) throw new Error(`no such mesh tool: ${name}`);
+    return found;
+  };
+  return { services, stubs, tool };
+}
+
+describe("ask", () => {
+  it("sends the ask under a fresh request id and projects the response", async () => {
+    const { tool, stubs } = harness();
+    const result = await tool("ask").handler({
+      target_agent_id: "agent_target",
+      question: "is X feasible?",
+    });
+
+    expect(stubs.sendAsk).toHaveBeenCalledOnce();
+    const [requestId, from, to, question] = stubs.sendAsk.mock.calls[0]!;
+    expect(typeof requestId).toBe("string");
+    expect(requestId).not.toHaveLength(0);
+    expect([from, to, question]).toEqual(["agent_x", "agent_target", "is X feasible?"]);
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({
+      request_id: "req_1",
+      from_agent_id: "agent_target",
+      answer: "yes, feasible",
+    });
+  });
+
+  it("mints a distinct request id per call", async () => {
+    const { tool, stubs } = harness();
+    await tool("ask").handler({ target_agent_id: "a", question: "q" });
+    await tool("ask").handler({ target_agent_id: "a", question: "q" });
+
+    expect(stubs.sendAsk.mock.calls[0]![0]).not.toBe(stubs.sendAsk.mock.calls[1]![0]);
+  });
+
+  it.each([
+    ["no target", { question: "q" }],
+    ["no question", { target_agent_id: "a" }],
+    ["an empty target", { target_agent_id: "", question: "q" }],
+    ["an empty question", { target_agent_id: "a", question: "" }],
+  ])("refuses %s without reaching the mesh", async (_label, input) => {
+    const { tool, stubs } = harness();
+    const result = await tool("ask").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "target_agent_id and question required" });
+    expect(stubs.sendAsk).not.toHaveBeenCalled();
+  });
+
+  it("projects a CodedMeshError with its code and meta", async () => {
+    const { tool, stubs } = harness();
+    stubs.sendAsk.mockRejectedValueOnce(
+      new MeshCapacityError("at capacity", { agentId: "agent_target", running: 3, cap: 3 }),
+    );
+    const result = await tool("ask").handler({ target_agent_id: "a", question: "q" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "MESH_CAPACITY_EXCEEDED",
+      agentId: "agent_target",
+      running: 3,
+      cap: 3,
+      message: "at capacity",
+    });
+  });
+
+  it("degrades a plain Error to the catch-all envelope", async () => {
+    const { tool, stubs } = harness();
+    stubs.sendAsk.mockRejectedValueOnce(new Error("target offline"));
+    const result = await tool("ask").handler({ target_agent_id: "a", question: "q" });
+
+    expect(result.content).toEqual({ error: "target offline" });
+  });
+});
+
+describe("respond_ask", () => {
+  it("resolves the waiting ask with the responder's identity", async () => {
+    const { tool, stubs } = harness();
+    const result = await tool("respond_ask").handler({
+      request_id: "req_1",
+      answer: "no, blocked on Y",
+    });
+
+    expect(stubs.respondAsk).toHaveBeenCalledWith("req_1", {
+      request_id: "req_1",
+      from_agent_id: "agent_x",
+      answer: "no, blocked on Y",
+    });
+    expect(result.content).toEqual({ responded: true, request_id: "req_1" });
+  });
+
+  it.each([
+    ["no request_id", { answer: "a" }],
+    ["no answer", { request_id: "req_1" }],
+  ])("refuses %s", async (_label, input) => {
+    const { tool, stubs } = harness();
+    const result = await tool("respond_ask").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "request_id and answer required" });
+    expect(stubs.respondAsk).not.toHaveBeenCalled();
+  });
+
+  it("envelopes a synchronous throw from the mesh", async () => {
+    const { tool, stubs } = harness();
+    stubs.respondAsk.mockImplementationOnce(() => {
+      throw new Error("no waiter for req_1");
+    });
+    const result = await tool("respond_ask").handler({ request_id: "req_1", answer: "a" });
+
+    expect(result.content).toEqual({ error: "no waiter for req_1" });
+  });
+});
+
+describe("negotiate", () => {
+  it("opens round 1 with the caller's session as originator and projects the counter", async () => {
+    const { tool, stubs } = harness();
+    const result = await tool("negotiate").handler({
+      peer_id: "agent_peer",
+      proposal: "ship Monday",
+      task_id: "tsk_1",
+    });
+
+    expect(stubs.sendNegotiate).toHaveBeenCalledWith("agent_x", "agent_peer", "ship Monday", {
+      taskId: "tsk_1",
+      initiatorSessionId: "ses_x",
+    });
+    expect(result.content).toEqual({
+      negotiation_id: "neg_1",
+      from_agent_id: "agent_peer",
+      decision: "counter",
+      message: "how about Tuesday",
+      counter_proposal: "ship Tuesday",
+    });
+  });
+
+  it("omits task_id when it is absent or empty", async () => {
+    const { tool, stubs } = harness();
+    await tool("negotiate").handler({ peer_id: "p", proposal: "x", task_id: "" });
+    expect(stubs.sendNegotiate.mock.calls[0]![3]).toMatchObject({ taskId: undefined });
+  });
+
+  it.each([
+    ["no peer", { proposal: "x" }],
+    ["no proposal", { peer_id: "p" }],
+  ])("refuses %s without reaching the mesh", async (_label, input) => {
+    const { tool, stubs } = harness();
+    const result = await tool("negotiate").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "peer_id and proposal required" });
+    expect(stubs.sendNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("projects the escalated sentinel rather than a normal round", async () => {
+    const { tool, stubs } = harness();
+    stubs.sendNegotiate.mockResolvedValueOnce({
+      decision: "escalated",
+      escalation_id: "esc_1",
+      negotiation_id: "neg_1",
+      message: "handed to humans",
+    });
+    const result = await tool("negotiate").handler({ peer_id: "p", proposal: "x" });
+
+    expect(result.content).toEqual({
+      decision: "escalated",
+      escalation_id: "esc_1",
+      negotiation_id: "neg_1",
+      message: "handed to humans",
+    });
+  });
+
+  it("surfaces CANNOT_NEGOTIATE_WITH_IC with the offending agent id", async () => {
+    const { tool, stubs } = harness();
+    stubs.sendNegotiate.mockRejectedValueOnce(
+      new CannotNegotiateWithIcError({ agentId: "agent_ic" }),
+    );
+    const result = await tool("negotiate").handler({ peer_id: "agent_ic", proposal: "x" });
+
+    expect(result.content).toMatchObject({
+      error: "CANNOT_NEGOTIATE_WITH_IC",
+      agentId: "agent_ic",
+    });
+  });
+});
+
+describe("respond_negotiate", () => {
+  it("forwards the round and reports terminal when the server returns null", async () => {
+    const { tool, stubs } = harness();
+    const result = await tool("respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "accept",
+      message: "works for me",
+    });
+
+    expect(stubs.respondNegotiate).toHaveBeenCalledWith(
+      "neg_1",
+      {
+        negotiation_id: "neg_1",
+        from_agent_id: "agent_x",
+        decision: "accept",
+        message: "works for me",
+        counter_proposal: undefined,
+      },
+      "ses_x",
+    );
+    expect(result.content).toEqual({
+      negotiation_id: "neg_1",
+      decision: "accept",
+      terminal: true,
+    });
+  });
+
+  it("projects the peer's next round when the server returns one", async () => {
+    const { tool, stubs } = harness();
+    stubs.respondNegotiate.mockResolvedValueOnce({
+      negotiation_id: "neg_1",
+      from_agent_id: "agent_peer",
+      decision: "reject",
+      message: "no",
+      counter_proposal: undefined,
+    });
+    const result = await tool("respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "how about Wednesday",
+      counter_proposal: "ship Wednesday",
+    });
+
+    expect(result.content).toMatchObject({ from_agent_id: "agent_peer", decision: "reject" });
+  });
+
+  it.each([
+    ["no negotiation_id", { decision: "accept", message: "m" }],
+    ["no message", { negotiation_id: "neg_1", decision: "accept" }],
+  ])("refuses %s", async (_label, input) => {
+    const { tool, stubs } = harness();
+    const result = await tool("respond_negotiate").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "negotiation_id and message required" });
+    expect(stubs.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("refuses a decision outside the enum and names the valid ones", async () => {
+    const { tool, stubs } = harness();
+    const result = await tool("respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "maybe",
+      message: "m",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content.error).toBe("decision must be one of: counter, accept, reject");
+    expect(stubs.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("refuses a counter with no counter_proposal", async () => {
+    const { tool, stubs } = harness();
+    const result = await tool("respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "m",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "counter_proposal required when decision='counter'",
+    });
+    expect(stubs.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("surfaces MAX_ROUNDS_EXCEEDED with the round counters", async () => {
+    const { tool, stubs } = harness();
+    stubs.respondNegotiate.mockRejectedValueOnce(
+      new MeshMaxRoundsError({
+        negotiationId: "neg_1",
+        rounds_completed: 5,
+        max_rounds: 5,
+      }),
+    );
+    const result = await tool("respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "m",
+      counter_proposal: "c",
+    });
+
+    expect(result.content).toMatchObject({
+      error: "MAX_ROUNDS_EXCEEDED",
+      rounds_completed: 5,
+      max_rounds: 5,
+    });
+  });
+});
+
+describe("report_blocker", () => {
+  it("marks the task blocked, then spawns the parent, and returns the parent id", async () => {
+    const { tool, stubs } = harness();
+    const result = await tool("report_blocker").handler({
+      task_id: "tsk_1",
+      description: "credentials missing",
+    });
+
+    expect(stubs.findParent).toHaveBeenCalledWith("agent_x");
+    expect(stubs.markBlocked).toHaveBeenCalledWith("tsk_1", "agent_x", "credentials missing");
+    expect(stubs.reportBlocker).toHaveBeenCalledWith(
+      "agent_parent",
+      "agent_x",
+      "tsk_1",
+      "credentials missing",
+    );
+    expect(result.content).toEqual({
+      reported: true,
+      parent_agent_id: "agent_parent",
+      task_id: "tsk_1",
+    });
+  });
+
+  it.each([
+    ["no task_id", { description: "d" }],
+    ["no description", { task_id: "tsk_1" }],
+  ])("refuses %s before looking up the parent", async (_label, input) => {
+    const { tool, stubs } = harness();
+    const result = await tool("report_blocker").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "task_id and description required" });
+    expect(stubs.findParent).not.toHaveBeenCalled();
+  });
+
+  it("returns no_parent_to_block for a top-level agent, leaving the task alone", async () => {
+    const { tool, stubs } = harness();
+    stubs.findParent.mockResolvedValueOnce(null);
+    const result = await tool("report_blocker").handler({ task_id: "tsk_1", description: "d" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "no_parent_to_block" });
+    expect(stubs.markBlocked).not.toHaveBeenCalled();
+    expect(stubs.reportBlocker).not.toHaveBeenCalled();
+  });
+
+  it("does not spawn the parent when marking the task blocked fails", async () => {
+    const { tool, stubs } = harness();
+    stubs.markBlocked.mockRejectedValueOnce(new Error("task not found"));
+    const result = await tool("report_blocker").handler({ task_id: "tsk_1", description: "d" });
+
+    expect(result.content).toEqual({ error: "task not found" });
+    expect(stubs.reportBlocker).not.toHaveBeenCalled();
+  });
+
+  it("is available to ICs too — escalating upward is the one thing they initiate", async () => {
+    const { services, stubs } = harness();
+    const icTools = buildIcMeshTools(
+      { caller: { ...fakeCaller, hierarchyLevel: "ic" }, beevibeSid: "ses_ic" },
+      services,
+    );
+    const blocker = icTools.find((t) => t.name === "report_blocker")!;
+    await blocker.handler({ task_id: "tsk_1", description: "d" });
+
+    expect(stubs.reportBlocker).toHaveBeenCalledOnce();
+  });
+});
+
+describe("escalate_to_humans", () => {
+  it("creates the escalation, unblocks the peer, and notifies listeners", async () => {
+    const { tool, stubs } = harness();
+    const result = await tool("escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "stuck on the rollout date",
+      proposals: [{ title: "Monday", description: "ship early" }],
+      open_questions: ["is the customer flexible?", 42],
+    });
+
+    expect(stubs.createEscalation).toHaveBeenCalledWith({
+      negotiationId: "neg_1",
+      callerAgentId: "agent_x",
+      summary: "stuck on the rollout date",
+      proposals: [{ title: "Monday", description: "ship early" }],
+      // non-string open questions are dropped, not forwarded
+      openQuestions: ["is the customer flexible?"],
+    });
+    expect(stubs.unblockOnEscalate).toHaveBeenCalledWith("neg_1", "esc_1");
+    expect(stubs.query).toHaveBeenCalledWith(expect.stringContaining("pg_notify"), ["esc_1"]);
+    expect(result.content).toEqual({
+      escalation_id: "esc_1",
+      status: "open",
+      negotiation_id: "neg_1",
+    });
+  });
+
+  it("leaves proposals and open_questions undefined when they are not arrays", async () => {
+    const { tool, stubs } = harness();
+    await tool("escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "s",
+      proposals: "one option",
+      open_questions: "a question",
+    });
+
+    expect(stubs.createEscalation.mock.calls[0]![0]).toMatchObject({
+      proposals: undefined,
+      openQuestions: undefined,
+    });
+  });
+
+  it.each([
+    ["no negotiation_id", { summary: "s" }],
+    ["no summary", { negotiation_id: "neg_1" }],
+  ])("refuses %s without creating anything", async (_label, input) => {
+    const { tool, stubs } = harness();
+    const result = await tool("escalate_to_humans").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "negotiation_id and summary required" });
+    expect(stubs.createEscalation).not.toHaveBeenCalled();
+  });
+
+  it("does not unblock the peer when the escalation fails to create", async () => {
+    const { tool, stubs } = harness();
+    stubs.createEscalation.mockRejectedValueOnce(new Error("negotiation not found"));
+    const result = await tool("escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "s",
+    });
+
+    expect(result.content).toEqual({ error: "negotiation not found" });
+    expect(stubs.unblockOnEscalate).not.toHaveBeenCalled();
+    expect(stubs.query).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/tools/session-search.test.ts
+++ b/packages/api/src/tools/session-search.test.ts
@@ -1,0 +1,291 @@
+/**
+ * session_search tool tests.
+ *
+ * The retrieval itself is SessionSearchService's job (and is covered
+ * against a real Postgres in core). What this file locks down is the
+ * adapter: the four calling shapes the tool description promises, how
+ * raw MCP input maps onto a typed SessionSearchRequest, and the error
+ * envelope — including the by-name fallback that keeps the structured
+ * code when src/ and dist/ copies of the error class are both loaded.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { SessionSearchRequest } from "@beevibe/core";
+import {
+  SessionSearchError,
+  type SessionSearchService,
+} from "@beevibe/core/services/session-search";
+import {
+  createSessionSearchTool,
+  type SessionSearchToolContext,
+} from "./session-search.js";
+
+const CTX: SessionSearchToolContext = {
+  agentId: "agent_a",
+  hierarchyLevel: "team",
+  sessionId: "ses_current",
+};
+
+function build(
+  behavior: { result?: unknown; throws?: unknown } = {},
+  ctx: SessionSearchToolContext = CTX,
+) {
+  const search = vi.fn(async (_req: SessionSearchRequest, _scope: unknown) => {
+    if (behavior.throws) throw behavior.throws;
+    return behavior.result === undefined ? { results: [] } : behavior.result;
+  });
+  const sessionSearch = { search } as unknown as SessionSearchService;
+  return { search, tool: createSessionSearchTool(ctx, { sessionSearch }) };
+}
+
+type SearchStub = ReturnType<typeof build>["search"];
+
+/** The request the handler built, typed for readable assertions. */
+function requestOf(search: SearchStub): SessionSearchRequest {
+  return search.mock.calls[0]![0];
+}
+
+/** The caller-scope argument the handler passed alongside the request. */
+function scopeOf(search: SearchStub): unknown {
+  return search.mock.calls[0]![1];
+}
+
+describe("session_search descriptor", () => {
+  it("is named session_search and has no required fields — every shape is optional", () => {
+    const { tool } = build();
+    expect(tool.name).toBe("session_search");
+    expect(tool.schema.required).toBeUndefined();
+  });
+
+  it("documents all four calling shapes in the description", () => {
+    const { tool } = build();
+    for (const shape of ["DISCOVERY", "SCROLL", "READ", "BROWSE"]) {
+      expect(tool.description).toContain(shape);
+    }
+  });
+});
+
+describe("caller scope", () => {
+  it("passes agent id, tier and the active session through on every call", async () => {
+    const { tool, search } = build();
+    await tool.handler({});
+
+    expect(scopeOf(search)).toEqual({
+      callerAgentId: "agent_a",
+      hierarchyLevel: "team",
+      currentSessionId: "ses_current",
+    });
+  });
+
+  it("forwards the caller's own tier, not a fixed one", async () => {
+    const { tool, search } = build({}, { ...CTX, hierarchyLevel: "ic" });
+    await tool.handler({ query: "auth" });
+    expect(scopeOf(search)).toMatchObject({ hierarchyLevel: "ic" });
+  });
+});
+
+describe("shape inference", () => {
+  it("browses when nothing is passed", async () => {
+    const { tool, search } = build();
+    await tool.handler({});
+    expect(requestOf(search)).toEqual({
+      kind: "browse",
+      limit: undefined,
+      filters: undefined,
+    });
+  });
+
+  it("carries a numeric limit into the browse request", async () => {
+    const { tool, search } = build();
+    await tool.handler({ limit: 10 });
+    expect(requestOf(search)).toMatchObject({ kind: "browse", limit: 10 });
+  });
+
+  it("discovers when a query is passed, trimming it", async () => {
+    const { tool, search } = build();
+    await tool.handler({ query: "  auth refactor  ", limit: 5, sort: "newest" });
+
+    expect(requestOf(search)).toEqual({
+      kind: "discover",
+      query: "auth refactor",
+      limit: 5,
+      sort: "newest",
+      filters: undefined,
+    });
+  });
+
+  it("reads when only a session_id is passed", async () => {
+    const { tool, search } = build();
+    await tool.handler({ session_id: " ses_42 " });
+    expect(requestOf(search)).toEqual({ kind: "read", session_id: "ses_42" });
+  });
+
+  it("scrolls when session_id and around_message_id are both passed", async () => {
+    const { tool, search } = build();
+    await tool.handler({
+      session_id: "ses_42",
+      around_message_id: "evt_7",
+      window: 10,
+    });
+
+    expect(requestOf(search)).toEqual({
+      kind: "scroll",
+      session_id: "ses_42",
+      around_message_id: "evt_7",
+      window: 10,
+    });
+  });
+
+  it("lets scroll win over a query passed alongside it", async () => {
+    const { tool, search } = build();
+    await tool.handler({
+      query: "ignored",
+      session_id: "ses_42",
+      around_message_id: "evt_7",
+    });
+    expect(requestOf(search).kind).toBe("scroll");
+  });
+
+  it("lets read win over a query passed alongside it", async () => {
+    const { tool, search } = build();
+    await tool.handler({ query: "ignored", session_id: "ses_42" });
+    expect(requestOf(search).kind).toBe("read");
+  });
+
+  it("treats a blank session_id / anchor / query as absent and browses", async () => {
+    const { tool, search } = build();
+    await tool.handler({ session_id: "   ", around_message_id: "  ", query: " " });
+    expect(requestOf(search).kind).toBe("browse");
+  });
+
+  it("falls back to discover when only the anchor is blank", async () => {
+    const { tool, search } = build();
+    await tool.handler({ query: "auth", around_message_id: "   " });
+    expect(requestOf(search).kind).toBe("discover");
+  });
+
+  it("ignores non-string session_id / anchor / query", async () => {
+    const { tool, search } = build();
+    await tool.handler({ session_id: 42, around_message_id: {}, query: [] });
+    expect(requestOf(search).kind).toBe("browse");
+  });
+
+  it("drops a non-number window rather than passing it through", async () => {
+    const { tool, search } = build();
+    await tool.handler({
+      session_id: "ses_42",
+      around_message_id: "evt_7",
+      window: "10",
+    });
+    expect(requestOf(search)).toMatchObject({ window: undefined });
+  });
+
+  it("drops a non-number limit rather than passing it through", async () => {
+    const { tool, search } = build();
+    await tool.handler({ query: "auth", limit: "5" });
+    expect(requestOf(search)).toMatchObject({ limit: undefined });
+  });
+
+  it("ignores a sort value outside the enum", async () => {
+    const { tool, search } = build();
+    await tool.handler({ query: "auth", sort: "relevance" });
+    expect(requestOf(search)).toMatchObject({ sort: undefined });
+  });
+});
+
+describe("filters", () => {
+  it("passes a filters object through on discovery", async () => {
+    const { tool, search } = build();
+    const filters = { session_type: "task", status: "failed" };
+    await tool.handler({ query: "deploy", filters });
+    expect(requestOf(search)).toMatchObject({ filters });
+  });
+
+  it("passes a filters object through on browse", async () => {
+    const { tool, search } = build();
+    const filters = { agent_id: "agent_b" };
+    await tool.handler({ filters });
+    expect(requestOf(search)).toMatchObject({ kind: "browse", filters });
+  });
+
+  it("treats a non-object filters value as absent", async () => {
+    const { tool, search } = build();
+    await tool.handler({ query: "deploy", filters: "task" });
+    expect(requestOf(search)).toMatchObject({ filters: undefined });
+  });
+
+  it("treats null filters as absent", async () => {
+    const { tool, search } = build();
+    await tool.handler({ query: "deploy", filters: null });
+    expect(requestOf(search)).toMatchObject({ filters: undefined });
+  });
+
+  it("does not attach filters to scroll or read", async () => {
+    const { tool, search } = build();
+    await tool.handler({ session_id: "ses_42", filters: { status: "failed" } });
+    expect(requestOf(search)).not.toHaveProperty("filters");
+  });
+});
+
+describe("results and errors", () => {
+  it("returns the service payload verbatim", async () => {
+    const payload = { kind: "read", session_id: "ses_42", messages: [{ id: "evt_1" }] };
+    const { tool } = build({ result: payload });
+    const result = await tool.handler({ session_id: "ses_42" });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toBe(payload);
+  });
+
+  it("maps a null result to not_found_or_forbidden", async () => {
+    const { tool } = build({ result: null });
+    const result = await tool.handler({ session_id: "ses_other" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "not_found_or_forbidden" });
+  });
+
+  it.each(["forbidden_agent_filter", "missing_query", "missing_args"] as const)(
+    "surfaces the %s code from a SessionSearchError",
+    async (code) => {
+      const { tool } = build({ throws: new SessionSearchError(code, `${code} detail`) });
+      const result = await tool.handler({ query: "x" });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual({ error: code, message: `${code} detail` });
+    },
+  );
+
+  it("matches a cross-bundle SessionSearchError by name, not just instanceof", async () => {
+    // A second copy of the class (src/ vs dist/) fails instanceof but
+    // still carries the name and code the agent branches on.
+    const impostor = Object.assign(new Error("out of scope"), {
+      name: "SessionSearchError",
+      code: "forbidden_agent_filter",
+    });
+    const { tool } = build({ throws: impostor });
+    const result = await tool.handler({ query: "x", filters: { agent_id: "agent_z" } });
+
+    expect(result.content).toEqual({
+      error: "forbidden_agent_filter",
+      message: "out of scope",
+    });
+  });
+
+  it("wraps an unexpected Error as internal_error", async () => {
+    const { tool } = build({ throws: new Error("pool exhausted") });
+    const result = await tool.handler({ query: "x" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "internal_error",
+      message: "pool exhausted",
+    });
+  });
+
+  it("stringifies a non-Error throw", async () => {
+    const { tool } = build({ throws: "kaboom" });
+    const result = await tool.handler({});
+
+    expect(result.content).toEqual({ error: "internal_error", message: "kaboom" });
+  });
+});

--- a/packages/api/src/tools/use-repo.test.ts
+++ b/packages/api/src/tools/use-repo.test.ts
@@ -1,0 +1,357 @@
+/**
+ * use_repo tool tests.
+ *
+ * The handler's job is ordering + validation, not sandbox mechanics: mint
+ * a container task, dispatch (which creates the session row), then insert
+ * the repo_run that FKs to it. Every dependency is faked — the real ones
+ * need Postgres and a live daemon.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type {
+  AgentRepository,
+  RepoRunRepository,
+  TaskRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import { createUseRepoTool, type UseRepoServices } from "./use-repo.js";
+
+interface Recorder {
+  services: UseRepoServices;
+  taskCreates: Array<Record<string, unknown>>;
+  dispatches: Array<Record<string, unknown>>;
+  repoRunCreates: Array<Record<string, unknown>>;
+}
+
+function fakeServices(
+  overrides: {
+    agent?: { id: string } | null;
+    dispatchThrows?: unknown;
+    repoRunThrows?: unknown;
+  } = {},
+): Recorder {
+  const taskCreates: Array<Record<string, unknown>> = [];
+  const dispatches: Array<Record<string, unknown>> = [];
+  const repoRunCreates: Array<Record<string, unknown>> = [];
+  const agent =
+    overrides.agent === undefined ? { id: "agent_caller" } : overrides.agent;
+
+  const services = {
+    agentRepo: {
+      findById: vi.fn(async () => agent),
+    } as unknown as AgentRepository,
+    taskRepo: {
+      create: vi.fn(async (row: Record<string, unknown>) => {
+        taskCreates.push(row);
+        return row;
+      }),
+    } as unknown as TaskRepository,
+    repoRunRepo: {
+      create: vi.fn(async (row: Record<string, unknown>) => {
+        if (overrides.repoRunThrows) throw overrides.repoRunThrows;
+        repoRunCreates.push(row);
+        return row;
+      }),
+    } as unknown as RepoRunRepository,
+    dispatchService: {
+      dispatchTask: vi.fn(async (input: Record<string, unknown>) => {
+        if (overrides.dispatchThrows) throw overrides.dispatchThrows;
+        dispatches.push(input);
+        return undefined;
+      }),
+    } as unknown as DispatchService,
+  };
+
+  return { services, taskCreates, dispatches, repoRunCreates };
+}
+
+function build(overrides?: Parameters<typeof fakeServices>[0]) {
+  const rec = fakeServices(overrides);
+  return { rec, tool: createUseRepoTool({ agentId: "agent_caller" }, rec.services) };
+}
+
+const OK_INPUT = {
+  goal: "Extract the tables from this PDF as JSON",
+  repo_url: "https://github.com/jsvine/pdfplumber",
+};
+
+describe("use_repo tool descriptor", () => {
+  it("exposes the name and the two required schema fields", () => {
+    const { tool } = build();
+    expect(tool.name).toBe("use_repo");
+    expect(tool.schema.required).toEqual(["goal", "repo_url"]);
+  });
+});
+
+describe("use_repo validation", () => {
+  it("rejects a missing goal before touching any service", async () => {
+    const { rec, tool } = build();
+    const result = await tool.handler({ repo_url: OK_INPUT.repo_url });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "invalid_goal" });
+    expect(rec.taskCreates).toHaveLength(0);
+    expect(rec.dispatches).toHaveLength(0);
+  });
+
+  it("rejects a whitespace-only goal", async () => {
+    const { tool } = build();
+    const result = await tool.handler({ ...OK_INPUT, goal: "   " });
+    expect(result.content).toMatchObject({ error: "invalid_goal" });
+  });
+
+  it("rejects a non-string goal", async () => {
+    const { tool } = build();
+    const result = await tool.handler({ ...OK_INPUT, goal: 42 });
+    expect(result.content).toMatchObject({ error: "invalid_goal" });
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["empty", ""],
+    ["http, not https", "http://github.com/foo/bar"],
+    ["a non-GitHub host", "https://gitlab.com/foo/bar"],
+    ["a lookalike host", "https://notgithub.com/foo/bar"],
+    ["a host that only ends in the string", "https://evilgithub.com/foo/bar"],
+    ["unparseable", "not a url at all"],
+    ["a non-string", 7],
+  ])("rejects repo_url when it is %s", async (_label, repoUrl) => {
+    const { rec, tool } = build();
+    const result = await tool.handler({ ...OK_INPUT, repo_url: repoUrl });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "invalid_repo_url" });
+    expect(rec.dispatches).toHaveLength(0);
+  });
+
+  it.each([
+    "https://github.com/jsvine/pdfplumber",
+    "https://www.github.com/jsvine/pdfplumber",
+    "https://GitHub.com/jsvine/pdfplumber",
+  ])("accepts %s", async (repoUrl) => {
+    const { tool } = build();
+    const result = await tool.handler({ ...OK_INPUT, repo_url: repoUrl });
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("returns agent_not_found when the caller is not in the agent repo", async () => {
+    const { rec, tool } = build({ agent: null });
+    const result = await tool.handler(OK_INPUT);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "agent_not_found" });
+    expect(rec.taskCreates).toHaveLength(0);
+  });
+});
+
+describe("use_repo happy path", () => {
+  it("mints a container task assigned to and created by the caller", async () => {
+    const { rec, tool } = build();
+    await tool.handler(OK_INPUT);
+
+    expect(rec.taskCreates).toHaveLength(1);
+    expect(rec.taskCreates[0]).toMatchObject({
+      title: OK_INPUT.goal,
+      description: OK_INPUT.goal,
+      priority: "medium",
+      assignee_id: "agent_caller",
+      creator_id: "agent_caller",
+      creator_type: "agent",
+    });
+  });
+
+  it("truncates a long goal to an 80-char task title but keeps the full description", async () => {
+    const { rec, tool } = build();
+    const goal = "x".repeat(200);
+    await tool.handler({ ...OK_INPUT, goal });
+
+    const title = rec.taskCreates[0]?.title as string;
+    expect(title).toHaveLength(78); // 77 chars + the ellipsis
+    expect(title.endsWith("…")).toBe(true);
+    expect(rec.taskCreates[0]?.description).toBe(goal);
+  });
+
+  it("collapses whitespace in the task title", async () => {
+    const { rec, tool } = build();
+    await tool.handler({ ...OK_INPUT, goal: "  extract\n\n  the   tables  " });
+    expect(rec.taskCreates[0]?.title).toBe("extract the tables");
+  });
+
+  it("dispatches a run_repo session under the pre-minted session id, then inserts the repo_run", async () => {
+    const { rec, tool } = build();
+    const result = await tool.handler(OK_INPUT);
+
+    expect(rec.dispatches).toHaveLength(1);
+    const dispatch = rec.dispatches[0]!;
+    expect(dispatch).toMatchObject({
+      agentId: "agent_caller",
+      type: "run_repo",
+      intent: OK_INPUT.goal,
+      reason: { kind: "fresh" },
+    });
+
+    // repo_run.session_id FKs to session.id, so the id the dispatch
+    // created the session under must be the one the repo_run carries.
+    expect(rec.repoRunCreates).toHaveLength(1);
+    expect(rec.repoRunCreates[0]?.session_id).toBe(dispatch.sessionIdOverride);
+    expect(result.content.session_id).toBe(dispatch.sessionIdOverride);
+  });
+
+  it("ties the repo_run to the container task and the caller, pending", async () => {
+    const { rec, tool } = build();
+    await tool.handler(OK_INPUT);
+
+    expect(rec.repoRunCreates[0]).toMatchObject({
+      task_id: rec.taskCreates[0]?.id,
+      agent_id: "agent_caller",
+      goal: OK_INPUT.goal,
+      repo_url: OK_INPUT.repo_url,
+      status: "pending",
+    });
+  });
+
+  it("returns the ids, a pending status and a watch url built from the repo_run id", async () => {
+    const { rec, tool } = build();
+    const result = await tool.handler(OK_INPUT);
+
+    expect(result.isError).toBeFalsy();
+    const repoRunId = rec.repoRunCreates[0]?.id as string;
+    expect(result.content).toMatchObject({
+      repo_run_id: repoRunId,
+      task_id: rec.taskCreates[0]?.id,
+      status: "pending",
+      watch_url: `/capabilities/runs/${repoRunId}`,
+    });
+  });
+
+  it("echoes trimmed input_url / input_filename back to the caller", async () => {
+    const { tool } = build();
+    const result = await tool.handler({
+      ...OK_INPUT,
+      input_url: "  https://example.com/report.pdf  ",
+      input_filename: "  report.pdf ",
+    });
+
+    expect(result.content).toMatchObject({
+      input_url: "https://example.com/report.pdf",
+      input_filename: "report.pdf",
+    });
+  });
+
+  it("leaves input_url / input_filename undefined when they are not strings", async () => {
+    const { tool } = build();
+    const result = await tool.handler({ ...OK_INPUT, input_url: 1, input_filename: {} });
+
+    expect(result.content.input_url).toBeUndefined();
+    expect(result.content.input_filename).toBeUndefined();
+  });
+});
+
+describe("use_repo limits parsing", () => {
+  it("returns an empty object when limits is absent or not an object", async () => {
+    const { tool } = build();
+    for (const limits of [undefined, null, "20", 5]) {
+      const result = await tool.handler({ ...OK_INPUT, limits });
+      expect(result.content.limits).toEqual({});
+    }
+  });
+
+  it("passes sane values through untouched", async () => {
+    const { tool } = build();
+    const result = await tool.handler({
+      ...OK_INPUT,
+      limits: { wall_clock_minutes: 15, max_install_attempts: 3, disk_mb: 1024 },
+    });
+
+    expect(result.content.limits).toEqual({
+      wall_clock_minutes: 15,
+      max_install_attempts: 3,
+      disk_mb: 1024,
+    });
+  });
+
+  it("clamps each limit to its ceiling", async () => {
+    const { tool } = build();
+    const result = await tool.handler({
+      ...OK_INPUT,
+      limits: {
+        wall_clock_minutes: 600,
+        max_install_attempts: 99,
+        disk_mb: 999_999,
+      },
+    });
+
+    expect(result.content.limits).toEqual({
+      wall_clock_minutes: 60,
+      max_install_attempts: 5,
+      disk_mb: 10_000,
+    });
+  });
+
+  it("floors fractional attempt / disk values", async () => {
+    const { tool } = build();
+    const result = await tool.handler({
+      ...OK_INPUT,
+      limits: { max_install_attempts: 2.9, disk_mb: 512.7 },
+    });
+
+    expect(result.content.limits).toEqual({
+      max_install_attempts: 2,
+      disk_mb: 512,
+    });
+  });
+
+  it("drops non-positive and non-numeric limits rather than passing them on", async () => {
+    const { tool } = build();
+    const result = await tool.handler({
+      ...OK_INPUT,
+      limits: {
+        wall_clock_minutes: 0,
+        max_install_attempts: -1,
+        disk_mb: "2048",
+      },
+    });
+
+    expect(result.content.limits).toEqual({});
+  });
+});
+
+describe("use_repo failure paths", () => {
+  it("surfaces dispatch_failed and never inserts the repo_run", async () => {
+    const { rec, tool } = build({ dispatchThrows: new Error("daemon offline") });
+    const result = await tool.handler(OK_INPUT);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "dispatch_failed",
+      message: "daemon offline",
+    });
+    expect(rec.repoRunCreates).toHaveLength(0);
+  });
+
+  it("stringifies a non-Error dispatch throw", async () => {
+    const { tool } = build({ dispatchThrows: "boom" });
+    const result = await tool.handler(OK_INPUT);
+    expect(result.content).toMatchObject({
+      error: "dispatch_failed",
+      message: "boom",
+    });
+  });
+
+  it("surfaces repo_run_create_failed rather than silently orphaning the session", async () => {
+    const { tool } = build({ repoRunThrows: new Error("fk violation") });
+    const result = await tool.handler(OK_INPUT);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "repo_run_create_failed",
+      message: "fk violation",
+    });
+  });
+
+  it("stringifies a non-Error repo_run throw", async () => {
+    const { tool } = build({ repoRunThrows: { code: "23503" } });
+    const result = await tool.handler(OK_INPUT);
+    expect(result.content).toMatchObject({ error: "repo_run_create_failed" });
+    expect(typeof result.content.message).toBe("string");
+  });
+});

--- a/packages/api/src/tools/watch.test.ts
+++ b/packages/api/src/tools/watch.test.ts
@@ -1,0 +1,210 @@
+/**
+ * watch_tasks + unwatch tool tests.
+ *
+ * Both tools are thin adapters over WatchService — the service owns the
+ * auth check, the insert and the already-terminal race. What lives here
+ * is the adapter's own logic: input coercion, the mode default, the
+ * session-context requirement, and the mapping of each service error
+ * class onto a stable `error` code the agent can branch on.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  WatchAuthError,
+  WatchNotFoundError,
+  WatchValidationError,
+  type WatchService,
+} from "@beevibe/core/services/watch-service";
+import { buildWatchTools, type WatchToolContext } from "./watch.js";
+
+interface Harness {
+  watchTasks: ReturnType<typeof vi.fn>;
+  unwatch: ReturnType<typeof vi.fn>;
+  watch: ReturnType<typeof buildWatchTools>[number];
+  unwatchTool: ReturnType<typeof buildWatchTools>[number];
+}
+
+function build(
+  ctx: WatchToolContext = { agentId: "agent_a", sessionId: "ses_1" },
+  behavior: { watchThrows?: unknown; unwatchThrows?: unknown } = {},
+): Harness {
+  const watchTasks = vi.fn(async () => {
+    if (behavior.watchThrows) throw behavior.watchThrows;
+    return { watchId: "twt_1", firedImmediately: false };
+  });
+  const unwatch = vi.fn(async () => {
+    if (behavior.unwatchThrows) throw behavior.unwatchThrows;
+  });
+  const watchService = { watchTasks, unwatch } as unknown as WatchService;
+  const [watch, unwatchTool] = buildWatchTools(ctx, { watchService });
+  return { watchTasks, unwatch, watch: watch!, unwatchTool: unwatchTool! };
+}
+
+describe("buildWatchTools", () => {
+  it("returns watch_tasks and unwatch, in that order", () => {
+    const { watch, unwatchTool } = build();
+    expect(watch.name).toBe("watch_tasks");
+    expect(unwatchTool.name).toBe("unwatch");
+  });
+
+  it("declares the required fields on each schema", () => {
+    const { watch, unwatchTool } = build();
+    expect(watch.schema.required).toEqual(["task_ids"]);
+    expect(unwatchTool.schema.required).toEqual(["watch_id"]);
+  });
+
+  it("enumerates the real watch modes in the schema", () => {
+    const { watch } = build();
+    const props = watch.schema.properties as { mode: { enum: string[] } };
+    expect(props.mode.enum).toEqual(expect.arrayContaining(["all", "any"]));
+  });
+});
+
+describe("watch_tasks", () => {
+  it("forwards caller identity, task ids, mode and reason to the service", async () => {
+    const { watch, watchTasks } = build();
+    const result = await watch.handler({
+      task_ids: ["tsk_1", "tsk_2"],
+      mode: "any",
+      reason: "  need the first result  ",
+    });
+
+    expect(watchTasks).toHaveBeenCalledWith({
+      callerAgentId: "agent_a",
+      callerSessionId: "ses_1",
+      taskIds: ["tsk_1", "tsk_2"],
+      mode: "any",
+      reason: "need the first result",
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({ watch_id: "twt_1", fired_immediately: false });
+  });
+
+  it("defaults mode to 'all' when omitted or not a known mode", async () => {
+    for (const mode of [undefined, "either", 3, null]) {
+      const { watch, watchTasks } = build();
+      await watch.handler({ task_ids: ["tsk_1"], mode });
+      expect(watchTasks.mock.calls[0]?.[0]).toMatchObject({ mode: "all" });
+    }
+  });
+
+  it("drops a blank reason instead of forwarding an empty string", async () => {
+    const { watch, watchTasks } = build();
+    await watch.handler({ task_ids: ["tsk_1"], reason: "   " });
+    expect(watchTasks.mock.calls[0]?.[0]).toMatchObject({ reason: undefined });
+  });
+
+  it("filters non-string entries out of task_ids", async () => {
+    const { watch, watchTasks } = build();
+    await watch.handler({ task_ids: ["tsk_1", 2, null, "tsk_3"] });
+    expect(watchTasks.mock.calls[0]?.[0]).toMatchObject({
+      taskIds: ["tsk_1", "tsk_3"],
+    });
+  });
+
+  it.each([
+    ["absent", undefined],
+    ["not an array", "tsk_1"],
+    ["empty", []],
+    ["all non-strings", [1, 2]],
+  ])("rejects task_ids when %s, without calling the service", async (_l, task_ids) => {
+    const { watch, watchTasks } = build();
+    const result = await watch.handler({ task_ids });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "watch_validation" });
+    expect(watchTasks).not.toHaveBeenCalled();
+  });
+
+  it("refuses to register a watch outside a session context", async () => {
+    const { watch, watchTasks } = build({ agentId: "agent_a" });
+    const result = await watch.handler({ task_ids: ["tsk_1"] });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "watch_validation",
+      message: expect.stringContaining("session context"),
+    });
+    expect(watchTasks).not.toHaveBeenCalled();
+  });
+
+  it("reports fired_immediately when the condition was already met", async () => {
+    const { watch, watchTasks } = build();
+    watchTasks.mockResolvedValueOnce({ watchId: "twt_9", firedImmediately: true });
+    const result = await watch.handler({ task_ids: ["tsk_done"] });
+
+    expect(result.content).toEqual({ watch_id: "twt_9", fired_immediately: true });
+  });
+});
+
+describe("unwatch", () => {
+  it("forwards the caller and watch id", async () => {
+    const { unwatchTool, unwatch } = build();
+    const result = await unwatchTool.handler({ watch_id: "twt_1" });
+
+    expect(unwatch).toHaveBeenCalledWith({
+      callerAgentId: "agent_a",
+      watchId: "twt_1",
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({ ok: true });
+  });
+
+  it.each([
+    ["absent", undefined],
+    ["empty", ""],
+    ["not a string", 5],
+  ])("rejects watch_id when %s, without calling the service", async (_l, watch_id) => {
+    const { unwatchTool, unwatch } = build();
+    const result = await unwatchTool.handler({ watch_id });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "watch_validation" });
+    expect(unwatch).not.toHaveBeenCalled();
+  });
+
+  it("works without a session id — unwatch only needs the agent", async () => {
+    const { unwatchTool, unwatch } = build({ agentId: "agent_a" });
+    const result = await unwatchTool.handler({ watch_id: "twt_1" });
+
+    expect(result.content).toEqual({ ok: true });
+    expect(unwatch).toHaveBeenCalledOnce();
+  });
+});
+
+describe("service error mapping", () => {
+  const cases: Array<[string, unknown, string]> = [
+    ["WatchAuthError", new WatchAuthError("not your task"), "watch_auth"],
+    ["WatchValidationError", new WatchValidationError("bad ids"), "watch_validation"],
+    ["WatchNotFoundError", new WatchNotFoundError("no such watch"), "watch_not_found"],
+    ["a plain Error", new Error("pool exhausted"), "watch_error"],
+    ["a non-Error throw", "kaboom", "watch_error"],
+  ];
+
+  it.each(cases)("watch_tasks maps %s to %s", async (_label, thrown, code) => {
+    const { watch } = build(undefined, { watchThrows: thrown });
+    const result = await watch.handler({ task_ids: ["tsk_1"] });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: code });
+    expect(typeof result.content.message).toBe("string");
+  });
+
+  it.each(cases)("unwatch maps %s to %s", async (_label, thrown, code) => {
+    const { unwatchTool } = build(undefined, { unwatchThrows: thrown });
+    const result = await unwatchTool.handler({ watch_id: "twt_1" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: code });
+  });
+
+  it("keeps the service's message on a mapped error", async () => {
+    const { watch } = build(undefined, {
+      watchThrows: new WatchAuthError("task tsk_x is not in your conversation chain"),
+    });
+    const result = await watch.handler({ task_ids: ["tsk_x"] });
+
+    expect(result.content.message).toBe(
+      "task tsk_x is not in your conversation chain",
+    );
+  });
+});


### PR DESCRIPTION
## Why

A coverage sweep over the non-DB-gated code (`typecheck`/`lint`/vitest with the Postgres- and key-gated suites excluded) found the agent-facing MCP tool surface in `packages/api` to be the largest real gap. Three tool modules had **no test file at all**, and the two largest had only a descriptor/tier-inventory test between them — even though these are the handlers every agent session calls.

Everything else that reads low in a bare sandbox is either DB-gated (covered in CI), a barrel, or a process entrypoint.

## What changed

Tests only — **no production code changed**. 152 new tests. Line coverage for `packages/api/src/tools` as a whole goes **71% → 95.5%**:

| Module | Before | After | Note |
| --- | --- | --- | --- |
| `tools/use-repo.ts` | 32% | **100%** | no test file before |
| `tools/watch.ts` | 46% | **100%** | no test file before |
| `tools/session-search.ts` | 64% | **100%** | no test file before |
| `tools/mesh.ts` | 46% | **100%** | assembly/tier inventory only before |
| `tools/hierarchy.ts` | 71% | **94%** | `revise_task`, `add_to_escalation`, `create_subordinate_agent` handlers were untested |

`hierarchy.ts` stops at 94% because the remaining uncovered lines are defensive branches unreachable through `buildHierarchyTools` — chiefly the `ic_cannot_spawn` guard inside `create_subordinate_agent`, which the tier gate already prevents an IC from reaching. The tier gate itself is tested.

## What the tests pin down

Beyond the happy paths, the cases worth calling out:

- **`use_repo` write ordering.** `repo_run.session_id` FKs to `session.id`, so the session the dispatch mints must be the one the `repo_run` carries. A dispatch failure must not leave a `repo_run` behind; a `repo_run` failure must surface `repo_run_create_failed` rather than silently orphan the session. Plus GitHub-URL validation (lookalike hosts, `http`) and the three limit clamps.
- **`watch_tasks` / `unwatch`** input coercion, the `mode` default, the session-context requirement, and the mapping of each `WatchService` error class onto its stable `error` code.
- **`session_search`'s four calling shapes** and their precedence (scroll beats read beats discover beats browse), plus the by-name `SessionSearchError` match that keeps the structured code when `src/` and `dist/` copies of the class are both loaded.
- **Every mesh handler's** validation and response projection, including the `escalated` sentinel and the `CodedMeshError` envelope (`MESH_CAPACITY_EXCEEDED`, `MAX_ROUNDS_EXCEEDED`, `CANNOT_NEGOTIATE_WITH_IC`).
- **`create_subordinate_agent`'s** runtime/owner inheritance, core-memory block seeding, the per-parent daily cap, and that a failed audit-row write does not fail the spawn.

## Fakes

Two additions to the shared `hierarchy.test.ts` harness were needed: `coreMemoryRepo.initDefaults` (which `provisionAgent` calls) and a `fakeEscalation()` builder so `addContribution` fakes satisfy the `Escalation` type.

## Verification

- `packages/api` typecheck + lint clean.
- Full api suite: **983 tests pass, 0 fail**. The 9 failing *files* are the 9 integration suites that need Postgres — the documented environmental baseline in `CLAUDE.md`, unaffected by this change.
- Coverage was measured with a temporarily-installed `@vitest/coverage-v8`, not committed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2sf1kio4wV9YAEZQJ6wwq)_