### PR TITLE
chore: remove dead members left behind by the top-level sweeps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,6 +244,32 @@ its own test — check whether it's a deliberate test seam (`clearCache()`
 in `api/src/sse/owner-lookup.ts` is marked `@internal Tests only`) before
 touching it.
 
+### The remaining seam: members, not modules
+
+Top-level exports are swept clean; what's left hides one level down, and
+**no tool in the repo looks there**. knip reports `classMembers` (that's
+how `CoreMemory.initDefaults` surfaced in #292) but has no equivalent for
+interface members or object-literal members, and `tsc` can't help because
+an unread optional field is still well-typed.
+
+Sweep those by name too. Two shapes are worth the pass:
+
+- **Interface members** — `export interface X { … }` in `views/types.ts`
+  and `web/lib/types/*.ts`. These are display DTOs, so a field that no
+  mapper writes can never arrive; check the single producer
+  (`toAgentDisplay`, `rowToMemoryFactDisplay`, `askToDisplay`) rather
+  than trusting a bare `git grep` — field names like `response`,
+  `arrow`, and `body` collide with half the codebase.
+- **Object-literal members** — `export const X = { … }`. Mostly false
+  positives: lookup tables read as `TABLE[key]` (`FACT_TYPE_DESCRIPTIONS`,
+  `RECENT_ROW_DOT`, `TASK_STATUSES_BY_VIEW`) never show a literal
+  `X.member` hit. Confirm the table isn't indexed dynamically before
+  calling a member dead.
+
+A grep for the bare member name is the wrong filter here and reports
+zero — match `\.member\b` and `member\s*:` instead, and exclude the type
+files themselves.
+
 ### Dead in-repo, but not ours to delete
 
 | Thing | Why it survived the sweep |
@@ -251,6 +277,10 @@ touching it.
 | `GET /activity` → `api/src/views/activity.ts` | No caller anywhere in the monorepo, but it's a **documented public endpoint** (`packages/api/README.md`). Retiring it is a product call. The web side is fully gone: the client stub (`api.activity.list`) went with #273, and `queryKeys.activity` + its no-op `lib/sse.ts` invalidations went with #283. |
 | `SkillOutcomeRepository.listBySkill` / `.statsForSkill`, `AgentProvisionEventRepository.listByParent` | Uncalled **read** halves of audit trails whose write side is live and accumulating rows (`skill_outcome` via `recordCapabilityOutcome`, `agent_provision_event` via `create_subordinate_agent`). Same call as the promotion repo below — the consumers (discovery-ranker feedback, agents-page audit panel) are unbuilt, not removed. Deleting the queries makes finishing them harder. |
 | `PostgresMemoryPromotionEventRepository` | Never constructed — `bootstrap.ts` builds the MemoryAgent without `promotionEventRepo`, so the M8.D promotion audit log never writes even though the port, the service branch, its tests and the read-side `views/promotions.ts` all exist. That's **unfinished wiring, not dead code**; deleting the adapter makes finishing it harder. |
+| `AgentDisplay.merge_events` | No producer and no reader, but carries an explicit `/** Reserved for future memory-merge telemetry. */`. The marker is the decision; #292 removed its unmarked neighbour `themes` and left this one. |
+| `queryKeys.workProducts.all` / `queryKeys.chat.all` | The only two `.all` prefixes in `web/lib/hooks/keys.ts` nothing invalidates. Every other group has one and uses it — the entry is **structural, not dead**, and dropping two of sixteen just invites someone to put them back. |
+| `ApiError.body` on `web/lib/api/http.ts` | Product code reads `errorCode` / `serverMessage` instead (#283 refactor), so only `http.test.ts` touches `body` — but it's the raw server payload on an error class, i.e. the field you want present when debugging a 500. |
+| `StreamJsonMessage.duration_ms` / `.num_turns` | Unread by the parser, but `StreamJsonMessage` documents Claude Code's `stream-json` **wire format**; the CLI does emit both on `result` messages. Trimming it to what we happen to parse makes the next field addition a guess. |
 
 ## Deploying
 

--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -96,7 +96,6 @@ export interface AgentDisplay
   /** Reserved for future memory-merge telemetry. */
   merge_events?: number;
   specialization?: string;
-  themes?: string[];
   /** CLI tool the agent uses — derived from `runtime_config.type`. */
   runtime?: string;
   /**
@@ -404,7 +403,6 @@ export interface MemoryFactDisplay {
   source_session_count: number;
   created_at: Date;
   merge_origin?: MergeOrigin;
-  promotion_origin_scope?: MemoryScope;
 }
 
 /**

--- a/packages/core/src/ports/runtime.ts
+++ b/packages/core/src/ports/runtime.ts
@@ -199,7 +199,6 @@ export interface RuntimeResult {
 /** Result of `healthCheck()`. */
 export interface RuntimeHealth {
   healthy: boolean;
-  latency_ms?: number;
   error?: string;
 }
 

--- a/packages/core/src/services/memory/core-memory.ts
+++ b/packages/core/src/services/memory/core-memory.ts
@@ -1,5 +1,4 @@
 import type { CoreMemoryBlock } from "../../domain/core-memory.js";
-import type { HierarchyLevel } from "../../domain/agent.js";
 import type { CoreMemoryBlockRepository } from "../../ports/core-memory-repo.js";
 
 export type CoreMemoryOperation = "append" | "replace";
@@ -25,10 +24,6 @@ export class CoreMemory {
 
   async read(agentId: string): Promise<CoreMemoryBlock[]> {
     return this.deps.repo.findByAgent(agentId);
-  }
-
-  async initDefaults(agentId: string, level: HierarchyLevel): Promise<CoreMemoryBlock[]> {
-    return this.deps.repo.initDefaults(agentId, level);
   }
 
   async applyUpdate(

--- a/packages/web/lib/types/mesh.ts
+++ b/packages/web/lib/types/mesh.ts
@@ -10,21 +10,12 @@ export interface MeshAsk {
   id: string;
   caller: string;
   target: string;
-  intermediate?: string;
-  arrow?: "right" | "up";
   type: "ask" | "negotiate" | "blocker";
-  type_label?: string;
   status: "in_flight" | "succeeded" | "blocked";
   duration_label: string;
   intent: RichText;
-  response?: { agent: string; content: RichText };
   chain_depth: string;
-  chain_depth_color?: "review";
-  source_session?: string;
   source_task_short_id?: string;
-  source_task_age?: string;
-  awaiting_label?: string;
-  awaiting_task_short_id?: string;
 }
 
 export interface ChainBudgetRow {
@@ -90,7 +81,6 @@ export type {
   MeshAskStatus,
   GraphNodeData,
   GraphEdgeData,
-  MeshSummaryData,
   MeshWindow,
 } from "@beevibe/api/views/types";
 


### PR DESCRIPTION
## What the sweep found

The module- and export-level checks come back **clean** after #285 / #291. Nothing to report from any of:

| Check | Result |
| --- | --- |
| `tsc --noEmit --noUnusedLocals --noUnusedParameters` (×5 packages) | clean |
| `tsc --noEmit --allowUnreachableCode false` (×5 packages) | clean |
| `pnpm lint` | 0 errors (10 pre-existing `import/*` warnings) |
| `knip` — unused files / exports / deps | only the false positives already tabled in CLAUDE.md |
| `depcheck` (root + per package) | `node-pg-migrate`, `zod`, `postcss`, `autoprefixer`, `prettier` — all documented false positives |
| name-by-name grep of every `export function\|class\|const\|interface\|type` under `packages/*/src/**` | 127 hits, **all** used inside their own file (redundant `export`, not dead) |
| 287 class-method declarations, grepped by name | no method without a call site |
| 54 `api.*.*` web client methods | all reachable |
| `overviewToDisplay` / `queryKeys` / `eventInvalidations` tables | no orphan entries |
| import-graph reachability (358 modules) | only test seams, documented dev scripts, and Next.js file-convention routes |
| coverage (`--coverage.all`, DB- and key-gated suites excluded) | every 0% file is DB-gated or a barrel — no dead module |

What *is* left sits one level down, in **members no tool in the repo looks at**. knip reports `classMembers` but has no equivalent for interface members or object-literal members, and `tsc` can't help — an unread optional field is still well-typed.

## Removed

Each verified against its single producer rather than a bare grep — field names like `response`, `arrow` and `body` collide with half the codebase.

- **`CoreMemory.initDefaults`** (`core/services/memory/core-memory.ts`) — a pass-through to `repo.initDefaults` that nothing ever called. Both real callers go straight to the repo: `auth/provision.ts` on agent creation, `scripts/sync-core-memory-descriptions.ts` on template propagation. No test covered the service method either. Surfaced by knip's `classMembers`.
- **9 `MeshAsk` fields** (`web/lib/types/mesh.ts`) — `intermediate`, `arrow`, `type_label`, `response`, `chain_depth_color`, `source_session`, `source_task_age`, `awaiting_label`, `awaiting_task_short_id`. The type has exactly one producer, `mesh-display.ts:askToDisplay()`, which sets none of them, and the backing `MeshAskData` DTO carries no column they could come from. `activity-feed.tsx` — the only consumer — reads `caller`, `target`, `type`, `duration_label`, `id`, `source_task_short_id`. Leftovers from the mock-data prototype.
- **`MeshSummaryData`** from the same file's re-export block — nothing in web imports it; the page binds to web's own `MeshSummary`.
- **`AgentDisplay.themes`** and **`MemoryFactDisplay.promotion_origin_scope`** (`api/views/types.ts`) — neither `toAgentDisplay` nor `rowToMemoryFactDisplay` writes them, and no web component reads them.
- **`RuntimeHealth.latency_ms`** (`core/ports/runtime.ts`) — all three runtimes return through `cliVersionHealthCheck`, which yields `{healthy, error?}`. The identifier appears nowhere else in the repo.

## Deliberately kept

Five members the sweep flagged that shouldn't go. Each is now a row in CLAUDE.md's "dead in-repo, but not ours to delete" table so the next sweep doesn't re-litigate them:

- `AgentDisplay.merge_events` — carries an explicit `/** Reserved for future memory-merge telemetry. */`. The marker is the decision; its unmarked neighbour `themes` went.
- `queryKeys.workProducts.all` / `queryKeys.chat.all` — the only two `.all` prefixes nothing invalidates. Every other group has one and uses it; the entry is structural, and dropping two of sixteen just invites someone to put them back.
- `ApiError.body` — product code reads `errorCode` / `serverMessage` since #283, so only `http.test.ts` touches it, but it's the raw server payload on an error class: the field you want present when debugging a 500.
- `StreamJsonMessage.duration_ms` / `.num_turns` — unread by the parser, but the interface documents Claude Code's `stream-json` **wire format** and the CLI does emit both on `result` messages.

## Also in CLAUDE.md

The member-level sweep is documented as a step, with the trap that sank the first attempt: grepping for the bare member name reports zero findings, because lookup tables read as `TABLE[key]` never show a literal `X.member` hit, and common field names match everywhere. Match `\.member\b` and `member\s*:` instead, exclude the type files themselves, and check the producer.

## Verification

CI is green on `6f7a402` — Build/Typecheck/Lint, Unit + Integration Tests (with a real Postgres, so the DB-gated suites the sandbox can't run are covered), and the Sign-off check.

Locally, in a sandbox with no Docker and no provider keys: `pnpm typecheck`, `pnpm build`, `pnpm lint` clean; `@beevibe/core` 595 pass / 2 skipped; `@beevibe/web` 203 pass; `@beevibe/api` 820 pass / 110 skipped with 9 suites failing only on the documented `DATABASE_URL_TEST` gate and its `afterAll` knock-on — zero assertion failures, and green in CI where Postgres exists.

The `@vitest/coverage-v8` install needed for the coverage pass was reverted, per CLAUDE.md; `package.json` and the lockfile are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gJaHtfZV8khJxLpUoVap5