### PR TITLE
test: cover three untested MCP tool modules (32-65% -> 100% lines)

### DIFF
--- a/packages/api/src/tools/session-search.test.ts
+++ b/packages/api/src/tools/session-search.test.ts
@@ -1,0 +1,345 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SessionSearchRequest } from "@beevibe/core";
+import {
+  SessionSearchError,
+  type SessionSearchService,
+} from "@beevibe/core/services/session-search";
+import {
+  createSessionSearchTool,
+  type SessionSearchToolContext,
+} from "./session-search.js";
+
+/**
+ * The service does the scope resolution and the SQL; the tool's own logic
+ * is shape inference (`inferRequest`) plus the error envelope. Both are
+ * exercised through the public handler, with the service faked so each
+ * assertion is about the request the tool built.
+ */
+function harness(
+  ctx: Partial<SessionSearchToolContext> = {},
+  behaviour: { search?: () => Promise<unknown> } = {},
+) {
+  const requests: SessionSearchRequest[] = [];
+  const scopes: Array<Record<string, unknown>> = [];
+
+  const sessionSearch = {
+    search: vi.fn(
+      async (req: SessionSearchRequest, scope: Record<string, unknown>) => {
+        requests.push(req);
+        scopes.push(scope);
+        if (behaviour.search) return behaviour.search();
+        return { results: [] };
+      },
+    ),
+  } as unknown as SessionSearchService;
+
+  const tool = createSessionSearchTool(
+    {
+      agentId: "agent_a",
+      hierarchyLevel: "ic",
+      sessionId: "sess_current",
+      ...ctx,
+    },
+    { sessionSearch },
+  );
+  return { tool, requests, scopes };
+}
+
+describe("session_search tool", () => {
+  describe("descriptor", () => {
+    it("names the tool and documents the four shapes", () => {
+      const { tool } = harness();
+      expect(tool.name).toBe("session_search");
+      expect(tool.description).toContain("DISCOVERY");
+      expect(tool.description).toContain("SCROLL");
+      expect(tool.description).toContain("READ");
+      expect(tool.description).toContain("BROWSE");
+    });
+
+    it("declares no required fields, since browse takes no args", () => {
+      const { tool } = harness();
+      expect(tool.schema.required).toBeUndefined();
+    });
+  });
+
+  describe("caller scope", () => {
+    it("passes the caller agent, tier and active session to the service", async () => {
+      const { tool, scopes } = harness({
+        agentId: "agent_team",
+        hierarchyLevel: "team",
+        sessionId: "sess_live",
+      });
+
+      await tool.handler({});
+
+      expect(scopes[0]).toEqual({
+        callerAgentId: "agent_team",
+        hierarchyLevel: "team",
+        currentSessionId: "sess_live",
+      });
+    });
+  });
+
+  describe("shape inference", () => {
+    it("infers browse from no arguments", async () => {
+      const { tool, requests } = harness();
+
+      await tool.handler({});
+
+      expect(requests[0]).toMatchObject({ kind: "browse" });
+    });
+
+    it("infers discover from a query", async () => {
+      const { tool, requests } = harness();
+
+      await tool.handler({ query: "auth refactor", limit: 7, sort: "newest" });
+
+      expect(requests[0]).toMatchObject({
+        kind: "discover",
+        query: "auth refactor",
+        limit: 7,
+        sort: "newest",
+      });
+    });
+
+    it("infers read from a bare session_id", async () => {
+      const { tool, requests } = harness();
+
+      await tool.handler({ session_id: "sess_past" });
+
+      expect(requests[0]).toEqual({ kind: "read", session_id: "sess_past" });
+    });
+
+    it("infers scroll from session_id plus around_message_id", async () => {
+      const { tool, requests } = harness();
+
+      await tool.handler({
+        session_id: "sess_past",
+        around_message_id: "evt_9",
+        window: 10,
+      });
+
+      expect(requests[0]).toEqual({
+        kind: "scroll",
+        session_id: "sess_past",
+        around_message_id: "evt_9",
+        window: 10,
+      });
+    });
+
+    it("prefers scroll over discover when a query is also present", async () => {
+      const { tool, requests } = harness();
+
+      await tool.handler({
+        session_id: "sess_past",
+        around_message_id: "evt_9",
+        query: "ignored",
+      });
+
+      expect(requests[0]).toMatchObject({ kind: "scroll" });
+    });
+
+    it("prefers read over discover when a query is also present", async () => {
+      const { tool, requests } = harness();
+
+      await tool.handler({ session_id: "sess_past", query: "ignored" });
+
+      expect(requests[0]).toEqual({ kind: "read", session_id: "sess_past" });
+    });
+
+    it("trims the string inputs it infers on", async () => {
+      const { tool, requests } = harness();
+
+      await tool.handler({
+        session_id: "  sess_past  ",
+        around_message_id: "  evt_9  ",
+      });
+
+      expect(requests[0]).toMatchObject({
+        kind: "scroll",
+        session_id: "sess_past",
+        around_message_id: "evt_9",
+      });
+    });
+
+    it.each([
+      ["blank", "   "],
+      ["a non-string", 42],
+    ])("treats a session_id that is %s as absent", async (_label, session_id) => {
+      const { tool, requests } = harness();
+
+      await tool.handler({ session_id, query: "topic" });
+
+      expect(requests[0]).toMatchObject({ kind: "discover", query: "topic" });
+    });
+
+    it.each([
+      ["blank", "   "],
+      ["a non-string", 42],
+    ])("treats a query that is %s as absent", async (_label, query) => {
+      const { tool, requests } = harness();
+
+      await tool.handler({ query });
+
+      expect(requests[0]).toMatchObject({ kind: "browse" });
+    });
+
+    it("falls back to read when around_message_id is blank", async () => {
+      const { tool, requests } = harness();
+
+      await tool.handler({ session_id: "sess_past", around_message_id: "  " });
+
+      expect(requests[0]).toEqual({ kind: "read", session_id: "sess_past" });
+    });
+
+    it("leaves a non-numeric window undefined for the service to default", async () => {
+      const { tool, requests } = harness();
+
+      await tool.handler({
+        session_id: "sess_past",
+        around_message_id: "evt_9",
+        window: "10",
+      });
+
+      expect(requests[0]).toMatchObject({ window: undefined });
+    });
+
+    it.each([
+      ["discover", { query: "topic", limit: "3" }],
+      ["browse", { limit: "3" }],
+    ])("leaves a non-numeric limit undefined in %s", async (_label, input) => {
+      const { tool, requests } = harness();
+
+      await tool.handler(input);
+
+      expect(requests[0]).toMatchObject({ limit: undefined });
+    });
+
+    it("ignores a sort value outside the allowed pair", async () => {
+      const { tool, requests } = harness();
+
+      await tool.handler({ query: "topic", sort: "sideways" });
+
+      expect(requests[0]).toMatchObject({ sort: undefined });
+    });
+  });
+
+  describe("filters", () => {
+    it("forwards filters on discover", async () => {
+      const { tool, requests } = harness();
+      const filters = { session_type: "task", status: "failed" };
+
+      await tool.handler({ query: "topic", filters });
+
+      expect(requests[0]).toMatchObject({ kind: "discover", filters });
+    });
+
+    it("forwards filters on browse", async () => {
+      const { tool, requests } = harness();
+      const filters = { agent_id: "agent_b" };
+
+      await tool.handler({ filters });
+
+      expect(requests[0]).toMatchObject({ kind: "browse", filters });
+    });
+
+    it.each([
+      ["null", null],
+      ["not an object", "task"],
+      ["absent", undefined],
+    ])("drops filters that are %s", async (_label, filters) => {
+      const { tool, requests } = harness();
+
+      await tool.handler({ filters });
+
+      expect(requests[0]).toMatchObject({ filters: undefined });
+    });
+  });
+
+  describe("results", () => {
+    it("returns the service payload unchanged on success", async () => {
+      const payload = { results: [{ session: { id: "sess_1" } }] };
+      const { tool } = harness({}, { search: async () => payload });
+
+      const result = await tool.handler({ query: "topic" });
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content).toBe(payload);
+    });
+
+    it("maps a null result to not_found_or_forbidden", async () => {
+      const { tool } = harness({}, { search: async () => null });
+
+      const result = await tool.handler({ session_id: "sess_other" });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({
+        error: "not_found_or_forbidden",
+      });
+    });
+  });
+
+  describe("error mapping", () => {
+    it.each([
+      ["forbidden_agent_filter"],
+      ["missing_query"],
+      ["missing_args"],
+    ] as const)("surfaces the %s code from a SessionSearchError", async (code) => {
+      const { tool } = harness(
+        {},
+        {
+          search: () =>
+            Promise.reject(new SessionSearchError(code, "nope")),
+        },
+      );
+
+      const result = await tool.handler({ query: "topic" });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual({ error: code, message: "nope" });
+    });
+
+    it("matches by name too, so a cross-bundle error keeps its code", async () => {
+      // src/ and dist/ copies of the class fail `instanceof`; the name
+      // check is what keeps the structured code from degrading.
+      const impostor = Object.assign(new Error("scope violation"), {
+        name: "SessionSearchError",
+        code: "forbidden_agent_filter",
+      });
+      const { tool } = harness({}, { search: () => Promise.reject(impostor) });
+
+      const result = await tool.handler({ query: "topic" });
+
+      expect(result.content).toEqual({
+        error: "forbidden_agent_filter",
+        message: "scope violation",
+      });
+    });
+
+    it("degrades an unrelated Error to internal_error", async () => {
+      const { tool } = harness(
+        {},
+        { search: () => Promise.reject(new Error("connection reset")) },
+      );
+
+      const result = await tool.handler({ query: "topic" });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual({
+        error: "internal_error",
+        message: "connection reset",
+      });
+    });
+
+    it("stringifies a non-Error rejection", async () => {
+      const { tool } = harness({}, { search: () => Promise.reject("weird") });
+
+      const result = await tool.handler({ query: "topic" });
+
+      expect(result.content).toEqual({
+        error: "internal_error",
+        message: "weird",
+      });
+    });
+  });
+});

--- a/packages/api/src/tools/use-repo.test.ts
+++ b/packages/api/src/tools/use-repo.test.ts
@@ -1,0 +1,422 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  RepoRunRepository,
+  Task,
+  TaskRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import { createUseRepoTool, type UseRepoServices } from "./use-repo.js";
+
+/**
+ * The tool is a closure over four ports, so every path below is driven by
+ * swapping a fake rather than touching Postgres or the daemon. `order`
+ * records the sequence of port calls — the dispatch-before-repo_run
+ * ordering is load-bearing (repo_run.session_id FKs to session.id), so it
+ * gets asserted rather than assumed.
+ */
+function harness(
+  overrides: {
+    agent?: Agent | null;
+    dispatch?: () => Promise<unknown>;
+    createRepoRun?: () => Promise<unknown>;
+  } = {},
+) {
+  const order: string[] = [];
+  const createdTasks: Array<Record<string, unknown>> = [];
+  const dispatchArgs: Array<Record<string, unknown>> = [];
+  const repoRunArgs: Array<Record<string, unknown>> = [];
+
+  const agent =
+    overrides.agent === undefined
+      ? ({ id: "agent_caller" } as unknown as Agent)
+      : overrides.agent;
+
+  const agentRepo = {
+    findById: vi.fn(async (id: string) => {
+      order.push("agent.findById");
+      expect(id).toBe("agent_caller");
+      return agent;
+    }),
+  } as unknown as AgentRepository;
+
+  const taskRepo = {
+    create: vi.fn(async (row: Record<string, unknown>) => {
+      order.push("task.create");
+      createdTasks.push(row);
+      return row as unknown as Task;
+    }),
+  } as unknown as TaskRepository;
+
+  const repoRunRepo = {
+    create: vi.fn(async (row: Record<string, unknown>) => {
+      order.push("repoRun.create");
+      repoRunArgs.push(row);
+      if (overrides.createRepoRun) return overrides.createRepoRun();
+      return row;
+    }),
+  } as unknown as RepoRunRepository;
+
+  const dispatchService = {
+    dispatchTask: vi.fn(async (args: Record<string, unknown>) => {
+      order.push("dispatch");
+      dispatchArgs.push(args);
+      if (overrides.dispatch) return overrides.dispatch();
+      return undefined;
+    }),
+  } as unknown as DispatchService;
+
+  const services: UseRepoServices = {
+    agentRepo,
+    taskRepo,
+    repoRunRepo,
+    dispatchService,
+  };
+  const tool = createUseRepoTool({ agentId: "agent_caller" }, services);
+  return { tool, order, createdTasks, dispatchArgs, repoRunArgs, services };
+}
+
+const OK_INPUT = {
+  goal: "Extract the tables from this PDF as JSON",
+  repo_url: "https://github.com/acme/pdf-tools",
+};
+
+describe("use_repo tool", () => {
+  describe("descriptor", () => {
+    it("exposes the tool name and required fields", () => {
+      const { tool } = harness();
+      expect(tool.name).toBe("use_repo");
+      expect(tool.schema.required).toEqual(["goal", "repo_url"]);
+      expect(tool.description).toContain("Docker sandbox");
+    });
+  });
+
+  describe("happy path", () => {
+    it("creates the container task, dispatches, then inserts the repo_run", async () => {
+      const { tool, order, createdTasks, dispatchArgs, repoRunArgs } = harness();
+
+      const result = await tool.handler({ ...OK_INPUT });
+
+      expect(result.isError).toBeFalsy();
+      // The session row must exist before the repo_run insert; the FK
+      // depends on it.
+      expect(order).toEqual([
+        "agent.findById",
+        "task.create",
+        "dispatch",
+        "repoRun.create",
+      ]);
+
+      expect(createdTasks[0]).toMatchObject({
+        title: OK_INPUT.goal,
+        description: OK_INPUT.goal,
+        priority: "medium",
+        assignee_id: "agent_caller",
+        creator_id: "agent_caller",
+        creator_type: "agent",
+      });
+
+      expect(dispatchArgs[0]).toMatchObject({
+        agentId: "agent_caller",
+        type: "run_repo",
+        intent: OK_INPUT.goal,
+        reason: { kind: "fresh" },
+      });
+
+      expect(repoRunArgs[0]).toMatchObject({
+        agent_id: "agent_caller",
+        goal: OK_INPUT.goal,
+        repo_url: OK_INPUT.repo_url,
+        status: "pending",
+      });
+    });
+
+    it("returns the minted ids, and they line up across the three rows", async () => {
+      const { tool, createdTasks, dispatchArgs, repoRunArgs } = harness();
+
+      const result = await tool.handler({ ...OK_INPUT });
+      const content = result.content as Record<string, string>;
+
+      expect(content.status).toBe("pending");
+      expect(content.watch_url).toBe(`/capabilities/runs/${content.repo_run_id}`);
+
+      // The session id handed to dispatch is the one reported back and the
+      // one the repo_run row points at.
+      expect(dispatchArgs[0]?.sessionIdOverride).toBe(content.session_id);
+      expect(repoRunArgs[0]?.session_id).toBe(content.session_id);
+      expect(repoRunArgs[0]?.id).toBe(content.repo_run_id);
+
+      // The container task carries the work product.
+      expect(content.task_id).toBe(createdTasks[0]?.id);
+      expect(repoRunArgs[0]?.task_id).toBe(content.task_id);
+      expect(dispatchArgs[0]?.task).toBe(createdTasks[0]);
+    });
+
+    it("trims and passes through input_url and input_filename", async () => {
+      const { tool } = harness();
+
+      const result = await tool.handler({
+        ...OK_INPUT,
+        input_url: "  https://example.com/doc.pdf  ",
+        input_filename: "  doc.pdf  ",
+      });
+
+      expect(result.content).toMatchObject({
+        input_url: "https://example.com/doc.pdf",
+        input_filename: "doc.pdf",
+      });
+    });
+
+    it("leaves input_url and input_filename undefined when absent", async () => {
+      const { tool } = harness();
+
+      const result = await tool.handler({ ...OK_INPUT });
+
+      expect(result.content.input_url).toBeUndefined();
+      expect(result.content.input_filename).toBeUndefined();
+    });
+  });
+
+  describe("goal validation", () => {
+    it.each([
+      ["empty string", ""],
+      ["whitespace only", "   "],
+    ])("rejects a goal that is %s", async (_label, goal) => {
+      const { tool, order } = harness();
+
+      const result = await tool.handler({ ...OK_INPUT, goal });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({ error: "invalid_goal" });
+      // Rejected before any port is touched — no orphan task row.
+      expect(order).toEqual([]);
+    });
+
+    it("rejects a non-string goal", async () => {
+      const { tool, order } = harness();
+
+      const result = await tool.handler({ ...OK_INPUT, goal: 42 });
+
+      expect(result.content).toMatchObject({ error: "invalid_goal" });
+      expect(order).toEqual([]);
+    });
+
+    it("trims the goal before storing it", async () => {
+      const { tool, createdTasks, repoRunArgs } = harness();
+
+      await tool.handler({ ...OK_INPUT, goal: "  do the thing  " });
+
+      expect(createdTasks[0]?.description).toBe("do the thing");
+      expect(repoRunArgs[0]?.goal).toBe("do the thing");
+    });
+  });
+
+  describe("repo_url validation", () => {
+    it.each([
+      ["missing", undefined],
+      ["empty", ""],
+      ["plain http", "http://github.com/acme/repo"],
+      ["a non-GitHub host", "https://gitlab.com/acme/repo"],
+      ["a host that merely ends in the string", "https://notgithub.com/a/b"],
+      ["unparseable", "not a url"],
+      ["a non-string", 7],
+    ])("rejects repo_url that is %s", async (_label, repo_url) => {
+      const { tool, order } = harness();
+
+      const result = await tool.handler({ ...OK_INPUT, repo_url });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({ error: "invalid_repo_url" });
+      expect(order).toEqual([]);
+    });
+
+    it.each([
+      ["github.com", "https://github.com/acme/repo"],
+      ["a subdomain of github.com", "https://www.github.com/acme/repo"],
+    ])("accepts %s", async (_label, repo_url) => {
+      const { tool } = harness();
+
+      const result = await tool.handler({ ...OK_INPUT, repo_url });
+
+      expect(result.isError).toBeFalsy();
+    });
+
+    it("trims surrounding whitespace before validating", async () => {
+      const { tool, repoRunArgs } = harness();
+
+      const result = await tool.handler({
+        ...OK_INPUT,
+        repo_url: "  https://github.com/acme/repo  ",
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(repoRunArgs[0]?.repo_url).toBe("https://github.com/acme/repo");
+    });
+  });
+
+  describe("container task title", () => {
+    it("collapses runs of whitespace", async () => {
+      const { tool, createdTasks } = harness();
+
+      await tool.handler({ ...OK_INPUT, goal: "extract\n\ntables   from\tthis" });
+
+      expect(createdTasks[0]?.title).toBe("extract tables from this");
+    });
+
+    it("keeps a title of exactly 80 characters intact", async () => {
+      const goal = "x".repeat(80);
+      const { tool, createdTasks } = harness();
+
+      await tool.handler({ ...OK_INPUT, goal });
+
+      expect(createdTasks[0]?.title).toBe(goal);
+    });
+
+    it("truncates a longer title to 77 chars plus an ellipsis", async () => {
+      const goal = "y".repeat(81);
+      const { tool, createdTasks } = harness();
+
+      await tool.handler({ ...OK_INPUT, goal });
+
+      expect(createdTasks[0]?.title).toBe("y".repeat(77) + "…");
+      // The untruncated goal still reaches the description and the run row.
+      expect(createdTasks[0]?.description).toBe(goal);
+    });
+  });
+
+  describe("limits parsing", () => {
+    async function limitsFor(limits: unknown) {
+      const { tool } = harness();
+      const result = await tool.handler({ ...OK_INPUT, limits });
+      return (result.content as Record<string, unknown>).limits;
+    }
+
+    it("passes sane values through unchanged", async () => {
+      expect(
+        await limitsFor({
+          wall_clock_minutes: 10,
+          max_install_attempts: 3,
+          disk_mb: 512,
+        }),
+      ).toEqual({
+        wall_clock_minutes: 10,
+        max_install_attempts: 3,
+        disk_mb: 512,
+      });
+    });
+
+    it("clamps each limit to its ceiling", async () => {
+      expect(
+        await limitsFor({
+          wall_clock_minutes: 999,
+          max_install_attempts: 99,
+          disk_mb: 1_000_000,
+        }),
+      ).toEqual({
+        wall_clock_minutes: 60,
+        max_install_attempts: 5,
+        disk_mb: 10_000,
+      });
+    });
+
+    it("floors the integer limits but leaves wall clock fractional", async () => {
+      expect(
+        await limitsFor({
+          wall_clock_minutes: 1.5,
+          max_install_attempts: 2.9,
+          disk_mb: 100.7,
+        }),
+      ).toEqual({
+        wall_clock_minutes: 1.5,
+        max_install_attempts: 2,
+        disk_mb: 100,
+      });
+    });
+
+    it.each([
+      ["zero", 0],
+      ["negative", -5],
+      ["a string", "10"],
+    ])("drops a limit that is %s", async (_label, value) => {
+      expect(
+        await limitsFor({
+          wall_clock_minutes: value,
+          max_install_attempts: value,
+          disk_mb: value,
+        }),
+      ).toEqual({});
+    });
+
+    it.each([
+      ["absent", undefined],
+      ["null", null],
+      ["not an object", "20"],
+    ])("returns an empty object when limits is %s", async (_label, limits) => {
+      expect(await limitsFor(limits)).toEqual({});
+    });
+  });
+
+  describe("failure paths", () => {
+    it("reports agent_not_found and creates nothing", async () => {
+      const { tool, order } = harness({ agent: null });
+
+      const result = await tool.handler({ ...OK_INPUT });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({ error: "agent_not_found" });
+      expect(order).toEqual(["agent.findById"]);
+    });
+
+    it("reports dispatch_failed without inserting a repo_run", async () => {
+      const { tool, order } = harness({
+        dispatch: () => Promise.reject(new Error("no daemon online")),
+      });
+
+      const result = await tool.handler({ ...OK_INPUT });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({
+        error: "dispatch_failed",
+        message: "no daemon online",
+      });
+      expect(order).not.toContain("repoRun.create");
+    });
+
+    it("stringifies a non-Error thrown from dispatch", async () => {
+      const { tool } = harness({ dispatch: () => Promise.reject("boom") });
+
+      const result = await tool.handler({ ...OK_INPUT });
+
+      expect(result.content).toMatchObject({
+        error: "dispatch_failed",
+        message: "boom",
+      });
+    });
+
+    it("reports repo_run_create_failed when the insert throws", async () => {
+      const { tool } = harness({
+        createRepoRun: () => Promise.reject(new Error("fk violation")),
+      });
+
+      const result = await tool.handler({ ...OK_INPUT });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({
+        error: "repo_run_create_failed",
+        message: "fk violation",
+      });
+    });
+
+    it("stringifies a non-Error thrown from the repo_run insert", async () => {
+      const { tool } = harness({ createRepoRun: () => Promise.reject(404) });
+
+      const result = await tool.handler({ ...OK_INPUT });
+
+      expect(result.content).toMatchObject({
+        error: "repo_run_create_failed",
+        message: "404",
+      });
+    });
+  });
+});

--- a/packages/api/src/tools/watch.test.ts
+++ b/packages/api/src/tools/watch.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  WatchAuthError,
+  WatchNotFoundError,
+  WatchValidationError,
+  type WatchService,
+} from "@beevibe/core/services/watch-service";
+import { buildWatchTools, type WatchToolContext } from "./watch.js";
+
+/**
+ * Both tools are thin adapters over WatchService — the service owns the
+ * auth check and the state machine. What's worth pinning here is the
+ * adapter's own logic: input coercion, the mode default, and the mapping
+ * from each service error class to a stable tool error code.
+ */
+function harness(
+  ctx: Partial<WatchToolContext> = {},
+  behaviour: {
+    watchTasks?: () => Promise<unknown>;
+    unwatch?: () => Promise<unknown>;
+  } = {},
+) {
+  const watchCalls: Array<Record<string, unknown>> = [];
+  const unwatchCalls: Array<Record<string, unknown>> = [];
+
+  const watchService = {
+    watchTasks: vi.fn(async (args: Record<string, unknown>) => {
+      watchCalls.push(args);
+      if (behaviour.watchTasks) return behaviour.watchTasks();
+      return { watchId: "watch_1", firedImmediately: false };
+    }),
+    unwatch: vi.fn(async (args: Record<string, unknown>) => {
+      unwatchCalls.push(args);
+      if (behaviour.unwatch) return behaviour.unwatch();
+      return undefined;
+    }),
+  } as unknown as WatchService;
+
+  const [watchTasks, unwatch] = buildWatchTools(
+    { agentId: "agent_a", sessionId: "sess_1", ...ctx },
+    { watchService },
+  );
+  return { watchTasks: watchTasks!, unwatch: unwatch!, watchCalls, unwatchCalls };
+}
+
+describe("buildWatchTools", () => {
+  it("returns watch_tasks and unwatch, in that order", () => {
+    const { watchTasks, unwatch } = harness();
+    expect(watchTasks.name).toBe("watch_tasks");
+    expect(unwatch.name).toBe("unwatch");
+  });
+
+  it("exposes the required fields on each schema", () => {
+    const { watchTasks, unwatch } = harness();
+    expect(watchTasks.schema.required).toEqual(["task_ids"]);
+    expect(unwatch.schema.required).toEqual(["watch_id"]);
+  });
+
+  it("advertises both fire modes on the watch_tasks schema", () => {
+    const { watchTasks } = harness();
+    const props = watchTasks.schema.properties as Record<
+      string,
+      { enum?: string[] }
+    >;
+    expect(props.mode?.enum).toEqual(expect.arrayContaining(["all", "any"]));
+  });
+});
+
+describe("watch_tasks", () => {
+  it("forwards caller context, task ids, mode and reason to the service", async () => {
+    const { watchTasks, watchCalls } = harness();
+
+    const result = await watchTasks.handler({
+      task_ids: ["task_1", "task_2"],
+      mode: "any",
+      reason: "  need the first result  ",
+    });
+
+    expect(watchCalls[0]).toEqual({
+      callerAgentId: "agent_a",
+      callerSessionId: "sess_1",
+      taskIds: ["task_1", "task_2"],
+      mode: "any",
+      reason: "need the first result",
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({
+      watch_id: "watch_1",
+      fired_immediately: false,
+    });
+  });
+
+  it("surfaces fired_immediately from the service", async () => {
+    const { watchTasks } = harness(
+      {},
+      {
+        watchTasks: async () => ({
+          watchId: "watch_9",
+          firedImmediately: true,
+        }),
+      },
+    );
+
+    const result = await watchTasks.handler({ task_ids: ["task_1"] });
+
+    expect(result.content).toEqual({
+      watch_id: "watch_9",
+      fired_immediately: true,
+    });
+  });
+
+  it("defaults mode to 'all' when omitted", async () => {
+    const { watchTasks, watchCalls } = harness();
+
+    await watchTasks.handler({ task_ids: ["task_1"] });
+
+    expect(watchCalls[0]?.mode).toBe("all");
+  });
+
+  it.each([
+    ["an unknown string", "eventually"],
+    ["a non-string", 1],
+    ["null", null],
+  ])("falls back to 'all' when mode is %s", async (_label, mode) => {
+    const { watchTasks, watchCalls } = harness();
+
+    await watchTasks.handler({ task_ids: ["task_1"], mode });
+
+    expect(watchCalls[0]?.mode).toBe("all");
+  });
+
+  it("drops non-string entries from task_ids", async () => {
+    const { watchTasks, watchCalls } = harness();
+
+    await watchTasks.handler({ task_ids: ["task_1", 2, null, "task_3"] });
+
+    expect(watchCalls[0]?.taskIds).toEqual(["task_1", "task_3"]);
+  });
+
+  it.each([
+    ["empty", []],
+    ["all non-strings", [1, null]],
+    ["not an array", "task_1"],
+    ["absent", undefined],
+  ])("rejects task_ids that are %s", async (_label, task_ids) => {
+    const { watchTasks, watchCalls } = harness();
+
+    const result = await watchTasks.handler({ task_ids });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "watch_validation" });
+    expect(watchCalls).toHaveLength(0);
+  });
+
+  it.each([
+    ["blank", "   "],
+    ["a non-string", 5],
+  ])("omits a reason that is %s", async (_label, reason) => {
+    const { watchTasks, watchCalls } = harness();
+
+    await watchTasks.handler({ task_ids: ["task_1"], reason });
+
+    expect(watchCalls[0]?.reason).toBeUndefined();
+  });
+
+  it("refuses to register a watch without a session context", async () => {
+    const { watchTasks, watchCalls } = harness({ sessionId: undefined });
+
+    const result = await watchTasks.handler({ task_ids: ["task_1"] });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "watch_validation",
+      message: "watch_tasks must be called inside a session context",
+    });
+    expect(watchCalls).toHaveLength(0);
+  });
+
+  it.each([
+    ["WatchAuthError", () => new WatchAuthError("not yours"), "watch_auth"],
+    [
+      "WatchValidationError",
+      () => new WatchValidationError("bad ids"),
+      "watch_validation",
+    ],
+    [
+      "WatchNotFoundError",
+      () => new WatchNotFoundError("gone"),
+      "watch_not_found",
+    ],
+    ["a plain Error", () => new Error("db down"), "watch_error"],
+  ])("maps %s to the %s code", async (_label, make, code) => {
+    const { watchTasks } = harness(
+      {},
+      { watchTasks: () => Promise.reject(make()) },
+    );
+
+    const result = await watchTasks.handler({ task_ids: ["task_1"] });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: code });
+  });
+
+  it("stringifies a non-Error rejection", async () => {
+    const { watchTasks } = harness(
+      {},
+      { watchTasks: () => Promise.reject("nope") },
+    );
+
+    const result = await watchTasks.handler({ task_ids: ["task_1"] });
+
+    expect(result.content).toMatchObject({
+      error: "watch_error",
+      message: "nope",
+    });
+  });
+});
+
+describe("unwatch", () => {
+  it("forwards the caller agent and watch id, and reports ok", async () => {
+    const { unwatch, unwatchCalls } = harness();
+
+    const result = await unwatch.handler({ watch_id: "watch_1" });
+
+    expect(unwatchCalls[0]).toEqual({
+      callerAgentId: "agent_a",
+      watchId: "watch_1",
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({ ok: true });
+  });
+
+  it.each([
+    ["empty", ""],
+    ["a non-string", 3],
+    ["absent", undefined],
+  ])("rejects a watch_id that is %s", async (_label, watch_id) => {
+    const { unwatch, unwatchCalls } = harness();
+
+    const result = await unwatch.handler({ watch_id });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "watch_validation" });
+    expect(unwatchCalls).toHaveLength(0);
+  });
+
+  it.each([
+    ["WatchAuthError", () => new WatchAuthError("not yours"), "watch_auth"],
+    [
+      "WatchNotFoundError",
+      () => new WatchNotFoundError("no such watch"),
+      "watch_not_found",
+    ],
+    ["a plain Error", () => new Error("db down"), "watch_error"],
+  ])("maps %s to the %s code", async (_label, make, code) => {
+    const { unwatch } = harness({}, { unwatch: () => Promise.reject(make()) });
+
+    const result = await unwatch.handler({ watch_id: "watch_1" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: code });
+  });
+
+  it("does not require a session context", async () => {
+    const { unwatch, unwatchCalls } = harness({ sessionId: undefined });
+
+    const result = await unwatch.handler({ watch_id: "watch_1" });
+
+    expect(result.isError).toBeFalsy();
+    expect(unwatchCalls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## What

A coverage sweep across `core`, `api`, `daemon` and `scheduler` turned up three agent-facing MCP tool modules with **no test file at all**. They sit on the tool surface every agent calls, so a regression there is silent until an agent misbehaves in production.

| Module | Before | After | Lines closed |
| --- | --- | --- | --- |
| `api/src/tools/use-repo.ts` | 32.0% | **100%** | 123 |
| `api/src/tools/watch.ts` | 46.3% | **100%** | 72 |
| `api/src/tools/session-search.ts` | 64.7% | **100%** | 82 |

98 new tests, **no source changes**. Each module is a closure over its ports, so everything is driven by swapping fakes — no Postgres, no daemon, no provider keys required.

## Why these three

The sweep's raw output is misleading in a bare sandbox: most 0% files are the DB-gated suites that simply can't run without Postgres, and the barrel/re-export files were deliberately left uncovered by #284. Filtering to *files with low coverage **and** no test file*, and then to product-critical code, left these three. They're the MCP tool surface — the contract between every agent and the platform.

## What the tests actually pin down

Beyond the line count, they lock in the behaviour that would be expensive to get wrong:

**`use_repo`**
- The **dispatch-before-`repo_run` ordering**. `repo_run.session_id` has an FK to `session.id`, so the session row must land first; the test asserts the call sequence rather than assuming it.
- That the minted session / task / run ids agree across all three rows and the returned `watch_url`.
- Limit clamping — 60 min, 5 install attempts, 10 GB — including flooring of the integer limits and dropping of zero/negative/non-numeric values.
- The 80-char container-task title truncation (and that the untruncated goal still reaches `description`).
- That each failure path (`invalid_goal`, `invalid_repo_url`, `agent_not_found`, `dispatch_failed`, `repo_run_create_failed`) bails **before** creating an orphan row.

**`watch_tasks` + `unwatch`**
- The `'all'` mode default and its fallback for unknown/non-string modes.
- `task_ids` coercion (non-string entries dropped; empty result rejected).
- The mapping from each `WatchService` error class to its stable tool error code (`watch_auth`, `watch_validation`, `watch_not_found`, `watch_error`).

**`session_search`**
- The four-way shape inference — scroll > read > discover > browse — including precedence when inputs overlap.
- That a cross-bundle `SessionSearchError` **matched by name** keeps its structured code instead of degrading to `internal_error`. This is the `src/` vs `dist/` `instanceof` hazard the source comments call out, and it had no test.

## Verification

- All 98 new tests pass.
- **Mutation-checked**, so the suite isn't passing vacuously: flipping the limit ceiling (60→600), the mode default (`all`→`any`), and the scroll branch each fails the suite.
- Full `api` suite (DB-gated suites excluded, per CLAUDE.md): **32 files / 753 tests pass**, no regressions.
- `tsc --noEmit` and `eslint` clean on the package.

Coverage was measured with a temporarily-installed `@vitest/coverage-v8`, **not committed**, per CLAUDE.md.

---
_Generated by [Claude Code](https://claude.ai/code/session_013haN7UHmy2hdqc2cgBeNPR)_