### PR TITLE
test: replace an unfalsifiable regex-state test, drop three dead fixture fields

### DIFF
--- a/packages/core/src/domain/github-url.test.ts
+++ b/packages/core/src/domain/github-url.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { extractGitHubRepoRefs, NON_REPO_OWNERS } from "./github-url.js";
+import {
+  extractGitHubRepoRefs,
+  GITHUB_REPO_URL_RE,
+  NON_REPO_OWNERS,
+} from "./github-url.js";
 
 describe("extractGitHubRepoRefs", () => {
   it("pulls owner, name and canonical root out of a bare URL", () => {
@@ -69,10 +73,24 @@ describe("extractGitHubRepoRefs", () => {
     ]);
   });
 
-  // The module-level regex is global; a stale lastIndex would make the second
-  // call start mid-string and miss the match.
-  it("is not order-dependent across calls", () => {
-    const text = "https://github.com/owner/repo";
-    expect(extractGitHubRepoRefs(text)).toEqual(extractGitHubRepoRefs(text));
+  // GITHUB_REPO_URL_RE is module-level and /g, so `lastIndex` is shared
+  // state. The reset at the top of extractGitHubRepoRefs is what makes the
+  // function safe to call after someone else has driven the regex by hand
+  // — which the regex's own docstring tells callers not to do.
+  //
+  // Comparing two back-to-back calls does NOT test this: the `while (exec)`
+  // loop always runs to a null match, and a failed exec resets lastIndex to
+  // 0 on its own, so the second call starts clean whether or not the guard
+  // is there. Dirtying lastIndex from outside is the only way to make the
+  // missing reset observable.
+  it("resets a lastIndex left dirty by an outside caller", () => {
+    const text = "see https://github.com/owner/repo";
+    GITHUB_REPO_URL_RE.lastIndex = 0;
+    expect(GITHUB_REPO_URL_RE.exec(text)).not.toBeNull();
+    expect(GITHUB_REPO_URL_RE.lastIndex).toBeGreaterThan(0);
+
+    expect(extractGitHubRepoRefs(text).map((r) => r.url)).toEqual([
+      "https://github.com/owner/repo",
+    ]);
   });
 });

--- a/packages/core/src/services/dispatch-service.test.ts
+++ b/packages/core/src/services/dispatch-service.test.ts
@@ -189,7 +189,7 @@ describe("DispatchService.dispatchTask", () => {
     const reason: ResumeReason = {
       kind: "post_escalation",
       role: "initiator",
-      resolution: { title: "T", description: "D", proposals: [], notes: "" },
+      resolution: { title: "T", description: "D", source: "human" },
       prior_session_id: "sess_neg",
     };
 

--- a/packages/core/src/services/task-service.test.ts
+++ b/packages/core/src/services/task-service.test.ts
@@ -49,7 +49,6 @@ function makeSession(overrides: Partial<Session> = {}): Session {
     intent: "test",
     cli_session_id: "cli_abc",
     created_at: new Date(),
-    updated_at: new Date(),
     ...overrides,
   };
 }


### PR DESCRIPTION
## What this is

A sweep of all 160 test files against four criteria — skipped/disabled without a clear reason, subject removed or significantly refactored, no assertions or implementation-detail-only, orphaned test files.

**Nothing needed deleting.** #284, #285, #286 and #291 already took what was there, and the earlier sweep in #329 reached the same conclusion. Three things survived this pass, and they are what this PR fixes.

## 1. `packages/core/src/domain/github-url.test.ts` — a test that could not fail

```ts
// The module-level regex is global; a stale lastIndex would make the second
// call start mid-string and miss the match.
it("is not order-dependent across calls", () => {
  const text = "https://github.com/owner/repo";
  expect(extractGitHubRepoRefs(text)).toEqual(extractGitHubRepoRefs(text));
});
```

The comment names the regression precisely, and comparing two back-to-back calls cannot see it. `extractGitHubRepoRefs` drives the regex with `while ((match = GITHUB_REPO_URL_RE.exec(text)) !== null)`, which always runs to a null match — and a failed `exec` resets `lastIndex` to `0` on its own. So the second call starts clean whether or not `GITHUB_REPO_URL_RE.lastIndex = 0` is there.

Verified by mutation. With that line commented out in `github-url.ts`:

```
✓ src/domain/github-url.test.ts (11 tests) 6ms
Test Files  1 passed (1)
```

Replaced with a test that dirties `lastIndex` from outside first — the case the regex's own docstring warns callers about (*"callers using `.exec()` in a loop must reset `lastIndex` first, which is why `extractGitHubRepoRefs` exists"*), and the only way the missing reset becomes observable. Under the same mutation it now fails:

```
Test Files  1 failed (1)
     Tests  1 failed | 10 passed (11)
```

## 2. `task-service.test.ts` — `makeSession` set a field that doesn't exist

`Session` (`core/src/domain/session.ts:124`) has `created_at` and no `updated_at`. The fixture line was inert.

## 3. `dispatch-service.test.ts` — the `post_escalation` resolution fixture

```ts
resolution: { title: "T", description: "D", proposals: [], notes: "" },
```

Built against an older shape. `ResolutionProposal` (`core/src/domain/escalation.ts:39`) is `{ title, description, source, source_index? }` — `proposals` and `notes` are not on it, and the required `source` was missing. Reshaped to the live type; the test itself (runtime_id pinning on resume) is unchanged and still passes.

## Why (2) and (3) went unnoticed — worth its own change

`packages/core/tsconfig.json` excludes `**/*.test.ts` and `**/test-fakes.ts`; `packages/scheduler/tsconfig.json` excludes `**/*.test.ts`. Both packages reuse that one config for `build` **and** `typecheck`, so `pnpm typecheck` never sees either package's tests. (`api`, `daemon`, `sandbox` and `web` do typecheck theirs.)

Typechecking `core`'s `src/**/*` with tests included reports **64 errors on main** (62 after this PR); `scheduler` reports 6. The remaining ones are incomplete `vi.fn()` fakes (`AgentRepository.findDescendantIds`, `TaskRepository.findByIds`, `SessionRepository` missing 6–10 members, `MemoryAgent.prepareCoreOnly`, `AgentRuntime.skillsDir`) and un-narrowed access — drift, but not stale tests, so they are left alone here.

It matters because it is the same blind spot that produced #291: 269 of core's 885 tests are DB-gated and never execute without Postgres, and they aren't typechecked either — so #285's removals stayed invisible until CI ran with a database. Closing it means a `tsconfig.test.json` per package plus fixing ~70 errors, which is a larger and separate change than a test cleanup.

## Deliberately left alone

| Thing | Why |
| --- | --- |
| `docker.e2e.test.ts`, `multi-instance.e2e.test.ts`, `smoke.test.ts` | Opt-in by env flag, each documenting its enable command in its own header. Working as designed. |
| `it.skipIf(process.platform === "win32")` in `spawn.test.ts` / `manager.test.ts`, `describe.skipIf(!HAS_LIVE_API_KEYS)` in `mcp.test.ts` | Correctly gated on platform / live keys. |
| `views/activity.test.ts`, `views/promotions.test.ts` | Subjects have no in-repo caller, but CLAUDE.md records both as kept on purpose (documented public endpoint; unfinished wiring). |
| `stream-json.test.ts`'s `thinking` block, `api-key.test.ts`'s `hierarchyLevel` access | The two remaining core test type errors. The CLI really does emit thinking blocks and `ResolvedCaller` really is a union — narrow types / missing narrowing, not stale tests. |
| Redundancy already proposed in #315, #321, #325, #336 | Those PRs are open against the same files; not duplicated here. |

## What the sweep checked and found nothing on

- Zero tests with no assertions; zero empty or commented-out test bodies
- Zero orphaned test files (`smoke.test.ts` and `auth.integration.test.ts` have no same-named sibling by design — both import live modules)
- Zero unresolved `vi.mock()` / relative-import paths across all 160 files
- Zero leftover `vi.fn()` stubs for the methods removed by #285/#291
- Zero `.only`, `TODO`/`FIXME`-marked, or unexplained `.skip` tests
- One tautological assertion monorepo-wide — item 1 above

## Verification

| Gate | Result |
| --- | --- |
| `pnpm typecheck` | 9/9 tasks clean |
| `pnpm lint` | 9/9 tasks clean (pre-existing `import/no-duplicates` warning in web unchanged) |
| `pnpm build` | clean |
| `@beevibe/core` tests | 609 passed / 7 failed / 269 skipped — byte-identical to the pre-change baseline |

The 7 failures are the documented bare-sandbox baseline (no `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`); the 269 skips are the DB-gated suites (no Docker here). Pre-existing Prettier warnings on all three touched files are unchanged, confirmed against a clean tree.

---
_Generated by [Claude Code](https://claude.ai/code/session_017EBeToeRVfue3iKLSUA6Ng)_