### PR TITLE
chore: remove six dead type fields found by a static + dynamic sweep

### DIFF
--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -96,7 +96,6 @@ export interface AgentDisplay
   /** Reserved for future memory-merge telemetry. */
   merge_events?: number;
   specialization?: string;
-  themes?: string[];
   /** CLI tool the agent uses — derived from `runtime_config.type`. */
   runtime?: string;
   /**
@@ -404,7 +403,6 @@ export interface MemoryFactDisplay {
   source_session_count: number;
   created_at: Date;
   merge_origin?: MergeOrigin;
-  promotion_origin_scope?: MemoryScope;
 }
 
 /**

--- a/packages/core/src/adapters/claude-code/stream-json.ts
+++ b/packages/core/src/adapters/claude-code/stream-json.ts
@@ -46,8 +46,6 @@ export interface StreamJsonMessage {
   session_id?: string;
   cost_usd?: number;
   total_cost_usd?: number;
-  duration_ms?: number;
-  num_turns?: number;
   usage?: {
     input_tokens?: number;
     output_tokens?: number;

--- a/packages/core/src/domain/agent.ts
+++ b/packages/core/src/domain/agent.ts
@@ -26,7 +26,6 @@ export interface RuntimeConfig {
    */
   model?: string;
   max_turns?: number;
-  timeout_ms?: number;
   system_prompt_addition?: string;
 }
 

--- a/packages/core/src/ports/runtime.ts
+++ b/packages/core/src/ports/runtime.ts
@@ -199,7 +199,6 @@ export interface RuntimeResult {
 /** Result of `healthCheck()`. */
 export interface RuntimeHealth {
   healthy: boolean;
-  latency_ms?: number;
   error?: string;
 }
 


### PR DESCRIPTION
## What this removes

Six interface fields that are declared but never written and never read — anywhere in the repo's tracked history, including code, tests, migrations and docs:

| Field | File | Why it's dead |
| --- | --- | --- |
| `RuntimeConfig.timeout_ms` | `core/src/domain/agent.ts` | Never set, never read. The only other `timeout_ms` in the repo is an unrelated field on chat's 504 JSON error body. Its four siblings (`type`, `model`, `max_turns`, `system_prompt_addition`) all have live read sites. |
| `RuntimeHealth.latency_ms` | `core/src/ports/runtime.ts` | None of the three `healthCheck()` implementations populate it, and its only consumer (`GET /health/runtime`) reads just `healthy` and `error`. |
| `StreamJsonMessage.duration_ms` | `core/src/adapters/claude-code/stream-json.ts` | Every other field on this interface is parsed somewhere, so the type describes what we consume rather than the CLI's full wire format. |
| `StreamJsonMessage.num_turns` | same | Same — the only two members nothing touches. |
| `AgentDisplay.themes` | `api/src/views/types.ts` | Never populated server-side, never read by web. |
| `MemoryFactDisplay.promotion_origin_scope` | `api/src/views/types.ts` | Same. |

All six are optional, so no implementation or call site had to change.

## How they were found

The sweep ran every check the repo documents, and each came back clean on the categories [#285](https://github.com/beevibe-ai/beevibe/pull/285) already covered:

- `tsc --noUnusedLocals --noUnusedParameters` and `--allowUnreachableCode false` (TS7027) across all six packages — clean
- `knip` and `depcheck` — findings were exactly the false positives already catalogued in `CLAUDE.md` (`node-pg-migrate`, `zod`, `postcss`/`autoprefixer`, `prettier`, the shell-invoked scripts, migration files)
- `eslint` — 0 errors; only `import/no-duplicates` style warnings in test files
- v8 coverage on `@beevibe/core` — the zero-coverage files map exactly onto the Postgres-gated suites that were excluded to get a report at all, so the gaps are an artifact of the exclusion rather than evidence of dead code
- a name-by-name grep of all 955 exported symbols and 431 class methods — every hit turned out to be used within its own declaring file (a redundant `export`, which `CLAUDE.md` says to leave alone) or is a documented false positive

What surfaced these six is a category none of those tools check. `knip` only tracks whether a *symbol* is imported, and `tsc`'s unused checks stop at locals and parameters, so an unused **member of an exported interface** is invisible to both. Sweeping every field of every exported interface against the whole monorepo is what found them.

## Deliberately kept

`AgentDisplay.merge_events` is equally unreferenced but is documented `/** Reserved for future memory-merge telemetry. */` — an explicit statement of intent, so it's left alone on the same grounds as the unfinished-wiring entries in `CLAUDE.md`. Happy to drop it too if that reservation is stale.

## Risk

Types are erased at runtime, so there is no behavioural change. `runtime_config` is JSONB, so any stored row that happens to carry a `timeout_ms` key is unaffected — nothing read it before this change either.

## Validation

`typecheck`, `lint` and `build` are green across all packages (web built directly via `next build` to bypass Turbo's env stripping). Full test suite run per package:

| Package | Result |
| --- | --- |
| `@beevibe/core` | 609 pass, 7 fail |
| `@beevibe/api` | 820 pass, 0 fail |
| `@beevibe/scheduler` | 10 pass |
| `@beevibe/daemon` | 156 pass, 0 fail |
| `@beevibe/sandbox` | 109 pass, 0 fail |
| `@beevibe/web` | 203 pass, 0 fail |

Every failure is `DATABASE_URL_TEST env var is required` or a missing `OPENAI_API_KEY`/`ANTHROPIC_API_KEY` — the environmental set documented in `CLAUDE.md`, matching the recorded bare-sandbox baseline. None touch the changed files.

The `@vitest/coverage-v8` provider installed for the coverage pass was reverted and is not part of this diff, per `CLAUDE.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011TMB2t1WQF93MRUoEYc2rz)_