### PR TITLE
test: drop the last thin-delegation test, make assembleTools pin sets not counts

### DIFF
--- a/packages/api/src/tools/assemble.test.ts
+++ b/packages/api/src/tools/assemble.test.ts
@@ -7,6 +7,12 @@
  * conversation. This test pins exactly which tool names survive the filter
  * so a future tool addition can't accidentally leak into the restricted
  * surface.
+ *
+ * Every assertion here compares the whole sorted name set rather than
+ * spot-checking membership or counting — a count passes for the wrong set,
+ * and a `names.has(...)` sweep says nothing about a tool nobody thought to
+ * list. Adding a tool is meant to fail these; the fix is to add it to the
+ * table above the tier it belongs to, which is the review moment.
  */
 import { describe, expect, it, vi } from "vitest";
 import type {
@@ -100,108 +106,144 @@ function icCtx(
   return { caller, beevibeSid: "sess_test", spawnMode, capabilityNetworkEnabled };
 }
 
+/** Everything an IC gets on a daemon, capability network on. */
+const IC_TOOLS = [
+  "create_work_product",
+  "find_repo",
+  "find_up",
+  "get_agent_profile",
+  "get_task",
+  "get_work_product",
+  "list_work_products",
+  "report_blocker",
+  "respond_ask",
+  "save_memory",
+  "search_context",
+  "session_search",
+  "update_core_memory",
+  "update_progress",
+  "update_work_product",
+  "use_repo",
+];
+
+/** Added on top of the IC set for tiers that can have subordinates. */
+const TEAM_ONLY_TOOLS = [
+  "add_to_escalation",
+  "ask",
+  "check_work_status",
+  "create_subordinate_agent",
+  "create_task",
+  "escalate_to_humans",
+  "find_peers",
+  "find_subordinates",
+  "negotiate",
+  "respond_negotiate",
+  "revise_task",
+  "unwatch",
+  "watch_tasks",
+];
+
+/** Gated off by owner flag `capability_network_enabled = false`. */
+const CAPABILITY_NETWORK_TOOLS = ["find_repo", "use_repo"];
+
+/**
+ * Exactly what a team caller keeps under `server_fallback_mesh`: mesh
+ * response paths, escalation openers, read-only context, progress on the
+ * in-flight session, and the memory writes that are part of the
+ * conversation's own record. Nothing that mutates state outside it, and
+ * no capability-network tools.
+ */
+const TEAM_FALLBACK_TOOLS = [
+  "check_work_status",
+  "escalate_to_humans",
+  "find_peers",
+  "find_subordinates",
+  "find_up",
+  "get_agent_profile",
+  "get_task",
+  "get_work_product",
+  "list_work_products",
+  "report_blocker",
+  "respond_ask",
+  "respond_negotiate",
+  "save_memory",
+  "search_context",
+  "session_search",
+  "update_core_memory",
+  "update_progress",
+];
+
+/** The team fallback set minus everything that implies subordinates. */
+const IC_FALLBACK_TOOLS = TEAM_FALLBACK_TOOLS.filter(
+  (n) =>
+    ![
+      "check_work_status",
+      "escalate_to_humans",
+      "find_peers",
+      "find_subordinates",
+      "respond_negotiate",
+    ].includes(n),
+);
+
+function toolNames(ctx: AssembleToolsContext): string[] {
+  return assembleTools(ctx, buildMinimalServices())
+    .map((t) => t.name)
+    .sort();
+}
+
 describe("assembleTools — daemon (full surface)", () => {
-  it("team caller gets the full team surface (29 tools, includes find_repo + use_repo + watch_tasks/unwatch + session_search)", () => {
-    const tools = assembleTools(teamCtx(), buildMinimalServices());
-    expect(tools.length).toBe(29);
-    const names = new Set(tools.map((t) => t.name));
-    expect(names.has("create_task")).toBe(true);
-    expect(names.has("update_work_product")).toBe(true);
-    expect(names.has("get_work_product")).toBe(true);
-    expect(names.has("revise_task")).toBe(true);
-    expect(names.has("add_to_escalation")).toBe(true);
-    expect(names.has("create_subordinate_agent")).toBe(true);
-    expect(names.has("find_repo")).toBe(true);
-    expect(names.has("use_repo")).toBe(true);
-    expect(names.has("watch_tasks")).toBe(true);
-    expect(names.has("unwatch")).toBe(true);
-    expect(names.has("session_search")).toBe(true);
+  it("ic caller gets exactly the IC surface", () => {
+    expect(toolNames(icCtx())).toEqual([...IC_TOOLS].sort());
   });
 
-  it("ic caller gets the IC surface (16 tools, includes find_repo + use_repo + session_search; NO watch_tasks)", () => {
-    const tools = assembleTools(icCtx(), buildMinimalServices());
-    expect(tools.length).toBe(16);
-    const names = new Set(tools.map((t) => t.name));
-    expect(names.has("create_task")).toBe(false);
-    expect(names.has("respond_ask")).toBe(true);
-    expect(names.has("report_blocker")).toBe(true);
-    expect(names.has("find_repo")).toBe(true);
-    expect(names.has("use_repo")).toBe(true);
-    expect(names.has("session_search")).toBe(true);
-    expect(names.has("watch_tasks")).toBe(false);
-    expect(names.has("unwatch")).toBe(false);
+  it("team caller gets exactly the IC surface plus the delegation surface", () => {
+    expect(toolNames(teamCtx())).toEqual([...IC_TOOLS, ...TEAM_ONLY_TOOLS].sort());
   });
 
-  it("owner with capability_network_enabled=false gets neither find_repo nor use_repo", () => {
-    const teamTools = assembleTools(teamCtx(undefined, false), buildMinimalServices());
-    const teamNames = new Set(teamTools.map((t) => t.name));
-    expect(teamNames.has("find_repo")).toBe(false);
-    expect(teamNames.has("use_repo")).toBe(false);
-    // Other tools survive — flag only gates capability network.
-    expect(teamNames.has("create_task")).toBe(true);
-    expect(teamNames.has("save_memory")).toBe(true);
-
-    const icTools = assembleTools(icCtx(undefined, false), buildMinimalServices());
-    const icNames = new Set(icTools.map((t) => t.name));
-    expect(icNames.has("find_repo")).toBe(false);
-    expect(icNames.has("use_repo")).toBe(false);
+  it("capability_network_enabled=false drops find_repo + use_repo and nothing else", () => {
+    expect(toolNames(teamCtx(undefined, false))).toEqual(
+      [...IC_TOOLS, ...TEAM_ONLY_TOOLS]
+        .filter((n) => !CAPABILITY_NETWORK_TOOLS.includes(n))
+        .sort(),
+    );
+    expect(toolNames(icCtx(undefined, false))).toEqual(
+      IC_TOOLS.filter((n) => !CAPABILITY_NETWORK_TOOLS.includes(n)).sort(),
+    );
   });
 });
 
 describe("assembleTools — server_fallback_mesh (restricted surface)", () => {
-  it("strips mutating tools from a team caller", () => {
-    const tools = assembleTools(
-      teamCtx("server_fallback_mesh"),
-      buildMinimalServices(),
+  it("a team caller keeps exactly the read/respond/memory surface", () => {
+    expect(toolNames(teamCtx("server_fallback_mesh"))).toEqual(
+      [...TEAM_FALLBACK_TOOLS].sort(),
     );
-    const names = new Set(tools.map((t) => t.name));
-    // Mutating tools — must NOT be present
-    expect(names.has("create_task")).toBe(false);
-    expect(names.has("update_work_product")).toBe(false);
-    expect(names.has("revise_task")).toBe(false);
-    expect(names.has("add_to_escalation")).toBe(false);
-    expect(names.has("create_subordinate_agent")).toBe(false);
-    expect(names.has("create_work_product")).toBe(false);
   });
 
-  it("keeps response, read, escalation, and memory tools for a team caller", () => {
-    const tools = assembleTools(
-      teamCtx("server_fallback_mesh"),
-      buildMinimalServices(),
+  it("an ic caller keeps exactly that set minus the subordinate-implying tools", () => {
+    expect(toolNames(icCtx("server_fallback_mesh"))).toEqual(
+      [...IC_FALLBACK_TOOLS].sort(),
     );
-    const names = new Set(tools.map((t) => t.name));
-    // Mesh response paths
-    expect(names.has("respond_ask")).toBe(true);
-    expect(names.has("respond_negotiate")).toBe(true);
-    // Escalation paths (they don't write to escalation, they just open one)
-    expect(names.has("report_blocker")).toBe(true);
-    expect(names.has("escalate_to_humans")).toBe(true);
-    // Read context
-    expect(names.has("search_context")).toBe(true);
-    expect(names.has("get_agent_profile")).toBe(true);
-    expect(names.has("get_task")).toBe(true);
-    expect(names.has("find_up")).toBe(true);
-    expect(names.has("find_subordinates")).toBe(true);
-    expect(names.has("find_peers")).toBe(true);
-    expect(names.has("list_work_products")).toBe(true);
-    expect(names.has("check_work_status")).toBe(true);
-    // Update progress on the in-flight session itself
-    expect(names.has("update_progress")).toBe(true);
-    // Memory writes are part of the conversation's record
-    expect(names.has("save_memory")).toBe(true);
-    expect(names.has("update_core_memory")).toBe(true);
-    // Layer-3 recall is read-only and scope-respected — safe under fallback
-    expect(names.has("session_search")).toBe(true);
   });
 
-  it("ic caller in server_fallback_mesh has no mutating tools either", () => {
-    const tools = assembleTools(
-      icCtx("server_fallback_mesh"),
-      buildMinimalServices(),
-    );
-    const names = new Set(tools.map((t) => t.name));
-    expect(names.has("create_task")).toBe(false);
-    expect(names.has("update_work_product")).toBe(false);
-    expect(names.has("respond_ask")).toBe(true);
+  it("every mutating tool is stripped for both tiers", () => {
+    // The invariant the filter exists for: nothing that writes state
+    // outside the in-flight conversation survives.
+    const mutating = [
+      "add_to_escalation",
+      "ask",
+      "create_subordinate_agent",
+      "create_task",
+      "create_work_product",
+      "negotiate",
+      "revise_task",
+      "unwatch",
+      "update_work_product",
+      "watch_tasks",
+    ];
+    for (const name of mutating) {
+      expect(TEAM_FALLBACK_TOOLS).not.toContain(name);
+      expect(toolNames(teamCtx("server_fallback_mesh"))).not.toContain(name);
+      expect(toolNames(icCtx("server_fallback_mesh"))).not.toContain(name);
+    }
   });
 });

--- a/packages/core/src/services/memory/fact-store.test.ts
+++ b/packages/core/src/services/memory/fact-store.test.ts
@@ -184,12 +184,3 @@ describe("FactStore.addOrMerge — merge path", () => {
     expect(vi.mocked(repo.update).mock.calls[0]![1].content).toBe("merged text");
   });
 });
-
-describe("FactStore thin delegations", () => {
-  it("updateScope calls repo.update with just scope", async () => {
-    vi.mocked(repo.update).mockResolvedValue(makeFact({ scope: "team" }));
-    await store.updateScope("fact_x", "team");
-    expect(repo.update).toHaveBeenCalledWith("fact_x", { scope: "team" });
-  });
-
-});


### PR DESCRIPTION
Fifth sweep of the suite for tests that no longer earn their place. Most of the usual categories came back clean, so this is a small diff.

## Came back clean

- **No unconditional `.skip`, `.only`, `.todo`, or xfail anywhere.** Every skip in the tree is a live environment gate — `RUN_CLAUDE_SMOKE`, `BEEVIBE_E2E_DOCKER`, `BEEVIBE_E2E_MULTI_INSTANCE`, `HAS_LIVE_API_KEYS`, `process.platform === "win32"`.
- **No test references a removed API.** `pnpm typecheck` is clean across all 9 packages, so nothing imports a symbol dropped by the recent dead-code sweeps (#274, #285) or the contract unifications (#277, #279, #281, #283).
- **No assertion-free tests, no dead test helpers.** A scan of all 1,400-odd test blocks found none without assertions, and no unused locals left behind inside test files.

Two things did turn up.

## Removed — `updateScope calls repo.update with just scope`

`packages/core/src/services/memory/fact-store.test.ts`

#270 removed the two other tests in the `FactStore thin delegations` block for being pure pass-through, but left this one and the now single-test `describe` behind — along with the stray blank line where its siblings used to be. `FactStore.updateScope`'s entire body is:

```ts
return this.deps.repo.update(id, { scope: targetScope });
```

and the test asserts only that the mock received the argument the test just handed it. A wrong repo method fails typecheck first, so it can only fail when the test itself is edited. Same category, same block — it was simply missed.

## Strengthened — `assembleTools` tier and fallback gating

`packages/api/src/tools/assemble.test.ts`

The file's own docstring says it "pins exactly which tool names survive the filter so a future tool addition can't accidentally leak into the restricted surface." It did not:

- the full-surface tests asserted `tools.length === 29` / `=== 16` plus a handful of `names.has(...)` spot-checks;
- the two `server_fallback_mesh` tests were spot-checks only.

A magic count passes for the wrong set of the right size, and a membership sweep says nothing about a tool nobody thought to list.

All five assertions now compare the whole sorted name set against a named table, the shape #270 established for `buildHierarchyTools`: `IC_TOOLS`, `TEAM_ONLY_TOOLS`, `CAPABILITY_NETWORK_TOOLS`, `TEAM_FALLBACK_TOOLS`, and `IC_FALLBACK_TOOLS` derived from the team set by subtracting the subordinate-implying tools. A sixth test asserts the invariant the filter exists for directly: no mutating tool survives for either tier. The magic numbers are gone.

**Verified by mutation.** Adding `"ask"` to `filterForServerFallback`'s `allowedMesh` — leaking a tool that opens a new mesh ask to another agent into the restricted surface, exactly what the docstring promises to catch — passes the old tests 6/6 and fails two of the new ones. No production file changed in this PR.

## Considered and deliberately kept

- **`mcp.test.ts`'s `tools.tools.length === 29`.** Same magic number, but it sits in the live-API-key-gated integration suite where the count is a wire-level assertion against a real MCP `tools/list` round-trip, and it already lists the names it cares about.
- **The SQL-text assertions in `views/dashboard.test.ts`.** They read as implementation detail, but each guards a documented regression (the chat-session gauge oscillation) that a mock pool gives no other way to observe.
- **`views/activity.test.ts` and `views/promotions.test.ts`,** which cover surfaces with no in-repo caller. CLAUDE.md marks both as deliberate: `GET /activity` is a documented public endpoint, and the promotion read side is unfinished wiring, not dead code.
- **`tools/save-memory.test.ts` and `tools/update-core-memory.test.ts` "delegates to …" tests.** Despite the names they assert the MCP result envelope and the tool descriptor's `name` / `schema.required`, which cross a protocol boundary TypeScript can't pin.

## Verification

- `pnpm typecheck` and `pnpm lint` clean across all 9 packages.
- Core: **609 → 608 passing**, failure count unchanged at **7** (all environmental — no Postgres, no provider keys). Exactly the one removed test and nothing else.
- api: **820 passing, 0 test failures**. The 7 file-level errors are the documented DB-gated collection failures.
- web: **203/203**.

---
_Generated by [Claude Code](https://claude.ai/code/session_015J3uHrbRukE5TXYjnskJDc)_