### PR TITLE
test: cover the agent-facing MCP tool surface (87% → 99.7% lines)

### DIFF
--- a/packages/api/src/tools/find-repo.test.ts
+++ b/packages/api/src/tools/find-repo.test.ts
@@ -569,3 +569,291 @@ describe("find_repo tool — output shape", () => {
     ]);
   });
 });
+
+/* ─── Default HTTP clients ──────────────────────────────────────────
+ *
+ * Every test above injects `communityRegistry` / `trending` fakes, which
+ * leaves the shipped HTTP clients — the ones production actually runs —
+ * untested. Omitting those two services from `services` selects the real
+ * clients; the injected `fetcher` still keeps the network out of it.
+ * What matters here is the failure posture: these are best-effort tiers,
+ * so a 404, malformed JSON, or a hung socket must degrade to "no
+ * candidates from this tier", never take the whole call down.
+ */
+
+const REGISTRY_URL =
+  "https://raw.githubusercontent.com/beevibe-ai/beevibe-capabilities/main/data/registry.json";
+const TRENDING_DAILY_URL =
+  "https://raw.githubusercontent.com/beevibe-ai/beevibe-capabilities/main/data/trending-daily.json";
+
+interface CapabilitiesRoutes {
+  registry?: { ok?: boolean; body?: unknown };
+  trendingDaily?: { ok?: boolean; body?: unknown };
+  github?: Array<{ html_url: string; description?: string | null; stargazers_count?: number }>;
+}
+
+/** Fetcher that answers the capabilities-repo URLs and the GitHub search. */
+function capabilitiesFetcher(routes: CapabilitiesRoutes): typeof fetch {
+  return vi.fn(async (url: unknown) => {
+    const u = String(url);
+    if (u === REGISTRY_URL) {
+      const r = routes.registry;
+      if (!r) return { ok: false, status: 404, json: async () => ({}) };
+      return { ok: r.ok !== false, status: 200, json: async () => r.body };
+    }
+    if (u === TRENDING_DAILY_URL) {
+      const t = routes.trendingDaily;
+      if (!t) return { ok: false, status: 404, json: async () => ({}) };
+      return { ok: t.ok !== false, status: 200, json: async () => t.body };
+    }
+    if (u.includes("api.github.com/search/repositories")) {
+      return { ok: true, status: 200, json: async () => ({ items: routes.github ?? [] }) };
+    }
+    // Everything else (trending-weekly) 404s.
+    return { ok: false, status: 404, json: async () => ({}) };
+  }) as unknown as typeof fetch;
+}
+
+/** Services with the real HTTP clients, only the fetcher faked. */
+function httpClientServices(fetcher: typeof fetch) {
+  return {
+    agentRepo: fakeAgentRepo(),
+    learnedSkillRepo: fakeLearnedSkillRepo(),
+    embeddings: fakeEmbeddingsAllMatch(),
+    fetcher,
+  };
+}
+
+describe("find_repo — default community registry client", () => {
+  it("scores repos from a fetched registry", async () => {
+    const fetcher = capabilitiesFetcher({
+      registry: {
+        body: {
+          skills: [{ repo_url: CAMELOT, goal_pattern: "extract tables from PDFs" }],
+        },
+      },
+    });
+    const tool = createFindRepoTool({ agentId: AGENT_ID }, httpClientServices(fetcher));
+
+    const result = await tool.handler({ goal: "extract tables from a PDF" });
+
+    const candidates = (result.content as { candidates: FindRepoCandidate[] }).candidates;
+    expect(candidates.map((c) => c.repo_url)).toContain(CAMELOT);
+    expect(candidates[0]?.sources).toContain("community");
+  });
+
+  it("caches the registry for the tool's lifetime", async () => {
+    const fetcher = capabilitiesFetcher({
+      registry: {
+        body: { skills: [{ repo_url: CAMELOT, goal_pattern: "extract tables" }] },
+      },
+    });
+    const tool = createFindRepoTool({ agentId: AGENT_ID }, httpClientServices(fetcher));
+
+    await tool.handler({ goal: "extract tables from a PDF" });
+    await tool.handler({ goal: "extract tables from a PDF" });
+
+    const registryCalls = (fetcher as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c) => String(c[0]) === REGISTRY_URL,
+    );
+    expect(registryCalls).toHaveLength(1);
+  });
+
+  it.each([
+    ["a non-ok response", {}],
+    ["a null body", { registry: { body: null } }],
+    ["a body with no skills array", { registry: { body: { skills: "nope" } } }],
+  ])("notes the tier as unavailable on %s", async (_label, routes) => {
+    const fetcher = capabilitiesFetcher(routes as CapabilitiesRoutes);
+    const tool = createFindRepoTool({ agentId: AGENT_ID }, httpClientServices(fetcher));
+
+    const result = await tool.handler({ goal: "extract tables from a PDF" });
+
+    expect(result.isError).toBeFalsy();
+    expect((result.content as { notes?: string[] }).notes).toContain(
+      "community registry unavailable (proceeding without Tier 1)",
+    );
+  });
+
+  it("swallows a thrown fetch rather than failing the call", async () => {
+    const fetcher = vi.fn(async (url: unknown) => {
+      if (String(url).includes("api.github.com")) {
+        return { ok: true, status: 200, json: async () => ({ items: [] }) };
+      }
+      throw new Error("socket hang up");
+    }) as unknown as typeof fetch;
+    const tool = createFindRepoTool({ agentId: AGENT_ID }, httpClientServices(fetcher));
+
+    const result = await tool.handler({ goal: "extract tables from a PDF" });
+
+    expect(result.isError).toBeFalsy();
+    expect((result.content as { notes?: string[] }).notes).toContain(
+      "community registry unavailable (proceeding without Tier 1)",
+    );
+  });
+});
+
+describe("find_repo — default trending client", () => {
+  it("boosts a github candidate that appears in the daily snapshot", async () => {
+    const fetcher = capabilitiesFetcher({
+      trendingDaily: { body: { period: "daily", repos: [{ repo_url: CAMELOT }] } },
+      github: [
+        { html_url: CAMELOT, description: "table extraction", stargazers_count: 10 },
+        { html_url: RANDOM, description: "unrelated", stargazers_count: 10 },
+      ],
+    });
+    const tool = createFindRepoTool({ agentId: AGENT_ID }, httpClientServices(fetcher));
+
+    const result = await tool.handler({ goal: "extract tables from a PDF" });
+
+    const candidates = (result.content as { candidates: FindRepoCandidate[] }).candidates;
+    expect(candidates[0]?.repo_url).toBe(CAMELOT);
+    expect(candidates[0]?.sources).toContain("trending");
+  });
+
+  it("caches each period separately, including the 404 miss", async () => {
+    const fetcher = capabilitiesFetcher({
+      trendingDaily: { body: { period: "daily", repos: [{ repo_url: CAMELOT }] } },
+    });
+    const tool = createFindRepoTool({ agentId: AGENT_ID }, httpClientServices(fetcher));
+
+    await tool.handler({ goal: "extract tables from a PDF" });
+    await tool.handler({ goal: "extract tables from a PDF" });
+
+    const calls = (fetcher as unknown as ReturnType<typeof vi.fn>).mock.calls.map((c) =>
+      String(c[0]),
+    );
+    // Caching the miss matters as much as caching the hit — a long
+    // outage must not turn into two raw.githubusercontent hits per call.
+    expect(calls.filter((u) => u === TRENDING_DAILY_URL)).toHaveLength(1);
+    expect(calls.filter((u) => u.includes("trending-weekly"))).toHaveLength(1);
+  });
+
+  it("tolerates a snapshot whose repos field isn't an array", async () => {
+    const fetcher = capabilitiesFetcher({
+      trendingDaily: { body: { period: "daily", repos: null } },
+      github: [{ html_url: CAMELOT, description: "table extraction", stargazers_count: 10 }],
+    });
+    const tool = createFindRepoTool({ agentId: AGENT_ID }, httpClientServices(fetcher));
+
+    const result = await tool.handler({ goal: "extract tables from a PDF" });
+
+    const candidates = (result.content as { candidates: FindRepoCandidate[] }).candidates;
+    expect(candidates[0]?.sources).not.toContain("trending");
+  });
+
+  it("swallows a thrown fetch rather than failing the call", async () => {
+    const fetcher = vi.fn(async (url: unknown) => {
+      const u = String(url);
+      if (u.includes("api.github.com")) {
+        return { ok: true, status: 200, json: async () => ({ items: [] }) };
+      }
+      if (u === REGISTRY_URL) return { ok: false, status: 404, json: async () => ({}) };
+      throw new Error("socket hang up");
+    }) as unknown as typeof fetch;
+    const tool = createFindRepoTool({ agentId: AGENT_ID }, httpClientServices(fetcher));
+
+    const result = await tool.handler({ goal: "extract tables from a PDF" });
+
+    expect(result.isError).toBeFalsy();
+  });
+});
+
+describe("find_repo — precomputed embeddings", () => {
+  it("skips the runtime embed call for entries that ship a vector", async () => {
+    const embeddings = fakeEmbeddingsAllMatch();
+    const tool = createFindRepoTool(
+      { agentId: AGENT_ID },
+      {
+        ...BASE_SERVICES(),
+        embeddings,
+        trending: trendingWithEntriesAndVectors([
+          {
+            repo_url: CAMELOT,
+            owner: "camelot-dev",
+            name: "camelot",
+            description: "PDF table extraction",
+            stars_gained: 400,
+            embedding: [1, 0],
+          },
+        ]),
+      },
+    );
+
+    const result = await tool.handler({ goal: "extract tables from a PDF" });
+
+    const candidates = (result.content as { candidates: FindRepoCandidate[] }).candidates;
+    expect(candidates.map((c) => c.repo_url)).toContain(CAMELOT);
+    // One embed call for the goal itself; the entry's vector came from
+    // the snapshot, so nothing was batched.
+    expect(embeddings.embedBatch).not.toHaveBeenCalled();
+    expect(embeddings.embed).toHaveBeenCalledTimes(1);
+  });
+});
+
+function trendingWithEntriesAndVectors(
+  entries: Array<{
+    repo_url: string;
+    owner?: string;
+    name?: string;
+    description?: string | null;
+    stars_gained?: number;
+    embedding?: number[];
+  }>,
+): TrendingClient {
+  const urls = new Set<string>(entries.map((e) => normalizeForTest(e.repo_url)));
+  return {
+    snapshot: vi.fn(async (p: TrendingPeriod) =>
+      p === "daily" ? { urls, entries } : { urls: new Set<string>(), entries: [] },
+    ),
+  };
+}
+
+describe("find_repo — github search failures", () => {
+  it("notes a non-ok GitHub search instead of failing the call", async () => {
+    const fetcher = vi.fn(async (url: unknown) => {
+      if (String(url).includes("api.github.com")) {
+        return { ok: false, status: 403, json: async () => ({}) };
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    }) as unknown as typeof fetch;
+    const tool = createFindRepoTool({ agentId: AGENT_ID }, httpClientServices(fetcher));
+
+    const result = await tool.handler({ goal: "extract tables from a PDF" });
+
+    expect(result.isError).toBeFalsy();
+    const notes = (result.content as { notes?: string[] }).notes ?? [];
+    expect(notes.some((n) => n.includes("403"))).toBe(true);
+  });
+});
+
+describe("find_repo — embedding outage", () => {
+  it("drops to github-search-only and says so when the goal can't be embedded", async () => {
+    const embeddings = {
+      type: "fake:down",
+      embed: vi.fn(async () => {
+        throw new Error("provider 503");
+      }),
+      embedBatch: vi.fn(async () => []),
+    } as unknown as EmbeddingService;
+    const tool = createFindRepoTool(
+      { agentId: AGENT_ID },
+      {
+        ...BASE_SERVICES(),
+        embeddings,
+        trending: trendingWith([CAMELOT]),
+        fetcher: githubFetcher([
+          { html_url: CAMELOT, description: "table extraction", stargazers_count: 10 },
+        ]),
+      },
+    );
+
+    const result = await tool.handler({ goal: "extract tables from a PDF" });
+
+    expect(result.isError).toBeFalsy();
+    const body = result.content as { candidates: FindRepoCandidate[]; notes?: string[] };
+    expect(body.notes?.some((n) => n.includes("embedding goal failed"))).toBe(true);
+    // The non-semantic tiers still run — github search is unaffected.
+    expect(body.candidates.map((c) => c.repo_url)).toContain(CAMELOT);
+  });
+});

--- a/packages/api/src/tools/hierarchy.test.ts
+++ b/packages/api/src/tools/hierarchy.test.ts
@@ -6,11 +6,13 @@
  * (ctx, services); the fakes here exercise auth + delegation.
  */
 import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_BLOCK_TEMPLATES } from "@beevibe/core";
 import type {
   Agent,
   AgentProvisionEventRepository,
   AgentRepository,
   CoreMemoryBlockRepository,
+  Escalation,
   HierarchyLevel,
   Session,
   Task,
@@ -20,7 +22,10 @@ import type {
   WorkProductRepository,
 } from "@beevibe/core";
 import type { MemoryAgent } from "@beevibe/core/services/memory";
-import type { TaskService } from "@beevibe/core/services/task-service";
+import {
+  InvalidTaskTransitionError,
+  type TaskService,
+} from "@beevibe/core/services/task-service";
 import type { EscalationService } from "@beevibe/core/services/escalation-service";
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
 import type { Pool } from "@beevibe/core/adapters/postgres";
@@ -69,6 +74,23 @@ function fakeWp(overrides: Partial<WorkProduct> = {}): WorkProduct {
   };
 }
 
+function fakeEscalation(overrides: Partial<Escalation> = {}): Escalation {
+  return {
+    id: "esc_1",
+    negotiation_id: "neg_1",
+    initiator_session_id: "sess_i",
+    counterparty_session_id: "sess_c",
+    summary: "stuck on scheduling",
+    initiator_open_questions: [],
+    counterparty_open_questions: [],
+    escalated_by_role: "initiator",
+    status: "pending",
+    created_at: new Date("2026-04-01"),
+    updated_at: new Date("2026-04-01"),
+    ...overrides,
+  };
+}
+
 function fakeWpListItem(
   overrides: Partial<WorkProductListItem> = {},
 ): WorkProductListItem {
@@ -84,6 +106,8 @@ function buildServices(overrides: {
   memoryAgent?: Partial<MemoryAgent>;
   escalationService?: Partial<EscalationService>;
   dispatchService?: Partial<DispatchService>;
+  coreMemoryRepo?: Partial<CoreMemoryBlockRepository>;
+  agentProvisionEventRepo?: Partial<AgentProvisionEventRepository>;
 } = {}) {
   const agentRepo = {
     findById: vi.fn(async () => undefined),
@@ -128,7 +152,7 @@ function buildServices(overrides: {
 
   const escalationService = {
     create: vi.fn(),
-    addContribution: vi.fn(async () => ({ id: "esc_1", status: "pending" })),
+    addContribution: vi.fn(async () => fakeEscalation()),
     resolve: vi.fn(),
     ...overrides.escalationService,
   } as unknown as EscalationService;
@@ -154,13 +178,16 @@ function buildServices(overrides: {
 
   const coreMemoryRepo = {
     findByAgent: vi.fn(async () => []),
+    initDefaults: vi.fn(async () => []),
     updateContent: vi.fn(async () => undefined),
+    ...overrides.coreMemoryRepo,
   } as unknown as CoreMemoryBlockRepository;
 
   const agentProvisionEventRepo = {
     create: vi.fn(async () => ({})),
     countByParentSince: vi.fn(async () => 0),
     listByParent: vi.fn(async () => []),
+    ...overrides.agentProvisionEventRepo,
   } as unknown as AgentProvisionEventRepository;
 
   return {
@@ -574,5 +601,769 @@ describe("check_work_status", () => {
     const result = await callTool(tools, "check_work_status", { agent_id: "rando" });
     expect(result.isError).toBe(true);
     expect((result.content as { error: string }).error).toBe("unauthorized");
+  });
+});
+
+describe("revise_task", () => {
+  const revision = {
+    kind: "revision" as const,
+    source: "parent_agent" as const,
+    from_status: "blocked" as const,
+    feedback: "use the mirror registry",
+  };
+
+  /** Blocked task assigned to a direct child of `agent_t`. */
+  function reviseServices(
+    overrides: Parameters<typeof buildServices>[0] = {},
+  ): ReturnType<typeof buildServices> {
+    return buildServices({
+      taskRepo: {
+        findById: vi.fn(async () =>
+          fakeTask({ id: "task_1", status: "blocked", assignee_id: "sub_1" }),
+        ),
+        ...overrides.taskRepo,
+      },
+      agentRepo: {
+        findById: vi.fn(async () =>
+          fakeAgent({ id: "sub_1", hierarchy_level: "ic", parent_agent_id: "agent_t" }),
+        ),
+        ...overrides.agentRepo,
+      },
+      taskService: {
+        reviseTask: vi.fn(async () =>
+          fakeTask({
+            id: "task_1",
+            status: "needs_revision",
+            assignee_id: "sub_1",
+            next_dispatch_context: revision,
+          }),
+        ),
+        ...overrides.taskService,
+      },
+    });
+  }
+
+  function reviseTools(services: ReturnType<typeof buildServices>): AgentTool[] {
+    return buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+  }
+
+  it("revises then dispatches the resume session with the stamped context", async () => {
+    const services = reviseServices();
+
+    const result = await callTool(reviseTools(services), "revise_task", {
+      task_id: "task_1",
+      feedback: "use the mirror registry",
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(services.taskService.reviseTask).toHaveBeenCalledWith(
+      "task_1",
+      "use the mirror registry",
+      { source: "parent_agent", reviserAgentId: "agent_t" },
+    );
+    expect(services.dispatchService.dispatchTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "sub_1",
+        type: "task",
+        reason: revision,
+        intent: expect.stringContaining('<context type="revision"'),
+      }),
+    );
+    expect(result.content).toMatchObject({
+      revised: true,
+      task_id: "task_1",
+      // The task stays at needs_revision until the daemon claims the
+      // session — the tool must not optimistically report "revision".
+      status: "needs_revision",
+      from_status: "blocked",
+    });
+  });
+
+  it("skips the dispatch when reviseTask stamped no revision context", async () => {
+    const services = reviseServices({
+      taskService: {
+        reviseTask: vi.fn(async () =>
+          fakeTask({ id: "task_1", status: "needs_revision", assignee_id: "sub_1" }),
+        ),
+      },
+    });
+
+    const result = await callTool(reviseTools(services), "revise_task", {
+      task_id: "task_1",
+      feedback: "f",
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(services.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["a missing task_id", { feedback: "f" }],
+    ["a missing feedback", { task_id: "task_1" }],
+  ])("rejects %s", async (_label, input) => {
+    const services = reviseServices();
+
+    const result = await callTool(reviseTools(services), "revise_task", input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "task_id and feedback required" });
+    expect(services.taskService.reviseTask).not.toHaveBeenCalled();
+  });
+
+  it("404s an unknown task", async () => {
+    const services = reviseServices({
+      taskRepo: { findById: vi.fn(async () => undefined) },
+    });
+
+    const result = await callTool(reviseTools(services), "revise_task", {
+      task_id: "task_nope",
+      feedback: "f",
+    });
+
+    expect(result.content).toEqual({ error: "task_not_found", task_id: "task_nope" });
+  });
+
+  it("refuses an unassigned task", async () => {
+    const services = reviseServices({
+      taskRepo: {
+        findById: vi.fn(async () => fakeTask({ id: "task_1", status: "blocked" })),
+      },
+    });
+
+    const result = await callTool(reviseTools(services), "revise_task", {
+      task_id: "task_1",
+      feedback: "f",
+    });
+
+    expect(result.content).toMatchObject({ error: "task_unassigned" });
+  });
+
+  it("refuses when the assignee row is gone", async () => {
+    const services = reviseServices({
+      agentRepo: { findById: vi.fn(async () => undefined) },
+    });
+
+    const result = await callTool(reviseTools(services), "revise_task", {
+      task_id: "task_1",
+      feedback: "f",
+    });
+
+    expect(result.content).toEqual({ error: "assignee_not_found" });
+  });
+
+  it("refuses a caller who is not the assignee's direct parent", async () => {
+    const services = reviseServices({
+      agentRepo: {
+        findById: vi.fn(async () =>
+          fakeAgent({ id: "sub_1", parent_agent_id: "agent_someone_else" }),
+        ),
+      },
+    });
+
+    const result = await callTool(reviseTools(services), "revise_task", {
+      task_id: "task_1",
+      feedback: "f",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "not_parent" });
+    expect(services.taskService.reviseTask).not.toHaveBeenCalled();
+  });
+
+  it("maps InvalidTaskTransitionError to invalid_transition", async () => {
+    const services = reviseServices({
+      taskService: {
+        reviseTask: vi.fn(async () => {
+          throw new InvalidTaskTransitionError(
+            "cannot revise task task_1 from status done",
+          );
+        }),
+      },
+    });
+
+    const result = await callTool(reviseTools(services), "revise_task", {
+      task_id: "task_1",
+      feedback: "f",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "invalid_transition" });
+  });
+
+  it("falls back to the catch-all envelope for any other throw", async () => {
+    const services = reviseServices({
+      taskService: {
+        reviseTask: vi.fn(async () => {
+          throw new Error("pool exhausted");
+        }),
+      },
+    });
+
+    const result = await callTool(reviseTools(services), "revise_task", {
+      task_id: "task_1",
+      feedback: "f",
+    });
+
+    expect(result.content).toEqual({ error: "pool exhausted" });
+  });
+});
+
+describe("add_to_escalation", () => {
+  function tools(services: ReturnType<typeof buildServices>): AgentTool[] {
+    return buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+  }
+
+  it("submits the caller's slot, notifies listeners, and reports both-sides state", async () => {
+    const services = buildServices({
+      escalationService: {
+        addContribution: vi.fn(async () =>
+          fakeEscalation({
+            initiator_submitted_at: new Date("2026-04-01"),
+            counterparty_submitted_at: new Date("2026-04-02"),
+          }),
+        ),
+      } as Partial<EscalationService>,
+    });
+    const proposals = [{ title: "A", description: "do A" }];
+
+    const result = await callTool(tools(services), "add_to_escalation", {
+      escalation_id: "esc_1",
+      proposals,
+      open_questions: ["when?", 42],
+    });
+
+    expect(services.escalationService.addContribution).toHaveBeenCalledWith({
+      escalationId: "esc_1",
+      callerAgentId: "agent_t",
+      proposals,
+      // Non-string questions are filtered, not forwarded.
+      openQuestions: ["when?"],
+    });
+    expect(services.pool.query).toHaveBeenCalledWith(
+      expect.stringContaining("pg_notify('escalation_updated'"),
+      ["esc_1"],
+    );
+    expect(result.content).toEqual({
+      escalation_id: "esc_1",
+      status: "pending",
+      both_sides_submitted: true,
+    });
+  });
+
+  it("reports both_sides_submitted false while a slot is still empty", async () => {
+    const services = buildServices({
+      escalationService: {
+        addContribution: vi.fn(async () =>
+          fakeEscalation({ initiator_submitted_at: new Date("2026-04-01") }),
+        ),
+      } as Partial<EscalationService>,
+    });
+
+    const result = await callTool(tools(services), "add_to_escalation", {
+      escalation_id: "esc_1",
+    });
+
+    expect(result.content).toMatchObject({ both_sides_submitted: false });
+  });
+
+  it("omits proposals and open_questions when they aren't arrays", async () => {
+    const services = buildServices();
+
+    await callTool(tools(services), "add_to_escalation", {
+      escalation_id: "esc_1",
+      proposals: "A or B",
+      open_questions: "when?",
+    });
+
+    expect(services.escalationService.addContribution).toHaveBeenCalledWith(
+      expect.objectContaining({ proposals: undefined, openQuestions: undefined }),
+    );
+  });
+
+  it("rejects a missing escalation_id", async () => {
+    const services = buildServices();
+
+    const result = await callTool(tools(services), "add_to_escalation", {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "escalation_id required" });
+    expect(services.escalationService.addContribution).not.toHaveBeenCalled();
+  });
+
+  it("wraps a service throw in the catch-all envelope", async () => {
+    const services = buildServices({
+      escalationService: {
+        addContribution: vi.fn(async () => {
+          throw new Error("already submitted");
+        }),
+      } as Partial<EscalationService>,
+    });
+
+    const result = await callTool(tools(services), "add_to_escalation", {
+      escalation_id: "esc_1",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "already submitted" });
+  });
+});
+
+describe("create_subordinate_agent", () => {
+  const validInput = {
+    name: "Backend specialist",
+    tag_line: "Owns the API surface",
+    persona: "Pragmatic, terse, tests first.",
+    domain: "packages/api",
+  };
+
+  function spawnServices(
+    overrides: Parameters<typeof buildServices>[0] = {},
+  ): ReturnType<typeof buildServices> {
+    return buildServices({
+      agentRepo: {
+        findById: vi.fn(async () =>
+          fakeAgent({
+            id: "agent_t",
+            name: "Team lead",
+            owner_id: "person_1",
+            runtime_config: { type: "claude", model: "opus" },
+          }),
+        ),
+        create: vi.fn(async (input: unknown) => fakeAgent(input as Partial<Agent>)),
+        ...overrides.agentRepo,
+      },
+      coreMemoryRepo: overrides.coreMemoryRepo,
+      agentProvisionEventRepo: overrides.agentProvisionEventRepo,
+    });
+  }
+
+  function spawnTools(services: ReturnType<typeof buildServices>): AgentTool[] {
+    return buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+  }
+
+  it("provisions an IC under the caller, inheriting owner and runtime", async () => {
+    const services = spawnServices();
+
+    const result = await callTool(spawnTools(services), "create_subordinate_agent", validInput);
+
+    expect(result.isError).toBeFalsy();
+    expect(services.agentRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Backend specialist",
+        owner_id: "person_1",
+        parent_agent_id: "agent_t",
+        hierarchy_level: "ic",
+        runtime_config: expect.objectContaining({
+          type: "claude",
+          model: "opus",
+          // The persona lives in core memory; the system prompt carries
+          // the name only.
+          system_prompt_addition: "You are Backend specialist.",
+        }),
+      }),
+    );
+    expect(result.content).toMatchObject({
+      created: { hierarchy_level: "ic", parent_agent_id: "agent_t" },
+    });
+  });
+
+  it("seeds only the identity blocks the parent actually supplied", async () => {
+    const services = spawnServices();
+
+    await callTool(spawnTools(services), "create_subordinate_agent", validInput);
+
+    const seeded = (services.coreMemoryRepo.updateContent as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[1],
+    );
+    expect(seeded.sort()).toEqual(["domain", "persona", "tag_line"]);
+  });
+
+  it("seeds the optional blocks when they carry content", async () => {
+    const services = spawnServices();
+
+    await callTool(spawnTools(services), "create_subordinate_agent", {
+      ...validInput,
+      active_context: "Migrating auth to JWT",
+      constraints: "No breaking API changes",
+    });
+
+    const seeded = (services.coreMemoryRepo.updateContent as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[1],
+    );
+    expect(seeded.sort()).toEqual([
+      "active_context",
+      "constraints",
+      "domain",
+      "persona",
+      "tag_line",
+    ]);
+  });
+
+  it("pins the child to the parent's runtime when the parent has one", async () => {
+    const services = spawnServices({
+      agentRepo: {
+        findById: vi.fn(async () =>
+          fakeAgent({ id: "agent_t", preferred_runtime_id: "rt_1" }),
+        ),
+        create: vi.fn(async (input: Partial<Agent>) => fakeAgent(input)),
+      },
+    });
+
+    await callTool(spawnTools(services), "create_subordinate_agent", validInput);
+
+    expect(services.agentRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ preferred_runtime_id: "rt_1" }),
+    );
+  });
+
+  it("writes the audit row that backs the daily cap", async () => {
+    const services = spawnServices();
+
+    await callTool(spawnTools(services), "create_subordinate_agent", validInput);
+
+    expect(services.agentProvisionEventRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parent_agent_id: "agent_t",
+        owner_person_id: "person_1",
+        child_name: "Backend specialist",
+        persona: validInput.persona,
+        domain: validInput.domain,
+      }),
+    );
+  });
+
+  it("still returns the new agent when the audit row fails to write", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const services = spawnServices({
+      agentProvisionEventRepo: {
+        create: vi.fn(async () => {
+          throw new Error("audit table locked");
+        }),
+      },
+    });
+
+    const result = await callTool(spawnTools(services), "create_subordinate_agent", validInput);
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toMatchObject({ created: { hierarchy_level: "ic" } });
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it.each([
+    ["name", { ...validInput, name: "  " }],
+    ["tag_line", { ...validInput, tag_line: "" }],
+    ["persona", { ...validInput, persona: "   " }],
+    ["domain", { ...validInput, domain: "" }],
+  ])("rejects a blank %s", async (_field, input) => {
+    const services = spawnServices();
+
+    const result = await callTool(spawnTools(services), "create_subordinate_agent", input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "missing_required_fields" });
+    expect(services.agentRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects a tag_line over 100 chars and reports the actual length", async () => {
+    const services = spawnServices();
+
+    const result = await callTool(spawnTools(services), "create_subordinate_agent", {
+      ...validInput,
+      tag_line: "x".repeat(101),
+    });
+
+    expect(result.content).toMatchObject({ error: "tag_line_too_long", actual: 101 });
+    expect(services.agentRepo.create).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["over 80 chars", "n".repeat(81)],
+    ["carrying a control character", "Backend\u0001specialist"],
+  ])("rejects a name %s", async (_label, name) => {
+    const services = spawnServices();
+
+    const result = await callTool(spawnTools(services), "create_subordinate_agent", {
+      ...validInput,
+      name,
+    });
+
+    expect(result.content).toMatchObject({ error: "invalid_name" });
+    expect(services.agentRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("404s when the calling parent row is gone", async () => {
+    const services = spawnServices({
+      agentRepo: { findById: vi.fn(async () => undefined) },
+    });
+
+    const result = await callTool(spawnTools(services), "create_subordinate_agent", validInput);
+
+    expect(result.content).toMatchObject({
+      error: "parent_not_found",
+      agent_id: "agent_t",
+    });
+  });
+
+  it("enforces the per-parent daily spawn cap", async () => {
+    const services = spawnServices({
+      agentProvisionEventRepo: { countByParentSince: vi.fn(async () => 8) },
+    });
+
+    const result = await callTool(spawnTools(services), "create_subordinate_agent", validInput);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "subordinate_daily_cap",
+      cap: 8,
+      count: 8,
+    });
+    expect(services.agentRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("counts spawns over a 24-hour window", async () => {
+    const services = spawnServices();
+
+    await callTool(spawnTools(services), "create_subordinate_agent", validInput);
+
+    expect(services.agentProvisionEventRepo.countByParentSince).toHaveBeenCalledWith(
+      "agent_t",
+      86_400,
+    );
+  });
+
+  it("wraps a provisioning throw in the catch-all envelope", async () => {
+    const services = spawnServices({
+      agentRepo: {
+        findById: vi.fn(async () => fakeAgent({ id: "agent_t" })),
+        create: vi.fn(async () => {
+          throw new Error("unique violation on name");
+        }),
+      },
+    });
+
+    const result = await callTool(spawnTools(services), "create_subordinate_agent", validInput);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "unique violation on name" });
+  });
+
+  it("borrows its field descriptions from the IC block templates", () => {
+    const services = spawnServices();
+    const tool = findTool(spawnTools(services), "create_subordinate_agent");
+    const props = tool.schema.properties as Record<string, { description: string }>;
+    const icDescriptions = new Map(
+      DEFAULT_BLOCK_TEMPLATES.ic.map((t) => [t.block_name, t.description]),
+    );
+
+    for (const field of ["tag_line", "persona", "domain", "active_context", "constraints"]) {
+      expect(props[field]?.description).toBe(icDescriptions.get(field));
+    }
+    expect(tool.schema.required).toEqual(["name", "tag_line", "persona", "domain"]);
+  });
+});
+
+// ── Projections + remaining argument guards ──────────────────────────────
+
+describe("projections", () => {
+  it("get_task nulls every optional column rather than omitting it", async () => {
+    const services = buildServices({
+      taskRepo: { findById: vi.fn(async () => fakeTask({ id: "task_1" })) },
+    });
+    const tools = buildHierarchyTools({ agentId: "a", hierarchyLevel: "ic" }, services);
+
+    const result = await callTool(tools, "get_task", { task_id: "task_1" });
+
+    expect((result.content as { task: Record<string, unknown> }).task).toEqual({
+      id: "task_1",
+      title: "Build X",
+      description: null,
+      status: "in_progress",
+      priority: "medium",
+      assignee_id: null,
+      creator_id: "agent_a",
+      creator_type: "agent",
+      parent_task_id: null,
+      repo_url: null,
+      result_summary: null,
+      blocker_agent_id: null,
+      blocker_reason: null,
+      created_at: "2026-04-01T00:00:00.000Z",
+      updated_at: "2026-04-01T00:00:00.000Z",
+    });
+  });
+
+  it("find_up nulls a top-level parent's own parent_agent_id", async () => {
+    const services = buildServices({
+      agentRepo: {
+        findParent: vi.fn(async () => fakeAgent({ id: "agent_parent" })),
+      },
+    });
+    const tools = buildHierarchyTools({ agentId: "a", hierarchyLevel: "ic" }, services);
+
+    const result = await callTool(tools, "find_up");
+
+    expect((result.content as { parent: Record<string, unknown> }).parent).toEqual({
+      id: "agent_parent",
+      name: "A",
+      hierarchy_level: "team",
+      parent_agent_id: null,
+      owner_id: "person_1",
+    });
+  });
+});
+
+describe("argument guards", () => {
+  const icTools = () => {
+    const services = buildServices();
+    return {
+      services,
+      tools: buildHierarchyTools({ agentId: "a", hierarchyLevel: "ic" }, services),
+    };
+  };
+
+  it.each([
+    ["a missing task_id", { type: "pull_request", title: "t" }],
+    ["a missing title", { task_id: "t1", type: "pull_request" }],
+  ])("create_work_product rejects %s", async (_label, input) => {
+    const { services, tools } = icTools();
+
+    const result = await callTool(tools, "create_work_product", input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "task_id and title required" });
+    expect(services.taskService.createWorkProduct).not.toHaveBeenCalled();
+  });
+
+  it("create_work_product forwards a metadata object and drops a non-object one", async () => {
+    const { services, tools } = icTools();
+
+    await callTool(tools, "create_work_product", {
+      task_id: "t1",
+      type: "analysis",
+      title: "t",
+      metadata: { rows: 3 },
+    });
+    await callTool(tools, "create_work_product", {
+      task_id: "t1",
+      type: "analysis",
+      title: "t",
+      metadata: "rows=3",
+    });
+
+    const calls = (services.taskService.createWorkProduct as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]?.[0]).toMatchObject({ metadata: { rows: 3 } });
+    expect(calls[1]?.[0]).toMatchObject({ metadata: undefined });
+  });
+
+  it("update_work_product forwards a metadata object and drops a non-object one", async () => {
+    const { services, tools } = icTools();
+
+    await callTool(tools, "update_work_product", {
+      id: "wp_1",
+      metadata: { reviewed: true },
+    });
+    await callTool(tools, "update_work_product", { id: "wp_1", metadata: 3 });
+
+    const calls = (services.taskService.updateWorkProduct as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0]?.[1]).toMatchObject({ metadata: { reviewed: true } });
+    expect(calls[1]?.[1]).toMatchObject({ metadata: undefined });
+  });
+
+  it("update_work_product rejects a missing id", async () => {
+    const { services, tools } = icTools();
+
+    const result = await callTool(tools, "update_work_product", {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "id required" });
+    expect(services.taskService.updateWorkProduct).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["a missing intent", { agent_id: "sub_1" }],
+    ["a missing agent_id", { intent: "do X" }],
+  ])("create_task rejects %s before the authz lookup", async (_label, input) => {
+    const services = buildServices();
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "create_task", input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "intent and agent_id required" });
+    expect(services.agentRepo.findSubordinates).not.toHaveBeenCalled();
+  });
+
+  it("create_task rejects an unknown priority after authz passes", async () => {
+    const services = buildServices({
+      agentRepo: {
+        findSubordinates: vi.fn(async () => [fakeAgent({ id: "sub_1" })]),
+      },
+    });
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "create_task", {
+      intent: "do X",
+      agent_id: "sub_1",
+      priority: "yesterday",
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.content as { error: string }).error).toContain("priority must be one of");
+    expect(services.taskRepo.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("every tool wraps an unexpected service throw", () => {
+  // One table instead of a per-tool test: the envelope is the contract, and
+  // a tool that forgets its try/catch would otherwise reject the MCP call
+  // instead of handing the agent something it can read.
+  const boom = () => {
+    throw new Error("pool exhausted");
+  };
+
+  function throwingServices(): ReturnType<typeof buildServices> {
+    return buildServices({
+      agentRepo: {
+        findById: vi.fn(boom),
+        findParent: vi.fn(boom),
+        findSubordinates: vi.fn(boom),
+        findPeers: vi.fn(boom),
+      },
+      taskRepo: { findById: vi.fn(boom), listByAssignee: vi.fn(boom) },
+      taskService: {
+        updateProgress: vi.fn(boom),
+        createWorkProduct: vi.fn(boom),
+        listWorkProducts: vi.fn(boom),
+        getWorkProduct: vi.fn(boom),
+        updateWorkProduct: vi.fn(boom),
+      },
+      memoryAgent: { searchArchival: vi.fn(boom) } as Partial<MemoryAgent>,
+    });
+  }
+
+  it.each<[string, Record<string, unknown>]>([
+    ["search_context", { query: "auth" }],
+    ["update_progress", { task_id: "t1", status: "done", summary: "s" }],
+    ["find_up", {}],
+    ["get_agent_profile", { agent_id: "agent_x" }],
+    ["get_task", { task_id: "t1" }],
+    ["create_work_product", { task_id: "t1", type: "pull_request", title: "t" }],
+    ["list_work_products", { task_id: "t1" }],
+    ["get_work_product", { id: "wp_1" }],
+    ["update_work_product", { id: "wp_1", summary: "s" }],
+    ["find_subordinates", {}],
+    ["find_peers", {}],
+    ["create_task", { intent: "do X", agent_id: "sub_1" }],
+    // Own-agent status skips the subordinate lookup and hits listByAssignee.
+    ["check_work_status", { agent_id: "agent_t" }],
+  ])("%s", async (name, input) => {
+    const services = throwingServices();
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, name, input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "pool exhausted" });
   });
 });

--- a/packages/api/src/tools/mesh.test.ts
+++ b/packages/api/src/tools/mesh.test.ts
@@ -1,14 +1,27 @@
 /**
- * Mesh tool assembly tests — IC vs team tier gating.
+ * Mesh tool tests — tier gating plus each handler's own share of the work.
  *
- * Per-tool handler behavior is covered indirectly by the m6/m7 e2e scripts
- * (mesh flows require live Postgres + spawned CLI subprocesses). This file
- * locks the static tier inventory — the exact tool *names* each tier gets,
- * so future skill-loader work can rely on the surface being stable.
+ * The end-to-end flows (spawning the peer's CLI, blocking on their reply)
+ * need live Postgres and subprocesses and stay in the m6/m7 e2e scripts.
+ * What's unit-testable, and tested here, is everything the handler does on
+ * either side of the MeshServer call: argument coercion, the guards that
+ * short-circuit before any spawn, the projection of the response onto the
+ * agent-facing wire shape, and the coded-error envelope.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { Agent, AgentRepository } from "@beevibe/core";
 import type { ResolvedCaller } from "@beevibe/core/auth";
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import type { EscalationService } from "@beevibe/core/services/escalation-service";
+import type { TaskService } from "@beevibe/core/services/task-service";
 import { buildIcMeshTools, buildTeamMeshTools, type MeshToolServices } from "./mesh.js";
+import type { AgentTool } from "./types.js";
+import type { MeshServer } from "../mesh/server.js";
+import {
+  CannotNegotiateWithIcError,
+  MeshCapacityError,
+  MeshMaxRoundsError,
+} from "../mesh/types.js";
 
 // Fake services — the assembly itself doesn't invoke handlers, so the
 // dependencies just need to be the right shape.
@@ -45,5 +58,621 @@ describe("buildTeamMeshTools", () => {
       "respond_ask",
       "respond_negotiate",
     ]);
+  });
+});
+
+// ── Handler tests ────────────────────────────────────────────────────────
+
+interface MeshStub {
+  sendAsk: ReturnType<typeof vi.fn>;
+  respondAsk: ReturnType<typeof vi.fn>;
+  sendNegotiate: ReturnType<typeof vi.fn>;
+  respondNegotiate: ReturnType<typeof vi.fn>;
+  reportBlocker: ReturnType<typeof vi.fn>;
+  unblockOnEscalate: ReturnType<typeof vi.fn>;
+}
+
+interface Harness {
+  services: MeshToolServices;
+  mesh: MeshStub;
+  markBlocked: ReturnType<typeof vi.fn>;
+  escalationCreate: ReturnType<typeof vi.fn>;
+  query: ReturnType<typeof vi.fn>;
+  tool: (name: string) => AgentTool;
+}
+
+function harness(
+  opts: {
+    parent?: Agent | null;
+    askResponse?: unknown;
+    negotiateResponse?: unknown;
+    respondNegotiateResponse?: unknown;
+    escalation?: unknown;
+    throws?: unknown;
+  } = {},
+): Harness {
+  const boom = (): never => {
+    throw opts.throws;
+  };
+  const maybeThrow = <T>(value: T): T => (opts.throws ? boom() : value);
+
+  const mesh: MeshStub = {
+    sendAsk: vi.fn(async () =>
+      maybeThrow(
+        opts.askResponse ?? {
+          request_id: "req_1",
+          from_agent_id: "agent_target",
+          answer: "yes, feasible",
+        },
+      ),
+    ),
+    respondAsk: vi.fn(() => maybeThrow(undefined)),
+    sendNegotiate: vi.fn(async () =>
+      maybeThrow(
+        opts.negotiateResponse ?? {
+          negotiation_id: "neg_1",
+          from_agent_id: "agent_peer",
+          decision: "counter",
+          message: "how about Tuesday",
+          counter_proposal: "ship Tuesday",
+        },
+      ),
+    ),
+    respondNegotiate: vi.fn(async () =>
+      maybeThrow(
+        opts.respondNegotiateResponse === undefined
+          ? {
+              negotiation_id: "neg_1",
+              from_agent_id: "agent_peer",
+              decision: "counter",
+              message: "still no",
+              counter_proposal: "ship Wednesday",
+            }
+          : opts.respondNegotiateResponse,
+      ),
+    ),
+    reportBlocker: vi.fn(),
+    unblockOnEscalate: vi.fn(),
+  };
+
+  const parent = opts.parent === undefined ? ({ id: "agent_parent" } as Agent) : opts.parent;
+  const agentRepo = {
+    findParent: vi.fn(async () => maybeThrow(parent ?? undefined)),
+  } as unknown as AgentRepository;
+
+  const markBlocked = vi.fn(async () => maybeThrow(undefined));
+  const taskService = { markBlocked } as unknown as TaskService;
+
+  const escalationCreate = vi.fn(async () =>
+    maybeThrow(
+      opts.escalation ?? {
+        id: "esc_1",
+        status: "open",
+        negotiation_id: "neg_1",
+      },
+    ),
+  );
+  const escalationService = { create: escalationCreate } as unknown as EscalationService;
+
+  const query = vi.fn(async () => ({ rows: [] }));
+  const pool = { query } as unknown as Pool;
+
+  const services = {
+    mesh: mesh as unknown as MeshServer,
+    agentRepo,
+    taskRepo: {} as MeshToolServices["taskRepo"],
+    taskService,
+    escalationService,
+    pool,
+  };
+
+  const built = buildTeamMeshTools(fakeCtx, services);
+  return {
+    services,
+    mesh,
+    markBlocked,
+    escalationCreate,
+    query,
+    tool: (name) => {
+      const found = built.find((t) => t.name === name);
+      if (!found) throw new Error(`no such mesh tool: ${name}`);
+      return found;
+    },
+  };
+}
+
+describe("ask", () => {
+  it("mints a request id, forwards the caller as sender, and projects the response", async () => {
+    const h = harness();
+
+    const result = await h
+      .tool("ask")
+      .handler({ target_agent_id: "agent_target", question: "is X feasible?" });
+
+    const [requestId, from, to, question] = h.mesh.sendAsk.mock.calls[0] as string[];
+    expect(requestId).toMatch(/^[0-9a-f-]{36}$/);
+    expect([from, to, question]).toEqual([
+      "agent_x",
+      "agent_target",
+      "is X feasible?",
+    ]);
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({
+      request_id: "req_1",
+      from_agent_id: "agent_target",
+      answer: "yes, feasible",
+    });
+  });
+
+  it("mints a fresh request id per call", async () => {
+    const h = harness();
+    const input = { target_agent_id: "agent_target", question: "q" };
+
+    await h.tool("ask").handler(input);
+    await h.tool("ask").handler(input);
+
+    const [first] = h.mesh.sendAsk.mock.calls[0] as string[];
+    const [second] = h.mesh.sendAsk.mock.calls[1] as string[];
+    expect(first).not.toBe(second);
+  });
+
+  it.each([
+    ["a missing target", { question: "q" }],
+    ["a missing question", { target_agent_id: "agent_target" }],
+    ["an empty target", { target_agent_id: "", question: "q" }],
+  ])("rejects %s without spawning the peer", async (_label, input) => {
+    const h = harness();
+
+    const result = await h.tool("ask").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "target_agent_id and question required",
+    });
+    expect(h.mesh.sendAsk).not.toHaveBeenCalled();
+  });
+});
+
+describe("respond_ask", () => {
+  it("resolves the asker's pending request with the caller as responder", async () => {
+    const h = harness();
+
+    const result = await h
+      .tool("respond_ask")
+      .handler({ request_id: "req_1", answer: "here you go" });
+
+    expect(h.mesh.respondAsk).toHaveBeenCalledWith("req_1", {
+      request_id: "req_1",
+      from_agent_id: "agent_x",
+      answer: "here you go",
+    });
+    expect(result.content).toEqual({ responded: true, request_id: "req_1" });
+  });
+
+  it.each([
+    ["a missing request_id", { answer: "a" }],
+    ["a missing answer", { request_id: "req_1" }],
+  ])("rejects %s", async (_label, input) => {
+    const h = harness();
+
+    const result = await h.tool("respond_ask").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "request_id and answer required" });
+    expect(h.mesh.respondAsk).not.toHaveBeenCalled();
+  });
+});
+
+describe("negotiate", () => {
+  it("forwards the proposal with the caller's session as initiator metadata", async () => {
+    const h = harness();
+
+    const result = await h.tool("negotiate").handler({
+      peer_id: "agent_peer",
+      proposal: "ship Monday",
+      task_id: "task_1",
+    });
+
+    expect(h.mesh.sendNegotiate).toHaveBeenCalledWith(
+      "agent_x",
+      "agent_peer",
+      "ship Monday",
+      { taskId: "task_1", initiatorSessionId: "ses_x" },
+    );
+    expect(result.content).toEqual({
+      negotiation_id: "neg_1",
+      from_agent_id: "agent_peer",
+      decision: "counter",
+      message: "how about Tuesday",
+      counter_proposal: "ship Tuesday",
+    });
+  });
+
+  it.each([
+    ["absent", undefined],
+    ["an empty string", ""],
+    ["a non-string", 7],
+  ])("drops a task_id that is %s", async (_label, task_id) => {
+    const h = harness();
+
+    await h
+      .tool("negotiate")
+      .handler({ peer_id: "agent_peer", proposal: "p", task_id });
+
+    expect(h.mesh.sendNegotiate.mock.calls[0]?.[3]).toEqual({
+      taskId: undefined,
+      initiatorSessionId: "ses_x",
+    });
+  });
+
+  it("projects the escalated sentinel onto its own wire shape", async () => {
+    const h = harness({
+      negotiateResponse: {
+        decision: "escalated",
+        escalation_id: "esc_7",
+        negotiation_id: "neg_1",
+        message: "peer escalated",
+      },
+    });
+
+    const result = await h
+      .tool("negotiate")
+      .handler({ peer_id: "agent_peer", proposal: "p" });
+
+    // No from_agent_id / counter_proposal on this branch — the sentinel is
+    // not a peer response, it's a state change.
+    expect(result.content).toEqual({
+      decision: "escalated",
+      escalation_id: "esc_7",
+      negotiation_id: "neg_1",
+      message: "peer escalated",
+    });
+  });
+
+  it.each([
+    ["a missing peer_id", { proposal: "p" }],
+    ["a missing proposal", { peer_id: "agent_peer" }],
+  ])("rejects %s without spawning the peer", async (_label, input) => {
+    const h = harness();
+
+    const result = await h.tool("negotiate").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "peer_id and proposal required" });
+    expect(h.mesh.sendNegotiate).not.toHaveBeenCalled();
+  });
+});
+
+describe("respond_negotiate", () => {
+  it("sends a counter and projects the peer's next round", async () => {
+    const h = harness();
+
+    const result = await h.tool("respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "not quite",
+      counter_proposal: "ship Thursday",
+    });
+
+    expect(h.mesh.respondNegotiate).toHaveBeenCalledWith(
+      "neg_1",
+      {
+        negotiation_id: "neg_1",
+        from_agent_id: "agent_x",
+        decision: "counter",
+        message: "not quite",
+        counter_proposal: "ship Thursday",
+      },
+      "ses_x",
+    );
+    expect(result.content).toMatchObject({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      counter_proposal: "ship Wednesday",
+    });
+  });
+
+  it.each(["accept", "reject"] as const)(
+    "reports %s as terminal when the server returns null",
+    async (decision) => {
+      const h = harness({ respondNegotiateResponse: null });
+
+      const result = await h
+        .tool("respond_negotiate")
+        .handler({ negotiation_id: "neg_1", decision, message: "done" });
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content).toEqual({
+        negotiation_id: "neg_1",
+        decision,
+        terminal: true,
+      });
+    },
+  );
+
+  it("passes counter_proposal as undefined when it isn't a string", async () => {
+    const h = harness({ respondNegotiateResponse: null });
+
+    await h.tool("respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "accept",
+      message: "ok",
+      counter_proposal: 3,
+    });
+
+    expect(h.mesh.respondNegotiate.mock.calls[0]?.[1]).toMatchObject({
+      counter_proposal: undefined,
+    });
+  });
+
+  it("projects an escalated sentinel returned mid-round", async () => {
+    const h = harness({
+      respondNegotiateResponse: {
+        decision: "escalated",
+        escalation_id: "esc_2",
+        negotiation_id: "neg_1",
+        message: "peer escalated",
+      },
+    });
+
+    const result = await h
+      .tool("respond_negotiate")
+      .handler({ negotiation_id: "neg_1", decision: "counter", message: "m", counter_proposal: "c" });
+
+    expect(result.content).toMatchObject({
+      decision: "escalated",
+      escalation_id: "esc_2",
+    });
+  });
+
+  it.each([
+    ["a missing negotiation_id", { decision: "accept", message: "m" }],
+    ["a missing message", { negotiation_id: "neg_1", decision: "accept" }],
+  ])("rejects %s", async (_label, input) => {
+    const h = harness();
+
+    const result = await h.tool("respond_negotiate").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "negotiation_id and message required",
+    });
+    expect(h.mesh.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("rejects a decision outside counter/accept/reject", async () => {
+    const h = harness();
+
+    const result = await h
+      .tool("respond_negotiate")
+      .handler({ negotiation_id: "neg_1", decision: "maybe", message: "m" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "decision must be one of: counter, accept, reject",
+    });
+    expect(h.mesh.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("requires counter_proposal when countering", async () => {
+    const h = harness();
+
+    const result = await h
+      .tool("respond_negotiate")
+      .handler({ negotiation_id: "neg_1", decision: "counter", message: "m" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "counter_proposal required when decision='counter'",
+    });
+    expect(h.mesh.respondNegotiate).not.toHaveBeenCalled();
+  });
+});
+
+describe("report_blocker", () => {
+  it("marks the task blocked, then spawns the parent fire-and-forget", async () => {
+    const h = harness();
+
+    const result = await h
+      .tool("report_blocker")
+      .handler({ task_id: "task_1", description: "npm registry is down" });
+
+    expect(h.markBlocked).toHaveBeenCalledWith(
+      "task_1",
+      "agent_x",
+      "npm registry is down",
+    );
+    expect(h.mesh.reportBlocker).toHaveBeenCalledWith(
+      "agent_parent",
+      "agent_x",
+      "task_1",
+      "npm registry is down",
+    );
+    expect(result.content).toEqual({
+      reported: true,
+      parent_agent_id: "agent_parent",
+      task_id: "task_1",
+    });
+  });
+
+  it("refuses for a top-level agent and leaves the task untouched", async () => {
+    const h = harness({ parent: null });
+
+    const result = await h
+      .tool("report_blocker")
+      .handler({ task_id: "task_1", description: "stuck" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "no_parent_to_block" });
+    expect(h.markBlocked).not.toHaveBeenCalled();
+    expect(h.mesh.reportBlocker).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["a missing task_id", { description: "d" }],
+    ["a missing description", { task_id: "task_1" }],
+  ])("rejects %s before the parent lookup", async (_label, input) => {
+    const h = harness();
+
+    const result = await h.tool("report_blocker").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "task_id and description required" });
+    expect(h.markBlocked).not.toHaveBeenCalled();
+  });
+});
+
+describe("escalate_to_humans", () => {
+  it("creates the escalation, unblocks the peer, then notifies listeners", async () => {
+    const h = harness();
+    const proposals = [{ title: "A", description: "do A" }];
+
+    const result = await h.tool("escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "stuck on scheduling",
+      proposals,
+      open_questions: ["what's the deadline?", 42],
+    });
+
+    expect(h.escalationCreate).toHaveBeenCalledWith({
+      negotiationId: "neg_1",
+      callerAgentId: "agent_x",
+      summary: "stuck on scheduling",
+      proposals,
+      // Non-string questions are filtered out rather than passed through.
+      openQuestions: ["what's the deadline?"],
+    });
+    expect(h.mesh.unblockOnEscalate).toHaveBeenCalledWith("neg_1", "esc_1");
+    expect(h.query).toHaveBeenCalledWith(
+      expect.stringContaining("pg_notify('escalation_created'"),
+      ["esc_1"],
+    );
+    expect(result.content).toEqual({
+      escalation_id: "esc_1",
+      status: "open",
+      negotiation_id: "neg_1",
+    });
+  });
+
+  it("omits proposals and open_questions when they aren't arrays", async () => {
+    const h = harness();
+
+    await h.tool("escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "stuck",
+      proposals: "A or B",
+      open_questions: "when?",
+    });
+
+    expect(h.escalationCreate.mock.calls[0]?.[0]).toMatchObject({
+      proposals: undefined,
+      openQuestions: undefined,
+    });
+  });
+
+  it.each([
+    ["a missing negotiation_id", { summary: "s" }],
+    ["a missing summary", { negotiation_id: "neg_1" }],
+  ])("rejects %s without creating an escalation", async (_label, input) => {
+    const h = harness();
+
+    const result = await h.tool("escalate_to_humans").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "negotiation_id and summary required",
+    });
+    expect(h.escalationCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe("error envelopes", () => {
+  // Every mesh handler funnels throws through toolErrorFromThrown, so a
+  // coded error has to survive with its code and meta intact on all of
+  // them — that's what the agent branches on.
+  const invocations: Array<[string, Record<string, unknown>]> = [
+    ["ask", { target_agent_id: "agent_t", question: "q" }],
+    ["respond_ask", { request_id: "req_1", answer: "a" }],
+    ["negotiate", { peer_id: "agent_p", proposal: "p" }],
+    [
+      "respond_negotiate",
+      { negotiation_id: "neg_1", decision: "accept", message: "m" },
+    ],
+    ["report_blocker", { task_id: "task_1", description: "d" }],
+    ["escalate_to_humans", { negotiation_id: "neg_1", summary: "s" }],
+  ];
+
+  it.each(invocations)("%s degrades a plain Error to the catch-all shape", async (name, input) => {
+    const h = harness({ throws: new Error("mesh offline") });
+
+    const result = await h.tool(name).handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "mesh offline" });
+  });
+
+  it.each(invocations)("%s stringifies a non-Error throw", async (name, input) => {
+    const h = harness({ throws: "raw string" });
+
+    const result = await h.tool(name).handler(input);
+
+    expect(result.content).toEqual({ error: "raw string" });
+  });
+
+  it("keeps MeshCapacityError's code and meta on ask", async () => {
+    const h = harness({
+      throws: new MeshCapacityError("at capacity", {
+        agentId: "agent_t",
+        running: 3,
+        cap: 3,
+      }),
+    });
+
+    const result = await h
+      .tool("ask")
+      .handler({ target_agent_id: "agent_t", question: "q" });
+
+    expect(result.content).toEqual({
+      error: "MESH_CAPACITY_EXCEEDED",
+      agentId: "agent_t",
+      running: 3,
+      cap: 3,
+      message: "at capacity",
+    });
+  });
+
+  it("keeps CannotNegotiateWithIcError's code on negotiate", async () => {
+    const h = harness({
+      throws: new CannotNegotiateWithIcError({ agentId: "agent_ic" }),
+    });
+
+    const result = await h
+      .tool("negotiate")
+      .handler({ peer_id: "agent_ic", proposal: "p" });
+
+    expect(result.content).toMatchObject({
+      error: "CANNOT_NEGOTIATE_WITH_IC",
+      agentId: "agent_ic",
+    });
+  });
+
+  it("keeps MeshMaxRoundsError's round counters on respond_negotiate", async () => {
+    const h = harness({
+      throws: new MeshMaxRoundsError({
+        negotiationId: "neg_1",
+        rounds_completed: 5,
+        max_rounds: 5,
+      }),
+    });
+
+    const result = await h
+      .tool("respond_negotiate")
+      .handler({ negotiation_id: "neg_1", decision: "accept", message: "m" });
+
+    expect(result.content).toMatchObject({
+      error: "MAX_ROUNDS_EXCEEDED",
+      rounds_completed: 5,
+      max_rounds: 5,
+    });
   });
 });

--- a/packages/api/src/tools/session-search.test.ts
+++ b/packages/api/src/tools/session-search.test.ts
@@ -1,0 +1,278 @@
+/**
+ * session_search tool tests.
+ *
+ * The tool's own job is shape inference — turning one flat bag of MCP
+ * arguments into exactly one of the four typed SessionSearchRequests —
+ * plus threading caller context and translating the service's failures.
+ * The FTS itself lives behind SessionSearchRepository and is covered by
+ * the DB-backed suite, so the service is faked here and the assertions
+ * are about which request it was handed.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { SessionSearchRequest, SessionSearchResult } from "@beevibe/core";
+import {
+  SessionSearchError,
+  type SessionSearchService,
+} from "@beevibe/core/services/session-search";
+import {
+  createSessionSearchTool,
+  type SessionSearchToolContext,
+} from "./session-search.js";
+
+const RESULT = { kind: "browse", sessions: [] } as unknown as SessionSearchResult;
+
+function harness(opts: { result?: SessionSearchResult | null; throws?: unknown } = {}) {
+  const calls: Array<{ req: SessionSearchRequest; ctx: unknown }> = [];
+  const sessionSearch = {
+    search: vi.fn(async (req: SessionSearchRequest, searchCtx: unknown) => {
+      if (opts.throws) throw opts.throws;
+      calls.push({ req, ctx: searchCtx });
+      return opts.result === undefined ? RESULT : opts.result;
+    }),
+  } as unknown as SessionSearchService;
+  return { sessionSearch, calls };
+}
+
+const ctx: SessionSearchToolContext = {
+  agentId: "agent_a",
+  hierarchyLevel: "team",
+  sessionId: "sess_current",
+};
+
+function tool(sessionSearch: SessionSearchService) {
+  return createSessionSearchTool(ctx, { sessionSearch });
+}
+
+describe("session_search descriptor", () => {
+  it("exposes all four calling shapes' arguments with no required set", () => {
+    const { sessionSearch } = harness();
+    const t = tool(sessionSearch);
+
+    expect(t.name).toBe("session_search");
+    expect(Object.keys(t.schema.properties as object).sort()).toEqual([
+      "around_message_id",
+      "filters",
+      "limit",
+      "query",
+      "session_id",
+      "sort",
+      "window",
+    ]);
+    // Every shape is reachable, including the zero-argument browse.
+    expect(t.schema.required).toBeUndefined();
+  });
+});
+
+describe("shape inference", () => {
+  it("infers scroll when session_id and around_message_id are both present", async () => {
+    const { sessionSearch, calls } = harness();
+
+    await tool(sessionSearch).handler({
+      session_id: "sess_1",
+      around_message_id: "evt_9",
+      window: 10,
+      // Discovery-only args must not leak into the scroll request.
+      query: "auth refactor",
+      limit: 7,
+    });
+
+    expect(calls[0]?.req).toEqual({
+      kind: "scroll",
+      session_id: "sess_1",
+      around_message_id: "evt_9",
+      window: 10,
+    });
+  });
+
+  it("drops a non-numeric window rather than forwarding it", async () => {
+    const { sessionSearch, calls } = harness();
+
+    await tool(sessionSearch).handler({
+      session_id: "sess_1",
+      around_message_id: "evt_9",
+      window: "10",
+    });
+
+    expect(calls[0]?.req).toMatchObject({ kind: "scroll", window: undefined });
+  });
+
+  it("infers read from a bare session_id", async () => {
+    const { sessionSearch, calls } = harness();
+
+    await tool(sessionSearch).handler({ session_id: "sess_1", query: "ignored" });
+
+    expect(calls[0]?.req).toEqual({ kind: "read", session_id: "sess_1" });
+  });
+
+  it("treats a blank around_message_id as absent, falling back to read", async () => {
+    const { sessionSearch, calls } = harness();
+
+    await tool(sessionSearch).handler({
+      session_id: "sess_1",
+      around_message_id: "   ",
+    });
+
+    expect(calls[0]?.req).toEqual({ kind: "read", session_id: "sess_1" });
+  });
+
+  it("infers discover from a query, forwarding limit, sort and filters", async () => {
+    const { sessionSearch, calls } = harness();
+    const filters = { session_type: "task", status: "failed" };
+
+    await tool(sessionSearch).handler({
+      query: "  auth refactor  ",
+      limit: 5,
+      sort: "newest",
+      filters,
+    });
+
+    expect(calls[0]?.req).toEqual({
+      kind: "discover",
+      query: "auth refactor",
+      limit: 5,
+      sort: "newest",
+      filters,
+    });
+  });
+
+  it("drops an unrecognized sort", async () => {
+    const { sessionSearch, calls } = harness();
+
+    await tool(sessionSearch).handler({ query: "x", sort: "relevance" });
+
+    expect(calls[0]?.req).toMatchObject({ kind: "discover", sort: undefined });
+  });
+
+  it("infers browse from no arguments at all", async () => {
+    const { sessionSearch, calls } = harness();
+
+    await tool(sessionSearch).handler({});
+
+    expect(calls[0]?.req).toEqual({
+      kind: "browse",
+      limit: undefined,
+      filters: undefined,
+    });
+  });
+
+  it.each([
+    ["a blank query", { query: "   " }],
+    ["a non-string query", { query: 42 }],
+    ["a blank session_id", { session_id: "  " }],
+  ])("falls back to browse for %s", async (_label, input) => {
+    const { sessionSearch, calls } = harness();
+
+    await tool(sessionSearch).handler(input);
+
+    expect(calls[0]?.req).toMatchObject({ kind: "browse" });
+  });
+
+  it("carries limit and filters into browse", async () => {
+    const { sessionSearch, calls } = harness();
+    const filters = { since: "2026-01-01T00:00:00Z" };
+
+    await tool(sessionSearch).handler({ limit: 8, filters });
+
+    expect(calls[0]?.req).toEqual({ kind: "browse", limit: 8, filters });
+  });
+
+  it("ignores a null or non-object filters bag", async () => {
+    const { sessionSearch, calls } = harness();
+
+    await tool(sessionSearch).handler({ query: "x", filters: null });
+    await tool(sessionSearch).handler({ query: "x", filters: "task" });
+
+    expect(calls.map((c) => (c.req as { filters?: unknown }).filters)).toEqual([
+      undefined,
+      undefined,
+    ]);
+  });
+});
+
+describe("caller context", () => {
+  it("threads agent id, tier and current session to the service", async () => {
+    const { sessionSearch, calls } = harness();
+
+    await tool(sessionSearch).handler({ query: "x" });
+
+    expect(calls[0]?.ctx).toEqual({
+      callerAgentId: "agent_a",
+      hierarchyLevel: "team",
+      currentSessionId: "sess_current",
+    });
+  });
+
+  it("returns the service result unwrapped on success", async () => {
+    const { sessionSearch } = harness();
+
+    const result = await tool(sessionSearch).handler({});
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toBe(RESULT);
+  });
+});
+
+describe("error translation", () => {
+  it("turns a null result into not_found_or_forbidden", async () => {
+    const { sessionSearch } = harness({ result: null });
+
+    const result = await tool(sessionSearch).handler({ session_id: "sess_x" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "not_found_or_forbidden" });
+  });
+
+  it.each(["forbidden_agent_filter", "missing_query", "missing_args"] as const)(
+    "surfaces SessionSearchError code %s verbatim",
+    async (code) => {
+      const { sessionSearch } = harness({
+        throws: new SessionSearchError(code, `nope: ${code}`),
+      });
+
+      const result = await tool(sessionSearch).handler({ query: "x" });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual({ error: code, message: `nope: ${code}` });
+    },
+  );
+
+  it("matches a cross-bundle SessionSearchError by name, not just instanceof", async () => {
+    // An integration script consuming core's src/ while the api consumes
+    // dist/ throws a structurally identical error from a different class
+    // identity; the code still has to reach the agent.
+    const impostor = new Error("out of scope");
+    impostor.name = "SessionSearchError";
+    (impostor as unknown as { code: string }).code = "forbidden_agent_filter";
+    const { sessionSearch } = harness({ throws: impostor });
+
+    const result = await tool(sessionSearch).handler({ query: "x" });
+
+    expect(result.content).toEqual({
+      error: "forbidden_agent_filter",
+      message: "out of scope",
+    });
+  });
+
+  it("wraps any other Error as internal_error", async () => {
+    const { sessionSearch } = harness({ throws: new Error("connection reset") });
+
+    const result = await tool(sessionSearch).handler({ query: "x" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "internal_error",
+      message: "connection reset",
+    });
+  });
+
+  it("stringifies a non-Error throw", async () => {
+    const { sessionSearch } = harness({ throws: "just a string" });
+
+    const result = await tool(sessionSearch).handler({ query: "x" });
+
+    expect(result.content).toEqual({
+      error: "internal_error",
+      message: "just a string",
+    });
+  });
+});

--- a/packages/api/src/tools/update-core-memory.test.ts
+++ b/packages/api/src/tools/update-core-memory.test.ts
@@ -77,6 +77,42 @@ describe("update_core_memory tool", () => {
     expect(calls).toHaveLength(0);
   });
 
+  it.each([
+    ["a missing block_name", { operation: "append", content: "x" }],
+    ["a blank block_name", { block_name: "   ", operation: "append", content: "x" }],
+    ["a non-string block_name", { block_name: 7, operation: "append", content: "x" }],
+  ])("rejects %s", async (_label, input) => {
+    const { coreMemory, calls } = fakeCoreMemory();
+    const tool = createUpdateCoreMemoryTool(
+      { agentId: "agent_a", hierarchyLevel: "ic" },
+      { coreMemory },
+    );
+
+    const result = await tool.handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "invalid_block_name" });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("rejects a non-string content", async () => {
+    const { coreMemory, calls } = fakeCoreMemory();
+    const tool = createUpdateCoreMemoryTool(
+      { agentId: "agent_a", hierarchyLevel: "ic" },
+      { coreMemory },
+    );
+
+    const result = await tool.handler({
+      block_name: "persona",
+      operation: "append",
+      content: 42,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "invalid_content" });
+    expect(calls).toHaveLength(0);
+  });
+
   it("rejects unknown operation", async () => {
     const { coreMemory, calls } = fakeCoreMemory();
     const tool = createUpdateCoreMemoryTool({ agentId: "agent_a", hierarchyLevel: "ic" }, { coreMemory });

--- a/packages/api/src/tools/use-repo.test.ts
+++ b/packages/api/src/tools/use-repo.test.ts
@@ -1,0 +1,363 @@
+/**
+ * use_repo tool tests — input validation, the ordered write sequence
+ * (task → dispatch → repo_run), and the two failure envelopes.
+ *
+ * The real flow needs Postgres and a daemon to claim the session, so the
+ * repositories and DispatchService are faked. What's worth locking here is
+ * the handler's own logic: what counts as a GitHub URL, how `limits` are
+ * clamped, that the session row is dispatched *before* the repo_run insert
+ * (FK ordering the module comments call out), and that a failure at either
+ * write step returns a distinguishable error code rather than a bare throw.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  RepoRun,
+  RepoRunRepository,
+  Task,
+  TaskRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import { createUseRepoTool, type UseRepoServices } from "./use-repo.js";
+
+interface Harness {
+  services: UseRepoServices;
+  /** Call order across the three collaborators, for FK-ordering assertions. */
+  order: string[];
+  created: { task?: Record<string, unknown>; repoRun?: Record<string, unknown> };
+  dispatched: Array<Record<string, unknown>>;
+}
+
+function harness(
+  opts: {
+    agentMissing?: boolean;
+    dispatchThrows?: Error;
+    repoRunThrows?: Error;
+  } = {},
+): Harness {
+  const order: string[] = [];
+  const created: Harness["created"] = {};
+  const dispatched: Array<Record<string, unknown>> = [];
+
+  const agent = opts.agentMissing
+    ? undefined
+    : ({ id: "agent_caller", name: "Caller" } as unknown as Agent);
+
+  const agentRepo = {
+    findById: vi.fn(async () => agent),
+  } as unknown as AgentRepository;
+
+  const taskRepo = {
+    create: vi.fn(async (row: Record<string, unknown>) => {
+      order.push("task.create");
+      created.task = row;
+      return row as unknown as Task;
+    }),
+  } as unknown as TaskRepository;
+
+  const repoRunRepo = {
+    create: vi.fn(async (row: Record<string, unknown>) => {
+      order.push("repoRun.create");
+      if (opts.repoRunThrows) throw opts.repoRunThrows;
+      created.repoRun = row;
+      return row as unknown as RepoRun;
+    }),
+  } as unknown as RepoRunRepository;
+
+  const dispatchService = {
+    dispatchTask: vi.fn(async (input: Record<string, unknown>) => {
+      order.push("dispatch");
+      if (opts.dispatchThrows) throw opts.dispatchThrows;
+      dispatched.push(input);
+      return {} as never;
+    }),
+  } as unknown as DispatchService;
+
+  return {
+    services: { agentRepo, taskRepo, repoRunRepo, dispatchService },
+    order,
+    created,
+    dispatched,
+  };
+}
+
+const ctx = { agentId: "agent_caller" };
+
+const validInput = {
+  goal: "Extract the tables from this PDF as JSON",
+  repo_url: "https://github.com/jsvine/pdfplumber",
+};
+
+describe("use_repo descriptor", () => {
+  it("requires goal + repo_url and rejects unknown properties", () => {
+    const tool = createUseRepoTool(ctx, harness().services);
+    expect(tool.name).toBe("use_repo");
+    expect(tool.schema.required).toEqual(["goal", "repo_url"]);
+    expect(tool.schema.additionalProperties).toBe(false);
+  });
+});
+
+describe("use_repo input validation", () => {
+  it("rejects a missing or blank goal before touching any repository", async () => {
+    const h = harness();
+    const tool = createUseRepoTool(ctx, h.services);
+
+    for (const goal of [undefined, "", "   ", 42]) {
+      const result = await tool.handler({ ...validInput, goal });
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({ error: "invalid_goal" });
+    }
+    expect(h.order).toEqual([]);
+  });
+
+  it.each([
+    ["http (not https)", "http://github.com/foo/bar"],
+    ["a non-github host", "https://gitlab.com/foo/bar"],
+    ["a lookalike host", "https://notgithub.com/foo/bar"],
+    ["an unparseable url", "not-a-url"],
+    ["an empty string", ""],
+    ["git+ssh", "git@github.com:foo/bar.git"],
+  ])("rejects %s as repo_url", async (_label, repo_url) => {
+    const h = harness();
+    const tool = createUseRepoTool(ctx, h.services);
+
+    const result = await tool.handler({ ...validInput, repo_url });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "invalid_repo_url" });
+    expect(h.order).toEqual([]);
+  });
+
+  it.each([
+    ["apex github.com", "https://github.com/jsvine/pdfplumber"],
+    ["a subdomain", "https://www.github.com/jsvine/pdfplumber"],
+    ["mixed case host", "https://GitHub.com/jsvine/pdfplumber"],
+  ])("accepts %s", async (_label, repo_url) => {
+    const h = harness();
+    const tool = createUseRepoTool(ctx, h.services);
+
+    const result = await tool.handler({ ...validInput, repo_url });
+
+    expect(result.isError).toBeFalsy();
+    expect(h.created.repoRun).toMatchObject({ repo_url });
+  });
+
+  it("returns agent_not_found when the caller does not resolve", async () => {
+    const h = harness({ agentMissing: true });
+    const tool = createUseRepoTool(ctx, h.services);
+
+    const result = await tool.handler(validInput);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "agent_not_found" });
+    expect(h.order).toEqual([]);
+  });
+});
+
+describe("use_repo happy path", () => {
+  it("creates the container task, dispatches, then inserts repo_run — in that order", async () => {
+    const h = harness();
+    const tool = createUseRepoTool(ctx, h.services);
+
+    const result = await tool.handler(validInput);
+
+    // repo_run.session_id FKs to session.id, and dispatchTask is what
+    // creates the session row — so the insert must come after dispatch.
+    expect(h.order).toEqual(["task.create", "dispatch", "repoRun.create"]);
+    expect(result.isError).toBeFalsy();
+
+    const content = result.content as Record<string, string>;
+    expect(content.repo_run_id).toMatch(/^repo_/);
+    expect(content.session_id).toMatch(/^sess_/);
+    expect(content.task_id).toMatch(/^task_/);
+    expect(content.status).toBe("pending");
+    expect(content.watch_url).toBe(`/capabilities/runs/${content.repo_run_id}`);
+  });
+
+  it("pins the container task to the resolved agent on both sides", async () => {
+    const h = harness();
+    const tool = createUseRepoTool(ctx, h.services);
+
+    await tool.handler(validInput);
+
+    expect(h.created.task).toMatchObject({
+      description: validInput.goal,
+      priority: "medium",
+      assignee_id: "agent_caller",
+      creator_id: "agent_caller",
+      creator_type: "agent",
+    });
+  });
+
+  it("dispatches under the same pre-minted session id the repo_run points at", async () => {
+    const h = harness();
+    const tool = createUseRepoTool(ctx, h.services);
+
+    const result = await tool.handler(validInput);
+    const content = result.content as Record<string, string>;
+
+    expect(h.dispatched[0]).toMatchObject({
+      agentId: "agent_caller",
+      type: "run_repo",
+      intent: validInput.goal,
+      reason: { kind: "fresh" },
+      sessionIdOverride: content.session_id,
+    });
+    expect(h.created.repoRun).toMatchObject({
+      session_id: content.session_id,
+      task_id: content.task_id,
+      agent_id: "agent_caller",
+      goal: validInput.goal,
+      status: "pending",
+    });
+  });
+
+  it("truncates a long goal into an 80-char task title and collapses whitespace", async () => {
+    const h = harness();
+    const tool = createUseRepoTool(ctx, h.services);
+    const goal = "a".repeat(200);
+
+    await tool.handler({ ...validInput, goal });
+
+    const title = (h.created.task as { title: string }).title;
+    expect(title).toHaveLength(78); // 77 chars + the ellipsis
+    expect(title.endsWith("…")).toBe(true);
+    // The untruncated goal still reaches the description in full.
+    expect(h.created.task).toMatchObject({ description: goal });
+  });
+
+  it("keeps a short goal as the title verbatim, whitespace-normalized", async () => {
+    const h = harness();
+    const tool = createUseRepoTool(ctx, h.services);
+
+    await tool.handler({ ...validInput, goal: "  extract\n\ttables  " });
+
+    expect(h.created.task).toMatchObject({ title: "extract tables" });
+  });
+
+  it("passes optional input_url / input_filename back trimmed", async () => {
+    const h = harness();
+    const tool = createUseRepoTool(ctx, h.services);
+
+    const result = await tool.handler({
+      ...validInput,
+      input_url: "  https://example.com/report.pdf  ",
+      input_filename: " report.pdf ",
+    });
+
+    expect(result.content).toMatchObject({
+      input_url: "https://example.com/report.pdf",
+      input_filename: "report.pdf",
+    });
+  });
+
+  it("omits input_url / input_filename when they are not strings", async () => {
+    const h = harness();
+    const tool = createUseRepoTool(ctx, h.services);
+
+    const result = await tool.handler({ ...validInput, input_url: 7 });
+
+    expect(result.content.input_url).toBeUndefined();
+    expect(result.content.input_filename).toBeUndefined();
+  });
+});
+
+describe("use_repo limits parsing", () => {
+  async function limitsFor(limits: unknown): Promise<Record<string, number>> {
+    const tool = createUseRepoTool(ctx, harness().services);
+    const result = await tool.handler({ ...validInput, limits });
+    return result.content.limits as Record<string, number>;
+  }
+
+  it("passes sane values through untouched", async () => {
+    expect(
+      await limitsFor({
+        wall_clock_minutes: 10,
+        max_install_attempts: 3,
+        disk_mb: 512,
+      }),
+    ).toEqual({
+      wall_clock_minutes: 10,
+      max_install_attempts: 3,
+      disk_mb: 512,
+    });
+  });
+
+  it("clamps each limit to its ceiling", async () => {
+    expect(
+      await limitsFor({
+        wall_clock_minutes: 999,
+        max_install_attempts: 99,
+        disk_mb: 1_000_000,
+      }),
+    ).toEqual({
+      wall_clock_minutes: 60,
+      max_install_attempts: 5,
+      disk_mb: 10_000,
+    });
+  });
+
+  it("floors the integer-valued limits but not the wall clock", async () => {
+    expect(await limitsFor({ max_install_attempts: 2.9, disk_mb: 100.7 })).toEqual({
+      max_install_attempts: 2,
+      disk_mb: 100,
+    });
+    expect(await limitsFor({ wall_clock_minutes: 1.5 })).toEqual({
+      wall_clock_minutes: 1.5,
+    });
+  });
+
+  it.each([
+    ["a non-object", "20"],
+    ["null", null],
+    ["an empty object", {}],
+    ["zero values", { wall_clock_minutes: 0, max_install_attempts: 0, disk_mb: 0 }],
+    ["negative values", { wall_clock_minutes: -5, disk_mb: -1 }],
+    ["wrong-typed values", { wall_clock_minutes: "20", disk_mb: true }],
+  ])("drops %s to an empty limits object", async (_label, limits) => {
+    expect(await limitsFor(limits)).toEqual({});
+  });
+});
+
+describe("use_repo write failures", () => {
+  it("returns dispatch_failed without attempting the repo_run insert", async () => {
+    const h = harness({ dispatchThrows: new Error("no runtime online") });
+    const tool = createUseRepoTool(ctx, h.services);
+
+    const result = await tool.handler(validInput);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "dispatch_failed",
+      message: "no runtime online",
+    });
+    expect(h.order).toEqual(["task.create", "dispatch"]);
+  });
+
+  it("stringifies a non-Error dispatch throw", async () => {
+    const h = harness({ dispatchThrows: "boom" as unknown as Error });
+    const tool = createUseRepoTool(ctx, h.services);
+
+    const result = await tool.handler(validInput);
+
+    expect(result.content).toMatchObject({
+      error: "dispatch_failed",
+      message: "boom",
+    });
+  });
+
+  it("surfaces repo_run_create_failed so the agent doesn't wait on an orphan session", async () => {
+    const h = harness({ repoRunThrows: new Error("duplicate key") });
+    const tool = createUseRepoTool(ctx, h.services);
+
+    const result = await tool.handler(validInput);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "repo_run_create_failed",
+      message: "duplicate key",
+    });
+    expect(h.order).toEqual(["task.create", "dispatch", "repoRun.create"]);
+  });
+});

--- a/packages/api/src/tools/watch.test.ts
+++ b/packages/api/src/tools/watch.test.ts
@@ -1,0 +1,249 @@
+/**
+ * watch_tasks + unwatch tool tests.
+ *
+ * Both tools are thin adapters over WatchService, so what's tested here is
+ * exactly the adapter's own share of the contract: argument coercion before
+ * the service call, the two guards that short-circuit without touching the
+ * service (empty task_ids, absent session context), the mode default, and
+ * the mapping from each WatchService error class to its stable error code.
+ * The service's own behavior (the insert, the already-terminal race fire,
+ * the unwatch state machine) is covered by its DB-backed suite.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { TASK_WATCH_MODES } from "@beevibe/core";
+import {
+  WatchAuthError,
+  WatchNotFoundError,
+  WatchValidationError,
+  type WatchService,
+} from "@beevibe/core/services/watch-service";
+import { buildWatchTools, type WatchToolContext } from "./watch.js";
+
+function harness(opts: { watchThrows?: unknown; unwatchThrows?: unknown } = {}) {
+  const watchCalls: Array<Record<string, unknown>> = [];
+  const unwatchCalls: Array<Record<string, unknown>> = [];
+  const watchService = {
+    watchTasks: vi.fn(async (input: Record<string, unknown>) => {
+      if (opts.watchThrows) throw opts.watchThrows;
+      watchCalls.push(input);
+      return { watchId: "twch_1", firedImmediately: false };
+    }),
+    unwatch: vi.fn(async (input: Record<string, unknown>) => {
+      if (opts.unwatchThrows) throw opts.unwatchThrows;
+      unwatchCalls.push(input);
+    }),
+  } as unknown as WatchService;
+  return { watchService, watchCalls, unwatchCalls };
+}
+
+function tools(ctx: WatchToolContext, watchService: WatchService) {
+  const [watchTasks, unwatch] = buildWatchTools(ctx, { watchService });
+  if (!watchTasks || !unwatch) throw new Error("expected two watch tools");
+  return { watchTasks, unwatch };
+}
+
+const ctx: WatchToolContext = { agentId: "agent_a", sessionId: "sess_1" };
+
+describe("buildWatchTools", () => {
+  it("returns watch_tasks and unwatch, in that order", () => {
+    const { watchService } = harness();
+    const built = buildWatchTools(ctx, { watchService });
+    expect(built.map((t) => t.name)).toEqual(["watch_tasks", "unwatch"]);
+  });
+
+  it("advertises the domain's mode enum rather than a hand-copied list", () => {
+    const { watchService } = harness();
+    const { watchTasks } = tools(ctx, watchService);
+    const props = watchTasks.schema.properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(props.mode?.enum).toEqual([...TASK_WATCH_MODES]);
+    expect(watchTasks.schema.required).toEqual(["task_ids"]);
+  });
+});
+
+describe("watch_tasks", () => {
+  it("forwards caller identity, ids, mode and trimmed reason to the service", async () => {
+    const { watchService, watchCalls } = harness();
+    const { watchTasks } = tools(ctx, watchService);
+
+    const result = await watchTasks.handler({
+      task_ids: ["task_1", "task_2"],
+      mode: "any",
+      reason: "  waiting on the migration  ",
+    });
+
+    expect(watchCalls).toEqual([
+      {
+        callerAgentId: "agent_a",
+        callerSessionId: "sess_1",
+        taskIds: ["task_1", "task_2"],
+        mode: "any",
+        reason: "waiting on the migration",
+      },
+    ]);
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({
+      watch_id: "twch_1",
+      fired_immediately: false,
+    });
+  });
+
+  it("reports fired_immediately from the service verbatim", async () => {
+    const watchService = {
+      watchTasks: vi.fn(async () => ({
+        watchId: "twch_9",
+        firedImmediately: true,
+      })),
+    } as unknown as WatchService;
+    const { watchTasks } = tools(ctx, watchService);
+
+    const result = await watchTasks.handler({ task_ids: ["task_1"] });
+
+    expect(result.content).toEqual({
+      watch_id: "twch_9",
+      fired_immediately: true,
+    });
+  });
+
+  it("defaults mode to 'all' when absent or not a known mode", async () => {
+    const { watchService, watchCalls } = harness();
+    const { watchTasks } = tools(ctx, watchService);
+
+    await watchTasks.handler({ task_ids: ["task_1"] });
+    await watchTasks.handler({ task_ids: ["task_1"], mode: "sometimes" });
+    await watchTasks.handler({ task_ids: ["task_1"], mode: 3 });
+
+    expect(watchCalls.map((c) => c.mode)).toEqual(["all", "all", "all"]);
+  });
+
+  it("drops a blank or non-string reason rather than passing it on", async () => {
+    const { watchService, watchCalls } = harness();
+    const { watchTasks } = tools(ctx, watchService);
+
+    await watchTasks.handler({ task_ids: ["task_1"], reason: "   " });
+    await watchTasks.handler({ task_ids: ["task_1"], reason: 5 });
+
+    expect(watchCalls.map((c) => c.reason)).toEqual([undefined, undefined]);
+  });
+
+  it("filters non-string entries out of task_ids", async () => {
+    const { watchService, watchCalls } = harness();
+    const { watchTasks } = tools(ctx, watchService);
+
+    await watchTasks.handler({ task_ids: ["task_1", 2, null, "task_3"] });
+
+    expect(watchCalls[0]?.taskIds).toEqual(["task_1", "task_3"]);
+  });
+
+  it.each([
+    ["an empty array", []],
+    ["an all-non-string array", [1, 2]],
+    ["a non-array", "task_1"],
+    ["undefined", undefined],
+  ])("rejects %s as task_ids without calling the service", async (_label, task_ids) => {
+    const { watchService, watchCalls } = harness();
+    const { watchTasks } = tools(ctx, watchService);
+
+    const result = await watchTasks.handler({ task_ids });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "watch_validation" });
+    expect(watchCalls).toEqual([]);
+  });
+
+  it("refuses to register a watch outside a session context", async () => {
+    const { watchService, watchCalls } = harness();
+    const { watchTasks } = tools({ agentId: "agent_a" }, watchService);
+
+    const result = await watchTasks.handler({ task_ids: ["task_1"] });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "watch_validation",
+      message: "watch_tasks must be called inside a session context",
+    });
+    expect(watchCalls).toEqual([]);
+  });
+});
+
+describe("unwatch", () => {
+  it("forwards the caller agent and watch id", async () => {
+    const { watchService, unwatchCalls } = harness();
+    const { unwatch } = tools(ctx, watchService);
+
+    const result = await unwatch.handler({ watch_id: "twch_1" });
+
+    expect(unwatchCalls).toEqual([
+      { callerAgentId: "agent_a", watchId: "twch_1" },
+    ]);
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({ ok: true });
+  });
+
+  it.each([
+    ["an empty string", ""],
+    ["a non-string", 12],
+    ["undefined", undefined],
+  ])("rejects %s as watch_id without calling the service", async (_label, watch_id) => {
+    const { watchService, unwatchCalls } = harness();
+    const { unwatch } = tools(ctx, watchService);
+
+    const result = await unwatch.handler({ watch_id });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "watch_validation" });
+    expect(unwatchCalls).toEqual([]);
+  });
+});
+
+describe("service error mapping", () => {
+  // The codes are the agent-facing contract — an agent branches on
+  // `error` to decide whether to retry, re-scope, or give up.
+  it.each([
+    ["WatchAuthError", new WatchAuthError("not your task"), "watch_auth"],
+    [
+      "WatchValidationError",
+      new WatchValidationError("too many tasks"),
+      "watch_validation",
+    ],
+    ["WatchNotFoundError", new WatchNotFoundError("twch_x"), "watch_not_found"],
+    ["a plain Error", new Error("pool exhausted"), "watch_error"],
+  ])("maps %s to %s", async (_label, thrown, code) => {
+    const { watchService } = harness({
+      watchThrows: thrown,
+      unwatchThrows: thrown,
+    });
+    const { watchTasks, unwatch } = tools(ctx, watchService);
+
+    const watchResult = await watchTasks.handler({ task_ids: ["task_1"] });
+    const unwatchResult = await unwatch.handler({ watch_id: "twch_1" });
+
+    for (const result of [watchResult, unwatchResult]) {
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({
+        error: code,
+        message: (thrown as Error).message,
+      });
+    }
+  });
+
+  it("stringifies a non-Error throw under watch_error", async () => {
+    const { watchService } = harness({
+      watchThrows: "kaboom",
+      unwatchThrows: "kaboom",
+    });
+    const { watchTasks, unwatch } = tools(ctx, watchService);
+
+    for (const result of [
+      await watchTasks.handler({ task_ids: ["task_1"] }),
+      await unwatch.handler({ watch_id: "twch_1" }),
+    ]) {
+      expect(result.content).toMatchObject({
+        error: "watch_error",
+        message: "kaboom",
+      });
+    }
+  });
+});


### PR DESCRIPTION
## What this is

A coverage sweep across the monorepo, then tests for the worst-covered area that is both critical and unit-testable: `packages/api/src/tools/` — the MCP tool surface every agent session actually calls.

It sat at **87.05% lines / 81.09% branches**, with three modules carrying **no test file at all**. It is now **99.66% lines / 90.80% branches**, +268 tests in the directory.

**No production code changed.** Tests only.

## Where the coverage went

| Module | Lines before → after | What's now covered |
| --- | --- | --- |
| `use-repo.ts` | 32% → **100%** | *(new file)* GitHub-URL and `limits` validation, the `task → dispatch → repo_run` write order the FK depends on, and both write-failure envelopes |
| `watch.ts` | 46% → **100%** | *(new file)* argument coercion, the two guards that short-circuit before the service, and the mapping from each `WatchService` error class to its agent-facing code |
| `session-search.ts` | 65% → **100%** | *(new file)* shape inference across all four calling shapes (discover / scroll / read / browse), plus the cross-bundle `SessionSearchError` match by `name` |
| `mesh.ts` | 46% → **100%** | handler behavior for all six tools: coercion, pre-spawn guards, response projection (including the `escalated` sentinel), and the coded-error envelopes |
| `hierarchy.ts` | 71% → **99%** | `revise_task`, `add_to_escalation`, `create_subordinate_agent` — none had any handler coverage — plus projections, the remaining argument guards, and one table asserting every tool wraps a thrown service call rather than rejecting the MCP request |
| `find-repo.ts` | 87% → **100%** | the shipped HTTP clients for the community registry and trending snapshots, previously bypassed by injected fakes — their TTL caches (including the cached 404 miss) and best-effort failure paths |
| `update-core-memory.ts` | 92% → **100%** | the remaining input guards |

## How the target was picked

Ran `@vitest/coverage-v8` per package with `--coverage.all`, excluding the DB- and provider-key-gated suites (per `CLAUDE.md`, an unhandled error in those aborts report generation). Package totals: api 64.5%, daemon 80.4%, core 83.3%, sandbox 75.1%.

Most of the remaining 0% files are entrypoints (`bootstrap.ts`, `main.ts`) or modules whose only tests are the DB-gated ones — they're covered in CI with Postgres, just not measurable in a bare sandbox. The tool directory was the largest block of genuinely untested, product-critical, dependency-injectable logic.

## Deliberately left uncovered

- `hierarchy.ts:1137-1145` — the `ic_cannot_spawn` guard is unreachable: `buildHierarchyTools` never hands the IC tier `create_subordinate_agent` in the first place. Left as defence in depth rather than tested through a back door.
- `types.ts` — interfaces only, no runtime code.

## Verification

- `tsc --noEmit` on `packages/api` — clean
- `eslint packages/api/src` — 0 errors (4 pre-existing warnings in files this PR doesn't touch)
- `packages/api` suite: 46 files pass, 9 fail — the same nine DB-gated files that fail without Postgres on `main`, unchanged by this PR
- `@vitest/coverage-v8` was installed for the sweep and removed again; `package.json` and `pnpm-lock.yaml` are untouched

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwucDAcvNRYyBFT6XfiFJC)_