### PR TITLE
refactor: unify four more clusters of near-duplicate abstractions

### DIFF
--- a/packages/api/src/routes/escalation.ts
+++ b/packages/api/src/routes/escalation.ts
@@ -17,7 +17,7 @@
  * executor picks both up within ≤30s.
  */
 
-import { Router, type RequestHandler, type Response } from "express";
+import { Router, type RequestHandler } from "express";
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import {
   type EscalationService,
@@ -27,7 +27,7 @@ import {
 } from "@beevibe/core/services/escalation-service";
 import { NegotiationNotFoundError } from "@beevibe/core/services/negotiation-service";
 import { requireHuman } from "../auth/middleware.js";
-import { requireParam } from "./http-errors.js";
+import { makeDomainErrorHandler, requireParam } from "./http-errors.js";
 
 export interface EscalationRoutesDeps {
   authMiddleware: RequestHandler;
@@ -88,25 +88,11 @@ function buildSelector(body: unknown):
   };
 }
 
-function handleEscalationError(err: unknown, res: Response): void {
-  if (err instanceof EscalationNotFoundError) {
-    res.status(404).json({ error: "escalation_not_found", message: err.message });
-    return;
-  }
-  if (err instanceof NegotiationNotFoundError) {
-    res.status(404).json({ error: "negotiation_not_found", message: err.message });
-    return;
-  }
-  if (err instanceof EscalationStateError) {
-    res.status(409).json({ error: "invalid_state", message: err.message });
-    return;
-  }
-  console.error("[escalation route]", err);
-  res.status(500).json({
-    error: "internal_error",
-    message: err instanceof Error ? err.message : String(err),
-  });
-}
+const handleEscalationError = makeDomainErrorHandler("escalation route", [
+  [EscalationNotFoundError, { status: 404, error: "escalation_not_found" }],
+  [NegotiationNotFoundError, { status: 404, error: "negotiation_not_found" }],
+  [EscalationStateError, { status: 409, error: "invalid_state" }],
+]);
 
 export function createEscalationRouter(deps: EscalationRoutesDeps): Router {
   const router = Router();

--- a/packages/api/src/routes/http-errors.test.ts
+++ b/packages/api/src/routes/http-errors.test.ts
@@ -3,6 +3,7 @@ import type { Request, Response } from "express";
 import {
   invalidBody,
   loadOwned,
+  makeDomainErrorHandler,
   requireNullableString,
   requireParam,
 } from "./http-errors.js";
@@ -217,5 +218,69 @@ describe("requireNullableString", () => {
     expect(res.body).toMatchObject({
       message: "expected { runtime_id: string | null }",
     });
+  });
+});
+
+describe("makeDomainErrorHandler", () => {
+  class NotFound extends Error {}
+  class Conflict extends Error {}
+  class SubclassOfNotFound extends NotFound {}
+
+  const mappings = [
+    [SubclassOfNotFound, { status: 410, error: "gone" }],
+    [NotFound, { status: 404, error: "thing_not_found" }],
+    [Conflict, { status: 409, error: "invalid_state" }],
+  ] as const;
+
+  it("maps a known domain error to its status and code, keeping the message", () => {
+    const res = fakeRes();
+    makeDomainErrorHandler("test route", mappings)(new NotFound("no such thing"), res);
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({ error: "thing_not_found", message: "no such thing" });
+  });
+
+  it("picks each mapping independently", () => {
+    const res = fakeRes();
+    makeDomainErrorHandler("test route", mappings)(new Conflict("already resolved"), res);
+    expect(res.statusCode).toBe(409);
+    expect(res.body).toEqual({ error: "invalid_state", message: "already resolved" });
+  });
+
+  it("takes the first matching mapping, so a subclass listed first wins", () => {
+    // `instanceof` matches the base class too. Order is the only thing
+    // that distinguishes them, and the routers rely on their declared
+    // order — this pins that the ladder is not reordered.
+    const res = fakeRes();
+    makeDomainErrorHandler("test route", mappings)(new SubclassOfNotFound("x"), res);
+    expect(res.statusCode).toBe(410);
+    expect(res.body).toEqual({ error: "gone", message: "x" });
+  });
+
+  it("falls through to the shared 500 for an unmapped error", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = fakeRes();
+    makeDomainErrorHandler("test route", mappings)(new Error("kaboom"), res);
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: "internal_error", message: "kaboom" });
+    expect(spy).toHaveBeenCalledWith("[test route]", expect.any(Error));
+    spy.mockRestore();
+  });
+
+  it("stringifies a non-Error throw on the fallthrough", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = fakeRes();
+    makeDomainErrorHandler("test route", mappings)("just a string", res);
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: "internal_error", message: "just a string" });
+    spy.mockRestore();
+  });
+
+  it("sends exactly one response for a mapped error", () => {
+    // The hand-written ladders each ended their branch with a bare
+    // `return`; a helper that forgot one would 404 and then 500.
+    const res = fakeRes();
+    const json = vi.spyOn(res, "json");
+    makeDomainErrorHandler("test route", mappings)(new NotFound("once"), res);
+    expect(json).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/api/src/routes/http-errors.ts
+++ b/packages/api/src/routes/http-errors.ts
@@ -139,6 +139,53 @@ export async function loadOwned<T>(
  * copy-paste, so chat keeps its own handler and this factory preserves the
  * existing behavior of the other four rather than quietly changing it.
  */
+/**
+ * A domain error class paired with the HTTP response it maps to.
+ *
+ * `abstract new (...args: never[])` is just "some error constructor" —
+ * it exists to be the right-hand side of an `instanceof`, so the
+ * constructor's real parameters are irrelevant here.
+ */
+export type DomainErrorMapping = readonly [
+  abstract new (...args: never[]) => Error,
+  { status: number; error: string },
+];
+
+/**
+ * A router's `handleError`: try each domain-error mapping in order,
+ * then fall through to {@link makeErrorHandler}'s 500.
+ *
+ * `escalation`, `negotiation` and `task` each hand-wrote this ladder —
+ * an `if (err instanceof X) { res.status(n).json({ error, message });
+ * return; }` per known failure, then a verbatim copy of the 500 the four
+ * routers on `makeErrorHandler` already shared. Three more copies of the
+ * envelope, and the tail is the half nobody looks at when adding a case.
+ *
+ * The mappings stay per-router because they are the actual contract, but
+ * one of them was already duplicated across routers:
+ * `NegotiationNotFoundError → 404 negotiation_not_found` is declared by
+ * both `escalation` and `negotiation`, which is exactly the pair that
+ * would drift.
+ *
+ * Order matters and is preserved from each call site: the first
+ * matching mapping wins, so a subclass must be listed before its base.
+ */
+export function makeDomainErrorHandler(
+  tag: string,
+  mappings: readonly DomainErrorMapping[],
+): (err: unknown, res: Response) => void {
+  const fallback = makeErrorHandler(tag);
+  return (err, res) => {
+    for (const [ErrorClass, { status, error }] of mappings) {
+      if (err instanceof ErrorClass) {
+        res.status(status).json({ error, message: err.message });
+        return;
+      }
+    }
+    fallback(err, res);
+  };
+}
+
 export function makeErrorHandler(
   tag: string,
 ): (err: unknown, res: Response, context?: string) => void {

--- a/packages/api/src/routes/negotiation.ts
+++ b/packages/api/src/routes/negotiation.ts
@@ -14,7 +14,11 @@ import {
   NegotiationNotFoundError,
 } from "@beevibe/core/services/negotiation-service";
 import { requireHuman } from "../auth/middleware.js";
-import { requireParam } from "./http-errors.js";
+import { makeDomainErrorHandler, requireParam } from "./http-errors.js";
+
+const handleNegotiationError = makeDomainErrorHandler("negotiation route", [
+  [NegotiationNotFoundError, { status: 404, error: "negotiation_not_found" }],
+]);
 
 export interface NegotiationRoutesDeps {
   authMiddleware: RequestHandler;
@@ -33,15 +37,7 @@ export function createNegotiationRouter(deps: NegotiationRoutesDeps): Router {
       const negotiation = await deps.negotiationService.getReview(id);
       res.json({ ok: true, negotiation });
     } catch (err) {
-      if (err instanceof NegotiationNotFoundError) {
-        res.status(404).json({ error: "negotiation_not_found", message: err.message });
-        return;
-      }
-      console.error("[negotiation route]", err);
-      res.status(500).json({
-        error: "internal_error",
-        message: err instanceof Error ? err.message : String(err),
-      });
+      handleNegotiationError(err, res);
     }
   });
 

--- a/packages/api/src/routes/task.ts
+++ b/packages/api/src/routes/task.ts
@@ -16,7 +16,7 @@
  *     killed).
  */
 
-import { Router, type RequestHandler, type Response } from "express";
+import { Router, type RequestHandler } from "express";
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import {
   TASK_PRIORITIES,
@@ -42,7 +42,7 @@ import { buildIntent, type ResumeReason } from "@beevibe/core/services/agent-ses
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
 import { requireHuman } from "../auth/middleware.js";
 import type { DaemonHub } from "../runtime/hub.js";
-import { requireParam } from "./http-errors.js";
+import { makeDomainErrorHandler, requireParam } from "./http-errors.js";
 
 /** Statuses from which /cancel is legal. Anything non-terminal. */
 const CANCELLABLE_FROM: readonly TaskStatus[] = [
@@ -115,21 +115,10 @@ async function recordCapabilityOutcome(
   }
 }
 
-function handleServiceError(err: unknown, res: Response): void {
-  if (err instanceof TaskNotFoundError) {
-    res.status(404).json({ error: "task_not_found", message: err.message });
-    return;
-  }
-  if (err instanceof InvalidTaskTransitionError) {
-    res.status(409).json({ error: "invalid_transition", message: err.message });
-    return;
-  }
-  console.error("[task route]", err);
-  res.status(500).json({
-    error: "internal_error",
-    message: err instanceof Error ? err.message : String(err),
-  });
-}
+const handleServiceError = makeDomainErrorHandler("task route", [
+  [TaskNotFoundError, { status: 404, error: "task_not_found" }],
+  [InvalidTaskTransitionError, { status: 409, error: "invalid_transition" }],
+]);
 
 function parsePriority(input: unknown): TaskPriority | undefined {
   if (typeof input !== "string") return undefined;

--- a/packages/api/src/tools/escalation-input.test.ts
+++ b/packages/api/src/tools/escalation-input.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  escalationContributionSchema,
+  parseEscalationContribution,
+} from "./escalation-input.js";
+
+describe("escalationContributionSchema", () => {
+  it("declares both args with the caller's prose", () => {
+    const schema = escalationContributionSchema({
+      proposals: "Your options.",
+      openQuestions: "What you'd like to know.",
+    });
+    expect(Object.keys(schema)).toEqual(["proposals", "open_questions"]);
+    expect(schema.proposals).toMatchObject({ description: "Your options." });
+    expect(schema.open_questions).toMatchObject({
+      type: "array",
+      items: { type: "string" },
+      description: "What you'd like to know.",
+    });
+  });
+
+  it("requires title and description on a proposal but not tradeoffs", () => {
+    // This is the model-facing contract for both escalation tools; it
+    // was written out twice before and is the thing that could drift.
+    const schema = escalationContributionSchema({ proposals: "a", openQuestions: "b" });
+    expect(schema.proposals).toMatchObject({
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          description: { type: "string" },
+          tradeoffs: { type: "string" },
+        },
+        required: ["title", "description"],
+      },
+    });
+  });
+
+  it("varies nothing but the prose between the two callers", () => {
+    const initiator = escalationContributionSchema({ proposals: "A", openQuestions: "B" });
+    const counterparty = escalationContributionSchema({ proposals: "C", openQuestions: "D" });
+    const strip = (s: Record<string, unknown>) =>
+      JSON.parse(JSON.stringify(s), (k, v) => (k === "description" ? undefined : v));
+    expect(strip(initiator)).toEqual(strip(counterparty));
+  });
+});
+
+describe("parseEscalationContribution", () => {
+  it("reads both arrays off the raw input", () => {
+    expect(
+      parseEscalationContribution({
+        proposals: [{ title: "Ship it", description: "now" }],
+        open_questions: ["what is the deadline?"],
+      }),
+    ).toEqual({
+      proposals: [{ title: "Ship it", description: "now" }],
+      openQuestions: ["what is the deadline?"],
+    });
+  });
+
+  it("leaves an omitted arg undefined rather than defaulting it to []", () => {
+    // EscalationService distinguishes the two: absent leaves the slot
+    // unset, [] records that the agent filed nothing.
+    expect(parseEscalationContribution({})).toEqual({
+      proposals: undefined,
+      openQuestions: undefined,
+    });
+    expect(parseEscalationContribution({ proposals: [], open_questions: [] })).toEqual({
+      proposals: [],
+      openQuestions: [],
+    });
+  });
+
+  it("filters non-strings out of open_questions", () => {
+    expect(
+      parseEscalationContribution({ open_questions: ["a", 3, null, "b"] }).openQuestions,
+    ).toEqual(["a", "b"]);
+  });
+
+  it("passes proposal objects through uninspected", () => {
+    // Matches what both call sites did — an unchecked cast. Pinned so a
+    // future tightening is a deliberate change, not a silent one.
+    const junk = [{ nope: true }];
+    expect(parseEscalationContribution({ proposals: junk }).proposals).toEqual(junk);
+  });
+
+  it("treats a non-array as absent", () => {
+    expect(
+      parseEscalationContribution({ proposals: "one", open_questions: {} }),
+    ).toEqual({ proposals: undefined, openQuestions: undefined });
+  });
+});

--- a/packages/api/src/tools/escalation-input.ts
+++ b/packages/api/src/tools/escalation-input.ts
@@ -1,0 +1,81 @@
+/**
+ * The escalation contribution block — one declaration.
+ *
+ * An escalation carries two role-tagged slots, and both are filled by a
+ * tool that takes the same pair of args: `proposals` (options for the
+ * human) and `open_questions`. `escalate_to_humans` in `mesh.ts` files
+ * the initiator's slot; `add_to_escalation` in `hierarchy.ts` files the
+ * counterparty's. The two tools live in different modules and had each
+ * written out the pair twice over — once as JSON Schema for the model,
+ * once as a parse in the handler.
+ *
+ * The schemas were identical bar their `description` prose. The parses
+ * were identical in behavior but not in type: `mesh.ts` cast to
+ * `CreateEscalationInput["proposals"]` while `hierarchy.ts` cast to a
+ * hand-written `Array<{ title: string; description: string; tradeoffs?:
+ * string }>`. Both resolve to `Proposal[]`, so the duplication was
+ * invisible to the compiler — a field added to `Proposal` would have
+ * silently kept working on one side and not the other.
+ */
+
+import type { Proposal } from "@beevibe/core";
+
+/**
+ * JSON Schema for the two contribution args, sent verbatim to the model.
+ *
+ * The per-tool prose stays a parameter: the initiator is asked for "your
+ * concrete options for the human (2-3 typical)" while the counterparty
+ * is told theirs must be "different from initiator's", and that framing
+ * is the whole reason the second tool exists.
+ */
+export function escalationContributionSchema(descriptions: {
+  proposals: string;
+  openQuestions: string;
+}): Record<string, unknown> {
+  return {
+    proposals: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          description: { type: "string" },
+          tradeoffs: { type: "string" },
+        },
+        required: ["title", "description"],
+      },
+      description: descriptions.proposals,
+    },
+    open_questions: {
+      type: "array",
+      items: { type: "string" },
+      description: descriptions.openQuestions,
+    },
+  };
+}
+
+/**
+ * Parse the two contribution args off a tool handler's raw input.
+ *
+ * `undefined` (rather than `[]`) for an arg the model omitted, which is
+ * what `EscalationService` distinguishes: an absent `proposals` leaves
+ * the slot unset, an empty array records that the agent filed nothing.
+ *
+ * Proposal objects are passed through uninspected — the same unchecked
+ * cast both call sites already performed. Only `open_questions` filters
+ * its elements, because a stray non-string there would be rendered
+ * straight into the human's review page.
+ */
+export function parseEscalationContribution(input: Record<string, unknown>): {
+  proposals: Proposal[] | undefined;
+  openQuestions: string[] | undefined;
+} {
+  return {
+    proposals: Array.isArray(input.proposals)
+      ? (input.proposals as Proposal[])
+      : undefined,
+    openQuestions: Array.isArray(input.open_questions)
+      ? (input.open_questions as string[]).filter((q) => typeof q === "string")
+      : undefined,
+  };
+}

--- a/packages/api/src/tools/find-repo.ts
+++ b/packages/api/src/tools/find-repo.ts
@@ -39,6 +39,7 @@ import type {
   EmbeddingService,
   LearnedSkillRepository,
 } from "@beevibe/core";
+import { optionalNumber, optionalTrimmedString } from "./input.js";
 import type { AgentTool, AgentToolResult } from "./types.js";
 
 /**
@@ -310,14 +311,14 @@ async function findRepoHandler(
   trending: TrendingClient,
   githubToken: string | undefined,
 ): Promise<AgentToolResult> {
-  const goal = typeof input.goal === "string" ? input.goal.trim() : "";
+  const goal = optionalTrimmedString(input, "goal") ?? "";
   if (!goal) {
     return {
       content: { error: "invalid_goal", message: "goal must be a non-empty string" },
       isError: true,
     };
   }
-  const limitRaw = typeof input.limit === "number" ? input.limit : 5;
+  const limitRaw = optionalNumber(input, "limit") ?? 5;
   const limit = Math.min(10, Math.max(1, Math.floor(limitRaw)));
 
   // Resolve the agent's owner so we can scope learned-skill lookups.

--- a/packages/api/src/tools/hierarchy.ts
+++ b/packages/api/src/tools/hierarchy.ts
@@ -53,6 +53,18 @@ import {
   type ResumeReason,
 } from "@beevibe/core/services/agent-session";
 import { toolErrorFromThrown } from "./errors.js";
+import {
+  escalationContributionSchema,
+  parseEscalationContribution,
+} from "./escalation-input.js";
+import {
+  missingArgs,
+  optionalNonEmptyString,
+  optionalObject,
+  optionalString,
+  stringArg,
+  trimmedArg,
+} from "./input.js";
 import type { AgentTool } from "./types.js";
 
 // ── Agent-callable status subsets ─────────────────────────────────────────
@@ -187,7 +199,7 @@ function searchContextTool(
     },
     handler: async (input) => {
       try {
-        const query = String(input.query ?? "").trim();
+        const query = trimmedArg(input, "query");
         if (!query) {
           return { content: { error: "query must be a non-empty string" }, isError: true };
         }
@@ -236,9 +248,9 @@ function updateProgressTool(
     },
     handler: async (input) => {
       try {
-        const taskId = String(input.task_id ?? "");
+        const taskId = stringArg(input, "task_id");
         const status = input.status as AgentEndStatus;
-        const summary = String(input.summary ?? "");
+        const summary = stringArg(input, "summary");
         if (!AGENT_END_STATUSES.includes(status)) {
           return {
             content: {
@@ -303,8 +315,8 @@ function getAgentProfileTool(
     },
     handler: async (input) => {
       try {
-        const id = String(input.agent_id ?? "");
-        if (!id) return { content: { error: "agent_id required" }, isError: true };
+        const id = stringArg(input, "agent_id");
+        if (!id) return missingArgs("agent_id");
         const agent = await services.agentRepo.findById(id);
         return { content: { agent: projectAgent(agent) } };
       } catch (err) {
@@ -333,8 +345,8 @@ function getTaskTool(
     },
     handler: async (input) => {
       try {
-        const id = String(input.task_id ?? "");
-        if (!id) return { content: { error: "task_id required" }, isError: true };
+        const id = stringArg(input, "task_id");
+        if (!id) return missingArgs("task_id");
         const task = await services.taskRepo.findById(id);
         return { content: { task: projectTask(task) } };
       } catch (err) {
@@ -383,15 +395,10 @@ function createWorkProductTool(
     },
     handler: async (input) => {
       try {
-        const taskId = String(input.task_id ?? "");
+        const taskId = stringArg(input, "task_id");
         const type = input.type;
-        const title = String(input.title ?? "");
-        if (!taskId || !title) {
-          return {
-            content: { error: "task_id and title required" },
-            isError: true,
-          };
-        }
+        const title = stringArg(input, "title");
+        if (!taskId || !title) return missingArgs("task_id", "title");
         if (!WORK_PRODUCT_TYPES.includes(type as (typeof WORK_PRODUCT_TYPES)[number])) {
           return {
             content: { error: `type must be one of: ${WORK_PRODUCT_TYPES.join(", ")}` },
@@ -404,15 +411,12 @@ function createWorkProductTool(
           agent_id: ctx.agentId,
           type: type as (typeof WORK_PRODUCT_TYPES)[number],
           title,
-          summary: typeof input.summary === "string" ? input.summary : undefined,
-          body: typeof input.body === "string" ? input.body : undefined,
-          url: typeof input.url === "string" ? input.url : undefined,
-          provider: typeof input.provider === "string" ? input.provider : undefined,
-          external_id: typeof input.external_id === "string" ? input.external_id : undefined,
-          metadata:
-            input.metadata && typeof input.metadata === "object"
-              ? (input.metadata as Record<string, unknown>)
-              : undefined,
+          summary: optionalString(input, "summary"),
+          body: optionalString(input, "body"),
+          url: optionalString(input, "url"),
+          provider: optionalString(input, "provider"),
+          external_id: optionalString(input, "external_id"),
+          metadata: optionalObject(input, "metadata"),
         });
         return {
           content: {
@@ -447,8 +451,8 @@ function listWorkProductsTool(
     },
     handler: async (input) => {
       try {
-        const taskId = String(input.task_id ?? "");
-        if (!taskId) return { content: { error: "task_id required" }, isError: true };
+        const taskId = stringArg(input, "task_id");
+        if (!taskId) return missingArgs("task_id");
         const wps = await services.taskService.listWorkProducts(taskId);
         return {
           content: {
@@ -491,8 +495,8 @@ function getWorkProductTool(
     },
     handler: async (input) => {
       try {
-        const id = String(input.id ?? "");
-        if (!id) return { content: { error: "id required" }, isError: true };
+        const id = stringArg(input, "id");
+        if (!id) return missingArgs("id");
         const wp = await services.taskService.getWorkProduct(id);
         if (!wp) {
           return { content: { error: `work_product ${id} not found` }, isError: true };
@@ -550,19 +554,15 @@ function updateWorkProductTool(
     },
     handler: async (input) => {
       try {
-        const id = String(input.id ?? "");
-        if (!id) return { content: { error: "id required" }, isError: true };
+        const id = stringArg(input, "id");
+        if (!id) return missingArgs("id");
         const updated = await services.taskService.updateWorkProduct(id, {
-          summary: typeof input.summary === "string" ? input.summary : undefined,
-          body: typeof input.body === "string" ? input.body : undefined,
-          url: typeof input.url === "string" ? input.url : undefined,
-          provider: typeof input.provider === "string" ? input.provider : undefined,
-          external_id:
-            typeof input.external_id === "string" ? input.external_id : undefined,
-          metadata:
-            input.metadata && typeof input.metadata === "object"
-              ? (input.metadata as Record<string, unknown>)
-              : undefined,
+          summary: optionalString(input, "summary"),
+          body: optionalString(input, "body"),
+          url: optionalString(input, "url"),
+          provider: optionalString(input, "provider"),
+          external_id: optionalString(input, "external_id"),
+          metadata: optionalObject(input, "metadata"),
         });
         return {
           content: {
@@ -673,14 +673,9 @@ function createTaskTool(
     },
     handler: async (input) => {
       try {
-        const intent = String(input.intent ?? "");
-        const targetId = String(input.agent_id ?? "");
-        if (!intent || !targetId) {
-          return {
-            content: { error: "intent and agent_id required" },
-            isError: true,
-          };
-        }
+        const intent = stringArg(input, "intent");
+        const targetId = stringArg(input, "agent_id");
+        if (!intent || !targetId) return missingArgs("intent", "agent_id");
 
         // Authz: assignee must be one of caller's subordinates.
         const subs = await services.agentRepo.findSubordinates(ctx.agentId);
@@ -705,16 +700,14 @@ function createTaskTool(
         const created = await services.taskRepo.create({
           id: makeTaskId(),
           title: intent,
-          description: typeof input.description === "string" ? input.description : undefined,
+          description: optionalString(input, "description"),
           status: "assigned",
           priority,
           assignee_id: targetId,
           creator_id: ctx.agentId,
           creator_type: "agent",
-          parent_task_id:
-            typeof input.parent_task_id === "string" ? input.parent_task_id : undefined,
-          repo_url:
-            typeof input.repo_url === "string" && input.repo_url ? input.repo_url : undefined,
+          parent_task_id: optionalString(input, "parent_task_id"),
+          repo_url: optionalNonEmptyString(input, "repo_url"),
         });
 
         // Dispatch creates the pending session row + advances task →
@@ -780,8 +773,8 @@ function checkWorkStatusTool(
     },
     handler: async (input) => {
       try {
-        const targetId = String(input.agent_id ?? "");
-        if (!targetId) return { content: { error: "agent_id required" }, isError: true };
+        const targetId = stringArg(input, "agent_id");
+        if (!targetId) return missingArgs("agent_id");
 
         // Authz: self or direct subordinate.
         if (targetId !== ctx.agentId) {
@@ -852,11 +845,9 @@ function reviseTaskTool(
     },
     handler: async (input) => {
       try {
-        const taskId = String(input.task_id ?? "");
-        const feedback = String(input.feedback ?? "");
-        if (!taskId || !feedback) {
-          return { content: { error: "task_id and feedback required" }, isError: true };
-        }
+        const taskId = stringArg(input, "task_id");
+        const feedback = stringArg(input, "feedback");
+        if (!taskId || !feedback) return missingArgs("task_id", "feedback");
 
         const task = await services.taskRepo.findById(taskId);
         if (!task) {
@@ -951,39 +942,18 @@ function addToEscalationTool(
           type: "string",
           description: "The escalation id (from the 'escalated' sentinel).",
         },
-        proposals: {
-          type: "array",
-          items: {
-            type: "object",
-            properties: {
-              title: { type: "string" },
-              description: { type: "string" },
-              tradeoffs: { type: "string" },
-            },
-            required: ["title", "description"],
-          },
-          description: "Your proposals for the human (different from initiator's).",
-        },
-        open_questions: {
-          type: "array",
-          items: { type: "string" },
-          description: "Questions in your domain that humans should know about.",
-        },
+        ...escalationContributionSchema({
+          proposals: "Your proposals for the human (different from initiator's).",
+          openQuestions: "Questions in your domain that humans should know about.",
+        }),
       },
       required: ["escalation_id"],
     },
     handler: async (input) => {
       try {
-        const escalationId = String(input.escalation_id ?? "");
-        if (!escalationId) {
-          return { content: { error: "escalation_id required" }, isError: true };
-        }
-        const proposals = Array.isArray(input.proposals)
-          ? (input.proposals as Array<{ title: string; description: string; tradeoffs?: string }>)
-          : undefined;
-        const openQuestions = Array.isArray(input.open_questions)
-          ? (input.open_questions as string[]).filter((q) => typeof q === "string")
-          : undefined;
+        const escalationId = stringArg(input, "escalation_id");
+        if (!escalationId) return missingArgs("escalation_id");
+        const { proposals, openQuestions } = parseEscalationContribution(input);
 
         const updated = await services.escalationService.addContribution({
           escalationId,
@@ -1144,12 +1114,14 @@ function createSubordinateAgentTool(
           };
         }
 
-        const name = String(input.name ?? "").trim();
-        const tagLine = String(input.tag_line ?? "").trim();
-        const persona = String(input.persona ?? "").trim();
-        const domain = String(input.domain ?? "").trim();
-        const activeContext = String(input.active_context ?? "").trim();
-        const constraints = String(input.constraints ?? "").trim();
+        const name = trimmedArg(input, "name");
+        const tagLine = trimmedArg(input, "tag_line");
+        const persona = trimmedArg(input, "persona");
+        const domain = trimmedArg(input, "domain");
+        const activeContext = trimmedArg(input, "active_context");
+        const constraints = trimmedArg(input, "constraints");
+        // Coded rather than the plain `missingArgs` shape — the agent
+        // branches on `missing_required_fields` here.
         if (!name || !tagLine || !persona || !domain) {
           return {
             content: {

--- a/packages/api/src/tools/input.test.ts
+++ b/packages/api/src/tools/input.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import {
+  missingArgs,
+  optionalNonEmptyString,
+  optionalNumber,
+  optionalObject,
+  optionalString,
+  optionalStringArray,
+  optionalTrimmedString,
+  stringArg,
+  trimmedArg,
+} from "./input.js";
+
+describe("stringArg", () => {
+  it("reads a string arg", () => {
+    expect(stringArg({ task_id: "task_1" }, "task_id")).toBe("task_1");
+  });
+
+  it("yields the empty string for absent and null, which is what callers guard on", () => {
+    expect(stringArg({}, "task_id")).toBe("");
+    expect(stringArg({ task_id: null }, "task_id")).toBe("");
+  });
+
+  it("coerces a non-string rather than rejecting it", () => {
+    // `String(input.x ?? "")` is what every call site did, and models do
+    // send bare numbers for id-shaped args. Tightening this to a
+    // `typeof` check would start rejecting calls that work today, so
+    // the coercion is pinned deliberately.
+    expect(stringArg({ task_id: 5 }, "task_id")).toBe("5");
+    expect(stringArg({ task_id: false }, "task_id")).toBe("false");
+  });
+
+  it("does not trim — a padded value stays padded", () => {
+    expect(stringArg({ q: "  hi  " }, "q")).toBe("  hi  ");
+  });
+});
+
+describe("trimmedArg", () => {
+  it("strips surrounding whitespace", () => {
+    expect(trimmedArg({ name: "  Ada  " }, "name")).toBe("Ada");
+  });
+
+  it("collapses a whitespace-only value to empty, so the caller's guard fires", () => {
+    expect(trimmedArg({ name: "   " }, "name")).toBe("");
+  });
+});
+
+describe("missingArgs", () => {
+  it("names a single arg", () => {
+    expect(missingArgs("task_id")).toEqual({
+      content: { error: "task_id required" },
+      isError: true,
+    });
+  });
+
+  it("joins a pair with 'and', matching the existing wire messages", () => {
+    expect(missingArgs("task_id", "feedback").content).toEqual({
+      error: "task_id and feedback required",
+    });
+  });
+
+  it("comma-separates three or more", () => {
+    expect(missingArgs("a", "b", "c").content).toEqual({ error: "a, b and c required" });
+  });
+
+  it("always marks the result as an error", () => {
+    expect(missingArgs("id").isError).toBe(true);
+  });
+});
+
+describe("optionalString", () => {
+  it("passes a string through verbatim, empty included", () => {
+    expect(optionalString({ url: "https://x" }, "url")).toBe("https://x");
+    expect(optionalString({ url: "" }, "url")).toBe("");
+  });
+
+  it("is undefined for absent or non-string", () => {
+    expect(optionalString({}, "url")).toBeUndefined();
+    expect(optionalString({ url: 7 }, "url")).toBeUndefined();
+    expect(optionalString({ url: null }, "url")).toBeUndefined();
+  });
+});
+
+describe("optionalNonEmptyString", () => {
+  it("rejects the empty string where optionalString would keep it", () => {
+    expect(optionalNonEmptyString({ repo_url: "" }, "repo_url")).toBeUndefined();
+    expect(optionalString({ repo_url: "" }, "repo_url")).toBe("");
+  });
+
+  it("keeps a whitespace-only value verbatim — it does not trim", () => {
+    // This is the difference from optionalTrimmedString, and the reason
+    // both exist rather than one with a flag.
+    expect(optionalNonEmptyString({ repo_url: "  " }, "repo_url")).toBe("  ");
+    expect(optionalTrimmedString({ repo_url: "  " }, "repo_url")).toBeUndefined();
+  });
+});
+
+describe("optionalTrimmedString", () => {
+  it("returns the trimmed value", () => {
+    expect(optionalTrimmedString({ q: "  hello  " }, "q")).toBe("hello");
+  });
+
+  it("is undefined for absent, non-string, empty and whitespace-only", () => {
+    expect(optionalTrimmedString({}, "q")).toBeUndefined();
+    expect(optionalTrimmedString({ q: 3 }, "q")).toBeUndefined();
+    expect(optionalTrimmedString({ q: "" }, "q")).toBeUndefined();
+    expect(optionalTrimmedString({ q: "\t \n" }, "q")).toBeUndefined();
+  });
+});
+
+describe("optionalNumber", () => {
+  it("passes a number through, zero included", () => {
+    expect(optionalNumber({ limit: 10 }, "limit")).toBe(10);
+    expect(optionalNumber({ limit: 0 }, "limit")).toBe(0);
+  });
+
+  it("does not coerce a numeric string", () => {
+    expect(optionalNumber({ limit: "10" }, "limit")).toBeUndefined();
+  });
+});
+
+describe("optionalStringArray", () => {
+  it("keeps the string elements", () => {
+    expect(optionalStringArray({ ids: ["a", "b"] }, "ids")).toEqual(["a", "b"]);
+  });
+
+  it("drops non-string elements rather than rejecting the call", () => {
+    expect(optionalStringArray({ ids: ["a", 1, null, "b"] }, "ids")).toEqual(["a", "b"]);
+  });
+
+  it("distinguishes 'not supplied' from 'supplied empty'", () => {
+    // watch_tasks defaults to [] and then rejects on length; the
+    // escalation tools leave the slot unset. Both need this gap.
+    expect(optionalStringArray({}, "ids")).toBeUndefined();
+    expect(optionalStringArray({ ids: [] }, "ids")).toEqual([]);
+  });
+
+  it("is undefined for a non-array", () => {
+    expect(optionalStringArray({ ids: "a" }, "ids")).toBeUndefined();
+  });
+});
+
+describe("optionalObject", () => {
+  it("passes an object bag through", () => {
+    expect(optionalObject({ metadata: { pr: 12 } }, "metadata")).toEqual({ pr: 12 });
+  });
+
+  it("is undefined for absent, null and primitives", () => {
+    expect(optionalObject({}, "metadata")).toBeUndefined();
+    expect(optionalObject({ metadata: null }, "metadata")).toBeUndefined();
+    expect(optionalObject({ metadata: "x" }, "metadata")).toBeUndefined();
+    expect(optionalObject({ metadata: 0 }, "metadata")).toBeUndefined();
+  });
+
+  it("lets an array through, as both call sites already did", () => {
+    // Pinned as existing behavior, not endorsed: `typeof [] === "object"`.
+    // Whether create_work_product should accept an array as `metadata`
+    // is a separate call from the refactor that introduced this helper.
+    expect(optionalObject({ metadata: [1] }, "metadata")).toEqual([1]);
+  });
+});

--- a/packages/api/src/tools/input.ts
+++ b/packages/api/src/tools/input.ts
@@ -1,0 +1,148 @@
+/**
+ * Argument coercion for MCP agent-tool handlers.
+ *
+ * A tool handler receives `Record<string, unknown>` — the JSON the model
+ * emitted, validated by nothing. Every handler therefore opens with the
+ * same coercion preamble, and across `hierarchy.ts`, `mesh.ts`,
+ * `watch.ts`, `use-repo.ts` and `session-search.ts` the same five idioms
+ * were written out by hand roughly forty times:
+ *
+ *   - `String(input.x ?? "")` for a required string (34 sites)
+ *   - `typeof input.x === "string" ? input.x : undefined` (13 sites)
+ *   - `typeof input.x === "number" ? input.x : undefined` (4 sites)
+ *   - `Array.isArray(input.x) ? input.x.filter(…) : undefined` (5 sites)
+ *   - `input.x && typeof input.x === "object" ? (input.x as …) : undefined`
+ *
+ * These are behavior-preserving names for exactly those expressions —
+ * note in particular that {@link stringArg} keeps `String(…)`'s coercion
+ * of a non-string (a model that sends `task_id: 5` gets `"5"`, as it
+ * always has) rather than tightening to a `typeof` check. Tightening it
+ * would be a wire-contract change, not a refactor.
+ *
+ * The guard itself stays at the call site. It is deliberately NOT folded
+ * into a combined "read and validate" helper: several tools read more
+ * args than they guard (`create_work_product` reads `task_id`, `type`
+ * and `title` but rejects only on the first and last), so a helper that
+ * validated everything it read would reject input the tools accept
+ * today.
+ */
+
+import type { AgentToolResult } from "./types.js";
+
+/**
+ * A required string arg: `String(input[key] ?? "")`.
+ *
+ * Returns `""` for absent/null, which is what the callers' `if (!x)`
+ * guards test. Pair with {@link missingArgs} for the rejection.
+ */
+export function stringArg(input: Record<string, unknown>, key: string): string {
+  return String(input[key] ?? "");
+}
+
+/** {@link stringArg} with surrounding whitespace stripped. */
+export function trimmedArg(input: Record<string, unknown>, key: string): string {
+  return stringArg(input, key).trim();
+}
+
+/**
+ * The "you didn't pass these" rejection, in the wording the tools
+ * already use: `missingArgs("task_id", "feedback")` produces
+ * `{ error: "task_id and feedback required" }`.
+ *
+ * Deriving the message from the arg names is the point — it was
+ * previously a hand-written string sitting next to a hand-written guard,
+ * so renaming an arg left the error naming the old one.
+ */
+export function missingArgs(...names: string[]): AgentToolResult {
+  const list =
+    names.length <= 1
+      ? (names[0] ?? "")
+      : `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
+  return { content: { error: `${list} required` }, isError: true };
+}
+
+/** An optional string arg, `undefined` when absent or not a string. */
+export function optionalString(
+  input: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const v = input[key];
+  return typeof v === "string" ? v : undefined;
+}
+
+/**
+ * An optional string arg that must be non-empty, kept verbatim —
+ * `undefined` for absent, non-string, or `""`.
+ *
+ * Distinct from {@link optionalTrimmedString}, which also strips: a
+ * whitespace-only value survives this one and not that one. The call
+ * sites really do differ (`create_task`'s `repo_url` is stored as sent;
+ * `session_search`'s `query` is trimmed before matching), so the two
+ * behaviors get two names rather than one helper with a flag nobody
+ * would read.
+ */
+export function optionalNonEmptyString(
+  input: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const v = input[key];
+  return typeof v === "string" && v ? v : undefined;
+}
+
+/**
+ * An optional string arg that must carry something once trimmed, and is
+ * returned trimmed — `undefined` for absent, non-string, empty, or
+ * whitespace-only.
+ */
+export function optionalTrimmedString(
+  input: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const v = input[key];
+  if (typeof v !== "string") return undefined;
+  const trimmed = v.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+/** An optional number arg, `undefined` when absent or not a number. */
+export function optionalNumber(
+  input: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const v = input[key];
+  return typeof v === "number" ? v : undefined;
+}
+
+/**
+ * An optional `string[]` arg, with non-string elements dropped rather
+ * than rejected — a model that puts a number in an array of questions
+ * loses that element, it doesn't lose the call. `undefined` when the arg
+ * isn't an array at all, so callers can distinguish "not supplied" from
+ * "supplied empty".
+ */
+export function optionalStringArray(
+  input: Record<string, unknown>,
+  key: string,
+): string[] | undefined {
+  const v = input[key];
+  if (!Array.isArray(v)) return undefined;
+  return v.filter((x): x is string => typeof x === "string");
+}
+
+/**
+ * An optional structured-object arg (a `metadata` / `filters` bag).
+ *
+ * Arrays pass, because `typeof [] === "object"` and both call sites this
+ * replaces let them through. That is almost certainly not what either
+ * tool wants, but rejecting them here would change what
+ * `create_work_product` accepts, so it stays a separate decision from
+ * this refactor.
+ */
+export function optionalObject(
+  input: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | undefined {
+  const v = input[key];
+  if (!v || typeof v !== "object") return undefined;
+  return v as Record<string, unknown>;
+}

--- a/packages/api/src/tools/mesh.ts
+++ b/packages/api/src/tools/mesh.ts
@@ -10,12 +10,19 @@
 import { randomUUID } from "node:crypto";
 import type { AgentRepository, TaskRepository } from "@beevibe/core";
 import type { TaskService } from "@beevibe/core/services/task-service";
-import type {
-  EscalationService,
-  CreateEscalationInput,
-} from "@beevibe/core/services/escalation-service";
+import type { EscalationService } from "@beevibe/core/services/escalation-service";
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import { toolErrorFromThrown } from "./errors.js";
+import {
+  escalationContributionSchema,
+  parseEscalationContribution,
+} from "./escalation-input.js";
+import {
+  missingArgs,
+  optionalNonEmptyString,
+  optionalString,
+  stringArg,
+} from "./input.js";
 import type { AgentTool } from "./types.js";
 import type { McpCaller } from "./assemble.js";
 import type { MeshServer } from "../mesh/server.js";
@@ -95,11 +102,9 @@ function askTool(ctx: MeshToolContext, services: MeshToolServices): AgentTool {
     },
     handler: async (input) => {
       try {
-        const target = String(input.target_agent_id ?? "");
-        const question = String(input.question ?? "");
-        if (!target || !question) {
-          return { content: { error: "target_agent_id and question required" }, isError: true };
-        }
+        const target = stringArg(input, "target_agent_id");
+        const question = stringArg(input, "question");
+        if (!target || !question) return missingArgs("target_agent_id", "question");
         const requestId = randomUUID();
         const response = await services.mesh.sendAsk(
           requestId,
@@ -133,11 +138,9 @@ function respondAskTool(ctx: MeshToolContext, services: MeshToolServices): Agent
     },
     handler: async (input) => {
       try {
-        const requestId = String(input.request_id ?? "");
-        const answer = String(input.answer ?? "");
-        if (!requestId || !answer) {
-          return { content: { error: "request_id and answer required" }, isError: true };
-        }
+        const requestId = stringArg(input, "request_id");
+        const answer = stringArg(input, "answer");
+        if (!requestId || !answer) return missingArgs("request_id", "answer");
         services.mesh.respondAsk(requestId, {
           request_id: requestId,
           from_agent_id: ctx.caller.agentId,
@@ -178,13 +181,10 @@ function negotiateTool(ctx: MeshToolContext, services: MeshToolServices): AgentT
     },
     handler: async (input) => {
       try {
-        const peerId = String(input.peer_id ?? "");
-        const proposal = String(input.proposal ?? "");
-        const taskId =
-          typeof input.task_id === "string" && input.task_id ? input.task_id : undefined;
-        if (!peerId || !proposal) {
-          return { content: { error: "peer_id and proposal required" }, isError: true };
-        }
+        const peerId = stringArg(input, "peer_id");
+        const proposal = stringArg(input, "proposal");
+        const taskId = optionalNonEmptyString(input, "task_id");
+        if (!peerId || !proposal) return missingArgs("peer_id", "proposal");
 
         const response = await services.mesh.sendNegotiate(
           ctx.caller.agentId,
@@ -228,15 +228,12 @@ function respondNegotiateTool(ctx: MeshToolContext, services: MeshToolServices):
     },
     handler: async (input) => {
       try {
-        const negId = String(input.negotiation_id ?? "");
+        const negId = stringArg(input, "negotiation_id");
         const decision = input.decision as (typeof NEGOTIATE_DECISIONS)[number];
-        const message = String(input.message ?? "");
-        const counter =
-          typeof input.counter_proposal === "string" ? input.counter_proposal : undefined;
+        const message = stringArg(input, "message");
+        const counter = optionalString(input, "counter_proposal");
 
-        if (!negId || !message) {
-          return { content: { error: "negotiation_id and message required" }, isError: true };
-        }
+        if (!negId || !message) return missingArgs("negotiation_id", "message");
         if (!NEGOTIATE_DECISIONS.includes(decision)) {
           return {
             content: { error: `decision must be one of: ${NEGOTIATE_DECISIONS.join(", ")}` },
@@ -299,14 +296,9 @@ function reportBlockerTool(ctx: MeshToolContext, services: MeshToolServices): Ag
     },
     handler: async (input) => {
       try {
-        const taskId = String(input.task_id ?? "");
-        const description = String(input.description ?? "");
-        if (!taskId || !description) {
-          return {
-            content: { error: "task_id and description required" },
-            isError: true,
-          };
-        }
+        const taskId = stringArg(input, "task_id");
+        const description = stringArg(input, "description");
+        if (!taskId || !description) return missingArgs("task_id", "description");
 
         // Server derives parent from caller's hierarchy. Direct parent only.
         const parent = await services.agentRepo.findParent(ctx.caller.agentId);
@@ -369,41 +361,20 @@ function escalateToHumansTool(
           description:
             "Single shared problem statement. Neutral phrasing — \"We're stuck on X; root disagreement is Y.\" Becomes the escalation row's summary; immutable thereafter (peer's add_to_escalation can't change it).",
         },
-        proposals: {
-          type: "array",
-          items: {
-            type: "object",
-            properties: {
-              title: { type: "string" },
-              description: { type: "string" },
-              tradeoffs: { type: "string" },
-            },
-            required: ["title", "description"],
-          },
-          description: "Your concrete options for the human (2-3 typical).",
-        },
-        open_questions: {
-          type: "array",
-          items: { type: "string" },
-          description: "Things the human might know that you don't.",
-        },
+        ...escalationContributionSchema({
+          proposals: "Your concrete options for the human (2-3 typical).",
+          openQuestions: "Things the human might know that you don't.",
+        }),
       },
       required: ["negotiation_id", "summary"],
     },
     handler: async (input) => {
       try {
-        const negotiationId = String(input.negotiation_id ?? "");
-        const summary = String(input.summary ?? "");
-        if (!negotiationId || !summary) {
-          return { content: { error: "negotiation_id and summary required" }, isError: true };
-        }
+        const negotiationId = stringArg(input, "negotiation_id");
+        const summary = stringArg(input, "summary");
+        if (!negotiationId || !summary) return missingArgs("negotiation_id", "summary");
 
-        const proposals = Array.isArray(input.proposals)
-          ? (input.proposals as CreateEscalationInput["proposals"])
-          : undefined;
-        const openQuestions = Array.isArray(input.open_questions)
-          ? (input.open_questions as string[]).filter((q) => typeof q === "string")
-          : undefined;
+        const { proposals, openQuestions } = parseEscalationContribution(input);
 
         const escalation = await services.escalationService.create({
           negotiationId,

--- a/packages/api/src/tools/session-search.ts
+++ b/packages/api/src/tools/session-search.ts
@@ -4,6 +4,7 @@ import {
   SessionSearchService,
 } from "@beevibe/core/services/session-search";
 import { SESSION_TYPES, SESSION_STATUSES } from "@beevibe/core";
+import { optionalNumber, optionalTrimmedString } from "./input.js";
 import type { AgentTool } from "./types.js";
 
 /**
@@ -192,23 +193,16 @@ function inferRequest(input: Record<string, unknown>): SessionSearchRequest {
       ? (input.filters as SessionSearchRequest extends { filters?: infer F } ? F : never)
       : undefined;
 
-  const sessionId =
-    typeof input.session_id === "string" && input.session_id.trim()
-      ? input.session_id.trim()
-      : null;
-  const anchor =
-    typeof input.around_message_id === "string" && input.around_message_id.trim()
-      ? input.around_message_id.trim()
-      : null;
-  const query =
-    typeof input.query === "string" && input.query.trim() ? input.query.trim() : null;
+  const sessionId = optionalTrimmedString(input, "session_id") ?? null;
+  const anchor = optionalTrimmedString(input, "around_message_id") ?? null;
+  const query = optionalTrimmedString(input, "query") ?? null;
 
   if (sessionId && anchor) {
     return {
       kind: "scroll",
       session_id: sessionId,
       around_message_id: anchor,
-      window: typeof input.window === "number" ? input.window : undefined,
+      window: optionalNumber(input, "window"),
     };
   }
   if (sessionId) {
@@ -218,7 +212,7 @@ function inferRequest(input: Record<string, unknown>): SessionSearchRequest {
     return {
       kind: "discover",
       query,
-      limit: typeof input.limit === "number" ? input.limit : undefined,
+      limit: optionalNumber(input, "limit"),
       sort:
         input.sort === "newest" || input.sort === "oldest"
           ? input.sort
@@ -228,7 +222,7 @@ function inferRequest(input: Record<string, unknown>): SessionSearchRequest {
   }
   return {
     kind: "browse",
-    limit: typeof input.limit === "number" ? input.limit : undefined,
+    limit: optionalNumber(input, "limit"),
     filters,
   };
 }

--- a/packages/api/src/tools/use-repo.ts
+++ b/packages/api/src/tools/use-repo.ts
@@ -27,6 +27,7 @@ import {
   type TaskRepository,
 } from "@beevibe/core";
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import { optionalTrimmedString } from "./input.js";
 import type { AgentTool } from "./types.js";
 
 const USE_REPO_SCHEMA = {
@@ -122,9 +123,8 @@ export function createUseRepoTool(
       "the UI, or read repo_run.status for completion.",
     schema: USE_REPO_SCHEMA as Record<string, unknown>,
     handler: async (input) => {
-      const goal = typeof input.goal === "string" ? input.goal.trim() : "";
-      const repoUrl =
-        typeof input.repo_url === "string" ? input.repo_url.trim() : "";
+      const goal = optionalTrimmedString(input, "goal") ?? "";
+      const repoUrl = optionalTrimmedString(input, "repo_url") ?? "";
       if (!goal) {
         return {
           content: { error: "invalid_goal", message: "goal must be a non-empty string" },
@@ -141,12 +141,11 @@ export function createUseRepoTool(
         };
       }
 
-      const inputUrl =
-        typeof input.input_url === "string" ? input.input_url.trim() : undefined;
-      const inputFilename =
-        typeof input.input_filename === "string"
-          ? input.input_filename.trim()
-          : undefined;
+      // `optionalTrimmedString` maps a whitespace-only value to undefined
+      // where this used to yield ""; both sandbox consumers gate on
+      // `if (opts.input_url)`, so the two are indistinguishable downstream.
+      const inputUrl = optionalTrimmedString(input, "input_url");
+      const inputFilename = optionalTrimmedString(input, "input_filename");
       const limits = parseLimits(input.limits);
 
       // Look the agent up so we can pin the container task's creator

--- a/packages/api/src/tools/watch.ts
+++ b/packages/api/src/tools/watch.ts
@@ -18,6 +18,11 @@ import {
   type WatchService,
 } from "@beevibe/core/services/watch-service";
 import { toolError } from "./errors.js";
+import {
+  optionalString,
+  optionalStringArray,
+  optionalTrimmedString,
+} from "./input.js";
 import type { AgentTool, AgentToolResult } from "./types.js";
 
 export interface WatchToolContext {
@@ -97,9 +102,7 @@ function buildWatchTasksTool(
     },
     handler: async (input) => {
       try {
-        const taskIds = Array.isArray(input.task_ids)
-          ? input.task_ids.filter((x): x is string => typeof x === "string")
-          : [];
+        const taskIds = optionalStringArray(input, "task_ids") ?? [];
         if (taskIds.length === 0) {
           return toolError(
             "watch_validation",
@@ -107,10 +110,7 @@ function buildWatchTasksTool(
           );
         }
         const mode: TaskWatchMode = isMode(input.mode) ? input.mode : "all";
-        const reason =
-          typeof input.reason === "string" && input.reason.trim().length > 0
-            ? input.reason.trim()
-            : undefined;
+        const reason = optionalTrimmedString(input, "reason");
         if (!ctx.sessionId) {
           return toolError(
             "watch_validation",
@@ -161,8 +161,7 @@ function buildUnwatchTool(
     },
     handler: async (input) => {
       try {
-        const watchId =
-          typeof input.watch_id === "string" ? input.watch_id : "";
+        const watchId = optionalString(input, "watch_id") ?? "";
         if (!watchId) {
           return toolError(
             "watch_validation",

--- a/packages/web/app/(authed)/rooms/[id]/room-detail-client.tsx
+++ b/packages/web/app/(authed)/rooms/[id]/room-detail-client.tsx
@@ -24,6 +24,7 @@ import { ToolStepList } from "@/components/chat/tool-step-list";
 import { useChatStream, type ChatStreamStep } from "@/lib/chat-stream";
 import { Skeleton } from "@/components/skeleton";
 import { EmptyState } from "@/components/empty-state";
+import { FIELD_INPUT_CLASS } from "@/components/form-field";
 import { formatRelativeTime, idSuffix, sessionHref, shortId } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
@@ -323,7 +324,7 @@ function InviteDialog({ roomId, onClose }: { roomId: string; onClose: () => void
           onChange={(e) => setEmail(e.target.value)}
           autoFocus
           placeholder="alice@example.com"
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          className={FIELD_INPUT_CLASS}
           disabled={invite.isPending}
         />
         {error ? (

--- a/packages/web/app/(authed)/rooms/rooms-list-client.tsx
+++ b/packages/web/app/(authed)/rooms/rooms-list-client.tsx
@@ -10,6 +10,7 @@ import { isApiConfigured } from "@/lib/api/config";
 import { queryKeys } from "@/lib/hooks/keys";
 import { Skeleton } from "@/components/skeleton";
 import { EmptyState } from "@/components/empty-state";
+import { FIELD_INPUT_CLASS, FieldLabel, FormError } from "@/components/form-field";
 import { formatRelativeTime, shortId } from "@/lib/format";
 
 export function RoomsListClient() {
@@ -70,16 +71,14 @@ export function RoomsListClient() {
           className="mb-6 flex items-end gap-2 bg-card border border-border rounded-lg p-3"
         >
           <div className="flex-1">
-            <label htmlFor="room-name" className="block text-xs font-medium text-foreground mb-1.5">
-              Create a new room
-            </label>
+            <FieldLabel htmlFor="room-name">Create a new room</FieldLabel>
             <input
               id="room-name"
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="e.g. Plan the M9 launch"
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+              className={FIELD_INPUT_CLASS}
               disabled={create.isPending}
             />
           </div>
@@ -92,12 +91,7 @@ export function RoomsListClient() {
             Create
           </button>
         </form>
-        {error ? (
-          <div className="mb-4 flex items-start gap-1.5 text-xs text-status-failed">
-            <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>{error}</span>
-          </div>
-        ) : null}
+        <FormError message={error} className="mb-4" />
 
         <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-2 font-medium">
           Your rooms

--- a/packages/web/app/sign-in/sign-in-client.tsx
+++ b/packages/web/app/sign-in/sign-in-client.tsx
@@ -3,10 +3,17 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { AlertTriangle, KeyRound, Loader2, LogIn } from "lucide-react";
+import { KeyRound, LogIn } from "lucide-react";
 import { SIGNIN_NO_PASSWORD_SET } from "@beevibe/core/auth/constants";
 import { api } from "@/lib/api/client";
 import { asApiError } from "@/lib/api/http";
+import {
+  FIELD_INPUT_CLASS,
+  FieldLabel,
+  FormError,
+  SubmitButton,
+} from "@/components/form-field";
+import { cn } from "@/lib/utils";
 import {
   getUserKey,
   isApiConfigured,
@@ -139,9 +146,7 @@ export function SignInClient() {
 
         {mode === "password" ? (
           <>
-            <label className="block text-xs font-medium text-foreground mb-1.5" htmlFor="email">
-              Email
-            </label>
+            <FieldLabel htmlFor="email">Email</FieldLabel>
             <input
               id="email"
               type="email"
@@ -151,13 +156,13 @@ export function SignInClient() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="alice@example.com"
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+              className={FIELD_INPUT_CLASS}
               disabled={submitting}
             />
 
-            <label className="block text-xs font-medium text-foreground mb-1.5 mt-3" htmlFor="password">
+            <FieldLabel htmlFor="password" mt>
               Password
-            </label>
+            </FieldLabel>
             <input
               id="password"
               type="password"
@@ -165,15 +170,13 @@ export function SignInClient() {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               placeholder="••••••••"
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+              className={FIELD_INPUT_CLASS}
               disabled={submitting}
             />
           </>
         ) : (
           <>
-            <label className="block text-xs font-medium text-foreground mb-1.5" htmlFor="key">
-              User API key
-            </label>
+            <FieldLabel htmlFor="key">User API key</FieldLabel>
             <input
               id="key"
               type="password"
@@ -183,41 +186,27 @@ export function SignInClient() {
               value={keyDraft}
               onChange={(e) => setKeyDraft(e.target.value)}
               placeholder="bv_u_..."
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-ring"
+              className={cn(FIELD_INPUT_CLASS, "font-mono")}
               disabled={submitting}
             />
           </>
         )}
 
-        {error ? (
-          <div className="mt-3 flex items-start gap-1.5 text-xs text-status-failed">
-            <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>{error}</span>
-          </div>
-        ) : null}
+        <FormError message={error} className="mt-3" />
 
-        <button
-          type="submit"
+        <SubmitButton
+          submitting={submitting}
           disabled={
             submitting ||
             (mode === "password"
               ? email.trim().length === 0 || password.length === 0
               : keyDraft.trim().length === 0)
           }
-          className="mt-5 w-full inline-flex items-center justify-center gap-1.5 h-9 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          pendingLabel={mode === "password" ? "Signing in…" : "Verifying…"}
+          icon={<LogIn className="h-3.5 w-3.5" />}
         >
-          {submitting ? (
-            <>
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              {mode === "password" ? "Signing in…" : "Verifying…"}
-            </>
-          ) : (
-            <>
-              <LogIn className="h-3.5 w-3.5" />
-              Sign in
-            </>
-          )}
-        </button>
+          Sign in
+        </SubmitButton>
 
         <button
           type="button"

--- a/packages/web/app/sign-up/sign-up-client.tsx
+++ b/packages/web/app/sign-up/sign-up-client.tsx
@@ -3,11 +3,17 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { AlertTriangle, Loader2, Sparkles, UserPlus } from "lucide-react";
+import { Sparkles, UserPlus } from "lucide-react";
 import { PASSWORD_MIN_LENGTH } from "@beevibe/core/auth/constants";
 import { api } from "@/lib/api/client";
 import { asApiError } from "@/lib/api/http";
 import { getUserKey, isApiConfigured, setUserKey } from "@/lib/api/config";
+import {
+  FIELD_INPUT_CLASS,
+  FieldLabel,
+  FormError,
+  SubmitButton,
+} from "@/components/form-field";
 
 /**
  * Self-serve signup. Visitor enters name + email; the api mints them a
@@ -104,9 +110,7 @@ export function SignUpClient() {
           </p>
         </header>
 
-        <label className="block text-xs font-medium text-foreground mb-1.5" htmlFor="name">
-          Name
-        </label>
+        <FieldLabel htmlFor="name">Name</FieldLabel>
         <input
           id="name"
           type="text"
@@ -115,13 +119,13 @@ export function SignUpClient() {
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="Alice"
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          className={FIELD_INPUT_CLASS}
           disabled={submitting}
         />
 
-        <label className="block text-xs font-medium text-foreground mb-1.5 mt-3" htmlFor="email">
+        <FieldLabel htmlFor="email" mt>
           Email
-        </label>
+        </FieldLabel>
         <input
           id="email"
           type="email"
@@ -130,13 +134,13 @@ export function SignUpClient() {
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           placeholder="alice@example.com"
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          className={FIELD_INPUT_CLASS}
           disabled={submitting}
         />
 
-        <label className="block text-xs font-medium text-foreground mb-1.5 mt-3" htmlFor="password">
+        <FieldLabel htmlFor="password" mt>
           Password
-        </label>
+        </FieldLabel>
         <input
           id="password"
           type="password"
@@ -145,39 +149,25 @@ export function SignUpClient() {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           placeholder={`at least ${PASSWORD_MIN_LENGTH} characters`}
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          className={FIELD_INPUT_CLASS}
           disabled={submitting}
         />
 
-        {error ? (
-          <div className="mt-3 flex items-start gap-1.5 text-xs text-status-failed">
-            <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>{error}</span>
-          </div>
-        ) : null}
+        <FormError message={error} className="mt-3" />
 
-        <button
-          type="submit"
+        <SubmitButton
+          submitting={submitting}
           disabled={
             submitting ||
             name.trim().length === 0 ||
             email.trim().length === 0 ||
             password.length < PASSWORD_MIN_LENGTH
           }
-          className="mt-5 w-full inline-flex items-center justify-center gap-1.5 h-9 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          pendingLabel="Provisioning…"
+          icon={<Sparkles className="h-3.5 w-3.5" />}
         >
-          {submitting ? (
-            <>
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              Provisioning…
-            </>
-          ) : (
-            <>
-              <Sparkles className="h-3.5 w-3.5" />
-              Create my team agent
-            </>
-          )}
-        </button>
+          Create my team agent
+        </SubmitButton>
 
         <footer className="mt-5 pt-4 border-t border-border/60 text-[11px] text-muted-foreground leading-relaxed">
           Already have a key?{" "}

--- a/packages/web/components/form-field.test.tsx
+++ b/packages/web/components/form-field.test.tsx
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FIELD_INPUT_CLASS, FieldLabel, FormError, SubmitButton } from "./form-field";
+
+describe("FIELD_INPUT_CLASS", () => {
+  it("carries the border, background and focus-ring the forms depend on", () => {
+    // The point of the constant is that these survive as one string;
+    // pinning the load-bearing utilities catches a partial edit.
+    for (const cls of [
+      "w-full",
+      "rounded",
+      "border-border",
+      "bg-background",
+      "text-sm",
+      "focus:ring-1",
+      "focus:ring-ring",
+    ]) {
+      expect(FIELD_INPUT_CLASS).toContain(cls);
+    }
+  });
+});
+
+describe("FieldLabel", () => {
+  it("binds to its input via htmlFor", () => {
+    render(<FieldLabel htmlFor="email">Email</FieldLabel>);
+    expect(screen.getByText("Email")).toHaveAttribute("for", "email");
+  });
+
+  it("sits flush by default and takes the stacked gap with `mt`", () => {
+    const { rerender } = render(<FieldLabel htmlFor="a">First</FieldLabel>);
+    expect(screen.getByText("First").className).not.toContain("mt-3");
+    rerender(
+      <FieldLabel htmlFor="a" mt>
+        Second
+      </FieldLabel>,
+    );
+    expect(screen.getByText("Second").className).toContain("mt-3");
+  });
+});
+
+describe("FormError", () => {
+  it("renders the message when there is one", () => {
+    render(<FormError message="Wrong password." />);
+    expect(screen.getByText("Wrong password.")).toBeInTheDocument();
+  });
+
+  it("renders nothing for null, undefined or empty — callers drop it in unconditionally", () => {
+    const { container, rerender } = render(<FormError message={null} />);
+    expect(container).toBeEmptyDOMElement();
+    rerender(<FormError message={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+    rerender(<FormError message="" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("applies the caller's spacing, since the block sits above the field in one form and below in another", () => {
+    const { container } = render(<FormError message="x" className="mb-4" />);
+    expect(container.firstElementChild?.className).toContain("mb-4");
+  });
+});
+
+describe("SubmitButton", () => {
+  it("shows the idle icon and label when not submitting", () => {
+    render(
+      <SubmitButton
+        submitting={false}
+        disabled={false}
+        pendingLabel="Signing in…"
+        icon={<span data-testid="idle-icon" />}
+      >
+        Sign in
+      </SubmitButton>,
+    );
+    expect(screen.getByRole("button")).toHaveTextContent("Sign in");
+    expect(screen.getByTestId("idle-icon")).toBeInTheDocument();
+    expect(screen.queryByText("Signing in…")).not.toBeInTheDocument();
+  });
+
+  it("swaps to the pending label while submitting, dropping the idle icon", () => {
+    render(
+      <SubmitButton
+        submitting
+        disabled
+        pendingLabel="Provisioning…"
+        icon={<span data-testid="idle-icon" />}
+      >
+        Create my team agent
+      </SubmitButton>,
+    );
+    expect(screen.getByText("Provisioning…")).toBeInTheDocument();
+    expect(screen.queryByTestId("idle-icon")).not.toBeInTheDocument();
+  });
+
+  it("takes `disabled` from the caller, not from `submitting`", () => {
+    // sign-in disables on empty fields too, so the two must stay
+    // separate props rather than one being derived from the other.
+    render(
+      <SubmitButton submitting={false} disabled pendingLabel="…" icon={null}>
+        Sign in
+      </SubmitButton>,
+    );
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+
+  it("submits its form", () => {
+    render(
+      <SubmitButton submitting={false} disabled={false} pendingLabel="…" icon={null}>
+        Go
+      </SubmitButton>,
+    );
+    expect(screen.getByRole("button")).toHaveAttribute("type", "submit");
+  });
+});

--- a/packages/web/components/form-field.tsx
+++ b/packages/web/components/form-field.tsx
@@ -1,0 +1,126 @@
+import type { ReactNode } from "react";
+import { AlertTriangle, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * The text-input chrome shared by every hand-written form in the app.
+ *
+ * `sign-in`, `sign-up`, the rooms list, the room invite dialog and the
+ * user widget each carried this exact 12-utility string — nine copies,
+ * character for character, with nothing but a `cn()` call between some
+ * of them. A form control is precisely the thing that must not drift:
+ * two inputs a user sees in one session at different heights or with
+ * different focus rings reads as a bug, and the only thing that had
+ * been keeping them equal was that nobody had edited one.
+ *
+ * Exported as a class string rather than an `<Input>` component on
+ * purpose. The call sites disagree on almost everything else — `type`,
+ * `autoComplete`, `inputMode`, `autoFocus`, `minLength`, `spellCheck`,
+ * whether they're controlled by a `useState` or a mutation's pending
+ * flag — so a wrapper would be all passthrough props. Compose it with
+ * `cn()` when a field needs an addition (`font-mono` for the API-key
+ * field).
+ */
+export const FIELD_INPUT_CLASS =
+  "w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring";
+
+/**
+ * The label above a {@link FIELD_INPUT_CLASS} input.
+ *
+ * `mt` is the top margin, which is the only thing that varied across
+ * the seven copies: the first field in a form sits flush, every
+ * subsequent one takes `mt-3`.
+ */
+export function FieldLabel({
+  htmlFor,
+  mt = false,
+  children,
+}: {
+  htmlFor: string;
+  /** Add the `mt-3` gap used between stacked fields. */
+  mt?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <label
+      htmlFor={htmlFor}
+      className={cn("block text-xs font-medium text-foreground mb-1.5", mt && "mt-3")}
+    >
+      {children}
+    </label>
+  );
+}
+
+/**
+ * The inline "that didn't work" row under a form — warning triangle
+ * plus the server's message. Renders nothing for a null/empty message,
+ * so callers drop it in without a surrounding conditional.
+ *
+ * `className` carries the caller's spacing (`mt-3` under the auth
+ * forms, `mb-4` above the rooms list) because the block sits below the
+ * field in one layout and above it in the other.
+ *
+ * Distinct from `<MutationError>`, which is the right-aligned
+ * "Couldn't <verb>: …" line used beside action buttons — same color
+ * token, different affordance.
+ */
+export function FormError({
+  message,
+  className,
+}: {
+  message: string | null | undefined;
+  className?: string;
+}) {
+  if (!message) return null;
+  return (
+    <div className={cn("flex items-start gap-1.5 text-xs text-status-failed", className)}>
+      <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+      <span>{message}</span>
+    </div>
+  );
+}
+
+/**
+ * The full-width primary submit at the foot of the auth forms, with the
+ * spinner-swap while in flight.
+ *
+ * `sign-in` and `sign-up` had this button's 15-utility class string
+ * byte-identical, along with the `{submitting ? <Loader2 …/> : <Icon
+ * …/>}` swap. What differs is only the icon and the two labels, so
+ * those are the props.
+ */
+export function SubmitButton({
+  submitting,
+  disabled,
+  pendingLabel,
+  icon,
+  children,
+}: {
+  submitting: boolean;
+  disabled: boolean;
+  /** Label shown while `submitting` — "Signing in…", "Provisioning…". */
+  pendingLabel: string;
+  /** The idle-state icon, already sized (`h-3.5 w-3.5`). */
+  icon: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="submit"
+      disabled={disabled}
+      className="mt-5 w-full inline-flex items-center justify-center gap-1.5 h-9 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      {submitting ? (
+        <>
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          {pendingLabel}
+        </>
+      ) : (
+        <>
+          {icon}
+          {children}
+        </>
+      )}
+    </button>
+  );
+}

--- a/packages/web/components/user-widget.tsx
+++ b/packages/web/components/user-widget.tsx
@@ -19,6 +19,7 @@ import { ModalOverlay } from "@/components/modal-overlay";
 import { clearUserKey } from "@/lib/api/config";
 import { cn } from "@/lib/utils";
 import { Avatar } from "@/components/avatar";
+import { FIELD_INPUT_CLASS } from "@/components/form-field";
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -170,7 +171,7 @@ function InviteTeammateDialog({ onClose }: { onClose: () => void }) {
           onChange={(e) => setEmail(e.target.value)}
           autoFocus
           placeholder="alice@example.com"
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          className={FIELD_INPUT_CLASS}
         />
         {shareLink ? (
           <div className="mt-3 rounded border border-border bg-muted/40 p-3">


### PR DESCRIPTION
Four clusters found by sweeping for near-duplicate abstractions. Everything here is behavior-preserving; the two places where an edge case shifts are called out below and argued.

## 1. Agent-tool argument coercion — ~45 sites across 6 modules

Every MCP tool handler takes `Record<string, unknown>` validated by nothing, so each opens with the same coercion preamble. Five idioms were written out by hand across `hierarchy`, `mesh`, `watch`, `use-repo`, `session-search` and `find-repo`:

| idiom | sites |
| --- | --- |
| `String(input.x ?? "")` | 34 |
| `typeof input.x === "string" ? input.x : undefined` | 13 |
| the same for numbers | 4 |
| `Array.isArray(input.x) ? input.x.filter(…) : undefined` | 5 |
| the metadata-bag object check | 3 |

`tools/input.ts` names exactly those expressions. Two deliberate choices:

- **`stringArg` keeps `String(…)`'s coercion of a non-string.** A model that sends `task_id: 5` gets `"5"`, as it always has. Tightening this to a `typeof` check would start rejecting calls that work today — a wire-contract change, not a refactor.
- **`optionalNonEmptyString` and `optionalTrimmedString` are separate helpers**, not one with a flag. The call sites genuinely differ on whether a whitespace-only value survives: `create_task`'s `repo_url` is stored as sent, `session_search`'s `query` is trimmed before matching.

`missingArgs("task_id", "feedback")` derives `"task_id and feedback required"` from the arg names. That's the point — the message was previously a hand-written string sitting beside a hand-written guard, so renaming an arg left the error naming the old one.

The guard itself stays at the call site. It is deliberately **not** folded into a combined read-and-validate helper: several tools read more args than they reject on (`create_work_product` reads `task_id`, `type` and `title` but rejects only on the first and last), so a helper that validated everything it read would reject input the tools accept today.

## 2. The escalation contribution block — declared twice

An escalation has two role-tagged slots, filled by tools in different modules: `escalate_to_humans` (`mesh.ts`) files the initiator's, `add_to_escalation` (`hierarchy.ts`) the counterparty's. Both take `proposals` + `open_questions`, and each had written the pair out twice over — once as JSON Schema for the model, once as a parse in the handler.

The schemas were identical bar their `description` prose. The parses were identical in behavior but **not in type**: `mesh.ts` cast to `CreateEscalationInput["proposals"]` while `hierarchy.ts` cast to a hand-written `Array<{ title: string; description: string; tradeoffs?: string }>`. Both resolve to `Proposal[]`, so the duplication was invisible to the compiler — a field added to `Proposal` would have silently kept working on one side and not the other.

`tools/escalation-input.ts` is now the one declaration. A test pins that the emitted schema is byte-identical to both original literals, key order included.

## 3. The route domain-error ladder — 3 routers

`escalation`, `negotiation` and `task` each hand-wrote `if (err instanceof X) { res.status(n).json({ error, message }); return; }` per known failure, then a verbatim copy of the 500 that `signin`/`signup`/`room`/`view` already shared via `makeErrorHandler`. Three more copies of the envelope, and the tail is the half nobody looks at when adding a case.

`makeDomainErrorHandler(tag, mappings)` takes the ladder and falls through to that shared 500. The mappings stay per-router because they are the actual contract — but one was **already duplicated across routers**: `NegotiationNotFoundError → 404 negotiation_not_found` is declared by both `escalation` and `negotiation`, exactly the pair that would drift.

Order is preserved from each call site and pinned by a test, since `instanceof` matches base classes and first-match wins.

## 4. Web form primitives — 9 copies of one class string across 5 files

`sign-in`, `sign-up`, the rooms list, the room invite dialog and the user widget each carried the same 12-utility input class **character for character**, plus 7 copies of the label class and, between the two auth pages, a byte-identical submit button and error row.

A form control is precisely the thing that must not drift: two inputs a user sees in one session at different heights or with different focus rings reads as a bug, and the only thing keeping them equal was that nobody had edited one.

`FIELD_INPUT_CLASS` is exported as a class string rather than an `<Input>` component on purpose — the call sites disagree on almost everything else (`type`, `autoComplete`, `inputMode`, `autoFocus`, `minLength`, `spellCheck`, controlled-by-state vs by a mutation's pending flag), so a wrapper would be all passthrough props. `FieldLabel`, `FormError` and `SubmitButton` take the parts that are real markup.

No visual change. The auth route bundles get slightly smaller and render identically.

## The two edge cases that shift

Both are in `use-repo`'s optional args, where `optionalTrimmedString` maps a whitespace-only value to `undefined` where the old expression yielded `""`. Both sandbox consumers gate on `if (opts.input_url)`, so the two are indistinguishable downstream — verified at `packages/sandbox/src/orchestrator.ts:212` and `:332`.

Separately, `optionalObject` **preserves** the existing behavior of letting an array through (`typeof [] === "object"`), rather than quietly fixing it. Whether `create_work_product` should accept an array as `metadata` is a separate call from this refactor; it's pinned by a test and noted in the doc comment.

## Verification

- `turbo run lint typecheck` — 15/15 tasks green, 0 errors (the remaining `import/no-duplicates` warnings are pre-existing and in untouched files).
- `next build` for web — clean.
- **49 new tests**: 25 for the coercion helpers (the non-string coercion, the empty-vs-whitespace split between the two optional-string variants, the "not supplied" vs "supplied empty" gap the escalation service depends on), 8 for the escalation block, 6 for `makeDomainErrorHandler` (first-match-wins, the fallthrough, exactly one response per error), 10 for the web primitives.
- All existing suites pass: api 859 tests, web 213 tests (25/25 files), scheduler 10.
- The 9 api / 20 core / 2 scheduler **files** that fail in this sandbox are the documented Postgres- and provider-key-gated ones (`DATABASE_URL_TEST`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`), unchanged by this diff — core has zero changes in it.

The three routers I touched have DB-gated integration suites that can't run without Docker here, so their error assertions were checked by hand against the new mappings (`escalation.test.ts:335,351,496`, `negotiation.test.ts:221`, `task.test.ts:201,333,353`) — status, `error` code and `message` all match. CI will run them for real.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1TAa258LfJotES8zTvX5y)_