### PR TITLE
test: cover the three untested MCP tool modules (32-65% → 100%)

### DIFF
--- a/packages/api/src/tools/session-search.test.ts
+++ b/packages/api/src/tools/session-search.test.ts
@@ -1,0 +1,366 @@
+/**
+ * session_search handler tests.
+ *
+ * The module's real logic is `inferRequest` — the shape inference that
+ * turns loose MCP input into one of four typed SessionSearchRequests.
+ * It isn't exported, so it's exercised through the handler with a stub
+ * service that records the request it was handed. The service itself
+ * (scope resolution, FTS, windowing) is covered by
+ * core/src/services/session-search.test.ts.
+ *
+ * The other half here is the error envelope: SessionSearchError keeps
+ * its structured `code`, and the null return — out of scope, or a
+ * missing anchor — becomes not_found_or_forbidden rather than an empty
+ * success.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { SessionSearchRequest } from "@beevibe/core";
+import {
+  SessionSearchError,
+  type SessionSearchContext,
+  type SessionSearchService,
+} from "@beevibe/core/services/session-search";
+import {
+  createSessionSearchTool,
+  type SessionSearchToolContext,
+} from "./session-search.js";
+
+const ctx: SessionSearchToolContext = {
+  agentId: "agent_1",
+  hierarchyLevel: "team",
+  sessionId: "ses_current",
+};
+
+/** Captures the (request, context) pair the tool builds. */
+function harness(result: unknown = { kind: "browse", sessions: [] }) {
+  const search = vi.fn(
+    async (_req: SessionSearchRequest, _ctx: SessionSearchContext) => result,
+  );
+  const tool = createSessionSearchTool(ctx, {
+    sessionSearch: { search } as unknown as SessionSearchService,
+  });
+  const req = () => search.mock.calls[0]![0];
+  return { tool, search, req };
+}
+
+function throwingHarness(err: unknown) {
+  const search = vi.fn(async () => {
+    throw err;
+  });
+  return createSessionSearchTool(ctx, {
+    sessionSearch: { search } as unknown as SessionSearchService,
+  });
+}
+
+describe("session_search tool definition", () => {
+  it("is named session_search and takes no required args", () => {
+    const { tool } = harness();
+    expect(tool.name).toBe("session_search");
+    // Every shape is optional — bare session_search() is the browse call.
+    expect(tool.schema.required).toBeUndefined();
+  });
+
+  it("advertises the sort enum the description documents", () => {
+    const { tool } = harness();
+    const props = tool.schema.properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(props.sort!.enum).toEqual(["newest", "oldest"]);
+  });
+});
+
+describe("shape inference", () => {
+  it("infers browse from no arguments", async () => {
+    const { tool, req } = harness();
+    await tool.handler({});
+
+    expect(req()).toEqual({ kind: "browse", limit: undefined, filters: undefined });
+  });
+
+  it("infers discover from a query", async () => {
+    const { tool, req } = harness();
+    await tool.handler({ query: "auth refactor", limit: 5, sort: "newest" });
+
+    expect(req()).toMatchObject({
+      kind: "discover",
+      query: "auth refactor",
+      limit: 5,
+      sort: "newest",
+    });
+  });
+
+  it("infers read from a bare session_id", async () => {
+    const { tool, req } = harness();
+    await tool.handler({ session_id: "ses_9" });
+
+    expect(req()).toEqual({ kind: "read", session_id: "ses_9" });
+  });
+
+  it("infers scroll from session_id + around_message_id", async () => {
+    const { tool, req } = harness();
+    await tool.handler({
+      session_id: "ses_9",
+      around_message_id: "evt_3",
+      window: 10,
+    });
+
+    expect(req()).toEqual({
+      kind: "scroll",
+      session_id: "ses_9",
+      around_message_id: "evt_3",
+      window: 10,
+    });
+  });
+
+  // Precedence is documented in the tool description: scroll beats read
+  // beats discover beats browse. An agent that passes a stale `query`
+  // alongside a scroll anchor must still get the scroll.
+  it("prefers scroll over discover when a query tags along", async () => {
+    const { tool, req } = harness();
+    await tool.handler({
+      session_id: "ses_9",
+      around_message_id: "evt_3",
+      query: "ignored",
+    });
+
+    expect(req().kind).toBe("scroll");
+  });
+
+  it("prefers read over discover when a query tags along", async () => {
+    const { tool, req } = harness();
+    await tool.handler({ session_id: "ses_9", query: "ignored" });
+
+    expect(req()).toEqual({ kind: "read", session_id: "ses_9" });
+  });
+
+  it("falls back to browse when an anchor arrives without a session_id", async () => {
+    const { tool, req } = harness();
+    await tool.handler({ around_message_id: "evt_3" });
+
+    expect(req().kind).toBe("browse");
+  });
+
+  it("keeps the synthetic user-turn anchor id intact", async () => {
+    const { tool, req } = harness();
+    await tool.handler({
+      session_id: "ses_9",
+      around_message_id: "intent:ses_9",
+    });
+
+    expect(req()).toMatchObject({ around_message_id: "intent:ses_9" });
+  });
+});
+
+describe("input coercion", () => {
+  it("trims session_id, anchor and query", async () => {
+    const { tool, req } = harness();
+    await tool.handler({ session_id: "  ses_9  ", around_message_id: " evt_3 " });
+
+    expect(req()).toMatchObject({
+      session_id: "ses_9",
+      around_message_id: "evt_3",
+    });
+  });
+
+  it("trims the discover query", async () => {
+    const { tool, req } = harness();
+    await tool.handler({ query: "  docker networking  " });
+
+    expect(req()).toMatchObject({ query: "docker networking" });
+  });
+
+  // Whitespace-only strings are absent, not present-and-empty — a blank
+  // session_id must not turn a browse into a read of "".
+  it.each([
+    ["blank", "   "],
+    ["empty", ""],
+  ])("treats a %s session_id as absent", async (_label, session_id) => {
+    const { tool, req } = harness();
+    await tool.handler({ session_id });
+
+    expect(req().kind).toBe("browse");
+  });
+
+  it("treats a blank query as absent", async () => {
+    const { tool, req } = harness();
+    await tool.handler({ query: "   " });
+
+    expect(req().kind).toBe("browse");
+  });
+
+  it.each([
+    ["session_id", { session_id: 5 }, "browse"],
+    ["query", { query: 5 }, "browse"],
+    // A non-string anchor demotes scroll to read, not to browse — the
+    // session_id is still good.
+    ["around_message_id", { session_id: "ses_9", around_message_id: 5 }, "read"],
+  ])("ignores a non-string %s", async (_label, input, kind) => {
+    const { tool, req } = harness();
+    await tool.handler(input as Record<string, unknown>);
+
+    expect(req().kind).toBe(kind);
+  });
+
+  it("drops a non-numeric limit, leaving the service default", async () => {
+    const { tool, req } = harness();
+    await tool.handler({ query: "x", limit: "3" });
+
+    expect(req()).toMatchObject({ kind: "discover", limit: undefined });
+  });
+
+  // Browse carries its own limit (default 5, where discover defaults to 3),
+  // so it has to forward the caller's number rather than fall through.
+  it("forwards a numeric limit on the browse shape", async () => {
+    const { tool, req } = harness();
+    await tool.handler({ limit: 8 });
+
+    expect(req()).toMatchObject({ kind: "browse", limit: 8 });
+  });
+
+  it("drops a non-numeric window on the scroll shape", async () => {
+    const { tool, req } = harness();
+    await tool.handler({
+      session_id: "ses_9",
+      around_message_id: "evt_3",
+      window: "10",
+    });
+
+    expect(req()).toMatchObject({ window: undefined });
+  });
+
+  it("drops an unrecognized sort value", async () => {
+    const { tool, req } = harness();
+    await tool.handler({ query: "x", sort: "relevance" });
+
+    expect(req()).toMatchObject({ sort: undefined });
+  });
+
+  it("forwards filters on discover and browse, but not on read", async () => {
+    const filters = { status: "failed" as const };
+
+    const discover = harness();
+    await discover.tool.handler({ query: "x", filters });
+    expect(discover.req()).toMatchObject({ filters });
+
+    const browse = harness();
+    await browse.tool.handler({ filters });
+    expect(browse.req()).toMatchObject({ filters });
+
+    const read = harness();
+    await read.tool.handler({ session_id: "ses_9", filters });
+    expect(read.req()).toEqual({ kind: "read", session_id: "ses_9" });
+  });
+
+  it.each([
+    ["null", null],
+    ["a string", "status:failed"],
+  ])("treats %s filters as absent", async (_label, filters) => {
+    const { tool, req } = harness();
+    await tool.handler({ query: "x", filters });
+
+    expect(req()).toMatchObject({ filters: undefined });
+  });
+});
+
+describe("caller context", () => {
+  it("passes agent id, tier and the active session through to the service", async () => {
+    const { tool, search } = harness();
+    await tool.handler({ query: "x" });
+
+    // currentSessionId is how the service excludes the caller's own live
+    // conversation from its own results.
+    expect(search.mock.calls[0]![1]).toEqual({
+      callerAgentId: "agent_1",
+      hierarchyLevel: "team",
+      currentSessionId: "ses_current",
+    });
+  });
+});
+
+describe("results and errors", () => {
+  it("returns the service result verbatim on success", async () => {
+    const result = { kind: "read", messages: [{ id: "evt_1" }] };
+    const { tool } = harness(result);
+
+    const res = await tool.handler({ session_id: "ses_9" });
+
+    expect(res.isError).toBeUndefined();
+    expect(res.content).toBe(result);
+  });
+
+  // A null return covers three distinct causes the agent can't
+  // distinguish, so the message names all of them.
+  it("maps a null result to not_found_or_forbidden", async () => {
+    const { tool } = harness(null);
+
+    const res = await tool.handler({ session_id: "ses_other" });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("not_found_or_forbidden");
+    expect(res.content.message).toContain("not in your scope");
+  });
+
+  it.each([
+    "forbidden_agent_filter",
+    "missing_query",
+    "missing_args",
+  ] as const)("preserves the %s code from a SessionSearchError", async (code) => {
+    const tool = throwingHarness(new SessionSearchError(code, `bad: ${code}`));
+
+    const res = await tool.handler({ query: "x" });
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({ error: code, message: `bad: ${code}` });
+  });
+
+  // The api consumes core's dist/ while integration scripts consume
+  // src/, so the same error class can arrive as a different constructor.
+  // Name matching is what keeps the code from degrading to
+  // internal_error across that boundary.
+  it("recognizes a SessionSearchError from another bundle by name", async () => {
+    const impostor = new Error("cross-bundle") as Error & { code: string };
+    impostor.name = "SessionSearchError";
+    impostor.code = "missing_query";
+    const tool = throwingHarness(impostor);
+
+    const res = await tool.handler({ query: "x" });
+
+    expect(res.content).toEqual({
+      error: "missing_query",
+      message: "cross-bundle",
+    });
+  });
+
+  it("wraps an unexpected Error as internal_error", async () => {
+    const tool = throwingHarness(new Error("pool timeout"));
+
+    const res = await tool.handler({ query: "x" });
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "internal_error",
+      message: "pool timeout",
+    });
+  });
+
+  it("stringifies a non-Error throw as internal_error", async () => {
+    const tool = throwingHarness("kaboom");
+
+    const res = await tool.handler({ query: "x" });
+
+    expect(res.content).toEqual({ error: "internal_error", message: "kaboom" });
+  });
+
+  // A plain Error whose name happens not to be SessionSearchError must
+  // not smuggle its `code` into the envelope.
+  it("does not treat an arbitrary error with a code as a SessionSearchError", async () => {
+    const err = new Error("nope") as Error & { code: string };
+    err.code = "ENOTFOUND";
+    const tool = throwingHarness(err);
+
+    const res = await tool.handler({ query: "x" });
+
+    expect(res.content.error).toBe("internal_error");
+  });
+});

--- a/packages/api/src/tools/use-repo.test.ts
+++ b/packages/api/src/tools/use-repo.test.ts
@@ -1,0 +1,403 @@
+/**
+ * use_repo handler tests.
+ *
+ * The handler is the ordering-sensitive part of the Capability Network
+ * path: validate input, resolve the caller, create the container task,
+ * dispatch (which creates the session row), then insert repo_run. The
+ * comment in the module explains why that order is load-bearing —
+ * repo_run.session_id has an FK to session.id — so the ordering is
+ * asserted here rather than left to the integration path, which needs a
+ * live Postgres and a spawned CLI.
+ *
+ * Everything downstream is stubbed; what's under test is the handler's
+ * own validation, limit clamping and failure envelopes.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type {
+  AgentRepository,
+  RepoRunRepository,
+  Task,
+  TaskRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import {
+  createUseRepoTool,
+  type UseRepoContext,
+  type UseRepoServices,
+} from "./use-repo.js";
+
+const ctx: UseRepoContext = { agentId: "agent_1" };
+
+const agent = { id: "agent_1", name: "Scout" };
+
+function makeTask(over: Partial<Task> = {}): Task {
+  return {
+    id: "tsk_1",
+    title: "t",
+    status: "todo",
+    priority: "medium",
+    creator_id: "agent_1",
+    creator_type: "agent",
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...over,
+  } as Task;
+}
+
+interface Harness {
+  services: UseRepoServices;
+  findById: ReturnType<typeof vi.fn>;
+  createTask: ReturnType<typeof vi.fn>;
+  dispatchTask: ReturnType<typeof vi.fn>;
+  createRepoRun: ReturnType<typeof vi.fn>;
+  /** Records the call order across the three collaborators. */
+  order: string[];
+}
+
+function harness(
+  opts: {
+    agent?: unknown;
+    dispatchThrows?: unknown;
+    repoRunThrows?: unknown;
+  } = {},
+): Harness {
+  const order: string[] = [];
+
+  const findById = vi.fn(async () => {
+    order.push("agent.findById");
+    return "agent" in opts ? opts.agent : agent;
+  });
+  const createTask = vi.fn(async (input: { id: string; title: string }) => {
+    order.push("task.create");
+    return makeTask({ id: input.id, title: input.title });
+  });
+  const dispatchTask = vi.fn(async () => {
+    order.push("dispatch");
+    if (opts.dispatchThrows) throw opts.dispatchThrows;
+    return { session: {}, runtime_id: null };
+  });
+  const createRepoRun = vi.fn(async () => {
+    order.push("repoRun.create");
+    if (opts.repoRunThrows) throw opts.repoRunThrows;
+    return {};
+  });
+
+  const services = {
+    agentRepo: { findById } as unknown as AgentRepository,
+    taskRepo: { create: createTask } as unknown as TaskRepository,
+    repoRunRepo: { create: createRepoRun } as unknown as RepoRunRepository,
+    dispatchService: { dispatchTask } as unknown as DispatchService,
+  };
+
+  return { services, findById, createTask, dispatchTask, createRepoRun, order };
+}
+
+function tool(h: Harness) {
+  return createUseRepoTool(ctx, h.services);
+}
+
+const GOOD = { goal: "extract tables", repo_url: "https://github.com/o/r" };
+
+describe("use_repo tool definition", () => {
+  it("is named use_repo and requires goal + repo_url", () => {
+    const t = tool(harness());
+    expect(t.name).toBe("use_repo");
+    expect(t.schema.required).toEqual(["goal", "repo_url"]);
+  });
+});
+
+describe("use_repo happy path", () => {
+  it("returns the minted ids, pending status and a watch url", async () => {
+    const h = harness();
+    const res = await tool(h).handler(GOOD);
+
+    expect(res.isError).toBeUndefined();
+    const c = res.content as Record<string, string>;
+    expect(c.status).toBe("pending");
+    expect(c.repo_run_id).toMatch(/^rrn_|^repo_run_|.+/);
+    expect(c.watch_url).toBe(`/capabilities/runs/${c.repo_run_id}`);
+    expect(c.task_id).toBeDefined();
+    expect(c.session_id).toBeDefined();
+  });
+
+  // The FK on repo_run.session_id means the session row (created by
+  // dispatchTask) must exist before the repo_run insert. If this order
+  // ever flips, the insert violates the constraint in production.
+  it("creates the task, dispatches, then inserts repo_run — in that order", async () => {
+    const h = harness();
+    await tool(h).handler(GOOD);
+
+    expect(h.order).toEqual([
+      "agent.findById",
+      "task.create",
+      "dispatch",
+      "repoRun.create",
+    ]);
+  });
+
+  it("pins the container task to the resolved agent and carries the goal", async () => {
+    const h = harness();
+    await tool(h).handler(GOOD);
+
+    expect(h.createTask.mock.calls[0]![0]).toMatchObject({
+      title: "extract tables",
+      description: "extract tables",
+      priority: "medium",
+      assignee_id: "agent_1",
+      creator_id: "agent_1",
+      creator_type: "agent",
+    });
+  });
+
+  it("dispatches a run_repo session under the pre-minted session id", async () => {
+    const h = harness();
+    const res = await tool(h).handler(GOOD);
+
+    const dispatched = h.dispatchTask.mock.calls[0]![0] as Record<string, unknown>;
+    expect(dispatched).toMatchObject({
+      agentId: "agent_1",
+      type: "run_repo",
+      intent: "extract tables",
+      reason: { kind: "fresh" },
+      sessionIdOverride: (res.content as Record<string, string>).session_id,
+    });
+  });
+
+  it("links the repo_run to the same session and task it dispatched", async () => {
+    const h = harness();
+    const res = await tool(h).handler(GOOD);
+    const c = res.content as Record<string, string>;
+
+    expect(h.createRepoRun.mock.calls[0]![0]).toMatchObject({
+      id: c.repo_run_id,
+      session_id: c.session_id,
+      task_id: c.task_id,
+      agent_id: "agent_1",
+      goal: "extract tables",
+      repo_url: "https://github.com/o/r",
+      status: "pending",
+    });
+  });
+
+  it("trims goal and repo_url before using them", async () => {
+    const h = harness();
+    await tool(h).handler({
+      goal: "  extract tables  ",
+      repo_url: "  https://github.com/o/r  ",
+    });
+
+    expect(h.createRepoRun.mock.calls[0]![0]).toMatchObject({
+      goal: "extract tables",
+      repo_url: "https://github.com/o/r",
+    });
+  });
+
+  it("echoes input_url and input_filename back, trimmed", async () => {
+    const h = harness();
+    const res = await tool(h).handler({
+      ...GOOD,
+      input_url: " https://x/y.pdf ",
+      input_filename: " y.pdf ",
+    });
+
+    expect(res.content).toMatchObject({
+      input_url: "https://x/y.pdf",
+      input_filename: "y.pdf",
+    });
+  });
+});
+
+describe("container task title", () => {
+  it("collapses whitespace", async () => {
+    const h = harness();
+    await tool(h).handler({ ...GOOD, goal: "extract\n\n  the   tables" });
+
+    expect(h.createTask.mock.calls[0]![0].title).toBe("extract the tables");
+  });
+
+  // The title is an inbox row, so anything over 80 chars is cut to 77
+  // plus an ellipsis — 78 in all. The description keeps the full goal.
+  it("truncates a long goal to 77 chars plus an ellipsis, leaving description whole", async () => {
+    const h = harness();
+    const goal = "x".repeat(200);
+    await tool(h).handler({ ...GOOD, goal });
+
+    const created = h.createTask.mock.calls[0]![0];
+    expect(created.title).toBe("x".repeat(77) + "…");
+    expect(created.description).toBe(goal);
+  });
+
+  it("leaves a goal of exactly 80 chars untouched", async () => {
+    const h = harness();
+    await tool(h).handler({ ...GOOD, goal: "y".repeat(80) });
+
+    expect(h.createTask.mock.calls[0]![0].title).toBe("y".repeat(80));
+  });
+});
+
+describe("input validation", () => {
+  it.each([
+    ["missing", {}],
+    ["blank", { goal: "   " }],
+    ["non-string", { goal: 5 }],
+  ])("rejects a %s goal before touching any collaborator", async (_l, over) => {
+    const h = harness();
+    const res = await tool(h).handler({ repo_url: GOOD.repo_url, ...over });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("invalid_goal");
+    expect(h.findById).not.toHaveBeenCalled();
+  });
+
+  // Sandbox runs clone whatever URL they're handed, so the host allowlist
+  // and the https requirement are a security boundary, not a nicety.
+  it.each([
+    ["http (not https)", "http://github.com/o/r"],
+    ["a non-github host", "https://gitlab.com/o/r"],
+    ["a github lookalike", "https://notgithub.com/o/r"],
+    ["a github-prefixed host", "https://github.com.evil.tld/o/r"],
+    ["an ssh scheme", "git@github.com:o/r.git"],
+    ["unparseable", "not a url"],
+    ["empty", ""],
+    ["whitespace only", "   "],
+    ["a non-string", 42],
+  ])("rejects %s", async (_label, repo_url) => {
+    const h = harness();
+    const res = await tool(h).handler({ goal: "g", repo_url });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("invalid_repo_url");
+    expect(h.findById).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["apex github.com", "https://github.com/o/r"],
+    ["a github subdomain", "https://www.github.com/o/r"],
+    ["mixed case host", "https://GitHub.com/o/r"],
+  ])("accepts %s", async (_label, repo_url) => {
+    const h = harness();
+    const res = await tool(h).handler({ goal: "g", repo_url });
+
+    expect(res.isError).toBeUndefined();
+  });
+
+  it("reports agent_not_found and creates nothing when the caller is unknown", async () => {
+    const h = harness({ agent: undefined });
+    const res = await tool(h).handler(GOOD);
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("agent_not_found");
+    expect(h.createTask).not.toHaveBeenCalled();
+    expect(h.dispatchTask).not.toHaveBeenCalled();
+  });
+});
+
+describe("limit clamping", () => {
+  it("passes through in-range limits", async () => {
+    const h = harness();
+    const res = await tool(h).handler({
+      ...GOOD,
+      limits: { wall_clock_minutes: 30, max_install_attempts: 3, disk_mb: 4096 },
+    });
+
+    expect(res.content.limits).toEqual({
+      wall_clock_minutes: 30,
+      max_install_attempts: 3,
+      disk_mb: 4096,
+    });
+  });
+
+  // Caps are the blast radius of a runaway sandbox — an agent asking for
+  // a 10-hour run with a 500GB disk gets the ceiling, not the ask.
+  it("clamps each limit to its ceiling", async () => {
+    const h = harness();
+    const res = await tool(h).handler({
+      ...GOOD,
+      limits: {
+        wall_clock_minutes: 600,
+        max_install_attempts: 99,
+        disk_mb: 500_000,
+      },
+    });
+
+    expect(res.content.limits).toEqual({
+      wall_clock_minutes: 60,
+      max_install_attempts: 5,
+      disk_mb: 10_000,
+    });
+  });
+
+  it("floors fractional counts", async () => {
+    const h = harness();
+    const res = await tool(h).handler({
+      ...GOOD,
+      limits: { max_install_attempts: 3.9, disk_mb: 100.7 },
+    });
+
+    expect(res.content.limits).toEqual({
+      max_install_attempts: 3,
+      disk_mb: 100,
+    });
+  });
+
+  it.each([
+    ["zero", { wall_clock_minutes: 0, max_install_attempts: 0, disk_mb: 0 }],
+    ["negative", { wall_clock_minutes: -5, disk_mb: -1 }],
+    ["non-numeric", { wall_clock_minutes: "20", disk_mb: null }],
+  ])("drops %s limits, leaving the defaults to apply downstream", async (_l, limits) => {
+    const h = harness();
+    const res = await tool(h).handler({ ...GOOD, limits });
+
+    expect(res.content.limits).toEqual({});
+  });
+
+  it.each([
+    ["omitted", undefined],
+    ["null", null],
+    ["not an object", "fast"],
+  ])("treats %s limits as none", async (_label, limits) => {
+    const h = harness();
+    const res = await tool(h).handler({ ...GOOD, limits });
+
+    expect(res.content.limits).toEqual({});
+  });
+});
+
+describe("downstream failures", () => {
+  it("reports dispatch_failed and never inserts a repo_run", async () => {
+    const h = harness({ dispatchThrows: new Error("no runtime available") });
+    const res = await tool(h).handler(GOOD);
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "dispatch_failed",
+      message: "no runtime available",
+    });
+    expect(h.createRepoRun).not.toHaveBeenCalled();
+  });
+
+  // The orphan-session case: the session row landed, the repo_run insert
+  // didn't. It self-recovers downstream, but the agent must not be left
+  // waiting on a run that will never report.
+  it("reports repo_run_create_failed rather than returning a run id", async () => {
+    const h = harness({ repoRunThrows: new Error("duplicate key") });
+    const res = await tool(h).handler(GOOD);
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "repo_run_create_failed",
+      message: "duplicate key",
+    });
+    expect(res.content.repo_run_id).toBeUndefined();
+  });
+
+  it.each([
+    ["dispatch", "dispatchThrows", "dispatch_failed"],
+    ["repo_run insert", "repoRunThrows", "repo_run_create_failed"],
+  ])("stringifies a non-Error thrown from %s", async (_l, key, code) => {
+    const h = harness({ [key]: "boom" } as Record<string, unknown>);
+    const res = await tool(h).handler(GOOD);
+
+    expect(res.content).toEqual({ error: code, message: "boom" });
+  });
+});

--- a/packages/api/src/tools/watch.test.ts
+++ b/packages/api/src/tools/watch.test.ts
@@ -1,0 +1,257 @@
+/**
+ * watch_tasks + unwatch handler tests.
+ *
+ * Both tools are thin adapters over WatchService: the service owns the
+ * auth check, the insert and the already-terminal race. What lives
+ * *here* is the input coercion (task_ids filtering, mode defaulting,
+ * reason trimming), the session-context guard, and the error-class ->
+ * error-code mapping. Those are the paths this file pins, with a stub
+ * service standing in for the DB-backed real one.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  WatchAuthError,
+  WatchNotFoundError,
+  WatchValidationError,
+  type UnwatchInput,
+  type WatchService,
+  type WatchTasksInput,
+} from "@beevibe/core/services/watch-service";
+import { buildWatchTools, type WatchToolContext } from "./watch.js";
+import type { AgentTool } from "./types.js";
+
+const ctx: WatchToolContext = { agentId: "agent_1", sessionId: "ses_1" };
+
+/** A WatchService stub whose two methods are vi.fn()s the test drives. */
+function stubService(overrides: Partial<Record<"watchTasks" | "unwatch", unknown>> = {}) {
+  const watchTasks = vi.fn(async (_input: WatchTasksInput) => ({
+    watchId: "twt_1",
+    firedImmediately: false,
+  }));
+  const unwatch = vi.fn(async (_input: UnwatchInput) => undefined);
+  const service = {
+    watchTasks: overrides.watchTasks ?? watchTasks,
+    unwatch: overrides.unwatch ?? unwatch,
+  } as unknown as WatchService;
+  return { service, watchTasks, unwatch };
+}
+
+function tools(service: WatchService, c: WatchToolContext = ctx) {
+  const built = buildWatchTools(c, { watchService: service });
+  const byName = (name: string): AgentTool => {
+    const tool = built.find((t) => t.name === name);
+    if (!tool) throw new Error(`buildWatchTools did not return ${name}`);
+    return tool;
+  };
+  return { watchTasks: byName("watch_tasks"), unwatch: byName("unwatch") };
+}
+
+describe("buildWatchTools", () => {
+  it("returns watch_tasks and unwatch, in that order", () => {
+    const { service } = stubService();
+    const built = buildWatchTools(ctx, { watchService: service });
+    expect(built.map((t) => t.name)).toEqual(["watch_tasks", "unwatch"]);
+  });
+
+  it("declares task_ids required and both modes on watch_tasks", () => {
+    const { service } = stubService();
+    const { watchTasks } = tools(service);
+    expect(watchTasks.schema.required).toEqual(["task_ids"]);
+    const props = watchTasks.schema.properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(props.mode!.enum).toEqual(["all", "any"]);
+  });
+});
+
+describe("watch_tasks handler", () => {
+  it("passes caller identity, ids and mode through to the service", async () => {
+    const { service, watchTasks: spy } = stubService();
+    const { watchTasks } = tools(service);
+
+    const res = await watchTasks.handler({
+      task_ids: ["tsk_a", "tsk_b"],
+      mode: "any",
+      reason: "need both results",
+    });
+
+    expect(spy).toHaveBeenCalledWith({
+      callerAgentId: "agent_1",
+      callerSessionId: "ses_1",
+      taskIds: ["tsk_a", "tsk_b"],
+      mode: "any",
+      reason: "need both results",
+    });
+    expect(res).toEqual({
+      content: { watch_id: "twt_1", fired_immediately: false },
+    });
+  });
+
+  it("surfaces fired_immediately from the already-terminal path", async () => {
+    const { service } = stubService({
+      watchTasks: vi.fn(async () => ({
+        watchId: "twt_9",
+        firedImmediately: true,
+      })),
+    });
+    const { watchTasks } = tools(service);
+
+    const res = await watchTasks.handler({ task_ids: ["tsk_a"] });
+    expect(res.content).toEqual({ watch_id: "twt_9", fired_immediately: true });
+  });
+
+  // "all" is the conservative default: waiting for every task can only
+  // delay the wake-up, where defaulting to "any" could fire before the
+  // results the agent asked for exist.
+  it("defaults mode to 'all' when omitted or not a valid mode", async () => {
+    const { service, watchTasks: spy } = stubService();
+    const { watchTasks } = tools(service);
+
+    await watchTasks.handler({ task_ids: ["tsk_a"] });
+    await watchTasks.handler({ task_ids: ["tsk_a"], mode: "eventually" });
+    await watchTasks.handler({ task_ids: ["tsk_a"], mode: 7 });
+
+    for (const call of spy.mock.calls) {
+      expect(call[0].mode).toBe("all");
+    }
+  });
+
+  it("drops non-string entries from task_ids rather than forwarding them", async () => {
+    const { service, watchTasks: spy } = stubService();
+    const { watchTasks } = tools(service);
+
+    await watchTasks.handler({ task_ids: ["tsk_a", 42, null, "tsk_b", {}] });
+
+    expect(spy.mock.calls[0]![0].taskIds).toEqual(["tsk_a", "tsk_b"]);
+  });
+
+  it("trims reason, and omits it when blank or non-string", async () => {
+    const { service, watchTasks: spy } = stubService();
+    const { watchTasks } = tools(service);
+
+    await watchTasks.handler({ task_ids: ["tsk_a"], reason: "  tidy  " });
+    await watchTasks.handler({ task_ids: ["tsk_a"], reason: "   " });
+    await watchTasks.handler({ task_ids: ["tsk_a"], reason: 12 });
+
+    const reasons = spy.mock.calls.map((c) => c[0].reason);
+    expect(reasons).toEqual(["tidy", undefined, undefined]);
+  });
+
+  it.each([
+    ["missing", {}],
+    ["empty array", { task_ids: [] }],
+    ["all non-strings", { task_ids: [1, 2] }],
+    ["not an array", { task_ids: "tsk_a" }],
+  ])("rejects %s task_ids without calling the service", async (_label, input) => {
+    const { service, watchTasks: spy } = stubService();
+    const { watchTasks } = tools(service);
+
+    const res = await watchTasks.handler(input as Record<string, unknown>);
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("watch_validation");
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  // Without a session id the service cannot identify the waiter, so the
+  // guard has to fire before the call, not surface as a service error.
+  it("refuses to register a watch outside a session context", async () => {
+    const { service, watchTasks: spy } = stubService();
+    const { watchTasks } = tools(service, { agentId: "agent_1" });
+
+    const res = await watchTasks.handler({ task_ids: ["tsk_a"] });
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "watch_validation",
+      message: "watch_tasks must be called inside a session context",
+    });
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe("unwatch handler", () => {
+  it("forwards the watch id and reports ok", async () => {
+    const { service, unwatch: spy } = stubService();
+    const { unwatch } = tools(service);
+
+    const res = await unwatch.handler({ watch_id: "twt_1" });
+
+    expect(spy).toHaveBeenCalledWith({
+      callerAgentId: "agent_1",
+      watchId: "twt_1",
+    });
+    expect(res).toEqual({ content: { ok: true } });
+  });
+
+  it.each([
+    ["missing", {}],
+    ["empty", { watch_id: "" }],
+    ["non-string", { watch_id: 5 }],
+  ])("rejects a %s watch_id without calling the service", async (_l, input) => {
+    const { service, unwatch: spy } = stubService();
+    const { unwatch } = tools(service);
+
+    const res = await unwatch.handler(input as Record<string, unknown>);
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("watch_validation");
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+// The agent branches on `error`, so each service failure class has to
+// keep its own stable code — collapsing them all to "watch_error" would
+// make an auth denial indistinguishable from a bad id.
+describe("service error mapping", () => {
+  it.each([
+    ["watch_auth", new WatchAuthError("not your task")],
+    ["watch_validation", new WatchValidationError("mode is bogus")],
+    ["watch_not_found", new WatchNotFoundError("twt_missing")],
+    ["watch_error", new Error("connection reset")],
+  ])("maps a thrown %s onto its code", async (code, thrown) => {
+    const { service } = stubService({
+      watchTasks: vi.fn(async () => {
+        throw thrown;
+      }),
+    });
+    const { watchTasks } = tools(service);
+
+    const res = await watchTasks.handler({ task_ids: ["tsk_a"] });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe(code);
+    expect(res.content.message).toBe(thrown.message);
+  });
+
+  it("stringifies a non-Error throw under the catch-all code", async () => {
+    const { service } = stubService({
+      watchTasks: vi.fn(async () => {
+        throw "pool exhausted";
+      }),
+    });
+    const { watchTasks } = tools(service);
+
+    const res = await watchTasks.handler({ task_ids: ["tsk_a"] });
+
+    expect(res.content).toEqual({
+      error: "watch_error",
+      message: "pool exhausted",
+    });
+  });
+
+  it("maps errors thrown out of unwatch through the same table", async () => {
+    const { service } = stubService({
+      unwatch: vi.fn(async () => {
+        throw new WatchNotFoundError("twt_gone");
+      }),
+    });
+    const { unwatch } = tools(service);
+
+    const res = await unwatch.handler({ watch_id: "twt_gone" });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("watch_not_found");
+  });
+});


### PR DESCRIPTION
## What this is

A coverage sweep across `core`, `api`, `daemon` and `scheduler`, followed by tests for what it actually found.

The gaps turned out to be concentrated in one place: **three agent-facing MCP tool modules in `packages/api/src/tools` with no test file at all.** Everything else reading low was a DB- or key-gated suite that simply can't run without Postgres and provider keys — those modules are covered, just not in a bare sandbox.

| Module | Lines | Functions |
| --- | --- | --- |
| `tools/watch.ts` | 46.26% → **100%** | 42.85% → **100%** |
| `tools/use-repo.ts` | 32.04% → **100%** | 20.00% → **100%** |
| `tools/session-search.ts` | 64.65% → **100%** | 33.33% → **100%** |

All three are at 100% on statements, branches, functions and lines. The package moves **64.92% → 68.00%** lines. No source changes — tests only.

## Why these three

Each is a thin adapter over an injected service, so the tests drive the handlers directly with stub services instead of standing up Postgres. They run in the fast suite, in a bare sandbox, in well under a second.

Beyond the line count, the 97 new tests pin behaviour that was genuinely unguarded:

- **`watch`** — the error-class → error-code mapping. Agents branch on `error`, so collapsing `WatchAuthError` and `WatchNotFoundError` into a generic `watch_error` would be a silent wire-contract break with nothing to catch it.
- **`use-repo`** — the load-bearing call order (task → dispatch → repo_run). `repo_run.session_id` has an FK to `session.id`, so a flipped order violates the constraint in production. The module comment explains exactly this and nothing was checking it. Also covered: the `https` + `github.com` host check (a security boundary on what a sandbox will clone — including the `github.com.evil.tld` lookalike case) and the limit clamps that bound a runaway run.
- **`session-search`** — the four-shape inference and its documented precedence (`scroll` > `read` > `discover` > `browse`), plus the by-name `SessionSearchError` match that keeps structured codes intact when api consumes core's `dist/` while a script consumes `src/`.

Two real branch gaps surfaced while measuring and are now covered: a numeric `limit` on the browse shape, and a non-string `repo_url`.

## Verification

- `typecheck` clean, `lint` clean (the 4 remaining warnings are pre-existing, in other files).
- The api suite goes from **820 → 917 passing**, with the same **9 pre-existing DB-gated failures** as the documented bare-sandbox baseline. No regressions.
- `@vitest/coverage-v8` was used for the sweep and is deliberately **not** committed, per `CLAUDE.md`.

## Note on the sweep itself

Worth recording for the next person who runs one: `pnpm add -Dw @vitest/coverage-v8` prunes the workspace's linked deps as a side effect — `pnpm install` and a `@beevibe/core` rebuild are needed afterwards or every suite fails to resolve imports. And per `CLAUDE.md`, an unhandled error in a DB-gated suite aborts report generation entirely, so those suites have to be excluded by name to get a `coverage-summary.json` at all.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQNfSdKHYoKaXMLRf8NzYc)_