### PR TITLE
chore: drop nine dead fields from the MeshAsk display type

### DIFF
--- a/packages/web/lib/types/mesh.ts
+++ b/packages/web/lib/types/mesh.ts
@@ -10,21 +10,12 @@ export interface MeshAsk {
   id: string;
   caller: string;
   target: string;
-  intermediate?: string;
-  arrow?: "right" | "up";
   type: "ask" | "negotiate" | "blocker";
-  type_label?: string;
   status: "in_flight" | "succeeded" | "blocked";
   duration_label: string;
   intent: RichText;
-  response?: { agent: string; content: RichText };
   chain_depth: string;
-  chain_depth_color?: "review";
-  source_session?: string;
   source_task_short_id?: string;
-  source_task_age?: string;
-  awaiting_label?: string;
-  awaiting_task_short_id?: string;
 }
 
 export interface ChainBudgetRow {


### PR DESCRIPTION
## What the sweep found

Ran the full documented battery against `main` (81530cc). **Every tool came back clean or reported only false positives already catalogued in `CLAUDE.md`:**

| Check | Result |
| --- | --- |
| `tsc --noUnusedLocals --noUnusedParameters` (6 packages) | clean |
| `tsc --allowUnreachableCode false` (TS7027) | clean |
| `eslint` | 0 errors (only pre-existing `import/no-duplicates` warnings) |
| `knip` — unused files / deps | exactly the known-false-positive table (`node-pg-migrate`, `prettier`, the shell-invoked ops scripts, the migration file) |
| `knip` — 12 unused exports, 107 unused exported types | all used *within their own file* — a redundant `export`, which `CLAUDE.md` says to leave alone |
| by-name grep of all 951 exported symbols | only **2** truly unreferenced: `PostgresMemoryPromotionEventRepository` and Next.js's `dynamic` route-segment config — both documented/framework, kept |
| string-literal union members (61 unions) | no dead variants |
| v8 coverage on `@beevibe/web` | zero-coverage files are type-only modules and thin React Query hooks — untested, not dead |

So the tool-visible categories are genuinely exhausted.

## What was actually dead

One class no tool here can see: **members of an object type that nothing writes and nothing reads.** `knip` tracks whether a *symbol* is imported, and `tsc`'s unused checks stop at locals and parameters, so an unused *field* is invisible to both.

`MeshAsk` is an internal display shape with exactly one producer (`lib/mesh-display.ts:askToDisplay`) and exactly one consumer (`components/mesh/activity-feed.tsx`). Nine of its eighteen fields appear in neither:

| Removed | |
| --- | --- |
| `intermediate` | `arrow` |
| `type_label` | `response` |
| `chain_depth_color` | `source_session` |
| `source_task_age` | `awaiting_label` |
| `awaiting_task_short_id` | |

They are leftovers of a richer feed row that was never built out. All nine are optional, so **no producer, consumer or test had to change** — the interface now describes exactly the nine fields `askToDisplay` actually emits.

## How they were found

A *global* grep misses these, which is why earlier sweeps didn't surface them: `arrow` and `response` are live fields on the unrelated `AskThread` type in `lib/types/sessions.ts`, so a repo-wide search for those names returns hits. Scoping each type's field search to only the files that reference *that type* is what isolated them.

## Deliberately kept

- **`status`, `intent`, `chain_depth`** — written by the mapper and covered by `mesh-display.test.ts`, but not yet rendered by the feed. That's unfinished UI wiring rather than dead code (the same call `CLAUDE.md` makes for the promotion-event repository), so removing them would only make finishing the row harder. `MeshDisplay.summary` is unrendered for the same reason and likewise kept.
- **`TrendingSnapshot.fetched_at`** (`capabilities-client.tsx`) — unread, but so are its siblings `period` and `source`; the type describes an external JSON payload fetched from `beevibe-capabilities`, which we don't own. Trimming one field of a foreign wire format would be arbitrary.
- The `RuntimeConfig`/`RevisionContext`/`RunRepoDispatch` fields the scoped sweep flagged all turned out to have live read sites reached without naming the type — verified individually and left alone.

## Overlap with open PRs

The four other zero-use fields still standing (`StreamJsonMessage.duration_ms` / `num_turns`, `RuntimeHealth.latency_ms`, `MemoryFactDisplay.promotion_origin_scope`) are already removed by open PR #343, so they're left to it — this diff touches one file and does not conflict with #343 or #347.

## Risk

None at runtime: types are erased, and all nine fields were optional and unpopulated.

## Validation

- `pnpm typecheck` — 9/9 successful
- `pnpm lint` — 0 errors
- `pnpm --filter @beevibe/web exec next build` — succeeds (direct, bypassing Turbo's env stripping per `CLAUDE.md`)
- `@beevibe/web` tests — **203 passed / 203**
- Re-ran the field sweep afterward: nothing newly orphaned, and the `RichText` import is still live via `intent`

The `@vitest/coverage-v8` provider installed for the coverage pass was reverted and is not part of this diff, per `CLAUDE.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZQdto7S7qqvt7RUUanrb1)_