### PR TITLE
test: cover the under-tested MCP tool + chat surfaces (74% → 88% in api)

### DIFF
--- a/packages/api/src/mesh/broker.test.ts
+++ b/packages/api/src/mesh/broker.test.ts
@@ -1,0 +1,603 @@
+/**
+ * MeshServer's broker half — capacity gate, spawn dispatch, negotiation
+ * round bookkeeping and the resolver handoff.
+ *
+ * `server.test.ts` covers one slice (failure propagation from a callee
+ * session). The rest of the class was only exercised by the m6/m7 e2e
+ * scripts, which need live Postgres plus spawned CLIs, so none of it ran
+ * in CI. It is all in-process state machinery over four repos, though,
+ * so fakes reach every branch — including the exchange-cap arithmetic,
+ * which is the one piece of real logic in here (`max_rounds` counts A↔B
+ * exchanges while the DB column counts rows) and the easiest to break.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  Negotiation,
+  NegotiationRepository,
+  NegotiationRound,
+  NegotiationRoundRepository,
+  RuntimeRegistry,
+  SessionEventRepository,
+  SessionRepository,
+  WorkspaceManager,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import { MeshServer } from "./server.js";
+import {
+  CannotNegotiateWithIcError,
+  MeshCapacityError,
+  MeshMaxRoundsError,
+  type NegotiateResponse,
+} from "./types.js";
+
+const A = "agent_initiator";
+const B = "agent_peer";
+
+function fakeAgent(id: string, overrides: Partial<Agent> = {}): Agent {
+  return {
+    id,
+    name: id,
+    owner_id: "person_1",
+    hierarchy_level: "team",
+    runtime_config: { type: "claude" },
+    created_at: new Date("2026-01-01T00:00:00Z"),
+    updated_at: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  } as Agent;
+}
+
+function fakeNegotiation(overrides: Partial<Negotiation> = {}): Negotiation {
+  return {
+    id: "neg_1",
+    initiator_agent_id: A,
+    initiator_session_id: "sess_a",
+    counterparty_agent_id: B,
+    max_rounds: 5,
+    rounds_completed: 1,
+    status: "active",
+    created_at: new Date("2026-01-01T00:00:00Z"),
+    updated_at: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+function harness(opts: { agents?: Record<string, Agent>; running?: number } = {}) {
+  const agents = opts.agents ?? { [A]: fakeAgent(A), [B]: fakeAgent(B) };
+
+  const agentRepo = {
+    findById: vi.fn(async (id: string) => agents[id]),
+  } as unknown as AgentRepository;
+
+  const sessionRepo = {
+    countRunningByAgent: vi.fn(async () => opts.running ?? 0),
+  } as unknown as SessionRepository;
+
+  let negotiation = fakeNegotiation();
+  const negotiationRepo = {
+    findById: vi.fn(async () => negotiation),
+    create: vi.fn(async (input: Partial<Negotiation>) => {
+      negotiation = fakeNegotiation({ ...input, rounds_completed: 0 });
+      return negotiation;
+    }),
+    update: vi.fn(async (_id: string, patch: Partial<Negotiation>) => {
+      negotiation = { ...negotiation, ...patch };
+      return negotiation;
+    }),
+  } as unknown as NegotiationRepository;
+
+  const negotiationRoundRepo = {
+    create: vi.fn(async (input: Partial<NegotiationRound>) => input as NegotiationRound),
+  } as unknown as NegotiationRoundRepository;
+
+  const dispatchService = {
+    dispatchTask: vi.fn().mockResolvedValue({ session: {}, runtime_id: null }),
+  } as unknown as DispatchService;
+
+  const mesh = new MeshServer({
+    agentRepo,
+    sessionRepo,
+    sessionEventRepo: {} as SessionEventRepository,
+    negotiationRepo,
+    negotiationRoundRepo,
+    workspaceManager: {} as WorkspaceManager,
+    runtimeRegistry: {} as RuntimeRegistry,
+    dispatchService,
+    makeMemoryAgent: () => ({}) as never,
+  });
+
+  return {
+    mesh,
+    agentRepo,
+    sessionRepo,
+    negotiationRepo,
+    negotiationRoundRepo,
+    dispatchService,
+    /** Current state of the single negotiation the fake repo holds. */
+    negotiation: () => negotiation,
+    setNegotiation: (patch: Partial<Negotiation>) => {
+      negotiation = { ...negotiation, ...patch };
+    },
+    /** Latest dispatch call's payload. */
+    lastDispatch: () =>
+      vi.mocked(dispatchService.dispatchTask).mock.calls.at(-1)?.[0] as
+        | Record<string, unknown>
+        | undefined,
+  };
+}
+
+/** Let the fire-and-forget spawn microtasks settle. */
+const settle = () => new Promise((r) => setImmediate(r));
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ── capacity gate ────────────────────────────────────────────────────────
+
+describe("mesh capacity gate", () => {
+  it("throws MeshCapacityError with the counts once the target is at cap", async () => {
+    const h = harness({
+      agents: { [A]: fakeAgent(A), [B]: fakeAgent(B, { max_mesh_sessions: 2 }) },
+      running: 2,
+    });
+
+    await expect(h.mesh.sendAsk("req_1", A, B, "q")).rejects.toBeInstanceOf(
+      MeshCapacityError,
+    );
+    expect(h.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the default cap of 3 when the agent sets none", async () => {
+    const h = harness({ running: 3 });
+    const err = await h.mesh.sendAsk("req_1", A, B, "q").catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(MeshCapacityError);
+    expect((err as MeshCapacityError).meta).toEqual({ agentId: B, running: 3, cap: 3 });
+  });
+
+  it("counts only the three mesh session types toward the cap", async () => {
+    const h = harness();
+    void h.mesh.sendAsk("req_1", A, B, "q");
+    await settle();
+    expect(h.sessionRepo.countRunningByAgent).toHaveBeenCalledWith(B, [
+      "mesh_ask",
+      "mesh_negotiate",
+      "blocker",
+    ]);
+  });
+
+  it("throws a plain error when the target agent does not exist", async () => {
+    const h = harness({ agents: { [A]: fakeAgent(A) } });
+    await expect(h.mesh.sendAsk("req_1", A, "agent_ghost", "q")).rejects.toThrow(
+      "target agent not found: agent_ghost",
+    );
+  });
+});
+
+// ── ask ──────────────────────────────────────────────────────────────────
+
+describe("sendAsk / respondAsk", () => {
+  it("dispatches a mesh_ask session and resolves when respond_ask fires", async () => {
+    const h = harness();
+    const pending = h.mesh.sendAsk("req_1", A, B, "is X feasible?");
+    await settle();
+
+    const dispatched = h.lastDispatch();
+    expect(dispatched).toMatchObject({
+      agentId: B,
+      type: "mesh_ask",
+      reason: { kind: "fresh" },
+      callerAgentId: A,
+    });
+    expect(String(dispatched?.intent)).toContain('<mesh-ask request_id="req_1" from="agent_initiator">');
+    expect(String(dispatched?.intent)).toContain("is X feasible?");
+    // The callee session id is pre-minted so the failure path can find it.
+    expect(String(dispatched?.sessionIdOverride)).toMatch(/^sess_/);
+    expect(h.mesh.hasPendingCalleeSession(String(dispatched?.sessionIdOverride))).toBe(true);
+
+    h.mesh.respondAsk("req_1", { request_id: "req_1", from_agent_id: B, answer: "yes" });
+    await expect(pending).resolves.toEqual({
+      request_id: "req_1",
+      from_agent_id: B,
+      answer: "yes",
+    });
+    // Reverse index drained once the waiter resolved.
+    expect(h.mesh.hasPendingCalleeSession(String(dispatched?.sessionIdOverride))).toBe(false);
+  });
+
+  it("escapes XML-significant characters in the ask intent attributes", async () => {
+    const h = harness();
+    void h.mesh.sendAsk('req"1', A, B, "q");
+    await settle();
+    const intent = String(h.lastDispatch()?.intent);
+    expect(intent).toContain('request_id="req&quot;1"');
+  });
+
+  it("ignores a respond_ask for a request nobody is waiting on", () => {
+    const h = harness();
+    expect(() =>
+      h.mesh.respondAsk("req_unknown", {
+        request_id: "req_unknown",
+        from_agent_id: B,
+        answer: "a",
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects the asker when the resolver times out", async () => {
+    vi.useFakeTimers();
+    const h = harness();
+    const pending = h.mesh.sendAsk("req_1", A, B, "q");
+    const assertion = expect(pending).rejects.toThrow(/mesh resolver timeout/);
+    await vi.advanceTimersByTimeAsync(5 * 60_000 + 1);
+    await assertion;
+  });
+
+  it("swallows a dispatch failure — the resolver, not the spawn, is awaited", async () => {
+    const h = harness();
+    vi.mocked(h.dispatchService.dispatchTask).mockRejectedValue(new Error("no runtime"));
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const pending = h.mesh.sendAsk("req_1", A, B, "q");
+    await settle();
+    expect(spy).toHaveBeenCalled();
+
+    // The caller is still blocked on the resolver, not rejected by the spawn.
+    h.mesh.respondAsk("req_1", { request_id: "req_1", from_agent_id: B, answer: "a" });
+    await expect(pending).resolves.toMatchObject({ answer: "a" });
+    spy.mockRestore();
+  });
+});
+
+// ── negotiate: round 1 ───────────────────────────────────────────────────
+
+describe("sendNegotiate", () => {
+  it("creates the negotiation, records round 1, and spawns the peer", async () => {
+    const h = harness();
+    void h.mesh.sendNegotiate(A, B, "ship friday", {
+      taskId: "tsk_1",
+      initiatorSessionId: "sess_a",
+    });
+    await settle();
+
+    expect(h.negotiationRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initiator_agent_id: A,
+        initiator_session_id: "sess_a",
+        counterparty_agent_id: B,
+        task_id: "tsk_1",
+        max_rounds: 5,
+      }),
+    );
+    expect(h.negotiationRoundRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        round_number: 1,
+        from_agent_id: A,
+        decision: "propose",
+        message: "ship friday",
+      }),
+    );
+    // rounds_completed is bumped in the same logical step so B's first
+    // respond_negotiate lands on round 2 rather than colliding on 1.
+    expect(h.negotiationRepo.update).toHaveBeenCalledWith(
+      expect.any(String),
+      { rounds_completed: 1 },
+    );
+    expect(h.lastDispatch()).toMatchObject({ agentId: B, type: "mesh_negotiate" });
+  });
+
+  it("stamps max_rounds from the initiator's own configuration", async () => {
+    const h = harness({
+      agents: {
+        [A]: fakeAgent(A, { max_negotiation_rounds: 2 }),
+        [B]: fakeAgent(B),
+      },
+    });
+    void h.mesh.sendNegotiate(A, B, "p", { initiatorSessionId: "sess_a" });
+    await settle();
+    expect(h.negotiationRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ max_rounds: 2 }),
+    );
+  });
+
+  it("refuses an IC target before touching capacity or the DB", async () => {
+    const h = harness({
+      agents: { [A]: fakeAgent(A), [B]: fakeAgent(B, { hierarchy_level: "ic" }) },
+    });
+
+    await expect(
+      h.mesh.sendNegotiate(A, B, "p", { initiatorSessionId: "sess_a" }),
+    ).rejects.toBeInstanceOf(CannotNegotiateWithIcError);
+    expect(h.sessionRepo.countRunningByAgent).not.toHaveBeenCalled();
+    expect(h.negotiationRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("throws when the initiator agent row is missing", async () => {
+    const h = harness({ agents: { [B]: fakeAgent(B) } });
+    await expect(
+      h.mesh.sendNegotiate("agent_ghost", B, "p", { initiatorSessionId: "sess_a" }),
+    ).rejects.toThrow("initiator agent not found: agent_ghost");
+  });
+
+  it("resolves the initiator when the peer's first respond_negotiate lands", async () => {
+    const h = harness();
+    const pending = h.mesh.sendNegotiate(A, B, "p", { initiatorSessionId: "sess_a" });
+    await settle();
+
+    const reply: NegotiateResponse = {
+      negotiation_id: h.negotiation().id,
+      from_agent_id: B,
+      decision: "accept",
+      message: "deal",
+    };
+    await h.mesh.respondNegotiate(h.negotiation().id, reply, "sess_b");
+
+    await expect(pending).resolves.toEqual(reply);
+  });
+});
+
+// ── negotiate: subsequent rounds ─────────────────────────────────────────
+
+describe("respondNegotiate", () => {
+  it("throws when the negotiation does not exist", async () => {
+    const h = harness();
+    vi.mocked(h.negotiationRepo.findById).mockResolvedValue(undefined);
+    await expect(
+      h.mesh.respondNegotiate(
+        "neg_gone",
+        { negotiation_id: "neg_gone", from_agent_id: B, decision: "accept", message: "m" },
+        "sess_b",
+      ),
+    ).rejects.toThrow("negotiation neg_gone not found");
+  });
+
+  it.each(["accepted", "rejected", "escalated"] as const)(
+    "refuses to add a round to a %s negotiation",
+    async (status) => {
+      const h = harness();
+      h.setNegotiation({ status });
+      await expect(
+        h.mesh.respondNegotiate(
+          "neg_1",
+          { negotiation_id: "neg_1", from_agent_id: B, decision: "accept", message: "m" },
+          "sess_b",
+        ),
+      ).rejects.toThrow(`is not active (status='${status}')`);
+      expect(h.negotiationRoundRepo.create).not.toHaveBeenCalled();
+    },
+  );
+
+  it("stamps counterparty_session_id on the peer's first response", async () => {
+    const h = harness();
+    await h.mesh.respondNegotiate(
+      "neg_1",
+      { negotiation_id: "neg_1", from_agent_id: B, decision: "accept", message: "ok" },
+      "sess_b",
+    );
+    expect(h.negotiationRepo.update).toHaveBeenCalledWith("neg_1", {
+      counterparty_session_id: "sess_b",
+    });
+  });
+
+  it("does not re-stamp the session id on later rounds", async () => {
+    const h = harness();
+    h.setNegotiation({ counterparty_session_id: "sess_b" });
+    await h.mesh.respondNegotiate(
+      "neg_1",
+      { negotiation_id: "neg_1", from_agent_id: B, decision: "accept", message: "ok" },
+      "sess_b_other",
+    );
+    expect(h.negotiationRepo.update).not.toHaveBeenCalledWith(
+      "neg_1",
+      expect.objectContaining({ counterparty_session_id: expect.anything() }),
+    );
+  });
+
+  it("does not stamp the session id for a response from the initiator's side", async () => {
+    const h = harness();
+    await h.mesh.respondNegotiate(
+      "neg_1",
+      { negotiation_id: "neg_1", from_agent_id: A, decision: "accept", message: "ok" },
+      "sess_a",
+    );
+    expect(h.negotiationRepo.update).not.toHaveBeenCalledWith(
+      "neg_1",
+      expect.objectContaining({ counterparty_session_id: expect.anything() }),
+    );
+  });
+
+  it.each([
+    ["accept", "accepted"],
+    ["reject", "rejected"],
+  ] as const)("closes the negotiation as %s → %s and returns null", async (decision, status) => {
+    const h = harness();
+    const result = await h.mesh.respondNegotiate(
+      "neg_1",
+      { negotiation_id: "neg_1", from_agent_id: B, decision, message: "m" },
+      "sess_b",
+    );
+    expect(result).toBeNull();
+    expect(h.negotiationRepo.update).toHaveBeenCalledWith("neg_1", { status });
+  });
+
+  it("persists each round under the next round number", async () => {
+    const h = harness();
+    h.setNegotiation({ rounds_completed: 3 });
+    await h.mesh.respondNegotiate(
+      "neg_1",
+      { negotiation_id: "neg_1", from_agent_id: B, decision: "accept", message: "m" },
+      "sess_b",
+    );
+    expect(h.negotiationRoundRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ round_number: 4, from_agent_id: B, decision: "accept" }),
+    );
+    expect(h.negotiationRepo.update).toHaveBeenCalledWith("neg_1", {
+      rounds_completed: 4,
+    });
+  });
+
+  it("blocks the responder on a counter, and resolves it on the peer's reply", async () => {
+    const h = harness();
+    h.setNegotiation({ counterparty_session_id: "sess_b" });
+
+    // B counters → B blocks on the initiator key (nobody was waiting).
+    const bWaiting = h.mesh.respondNegotiate(
+      "neg_1",
+      {
+        negotiation_id: "neg_1",
+        from_agent_id: B,
+        decision: "counter",
+        message: "not friday",
+        counter_proposal: "wednesday",
+      },
+      "sess_b",
+    );
+    await settle();
+    // The waiter is tied to B's resident session so a failure reaches it.
+    expect(h.mesh.hasPendingCalleeSession("sess_b")).toBe(true);
+
+    // A replies with accept → resolves B's pending promise, terminal for A.
+    const aReply: NegotiateResponse = {
+      negotiation_id: "neg_1",
+      from_agent_id: A,
+      decision: "accept",
+      message: "fine, wednesday",
+    };
+    await expect(h.mesh.respondNegotiate("neg_1", aReply, "sess_a")).resolves.toBeNull();
+    await expect(bWaiting).resolves.toEqual(aReply);
+  });
+
+  describe("max-rounds cap", () => {
+    // max_rounds counts A↔B exchanges; the column counts rows. Row N
+    // belongs to exchange ceil(N/2), so with a cap of 2 the first row
+    // that opens exchange 3 is row 5 — i.e. rounds_completed = 4.
+    it.each([
+      [1, false],
+      [2, false],
+      [3, false],
+      [4, true],
+      [5, true],
+    ])("rounds_completed=%i → throws: %s", async (completed, shouldThrow) => {
+      const h = harness();
+      h.setNegotiation({ rounds_completed: completed, max_rounds: 2 });
+      const call = h.mesh.respondNegotiate(
+        "neg_1",
+        {
+          negotiation_id: "neg_1",
+          from_agent_id: B,
+          decision: "accept",
+          message: "m",
+        },
+        "sess_b",
+      );
+      if (shouldThrow) {
+        await expect(call).rejects.toBeInstanceOf(MeshMaxRoundsError);
+      } else {
+        await expect(call).resolves.toBeNull();
+      }
+    });
+
+    it("carries the counters the agent needs to decide to escalate", async () => {
+      const h = harness();
+      h.setNegotiation({ rounds_completed: 10, max_rounds: 5 });
+      const err = await h.mesh
+        .respondNegotiate(
+          "neg_1",
+          { negotiation_id: "neg_1", from_agent_id: B, decision: "accept", message: "m" },
+          "sess_b",
+        )
+        .catch((e: unknown) => e);
+
+      expect((err as MeshMaxRoundsError).meta).toEqual({
+        negotiationId: "neg_1",
+        rounds_completed: 10,
+        max_rounds: 5,
+      });
+      // No round was written on the rejected path.
+      expect(h.negotiationRoundRepo.create).not.toHaveBeenCalled();
+    });
+  });
+});
+
+// ── escalation sentinel ──────────────────────────────────────────────────
+
+describe("unblockOnEscalate", () => {
+  it("releases whichever side is blocked with the escalated sentinel", async () => {
+    const h = harness();
+    h.setNegotiation({ counterparty_session_id: "sess_b" });
+    const bWaiting = h.mesh.respondNegotiate(
+      "neg_1",
+      {
+        negotiation_id: "neg_1",
+        from_agent_id: B,
+        decision: "counter",
+        message: "m",
+        counter_proposal: "c",
+      },
+      "sess_b",
+    );
+    await settle();
+
+    h.mesh.unblockOnEscalate("neg_1", "esc_1");
+
+    const sentinel = await bWaiting;
+    expect(sentinel).toMatchObject({
+      decision: "escalated",
+      escalation_id: "esc_1",
+      negotiation_id: "neg_1",
+    });
+    expect(String((sentinel as { message: string }).message)).toContain("add_to_escalation");
+  });
+
+  it("releases the initiator still waiting on round 1", async () => {
+    const h = harness();
+    const pending = h.mesh.sendNegotiate(A, B, "p", { initiatorSessionId: "sess_a" });
+    await settle();
+
+    h.mesh.unblockOnEscalate(h.negotiation().id, "esc_1");
+    await expect(pending).resolves.toMatchObject({ decision: "escalated" });
+  });
+
+  it("is a no-op when both sides have already exited", () => {
+    const h = harness();
+    expect(() => h.mesh.unblockOnEscalate("neg_nobody", "esc_1")).not.toThrow();
+  });
+});
+
+// ── blocker ──────────────────────────────────────────────────────────────
+
+describe("reportBlocker", () => {
+  it("dispatches a blocker session to the parent with revise_task guidance", async () => {
+    const h = harness();
+    h.mesh.reportBlocker("agent_parent", B, "tsk_1", "the API key is missing");
+    await settle();
+
+    const dispatched = h.lastDispatch();
+    expect(dispatched).toMatchObject({
+      agentId: "agent_parent",
+      type: "blocker",
+      callerAgentId: B,
+      // Fire-and-forget: no pre-minted session id to wait on.
+      sessionIdOverride: undefined,
+    });
+    const intent = String(dispatched?.intent);
+    expect(intent).toContain('<mesh-blocker from="agent_peer" task_id="tsk_1">');
+    expect(intent).toContain("the API key is missing");
+    expect(intent).toContain('revise_task(task_id="tsk_1"');
+  });
+
+  it("returns synchronously even when the dispatch rejects", async () => {
+    const h = harness();
+    vi.mocked(h.dispatchService.dispatchTask).mockRejectedValue(new Error("offline"));
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => h.mesh.reportBlocker("agent_parent", B, "tsk_1", "d")).not.toThrow();
+    await settle();
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining("[mesh] dispatch for agent_parent (blocker) failed:"),
+      "offline",
+    );
+    spy.mockRestore();
+  });
+});

--- a/packages/api/src/routes/chat-routes.test.ts
+++ b/packages/api/src/routes/chat-routes.test.ts
@@ -1,0 +1,935 @@
+/**
+ * `createChatRouter` handler tests — supertest over vitest fakes (no DB).
+ *
+ * `chat-internals.test.ts` already pins the exported pure helpers
+ * (`groupIntoConversations`, `chainToMessages`, `failureMessageFor`).
+ * What was untested is the router itself: four handlers whose branches
+ * are the ones a user actually hits — the human gate, the "no primary
+ * agent" shapes, the idempotent-replay ladder (403 / 409 / 200 replayed
+ * / fall-through), the rate limiter's 429, the offline-daemon 503, and
+ * the resolver's 504-vs-500 split. Every one of those returns a
+ * distinct wire shape the web client branches on.
+ *
+ * The router is a closure over seven ports, so a bag of `vi.fn()` repos
+ * plus a stub auth middleware reaches all of it. `processResponse` and
+ * `groupIntoConversations` run for real — their output is part of the
+ * wire contract asserted here.
+ */
+import express, { json } from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  Person,
+  PersonRepository,
+  Runtime,
+  RuntimeRepository,
+  Session,
+  SessionRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import type { ChatResolver } from "../runtime/chat-resolver.js";
+import type { DaemonHub } from "../runtime/hub.js";
+import { ChatRateLimiter } from "./chat-rate-limit.js";
+import { createChatRouter } from "./chat.js";
+
+const PERSON = "person_alice";
+const AGENT = "agent_alice_team";
+
+// ── Fakes ────────────────────────────────────────────────────────────────
+
+function fakeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: AGENT,
+    name: "Alice's Team",
+    owner_id: PERSON,
+    hierarchy_level: "team",
+    runtime_config: { type: "claude" },
+    created_at: new Date("2026-01-01T00:00:00Z"),
+    updated_at: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  } as Agent;
+}
+
+function fakePerson(overrides: Partial<Person> = {}): Person {
+  return {
+    id: PERSON,
+    name: "Alice",
+    email: "alice@example.com",
+    capability_network_enabled: true,
+    created_at: new Date("2026-01-01T00:00:00Z"),
+    updated_at: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  } as Person;
+}
+
+let sessionSeq = 0;
+function fakeSession(overrides: Partial<Session> = {}): Session {
+  sessionSeq += 1;
+  return {
+    id: `sess_${String(sessionSeq).padStart(12, "0")}`,
+    agent_id: AGENT,
+    type: "chat",
+    status: "succeeded",
+    intent: "hello",
+    created_at: new Date("2026-01-01T00:00:00Z"),
+    updated_at: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  } as unknown as Session;
+}
+
+interface Fakes {
+  agentRepo: AgentRepository;
+  personRepo: PersonRepository;
+  runtimeRepo: RuntimeRepository;
+  sessionRepo: SessionRepository;
+  dispatchService: DispatchService;
+  chatResolver: ChatResolver;
+  hub: DaemonHub;
+  rateLimiter: ChatRateLimiter;
+}
+
+function makeFakes(): Fakes {
+  return {
+    agentRepo: { findTopLevelForOwner: vi.fn() } as unknown as AgentRepository,
+    personRepo: {
+      findById: vi.fn().mockResolvedValue(
+        fakePerson({ onboarding_completed_at: new Date("2026-01-01T00:00:00Z") }),
+      ),
+      update: vi.fn().mockResolvedValue(fakePerson()),
+    } as unknown as PersonRepository,
+    runtimeRepo: { findById: vi.fn() } as unknown as RuntimeRepository,
+    sessionRepo: {
+      findById: vi.fn(),
+      listChatForAgent: vi.fn().mockResolvedValue([]),
+      softDeleteChatChain: vi.fn().mockResolvedValue(0),
+    } as unknown as SessionRepository,
+    dispatchService: { dispatchTask: vi.fn() } as unknown as DispatchService,
+    chatResolver: { register: vi.fn() } as unknown as ChatResolver,
+    hub: { isOnline: vi.fn().mockReturnValue(true) } as unknown as DaemonHub,
+    // maxPerWindow high enough that only the tests that mean to trip the
+    // limiter do; concurrency stays at the production default of 1.
+    rateLimiter: new ChatRateLimiter({ maxPerWindow: 1000 }),
+  };
+}
+
+function stubAuth(source: "human" | "agent") {
+  return (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    req.caller =
+      source === "human"
+        ? { source: "human", agentId: AGENT, hierarchyLevel: "team", personId: PERSON }
+        : { source: "agent", agentId: AGENT, hierarchyLevel: "ic" };
+    next();
+  };
+}
+
+function makeApp(fakes: Fakes, source: "human" | "agent" = "human") {
+  const app = express();
+  app.use(json());
+  app.use(
+    "/chat",
+    createChatRouter({
+      authMiddleware: stubAuth(source),
+      agentRepo: fakes.agentRepo,
+      personRepo: fakes.personRepo,
+      runtimeRepo: fakes.runtimeRepo,
+      sessionRepo: fakes.sessionRepo,
+      dispatchService: fakes.dispatchService,
+      chatResolver: fakes.chatResolver,
+      hub: fakes.hub,
+      rateLimiter: fakes.rateLimiter,
+    }),
+  );
+  return app;
+}
+
+/** Convenience: caller has a primary agent and it's the default one. */
+function withAgent(fakes: Fakes, agent: Agent = fakeAgent()): Agent {
+  vi.mocked(fakes.agentRepo.findTopLevelForOwner).mockResolvedValue(agent);
+  return agent;
+}
+
+// ── GET /chat/conversations ──────────────────────────────────────────────
+
+describe("GET /chat/conversations", () => {
+  it("403s a non-human caller", async () => {
+    const fakes = makeFakes();
+    const res = await request(makeApp(fakes, "agent")).get("/chat/conversations");
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("human_required");
+  });
+
+  it("returns an empty list when the caller has no primary agent", async () => {
+    const fakes = makeFakes();
+    vi.mocked(fakes.agentRepo.findTopLevelForOwner).mockResolvedValue(undefined);
+    const res = await request(makeApp(fakes)).get("/chat/conversations");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, conversations: [] });
+    expect(fakes.sessionRepo.listChatForAgent).not.toHaveBeenCalled();
+  });
+
+  it("summarizes each chain: title from the head, turn count, last preview", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    const head = fakeSession({
+      id: "sess_head",
+      intent: "plan the launch",
+      result_summary: "sure",
+      created_at: new Date("2026-01-01T10:00:00Z"),
+    });
+    const tail = fakeSession({
+      id: "sess_tail",
+      prior_session_id: "sess_head",
+      intent: "and the budget?",
+      result_summary: "  drafted   the\nbudget  ",
+      created_at: new Date("2026-01-01T10:05:00Z"),
+    });
+    vi.mocked(fakes.sessionRepo.listChatForAgent).mockResolvedValue([tail, head]);
+
+    const res = await request(makeApp(fakes)).get("/chat/conversations");
+    expect(res.status).toBe(200);
+    expect(res.body.conversations).toEqual([
+      {
+        head_id: "sess_head",
+        title: "plan the launch",
+        turn_count: 2,
+        last_at: "2026-01-01T10:05:00.000Z",
+        // Whitespace collapsed to single spaces and trimmed.
+        last_preview: "drafted the budget",
+      },
+    ]);
+  });
+
+  it("truncates a long title at CHAT_THREAD_TITLE_MAX with an ellipsis", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    const intent = "x".repeat(200);
+    vi.mocked(fakes.sessionRepo.listChatForAgent).mockResolvedValue([
+      fakeSession({ id: "sess_long", intent, result_summary: "ok" }),
+    ]);
+
+    const res = await request(makeApp(fakes)).get("/chat/conversations");
+    const title = res.body.conversations[0].title as string;
+    expect(title).toHaveLength(80);
+    expect(title.endsWith("…")).toBe(true);
+  });
+
+  it("previews the error, then the intent, when there is no result_summary", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    vi.mocked(fakes.sessionRepo.listChatForAgent).mockResolvedValue([
+      fakeSession({
+        id: "sess_err",
+        intent: "do the thing",
+        status: "failed",
+        error: "boom",
+        created_at: new Date("2026-01-01T11:00:00Z"),
+      }),
+      fakeSession({
+        id: "sess_bare",
+        intent: "no reply yet",
+        status: "pending",
+        created_at: new Date("2026-01-01T10:00:00Z"),
+      }),
+    ]);
+
+    const res = await request(makeApp(fakes)).get("/chat/conversations");
+    const previews = Object.fromEntries(
+      (res.body.conversations as { head_id: string; last_preview: string }[]).map((c) => [
+        c.head_id,
+        c.last_preview,
+      ]),
+    );
+    expect(previews.sess_err).toBe("boom");
+    expect(previews.sess_bare).toBe("no reply yet");
+  });
+
+  it("clips an over-long preview to 140 chars including the ellipsis", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    vi.mocked(fakes.sessionRepo.listChatForAgent).mockResolvedValue([
+      fakeSession({ id: "sess_p", result_summary: "y".repeat(500) }),
+    ]);
+
+    const res = await request(makeApp(fakes)).get("/chat/conversations");
+    const preview = res.body.conversations[0].last_preview as string;
+    expect(preview).toHaveLength(140);
+    expect(preview.endsWith("…")).toBe(true);
+  });
+});
+
+// ── DELETE /chat/conversations/:headId ───────────────────────────────────
+
+describe("DELETE /chat/conversations/:headId", () => {
+  it("403s a non-human caller", async () => {
+    const fakes = makeFakes();
+    const res = await request(makeApp(fakes, "agent")).delete("/chat/conversations/sess_h");
+    expect(res.status).toBe(403);
+  });
+
+  it("404s when the caller has no primary agent", async () => {
+    const fakes = makeFakes();
+    vi.mocked(fakes.agentRepo.findTopLevelForOwner).mockResolvedValue(undefined);
+    const res = await request(makeApp(fakes)).delete("/chat/conversations/sess_h");
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("agent_not_found");
+  });
+
+  it("soft-deletes the chain scoped to the caller's agent", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    vi.mocked(fakes.sessionRepo.softDeleteChatChain).mockResolvedValue(3);
+
+    const res = await request(makeApp(fakes)).delete("/chat/conversations/sess_h");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, deleted: 3 });
+    expect(fakes.sessionRepo.softDeleteChatChain).toHaveBeenCalledWith("sess_h", AGENT);
+  });
+
+  it("is idempotent — a second delete reports 0 rows, still 200", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    vi.mocked(fakes.sessionRepo.softDeleteChatChain).mockResolvedValue(0);
+    const res = await request(makeApp(fakes)).delete("/chat/conversations/sess_h");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, deleted: 0 });
+  });
+
+  it("500s with a request_id (and no internal detail) when the repo throws", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    vi.mocked(fakes.sessionRepo.softDeleteChatChain).mockRejectedValue(
+      new Error("connection terminated unexpectedly"),
+    );
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await request(makeApp(fakes)).delete("/chat/conversations/sess_h");
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("internal_error");
+    expect(res.body.request_id).toMatch(/^req_/);
+    expect(JSON.stringify(res.body)).not.toContain("connection terminated");
+    spy.mockRestore();
+  });
+});
+
+// ── GET /chat ────────────────────────────────────────────────────────────
+
+describe("GET /chat", () => {
+  it("403s a non-human caller", async () => {
+    const fakes = makeFakes();
+    const res = await request(makeApp(fakes, "agent")).get("/chat");
+    expect(res.status).toBe(403);
+  });
+
+  it("returns the null-agent shape when nothing is provisioned", async () => {
+    const fakes = makeFakes();
+    vi.mocked(fakes.agentRepo.findTopLevelForOwner).mockResolvedValue(undefined);
+    const res = await request(makeApp(fakes)).get("/chat");
+    expect(res.body).toEqual({
+      ok: true,
+      agent: null,
+      messages: [],
+      prior_session_id: null,
+      conversation_id: null,
+    });
+  });
+
+  it("renders the most recent chain as user/agent message pairs", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    vi.mocked(fakes.sessionRepo.listChatForAgent).mockResolvedValue([
+      fakeSession({
+        id: "sess_h",
+        intent: "hi",
+        result_summary: "hello back",
+        created_at: new Date("2026-01-01T10:00:00Z"),
+      }),
+    ]);
+
+    const res = await request(makeApp(fakes)).get("/chat");
+    expect(res.status).toBe(200);
+    expect(res.body.agent).toEqual({ id: AGENT, name: "Alice's Team", hierarchy: "team" });
+    expect(res.body.messages).toEqual([
+      { id: "u_sess_h", role: "user", content: "hi" },
+      { id: "a_sess_h", role: "agent", content: "hello back", session_id: "sess_h" },
+    ]);
+    expect(res.body.prior_session_id).toBe("sess_h");
+    expect(res.body.conversation_id).toBe("sess_h");
+    expect(res.body.in_flight_session_id).toBeUndefined();
+  });
+
+  it("selects the chain named by ?c= instead of the newest one", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    vi.mocked(fakes.sessionRepo.listChatForAgent).mockResolvedValue([
+      fakeSession({
+        id: "sess_new",
+        intent: "newer",
+        result_summary: "n",
+        created_at: new Date("2026-01-02T10:00:00Z"),
+      }),
+      fakeSession({
+        id: "sess_old",
+        intent: "older",
+        result_summary: "o",
+        created_at: new Date("2026-01-01T10:00:00Z"),
+      }),
+    ]);
+
+    const newest = await request(makeApp(fakes)).get("/chat");
+    expect(newest.body.conversation_id).toBe("sess_new");
+
+    const picked = await request(makeApp(fakes)).get("/chat").query({ c: "sess_old" });
+    expect(picked.body.conversation_id).toBe("sess_old");
+    expect(picked.body.messages[0].content).toBe("older");
+  });
+
+  it("returns the empty state (not 404) for an unknown ?c=", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    vi.mocked(fakes.sessionRepo.listChatForAgent).mockResolvedValue([
+      fakeSession({ id: "sess_a", result_summary: "a" }),
+    ]);
+
+    const res = await request(makeApp(fakes)).get("/chat").query({ c: "sess_nope" });
+    expect(res.status).toBe(200);
+    expect(res.body.messages).toEqual([]);
+    expect(res.body.prior_session_id).toBeNull();
+    expect(res.body.conversation_id).toBeNull();
+    expect(res.body.agent.id).toBe(AGENT);
+  });
+
+  it("keeps only the last 25 sessions of a long chain", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    const chain = Array.from({ length: 40 }, (_, i) =>
+      fakeSession({
+        id: `sess_${i}`,
+        intent: `turn ${i}`,
+        result_summary: `reply ${i}`,
+        prior_session_id: i === 0 ? undefined : `sess_${i - 1}`,
+        created_at: new Date(Date.UTC(2026, 0, 1, 10, i)),
+      }),
+    );
+    vi.mocked(fakes.sessionRepo.listChatForAgent).mockResolvedValue(chain);
+
+    const res = await request(makeApp(fakes)).get("/chat");
+    // 25 sessions × (user + agent) messages.
+    expect(res.body.messages).toHaveLength(50);
+    expect(res.body.messages[0].content).toBe("turn 15");
+    // Chain identity still comes from the full chain, not the window.
+    expect(res.body.conversation_id).toBe("sess_0");
+    expect(res.body.prior_session_id).toBe("sess_39");
+  });
+
+  it.each(["pending", "running"] as const)(
+    "surfaces in_flight_session_id when the tail is %s",
+    async (status) => {
+      const fakes = makeFakes();
+      withAgent(fakes);
+      vi.mocked(fakes.sessionRepo.listChatForAgent).mockResolvedValue([
+        fakeSession({ id: "sess_live", intent: "working?", status }),
+      ]);
+
+      const res = await request(makeApp(fakes)).get("/chat");
+      expect(res.body.in_flight_session_id).toBe("sess_live");
+      // The user turn is there; the agent reply slot stays empty.
+      expect(res.body.messages).toEqual([
+        { id: "u_sess_live", role: "user", content: "working?" },
+      ]);
+    },
+  );
+
+  it("reports runtime_mismatch when the chain is pinned to another CLI", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes, fakeAgent({ runtime_config: { type: "codex" } as Agent["runtime_config"] }));
+    vi.mocked(fakes.sessionRepo.listChatForAgent).mockResolvedValue([
+      fakeSession({ id: "sess_pin", result_summary: "ok", runtime_id: "rt_1" }),
+    ]);
+    vi.mocked(fakes.runtimeRepo.findById).mockResolvedValue({
+      id: "rt_1",
+      cli: "claude",
+    } as unknown as Runtime);
+
+    const res = await request(makeApp(fakes)).get("/chat");
+    expect(res.body.runtime_mismatch).toEqual({
+      pinned_cli: "claude",
+      current_cli: "codex",
+    });
+  });
+
+  it("omits runtime_mismatch when the pinned CLI matches the agent's", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    vi.mocked(fakes.sessionRepo.listChatForAgent).mockResolvedValue([
+      fakeSession({ id: "sess_pin", result_summary: "ok", runtime_id: "rt_1" }),
+    ]);
+    vi.mocked(fakes.runtimeRepo.findById).mockResolvedValue({
+      id: "rt_1",
+      cli: "claude",
+    } as unknown as Runtime);
+
+    const res = await request(makeApp(fakes)).get("/chat");
+    expect(res.body.runtime_mismatch).toBeUndefined();
+  });
+
+  it("omits runtime_mismatch when the tail has no runtime_id (no lookup at all)", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    vi.mocked(fakes.sessionRepo.listChatForAgent).mockResolvedValue([
+      fakeSession({ id: "sess_free", result_summary: "ok" }),
+    ]);
+
+    const res = await request(makeApp(fakes)).get("/chat");
+    expect(res.body.runtime_mismatch).toBeUndefined();
+    expect(fakes.runtimeRepo.findById).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["the runtime row is gone", undefined],
+    ["the runtime's cli is unrecognized", { id: "rt_1", cli: "cursor" }],
+  ])("omits runtime_mismatch when %s", async (_label, runtime) => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    vi.mocked(fakes.sessionRepo.listChatForAgent).mockResolvedValue([
+      fakeSession({ id: "sess_pin", result_summary: "ok", runtime_id: "rt_1" }),
+    ]);
+    vi.mocked(fakes.runtimeRepo.findById).mockResolvedValue(
+      runtime as unknown as Runtime | undefined,
+    );
+
+    const res = await request(makeApp(fakes)).get("/chat");
+    expect(res.body.runtime_mismatch).toBeUndefined();
+  });
+
+  it("renders a system-wake turn as a `system` message with the summary only", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    vi.mocked(fakes.sessionRepo.listChatForAgent).mockResolvedValue([
+      fakeSession({
+        id: "sess_wake",
+        intent: "<system-wake>task tsk_1 finished\n\nDecide next steps.</system-wake>",
+        result_summary: "acknowledged",
+      }),
+    ]);
+
+    const res = await request(makeApp(fakes)).get("/chat");
+    expect(res.body.messages[0]).toEqual({
+      id: "w_sess_wake",
+      role: "system",
+      content: "task tsk_1 finished",
+      session_id: "sess_wake",
+    });
+  });
+});
+
+// ── POST /chat ───────────────────────────────────────────────────────────
+
+/** Wire up a happy-path dispatch + resolve for the given final session. */
+function primeTurn(fakes: Fakes, final: Partial<Session> = {}) {
+  const dispatched = fakeSession({ id: "sess_dispatched", status: "pending" });
+  vi.mocked(fakes.dispatchService.dispatchTask).mockResolvedValue({
+    session: dispatched,
+    runtime_id: "rt_1",
+  });
+  vi.mocked(fakes.chatResolver.register).mockResolvedValue(
+    fakeSession({
+      id: dispatched.id,
+      status: "succeeded",
+      result_summary: "done",
+      ...final,
+    }),
+  );
+  return dispatched;
+}
+
+describe("POST /chat", () => {
+  it("403s a non-human caller", async () => {
+    const fakes = makeFakes();
+    const res = await request(makeApp(fakes, "agent")).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(403);
+  });
+
+  it.each([
+    ["missing", {}],
+    ["empty", { message: "" }],
+    ["whitespace only", { message: "   \n " }],
+    ["not a string", { message: 42 }],
+  ])("400s when `message` is %s", async (_label, body) => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    const res = await request(makeApp(fakes)).post("/chat").send(body);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("message_required");
+    expect(fakes.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("404s when the caller has no primary agent", async () => {
+    const fakes = makeFakes();
+    vi.mocked(fakes.agentRepo.findTopLevelForOwner).mockResolvedValue(undefined);
+    const res = await request(makeApp(fakes)).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("no_primary_agent");
+  });
+
+  it("dispatches a fresh chat turn and returns the resolver's result", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    primeTurn(fakes, { result_summary: "the answer is 4" });
+
+    const res = await request(makeApp(fakes)).post("/chat").send({ message: "  2+2  " });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      agent: { id: AGENT, name: "Alice's Team", hierarchy: "team" },
+      session_id: "sess_dispatched",
+      response: "the answer is 4",
+      status: "succeeded",
+      view_refs: [],
+    });
+    expect(res.body.replayed).toBeUndefined();
+    expect(fakes.dispatchService.dispatchTask).toHaveBeenCalledWith({
+      agentId: AGENT,
+      // Trimmed before dispatch.
+      intent: "2+2",
+      reason: { kind: "fresh" },
+      type: "chat",
+      sessionIdOverride: undefined,
+    });
+  });
+
+  it("passes prior_session_id through as a chat_continuation resume reason", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    primeTurn(fakes);
+
+    await request(makeApp(fakes))
+      .post("/chat")
+      .send({ message: "and then?", prior_session_id: "sess_prior" });
+
+    expect(fakes.dispatchService.dispatchTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: { kind: "chat_continuation", prior_session_id: "sess_prior" },
+      }),
+    );
+  });
+
+  it("ignores a client session_id that isn't a well-formed sess_ id", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    primeTurn(fakes);
+
+    await request(makeApp(fakes))
+      .post("/chat")
+      .send({ message: "hi", session_id: "not-a-session-id" });
+
+    // No replay lookup, and nothing pinned on the dispatch.
+    expect(fakes.sessionRepo.findById).not.toHaveBeenCalled();
+    expect(fakes.dispatchService.dispatchTask).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionIdOverride: undefined }),
+    );
+  });
+
+  it("maps a failed turn through failureMessageFor rather than echoing the bare exit", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    primeTurn(fakes, {
+      status: "failed",
+      result_summary: undefined,
+      error: "ENOENT: no such file",
+    });
+
+    const res = await request(makeApp(fakes)).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("failed");
+    expect(res.body.response).toBe("ENOENT: no such file");
+  });
+
+  it("extracts directives out of the summary into structured fields", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    primeTurn(fakes, {
+      result_summary:
+        'Here you go. <suggest_action label="Open the plan" prompt="show the plan" />',
+    });
+
+    const res = await request(makeApp(fakes)).post("/chat").send({ message: "hi" });
+    expect(res.body.response).toBe("Here you go.");
+    expect(res.body.suggested_actions).toEqual([
+      { label: "Open the plan", prompt: "show the plan" },
+    ]);
+  });
+
+  // ── idempotent replay ──────────────────────────────────────────────────
+
+  const CLIENT_SID = "sess_abc123def456";
+
+  it("replays a finished turn instead of dispatching again", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    vi.mocked(fakes.sessionRepo.findById).mockResolvedValue(
+      fakeSession({
+        id: CLIENT_SID,
+        type: "chat",
+        status: "succeeded",
+        result_summary: "already answered",
+      }),
+    );
+
+    const res = await request(makeApp(fakes))
+      .post("/chat")
+      .send({ message: "hi", session_id: CLIENT_SID });
+
+    expect(res.status).toBe(200);
+    expect(res.body.replayed).toBe(true);
+    expect(res.body.response).toBe("already answered");
+    expect(res.body.session_id).toBe(CLIENT_SID);
+    expect(fakes.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("409s when the replayed session is still running", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    vi.mocked(fakes.sessionRepo.findById).mockResolvedValue(
+      fakeSession({ id: CLIENT_SID, type: "chat", status: "running" }),
+    );
+
+    const res = await request(makeApp(fakes))
+      .post("/chat")
+      .send({ message: "hi", session_id: CLIENT_SID });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe("session_in_flight");
+    expect(fakes.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("403s when the session id collides with another caller's session", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    vi.mocked(fakes.sessionRepo.findById).mockResolvedValue(
+      fakeSession({ id: CLIENT_SID, type: "chat", agent_id: "agent_someone_else" }),
+    );
+
+    const res = await request(makeApp(fakes))
+      .post("/chat")
+      .send({ message: "hi", session_id: CLIENT_SID });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("session_belongs_to_other_caller");
+    expect(fakes.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["the row does not exist", undefined],
+    ["the row is not a chat session", { type: "task" as const }],
+  ])("falls through to a live dispatch when %s", async (_label, existing) => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    vi.mocked(fakes.sessionRepo.findById).mockResolvedValue(
+      existing ? fakeSession({ id: CLIENT_SID, ...existing }) : undefined,
+    );
+    primeTurn(fakes);
+
+    const res = await request(makeApp(fakes))
+      .post("/chat")
+      .send({ message: "hi", session_id: CLIENT_SID });
+
+    expect(res.status).toBe(200);
+    expect(fakes.dispatchService.dispatchTask).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionIdOverride: CLIENT_SID }),
+    );
+  });
+
+  it("falls through and re-dispatches a pending row under the same id", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    vi.mocked(fakes.sessionRepo.findById).mockResolvedValue(
+      fakeSession({ id: CLIENT_SID, type: "chat", status: "pending" }),
+    );
+    primeTurn(fakes);
+
+    const res = await request(makeApp(fakes))
+      .post("/chat")
+      .send({ message: "hi", session_id: CLIENT_SID });
+
+    expect(res.status).toBe(200);
+    expect(fakes.dispatchService.dispatchTask).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionIdOverride: CLIENT_SID }),
+    );
+  });
+
+  // ── rate limit / offline / failure ─────────────────────────────────────
+
+  it("429s a second concurrent turn for the same person, with Retry-After", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    primeTurn(fakes);
+    // Stand in for a turn already in flight for this person. Holding a
+    // real request open would mean an un-resolvable resolver promise;
+    // taking the slot directly reaches the same branch deterministically.
+    const held = fakes.rateLimiter.acquire(PERSON);
+    expect(held.ok).toBe(true);
+
+    const app = makeApp(fakes);
+    const res = await request(app).post("/chat").send({ message: "second" });
+    expect(res.status).toBe(429);
+    expect(res.body.error).toBe("turn_in_flight");
+    expect(res.body.retry_after_ms).toBe(1000);
+    expect(res.headers["retry-after"]).toBe("1");
+    expect(fakes.dispatchService.dispatchTask).not.toHaveBeenCalled();
+
+    // Releasing it lets the next turn straight through.
+    if (held.ok) held.release();
+    expect((await request(app).post("/chat").send({ message: "third" })).status).toBe(200);
+  });
+
+  it("429s with rate_limited once the sliding window is full", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    // One turn per 60s window; the first POST spends it.
+    fakes.rateLimiter = new ChatRateLimiter({ maxPerWindow: 1 });
+    primeTurn(fakes);
+
+    const app = makeApp(fakes);
+    expect((await request(app).post("/chat").send({ message: "one" })).status).toBe(200);
+
+    const res = await request(app).post("/chat").send({ message: "two" });
+    expect(res.status).toBe(429);
+    expect(res.body.error).toBe("rate_limited");
+    expect(res.body.retry_after_ms).toBeGreaterThan(0);
+  });
+
+  it("503s when the session is daemon-bound but the daemon is offline", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    primeTurn(fakes);
+    vi.mocked(fakes.hub.isOnline).mockReturnValue(false);
+
+    const res = await request(makeApp(fakes)).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe("agent_offline");
+    expect(fakes.chatResolver.register).not.toHaveBeenCalled();
+  });
+
+  it("does not check the hub for a null-runtime (executor fallback) dispatch", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    vi.mocked(fakes.dispatchService.dispatchTask).mockResolvedValue({
+      session: fakeSession({ id: "sess_exec", status: "pending" }),
+      runtime_id: null,
+    });
+    vi.mocked(fakes.chatResolver.register).mockResolvedValue(
+      fakeSession({ id: "sess_exec", status: "succeeded", result_summary: "ok" }),
+    );
+
+    const res = await request(makeApp(fakes)).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(200);
+    expect(fakes.hub.isOnline).not.toHaveBeenCalled();
+  });
+
+  it("releases the rate-limit slot and 500s when dispatch throws", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    vi.mocked(fakes.dispatchService.dispatchTask).mockRejectedValue(
+      new Error("DispatchService: agent not found"),
+    );
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const app = makeApp(fakes);
+    const res = await request(app).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("internal_error");
+
+    // Slot was released — the next turn is not blocked as "concurrent".
+    primeTurn(fakes);
+    expect((await request(app).post("/chat").send({ message: "again" })).status).toBe(200);
+    spy.mockRestore();
+  });
+
+  it("504s when the resolver times out", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    vi.mocked(fakes.dispatchService.dispatchTask).mockResolvedValue({
+      session: fakeSession({ id: "sess_slow", status: "pending" }),
+      runtime_id: "rt_1",
+    });
+    vi.mocked(fakes.chatResolver.register).mockRejectedValue(
+      new Error("chat resolver timeout (90000ms) for sess_slow"),
+    );
+
+    const res = await request(makeApp(fakes)).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(504);
+    expect(res.body.error).toBe("chat_turn_timeout");
+    expect(res.body.timeout_ms).toBe(90_000);
+  });
+
+  it("500s when the resolver rejects for any other reason", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    vi.mocked(fakes.dispatchService.dispatchTask).mockResolvedValue({
+      session: fakeSession({ id: "sess_x", status: "pending" }),
+      runtime_id: "rt_1",
+    });
+    vi.mocked(fakes.chatResolver.register).mockRejectedValue(
+      new Error("chat resolver already registered for sess_x"),
+    );
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await request(makeApp(fakes)).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("internal_error");
+    spy.mockRestore();
+  });
+
+  // ── onboarding flip ────────────────────────────────────────────────────
+
+  it("stamps onboarding_completed_at on the first successful turn", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    vi.mocked(fakes.personRepo.findById).mockResolvedValue(fakePerson());
+    primeTurn(fakes);
+
+    const res = await request(makeApp(fakes)).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(200);
+    expect(fakes.personRepo.update).toHaveBeenCalledWith(PERSON, {
+      onboarding_completed_at: expect.any(Date),
+    });
+  });
+
+  it("does not re-stamp for an already-onboarded person", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    primeTurn(fakes);
+
+    await request(makeApp(fakes)).post("/chat").send({ message: "hi" });
+    expect(fakes.personRepo.update).not.toHaveBeenCalled();
+  });
+
+  it("does not stamp when the first turn fails", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    vi.mocked(fakes.personRepo.findById).mockResolvedValue(fakePerson());
+    primeTurn(fakes, { status: "failed", result_summary: undefined, error: "nope" });
+
+    await request(makeApp(fakes)).post("/chat").send({ message: "hi" });
+    expect(fakes.personRepo.update).not.toHaveBeenCalled();
+  });
+
+  it("still answers when the onboarding stamp write fails", async () => {
+    const fakes = makeFakes();
+    withAgent(fakes);
+    vi.mocked(fakes.personRepo.findById).mockResolvedValue(fakePerson());
+    vi.mocked(fakes.personRepo.update).mockRejectedValue(new Error("write conflict"));
+    primeTurn(fakes, { result_summary: "answered anyway" });
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await request(makeApp(fakes)).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(200);
+    expect(res.body.response).toBe("answered anyway");
+    // Let the fire-and-forget rejection land before restoring the spy.
+    await new Promise((r) => setImmediate(r));
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/packages/api/src/tools/hierarchy.test.ts
+++ b/packages/api/src/tools/hierarchy.test.ts
@@ -11,6 +11,7 @@ import type {
   AgentProvisionEventRepository,
   AgentRepository,
   CoreMemoryBlockRepository,
+  Escalation,
   HierarchyLevel,
   Session,
   Task,
@@ -20,7 +21,10 @@ import type {
   WorkProductRepository,
 } from "@beevibe/core";
 import type { MemoryAgent } from "@beevibe/core/services/memory";
-import type { TaskService } from "@beevibe/core/services/task-service";
+import {
+  InvalidTaskTransitionError,
+  type TaskService,
+} from "@beevibe/core/services/task-service";
 import type { EscalationService } from "@beevibe/core/services/escalation-service";
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
 import type { Pool } from "@beevibe/core/adapters/postgres";
@@ -74,6 +78,23 @@ function fakeWpListItem(
 ): WorkProductListItem {
   const { body: _body, ...rest } = fakeWp();
   return { ...rest, body_bytes: 0, ...overrides };
+}
+
+function fakeEscalation(overrides: Partial<Escalation> = {}): Escalation {
+  return {
+    id: "esc_1",
+    negotiation_id: "neg_1",
+    initiator_session_id: "sess_a",
+    counterparty_session_id: "sess_b",
+    summary: "we disagree on the deadline",
+    initiator_open_questions: [],
+    counterparty_open_questions: [],
+    escalated_by_role: "initiator",
+    status: "pending",
+    created_at: new Date("2026-04-01"),
+    updated_at: new Date("2026-04-01"),
+    ...overrides,
+  } as Escalation;
 }
 
 function buildServices(overrides: {
@@ -155,6 +176,10 @@ function buildServices(overrides: {
   const coreMemoryRepo = {
     findByAgent: vi.fn(async () => []),
     updateContent: vi.fn(async () => undefined),
+    // provisionAgent (behind create_subordinate_agent) seeds the new
+    // agent's default blocks through this before the tool overwrites
+    // persona/domain with the parent's briefing.
+    initDefaults: vi.fn(async () => []),
   } as unknown as CoreMemoryBlockRepository;
 
   const agentProvisionEventRepo = {
@@ -176,6 +201,9 @@ function buildServices(overrides: {
     agentProvisionEventRepo,
   };
 }
+
+/** The (optional) overrides bag `buildServices` accepts, minus the undefined. */
+type ServiceOverrides = NonNullable<Parameters<typeof buildServices>[0]>;
 
 function findTool(tools: AgentTool[], name: string): AgentTool {
   const t = tools.find((t) => t.name === name);
@@ -574,5 +602,594 @@ describe("check_work_status", () => {
     const result = await callTool(tools, "check_work_status", { agent_id: "rando" });
     expect(result.isError).toBe(true);
     expect((result.content as { error: string }).error).toBe("unauthorized");
+  });
+});
+
+// ── create_task: the branches past the authz gate ────────────────────────
+
+describe("create_task — input handling", () => {
+  /** Services whose subordinate list contains `sub_1`. */
+  function withSubordinate() {
+    return buildServices({
+      agentRepo: { findSubordinates: vi.fn(async () => [fakeAgent({ id: "sub_1" })]) },
+    });
+  }
+
+  it.each([
+    ["intent", { agent_id: "sub_1" }],
+    ["agent_id", { intent: "do it" }],
+    ["both", {}],
+  ])("rejects a call missing %s before the subordinate lookup", async (_label, input) => {
+    const services = withSubordinate();
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "create_task", input);
+    expect(result.isError).toBe(true);
+    expect((result.content as { error: string }).error).toBe("intent and agent_id required");
+    expect(services.agentRepo.findSubordinates).not.toHaveBeenCalled();
+  });
+
+  it("rejects a priority outside the enum", async () => {
+    const services = withSubordinate();
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "create_task", {
+      intent: "do it",
+      agent_id: "sub_1",
+      priority: "urgent",
+    });
+    expect(result.isError).toBe(true);
+    expect(String((result.content as { error: string }).error)).toContain(
+      "priority must be one of:",
+    );
+    expect(services.taskRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("defaults priority to medium and forwards the optional fields", async () => {
+    const services = withSubordinate();
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    await callTool(tools, "create_task", {
+      intent: "do it",
+      agent_id: "sub_1",
+      description: "with detail",
+      parent_task_id: "task_parent",
+      repo_url: "https://github.com/foo/bar",
+    });
+
+    expect(services.taskRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "do it",
+        description: "with detail",
+        status: "assigned",
+        priority: "medium",
+        assignee_id: "sub_1",
+        creator_id: "agent_t",
+        creator_type: "agent",
+        parent_task_id: "task_parent",
+        repo_url: "https://github.com/foo/bar",
+      }),
+    );
+  });
+
+  it.each([
+    ["a non-string description", { description: 1 }, "description"],
+    ["a non-string parent_task_id", { parent_task_id: 1 }, "parent_task_id"],
+    ["an empty repo_url", { repo_url: "" }, "repo_url"],
+  ])("drops %s", async (_label, extra, field) => {
+    const services = withSubordinate();
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    await callTool(tools, "create_task", { intent: "do it", agent_id: "sub_1", ...extra });
+    expect(services.taskRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ [field]: undefined }),
+    );
+  });
+
+  it("links the spawned IC session back to the caller's session", async () => {
+    const services = withSubordinate();
+    const tools = buildHierarchyTools(
+      { agentId: "agent_t", hierarchyLevel: "team", sessionId: "sess_team" },
+      services,
+    );
+
+    await callTool(tools, "create_task", { intent: "do it", agent_id: "sub_1" });
+    expect(services.dispatchService.dispatchTask).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "sub_1", type: "task", parentSessionId: "sess_team" }),
+    );
+  });
+
+  it("envelopes a dispatch failure rather than reporting a created task", async () => {
+    const services = buildServices({
+      agentRepo: { findSubordinates: vi.fn(async () => [fakeAgent({ id: "sub_1" })]) },
+      dispatchService: {
+        dispatchTask: vi.fn(async () => {
+          throw new Error("no runtime bound");
+        }),
+      },
+    });
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "create_task", {
+      intent: "do it",
+      agent_id: "sub_1",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "no runtime bound" });
+  });
+});
+
+// ── revise_task ──────────────────────────────────────────────────────────
+
+describe("revise_task", () => {
+  const BLOCKED = fakeTask({ id: "task_b", status: "blocked", assignee_id: "sub_1" });
+
+  /** Caller `agent_t` is the direct parent of the task's assignee. */
+  function parentOfAssignee(overrides: ServiceOverrides = {}) {
+    return buildServices({
+      ...overrides,
+      taskRepo: { findById: vi.fn(async () => BLOCKED), ...overrides.taskRepo },
+      agentRepo: {
+        findById: vi.fn(async () => fakeAgent({ id: "sub_1", parent_agent_id: "agent_t" })),
+        ...overrides.agentRepo,
+      },
+    });
+  }
+
+  it.each([
+    ["task_id", { feedback: "try this" }],
+    ["feedback", { task_id: "task_b" }],
+  ])("rejects a call missing %s", async (_label, input) => {
+    const services = parentOfAssignee();
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "revise_task", input);
+    expect(result.isError).toBe(true);
+    expect((result.content as { error: string }).error).toBe("task_id and feedback required");
+    expect(services.taskRepo.findById).not.toHaveBeenCalled();
+  });
+
+  it("404s an unknown task", async () => {
+    const services = buildServices({ taskRepo: { findById: vi.fn(async () => undefined) } });
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "revise_task", {
+      task_id: "task_gone",
+      feedback: "f",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "task_not_found", task_id: "task_gone" });
+  });
+
+  it("refuses an unassigned task", async () => {
+    const services = buildServices({
+      taskRepo: { findById: vi.fn(async () => fakeTask({ assignee_id: undefined })) },
+    });
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "revise_task", { task_id: "task_1", feedback: "f" });
+    expect(result.isError).toBe(true);
+    expect((result.content as { error: string }).error).toBe("task_unassigned");
+  });
+
+  it("refuses when the assignee agent row is gone", async () => {
+    const services = buildServices({
+      taskRepo: { findById: vi.fn(async () => BLOCKED) },
+      agentRepo: { findById: vi.fn(async () => undefined) },
+    });
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "revise_task", { task_id: "task_b", feedback: "f" });
+    expect(result.isError).toBe(true);
+    expect((result.content as { error: string }).error).toBe("assignee_not_found");
+  });
+
+  it("refuses a caller who is not the assignee's direct parent", async () => {
+    const services = buildServices({
+      taskRepo: { findById: vi.fn(async () => BLOCKED) },
+      agentRepo: {
+        findById: vi.fn(async () =>
+          fakeAgent({ id: "sub_1", parent_agent_id: "agent_someone_else" }),
+        ),
+      },
+    });
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "revise_task", { task_id: "task_b", feedback: "f" });
+    expect(result.isError).toBe(true);
+    expect((result.content as { error: string }).error).toBe("not_parent");
+    expect(services.taskService.reviseTask).not.toHaveBeenCalled();
+  });
+
+  it("revises and dispatches the resume session with the parent's feedback", async () => {
+    const revised = fakeTask({
+      id: "task_b",
+      status: "needs_revision",
+      assignee_id: "sub_1",
+      next_dispatch_context: {
+        kind: "revision",
+        feedback: "try the other API",
+        source: "parent_agent",
+        from_status: "blocked",
+        reviser_agent_id: "agent_t",
+      },
+    });
+    const services = parentOfAssignee({
+      taskService: { reviseTask: vi.fn(async () => revised) },
+    });
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "revise_task", {
+      task_id: "task_b",
+      feedback: "try the other API",
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({
+      revised: true,
+      task_id: "task_b",
+      status: "needs_revision",
+      from_status: "blocked",
+    });
+    expect(services.taskService.reviseTask).toHaveBeenCalledWith(
+      "task_b",
+      "try the other API",
+      { source: "parent_agent", reviserAgentId: "agent_t" },
+    );
+    expect(services.dispatchService.dispatchTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "sub_1",
+        type: "task",
+        reason: revised.next_dispatch_context,
+      }),
+    );
+  });
+
+  it("skips the dispatch when the service left no revision context", async () => {
+    const services = parentOfAssignee({
+      taskService: {
+        reviseTask: vi.fn(async () => fakeTask({ id: "task_b", status: "needs_revision" })),
+      },
+    });
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "revise_task", { task_id: "task_b", feedback: "f" });
+    expect(result.isError).toBeFalsy();
+    expect(services.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("reports an illegal state transition under its own code", async () => {
+    const services = parentOfAssignee({
+      taskService: {
+        reviseTask: vi.fn(async () => {
+          throw new InvalidTaskTransitionError("cannot revise a done task");
+        }),
+      },
+    });
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "revise_task", { task_id: "task_b", feedback: "f" });
+    expect(result.isError).toBe(true);
+    expect((result.content as { error: string }).error).toBe("invalid_transition");
+  });
+
+  it("envelopes any other throw", async () => {
+    const services = parentOfAssignee({
+      taskService: {
+        reviseTask: vi.fn(async () => {
+          throw new Error("connection terminated");
+        }),
+      },
+    });
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "revise_task", { task_id: "task_b", feedback: "f" });
+    expect(result.content).toEqual({ error: "connection terminated" });
+  });
+});
+
+// ── add_to_escalation ────────────────────────────────────────────────────
+
+describe("add_to_escalation", () => {
+  it("rejects a missing escalation_id", async () => {
+    const services = buildServices();
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "add_to_escalation", {});
+    expect(result.isError).toBe(true);
+    expect((result.content as { error: string }).error).toBe("escalation_id required");
+    expect(services.escalationService.addContribution).not.toHaveBeenCalled();
+  });
+
+  it("submits the caller's contribution and notifies listeners", async () => {
+    const services = buildServices({
+      escalationService: {
+        addContribution: vi.fn(async () =>
+          fakeEscalation({ initiator_submitted_at: new Date("2026-04-01") }),
+        ),
+      },
+    });
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "add_to_escalation", {
+      escalation_id: "esc_1",
+      proposals: [{ title: "Option B", description: "swap the queue" }],
+      open_questions: ["is latency a hard requirement?", 3],
+    });
+
+    expect(services.escalationService.addContribution).toHaveBeenCalledWith({
+      escalationId: "esc_1",
+      callerAgentId: "agent_t",
+      proposals: [{ title: "Option B", description: "swap the queue" }],
+      // Non-string questions dropped.
+      openQuestions: ["is latency a hard requirement?"],
+    });
+    expect(services.pool.query).toHaveBeenCalledWith(
+      expect.stringContaining("pg_notify('escalation_updated'"),
+      ["esc_1"],
+    );
+    expect(result.content).toEqual({
+      escalation_id: "esc_1",
+      status: "pending",
+      // Only one side has submitted.
+      both_sides_submitted: false,
+    });
+  });
+
+  it("flags both_sides_submitted once the peer has contributed too", async () => {
+    const services = buildServices({
+      escalationService: {
+        addContribution: vi.fn(async () =>
+          fakeEscalation({
+            initiator_submitted_at: new Date("2026-04-01"),
+            counterparty_submitted_at: new Date("2026-04-02"),
+          }),
+        ),
+      },
+    });
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "add_to_escalation", { escalation_id: "esc_1" });
+    expect((result.content as { both_sides_submitted: boolean }).both_sides_submitted).toBe(
+      true,
+    );
+  });
+
+  it("passes undefined for non-array proposals / open_questions", async () => {
+    const services = buildServices();
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    await callTool(tools, "add_to_escalation", {
+      escalation_id: "esc_1",
+      proposals: "Option B",
+      open_questions: "is latency hard?",
+    });
+    expect(services.escalationService.addContribution).toHaveBeenCalledWith(
+      expect.objectContaining({ proposals: undefined, openQuestions: undefined }),
+    );
+  });
+
+  it("envelopes a service throw (e.g. already submitted)", async () => {
+    const services = buildServices({
+      escalationService: {
+        addContribution: vi.fn(async () => {
+          throw new Error("caller already submitted their slot");
+        }),
+      },
+    });
+    const tools = buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+
+    const result = await callTool(tools, "add_to_escalation", { escalation_id: "esc_1" });
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "caller already submitted their slot" });
+    expect(services.pool.query).not.toHaveBeenCalled();
+  });
+});
+
+// ── create_subordinate_agent ─────────────────────────────────────────────
+
+describe("create_subordinate_agent", () => {
+  const BRIEFING = {
+    name: "Backend specialist",
+    tag_line: "Owns the API layer",
+    persona: "A pragmatic backend engineer",
+    domain: "Node, Postgres, Express",
+  };
+
+  /** Services where the caller resolves to a real parent agent. */
+  function withParent(overrides: ServiceOverrides = {}) {
+    return buildServices({
+      ...overrides,
+      agentRepo: {
+        findById: vi.fn(async () => fakeAgent({ id: "agent_t", owner_id: "person_1" })),
+        create: vi.fn(async (input: Partial<Agent>) => fakeAgent(input)),
+        ...overrides.agentRepo,
+      },
+    });
+  }
+
+  function teamTools(services: ReturnType<typeof buildServices>) {
+    return buildHierarchyTools({ agentId: "agent_t", hierarchyLevel: "team" }, services);
+  }
+
+  it.each([
+    ["name", { ...BRIEFING, name: "  " }],
+    ["tag_line", { ...BRIEFING, tag_line: "" }],
+    ["persona", { ...BRIEFING, persona: undefined }],
+    ["domain", { ...BRIEFING, domain: "   " }],
+  ])("rejects a briefing missing %s", async (_label, input) => {
+    const services = withParent();
+    const result = await callTool(teamTools(services), "create_subordinate_agent", input);
+    expect(result.isError).toBe(true);
+    expect((result.content as { error: string }).error).toBe("missing_required_fields");
+    expect(services.agentRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects a tag_line over 100 chars and reports the actual length", async () => {
+    const services = withParent();
+    const result = await callTool(teamTools(services), "create_subordinate_agent", {
+      ...BRIEFING,
+      tag_line: "x".repeat(101),
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "tag_line_too_long", actual: 101 });
+  });
+
+  it.each([
+    ["over 80 chars", "n".repeat(81)],
+    ["containing a control character", "Back\u0007end"],
+  ])("rejects a name %s", async (_label, name) => {
+    const services = withParent();
+    const result = await callTool(teamTools(services), "create_subordinate_agent", {
+      ...BRIEFING,
+      name,
+    });
+    expect(result.isError).toBe(true);
+    expect((result.content as { error: string }).error).toBe("invalid_name");
+  });
+
+  it("404s when the calling parent's agent row is gone", async () => {
+    const services = withParent({ agentRepo: { findById: vi.fn(async () => undefined) } });
+    const result = await callTool(teamTools(services), "create_subordinate_agent", BRIEFING);
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "parent_not_found", agent_id: "agent_t" });
+  });
+
+  it("enforces the per-parent daily cap", async () => {
+    const services = withParent();
+    vi.mocked(services.agentProvisionEventRepo.countByParentSince).mockResolvedValue(8);
+
+    const result = await callTool(teamTools(services), "create_subordinate_agent", BRIEFING);
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "subordinate_daily_cap",
+      cap: 8,
+      count: 8,
+    });
+    expect(services.agentRepo.create).not.toHaveBeenCalled();
+    // Counted over a 24h window.
+    expect(services.agentProvisionEventRepo.countByParentSince).toHaveBeenCalledWith(
+      "agent_t",
+      86_400,
+    );
+  });
+
+  it("provisions the IC under the parent, inheriting owner and runtime", async () => {
+    const services = withParent({
+      agentRepo: {
+        findById: vi.fn(async () =>
+          fakeAgent({
+            id: "agent_t",
+            owner_id: "person_1",
+            runtime_config: { type: "codex", model: "gpt-5" },
+            preferred_runtime_id: "rt_1",
+          } as Partial<Agent>),
+        ),
+      },
+    });
+
+    const result = await callTool(teamTools(services), "create_subordinate_agent", BRIEFING);
+
+    expect(result.isError).toBeFalsy();
+    expect(services.agentRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Backend specialist",
+        owner_id: "person_1",
+        parent_agent_id: "agent_t",
+        hierarchy_level: "ic",
+        preferred_runtime_id: "rt_1",
+        runtime_config: expect.objectContaining({
+          type: "codex",
+          model: "gpt-5",
+          system_prompt_addition: "You are Backend specialist.",
+        }),
+      }),
+    );
+    expect((result.content as { created: { hierarchy_level: string } }).created)
+      .toMatchObject({ hierarchy_level: "ic", parent_agent_id: "agent_t" });
+  });
+
+  it("omits preferred_runtime_id when the parent has none", async () => {
+    const services = withParent();
+    await callTool(teamTools(services), "create_subordinate_agent", BRIEFING);
+    const created = vi.mocked(services.agentRepo.create).mock.calls[0]?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(created).not.toHaveProperty("preferred_runtime_id");
+  });
+
+  it("seeds only the identity blocks the parent actually supplied", async () => {
+    const services = withParent();
+    await callTool(teamTools(services), "create_subordinate_agent", BRIEFING);
+
+    const seeded = vi
+      .mocked(services.coreMemoryRepo.updateContent)
+      .mock.calls.map((c) => c[1]);
+    expect(seeded.sort()).toEqual(["domain", "persona", "tag_line"]);
+  });
+
+  it("seeds the optional blocks when they are supplied", async () => {
+    const services = withParent();
+    await callTool(teamTools(services), "create_subordinate_agent", {
+      ...BRIEFING,
+      active_context: "migrating auth to SSO",
+      constraints: "no breaking API changes",
+    });
+
+    const seeded = vi
+      .mocked(services.coreMemoryRepo.updateContent)
+      .mock.calls.map((c) => c[1]);
+    expect(seeded.sort()).toEqual([
+      "active_context",
+      "constraints",
+      "domain",
+      "persona",
+      "tag_line",
+    ]);
+  });
+
+  it("writes the audit row that backs the cap", async () => {
+    const services = withParent();
+    await callTool(teamTools(services), "create_subordinate_agent", BRIEFING);
+
+    expect(services.agentProvisionEventRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parent_agent_id: "agent_t",
+        owner_person_id: "person_1",
+        child_name: "Backend specialist",
+        persona: BRIEFING.persona,
+        domain: BRIEFING.domain,
+      }),
+    );
+  });
+
+  it("still returns the new agent when the audit row fails to write", async () => {
+    const services = withParent();
+    vi.mocked(services.agentProvisionEventRepo.create).mockRejectedValue(
+      new Error("connection terminated"),
+    );
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await callTool(teamTools(services), "create_subordinate_agent", BRIEFING);
+    expect(result.isError).toBeFalsy();
+    expect((result.content as { created: { name: string } }).created.name).toBe(
+      "Backend specialist",
+    );
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("envelopes a provisioning failure", async () => {
+    const services = withParent({
+      agentRepo: {
+        create: vi.fn(async () => {
+          throw new Error("duplicate key value violates unique constraint");
+        }),
+      },
+    });
+
+    const result = await callTool(teamTools(services), "create_subordinate_agent", BRIEFING);
+    expect(result.isError).toBe(true);
+    expect(String((result.content as { error: string }).error)).toContain("duplicate key");
   });
 });

--- a/packages/api/src/tools/mesh-handlers.test.ts
+++ b/packages/api/src/tools/mesh-handlers.test.ts
@@ -1,0 +1,619 @@
+/**
+ * Mesh tool *handler* behavior — the half `mesh.test.ts` leaves out.
+ *
+ * That file locks the per-tier tool inventory; the handlers themselves
+ * were only exercised by the m6/m7 e2e scripts (live Postgres + spawned
+ * CLIs), so none of the argument validation, response projection, or
+ * error enveloping ran in CI. Every branch here is a distinct wire shape
+ * an agent branches on, and all of it is reachable with a fake
+ * MeshServer — the tools are thin adapters by design.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { AgentRepository } from "@beevibe/core";
+import type { TaskService } from "@beevibe/core/services/task-service";
+import type { EscalationService } from "@beevibe/core/services/escalation-service";
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import {
+  CannotNegotiateWithIcError,
+  MeshCapacityError,
+  MeshMaxRoundsError,
+} from "../mesh/types.js";
+import type { MeshServer } from "../mesh/server.js";
+import {
+  buildIcMeshTools,
+  buildTeamMeshTools,
+  type MeshToolContext,
+  type MeshToolServices,
+} from "./mesh.js";
+import type { AgentTool } from "./types.js";
+
+const CALLER = "agent_caller";
+const SID = "sess_caller";
+
+interface Harness {
+  services: MeshToolServices;
+  mesh: {
+    sendAsk: ReturnType<typeof vi.fn>;
+    respondAsk: ReturnType<typeof vi.fn>;
+    sendNegotiate: ReturnType<typeof vi.fn>;
+    respondNegotiate: ReturnType<typeof vi.fn>;
+    reportBlocker: ReturnType<typeof vi.fn>;
+    unblockOnEscalate: ReturnType<typeof vi.fn>;
+  };
+  agentRepo: AgentRepository;
+  taskService: TaskService;
+  escalationService: EscalationService;
+  pool: Pool;
+  tool: (name: string) => AgentTool;
+}
+
+function harness(): Harness {
+  const mesh = {
+    sendAsk: vi.fn(),
+    respondAsk: vi.fn(),
+    sendNegotiate: vi.fn(),
+    respondNegotiate: vi.fn(),
+    reportBlocker: vi.fn(),
+    unblockOnEscalate: vi.fn(),
+  };
+  const agentRepo = { findParent: vi.fn() } as unknown as AgentRepository;
+  const taskService = { markBlocked: vi.fn() } as unknown as TaskService;
+  const escalationService = { create: vi.fn() } as unknown as EscalationService;
+  const pool = { query: vi.fn().mockResolvedValue({ rows: [] }) } as unknown as Pool;
+
+  const services = {
+    mesh: mesh as unknown as MeshServer,
+    agentRepo,
+    taskRepo: {} as MeshToolServices["taskRepo"],
+    taskService,
+    escalationService,
+    pool,
+  } satisfies MeshToolServices;
+
+  const ctx: MeshToolContext = {
+    caller: { source: "agent", agentId: CALLER, hierarchyLevel: "team" },
+    beevibeSid: SID,
+  };
+  const tools = buildTeamMeshTools(ctx, services);
+
+  return {
+    services,
+    mesh,
+    agentRepo,
+    taskService,
+    escalationService,
+    pool,
+    tool: (name) => {
+      const t = tools.find((x) => x.name === name);
+      if (!t) throw new Error(`no such tool: ${name}`);
+      return t;
+    },
+  };
+}
+
+// ── ask ──────────────────────────────────────────────────────────────────
+
+describe("ask", () => {
+  it("projects only request_id / from_agent_id / answer back to the caller", async () => {
+    const h = harness();
+    h.mesh.sendAsk.mockResolvedValue({
+      request_id: "req_1",
+      from_agent_id: "agent_target",
+      answer: "yes, feasible",
+      // Server-side extras must not leak into the agent-visible payload.
+      internal_session_id: "sess_secret",
+    });
+
+    const res = await h.tool("ask").handler({
+      target_agent_id: "agent_target",
+      question: "is X feasible?",
+    });
+
+    expect(res.isError).toBeUndefined();
+    expect(res.content).toEqual({
+      request_id: "req_1",
+      from_agent_id: "agent_target",
+      answer: "yes, feasible",
+    });
+  });
+
+  it("mints a fresh request id per call and passes the caller as sender", async () => {
+    const h = harness();
+    h.mesh.sendAsk.mockResolvedValue({ request_id: "x", from_agent_id: "y", answer: "z" });
+
+    await h.tool("ask").handler({ target_agent_id: "agent_t", question: "q1" });
+    await h.tool("ask").handler({ target_agent_id: "agent_t", question: "q2" });
+
+    const [first, second] = h.mesh.sendAsk.mock.calls;
+    expect(first?.[0]).toMatch(/^[0-9a-f-]{36}$/);
+    expect(first?.[0]).not.toBe(second?.[0]);
+    expect(first?.slice(1)).toEqual([CALLER, "agent_t", "q1"]);
+  });
+
+  it.each([
+    ["target_agent_id", { question: "q" }],
+    ["question", { target_agent_id: "agent_t" }],
+    ["both", {}],
+  ])("rejects a call missing %s without touching the mesh", async (_label, input) => {
+    const h = harness();
+    const res = await h.tool("ask").handler(input);
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("target_agent_id and question required");
+    expect(h.mesh.sendAsk).not.toHaveBeenCalled();
+  });
+
+  it("projects a coded mesh error with its code and meta intact", async () => {
+    const h = harness();
+    h.mesh.sendAsk.mockRejectedValue(
+      new MeshCapacityError("target at capacity", {
+        agentId: "agent_target",
+        running: 3,
+        cap: 3,
+      }),
+    );
+
+    const res = await h.tool("ask").handler({
+      target_agent_id: "agent_target",
+      question: "q",
+    });
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "MESH_CAPACITY_EXCEEDED",
+      agentId: "agent_target",
+      running: 3,
+      cap: 3,
+      message: "target at capacity",
+    });
+  });
+
+  it("degrades an uncoded throw to the catch-all envelope", async () => {
+    const h = harness();
+    h.mesh.sendAsk.mockRejectedValue(new Error("ask timed out"));
+    const res = await h.tool("ask").handler({ target_agent_id: "a", question: "q" });
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({ error: "ask timed out" });
+  });
+});
+
+// ── respond_ask ──────────────────────────────────────────────────────────
+
+describe("respond_ask", () => {
+  it("stamps the responder's own agent id on the response", async () => {
+    const h = harness();
+    const res = await h.tool("respond_ask").handler({
+      request_id: "req_1",
+      answer: "42",
+      // A responder cannot forge who the answer came from.
+      from_agent_id: "agent_someone_else",
+    });
+
+    expect(res.content).toEqual({ responded: true, request_id: "req_1" });
+    expect(h.mesh.respondAsk).toHaveBeenCalledWith("req_1", {
+      request_id: "req_1",
+      from_agent_id: CALLER,
+      answer: "42",
+    });
+  });
+
+  it.each([
+    ["request_id", { answer: "a" }],
+    ["answer", { request_id: "req_1" }],
+  ])("rejects a call missing %s", async (_label, input) => {
+    const h = harness();
+    const res = await h.tool("respond_ask").handler(input);
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("request_id and answer required");
+    expect(h.mesh.respondAsk).not.toHaveBeenCalled();
+  });
+
+  it("envelopes a throw from the mesh (e.g. nobody waiting on that id)", async () => {
+    const h = harness();
+    h.mesh.respondAsk.mockImplementation(() => {
+      throw new Error("no resolver for req_gone");
+    });
+    const res = await h.tool("respond_ask").handler({
+      request_id: "req_gone",
+      answer: "a",
+    });
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({ error: "no resolver for req_gone" });
+  });
+
+  it("is available to IC agents too", () => {
+    const ic = buildIcMeshTools(
+      {
+        caller: { source: "agent", agentId: CALLER, hierarchyLevel: "ic" },
+        beevibeSid: SID,
+      },
+      harness().services,
+    );
+    expect(ic.map((t) => t.name)).toContain("respond_ask");
+  });
+});
+
+// ── negotiate ────────────────────────────────────────────────────────────
+
+describe("negotiate", () => {
+  it("forwards the proposal with the caller's session id as originator", async () => {
+    const h = harness();
+    h.mesh.sendNegotiate.mockResolvedValue({
+      negotiation_id: "neg_1",
+      from_agent_id: "agent_peer",
+      decision: "counter",
+      message: "how about this",
+      counter_proposal: "do it next sprint",
+    });
+
+    const res = await h.tool("negotiate").handler({
+      peer_id: "agent_peer",
+      proposal: "ship friday",
+      task_id: "tsk_1",
+    });
+
+    expect(h.mesh.sendNegotiate).toHaveBeenCalledWith(CALLER, "agent_peer", "ship friday", {
+      taskId: "tsk_1",
+      initiatorSessionId: SID,
+    });
+    expect(res.content).toEqual({
+      negotiation_id: "neg_1",
+      from_agent_id: "agent_peer",
+      decision: "counter",
+      message: "how about this",
+      counter_proposal: "do it next sprint",
+    });
+  });
+
+  it("treats an empty task_id as absent", async () => {
+    const h = harness();
+    h.mesh.sendNegotiate.mockResolvedValue({
+      negotiation_id: "neg_1",
+      from_agent_id: "agent_peer",
+      decision: "accept",
+      message: "ok",
+    });
+
+    await h.tool("negotiate").handler({ peer_id: "p", proposal: "x", task_id: "" });
+    expect(h.mesh.sendNegotiate).toHaveBeenCalledWith(
+      CALLER,
+      "p",
+      "x",
+      expect.objectContaining({ taskId: undefined }),
+    );
+  });
+
+  it.each([
+    ["peer_id", { proposal: "p" }],
+    ["proposal", { peer_id: "agent_peer" }],
+  ])("rejects a call missing %s", async (_label, input) => {
+    const h = harness();
+    const res = await h.tool("negotiate").handler(input);
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("peer_id and proposal required");
+    expect(h.mesh.sendNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("projects the escalated sentinel through its own shape", async () => {
+    const h = harness();
+    h.mesh.sendNegotiate.mockResolvedValue({
+      decision: "escalated",
+      escalation_id: "esc_1",
+      negotiation_id: "neg_1",
+      message: "peer escalated to humans",
+    });
+
+    const res = await h.tool("negotiate").handler({ peer_id: "p", proposal: "x" });
+    expect(res.content).toEqual({
+      decision: "escalated",
+      escalation_id: "esc_1",
+      negotiation_id: "neg_1",
+      message: "peer escalated to humans",
+    });
+    // No from_agent_id / counter_proposal keys on the sentinel branch.
+    expect(res.content).not.toHaveProperty("from_agent_id");
+  });
+
+  it("surfaces the IC-target guardrail as its coded error", async () => {
+    const h = harness();
+    h.mesh.sendNegotiate.mockRejectedValue(
+      new CannotNegotiateWithIcError({ agentId: "agent_ic" }),
+    );
+
+    const res = await h.tool("negotiate").handler({ peer_id: "agent_ic", proposal: "x" });
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("CANNOT_NEGOTIATE_WITH_IC");
+    expect(res.content.agentId).toBe("agent_ic");
+  });
+});
+
+// ── respond_negotiate ────────────────────────────────────────────────────
+
+describe("respond_negotiate", () => {
+  it("returns the terminal shape when the server reports no continuation", async () => {
+    const h = harness();
+    h.mesh.respondNegotiate.mockResolvedValue(null);
+
+    const res = await h.tool("respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "accept",
+      message: "deal",
+    });
+
+    expect(res.content).toEqual({
+      negotiation_id: "neg_1",
+      decision: "accept",
+      terminal: true,
+    });
+    expect(h.mesh.respondNegotiate).toHaveBeenCalledWith(
+      "neg_1",
+      {
+        negotiation_id: "neg_1",
+        from_agent_id: CALLER,
+        decision: "accept",
+        message: "deal",
+        counter_proposal: undefined,
+      },
+      SID,
+    );
+  });
+
+  it("returns the peer's next round when the negotiation continues", async () => {
+    const h = harness();
+    h.mesh.respondNegotiate.mockResolvedValue({
+      negotiation_id: "neg_1",
+      from_agent_id: "agent_peer",
+      decision: "counter",
+      message: "not quite",
+      counter_proposal: "wednesday",
+    });
+
+    const res = await h.tool("respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "tuesday?",
+      counter_proposal: "tuesday",
+    });
+
+    expect(res.content).toMatchObject({
+      from_agent_id: "agent_peer",
+      decision: "counter",
+      counter_proposal: "wednesday",
+    });
+  });
+
+  it.each([
+    ["negotiation_id", { decision: "accept", message: "m" }],
+    ["message", { negotiation_id: "neg_1", decision: "accept" }],
+  ])("rejects a call missing %s", async (_label, input) => {
+    const h = harness();
+    const res = await h.tool("respond_negotiate").handler(input);
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("negotiation_id and message required");
+    expect(h.mesh.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("rejects an out-of-enum decision", async () => {
+    const h = harness();
+    const res = await h.tool("respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "maybe",
+      message: "m",
+    });
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("decision must be one of: counter, accept, reject");
+    expect(h.mesh.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("requires counter_proposal when countering", async () => {
+    const h = harness();
+    const res = await h.tool("respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "not this",
+    });
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("counter_proposal required when decision='counter'");
+    expect(h.mesh.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("surfaces MAX_ROUNDS_EXCEEDED with the round counters the agent needs", async () => {
+    const h = harness();
+    h.mesh.respondNegotiate.mockRejectedValue(
+      new MeshMaxRoundsError({
+        negotiationId: "neg_1",
+        rounds_completed: 5,
+        max_rounds: 5,
+      }),
+    );
+
+    const res = await h.tool("respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "again",
+      counter_proposal: "again",
+    });
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toMatchObject({
+      error: "MAX_ROUNDS_EXCEEDED",
+      negotiationId: "neg_1",
+      rounds_completed: 5,
+      max_rounds: 5,
+    });
+    expect(String(res.content.message)).toContain("escalate_to_humans");
+  });
+});
+
+// ── report_blocker ───────────────────────────────────────────────────────
+
+describe("report_blocker", () => {
+  it("marks the task blocked, then spawns the parent fire-and-forget", async () => {
+    const h = harness();
+    vi.mocked(h.agentRepo.findParent).mockResolvedValue({ id: "agent_parent" } as never);
+
+    const res = await h.tool("report_blocker").handler({
+      task_id: "tsk_1",
+      description: "the API key is missing",
+    });
+
+    expect(res.content).toEqual({
+      reported: true,
+      parent_agent_id: "agent_parent",
+      task_id: "tsk_1",
+    });
+    expect(h.taskService.markBlocked).toHaveBeenCalledWith(
+      "tsk_1",
+      CALLER,
+      "the API key is missing",
+    );
+    expect(h.mesh.reportBlocker).toHaveBeenCalledWith(
+      "agent_parent",
+      CALLER,
+      "tsk_1",
+      "the API key is missing",
+    );
+  });
+
+  it("refuses for a top-level agent and names the alternatives", async () => {
+    const h = harness();
+    vi.mocked(h.agentRepo.findParent).mockResolvedValue(undefined);
+
+    const res = await h.tool("report_blocker").handler({
+      task_id: "tsk_1",
+      description: "stuck",
+    });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("no_parent_to_block");
+    expect(String(res.content.message)).toContain("escalate_to_humans");
+    // Nothing was mutated on the way out.
+    expect(h.taskService.markBlocked).not.toHaveBeenCalled();
+    expect(h.mesh.reportBlocker).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["task_id", { description: "d" }],
+    ["description", { task_id: "tsk_1" }],
+  ])("rejects a call missing %s before looking up the parent", async (_label, input) => {
+    const h = harness();
+    const res = await h.tool("report_blocker").handler(input);
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("task_id and description required");
+    expect(h.agentRepo.findParent).not.toHaveBeenCalled();
+  });
+
+  it("does not spawn the parent when marking the task blocked fails", async () => {
+    const h = harness();
+    vi.mocked(h.agentRepo.findParent).mockResolvedValue({ id: "agent_parent" } as never);
+    vi.mocked(h.taskService.markBlocked).mockRejectedValue(new Error("task not found"));
+
+    const res = await h.tool("report_blocker").handler({
+      task_id: "tsk_gone",
+      description: "stuck",
+    });
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({ error: "task not found" });
+    expect(h.mesh.reportBlocker).not.toHaveBeenCalled();
+  });
+});
+
+// ── escalate_to_humans ───────────────────────────────────────────────────
+
+describe("escalate_to_humans", () => {
+  const ESCALATION = {
+    id: "esc_1",
+    status: "open",
+    negotiation_id: "neg_1",
+  };
+
+  it("creates the escalation, unblocks the peer, then notifies listeners", async () => {
+    const h = harness();
+    vi.mocked(h.escalationService.create).mockResolvedValue(ESCALATION as never);
+
+    const res = await h.tool("escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "we disagree on the deadline",
+      proposals: [{ title: "Ship friday", description: "cut scope" }],
+      open_questions: ["is the demo date fixed?", 7],
+    });
+
+    expect(res.content).toEqual({
+      escalation_id: "esc_1",
+      status: "open",
+      negotiation_id: "neg_1",
+    });
+    expect(h.escalationService.create).toHaveBeenCalledWith({
+      negotiationId: "neg_1",
+      callerAgentId: CALLER,
+      summary: "we disagree on the deadline",
+      proposals: [{ title: "Ship friday", description: "cut scope" }],
+      // Non-string open questions are dropped, not passed through.
+      openQuestions: ["is the demo date fixed?"],
+    });
+    expect(h.mesh.unblockOnEscalate).toHaveBeenCalledWith("neg_1", "esc_1");
+    expect(h.pool.query).toHaveBeenCalledWith(
+      expect.stringContaining("pg_notify('escalation_created'"),
+      ["esc_1"],
+    );
+  });
+
+  it("passes undefined for proposals / open_questions when they aren't arrays", async () => {
+    const h = harness();
+    vi.mocked(h.escalationService.create).mockResolvedValue(ESCALATION as never);
+
+    await h.tool("escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "s",
+      proposals: "not an array",
+    });
+
+    expect(h.escalationService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ proposals: undefined, openQuestions: undefined }),
+    );
+  });
+
+  it.each([
+    ["negotiation_id", { summary: "s" }],
+    ["summary", { negotiation_id: "neg_1" }],
+  ])("rejects a call missing %s", async (_label, input) => {
+    const h = harness();
+    const res = await h.tool("escalate_to_humans").handler(input);
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("negotiation_id and summary required");
+    expect(h.escalationService.create).not.toHaveBeenCalled();
+  });
+
+  it("does not unblock the peer when the escalation itself fails to create", async () => {
+    const h = harness();
+    vi.mocked(h.escalationService.create).mockRejectedValue(
+      new Error("negotiation already escalated"),
+    );
+
+    const res = await h.tool("escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "s",
+    });
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({ error: "negotiation already escalated" });
+    expect(h.mesh.unblockOnEscalate).not.toHaveBeenCalled();
+    expect(h.pool.query).not.toHaveBeenCalled();
+  });
+
+  it("reports the failure when the pg_notify write throws", async () => {
+    const h = harness();
+    vi.mocked(h.escalationService.create).mockResolvedValue(ESCALATION as never);
+    vi.mocked(h.pool.query).mockRejectedValue(new Error("connection terminated"));
+
+    const res = await h.tool("escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "s",
+    });
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({ error: "connection terminated" });
+    // The peer was still unblocked — that happens before the notify.
+    expect(h.mesh.unblockOnEscalate).toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/tools/session-search.test.ts
+++ b/packages/api/src/tools/session-search.test.ts
@@ -1,0 +1,250 @@
+/**
+ * `session_search` handler tests — shape inference and error enveloping.
+ *
+ * The tool's whole job is turning loose MCP input into one of four typed
+ * requests, and the precedence between them is not obvious from a call
+ * site: scroll beats read beats discover beats browse, and a blank-ish
+ * string counts as absent at every rung. Getting that wrong silently
+ * answers a different question than the agent asked. The rest is error
+ * enveloping — including the deliberate match-by-name fallback, which
+ * exists so a cross-bundle `SessionSearchError` (src/ vs dist/) still
+ * reports its code instead of degrading to `internal_error`.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  SessionSearchError,
+  type SessionSearchService,
+} from "@beevibe/core/services/session-search";
+import { createSessionSearchTool } from "./session-search.js";
+
+const AGENT = "agent_caller";
+const SESSION = "sess_current";
+
+function harness(level: "ic" | "team" | "org" = "team") {
+  const sessionSearch = {
+    search: vi.fn().mockResolvedValue({ kind: "browse", sessions: [] }),
+  } as unknown as SessionSearchService;
+
+  const tool = createSessionSearchTool(
+    { agentId: AGENT, hierarchyLevel: level, sessionId: SESSION },
+    { sessionSearch },
+  );
+  return { sessionSearch, tool, request: () => vi.mocked(sessionSearch.search).mock.calls[0]?.[0] };
+}
+
+describe("session_search — caller scope", () => {
+  it("passes the caller's agent, tier and active session to the service", async () => {
+    const h = harness("org");
+    await h.tool.handler({});
+    expect(vi.mocked(h.sessionSearch.search).mock.calls[0]?.[1]).toEqual({
+      callerAgentId: AGENT,
+      hierarchyLevel: "org",
+      currentSessionId: SESSION,
+    });
+  });
+});
+
+// ── shape inference ──────────────────────────────────────────────────────
+
+describe("session_search — shape inference", () => {
+  it("browses when nothing is passed", async () => {
+    const h = harness();
+    await h.tool.handler({});
+    expect(h.request()).toEqual({ kind: "browse", limit: undefined, filters: undefined });
+  });
+
+  it("discovers when a query is passed", async () => {
+    const h = harness();
+    await h.tool.handler({ query: "  auth refactor  ", limit: 7, sort: "newest" });
+    expect(h.request()).toEqual({
+      kind: "discover",
+      // Trimmed.
+      query: "auth refactor",
+      limit: 7,
+      sort: "newest",
+      filters: undefined,
+    });
+  });
+
+  it("reads when only a session_id is passed", async () => {
+    const h = harness();
+    await h.tool.handler({ session_id: " sess_x " });
+    expect(h.request()).toEqual({ kind: "read", session_id: "sess_x" });
+  });
+
+  it("scrolls when session_id and around_message_id are both passed", async () => {
+    const h = harness();
+    await h.tool.handler({
+      session_id: "sess_x",
+      around_message_id: " evt_1 ",
+      window: 12,
+    });
+    expect(h.request()).toEqual({
+      kind: "scroll",
+      session_id: "sess_x",
+      around_message_id: "evt_1",
+      window: 12,
+    });
+  });
+
+  it("prefers scroll over discover when a query tags along", async () => {
+    const h = harness();
+    await h.tool.handler({
+      session_id: "sess_x",
+      around_message_id: "evt_1",
+      query: "ignored",
+    });
+    expect(h.request()).toMatchObject({ kind: "scroll" });
+  });
+
+  it("prefers read over discover when a query tags along", async () => {
+    const h = harness();
+    await h.tool.handler({ session_id: "sess_x", query: "ignored" });
+    expect(h.request()).toEqual({ kind: "read", session_id: "sess_x" });
+  });
+
+  it("falls back to discover when the anchor is present but session_id isn't", async () => {
+    const h = harness();
+    await h.tool.handler({ around_message_id: "evt_1", query: "auth" });
+    expect(h.request()).toMatchObject({ kind: "discover", query: "auth" });
+  });
+
+  it.each([
+    ["a blank string", "   "],
+    ["an empty string", ""],
+    ["a non-string", 42],
+  ])("treats %s session_id as absent", async (_label, session_id) => {
+    const h = harness();
+    await h.tool.handler({ session_id, query: "auth" });
+    expect(h.request()).toMatchObject({ kind: "discover" });
+  });
+
+  it.each([
+    ["a blank string", "   "],
+    ["a non-string", 42],
+  ])("treats %s query as absent — browse, not discover", async (_label, query) => {
+    const h = harness();
+    await h.tool.handler({ query });
+    expect(h.request()).toMatchObject({ kind: "browse" });
+  });
+
+  it("treats a blank anchor as absent — read, not scroll", async () => {
+    const h = harness();
+    await h.tool.handler({ session_id: "sess_x", around_message_id: "  " });
+    expect(h.request()).toEqual({ kind: "read", session_id: "sess_x" });
+  });
+
+  it.each([
+    ["limit", "limit", "3"],
+    ["window", "window", "10"],
+  ])("drops a non-numeric %s rather than passing it through", async (_l, key, value) => {
+    const h = harness();
+    await h.tool.handler(
+      key === "window"
+        ? { session_id: "s", around_message_id: "e", window: value }
+        : { query: "q", limit: value },
+    );
+    expect(h.request()).toMatchObject({ [key]: undefined });
+  });
+
+  it("drops an out-of-enum sort", async () => {
+    const h = harness();
+    await h.tool.handler({ query: "q", sort: "relevance" });
+    expect(h.request()).toMatchObject({ sort: undefined });
+  });
+
+  it("forwards filters on the discover and browse shapes", async () => {
+    const filters = { session_type: "chat", status: "failed", since: "2026-01-01" };
+    const discover = harness();
+    await discover.tool.handler({ query: "q", filters });
+    expect(discover.request()).toMatchObject({ filters });
+
+    const browse = harness();
+    await browse.tool.handler({ filters });
+    expect(browse.request()).toMatchObject({ filters });
+  });
+
+  it.each([
+    ["null", null],
+    ["a non-object", "session_type=chat"],
+  ])("drops %s filters", async (_label, filters) => {
+    const h = harness();
+    await h.tool.handler({ query: "q", filters });
+    expect(h.request()).toMatchObject({ filters: undefined });
+  });
+});
+
+// ── results and errors ───────────────────────────────────────────────────
+
+describe("session_search — results", () => {
+  it("returns the service result verbatim", async () => {
+    const h = harness();
+    const result = { kind: "read", session: { id: "sess_x" }, messages: [] };
+    vi.mocked(h.sessionSearch.search).mockResolvedValue(result as never);
+
+    const res = await h.tool.handler({ session_id: "sess_x" });
+    expect(res.isError).toBeUndefined();
+    expect(res.content).toEqual(result);
+  });
+
+  it("maps a null result onto the not_found_or_forbidden envelope", async () => {
+    const h = harness();
+    vi.mocked(h.sessionSearch.search).mockResolvedValue(null as never);
+
+    const res = await h.tool.handler({ session_id: "sess_someone_elses" });
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("not_found_or_forbidden");
+    expect(String(res.content.message)).toContain("not in your scope");
+  });
+
+  it.each(["forbidden_agent_filter", "missing_query", "missing_args"] as const)(
+    "surfaces the %s code from a SessionSearchError",
+    async (code) => {
+      const h = harness();
+      vi.mocked(h.sessionSearch.search).mockRejectedValue(
+        new SessionSearchError(code, `rejected: ${code}`),
+      );
+
+      const res = await h.tool.handler({ query: "q" });
+      expect(res.isError).toBe(true);
+      expect(res.content).toEqual({ error: code, message: `rejected: ${code}` });
+    },
+  );
+
+  it("recognizes a SessionSearchError from another bundle by name", async () => {
+    const h = harness();
+    // Same shape, different class identity — what a src/-vs-dist/ import
+    // split produces. `instanceof` misses it; the name check must not.
+    const foreign = Object.assign(new Error("agent_id outside your scope"), {
+      name: "SessionSearchError",
+      code: "forbidden_agent_filter",
+    });
+    vi.mocked(h.sessionSearch.search).mockRejectedValue(foreign);
+
+    const res = await h.tool.handler({ query: "q", filters: { agent_id: "agent_other" } });
+    expect(res.content).toEqual({
+      error: "forbidden_agent_filter",
+      message: "agent_id outside your scope",
+    });
+  });
+
+  it("envelopes an unrelated throw as internal_error", async () => {
+    const h = harness();
+    vi.mocked(h.sessionSearch.search).mockRejectedValue(new Error("connection terminated"));
+
+    const res = await h.tool.handler({ query: "q" });
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "internal_error",
+      message: "connection terminated",
+    });
+  });
+
+  it("stringifies a non-Error throw", async () => {
+    const h = harness();
+    vi.mocked(h.sessionSearch.search).mockRejectedValue("pool is draining");
+
+    const res = await h.tool.handler({});
+    expect(res.content).toEqual({ error: "internal_error", message: "pool is draining" });
+  });
+});

--- a/packages/api/src/tools/use-repo.test.ts
+++ b/packages/api/src/tools/use-repo.test.ts
@@ -1,0 +1,273 @@
+/**
+ * `use_repo` handler tests — the Capability Network's write path.
+ *
+ * The tool was untested end to end even though it mints three rows in a
+ * fixed order (task → session → repo_run) and each ordering failure has
+ * its own documented recovery. What matters and is asserted here: the
+ * repo_url gate (it decides whether arbitrary URLs reach a sandbox), the
+ * limit clamps (they cap wall-clock, retries and disk), that the
+ * repo_run insert carries the same pre-minted session id the dispatch
+ * used, and that a partial failure reports rather than silently leaving
+ * the agent to wait on a run that will never start.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  RepoRunRepository,
+  Task,
+  TaskRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import { createUseRepoTool, type UseRepoServices } from "./use-repo.js";
+
+const AGENT = "agent_caller";
+
+function fakeAgent(): Agent {
+  return {
+    id: AGENT,
+    name: "Caller",
+    owner_id: "person_1",
+    hierarchy_level: "ic",
+    runtime_config: { type: "claude" },
+    created_at: new Date("2026-01-01T00:00:00Z"),
+    updated_at: new Date("2026-01-01T00:00:00Z"),
+  } as Agent;
+}
+
+function harness() {
+  const agentRepo = {
+    findById: vi.fn().mockResolvedValue(fakeAgent()),
+  } as unknown as AgentRepository;
+  const taskRepo = {
+    create: vi.fn(async (input: { id: string }) => ({ ...input }) as unknown as Task),
+  } as unknown as TaskRepository;
+  const repoRunRepo = { create: vi.fn().mockResolvedValue({}) } as unknown as RepoRunRepository;
+  const dispatchService = {
+    dispatchTask: vi.fn().mockResolvedValue({ session: {}, runtime_id: null }),
+  } as unknown as DispatchService;
+
+  const services: UseRepoServices = { agentRepo, taskRepo, repoRunRepo, dispatchService };
+  const tool = createUseRepoTool({ agentId: AGENT }, services);
+  return { agentRepo, taskRepo, repoRunRepo, dispatchService, tool };
+}
+
+const OK_INPUT = {
+  goal: "Extract the tables from this PDF as JSON",
+  repo_url: "https://github.com/jsvine/pdfplumber",
+};
+
+// ── argument validation ──────────────────────────────────────────────────
+
+describe("use_repo — input validation", () => {
+  it.each([
+    ["missing", undefined],
+    ["empty", ""],
+    ["whitespace only", "   "],
+    ["not a string", 42],
+  ])("rejects a %s goal before creating anything", async (_label, goal) => {
+    const h = harness();
+    const res = await h.tool.handler({ ...OK_INPUT, goal });
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("invalid_goal");
+    expect(h.taskRepo.create).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["a non-GitHub host", "https://gitlab.com/foo/bar"],
+    ["plain http", "http://github.com/foo/bar"],
+    ["an ssh remote", "git@github.com:foo/bar.git"],
+    ["a lookalike host", "https://github.com.evil.example/foo/bar"],
+    ["unparseable junk", "not a url"],
+    ["an empty string", ""],
+  ])("rejects %s as repo_url", async (_label, repo_url) => {
+    const h = harness();
+    const res = await h.tool.handler({ ...OK_INPUT, repo_url });
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("invalid_repo_url");
+    expect(h.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["the apex host", "https://github.com/foo/bar"],
+    ["a subdomain", "https://raw.github.com/foo/bar"],
+    ["mixed case", "https://GitHub.COM/foo/bar"],
+  ])("accepts %s", async (_label, repo_url) => {
+    const h = harness();
+    const res = await h.tool.handler({ ...OK_INPUT, repo_url });
+    expect(res.isError).toBeUndefined();
+  });
+
+  it("404s when the calling agent row is gone", async () => {
+    const h = harness();
+    vi.mocked(h.agentRepo.findById).mockResolvedValue(undefined);
+    const res = await h.tool.handler(OK_INPUT);
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("agent_not_found");
+    expect(h.taskRepo.create).not.toHaveBeenCalled();
+  });
+});
+
+// ── happy path ───────────────────────────────────────────────────────────
+
+describe("use_repo — run creation", () => {
+  it("creates task, session and repo_run and returns the watch handles", async () => {
+    const h = harness();
+    const res = await h.tool.handler({ ...OK_INPUT, input_url: " https://x/y.pdf " });
+
+    expect(res.isError).toBeUndefined();
+    const content = res.content as Record<string, string>;
+    expect(content.repo_run_id).toMatch(/^repo_/);
+    expect(content.session_id).toMatch(/^sess_/);
+    expect(content.task_id).toMatch(/^task_/);
+    expect(content.status).toBe("pending");
+    expect(content.watch_url).toBe(`/capabilities/runs/${content.repo_run_id}`);
+    // Trimmed on the way through.
+    expect(content.input_url).toBe("https://x/y.pdf");
+  });
+
+  it("pins the repo_run to the session id the dispatch was given", async () => {
+    const h = harness();
+    const res = await h.tool.handler(OK_INPUT);
+
+    const dispatched = vi.mocked(h.dispatchService.dispatchTask).mock.calls[0]?.[0];
+    const inserted = vi.mocked(h.repoRunRepo.create).mock.calls[0]?.[0];
+    expect(dispatched?.sessionIdOverride).toBe(inserted?.session_id);
+    expect(inserted?.session_id).toBe(res.content.session_id);
+    expect(inserted).toMatchObject({
+      agent_id: AGENT,
+      goal: OK_INPUT.goal,
+      repo_url: OK_INPUT.repo_url,
+      status: "pending",
+    });
+  });
+
+  it("dispatches a run_repo session carrying the container task", async () => {
+    const h = harness();
+    await h.tool.handler(OK_INPUT);
+
+    const created = vi.mocked(h.taskRepo.create).mock.calls[0]?.[0];
+    expect(created).toMatchObject({
+      description: OK_INPUT.goal,
+      priority: "medium",
+      assignee_id: AGENT,
+      creator_id: AGENT,
+      creator_type: "agent",
+    });
+    expect(h.dispatchService.dispatchTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: AGENT,
+        type: "run_repo",
+        intent: OK_INPUT.goal,
+        reason: { kind: "fresh" },
+      }),
+    );
+  });
+
+  it("cuts a long goal down to an 80-char container-task title", async () => {
+    const h = harness();
+    await h.tool.handler({ ...OK_INPUT, goal: "z".repeat(200) });
+    const title = vi.mocked(h.taskRepo.create).mock.calls[0]?.[0].title as string;
+    expect(title).toHaveLength(78);
+    expect(title.endsWith("…")).toBe(true);
+  });
+
+  it("collapses whitespace in the title but keeps the full goal as description", async () => {
+    const h = harness();
+    await h.tool.handler({ ...OK_INPUT, goal: "  do\n\n  the   thing  " });
+    const created = vi.mocked(h.taskRepo.create).mock.calls[0]?.[0];
+    expect(created?.title).toBe("do the thing");
+    expect(created?.description).toBe("do\n\n  the   thing");
+  });
+});
+
+// ── limits ───────────────────────────────────────────────────────────────
+
+describe("use_repo — limits", () => {
+  it("echoes limits within range untouched", async () => {
+    const h = harness();
+    const res = await h.tool.handler({
+      ...OK_INPUT,
+      limits: { wall_clock_minutes: 5, max_install_attempts: 3, disk_mb: 512 },
+    });
+    expect(res.content.limits).toEqual({
+      wall_clock_minutes: 5,
+      max_install_attempts: 3,
+      disk_mb: 512,
+    });
+  });
+
+  it("clamps each limit to its ceiling", async () => {
+    const h = harness();
+    const res = await h.tool.handler({
+      ...OK_INPUT,
+      limits: { wall_clock_minutes: 600, max_install_attempts: 99, disk_mb: 1_000_000 },
+    });
+    expect(res.content.limits).toEqual({
+      wall_clock_minutes: 60,
+      max_install_attempts: 5,
+      disk_mb: 10_000,
+    });
+  });
+
+  it("floors fractional counts", async () => {
+    const h = harness();
+    const res = await h.tool.handler({
+      ...OK_INPUT,
+      limits: { max_install_attempts: 2.9, disk_mb: 100.7 },
+    });
+    expect(res.content.limits).toEqual({ max_install_attempts: 2, disk_mb: 100 });
+  });
+
+  it.each([
+    ["absent", undefined],
+    ["not an object", "20"],
+    ["null", null],
+    ["zero / negative / non-numeric values", { wall_clock_minutes: 0, disk_mb: -1 }],
+  ])("drops %s limits to an empty object", async (_label, limits) => {
+    const h = harness();
+    const res = await h.tool.handler({ ...OK_INPUT, limits });
+    expect(res.content.limits).toEqual({});
+  });
+});
+
+// ── partial failure ──────────────────────────────────────────────────────
+
+describe("use_repo — failure reporting", () => {
+  it("reports dispatch_failed without attempting the repo_run insert", async () => {
+    const h = harness();
+    vi.mocked(h.dispatchService.dispatchTask).mockRejectedValue(
+      new Error("DispatchService: agent not found"),
+    );
+
+    const res = await h.tool.handler(OK_INPUT);
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "dispatch_failed",
+      message: "DispatchService: agent not found",
+    });
+    expect(h.repoRunRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("reports repo_run_create_failed so the agent doesn't wait on an orphan session", async () => {
+    const h = harness();
+    vi.mocked(h.repoRunRepo.create).mockRejectedValue(
+      new Error('duplicate key value violates unique constraint "repo_run_pkey"'),
+    );
+
+    const res = await h.tool.handler(OK_INPUT);
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("repo_run_create_failed");
+    expect(String(res.content.message)).toContain("duplicate key");
+  });
+
+  it("stringifies a non-Error throw rather than losing it", async () => {
+    const h = harness();
+    vi.mocked(h.dispatchService.dispatchTask).mockRejectedValue("pool is draining");
+    const res = await h.tool.handler(OK_INPUT);
+    expect(res.content).toEqual({
+      error: "dispatch_failed",
+      message: "pool is draining",
+    });
+  });
+});

--- a/packages/api/src/tools/watch.test.ts
+++ b/packages/api/src/tools/watch.test.ts
@@ -1,0 +1,209 @@
+/**
+ * `watch_tasks` / `unwatch` handler tests.
+ *
+ * Both tools are thin adapters over WatchService, so what's worth
+ * pinning is exactly the part the service doesn't do: the input
+ * coercion (non-string task ids dropped, unknown modes falling back to
+ * 'all', blank reasons normalized away), the missing-session guard, and
+ * the mapping of each WatchService error class onto its own stable
+ * `error` code — the codes are what an agent branches on, and a
+ * mis-mapped one reads as a generic failure.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  WatchAuthError,
+  WatchNotFoundError,
+  WatchValidationError,
+  type WatchService,
+} from "@beevibe/core/services/watch-service";
+import { buildWatchTools, type WatchToolContext } from "./watch.js";
+import type { AgentTool } from "./types.js";
+
+const AGENT = "agent_caller";
+const SESSION = "sess_caller";
+
+function harness(ctx: Partial<WatchToolContext> = {}) {
+  const watchService = {
+    watchTasks: vi.fn().mockResolvedValue({ watchId: "wch_1", firedImmediately: false }),
+    unwatch: vi.fn().mockResolvedValue(undefined),
+  } as unknown as WatchService;
+
+  const tools = buildWatchTools(
+    { agentId: AGENT, sessionId: SESSION, ...ctx },
+    { watchService },
+  );
+  const tool = (name: string): AgentTool => {
+    const t = tools.find((x) => x.name === name);
+    if (!t) throw new Error(`no such tool: ${name}`);
+    return t;
+  };
+  return { watchService, tools, tool };
+}
+
+describe("buildWatchTools", () => {
+  it("returns watch_tasks and unwatch, in that order", () => {
+    expect(harness().tools.map((t) => t.name)).toEqual(["watch_tasks", "unwatch"]);
+  });
+
+  it("advertises both modes in the watch_tasks schema", () => {
+    const schema = harness().tool("watch_tasks").schema as {
+      properties: { mode: { enum: string[] } };
+    };
+    expect(schema.properties.mode.enum).toEqual(["all", "any"]);
+  });
+});
+
+// ── watch_tasks ──────────────────────────────────────────────────────────
+
+describe("watch_tasks", () => {
+  it("registers the watch and returns the id plus the fired flag", async () => {
+    const h = harness();
+    const res = await h.tool("watch_tasks").handler({
+      task_ids: ["tsk_1", "tsk_2"],
+      mode: "any",
+      reason: "  need the first result  ",
+    });
+
+    expect(res.isError).toBeUndefined();
+    expect(res.content).toEqual({ watch_id: "wch_1", fired_immediately: false });
+    expect(h.watchService.watchTasks).toHaveBeenCalledWith({
+      callerAgentId: AGENT,
+      callerSessionId: SESSION,
+      taskIds: ["tsk_1", "tsk_2"],
+      mode: "any",
+      // Trimmed.
+      reason: "need the first result",
+    });
+  });
+
+  it("passes through fired_immediately when the condition was already met", async () => {
+    const h = harness();
+    vi.mocked(h.watchService.watchTasks).mockResolvedValue({
+      watchId: "wch_2",
+      firedImmediately: true,
+    });
+
+    const res = await h.tool("watch_tasks").handler({ task_ids: ["tsk_1"] });
+    expect(res.content).toEqual({ watch_id: "wch_2", fired_immediately: true });
+  });
+
+  it.each([
+    ["absent", undefined],
+    ["an unknown string", "either"],
+    ["not a string", 1],
+  ])("defaults mode to 'all' when it is %s", async (_label, mode) => {
+    const h = harness();
+    await h.tool("watch_tasks").handler({ task_ids: ["tsk_1"], mode });
+    expect(h.watchService.watchTasks).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "all" }),
+    );
+  });
+
+  it.each([
+    ["absent", undefined],
+    ["blank", "   "],
+    ["not a string", 5],
+  ])("omits the reason when it is %s", async (_label, reason) => {
+    const h = harness();
+    await h.tool("watch_tasks").handler({ task_ids: ["tsk_1"], reason });
+    expect(h.watchService.watchTasks).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: undefined }),
+    );
+  });
+
+  it("drops non-string entries from task_ids", async () => {
+    const h = harness();
+    await h.tool("watch_tasks").handler({ task_ids: ["tsk_1", 2, null, "tsk_3"] });
+    expect(h.watchService.watchTasks).toHaveBeenCalledWith(
+      expect.objectContaining({ taskIds: ["tsk_1", "tsk_3"] }),
+    );
+  });
+
+  it.each([
+    ["an empty array", []],
+    ["an array with no usable ids", [1, null]],
+    ["not an array", "tsk_1"],
+    ["absent", undefined],
+  ])("rejects task_ids that are %s", async (_label, task_ids) => {
+    const h = harness();
+    const res = await h.tool("watch_tasks").handler({ task_ids });
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("watch_validation");
+    expect(res.content.message).toBe("task_ids must be a non-empty array of strings");
+    expect(h.watchService.watchTasks).not.toHaveBeenCalled();
+  });
+
+  it("refuses to register outside a session context", async () => {
+    const h = harness({ sessionId: undefined });
+    const res = await h.tool("watch_tasks").handler({ task_ids: ["tsk_1"] });
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("watch_validation");
+    expect(res.content.message).toBe("watch_tasks must be called inside a session context");
+    expect(h.watchService.watchTasks).not.toHaveBeenCalled();
+  });
+});
+
+// ── unwatch ──────────────────────────────────────────────────────────────
+
+describe("unwatch", () => {
+  it("cancels the watch and reports ok", async () => {
+    const h = harness();
+    const res = await h.tool("unwatch").handler({ watch_id: "wch_1" });
+    expect(res.content).toEqual({ ok: true });
+    expect(h.watchService.unwatch).toHaveBeenCalledWith({
+      callerAgentId: AGENT,
+      watchId: "wch_1",
+    });
+  });
+
+  it.each([
+    ["absent", undefined],
+    ["empty", ""],
+    ["not a string", 7],
+  ])("rejects a watch_id that is %s", async (_label, watch_id) => {
+    const h = harness();
+    const res = await h.tool("unwatch").handler({ watch_id });
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "watch_validation",
+      message: "watch_id must be a non-empty string",
+    });
+    expect(h.watchService.unwatch).not.toHaveBeenCalled();
+  });
+});
+
+// ── error mapping (shared by both tools) ─────────────────────────────────
+
+describe("WatchService error mapping", () => {
+  it.each([
+    ["watch_auth", new WatchAuthError("task tsk_1 is not in your conversation chain")],
+    ["watch_validation", new WatchValidationError("task_ids must be non-empty")],
+    ["watch_not_found", new WatchNotFoundError("wch_gone")],
+    ["watch_error", new Error("connection terminated")],
+  ])("maps a thrown %s onto its code", async (code, thrown) => {
+    const h = harness();
+    vi.mocked(h.watchService.watchTasks).mockRejectedValue(thrown);
+
+    const res = await h.tool("watch_tasks").handler({ task_ids: ["tsk_1"] });
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe(code);
+    expect(res.content.message).toBe((thrown as Error).message);
+  });
+
+  it("stringifies a non-Error throw under watch_error", async () => {
+    const h = harness();
+    vi.mocked(h.watchService.unwatch).mockRejectedValue("pool is draining");
+
+    const res = await h.tool("unwatch").handler({ watch_id: "wch_1" });
+    expect(res.content).toEqual({ error: "watch_error", message: "pool is draining" });
+  });
+
+  it("maps unwatch's not-found the same way watch_tasks does", async () => {
+    const h = harness();
+    vi.mocked(h.watchService.unwatch).mockRejectedValue(new WatchNotFoundError("wch_gone"));
+
+    const res = await h.tool("unwatch").handler({ watch_id: "wch_gone" });
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("watch_not_found");
+  });
+});

--- a/packages/core/src/adapters/postgres/agent-provision-event-repo.test.ts
+++ b/packages/core/src/adapters/postgres/agent-provision-event-repo.test.ts
@@ -1,0 +1,214 @@
+/**
+ * `agent_provision_event` adapter — integration tests against Postgres.
+ *
+ * The write half is live: `create_subordinate_agent` appends a row per
+ * spawn and gates itself on `countByParentSince`. That count is a rate
+ * limit, so the window arithmetic (`NOW() - N * INTERVAL '1 second'`,
+ * inclusive at the boundary) is the part worth pinning — an off-by-one
+ * there either lets a runaway parent spawn past its cap or locks a
+ * legitimate one out. `listByParent` backs the (unbuilt) audit panel;
+ * its ordering and default limit are contract too.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_RUNTIME_CONFIG } from "../../domain/agent.js";
+import { agentId, agentProvisionEventId, personId } from "../../domain/ids.js";
+import type { Pool } from "./client.js";
+import { createTestPool, truncateAll } from "../../test-helpers.js";
+import { PostgresAgentProvisionEventRepository } from "./agent-provision-event-repo.js";
+import { PostgresAgentRepository } from "./agent-repo.js";
+import { PostgresPersonRepository } from "./person-repo.js";
+
+describe("PostgresAgentProvisionEventRepository", () => {
+  let pool: Pool;
+  let events: PostgresAgentProvisionEventRepository;
+  let agents: PostgresAgentRepository;
+  let persons: PostgresPersonRepository;
+  let ownerId: string;
+  let parentId: string;
+
+  beforeAll(() => {
+    pool = createTestPool();
+    events = new PostgresAgentProvisionEventRepository(pool);
+    agents = new PostgresAgentRepository(pool);
+    persons = new PostgresPersonRepository(pool);
+  });
+
+  beforeEach(async () => {
+    await truncateAll(pool);
+    const owner = await persons.create({ id: personId(), name: "Owner" });
+    ownerId = owner.id;
+    const parent = await agents.create({
+      id: agentId(),
+      name: "Team",
+      owner_id: ownerId,
+      hierarchy_level: "team",
+      runtime_config: DEFAULT_RUNTIME_CONFIG,
+    });
+    parentId = parent.id;
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  /** A fresh IC child under the shared parent. */
+  async function makeChild(name = "Specialist"): Promise<string> {
+    const child = await agents.create({
+      id: agentId(),
+      name,
+      owner_id: ownerId,
+      hierarchy_level: "ic",
+      parent_agent_id: parentId,
+      runtime_config: DEFAULT_RUNTIME_CONFIG,
+    });
+    return child.id;
+  }
+
+  async function record(
+    opts: { parent?: string; child?: string; name?: string; at?: Date } = {},
+  ) {
+    return events.create({
+      id: agentProvisionEventId(),
+      parent_agent_id: opts.parent ?? parentId,
+      child_agent_id: opts.child ?? (await makeChild(opts.name)),
+      owner_person_id: ownerId,
+      child_name: opts.name ?? "Specialist",
+      persona: "A careful reviewer",
+      domain: "code review",
+      ...(opts.at ? { created_at: opts.at } : {}),
+    });
+  }
+
+  it("round-trips every column on create", async () => {
+    const childId = await makeChild("Reviewer");
+    const id = agentProvisionEventId();
+    const created = await events.create({
+      id,
+      parent_agent_id: parentId,
+      child_agent_id: childId,
+      owner_person_id: ownerId,
+      child_name: "Reviewer",
+      persona: "A careful reviewer",
+      domain: "code review",
+    });
+
+    expect(created).toMatchObject({
+      id,
+      parent_agent_id: parentId,
+      child_agent_id: childId,
+      owner_person_id: ownerId,
+      child_name: "Reviewer",
+      persona: "A careful reviewer",
+      domain: "code review",
+    });
+    expect(created.created_at).toBeInstanceOf(Date);
+  });
+
+  it("defaults created_at to now when the caller omits it", async () => {
+    const before = Date.now();
+    const created = await record();
+    // Allow a second of clock skew between the test process and Postgres.
+    expect(created.created_at.getTime()).toBeGreaterThanOrEqual(before - 1_000);
+    expect(created.created_at.getTime()).toBeLessThanOrEqual(Date.now() + 1_000);
+  });
+
+  it("honors an explicit created_at (backfill path)", async () => {
+    const at = new Date("2026-02-03T04:05:06.000Z");
+    const created = await record({ at });
+    expect(created.created_at.toISOString()).toBe(at.toISOString());
+  });
+
+  describe("countByParentSince", () => {
+    it("returns 0 for a parent that has never spawned", async () => {
+      expect(await events.countByParentSince(parentId, 86_400)).toBe(0);
+    });
+
+    it("counts only events inside the window", async () => {
+      const now = Date.now();
+      await record({ at: new Date(now - 60 * 1000) }); // 1m ago — in
+      await record({ at: new Date(now - 30 * 60 * 1000) }); // 30m ago — in
+      await record({ at: new Date(now - 25 * 60 * 60 * 1000) }); // 25h ago — out
+
+      expect(await events.countByParentSince(parentId, 86_400)).toBe(2);
+      expect(await events.countByParentSince(parentId, 3_600)).toBe(2);
+      expect(await events.countByParentSince(parentId, 300)).toBe(1);
+    });
+
+    it("scopes the count to one parent", async () => {
+      const other = await agents.create({
+        id: agentId(),
+        name: "Other team",
+        owner_id: ownerId,
+        hierarchy_level: "team",
+        runtime_config: DEFAULT_RUNTIME_CONFIG,
+      });
+      await record();
+      await record();
+      await record({ parent: other.id });
+
+      expect(await events.countByParentSince(parentId, 86_400)).toBe(2);
+      expect(await events.countByParentSince(other.id, 86_400)).toBe(1);
+    });
+
+    it("counts nothing for a zero-length window", async () => {
+      await record({ at: new Date(Date.now() - 1_000) });
+      expect(await events.countByParentSince(parentId, 0)).toBe(0);
+    });
+  });
+
+  describe("listByParent", () => {
+    it("returns newest first", async () => {
+      const now = Date.now();
+      const oldest = await record({ name: "A", at: new Date(now - 3_000) });
+      const middle = await record({ name: "B", at: new Date(now - 2_000) });
+      const newest = await record({ name: "C", at: new Date(now - 1_000) });
+
+      const rows = await events.listByParent(parentId);
+      expect(rows.map((r) => r.id)).toEqual([newest.id, middle.id, oldest.id]);
+      expect(rows[0]?.child_name).toBe("C");
+    });
+
+    it("caps at the requested limit", async () => {
+      const now = Date.now();
+      await record({ at: new Date(now - 3_000) });
+      await record({ at: new Date(now - 2_000) });
+      const newest = await record({ at: new Date(now - 1_000) });
+
+      const rows = await events.listByParent(parentId, 1);
+      expect(rows.map((r) => r.id)).toEqual([newest.id]);
+    });
+
+    it("defaults to 50 rows", async () => {
+      const child = await makeChild();
+      const now = Date.now();
+      for (let i = 0; i < 55; i += 1) {
+        await events.create({
+          id: agentProvisionEventId(),
+          parent_agent_id: parentId,
+          child_agent_id: child,
+          owner_person_id: ownerId,
+          child_name: `S${i}`,
+          persona: "p",
+          domain: "d",
+          created_at: new Date(now - i * 1_000),
+        });
+      }
+      expect(await events.listByParent(parentId)).toHaveLength(50);
+    });
+
+    it("returns an empty array for an unknown parent", async () => {
+      await record();
+      expect(await events.listByParent("agent_nonexistent")).toEqual([]);
+    });
+  });
+
+  it("cascades away when the child agent is deleted", async () => {
+    const childId = await makeChild();
+    await record({ child: childId });
+    expect(await events.countByParentSince(parentId, 86_400)).toBe(1);
+
+    await agents.delete(childId);
+    expect(await events.listByParent(parentId)).toEqual([]);
+    expect(await events.countByParentSince(parentId, 86_400)).toBe(0);
+  });
+});

--- a/packages/core/src/adapters/postgres/promotion-event-repo.test.ts
+++ b/packages/core/src/adapters/postgres/promotion-event-repo.test.ts
@@ -1,0 +1,218 @@
+/**
+ * `memory_promotion_event` adapter — integration tests against Postgres.
+ *
+ * The M8.D promotion audit log is written by MemoryAgent and read by
+ * `views/promotions.ts`; the adapter itself was never covered because
+ * `bootstrap.ts` doesn't construct it yet (CLAUDE.md records this as
+ * unfinished wiring, not dead code). Testing it now means the read side
+ * is known-good when the wiring lands, and pins the two things a caller
+ * can't see from the port: the COALESCE defaults on `source_session_ids`
+ * / `rejected`, and that `listByOwner` joins through `agent.owner_id`
+ * rather than through the fact — so an event only reaches the owner of
+ * the *origin agent*.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_RUNTIME_CONFIG } from "../../domain/agent.js";
+import { agentId, factId, personId, promotionEventId, sessionId } from "../../domain/ids.js";
+import type { Pool } from "./client.js";
+import { createTestPool, truncateAll } from "../../test-helpers.js";
+import { PostgresAgentRepository } from "./agent-repo.js";
+import { PostgresMemoryFactRepository } from "./memory-fact-repo.js";
+import { PostgresMemoryPromotionEventRepository } from "./promotion-event-repo.js";
+import { PostgresPersonRepository } from "./person-repo.js";
+
+/** A deterministic 1536-dim unit vector; content doesn't matter here. */
+function unitVector(axis = 0, dims = 1536): number[] {
+  const v = new Array<number>(dims).fill(0);
+  v[axis] = 1;
+  return v;
+}
+
+describe("PostgresMemoryPromotionEventRepository", () => {
+  let pool: Pool;
+  let promotions: PostgresMemoryPromotionEventRepository;
+  let facts: PostgresMemoryFactRepository;
+  let agents: PostgresAgentRepository;
+  let persons: PostgresPersonRepository;
+  let ownerId: string;
+  let originAgentId: string;
+  let factRowId: string;
+
+  beforeAll(() => {
+    pool = createTestPool();
+    promotions = new PostgresMemoryPromotionEventRepository(pool);
+    facts = new PostgresMemoryFactRepository(pool);
+    agents = new PostgresAgentRepository(pool);
+    persons = new PostgresPersonRepository(pool);
+  });
+
+  beforeEach(async () => {
+    await truncateAll(pool);
+    const owner = await persons.create({ id: personId(), name: "Owner" });
+    ownerId = owner.id;
+    originAgentId = await makeAgent(ownerId, "Origin");
+    factRowId = await makeFact(originAgentId);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  async function makeAgent(owner: string, name: string): Promise<string> {
+    const a = await agents.create({
+      id: agentId(),
+      name,
+      owner_id: owner,
+      hierarchy_level: "ic",
+      runtime_config: DEFAULT_RUNTIME_CONFIG,
+    });
+    return a.id;
+  }
+
+  async function makeFact(agent: string): Promise<string> {
+    const f = await facts.create({
+      id: factId(),
+      agent_id: agent,
+      scope: "ic",
+      fact_type: "belief",
+      content: "pnpm is the package manager here",
+      embedding: unitVector(),
+      source_session_ids: [],
+    });
+    return f.id;
+  }
+
+  function newEvent(overrides: Record<string, unknown> = {}) {
+    return {
+      id: promotionEventId(),
+      fact_id: factRowId,
+      from_scope: "ic" as const,
+      to_scope: "team" as const,
+      origin_agent_id: originAgentId,
+      promoter_reason: "seen in three sessions",
+      source_session_ids: [] as string[],
+      rejected: false,
+      ...overrides,
+    };
+  }
+
+  it("round-trips every column on create", async () => {
+    const sid = sessionId();
+    const created = await promotions.create(
+      newEvent({ source_session_ids: [sid], promoter_reason: "corroborated twice" }),
+    );
+
+    expect(created).toMatchObject({
+      fact_id: factRowId,
+      from_scope: "ic",
+      to_scope: "team",
+      origin_agent_id: originAgentId,
+      promoter_reason: "corroborated twice",
+      source_session_ids: [sid],
+      rejected: false,
+    });
+    expect(created.created_at).toBeInstanceOf(Date);
+  });
+
+  it("records a null from_scope for a first-time promotion", async () => {
+    const created = await promotions.create(newEvent({ from_scope: null }));
+    expect(created.from_scope).toBeNull();
+
+    const fetched = await promotions.findById(created.id);
+    expect(fetched?.from_scope).toBeNull();
+  });
+
+  it("records a rejected decision — the audit log keeps both outcomes", async () => {
+    const created = await promotions.create(
+      newEvent({ rejected: true, promoter_reason: "single anecdote, not a pattern" }),
+    );
+    expect(created.rejected).toBe(true);
+    expect((await promotions.findById(created.id))?.rejected).toBe(true);
+  });
+
+  it.each([
+    ["undefined source_session_ids", { source_session_ids: undefined }],
+    ["null source_session_ids", { source_session_ids: null }],
+  ])("COALESCEs %s to an empty array", async (_label, patch) => {
+    const created = await promotions.create(
+      newEvent(patch) as unknown as Parameters<typeof promotions.create>[0],
+    );
+    expect(created.source_session_ids).toEqual([]);
+  });
+
+  it("COALESCEs an omitted `rejected` to false", async () => {
+    const created = await promotions.create(
+      newEvent({ rejected: undefined }) as unknown as Parameters<
+        typeof promotions.create
+      >[0],
+    );
+    expect(created.rejected).toBe(false);
+  });
+
+  describe("findById", () => {
+    it("returns undefined for an unknown id", async () => {
+      expect(await promotions.findById("mpe_nonexistent")).toBeUndefined();
+    });
+  });
+
+  describe("listByOwner", () => {
+    it("returns the owner's events newest first", async () => {
+      const first = await promotions.create(newEvent({ promoter_reason: "first" }));
+      const second = await promotions.create(newEvent({ promoter_reason: "second" }));
+      const third = await promotions.create(newEvent({ promoter_reason: "third" }));
+      // created_at defaults to now() at insert time; nudge them apart so
+      // the DESC ordering is unambiguous rather than tie-broken. `first`
+      // is stamped most recent, so it should come back at the head.
+      await spread(pool, [first.id, second.id, third.id]);
+
+      const rows = await promotions.listByOwner(ownerId, 10);
+      expect(rows.map((r) => r.promoter_reason)).toEqual(["first", "second", "third"]);
+    });
+
+    it("caps at the given limit", async () => {
+      await promotions.create(newEvent());
+      await promotions.create(newEvent());
+      await promotions.create(newEvent());
+      expect(await promotions.listByOwner(ownerId, 2)).toHaveLength(2);
+    });
+
+    it("excludes events whose origin agent belongs to another owner", async () => {
+      const other = await persons.create({ id: personId(), name: "Other" });
+      const otherAgent = await makeAgent(other.id, "Theirs");
+      const otherFact = await makeFact(otherAgent);
+
+      const mine = await promotions.create(newEvent());
+      await promotions.create(
+        newEvent({ origin_agent_id: otherAgent, fact_id: otherFact }),
+      );
+
+      const rows = await promotions.listByOwner(ownerId, 10);
+      expect(rows.map((r) => r.id)).toEqual([mine.id]);
+      expect(await promotions.listByOwner(other.id, 10)).toHaveLength(1);
+    });
+
+    it("returns an empty array for an owner with no events", async () => {
+      expect(await promotions.listByOwner("person_nonexistent", 10)).toEqual([]);
+    });
+  });
+
+  it("cascades away when the underlying fact is deleted", async () => {
+    const created = await promotions.create(newEvent());
+    await facts.delete(factRowId);
+    expect(await promotions.findById(created.id)).toBeUndefined();
+  });
+});
+
+/**
+ * Push the listed events one second apart, oldest-first in array order,
+ * so `ORDER BY created_at DESC` has a deterministic answer. Same-
+ * transaction inserts can otherwise share a now() timestamp.
+ */
+async function spread(pool: Pool, idsNewestFirst: string[]): Promise<void> {
+  for (const [i, id] of idsNewestFirst.entries()) {
+    await pool.query(
+      `UPDATE memory_promotion_event SET created_at = NOW() - ($2 * INTERVAL '1 second') WHERE id = $1`,
+      [id, i],
+    );
+  }
+}


### PR DESCRIPTION
## What this is

A coverage sweep followed by tests for what it turned up. **No production code changed** — this PR is test files only.

## How the gaps were found

Ran v8 coverage per package with `--coverage.all` (so files with no test file at all show up as 0% instead of being absent from the report), against a real Postgres so the DB-gated suites counted:

| Package | Lines before |
| --- | --- |
| `@beevibe/api` | 74.62% |
| `@beevibe/core` | 90.93% |
| `@beevibe/daemon` | 80.41% |
| `@beevibe/sandbox` | 75.11% |
| `@beevibe/scheduler` | 65.94% |

The gaps clustered in the **agent-facing surfaces**, not the library core: the chat route's handlers, four MCP tool modules, and `MeshServer` were reachable only through the m6/m7 e2e scripts — which need live Postgres plus spawned CLIs, so they never run in CI. That is also why these files look untested despite being the most product-critical code in the repo.

What's still low after this PR is composition roots (`bootstrap.ts`, `main.ts`, `server.ts`, `routes/mcp.ts`) and the documented manual dev/ops utilities under `packages/sandbox/src/scripts/` — deliberately left alone.

## Tests added

All fake-driven (no DB) except the two repo suites:

- **`routes/chat-routes.test.ts`** (53 tests) — the four handlers behind `createChatRouter`. `chat-internals.test.ts` already pinned the exported pure helpers; the router itself was not covered. Branches: the human gate, the no-primary-agent shapes, the idempotent-replay ladder (403 collision / 409 in-flight / 200 replayed / fall-through), the rate limiter's two distinct 429s, the offline-daemon 503, the resolver's 504-vs-500 split, and the onboarding-stamp fire-and-forget.
- **`tools/mesh-handlers.test.ts`** (36 tests) — per-tool behavior for all six mesh tools. `mesh.test.ts` only locked the per-tier inventory, so none of the argument validation, response projection, or coded-error enveloping ran.
- **`tools/use-repo.test.ts`** (29 tests) — the `repo_url` gate (it decides whether arbitrary URLs reach a sandbox), the limit clamps, that the `repo_run` insert carries the same pre-minted session id the dispatch used, and both partial-failure reports.
- **`tools/watch.test.ts`** (26 tests) — input coercion plus the mapping of each `WatchService` error class onto its own stable code, which is what agents branch on.
- **`tools/session-search.test.ts`** (28 tests) — the scroll > read > discover > browse shape precedence (getting it wrong silently answers a different question than the agent asked), and the deliberate match-by-name `SessionSearchError` fallback for cross-bundle imports.
- **`mesh/broker.test.ts`** (36 tests) — capacity gate, spawn dispatch, resolver handoff, and the exchange-cap arithmetic: `max_rounds` counts A↔B exchanges while `rounds_completed` counts rows, so the boundary is table-driven here.
- **`tools/hierarchy.test.ts`** (extended, 66 tests total) — adds `revise_task`, `add_to_escalation` and `create_subordinate_agent` (all three handlers were entirely uncovered), plus `create_task`'s branches past the authz gate.
- **`postgres/agent-provision-event-repo.test.ts`** / **`promotion-event-repo.test.ts`** — both adapters sat at 0%. The first backs a live per-parent rate limit, so its window arithmetic is pinned; the second is the read side of the unfinished M8.D wiring CLAUDE.md documents as "not dead code", so it is known-good when the wiring lands.

## Coverage after

| Package | Lines |
| --- | --- |
| `@beevibe/api` | 74.62% → **87.59%** |
| `@beevibe/core` | 90.93% → **92.53%** |

Per file:

| File | Before | After |
| --- | --- | --- |
| `api/src/routes/chat.ts` | 26.94% | 98.17% |
| `api/src/tools/use-repo.ts` | 32.04% | 99.44% |
| `api/src/mesh/server.ts` | 43.61% | 98.58% |
| `api/src/tools/mesh.ts` | 45.93% | 100% |
| `api/src/tools/watch.ts` | 46.26% | 100% |
| `api/src/tools/session-search.ts` | 64.65% | 100% |
| `api/src/tools/hierarchy.ts` | 71.25% | 95.48% |
| `core/…/agent-provision-event-repo.ts` | 0% | 100% |
| `core/…/promotion-event-repo.ts` | 0% | 100% |

## Verification

- `pnpm typecheck` — clean (9/9)
- `pnpm lint` — clean; the four warnings are pre-existing `import/no-duplicates` hits in files this PR doesn't touch
- `pnpm build` — clean
- Full suites against a local Postgres with migrations applied: api 1175 pass, core 900 pass, scheduler 27, daemon 156, sandbox 109, root scripts 11

The only failing tests are the **seven provider-key-gated ones** (`OPENAI_API_KEY` / `ANTHROPIC_API_KEY` missing) in `core/src/adapters/{openai,anthropic}`. They fail identically on `main` in a keyless sandbox and are unrelated to this change — CLAUDE.md documents them as the expected baseline.

The coverage provider (`@vitest/coverage-v8`) was installed only for the sweep and is **not** committed, per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1wWXg1Z7SGUJ4pWjCBJrF

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1wWXg1Z7SGUJ4pWjCBJrF)_