### PR TITLE
test: replace three change-detector tests with the invariants they meant to guard

### DIFF
--- a/packages/core/src/adapters/runtime-registry.test.ts
+++ b/packages/core/src/adapters/runtime-registry.test.ts
@@ -6,22 +6,16 @@ import {
 } from "./runtime-registry.js";
 
 describe("createDefaultRuntimeRegistry", () => {
-  it("registers claude-code", () => {
-    const registry = createDefaultRuntimeRegistry();
-    expect(registry["claude"]).toBeDefined();
-    expect(registry["claude"]!.type).toBe("claude");
-  });
-
-  it("registers opencode", () => {
-    const registry = createDefaultRuntimeRegistry();
-    expect(registry["opencode"]).toBeDefined();
-    expect(registry["opencode"]!.type).toBe("opencode");
-  });
-
-  it("registers codex", () => {
-    const registry = createDefaultRuntimeRegistry();
-    expect(registry["codex"]).toBeDefined();
-    expect(registry["codex"]!.type).toBe("codex");
+  // Membership as one exact-set assertion rather than three per-runtime
+  // `toBeDefined` cases: the set form also catches a *surplus* entry, and
+  // the per-key `.type` half each of them asserted is covered for every
+  // key at once by the sanity check below.
+  it("registers exactly the three CLI runtimes", () => {
+    expect(Object.keys(createDefaultRuntimeRegistry()).sort()).toEqual([
+      "claude",
+      "codex",
+      "opencode",
+    ]);
   });
 
   it("every registry value's .type matches its registry key (sanity check against typos)", () => {

--- a/packages/web/lib/api/client.test.ts
+++ b/packages/web/lib/api/client.test.ts
@@ -92,7 +92,10 @@ describe("api client (reads)", () => {
     });
   });
 
-  describe("deferred surfaces (paths set; backend not yet shipped)", () => {
+  // These three shipped after the block was written: the routers live in
+  // packages/api/src/views/{promotions,mesh,dashboard}.ts and the UI reads
+  // them through use-promotions / use-mesh / use-dashboard.
+  describe("promotions / mesh / dashboard", () => {
     it("promotions.list() hits /promotion", async () => {
       await api.promotions.list();
       expect(fetchJsonMock).toHaveBeenCalledWith("/promotion", { signal: undefined });

--- a/packages/web/lib/hooks/keys.test.ts
+++ b/packages/web/lib/hooks/keys.test.ts
@@ -2,14 +2,42 @@ import { describe, expect, it } from "vitest";
 import { queryKeys } from "./keys";
 
 describe("queryKeys", () => {
-  it("namespaces every domain under a stable root tuple", () => {
-    expect(queryKeys.tasks.all).toEqual(["tasks"]);
-    expect(queryKeys.agents.all).toEqual(["agents"]);
-    expect(queryKeys.sessions.all).toEqual(["sessions"]);
-    expect(queryKeys.memory.all).toEqual(["memory"]);
-    expect(queryKeys.promotions.all).toEqual(["promotions"]);
-    expect(queryKeys.mesh.all).toEqual(["mesh"]);
-    expect(queryKeys.dashboard.all).toEqual(["dashboard"]);
+  // `lib/sse.ts` invalidates by a domain's `all` tuple and relies on
+  // react-query's prefix matching to reach every slot under it. The literal
+  // root strings are private to this table — both producers (the hooks) and
+  // the consumer (sse.ts) go through the same constant, so pinning them
+  // detects renames without protecting anything. What actually has to hold
+  // is the prefix relationship, across every domain rather than a hand-kept
+  // subset: `agentNetwork.all` is `["agent-network"]`, so a derived key that
+  // drifted to `["agentNetwork", ...]` would silently stop being invalidated.
+  it("derives every key under its domain's `all` prefix (so SSE invalidation cascades reach it)", () => {
+    const mismatched: string[] = [];
+    let checked = 0;
+
+    for (const [domain, group] of Object.entries(queryKeys)) {
+      const { all, ...derived } = group as {
+        all: readonly unknown[];
+      } & Record<string, unknown>;
+
+      for (const [name, member] of Object.entries(derived)) {
+        // Every derived member is either a tuple or a builder; the args only
+        // land in trailing slots, so a dummy is enough to read the prefix.
+        const key =
+          typeof member === "function"
+            ? (member as (arg?: unknown) => readonly unknown[])({})
+            : (member as readonly unknown[]);
+        checked += 1;
+        if (JSON.stringify(key.slice(0, all.length)) !== JSON.stringify(all)) {
+          mismatched.push(
+            `${domain}.${name} -> ${JSON.stringify(key)} (expected prefix ${JSON.stringify(all)})`,
+          );
+        }
+      }
+    }
+
+    expect(mismatched).toEqual([]);
+    // Guard against the walk silently covering nothing if the table's shape changes.
+    expect(checked).toBeGreaterThan(20);
   });
 
   it("derives list/detail keys that share the root prefix (so SSE invalidation cascades work)", () => {


### PR DESCRIPTION
## Summary

A sweep of the whole test suite (2179 tests across 8 packages) for outdated tests came back **almost entirely clean**. Three items were worth changing; everything else was left alone.

## What the sweep checked, and found nothing

| Check | Result |
| --- | --- |
| Skipped / disabled / xfail without a reason | None. Every `describe.skip` / `skipIf` is an env- or platform-gated e2e with a documented opt-in (`BEEVIBE_E2E_DOCKER`, `BEEVIBE_E2E_MULTI_INSTANCE`, `RUN_CLAUDE_SMOKE`, `HAS_LIVE_API_KEYS`, `process.platform === "win32"`). The 267 tests that "skip" in a bare sandbox are the Postgres-gated suites failing loudly in `beforeAll` — the documented behaviour, not a stale skip. |
| Test files whose subject module is gone | None. The 7 files with no same-named sibling are cross-cutting by design (`shell-quote` → `docker.ts`, `chat-internals` → `chat.ts`, the three e2e files, `auth.integration`, `client-mutations`). |
| Tests with no assertions | None, across both `.test.ts` and `.test.tsx`. |
| Tests keeping otherwise-dead code alive | None. Swept all 1067 exported symbols for ones referenced only by their declaring file plus a test; every hit was either used in-file, a type, or a deliberate test helper. |
| Duplicate test bodies | None. The repeated *titles* (`"403s an agent caller"` ×5, `"500s when the composer throws"` ×14) are per-route cases in distinct `describe` blocks. |
| Tested-but-unmounted routers | None. Every router with a test is wired in `bootstrap.ts`. |

## What changed

**`packages/web/lib/hooks/keys.test.ts`** — `"namespaces every domain under a stable root tuple"` restated seven of the table's own literals. Both the producers (the hooks) and the consumer (`lib/sse.ts`) read those roots through the same constant, so renaming one breaks nothing at runtime and the test caught only the edit itself. The property that *does* matter is prefix containment, since `sse.ts` invalidates by a domain's `all` tuple and relies on react-query prefix matching. Replaced with a walk over all 16 domains asserting every derived key starts with its own `all`.

Verified non-vacuous by mutation: drifting `agentNetwork.self` to `["agentNetwork", ...]` (its `all` is `["agent-network"]`) fails the new test — and passed the old one, which did not cover that domain at all. Old test: 7 domains, 0 real invariants. New test: 16 domains, 1 real invariant.

**`packages/core/src/adapters/runtime-registry.test.ts`** — three near-identical per-runtime cases each asserting `toBeDefined()` plus `.type`. The `.type` half is already covered for *every* key by the file's own key/type sanity check, and membership is asserted in `composition.test.ts`. Collapsed to one exact-set assertion, which additionally catches a surplus entry that three `toBeDefined` checks cannot.

**`packages/web/lib/api/client.test.ts`** — the `"deferred surfaces (paths set; backend not yet shipped)"` block is mislabelled: `/promotion`, `/mesh` and `/dashboard` all ship routers (`packages/api/src/views/`) and have live UI hooks. Retitled; tests unchanged.

## Deliberately not touched

- `views/activity.ts` and its test — no in-repo caller, but a documented public endpoint per CLAUDE.md; retiring it is a product call.
- `PostgresMemoryPromotionEventRepository` tests — unfinished wiring, not dead code.
- `dashboard.test.ts`'s SQL-text assertions — implementation-detail in form, but they pin a real regression (the chat-exclusion filter) that the mock pool cannot otherwise express.

## Test plan

- `pnpm typecheck` — clean (9/9)
- `pnpm lint` — clean (9/9; the 2 `import/no-duplicates` warnings in `lib/types/dashboard.ts` are pre-existing and untouched)
- `pnpm --filter @beevibe/web test` — 203 passed (24 files)
- `pnpm --filter @beevibe/core test` — affected suites pass; package-level failures are the documented no-Postgres / no-provider-key baseline
- Mutation check on the new `keys.test.ts` assertion, described above

No test was dropped without its coverage being preserved or strengthened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016THgKB9r5nfqwszqxoEfRV

---
_Generated by [Claude Code](https://claude.ai/code/session_016THgKB9r5nfqwszqxoEfRV)_