### PR TITLE
refactor: unify four more clusters of near-duplicate abstractions

### DIFF
--- a/packages/api/src/routes/capabilities.ts
+++ b/packages/api/src/routes/capabilities.ts
@@ -28,6 +28,7 @@ import type {
 import { getReferencedRepos } from "@beevibe/core/services/referenced-repos";
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
 import { requireHuman } from "../auth/middleware.js";
+import { makeCodedErrorHandler } from "./http-errors.js";
 import { createUseRepoTool } from "../tools/use-repo.js";
 
 export interface CapabilitiesRouterDeps {
@@ -41,6 +42,8 @@ export interface CapabilitiesRouterDeps {
   learnedSkillRepo: LearnedSkillRepository;
   dispatchService: DispatchService;
 }
+
+const handleFailure = makeCodedErrorHandler("capabilities");
 
 export function createCapabilitiesRouter(deps: CapabilitiesRouterDeps): Router {
   const router = Router();
@@ -86,8 +89,7 @@ export function createCapabilitiesRouter(deps: CapabilitiesRouterDeps): Router {
       });
       res.status(200).json({ repos });
     } catch (err) {
-      console.error("[capabilities/referenced-repos]", err);
-      res.status(500).json({ error: "scan_failed" });
+      handleFailure(err, res, "referenced-repos", "scan_failed");
     }
   });
 
@@ -135,8 +137,7 @@ export function createCapabilitiesRouter(deps: CapabilitiesRouterDeps): Router {
       }
       res.status(202).json(result.content);
     } catch (err) {
-      console.error("[capabilities/use]", err);
-      res.status(500).json({ error: "use_failed" });
+      handleFailure(err, res, "use", "use_failed");
     }
   });
 

--- a/packages/api/src/routes/escalation.ts
+++ b/packages/api/src/routes/escalation.ts
@@ -17,7 +17,7 @@
  * executor picks both up within ≤30s.
  */
 
-import { Router, type RequestHandler, type Response } from "express";
+import { Router, type RequestHandler } from "express";
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import {
   type EscalationService,
@@ -27,7 +27,7 @@ import {
 } from "@beevibe/core/services/escalation-service";
 import { NegotiationNotFoundError } from "@beevibe/core/services/negotiation-service";
 import { requireHuman } from "../auth/middleware.js";
-import { requireParam } from "./http-errors.js";
+import { makeServiceErrorHandler, requireParam } from "./http-errors.js";
 
 export interface EscalationRoutesDeps {
   authMiddleware: RequestHandler;
@@ -88,25 +88,11 @@ function buildSelector(body: unknown):
   };
 }
 
-function handleEscalationError(err: unknown, res: Response): void {
-  if (err instanceof EscalationNotFoundError) {
-    res.status(404).json({ error: "escalation_not_found", message: err.message });
-    return;
-  }
-  if (err instanceof NegotiationNotFoundError) {
-    res.status(404).json({ error: "negotiation_not_found", message: err.message });
-    return;
-  }
-  if (err instanceof EscalationStateError) {
-    res.status(409).json({ error: "invalid_state", message: err.message });
-    return;
-  }
-  console.error("[escalation route]", err);
-  res.status(500).json({
-    error: "internal_error",
-    message: err instanceof Error ? err.message : String(err),
-  });
-}
+const handleEscalationError = makeServiceErrorHandler("escalation route", [
+  { error: EscalationNotFoundError, status: 404, code: "escalation_not_found" },
+  { error: NegotiationNotFoundError, status: 404, code: "negotiation_not_found" },
+  { error: EscalationStateError, status: 409, code: "invalid_state" },
+]);
 
 export function createEscalationRouter(deps: EscalationRoutesDeps): Router {
   const router = Router();

--- a/packages/api/src/routes/find-repo.ts
+++ b/packages/api/src/routes/find-repo.ts
@@ -16,6 +16,7 @@ import type {
   LearnedSkillRepository,
 } from "@beevibe/core";
 import { requireHuman } from "../auth/middleware.js";
+import { makeCodedErrorHandler } from "./http-errors.js";
 import { createFindRepoTool } from "../tools/find-repo.js";
 
 export interface FindRepoRouterDeps {
@@ -24,6 +25,8 @@ export interface FindRepoRouterDeps {
   learnedSkillRepo: LearnedSkillRepository;
   embeddings: EmbeddingService;
 }
+
+const handleFailure = makeCodedErrorHandler("find-repo");
 
 export function createFindRepoRouter(deps: FindRepoRouterDeps): Router {
   const router = Router();
@@ -68,8 +71,7 @@ export function createFindRepoRouter(deps: FindRepoRouterDeps): Router {
       }
       res.status(200).json(result.content);
     } catch (err) {
-      console.error("[find-repo/search]", err);
-      res.status(500).json({ error: "search_failed" });
+      handleFailure(err, res, "search", "search_failed");
     }
   });
 

--- a/packages/api/src/routes/http-errors.test.ts
+++ b/packages/api/src/routes/http-errors.test.ts
@@ -3,6 +3,8 @@ import type { Request, Response } from "express";
 import {
   invalidBody,
   loadOwned,
+  makeCodedErrorHandler,
+  makeServiceErrorHandler,
   requireNullableString,
   requireParam,
 } from "./http-errors.js";
@@ -217,5 +219,101 @@ describe("requireNullableString", () => {
     expect(res.body).toMatchObject({
       message: "expected { runtime_id: string | null }",
     });
+  });
+});
+
+describe("makeCodedErrorHandler", () => {
+  it("500s with the caller's code and no message", () => {
+    // The code-only envelope is the wire contract for these endpoints —
+    // err.message stays in the log, it must not reach the client.
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = fakeRes();
+    makeCodedErrorHandler("repo-runs")(new Error("boom"), res, "get", "get_failed");
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: "get_failed" });
+    spy.mockRestore();
+  });
+
+  it("logs under `[tag/op]`", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const err = new Error("boom");
+    makeCodedErrorHandler("runtime")(err, fakeRes(), "claim", "claim_failed");
+    expect(spy).toHaveBeenCalledWith("[runtime/claim]", err);
+    spy.mockRestore();
+  });
+
+  it("keeps the code independent of the op", () => {
+    // `runtime/skills` answers `skills_read_failed`, not `skills_failed` —
+    // the code is never derived from the operation name.
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = fakeRes();
+    makeCodedErrorHandler("runtime")(new Error("x"), res, "skills", "skills_read_failed");
+    expect(res.body).toEqual({ error: "skills_read_failed" });
+    spy.mockRestore();
+  });
+});
+
+describe("makeServiceErrorHandler", () => {
+  class NotFound extends Error {}
+  class BadState extends Error {}
+  class SubclassOfNotFound extends NotFound {}
+
+  const handle = makeServiceErrorHandler("task route", [
+    { error: NotFound, status: 404, code: "task_not_found" },
+    { error: BadState, status: 409, code: "invalid_transition" },
+  ]);
+
+  it("maps a matched domain error onto its status, code and message", () => {
+    const res = fakeRes();
+    handle(new NotFound("Task t_1 not found"), res);
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({
+      error: "task_not_found",
+      message: "Task t_1 not found",
+    });
+  });
+
+  it("picks the rule that matches, not the first one", () => {
+    const res = fakeRes();
+    handle(new BadState("cannot approve a cancelled task"), res);
+    expect(res.statusCode).toBe(409);
+    expect(res.body).toMatchObject({ error: "invalid_transition" });
+  });
+
+  it("falls through to the shared 500 envelope for an unknown error", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = fakeRes();
+    handle(new Error("connection reset"), res);
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({
+      error: "internal_error",
+      message: "connection reset",
+    });
+    expect(spy).toHaveBeenCalledWith("[task route]", expect.any(Error));
+    spy.mockRestore();
+  });
+
+  it("stringifies a non-Error throw on the fallback path", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = fakeRes();
+    handle("just a string", res);
+    expect(res.body).toEqual({ error: "internal_error", message: "just a string" });
+    spy.mockRestore();
+  });
+
+  it("tries rules in order, so a subclass listed first wins", () => {
+    const ordered = makeServiceErrorHandler("tag", [
+      { error: SubclassOfNotFound, status: 410, code: "gone" },
+      { error: NotFound, status: 404, code: "not_found" },
+    ]);
+    const res = fakeRes();
+    ordered(new SubclassOfNotFound("x"), res);
+    expect(res.statusCode).toBe(410);
+  });
+
+  it("matches a base-class rule listed first, which is why order matters", () => {
+    const res = fakeRes();
+    handle(new SubclassOfNotFound("x"), res);
+    expect(res.statusCode).toBe(404);
   });
 });

--- a/packages/api/src/routes/http-errors.ts
+++ b/packages/api/src/routes/http-errors.ts
@@ -150,3 +150,76 @@ export function makeErrorHandler(
     });
   };
 }
+
+/**
+ * The *other* 500 handler, for routers that answer with a per-operation
+ * error code and no message.
+ *
+ * `runtime/router`, `repo-runs`, `learned-skills`, `capabilities` and
+ * `find-repo` wrote out the same three lines at the end of 18 handlers —
+ * log `[<router>/<op>]`, then `res.status(500).json({ error: "<something>_failed" })`.
+ * They deliberately do not use {@link makeErrorHandler}: these endpoints
+ * return a bare machine-readable code and keep `err.message` in the logs,
+ * where `makeErrorHandler` reflects the message back to the client. Both
+ * shapes are in the wire contract already, so this factors out the second
+ * one rather than collapsing it into the first.
+ *
+ * `op` and `code` are separate parameters because the code is not derivable
+ * from the operation: `repo-runs/get` answers `get_failed`, but
+ * `runtime/skills` answers `skills_read_failed` and
+ * `capabilities/referenced-repos` answers `scan_failed`. Clients may branch
+ * on these, so — as with `requireParam`'s `errorCode` — this factors out the
+ * shape, not the codes.
+ */
+export function makeCodedErrorHandler(
+  tag: string,
+): (err: unknown, res: Response, op: string, code: string) => void {
+  return (err, res, op, code) => {
+    console.error(`[${tag}/${op}]`, err);
+    res.status(500).json({ error: code });
+  };
+}
+
+/** A domain error class, as passed to {@link makeServiceErrorHandler}. */
+type ServiceErrorClass = abstract new (...args: never[]) => Error;
+
+/** One `instanceof` → HTTP-status/error-code mapping. */
+export interface ServiceErrorRule {
+  /** Domain error class to match with `instanceof`. */
+  error: ServiceErrorClass;
+  status: number;
+  /** Wire error code, e.g. `"task_not_found"`. */
+  code: string;
+}
+
+/**
+ * A `makeErrorHandler` that first maps known domain errors onto their HTTP
+ * status.
+ *
+ * `task`, `escalation` and `negotiation` each hand-wrote the same shape: a
+ * chain of `if (err instanceof SomeDomainError) { res.status(N).json({ error,
+ * message: err.message }); return; }` ending in a byte-identical copy of the
+ * `makeErrorHandler` body. The chain is the part that legitimately differs
+ * per router (different error classes, different codes); the tail is not, and
+ * having it written out three more times meant the generic-500 envelope lived
+ * in seven places instead of one.
+ *
+ * Rules are tried in order, so a subclass must be listed before its base.
+ * Anything unmatched falls through to `makeErrorHandler(tag)` — same log tag,
+ * same `internal_error` envelope, same reflected `err.message`.
+ */
+export function makeServiceErrorHandler(
+  tag: string,
+  rules: readonly ServiceErrorRule[],
+): (err: unknown, res: Response) => void {
+  const fallback = makeErrorHandler(tag);
+  return (err, res) => {
+    for (const rule of rules) {
+      if (err instanceof rule.error) {
+        res.status(rule.status).json({ error: rule.code, message: err.message });
+        return;
+      }
+    }
+    fallback(err, res);
+  };
+}

--- a/packages/api/src/routes/learned-skills.ts
+++ b/packages/api/src/routes/learned-skills.ts
@@ -19,7 +19,12 @@ import {
 } from "@beevibe/core";
 import { requireHuman } from "../auth/middleware.js";
 import { readArtifactBody } from "../views/work-product.js";
-import { invalidBody, loadOwned, requireParam } from "./http-errors.js";
+import {
+  invalidBody,
+  loadOwned,
+  makeCodedErrorHandler,
+  requireParam,
+} from "./http-errors.js";
 
 export interface LearnedSkillsRouterDeps {
   authMiddleware: RequestHandler;
@@ -37,6 +42,8 @@ export interface LearnedSkillsRouterDeps {
    */
   repoRoot?: string;
 }
+
+const handleFailure = makeCodedErrorHandler("learned-skills");
 
 export function createLearnedSkillsRouter(deps: LearnedSkillsRouterDeps): Router {
   const router = Router();
@@ -63,8 +70,7 @@ export function createLearnedSkillsRouter(deps: LearnedSkillsRouterDeps): Router
       const skills = await deps.learnedSkillRepo.listByOwner(req.caller!.personId);
       res.status(200).json({ skills });
     } catch (err) {
-      console.error("[learned-skills/list]", err);
-      res.status(500).json({ error: "list_failed" });
+      handleFailure(err, res, "list", "list_failed");
     }
   });
 
@@ -141,8 +147,7 @@ export function createLearnedSkillsRouter(deps: LearnedSkillsRouterDeps): Router
 
       res.status(201).json({ skill });
     } catch (err) {
-      console.error("[learned-skills/create]", err);
-      res.status(500).json({ error: "create_failed" });
+      handleFailure(err, res, "create", "create_failed");
     }
   });
 
@@ -157,8 +162,7 @@ export function createLearnedSkillsRouter(deps: LearnedSkillsRouterDeps): Router
       await deps.learnedSkillRepo.delete(id);
       res.status(204).send();
     } catch (err) {
-      console.error("[learned-skills/delete]", err);
-      res.status(500).json({ error: "delete_failed" });
+      handleFailure(err, res, "delete", "delete_failed");
     }
   });
 

--- a/packages/api/src/routes/negotiation.ts
+++ b/packages/api/src/routes/negotiation.ts
@@ -14,12 +14,16 @@ import {
   NegotiationNotFoundError,
 } from "@beevibe/core/services/negotiation-service";
 import { requireHuman } from "../auth/middleware.js";
-import { requireParam } from "./http-errors.js";
+import { makeServiceErrorHandler, requireParam } from "./http-errors.js";
 
 export interface NegotiationRoutesDeps {
   authMiddleware: RequestHandler;
   negotiationService: NegotiationService;
 }
+
+const handleError = makeServiceErrorHandler("negotiation route", [
+  { error: NegotiationNotFoundError, status: 404, code: "negotiation_not_found" },
+]);
 
 export function createNegotiationRouter(deps: NegotiationRoutesDeps): Router {
   const router = Router();
@@ -33,15 +37,7 @@ export function createNegotiationRouter(deps: NegotiationRoutesDeps): Router {
       const negotiation = await deps.negotiationService.getReview(id);
       res.json({ ok: true, negotiation });
     } catch (err) {
-      if (err instanceof NegotiationNotFoundError) {
-        res.status(404).json({ error: "negotiation_not_found", message: err.message });
-        return;
-      }
-      console.error("[negotiation route]", err);
-      res.status(500).json({
-        error: "internal_error",
-        message: err instanceof Error ? err.message : String(err),
-      });
+      handleError(err, res);
     }
   });
 

--- a/packages/api/src/routes/repo-runs.ts
+++ b/packages/api/src/routes/repo-runs.ts
@@ -19,7 +19,7 @@ import type {
   SessionEventRepository,
 } from "@beevibe/core";
 import { requireHuman } from "../auth/middleware.js";
-import { requireParam } from "./http-errors.js";
+import { makeCodedErrorHandler, requireParam } from "./http-errors.js";
 
 export interface RepoRunsRouterDeps {
   authMiddleware: RequestHandler;
@@ -54,6 +54,8 @@ function sessionEventToTranscriptKind(
   }
 }
 
+const handleFailure = makeCodedErrorHandler("repo-runs");
+
 export function createRepoRunsRouter(deps: RepoRunsRouterDeps): Router {
   const router = Router();
   router.use(deps.authMiddleware);
@@ -67,8 +69,7 @@ export function createRepoRunsRouter(deps: RepoRunsRouterDeps): Router {
       const runs = await deps.repoRunRepo.listRecent({ limit: 50 });
       res.status(200).json({ runs });
     } catch (err) {
-      console.error("[repo-runs/list]", err);
-      res.status(500).json({ error: "list_failed" });
+      handleFailure(err, res, "list", "list_failed");
     }
   });
 
@@ -101,8 +102,7 @@ export function createRepoRunsRouter(deps: RepoRunsRouterDeps): Router {
       }
       res.status(200).json({ run: { ...run, transcript } });
     } catch (err) {
-      console.error("[repo-runs/get]", err);
-      res.status(500).json({ error: "get_failed" });
+      handleFailure(err, res, "get", "get_failed");
     }
   });
 
@@ -133,8 +133,7 @@ export function createRepoRunsRouter(deps: RepoRunsRouterDeps): Router {
       });
       res.status(200).json({ run: updated });
     } catch (err) {
-      console.error("[repo-runs/cancel]", err);
-      res.status(500).json({ error: "cancel_failed" });
+      handleFailure(err, res, "cancel", "cancel_failed");
     }
   });
 
@@ -187,8 +186,7 @@ export function createRepoRunsRouter(deps: RepoRunsRouterDeps): Router {
         task_id: run.task_id,
       });
     } catch (err) {
-      console.error("[repo-runs/artifact]", err);
-      res.status(500).json({ error: "artifact_failed" });
+      handleFailure(err, res, "artifact", "artifact_failed");
     }
   });
 

--- a/packages/api/src/routes/task.ts
+++ b/packages/api/src/routes/task.ts
@@ -16,7 +16,7 @@
  *     killed).
  */
 
-import { Router, type RequestHandler, type Response } from "express";
+import { Router, type RequestHandler } from "express";
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import {
   TASK_PRIORITIES,
@@ -42,7 +42,7 @@ import { buildIntent, type ResumeReason } from "@beevibe/core/services/agent-ses
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
 import { requireHuman } from "../auth/middleware.js";
 import type { DaemonHub } from "../runtime/hub.js";
-import { requireParam } from "./http-errors.js";
+import { makeServiceErrorHandler, requireParam } from "./http-errors.js";
 
 /** Statuses from which /cancel is legal. Anything non-terminal. */
 const CANCELLABLE_FROM: readonly TaskStatus[] = [
@@ -115,21 +115,10 @@ async function recordCapabilityOutcome(
   }
 }
 
-function handleServiceError(err: unknown, res: Response): void {
-  if (err instanceof TaskNotFoundError) {
-    res.status(404).json({ error: "task_not_found", message: err.message });
-    return;
-  }
-  if (err instanceof InvalidTaskTransitionError) {
-    res.status(409).json({ error: "invalid_transition", message: err.message });
-    return;
-  }
-  console.error("[task route]", err);
-  res.status(500).json({
-    error: "internal_error",
-    message: err instanceof Error ? err.message : String(err),
-  });
-}
+const handleServiceError = makeServiceErrorHandler("task route", [
+  { error: TaskNotFoundError, status: 404, code: "task_not_found" },
+  { error: InvalidTaskTransitionError, status: 409, code: "invalid_transition" },
+]);
 
 function parsePriority(input: unknown): TaskPriority | undefined {
   if (typeof input !== "string") return undefined;

--- a/packages/api/src/runtime/router.ts
+++ b/packages/api/src/runtime/router.ts
@@ -44,6 +44,7 @@ import {
 } from "@beevibe/core/services/agent-session";
 import { transitionTaskOnClaim } from "@beevibe/core/services/dispatch-service";
 import { requireDaemon, requireHuman } from "../auth/middleware.js";
+import { makeCodedErrorHandler } from "../routes/http-errors.js";
 import type { DaemonHub } from "./hub.js";
 
 export interface RuntimeRouterDeps {
@@ -76,6 +77,8 @@ export interface RuntimeRouterDeps {
   /** Hook fired after /runtime/done writes terminal state. Wired in M4.6. */
   onSessionComplete?: (session: Session) => void | Promise<void>;
 }
+
+const handleFailure = makeCodedErrorHandler("runtime");
 
 /**
  * Mounts the /runtime/* surface used by beevibe-daemon instances.
@@ -123,8 +126,7 @@ export function createRuntimeRouter(deps: RuntimeRouterDeps): Router {
       };
       res.status(isNew ? 201 : 200).json(response);
     } catch (err) {
-      console.error("[runtime/register]", err);
-      res.status(500).json({ error: "register_failed" });
+      handleFailure(err, res, "register", "register_failed");
     }
   });
 
@@ -147,8 +149,7 @@ export function createRuntimeRouter(deps: RuntimeRouterDeps): Router {
       };
       res.status(200).json(response);
     } catch (err) {
-      console.error("[runtime/sync]", err);
-      res.status(500).json({ error: "sync_failed" });
+      handleFailure(err, res, "sync", "sync_failed");
     }
   });
 
@@ -171,8 +172,7 @@ export function createRuntimeRouter(deps: RuntimeRouterDeps): Router {
       for (const id of runtimeIds) deps.hub.bumpLastSeen(id);
       res.status(204).send();
     } catch (err) {
-      console.error("[runtime/heartbeat]", err);
-      res.status(500).json({ error: "heartbeat_failed" });
+      handleFailure(err, res, "heartbeat", "heartbeat_failed");
     }
   });
 
@@ -220,8 +220,7 @@ export function createRuntimeRouter(deps: RuntimeRouterDeps): Router {
       await transitionTaskOnClaim(claimed, { taskRepo: deps.taskRepo });
       res.status(200).json(payload);
     } catch (err) {
-      console.error("[runtime/claim]", err);
-      res.status(500).json({ error: "claim_failed" });
+      handleFailure(err, res, "claim", "claim_failed");
     }
   });
 
@@ -261,8 +260,7 @@ export function createRuntimeRouter(deps: RuntimeRouterDeps): Router {
       );
       res.status(204).send();
     } catch (err) {
-      console.error("[runtime/events]", err);
-      res.status(500).json({ error: "events_failed" });
+      handleFailure(err, res, "events", "events_failed");
     }
   });
 
@@ -368,8 +366,7 @@ export function createRuntimeRouter(deps: RuntimeRouterDeps): Router {
       }
       res.status(204).send();
     } catch (err) {
-      console.error("[runtime/done]", err);
-      res.status(500).json({ error: "done_failed" });
+      handleFailure(err, res, "done", "done_failed");
     }
   });
 
@@ -379,8 +376,7 @@ export function createRuntimeRouter(deps: RuntimeRouterDeps): Router {
       const response = await readSkills(deps.skillsSourceDir);
       res.status(200).json(response);
     } catch (err) {
-      console.error("[runtime/skills]", err);
-      res.status(500).json({ error: "skills_read_failed" });
+      handleFailure(err, res, "skills", "skills_read_failed");
     }
   });
 

--- a/packages/core/src/adapters/anthropic/llm-provider.ts
+++ b/packages/core/src/adapters/anthropic/llm-provider.ts
@@ -7,6 +7,7 @@ import type {
   LlmStructuredResponse,
   LlmUsage,
 } from "../../ports/llm-provider.js";
+import { resolveLlmProviderConfig, type LlmProviderConfig } from "../llm-common.js";
 
 /**
  * Default model for the memory subsystem. Haiku is cheap + fast and more than
@@ -14,13 +15,13 @@ import type {
  */
 const DEFAULT_MODEL = "claude-haiku-4-5-20251001";
 
-export interface AnthropicLlmProviderConfig {
-  apiKey?: string;
-  /** Override DEFAULT_MODEL. Useful when a caller wants Opus for harder calls. */
-  defaultModel?: string;
-  /** Per-request timeout (ms). Default 30_000. */
-  timeoutMs?: number;
-}
+/**
+ * Alias of the shared {@link LlmProviderConfig}. Kept as a named export
+ * because `adapters/anthropic/index.ts` re-exports it as public API;
+ * `defaultModel` overrides {@link DEFAULT_MODEL}, useful when a caller wants
+ * Opus for harder calls.
+ */
+export type AnthropicLlmProviderConfig = LlmProviderConfig;
 
 /**
  * Anthropic Messages API adapter. `completeStructured` uses the native
@@ -39,15 +40,16 @@ export class AnthropicLlmProvider implements LlmProvider {
   private defaultModel: string;
 
   constructor(config: AnthropicLlmProviderConfig = {}) {
-    const apiKey = config.apiKey ?? process.env.ANTHROPIC_API_KEY;
-    if (!apiKey) {
-      throw new Error("AnthropicLlmProvider: ANTHROPIC_API_KEY missing");
-    }
-    this.client = new Anthropic({
-      apiKey,
-      timeout: config.timeoutMs ?? 30_000,
+    const resolved = resolveLlmProviderConfig(config, {
+      providerName: "AnthropicLlmProvider",
+      apiKeyEnvVar: "ANTHROPIC_API_KEY",
+      defaultModel: DEFAULT_MODEL,
     });
-    this.defaultModel = config.defaultModel ?? DEFAULT_MODEL;
+    this.client = new Anthropic({
+      apiKey: resolved.apiKey,
+      timeout: resolved.timeoutMs,
+    });
+    this.defaultModel = resolved.defaultModel;
   }
 
   async complete(req: LlmRequest): Promise<LlmResponse> {

--- a/packages/core/src/adapters/llm-common.ts
+++ b/packages/core/src/adapters/llm-common.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared construction helper for the SDK-backed `LlmProvider` adapters
+ * (anthropic, openai). Both wrap a vendor SDK client and differ genuinely in
+ * everything downstream of the constructor — request shape, structured-output
+ * feature, usage field names — so only the setup is shared here. The
+ * per-provider request mapping stays in each adapter's `llm-provider.ts`.
+ */
+
+/**
+ * Constructor config accepted by every LLM provider adapter.
+ *
+ * `AnthropicLlmProviderConfig` and `OpenAILlmProviderConfig` were separately
+ * declared and structurally identical; both are now aliases of this, so a new
+ * knob is added once rather than twice-and-hopefully-consistently.
+ */
+export interface LlmProviderConfig {
+  /** Falls back to the provider's API-key env var. */
+  apiKey?: string;
+  /** Override the adapter's default model. */
+  defaultModel?: string;
+  /** Per-request timeout (ms). Default {@link DEFAULT_LLM_TIMEOUT_MS}. */
+  timeoutMs?: number;
+}
+
+/** Per-request timeout every provider defaults to. */
+export const DEFAULT_LLM_TIMEOUT_MS = 30_000;
+
+export interface LlmProviderSpec {
+  /** Adapter class name, used in the missing-key error. */
+  providerName: string;
+  /** Env var consulted when `config.apiKey` is absent. */
+  apiKeyEnvVar: string;
+  /** Model used when neither the config nor the request names one. */
+  defaultModel: string;
+}
+
+/**
+ * Resolve the three constructor settings, throwing when no API key can be
+ * found. Both adapters spelled this out identically — env fallback, throw
+ * `"<Provider>: <ENV_VAR> missing"`, `?? 30_000`, `?? DEFAULT_MODEL` — which
+ * is four chances for the timeout default to drift apart between providers
+ * and for the two error strings to stop matching each other's format.
+ *
+ * Throws rather than returning a result type because a provider with no key
+ * is unusable: `bootstrap` constructs these eagerly and a missing key is a
+ * deployment error, not a runtime branch.
+ */
+export function resolveLlmProviderConfig(
+  config: LlmProviderConfig,
+  spec: LlmProviderSpec,
+): { apiKey: string; timeoutMs: number; defaultModel: string } {
+  const apiKey = config.apiKey ?? process.env[spec.apiKeyEnvVar];
+  if (!apiKey) {
+    throw new Error(`${spec.providerName}: ${spec.apiKeyEnvVar} missing`);
+  }
+  return {
+    apiKey,
+    timeoutMs: config.timeoutMs ?? DEFAULT_LLM_TIMEOUT_MS,
+    defaultModel: config.defaultModel ?? spec.defaultModel,
+  };
+}

--- a/packages/core/src/adapters/openai/llm-provider.ts
+++ b/packages/core/src/adapters/openai/llm-provider.ts
@@ -7,14 +7,15 @@ import type {
   LlmStructuredResponse,
   LlmUsage,
 } from "../../ports/llm-provider.js";
+import { resolveLlmProviderConfig, type LlmProviderConfig } from "../llm-common.js";
 
 const DEFAULT_MODEL = "gpt-4o-mini";
 
-export interface OpenAILlmProviderConfig {
-  apiKey?: string;
-  defaultModel?: string;
-  timeoutMs?: number;
-}
+/**
+ * Alias of the shared {@link LlmProviderConfig}. Kept as a named export
+ * because `adapters/openai/index.ts` re-exports it as public API.
+ */
+export type OpenAILlmProviderConfig = LlmProviderConfig;
 
 /**
  * OpenAI chat completions adapter. `completeStructured` uses strict JSON
@@ -29,15 +30,16 @@ export class OpenAILlmProvider implements LlmProvider {
   private defaultModel: string;
 
   constructor(config: OpenAILlmProviderConfig = {}) {
-    const apiKey = config.apiKey ?? process.env.OPENAI_API_KEY;
-    if (!apiKey) {
-      throw new Error("OpenAILlmProvider: OPENAI_API_KEY missing");
-    }
-    this.client = new OpenAI({
-      apiKey,
-      timeout: config.timeoutMs ?? 30_000,
+    const resolved = resolveLlmProviderConfig(config, {
+      providerName: "OpenAILlmProvider",
+      apiKeyEnvVar: "OPENAI_API_KEY",
+      defaultModel: DEFAULT_MODEL,
     });
-    this.defaultModel = config.defaultModel ?? DEFAULT_MODEL;
+    this.client = new OpenAI({
+      apiKey: resolved.apiKey,
+      timeout: resolved.timeoutMs,
+    });
+    this.defaultModel = resolved.defaultModel;
   }
 
   async complete(req: LlmRequest): Promise<LlmResponse> {

--- a/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
+++ b/packages/web/app/(authed)/agents/[id]/agent-detail-client.tsx
@@ -23,6 +23,7 @@ import { Skeleton } from "@/components/skeleton";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { DetailGate } from "@/components/detail/detail-gate";
 import { FooterField } from "@/components/detail/footer-field";
+import { DetailFooter } from "@/components/detail/detail-footer";
 import { Metric } from "@/components/detail/metric";
 import { cn } from "@/lib/utils";
 import type { AgentDetail } from "@/lib/api/types";
@@ -278,7 +279,7 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
         ) : null}
       </div>
 
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      <DetailFooter>
         <FooterField label="ID">
           <ClickToCopyId id={agent.id} />
         </FooterField>
@@ -294,7 +295,7 @@ function AgentDetailLoaded({ agent }: { agent: AgentDetail }) {
             {new Date(agent.archived_at).toLocaleString()}
           </FooterField>
         ) : null}
-      </footer>
+      </DetailFooter>
     </>
   );
 }

--- a/packages/web/app/(authed)/escalations/[id]/escalation-detail-client.tsx
+++ b/packages/web/app/(authed)/escalations/[id]/escalation-detail-client.tsx
@@ -10,6 +10,7 @@ import { ChatMarkdown } from "@/components/chat/markdown";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { DetailGate } from "@/components/detail/detail-gate";
 import { FooterField } from "@/components/detail/footer-field";
+import { DetailFooter } from "@/components/detail/detail-footer";
 import { Skeleton } from "@/components/skeleton";
 import { EscalationStatusPill } from "@/components/detail/status-pill";
 import { MutationError } from "@/components/mutation-error";
@@ -110,7 +111,7 @@ function EscalationDetailLoaded({ esc }: { esc: EscalationReviewDetail }) {
 
       {esc.status === "pending" ? <ResolveForm esc={esc} /> : <ResolvedView esc={esc} />}
 
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      <DetailFooter>
         <FooterField label="ID">
           <ClickToCopyId id={esc.id} />
         </FooterField>
@@ -124,7 +125,7 @@ function EscalationDetailLoaded({ esc }: { esc: EscalationReviewDetail }) {
         {esc.resolved_at ? (
           <FooterField label="Resolved">{formatRelativeTime(esc.resolved_at)}</FooterField>
         ) : null}
-      </footer>
+      </DetailFooter>
     </>
   );
 }

--- a/packages/web/app/(authed)/negotiations/[id]/negotiation-detail-client.tsx
+++ b/packages/web/app/(authed)/negotiations/[id]/negotiation-detail-client.tsx
@@ -8,6 +8,7 @@ import { ChatMarkdown } from "@/components/chat/markdown";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { DetailGate } from "@/components/detail/detail-gate";
 import { FooterField } from "@/components/detail/footer-field";
+import { DetailFooter } from "@/components/detail/detail-footer";
 import { NegotiationStatusPill } from "@/components/detail/status-pill";
 import { Skeleton } from "@/components/skeleton";
 import { formatRelativeTime } from "@/lib/format";
@@ -120,7 +121,7 @@ function NegotiationDetailLoaded({ neg }: { neg: NegotiationReviewDetail }) {
         )}
       </section>
 
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      <DetailFooter>
         <FooterField label="ID">
           <ClickToCopyId id={neg.id} />
         </FooterField>
@@ -141,7 +142,7 @@ function NegotiationDetailLoaded({ neg }: { neg: NegotiationReviewDetail }) {
         {neg.updated_at !== neg.created_at ? (
           <FooterField label="Updated">{formatRelativeTime(neg.updated_at)}</FooterField>
         ) : null}
-      </footer>
+      </DetailFooter>
     </>
   );
 }

--- a/packages/web/app/(authed)/sessions/[sid]/chat-session-detail-client.tsx
+++ b/packages/web/app/(authed)/sessions/[sid]/chat-session-detail-client.tsx
@@ -6,12 +6,11 @@ import { useConversation } from "@/lib/hooks/use-sessions";
 import { DetailGate } from "@/components/detail/detail-gate";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
-import { SessionStatusPill } from "@/components/detail/status-pill";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { FooterField } from "@/components/detail/footer-field";
+import { DetailFooter } from "@/components/detail/detail-footer";
 import { ChatMarkdown } from "@/components/chat/markdown";
-import { HierChip } from "@/components/hier-chip";
-import { Avatar } from "@/components/avatar";
+import { SessionHeader } from "@/components/sessions/session-header";
 import { UsagePanel } from "@/components/sessions/usage-panel";
 import type {
   ConversationDisplay,
@@ -91,37 +90,24 @@ function ConversationBody({ conversation }: { conversation: ConversationDisplay 
 
   return (
     <>
-      <header className="mb-6">
-        <div className="flex items-start gap-3">
-          <Avatar
-            initial={conversation.agent_label.charAt(0).toUpperCase()}
-            kind={conversation.agent_hierarchy}
-            label={conversation.agent_label}
-            size={40}
-            presence={conversation.status === "running" ? "running" : "idle"}
-          />
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 mb-1">
-              <h1 className="text-base font-semibold tracking-tight leading-tight">
-                {multiTurn ? "Conversation" : "One turn"}
-              </h1>
-              <SessionStatusPill status={conversation.status} />
-            </div>
-            <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <span className="text-foreground/85">{conversation.agent_label}</span>
-              <HierChip hier={conversation.agent_hierarchy} />
-              {multiTurn ? (
-                <>
-                  <span className="text-muted-foreground/50">·</span>
-                  <span className="tabular-nums">{turns.length} turns</span>
-                </>
-              ) : null}
-              <span className="text-muted-foreground/50">·</span>
-              <span className="text-foreground/70">{conversation.type}</span>
-            </div>
-          </div>
-        </div>
-      </header>
+      <SessionHeader
+        agentLabel={conversation.agent_label}
+        agentHierarchy={conversation.agent_hierarchy}
+        status={conversation.status}
+        title={multiTurn ? "Conversation" : "One turn"}
+        meta={
+          <>
+            {multiTurn ? (
+              <>
+                <span className="text-muted-foreground/50">·</span>
+                <span className="tabular-nums">{turns.length} turns</span>
+              </>
+            ) : null}
+            <span className="text-muted-foreground/50">·</span>
+            <span className="text-foreground/70">{conversation.type}</span>
+          </>
+        }
+      />
 
       <div className="space-y-6">
         {turns.map((turn) => (
@@ -131,7 +117,7 @@ function ConversationBody({ conversation }: { conversation: ConversationDisplay 
 
       {usage ? <UsagePanel usage={usage} /> : null}
 
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      <DetailFooter>
         <FooterField label="Conversation ID">
           <ClickToCopyId id={conversation.conversation_id} />
         </FooterField>
@@ -146,7 +132,7 @@ function ConversationBody({ conversation }: { conversation: ConversationDisplay 
           </FooterField>
         ) : null}
         <FooterField label="Type">{conversation.type}</FooterField>
-      </footer>
+      </DetailFooter>
     </>
   );
 }

--- a/packages/web/app/(authed)/tasks/[id]/sessions/[sid]/session-detail-client.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/sessions/[sid]/session-detail-client.tsx
@@ -3,13 +3,12 @@
 import Link from "next/link";
 import { ChevronRight, Terminal } from "lucide-react";
 import { useSession } from "@/lib/hooks/use-sessions";
-import { Avatar } from "@/components/avatar";
-import { HierChip } from "@/components/hier-chip";
-import { SessionStatusPill } from "@/components/detail/status-pill";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { DetailGate } from "@/components/detail/detail-gate";
 import { FooterField } from "@/components/detail/footer-field";
+import { DetailFooter } from "@/components/detail/detail-footer";
 import { BriefingComposer } from "@/components/sessions/briefing-composer";
+import { SessionHeader } from "@/components/sessions/session-header";
 import { Transcript } from "@/components/sessions/transcript";
 import { Skeleton } from "@/components/skeleton";
 import { formatIntent, shortId } from "@/lib/format";
@@ -87,35 +86,24 @@ function SessionDetailBody({ session, taskId: _taskId }: { session: SessionDispl
   // running session orphaned in the daemon-spawn path.
   return (
     <>
-      <header className="mb-6">
-        <div className="flex items-start gap-3">
-          <Avatar
-            initial={session.agent_label.charAt(0).toUpperCase()}
-            kind={session.agent_hierarchy}
-            label={session.agent_label}
-            size={40}
-            presence={session.status === "running" ? "running" : "idle"}
-          />
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 mb-1">
-              <h1 className="text-base font-semibold leading-tight truncate">{formatIntent(session.intent)}</h1>
-              <SessionStatusPill status={session.status} />
-            </div>
-            <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <span className="text-foreground/85">{session.agent_label}</span>
-              <HierChip hier={session.agent_hierarchy} />
-              <span className="text-muted-foreground/50">·</span>
-              <span className="tabular-nums">{session.duration_label}</span>
-            </div>
-          </div>
-        </div>
-      </header>
+      <SessionHeader
+        agentLabel={session.agent_label}
+        agentHierarchy={session.agent_hierarchy}
+        status={session.status}
+        title={formatIntent(session.intent)}
+        meta={
+          <>
+            <span className="text-muted-foreground/50">·</span>
+            <span className="tabular-nums">{session.duration_label}</span>
+          </>
+        }
+      />
 
       <BriefingComposer briefing={session.briefing} />
 
       <Transcript entries={session.transcript} ask_threads={session.ask_threads} />
 
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      <DetailFooter>
         <FooterField label="Session ID">
           <ClickToCopyId id={session.id} />
         </FooterField>
@@ -130,7 +118,7 @@ function SessionDetailBody({ session, taskId: _taskId }: { session: SessionDispl
           </FooterField>
         ) : null}
         <FooterField label="Type">{session.type}</FooterField>
-      </footer>
+      </DetailFooter>
     </>
   );
 }

--- a/packages/web/app/(authed)/tasks/[id]/task-detail-client.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/task-detail-client.tsx
@@ -26,6 +26,7 @@ import { ChatMarkdown } from "@/components/chat/markdown";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { DetailGate } from "@/components/detail/detail-gate";
 import { FooterField } from "@/components/detail/footer-field";
+import { DetailFooter } from "@/components/detail/detail-footer";
 import { HierChip } from "@/components/hier-chip";
 import { Skeleton } from "@/components/skeleton";
 import { richTextToMarkdown } from "@/components/rich-text";
@@ -293,7 +294,7 @@ function TaskDetailLoaded({ task }: { task: TaskDetail }) {
         </aside>
       </div>
 
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      <DetailFooter>
         <FooterField label="ID">
           <ClickToCopyId id={task.id} />
         </FooterField>
@@ -316,7 +317,7 @@ function TaskDetailLoaded({ task }: { task: TaskDetail }) {
             </Link>
           </FooterField>
         ) : null}
-      </footer>
+      </DetailFooter>
     </>
   );
 }

--- a/packages/web/app/(authed)/work-products/[id]/work-product-detail-client.tsx
+++ b/packages/web/app/(authed)/work-products/[id]/work-product-detail-client.tsx
@@ -17,6 +17,7 @@ import { Skeleton } from "@/components/skeleton";
 import { ChatMarkdown } from "@/components/chat/markdown";
 import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { FooterField } from "@/components/detail/footer-field";
+import { DetailFooter } from "@/components/detail/detail-footer";
 import { formatRelativeTime, shortId } from "@/lib/format";
 
 export function WorkProductDetailClient({ workProductId }: { workProductId: string }) {
@@ -125,7 +126,7 @@ function Body({ wp }: { wp: WorkProductDetail }) {
         />
       )}
 
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      <DetailFooter>
         <FooterField label="ID">
           <ClickToCopyId id={wp.id} />
         </FooterField>
@@ -143,7 +144,7 @@ function Body({ wp }: { wp: WorkProductDetail }) {
           </FooterField>
         ) : null}
         {wp.provider ? <FooterField label="Provider">{wp.provider}</FooterField> : null}
-      </footer>
+      </DetailFooter>
     </>
   );
 }

--- a/packages/web/components/detail/detail-footer.tsx
+++ b/packages/web/components/detail/detail-footer.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+
+/**
+ * The metadata strip every detail page closes with — id, related links,
+ * type, timestamps — laid out as a 2-up grid that widens to 4-up.
+ *
+ * All seven detail pages (task, agent, work product, escalation,
+ * negotiation, and both session views) opened their footer with the same
+ * eleven Tailwind classes copied verbatim. Nothing distinguished them, so
+ * the only thing seven copies bought was seven chances for the spacing or
+ * the rule above it to drift.
+ *
+ * Contents stay per-page: what belongs in the strip is genuinely different
+ * (a work product links its task, a session shows its worktree). Pass
+ * {@link FooterField} children.
+ */
+export function DetailFooter({ children }: { children: ReactNode }) {
+  return (
+    <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      {children}
+    </footer>
+  );
+}

--- a/packages/web/components/sessions/session-header.test.tsx
+++ b/packages/web/components/sessions/session-header.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { SessionHeader } from "./session-header";
+
+describe("SessionHeader", () => {
+  it("renders the title, the agent byline and its hierarchy chip", () => {
+    render(
+      <SessionHeader
+        agentLabel="Ada"
+        agentHierarchy="ic"
+        status="running"
+        title="Ship the parser"
+      />,
+    );
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Ship the parser");
+    expect(screen.getByText("Ada")).toBeInTheDocument();
+    expect(screen.getByText("ic")).toBeInTheDocument();
+  });
+
+  it("shows the session status, which both call sites also feed to the avatar", () => {
+    render(
+      <SessionHeader
+        agentLabel="Ada"
+        agentHierarchy="team"
+        status="succeeded"
+        title="One turn"
+      />,
+    );
+    expect(screen.getByText("succeeded")).toBeInTheDocument();
+  });
+
+  it("renders the caller's trailing meta after the hierarchy chip", () => {
+    render(
+      <SessionHeader
+        agentLabel="Ada"
+        agentHierarchy="ic"
+        status="succeeded"
+        title="Conversation"
+        meta={<span>3 turns</span>}
+      />,
+    );
+    expect(screen.getByText("3 turns")).toBeInTheDocument();
+  });
+
+  it("omits the meta slot entirely when the caller passes none", () => {
+    const { container } = render(
+      <SessionHeader
+        agentLabel="Ada"
+        agentHierarchy="ic"
+        status="succeeded"
+        title="One turn"
+      />,
+    );
+    expect(container.textContent).not.toContain("·");
+  });
+});

--- a/packages/web/components/sessions/session-header.tsx
+++ b/packages/web/components/sessions/session-header.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from "react";
+import { Avatar } from "@/components/avatar";
+import { HierChip } from "@/components/hier-chip";
+import { SessionStatusPill } from "@/components/detail/status-pill";
+import type { SessionDisplay } from "@/lib/types/sessions";
+
+interface Props {
+  /** Agent's display name — seeds the avatar initial and the byline. */
+  agentLabel: string;
+  agentHierarchy: SessionDisplay["agent_hierarchy"];
+  /** Drives both the status pill and the avatar's running/idle dot. */
+  status: SessionDisplay["status"];
+  /** Page title: the session's intent, or "Conversation" / "One turn". */
+  title: string;
+  /**
+   * Trailing byline items, rendered after the hierarchy chip. Genuinely
+   * per-page — the task view shows a duration, the chat view a turn count
+   * and the session type — so each supplies its own separators.
+   */
+  meta?: ReactNode;
+}
+
+/**
+ * The identity header both session detail pages open with: who ran it, what
+ * it was, and whether it's still going.
+ *
+ * `/tasks/[id]/sessions/[sid]` and `/sessions/[sid]` had written out the
+ * same twenty lines — the same avatar wiring (initial from the label,
+ * `presence` keyed off `status === "running"`), the same nested flex
+ * scaffold, the same `agent_label` + `<HierChip>` byline. Only the title
+ * and the trailing byline items differed, and those are the two props.
+ *
+ * The two copies had already drifted on the `<h1>`: one carried
+ * `tracking-tight`, the other `truncate`. This keeps both — `truncate` is
+ * inert on the short literal titles the chat view passes, and needs the
+ * `min-w-0` that the wrapper below already sets.
+ */
+export function SessionHeader({
+  agentLabel,
+  agentHierarchy,
+  status,
+  title,
+  meta,
+}: Props) {
+  return (
+    <header className="mb-6">
+      <div className="flex items-start gap-3">
+        <Avatar
+          initial={agentLabel.charAt(0).toUpperCase()}
+          kind={agentHierarchy}
+          label={agentLabel}
+          size={40}
+          presence={status === "running" ? "running" : "idle"}
+        />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <h1 className="text-base font-semibold tracking-tight leading-tight truncate">
+              {title}
+            </h1>
+            <SessionStatusPill status={status} />
+          </div>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span className="text-foreground/85">{agentLabel}</span>
+            <HierChip hier={agentHierarchy} />
+            {meta}
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
A sweep for near-duplicate abstractions across the monorepo. Textual duplication is already low (jscpd: **0.6%** on non-test sources), so these are mostly *semantic* near-duplicates — same shape, different spelling — that a token-based detector doesn't see.

Every change is shape-only: no wire contract, status code, error code, log tag or rendered markup changes.

---

## 1. api route 500 handlers — two shapes, 21 call sites

`routes/http-errors.ts` already owned `makeErrorHandler`. Two other handler shapes were still written out by hand.

**`makeCodedErrorHandler`** — 18 handlers across `runtime/router`, `repo-runs`, `learned-skills`, `capabilities` and `find-repo` ended in the same three lines: log `[<router>/<op>]`, then `res.status(500).json({ error: "<op>_failed" })`. These deliberately *don't* use `makeErrorHandler` — they return a bare machine-readable code and keep `err.message` in the log, where `makeErrorHandler` reflects it back to the client. Both shapes are in the wire contract, so this factors out the second rather than collapsing it into the first.

`op` and `code` stay separate parameters because the code isn't derivable from the op — `runtime/skills` answers `skills_read_failed`, `capabilities/referenced-repos` answers `scan_failed` — and clients may branch on it. Same reasoning as `requireParam`'s `errorCode`.

**`makeServiceErrorHandler`** — `task`, `escalation` and `negotiation` each hand-wrote an `instanceof` chain ending in a byte-identical copy of the `makeErrorHandler` body:

```ts
const handleServiceError = makeServiceErrorHandler("task route", [
  { error: TaskNotFoundError, status: 404, code: "task_not_found" },
  { error: InvalidTaskTransitionError, status: 409, code: "invalid_transition" },
]);
```

The chain legitimately differs per router; the tail did not, and having it written out three more times put the generic-500 envelope in seven places instead of one. Rules are tried in order; anything unmatched falls through to `makeErrorHandler(tag)` — same tag, same envelope, same reflected message.

**Left alone deliberately:** `learned-skills/publish` also returns a `message`, and `chat` returns a generic message plus a `request_id`. Both are real divergences in what we expose, not copy-paste, so both keep their own handler — the second for the reason already documented on `makeErrorHandler`.

## 2. `<DetailFooter>` — 7 call sites

All seven detail pages (task, agent, work product, escalation, negotiation, and both session views) opened their footer with the same eleven Tailwind classes copied verbatim. Nothing distinguished them, so seven copies bought seven chances for the spacing or the rule above it to drift. Contents stay per-page — what belongs in the strip genuinely differs.

## 3. `<SessionHeader>` — 2 call sites

`/tasks/[id]/sessions/[sid]` and `/sessions/[sid]` had the same twenty lines: the same avatar wiring (initial from the label, `presence` keyed off `status === "running"`), the same nested flex scaffold, the same `agent_label` + `<HierChip>` byline. Title and trailing byline items are the two props.

The two copies had already drifted on the `<h1>`: one carried `tracking-tight`, the other `truncate`. The shared one keeps both — `truncate` is inert on the short literal titles the chat view passes (`"Conversation"` / `"One turn"`), and needs the `min-w-0` the wrapper already sets.

## 4. `resolveLlmProviderConfig` — 2 call sites

The anthropic and openai adapters had structurally identical config interfaces and the same constructor preamble: env fallback, throw `"<Provider>: <ENV_VAR> missing"`, `?? 30_000`, `?? DEFAULT_MODEL`. Both config types are now aliases of one `LlmProviderConfig`, so the timeout default can't drift between providers and a new knob is added once. Request mapping stays per-adapter — different SDKs, different structured-output features, different usage field names.

Follows the `adapters/runtime-common.ts` precedent.

---

## Considered and left alone

- **The six domain error classes in core** share a shape (`readonly code`, `this.name = …`) but not logic. A `defineDomainError` factory would cost the named classes that routes match with `instanceof`, and the stack-trace names.
- **The three `stream-json.ts` parsers** (claude-code / codex / opencode) and **the postgres repos** — already factored into `runtime-common.ts` and `pg-helpers.ts` by earlier passes. What's left is genuinely provider- and table-specific.
- **`app/error.tsx` vs `app/global-error.tsx`** — global-error must use inline styles because it replaces the root `html`/`body`, where Tailwind may not have loaded. Deliberate.

## Verification

- `pnpm typecheck` — 9/9 clean
- `pnpm lint` — 9/9 clean, 0 errors (remaining warnings are pre-existing, in test files)
- `pnpm build` — 5/5 non-web clean; web built via `pnpm --filter @beevibe/web exec next build` (the documented Turbo/proxy font workaround), ✓ Compiled successfully
- Tests, before → after: **api 820 → 829** passing (+9 new `http-errors` tests); **core** 609 passing, **scheduler** 10 passing, both unchanged; **web 203 → 207** (25 files, new `session-header.test.tsx`)
- The DB- and key-gated suites fail *identically* before and after — no Docker and no provider keys in this sandbox, per CLAUDE.md's bare-sandbox baseline. Failure counts captured on a stashed tree to confirm.

New tests cover both factories: the code-only envelope, the `[tag/op]` log line, that the code stays independent of the op, rule ordering (including a subclass listed before its base), and the fallback path for unmatched and non-`Error` throws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Abrkni2zRLF29WqApHEVF

---
_Generated by [Claude Code](https://claude.ai/code/session_016Abrkni2zRLF29WqApHEVF)_