### PR TITLE
test: cover the MCP agent tool surface (32-71% -> 95-100% lines)

### DIFF
--- a/packages/api/src/tools/hierarchy.test.ts
+++ b/packages/api/src/tools/hierarchy.test.ts
@@ -11,6 +11,7 @@ import type {
   AgentProvisionEventRepository,
   AgentRepository,
   CoreMemoryBlockRepository,
+  Escalation,
   HierarchyLevel,
   Session,
   Task,
@@ -20,7 +21,10 @@ import type {
   WorkProductRepository,
 } from "@beevibe/core";
 import type { MemoryAgent } from "@beevibe/core/services/memory";
-import type { TaskService } from "@beevibe/core/services/task-service";
+import {
+  InvalidTaskTransitionError,
+  type TaskService,
+} from "@beevibe/core/services/task-service";
 import type { EscalationService } from "@beevibe/core/services/escalation-service";
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
 import type { Pool } from "@beevibe/core/adapters/postgres";
@@ -69,6 +73,23 @@ function fakeWp(overrides: Partial<WorkProduct> = {}): WorkProduct {
   };
 }
 
+function fakeEscalation(overrides: Partial<Escalation> = {}): Escalation {
+  return {
+    id: "esc_1",
+    negotiation_id: "neg_1",
+    initiator_session_id: "sess_i",
+    counterparty_session_id: "sess_c",
+    summary: "We're stuck on X.",
+    initiator_open_questions: [],
+    counterparty_open_questions: [],
+    escalated_by_role: "initiator",
+    status: "pending",
+    created_at: new Date("2026-04-01"),
+    updated_at: new Date("2026-04-01"),
+    ...overrides,
+  };
+}
+
 function fakeWpListItem(
   overrides: Partial<WorkProductListItem> = {},
 ): WorkProductListItem {
@@ -84,6 +105,8 @@ function buildServices(overrides: {
   memoryAgent?: Partial<MemoryAgent>;
   escalationService?: Partial<EscalationService>;
   dispatchService?: Partial<DispatchService>;
+  coreMemoryRepo?: Partial<CoreMemoryBlockRepository>;
+  agentProvisionEventRepo?: Partial<AgentProvisionEventRepository>;
 } = {}) {
   const agentRepo = {
     findById: vi.fn(async () => undefined),
@@ -155,12 +178,15 @@ function buildServices(overrides: {
   const coreMemoryRepo = {
     findByAgent: vi.fn(async () => []),
     updateContent: vi.fn(async () => undefined),
+    initDefaults: vi.fn(async () => []),
+    ...overrides.coreMemoryRepo,
   } as unknown as CoreMemoryBlockRepository;
 
   const agentProvisionEventRepo = {
     create: vi.fn(async () => ({})),
     countByParentSince: vi.fn(async () => 0),
     listByParent: vi.fn(async () => []),
+    ...overrides.agentProvisionEventRepo,
   } as unknown as AgentProvisionEventRepository;
 
   return {
@@ -574,5 +600,600 @@ describe("check_work_status", () => {
     const result = await callTool(tools, "check_work_status", { agent_id: "rando" });
     expect(result.isError).toBe(true);
     expect((result.content as { error: string }).error).toBe("unauthorized");
+  });
+});
+
+describe("revise_task", () => {
+  /** Parent `agent_t` with a blocked task assigned to its subordinate. */
+  function reviseServices(
+    over: Parameters<typeof buildServices>[0] = {},
+    task: Partial<Task> = {},
+  ) {
+    return buildServices({
+      taskRepo: {
+        findById: vi.fn(async () =>
+          fakeTask({ status: "blocked", assignee_id: "sub_1", ...task }),
+        ),
+      },
+      agentRepo: {
+        findById: vi.fn(async () =>
+          fakeAgent({ id: "sub_1", hierarchy_level: "ic", parent_agent_id: "agent_t" }),
+        ),
+      },
+      ...over,
+    });
+  }
+
+  const parentCtx = { agentId: "agent_t", hierarchyLevel: "team" as HierarchyLevel };
+
+  it("revises the task and dispatches the resume session", async () => {
+    const revised = fakeTask({
+      status: "needs_revision",
+      assignee_id: "sub_1",
+      next_dispatch_context: {
+        kind: "revision",
+        feedback: "use the staging key",
+        from_status: "blocked",
+        source: "parent_agent",
+      },
+    } as Partial<Task>);
+    const services = reviseServices({
+      taskService: { reviseTask: vi.fn(async () => revised) },
+    });
+    const tools = buildHierarchyTools(parentCtx, services);
+
+    const result = await callTool(tools, "revise_task", {
+      task_id: "task_1",
+      feedback: "use the staging key",
+    });
+
+    expect(services.taskService.reviseTask).toHaveBeenCalledWith(
+      "task_1",
+      "use the staging key",
+      { source: "parent_agent", reviserAgentId: "agent_t" },
+    );
+    expect(services.dispatchService.dispatchTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: revised,
+        agentId: "sub_1",
+        type: "task",
+        reason: revised.next_dispatch_context,
+      }),
+    );
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toMatchObject({
+      revised: true,
+      task_id: "task_1",
+      // #186: the task stays at needs_revision until the daemon claims it.
+      status: "needs_revision",
+      from_status: "blocked",
+    });
+  });
+
+  it("skips the dispatch when reviseTask stamped no revision context", async () => {
+    const services = reviseServices({
+      taskService: {
+        reviseTask: vi.fn(async () =>
+          fakeTask({ status: "needs_revision", assignee_id: "sub_1" }),
+        ),
+      },
+    });
+    const tools = buildHierarchyTools(parentCtx, services);
+
+    const result = await callTool(tools, "revise_task", {
+      task_id: "task_1",
+      feedback: "f",
+    });
+
+    expect(services.dispatchService.dispatchTask).not.toHaveBeenCalled();
+    expect(result.content).toMatchObject({ revised: true });
+  });
+
+  it("rejects a missing task_id or feedback", async () => {
+    const services = reviseServices();
+    const tools = buildHierarchyTools(parentCtx, services);
+
+    for (const input of [{}, { task_id: "task_1" }, { feedback: "f" }]) {
+      const result = await callTool(tools, "revise_task", input);
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({ error: "task_id and feedback required" });
+    }
+    expect(services.taskRepo.findById).not.toHaveBeenCalled();
+  });
+
+  it("reports task_not_found for an unknown task", async () => {
+    const services = buildServices({ taskRepo: { findById: vi.fn(async () => undefined) } });
+    const tools = buildHierarchyTools(parentCtx, services);
+
+    const result = await callTool(tools, "revise_task", { task_id: "nope", feedback: "f" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "task_not_found", task_id: "nope" });
+  });
+
+  it("reports task_unassigned when there is nobody to resume", async () => {
+    const services = buildServices({
+      taskRepo: {
+        findById: vi.fn(async () => {
+          const { assignee_id: _drop, ...rest } = fakeTask({ status: "blocked" });
+          return rest as Task;
+        }),
+      },
+    });
+    const tools = buildHierarchyTools(parentCtx, services);
+
+    const result = await callTool(tools, "revise_task", { task_id: "task_1", feedback: "f" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "task_unassigned" });
+  });
+
+  it("reports assignee_not_found when the assignee row is gone", async () => {
+    const services = reviseServices({ agentRepo: { findById: vi.fn(async () => undefined) } });
+    const tools = buildHierarchyTools(parentCtx, services);
+
+    const result = await callTool(tools, "revise_task", { task_id: "task_1", feedback: "f" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "assignee_not_found" });
+  });
+
+  it("refuses a caller who is not the assignee's direct parent", async () => {
+    const services = reviseServices({
+      agentRepo: {
+        findById: vi.fn(async () =>
+          fakeAgent({ id: "sub_1", parent_agent_id: "someone_else" }),
+        ),
+      },
+    });
+    const tools = buildHierarchyTools(parentCtx, services);
+
+    const result = await callTool(tools, "revise_task", { task_id: "task_1", feedback: "f" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "not_parent" });
+    expect(services.taskService.reviseTask).not.toHaveBeenCalled();
+  });
+
+  it("maps an InvalidTaskTransitionError to invalid_transition", async () => {
+    const services = reviseServices({
+      taskService: {
+        reviseTask: vi.fn(async () => {
+          throw new InvalidTaskTransitionError("cannot revise a task in status 'done'");
+        }),
+      },
+    });
+    const tools = buildHierarchyTools(parentCtx, services);
+
+    const result = await callTool(tools, "revise_task", { task_id: "task_1", feedback: "f" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "invalid_transition" });
+  });
+
+  it("wraps any other throw in the catch-all envelope", async () => {
+    const services = reviseServices({
+      taskService: {
+        reviseTask: vi.fn(async () => {
+          throw new Error("pg down");
+        }),
+      },
+    });
+    const tools = buildHierarchyTools(parentCtx, services);
+
+    const result = await callTool(tools, "revise_task", { task_id: "task_1", feedback: "f" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "pg down" });
+  });
+});
+
+describe("add_to_escalation", () => {
+  const teamCtx = { agentId: "agent_t", hierarchyLevel: "team" as HierarchyLevel };
+
+  it("submits the caller's slot and notifies listeners", async () => {
+    const services = buildServices({
+      escalationService: {
+        addContribution: vi.fn(async () =>
+          fakeEscalation({
+            initiator_submitted_at: new Date("2026-04-01"),
+            counterparty_submitted_at: new Date("2026-04-02"),
+          }),
+        ),
+      },
+    });
+    const tools = buildHierarchyTools(teamCtx, services);
+
+    const result = await callTool(tools, "add_to_escalation", {
+      escalation_id: "esc_1",
+      proposals: [{ title: "B", description: "do B" }],
+      open_questions: ["what is the budget?"],
+    });
+
+    expect(services.escalationService.addContribution).toHaveBeenCalledWith({
+      escalationId: "esc_1",
+      callerAgentId: "agent_t",
+      proposals: [{ title: "B", description: "do B" }],
+      openQuestions: ["what is the budget?"],
+    });
+    expect(services.pool.query).toHaveBeenCalledWith(
+      `SELECT pg_notify('escalation_updated', $1)`,
+      ["esc_1"],
+    );
+    expect(result.content).toEqual({
+      escalation_id: "esc_1",
+      status: "pending",
+      both_sides_submitted: true,
+    });
+  });
+
+  it("reports both_sides_submitted false while a slot is still empty", async () => {
+    const services = buildServices({
+      escalationService: {
+        addContribution: vi.fn(async () =>
+          fakeEscalation({ initiator_submitted_at: new Date("2026-04-01") }),
+        ),
+      },
+    });
+    const tools = buildHierarchyTools(teamCtx, services);
+
+    const result = await callTool(tools, "add_to_escalation", { escalation_id: "esc_1" });
+
+    expect(result.content).toMatchObject({ both_sides_submitted: false });
+  });
+
+  it("omits proposals and open_questions that are not arrays", async () => {
+    const services = buildServices();
+    const tools = buildHierarchyTools(teamCtx, services);
+
+    await callTool(tools, "add_to_escalation", {
+      escalation_id: "esc_1",
+      proposals: "B",
+      open_questions: "budget?",
+    });
+
+    expect(services.escalationService.addContribution).toHaveBeenCalledWith(
+      expect.objectContaining({ proposals: undefined, openQuestions: undefined }),
+    );
+  });
+
+  it("filters non-string entries out of open_questions", async () => {
+    const services = buildServices();
+    const tools = buildHierarchyTools(teamCtx, services);
+
+    await callTool(tools, "add_to_escalation", {
+      escalation_id: "esc_1",
+      open_questions: ["budget?", 1, null, "when?"],
+    });
+
+    expect(services.escalationService.addContribution).toHaveBeenCalledWith(
+      expect.objectContaining({ openQuestions: ["budget?", "when?"] }),
+    );
+  });
+
+  it("rejects a missing escalation_id", async () => {
+    const services = buildServices();
+    const tools = buildHierarchyTools(teamCtx, services);
+
+    const result = await callTool(tools, "add_to_escalation", {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "escalation_id required" });
+    expect(services.escalationService.addContribution).not.toHaveBeenCalled();
+  });
+
+  it("wraps a double-submit rejection from the service", async () => {
+    const services = buildServices({
+      escalationService: {
+        addContribution: vi.fn(async () => {
+          throw new Error("slot already submitted");
+        }),
+      },
+    });
+    const tools = buildHierarchyTools(teamCtx, services);
+
+    const result = await callTool(tools, "add_to_escalation", { escalation_id: "esc_1" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "slot already submitted" });
+    expect(services.pool.query).not.toHaveBeenCalled();
+  });
+});
+
+describe("create_subordinate_agent", () => {
+  const teamCtx = { agentId: "agent_t", hierarchyLevel: "team" as HierarchyLevel };
+
+  const OK_INPUT = {
+    name: "Backend specialist",
+    tag_line: "Owns the API surface",
+    persona: "Terse, test-first.",
+    domain: "Express + Postgres",
+  };
+
+  /** Parent lookup succeeds; agentRepo.create echoes the row back. */
+  function spawnServices(over: Parameters<typeof buildServices>[0] = {}) {
+    return buildServices({
+      agentRepo: {
+        findById: vi.fn(async () =>
+          fakeAgent({
+            id: "agent_t",
+            name: "Team lead",
+            owner_id: "person_1",
+            runtime_config: { type: "claude", model: "opus" },
+          }),
+        ),
+        create: vi.fn(async (input: { id: string } & Partial<Agent>) => fakeAgent(input)),
+      },
+      ...over,
+    });
+  }
+
+  /** The row handed to agentRepo.create on the most recent spawn. */
+  function createdRow(services: ReturnType<typeof buildServices>) {
+    const mock = services.agentRepo.create as unknown as ReturnType<typeof vi.fn>;
+    return mock.mock.calls[0]?.[0] as Record<string, unknown>;
+  }
+
+  /** Block names seeded via coreMemoryRepo.updateContent, sorted. */
+  function seededBlocks(services: ReturnType<typeof buildServices>) {
+    const mock = services.coreMemoryRepo.updateContent as unknown as ReturnType<typeof vi.fn>;
+    return mock.mock.calls.map((c) => c[1] as string).sort();
+  }
+
+  it("provisions an IC under the caller and seeds its identity blocks", async () => {
+    const services = spawnServices();
+    const tools = buildHierarchyTools(teamCtx, services);
+
+    const result = await callTool(tools, "create_subordinate_agent", {
+      ...OK_INPUT,
+      active_context: "Migrating auth to JWT",
+      constraints: "No breaking API changes",
+    });
+
+    const created = createdRow(services);
+    expect(created).toMatchObject({
+      name: "Backend specialist",
+      hierarchy_level: "ic",
+      parent_agent_id: "agent_t",
+      owner_id: "person_1",
+    });
+    // The child inherits the parent's runtime so both share the user's auth.
+    expect(created.runtime_config).toMatchObject({
+      type: "claude",
+      model: "opus",
+      system_prompt_addition: "You are Backend specialist.",
+    });
+
+    expect(seededBlocks(services)).toEqual([
+      "active_context",
+      "constraints",
+      "domain",
+      "persona",
+      "tag_line",
+    ]);
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({
+      created: {
+        id: created.id,
+        name: "Backend specialist",
+        hierarchy_level: "ic",
+        parent_agent_id: "agent_t",
+      },
+    });
+  });
+
+  it("leaves the optional blocks empty when the parent supplied nothing", async () => {
+    const services = spawnServices();
+    const tools = buildHierarchyTools(teamCtx, services);
+
+    await callTool(tools, "create_subordinate_agent", OK_INPUT);
+
+    expect(seededBlocks(services)).toEqual(["domain", "persona", "tag_line"]);
+  });
+
+  it("pins the child to the parent's runtime only when the parent has one", async () => {
+    const withRuntime = spawnServices({
+      agentRepo: {
+        findById: vi.fn(async () => fakeAgent({ id: "agent_t", preferred_runtime_id: "rt_1" })),
+        create: vi.fn(async (input: { id: string } & Partial<Agent>) => fakeAgent(input)),
+      },
+    });
+    await callTool(
+      buildHierarchyTools(teamCtx, withRuntime),
+      "create_subordinate_agent",
+      OK_INPUT,
+    );
+    expect(createdRow(withRuntime)).toMatchObject({ preferred_runtime_id: "rt_1" });
+
+    const without = spawnServices();
+    await callTool(buildHierarchyTools(teamCtx, without), "create_subordinate_agent", OK_INPUT);
+    expect(createdRow(without)).not.toHaveProperty("preferred_runtime_id");
+  });
+
+  it("writes the provision audit row the daily cap is counted from", async () => {
+    const services = spawnServices();
+    const tools = buildHierarchyTools(teamCtx, services);
+
+    await callTool(tools, "create_subordinate_agent", OK_INPUT);
+
+    expect(services.agentProvisionEventRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parent_agent_id: "agent_t",
+        owner_person_id: "person_1",
+        child_name: "Backend specialist",
+        persona: OK_INPUT.persona,
+        domain: OK_INPUT.domain,
+      }),
+    );
+  });
+
+  it("still reports success when the audit row fails to write", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const services = spawnServices({
+      agentProvisionEventRepo: {
+        create: vi.fn(async () => {
+          throw new Error("audit table locked");
+        }),
+      },
+    });
+    const tools = buildHierarchyTools(teamCtx, services);
+
+    // The agent + its memory are the user-visible artifacts; losing the
+    // audit row must not undo them.
+    const result = await callTool(tools, "create_subordinate_agent", OK_INPUT);
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toMatchObject({ created: expect.any(Object) });
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("guards against an IC-scoped context reaching the handler", async () => {
+    const services = spawnServices();
+    // The IC tool set omits this tool entirely, but the handler self-guards
+    // too — tier is resolved per request, the tool array is built once.
+    const ctx = { agentId: "agent_t", hierarchyLevel: "team" as HierarchyLevel };
+    const tools = buildHierarchyTools(ctx, services);
+    ctx.hierarchyLevel = "ic";
+
+    const result = await callTool(tools, "create_subordinate_agent", OK_INPUT);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "ic_cannot_spawn" });
+    expect(services.agentRepo.create).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["name", { ...OK_INPUT, name: "  " }],
+    ["tag_line", { ...OK_INPUT, tag_line: "" }],
+    ["persona", { ...OK_INPUT, persona: undefined }],
+    ["domain", { ...OK_INPUT, domain: undefined }],
+  ])("rejects a blank %s", async (_field, input) => {
+    const services = spawnServices();
+    const tools = buildHierarchyTools(teamCtx, services);
+
+    const result = await callTool(tools, "create_subordinate_agent", input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "missing_required_fields" });
+    expect(services.agentRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects a tag_line over 100 chars and says how long it was", async () => {
+    const services = spawnServices();
+    const tools = buildHierarchyTools(teamCtx, services);
+
+    const result = await callTool(tools, "create_subordinate_agent", {
+      ...OK_INPUT,
+      tag_line: "x".repeat(101),
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "tag_line_too_long", actual: 101 });
+  });
+
+  it.each([
+    ["over 80 chars", "n".repeat(81)],
+    ["containing a control character", "Backend\u0001specialist"],
+    ["containing a newline", "Backend\nspecialist"],
+  ])("rejects a name %s", async (_why, name) => {
+    const services = spawnServices();
+    const tools = buildHierarchyTools(teamCtx, services);
+
+    const result = await callTool(tools, "create_subordinate_agent", { ...OK_INPUT, name });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "invalid_name" });
+    expect(services.agentRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("accepts a name at exactly the 80-char limit", async () => {
+    const services = spawnServices();
+    const tools = buildHierarchyTools(teamCtx, services);
+
+    const result = await callTool(tools, "create_subordinate_agent", {
+      ...OK_INPUT,
+      name: "n".repeat(80),
+    });
+
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("reports parent_not_found when the caller's row is gone", async () => {
+    const services = spawnServices({
+      agentRepo: {
+        findById: vi.fn(async () => undefined),
+        create: vi.fn(async (input: { id: string } & Partial<Agent>) => fakeAgent(input)),
+      },
+    });
+    const tools = buildHierarchyTools(teamCtx, services);
+
+    const result = await callTool(tools, "create_subordinate_agent", OK_INPUT);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "parent_not_found", agent_id: "agent_t" });
+  });
+
+  it("enforces the per-parent daily spawn cap over a 24h window", async () => {
+    const services = spawnServices({
+      agentProvisionEventRepo: { countByParentSince: vi.fn(async () => 8) },
+    });
+    const tools = buildHierarchyTools(teamCtx, services);
+
+    const result = await callTool(tools, "create_subordinate_agent", OK_INPUT);
+
+    expect(services.agentProvisionEventRepo.countByParentSince).toHaveBeenCalledWith(
+      "agent_t",
+      24 * 60 * 60,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "subordinate_daily_cap",
+      cap: 8,
+      count: 8,
+    });
+    expect(services.agentRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("allows a spawn one under the cap", async () => {
+    const services = spawnServices({
+      agentProvisionEventRepo: { countByParentSince: vi.fn(async () => 7) },
+    });
+    const tools = buildHierarchyTools(teamCtx, services);
+
+    const result = await callTool(tools, "create_subordinate_agent", OK_INPUT);
+
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("wraps a provisioning failure in the catch-all envelope", async () => {
+    const services = spawnServices({
+      agentRepo: {
+        findById: vi.fn(async () => fakeAgent({ id: "agent_t" })),
+        create: vi.fn(async () => {
+          throw new Error("unique violation on agent.name");
+        }),
+      },
+    });
+    const tools = buildHierarchyTools(teamCtx, services);
+
+    const result = await callTool(tools, "create_subordinate_agent", OK_INPUT);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "unique violation on agent.name" });
+  });
+
+  it("carries the IC block descriptions into its schema", () => {
+    const services = spawnServices();
+    const tools = buildHierarchyTools(teamCtx, services);
+    const schema = findTool(tools, "create_subordinate_agent").schema;
+    const props = schema.properties as Record<string, { description: string }>;
+
+    // Descriptions come from DEFAULT_BLOCK_TEMPLATES.ic so the tool's
+    // guidance and the <core_memory> block docs can't drift apart.
+    for (const block of ["tag_line", "persona", "domain", "active_context", "constraints"]) {
+      expect(props[block]?.description.length).toBeGreaterThan(0);
+    }
+    expect(schema.required).toEqual(["name", "tag_line", "persona", "domain"]);
   });
 });

--- a/packages/api/src/tools/mesh.test.ts
+++ b/packages/api/src/tools/mesh.test.ts
@@ -1,20 +1,38 @@
 /**
- * Mesh tool assembly tests — IC vs team tier gating.
+ * Mesh tool tests — IC vs team tier gating, plus per-handler behavior.
  *
- * Per-tool handler behavior is covered indirectly by the m6/m7 e2e scripts
- * (mesh flows require live Postgres + spawned CLI subprocesses). This file
- * locks the static tier inventory — the exact tool *names* each tier gets,
- * so future skill-loader work can rely on the surface being stable.
+ * The tier inventory suites lock the exact tool *names* each tier gets, so
+ * future skill-loader work can rely on the surface being stable.
+ *
+ * The handler suites below drive each tool's argument coercion, validation
+ * and error envelope against fake services. The wire-level flows (a real
+ * spawn blocking until the peer responds) still belong to the m6/m7 e2e
+ * scripts, which need live Postgres + CLI subprocesses; what's unit-testable
+ * here is everything between the MCP boundary and the MeshServer call.
  */
-import { describe, expect, it } from "vitest";
-import type { ResolvedCaller } from "@beevibe/core/auth";
-import { buildIcMeshTools, buildTeamMeshTools, type MeshToolServices } from "./mesh.js";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentRepository, TaskRepository } from "@beevibe/core";
+import type { EscalationService } from "@beevibe/core/services/escalation-service";
+import type { TaskService } from "@beevibe/core/services/task-service";
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import { MeshCapacityError } from "../mesh/types.js";
+import type { MeshServer } from "../mesh/server.js";
+import type { McpCaller } from "./assemble.js";
+import type { AgentTool } from "./types.js";
+import {
+  buildIcMeshTools,
+  buildTeamMeshTools,
+  type MeshToolContext,
+  type MeshToolServices,
+} from "./mesh.js";
 
 // Fake services — the assembly itself doesn't invoke handlers, so the
 // dependencies just need to be the right shape.
 const fakeServices = {} as unknown as MeshToolServices;
 
-const fakeCaller: ResolvedCaller = {
+// McpCaller, not the wider ResolvedCaller: a mesh tool is never built for a
+// daemon caller, and MeshToolContext.caller excludes that variant.
+const fakeCaller: McpCaller = {
   agentId: "agent_x",
   source: "agent",
   hierarchyLevel: "team",
@@ -45,5 +63,624 @@ describe("buildTeamMeshTools", () => {
       "respond_ask",
       "respond_negotiate",
     ]);
+  });
+});
+
+// ── Handler harness ──────────────────────────────────────────────────────
+
+interface MeshFakes {
+  sendAsk: ReturnType<typeof vi.fn>;
+  respondAsk: ReturnType<typeof vi.fn>;
+  sendNegotiate: ReturnType<typeof vi.fn>;
+  respondNegotiate: ReturnType<typeof vi.fn>;
+  reportBlocker: ReturnType<typeof vi.fn>;
+  unblockOnEscalate: ReturnType<typeof vi.fn>;
+  findParent: ReturnType<typeof vi.fn>;
+  markBlocked: ReturnType<typeof vi.fn>;
+  createEscalation: ReturnType<typeof vi.fn>;
+  query: ReturnType<typeof vi.fn>;
+}
+
+function meshHarness(overrides: Partial<MeshFakes> = {}) {
+  const f: MeshFakes = {
+    sendAsk:
+      overrides.sendAsk ??
+      vi.fn(async (requestId: string) => ({
+        request_id: requestId,
+        from_agent_id: "agent_y",
+        answer: "yes",
+      })),
+    respondAsk: overrides.respondAsk ?? vi.fn(),
+    sendNegotiate:
+      overrides.sendNegotiate ??
+      vi.fn(async () => ({
+        negotiation_id: "neg_1",
+        from_agent_id: "agent_y",
+        decision: "counter",
+        message: "how about this",
+        counter_proposal: "half now, half later",
+      })),
+    respondNegotiate: overrides.respondNegotiate ?? vi.fn(async () => null),
+    reportBlocker: overrides.reportBlocker ?? vi.fn(),
+    unblockOnEscalate: overrides.unblockOnEscalate ?? vi.fn(),
+    findParent: overrides.findParent ?? vi.fn(async () => ({ id: "agent_parent" })),
+    markBlocked: overrides.markBlocked ?? vi.fn(async () => undefined),
+    createEscalation:
+      overrides.createEscalation ??
+      vi.fn(async () => ({
+        id: "esc_1",
+        status: "open",
+        negotiation_id: "neg_1",
+      })),
+    query: overrides.query ?? vi.fn(async () => ({ rows: [] })),
+  };
+
+  const services = {
+    mesh: {
+      sendAsk: f.sendAsk,
+      respondAsk: f.respondAsk,
+      sendNegotiate: f.sendNegotiate,
+      respondNegotiate: f.respondNegotiate,
+      reportBlocker: f.reportBlocker,
+      unblockOnEscalate: f.unblockOnEscalate,
+    } as unknown as MeshServer,
+    agentRepo: { findParent: f.findParent } as unknown as AgentRepository,
+    taskRepo: {} as unknown as TaskRepository,
+    taskService: { markBlocked: f.markBlocked } as unknown as TaskService,
+    escalationService: { create: f.createEscalation } as unknown as EscalationService,
+    pool: { query: f.query } as unknown as Pool,
+  } satisfies MeshToolServices;
+
+  const ctx: MeshToolContext = { caller: fakeCaller, beevibeSid: "ses_x" };
+  const tools = buildTeamMeshTools(ctx, services);
+  const tool = (name: string): AgentTool => {
+    const t = tools.find((x) => x.name === name);
+    if (!t) throw new Error(`tool ${name} not built`);
+    return t;
+  };
+  return { f, tool, ctx, services };
+}
+
+describe("ask handler", () => {
+  it("mints a request id and projects only the wire fields back", async () => {
+    const { f, tool } = meshHarness();
+
+    const result = await tool("ask").handler({
+      target_agent_id: "agent_y",
+      question: "is X feasible?",
+    });
+
+    const [requestId, from, target, question] = f.sendAsk.mock.calls[0] ?? [];
+    expect(requestId).toMatch(/^[0-9a-f-]{36}$/);
+    expect([from, target, question]).toEqual(["agent_x", "agent_y", "is X feasible?"]);
+    // Projection is deliberate: internal fields on AskResponse stay internal.
+    expect(result.content).toEqual({
+      request_id: requestId,
+      from_agent_id: "agent_y",
+      answer: "yes",
+    });
+  });
+
+  it("mints a fresh request id per call", async () => {
+    const { f, tool } = meshHarness();
+
+    await tool("ask").handler({ target_agent_id: "agent_y", question: "q1" });
+    await tool("ask").handler({ target_agent_id: "agent_y", question: "q2" });
+
+    expect(f.sendAsk.mock.calls[0]?.[0]).not.toBe(f.sendAsk.mock.calls[1]?.[0]);
+  });
+
+  it("rejects a missing target or question without spawning the peer", async () => {
+    const { f, tool } = meshHarness();
+
+    for (const input of [
+      {},
+      { target_agent_id: "agent_y" },
+      { question: "q" },
+      { target_agent_id: "", question: "q" },
+    ]) {
+      const result = await tool("ask").handler(input);
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({
+        error: "target_agent_id and question required",
+      });
+    }
+    expect(f.sendAsk).not.toHaveBeenCalled();
+  });
+
+  it("keeps a CodedMeshError's code and meta in the envelope", async () => {
+    const { tool } = meshHarness({
+      sendAsk: vi.fn(async () => {
+        throw new MeshCapacityError("too many running", {
+          agentId: "agent_y",
+          running: 5,
+          cap: 5,
+        });
+      }),
+    });
+
+    const result = await tool("ask").handler({
+      target_agent_id: "agent_y",
+      question: "q",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "MESH_CAPACITY_EXCEEDED",
+      agentId: "agent_y",
+      running: 5,
+      cap: 5,
+      message: "too many running",
+    });
+  });
+
+  it("degrades an unrecognized throw to the catch-all shape", async () => {
+    const { tool } = meshHarness({
+      sendAsk: vi.fn(async () => {
+        throw new Error("peer never spawned");
+      }),
+    });
+
+    const result = await tool("ask").handler({
+      target_agent_id: "agent_y",
+      question: "q",
+    });
+
+    expect(result.content).toEqual({ error: "peer never spawned" });
+  });
+});
+
+describe("respond_ask handler", () => {
+  it("unblocks the asker under the responder's own agent id", async () => {
+    const { f, tool } = meshHarness();
+
+    const result = await tool("respond_ask").handler({
+      request_id: "req_1",
+      answer: "yes, feasible",
+    });
+
+    expect(f.respondAsk).toHaveBeenCalledWith("req_1", {
+      request_id: "req_1",
+      from_agent_id: "agent_x",
+      answer: "yes, feasible",
+    });
+    expect(result.content).toEqual({ responded: true, request_id: "req_1" });
+  });
+
+  it("rejects a missing request_id or answer", async () => {
+    const { f, tool } = meshHarness();
+
+    for (const input of [{}, { request_id: "req_1" }, { answer: "a" }]) {
+      const result = await tool("respond_ask").handler(input);
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({
+        error: "request_id and answer required",
+      });
+    }
+    expect(f.respondAsk).not.toHaveBeenCalled();
+  });
+
+  it("wraps a throw from the mesh server", async () => {
+    const { tool } = meshHarness({
+      respondAsk: vi.fn(() => {
+        throw new Error("no waiter for req_1");
+      }),
+    });
+
+    const result = await tool("respond_ask").handler({
+      request_id: "req_1",
+      answer: "a",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "no waiter for req_1" });
+  });
+});
+
+describe("negotiate handler", () => {
+  it("passes the optional task id and the caller's session as originator metadata", async () => {
+    const { f, tool } = meshHarness();
+
+    const result = await tool("negotiate").handler({
+      peer_id: "agent_y",
+      proposal: "ship on Friday",
+      task_id: "task_1",
+    });
+
+    expect(f.sendNegotiate).toHaveBeenCalledWith("agent_x", "agent_y", "ship on Friday", {
+      taskId: "task_1",
+      initiatorSessionId: "ses_x",
+    });
+    expect(result.content).toEqual({
+      negotiation_id: "neg_1",
+      from_agent_id: "agent_y",
+      decision: "counter",
+      message: "how about this",
+      counter_proposal: "half now, half later",
+    });
+  });
+
+  it("omits a task id that is blank or not a string", async () => {
+    const { f, tool } = meshHarness();
+
+    await tool("negotiate").handler({ peer_id: "agent_y", proposal: "p" });
+    await tool("negotiate").handler({ peer_id: "agent_y", proposal: "p", task_id: "" });
+    await tool("negotiate").handler({ peer_id: "agent_y", proposal: "p", task_id: 7 });
+
+    for (const call of f.sendNegotiate.mock.calls) {
+      expect(call[3]).toMatchObject({ taskId: undefined });
+    }
+  });
+
+  it("projects the escalated sentinel through its own shape", async () => {
+    const { tool } = meshHarness({
+      sendNegotiate: vi.fn(async () => ({
+        decision: "escalated",
+        escalation_id: "esc_1",
+        negotiation_id: "neg_1",
+        message: "handed to humans",
+      })),
+    });
+
+    const result = await tool("negotiate").handler({
+      peer_id: "agent_y",
+      proposal: "p",
+    });
+
+    expect(result.content).toEqual({
+      decision: "escalated",
+      escalation_id: "esc_1",
+      negotiation_id: "neg_1",
+      message: "handed to humans",
+    });
+  });
+
+  it("rejects a missing peer_id or proposal", async () => {
+    const { f, tool } = meshHarness();
+
+    for (const input of [{}, { peer_id: "agent_y" }, { proposal: "p" }]) {
+      const result = await tool("negotiate").handler(input);
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({ error: "peer_id and proposal required" });
+    }
+    expect(f.sendNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the server's IC guardrail as a coded error", async () => {
+    const { tool } = meshHarness({
+      sendNegotiate: vi.fn(async () => {
+        throw new Error("cannot_negotiate_with_ic");
+      }),
+    });
+
+    const result = await tool("negotiate").handler({
+      peer_id: "agent_ic",
+      proposal: "p",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "cannot_negotiate_with_ic" });
+  });
+});
+
+describe("respond_negotiate handler", () => {
+  it("sends a counter with its proposal and returns the peer's reply", async () => {
+    const { f, tool } = meshHarness({
+      respondNegotiate: vi.fn(async () => ({
+        negotiation_id: "neg_1",
+        from_agent_id: "agent_y",
+        decision: "accept",
+        message: "works",
+        counter_proposal: undefined,
+      })),
+    });
+
+    const result = await tool("respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "not quite",
+      counter_proposal: "Monday instead",
+    });
+
+    // The round number is the server's to compute — the tool must not send one.
+    expect(f.respondNegotiate).toHaveBeenCalledWith(
+      "neg_1",
+      {
+        negotiation_id: "neg_1",
+        from_agent_id: "agent_x",
+        decision: "counter",
+        message: "not quite",
+        counter_proposal: "Monday instead",
+      },
+      "ses_x",
+    );
+    expect(result.content).toMatchObject({ decision: "accept" });
+  });
+
+  it("reports terminal when the server returns null", async () => {
+    const { tool } = meshHarness();
+
+    const result = await tool("respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "accept",
+      message: "agreed",
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({
+      negotiation_id: "neg_1",
+      decision: "accept",
+      terminal: true,
+    });
+  });
+
+  it("rejects a missing negotiation_id or message", async () => {
+    const { f, tool } = meshHarness();
+
+    for (const input of [
+      { decision: "accept", message: "m" },
+      { negotiation_id: "neg_1", decision: "accept" },
+    ]) {
+      const result = await tool("respond_negotiate").handler(input);
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({
+        error: "negotiation_id and message required",
+      });
+    }
+    expect(f.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("rejects a decision outside counter/accept/reject", async () => {
+    const { f, tool } = meshHarness();
+
+    const result = await tool("respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "maybe",
+      message: "m",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "decision must be one of: counter, accept, reject",
+    });
+    expect(f.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("rejects a counter with no counter_proposal", async () => {
+    const { f, tool } = meshHarness();
+
+    const result = await tool("respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "m",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "counter_proposal required when decision='counter'",
+    });
+    expect(f.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("surfaces max_rounds_exceeded from the server", async () => {
+    const { tool } = meshHarness({
+      respondNegotiate: vi.fn(async () => {
+        throw new Error("max_rounds_exceeded");
+      }),
+    });
+
+    const result = await tool("respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "accept",
+      message: "m",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "max_rounds_exceeded" });
+  });
+});
+
+describe("report_blocker handler", () => {
+  it("marks the task blocked, then spawns the direct parent", async () => {
+    const order: string[] = [];
+    const { f, tool } = meshHarness({
+      markBlocked: vi.fn(async () => {
+        order.push("markBlocked");
+      }),
+      reportBlocker: vi.fn(() => {
+        order.push("spawnParent");
+      }),
+    });
+
+    const result = await tool("report_blocker").handler({
+      task_id: "task_1",
+      description: "the API key is missing",
+    });
+
+    expect(f.findParent).toHaveBeenCalledWith("agent_x");
+    expect(f.markBlocked).toHaveBeenCalledWith(
+      "task_1",
+      "agent_x",
+      "the API key is missing",
+    );
+    expect(f.reportBlocker).toHaveBeenCalledWith(
+      "agent_parent",
+      "agent_x",
+      "task_1",
+      "the API key is missing",
+    );
+    // The task must read as blocked before the parent's session can look at it.
+    expect(order).toEqual(["markBlocked", "spawnParent"]);
+    expect(result.content).toEqual({
+      reported: true,
+      parent_agent_id: "agent_parent",
+      task_id: "task_1",
+    });
+  });
+
+  it("refuses a top-level agent with no parent, leaving the task alone", async () => {
+    const { f, tool } = meshHarness({ findParent: vi.fn(async () => null) });
+
+    const result = await tool("report_blocker").handler({
+      task_id: "task_1",
+      description: "stuck",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "no_parent_to_block" });
+    expect(f.markBlocked).not.toHaveBeenCalled();
+    expect(f.reportBlocker).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing task_id or description before touching the hierarchy", async () => {
+    const { f, tool } = meshHarness();
+
+    for (const input of [{}, { task_id: "task_1" }, { description: "d" }]) {
+      const result = await tool("report_blocker").handler(input);
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({
+        error: "task_id and description required",
+      });
+    }
+    expect(f.findParent).not.toHaveBeenCalled();
+  });
+
+  it("wraps a throw from markBlocked without spawning the parent", async () => {
+    const { f, tool } = meshHarness({
+      markBlocked: vi.fn(async () => {
+        throw new Error("task not found");
+      }),
+    });
+
+    const result = await tool("report_blocker").handler({
+      task_id: "task_1",
+      description: "d",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "task not found" });
+    expect(f.reportBlocker).not.toHaveBeenCalled();
+  });
+});
+
+describe("escalate_to_humans handler", () => {
+  it("creates the escalation, unblocks the peer, then notifies listeners", async () => {
+    const order: string[] = [];
+    const { f, tool } = meshHarness({
+      createEscalation: vi.fn(async () => {
+        order.push("create");
+        return { id: "esc_1", status: "open", negotiation_id: "neg_1" };
+      }),
+      unblockOnEscalate: vi.fn(() => {
+        order.push("unblock");
+      }),
+      query: vi.fn(async () => {
+        order.push("notify");
+        return { rows: [] };
+      }),
+    });
+
+    const result = await tool("escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "We're stuck on X.",
+      proposals: [{ title: "A", description: "do A" }],
+      open_questions: ["what is the deadline?"],
+    });
+
+    expect(f.createEscalation).toHaveBeenCalledWith({
+      negotiationId: "neg_1",
+      callerAgentId: "agent_x",
+      summary: "We're stuck on X.",
+      proposals: [{ title: "A", description: "do A" }],
+      openQuestions: ["what is the deadline?"],
+    });
+    expect(f.unblockOnEscalate).toHaveBeenCalledWith("neg_1", "esc_1");
+    expect(f.query).toHaveBeenCalledWith(
+      `SELECT pg_notify('escalation_created', $1)`,
+      ["esc_1"],
+    );
+    // The escalation row has to exist before anyone is told to go read it.
+    expect(order).toEqual(["create", "unblock", "notify"]);
+    expect(result.content).toEqual({
+      escalation_id: "esc_1",
+      status: "open",
+      negotiation_id: "neg_1",
+    });
+  });
+
+  it("omits proposals and open_questions that are not arrays", async () => {
+    const { f, tool } = meshHarness();
+
+    await tool("escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "s",
+      proposals: "A or B",
+      open_questions: "when?",
+    });
+
+    expect(f.createEscalation.mock.calls[0]?.[0]).toMatchObject({
+      proposals: undefined,
+      openQuestions: undefined,
+    });
+  });
+
+  it("filters non-string entries out of open_questions", async () => {
+    const { f, tool } = meshHarness();
+
+    await tool("escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "s",
+      open_questions: ["when?", 42, null, "who?"],
+    });
+
+    expect(f.createEscalation.mock.calls[0]?.[0]).toMatchObject({
+      openQuestions: ["when?", "who?"],
+    });
+  });
+
+  it("rejects a missing negotiation_id or summary", async () => {
+    const { f, tool } = meshHarness();
+
+    for (const input of [{}, { negotiation_id: "neg_1" }, { summary: "s" }]) {
+      const result = await tool("escalate_to_humans").handler(input);
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({
+        error: "negotiation_id and summary required",
+      });
+    }
+    expect(f.createEscalation).not.toHaveBeenCalled();
+  });
+
+  it("wraps a create failure without unblocking the peer", async () => {
+    const { f, tool } = meshHarness({
+      createEscalation: vi.fn(async () => {
+        throw new Error("negotiation already escalated");
+      }),
+    });
+
+    const result = await tool("escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "s",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "negotiation already escalated" });
+    expect(f.unblockOnEscalate).not.toHaveBeenCalled();
+  });
+});
+
+describe("IC mesh handlers", () => {
+  it("shares the same respond_ask and report_blocker implementations", async () => {
+    const { services, ctx, f } = meshHarness();
+    const icTools = buildIcMeshTools(ctx, services);
+
+    const respondAsk = icTools.find((t) => t.name === "respond_ask");
+    await respondAsk?.handler({ request_id: "req_1", answer: "a" });
+
+    expect(f.respondAsk).toHaveBeenCalledWith("req_1", {
+      request_id: "req_1",
+      from_agent_id: "agent_x",
+      answer: "a",
+    });
   });
 });

--- a/packages/api/src/tools/session-search.test.ts
+++ b/packages/api/src/tools/session-search.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SessionSearchRequest } from "@beevibe/core";
+import {
+  SessionSearchError,
+  type SessionSearchService,
+} from "@beevibe/core/services/session-search";
+import {
+  createSessionSearchTool,
+  type SessionSearchToolContext,
+} from "./session-search.js";
+
+const CTX: SessionSearchToolContext = {
+  agentId: "agent_a",
+  hierarchyLevel: "team",
+  sessionId: "sess_current",
+};
+
+/** Caller scope, as the tool hands it to the service. */
+interface CallerScope {
+  callerAgentId: string;
+  hierarchyLevel: string;
+  currentSessionId: string;
+}
+
+function fakeService(impl?: () => unknown) {
+  // Typed args so the assertions below can read `mock.calls[n][0|1]`.
+  const search = vi.fn(
+    async (_req: SessionSearchRequest, _scope: CallerScope): Promise<unknown> =>
+      impl ? impl() : { kind: "browse", sessions: [] },
+  );
+  return {
+    search,
+    sessionSearch: { search } as unknown as SessionSearchService,
+  };
+}
+
+function build(ctx: Partial<SessionSearchToolContext> = {}, fake = fakeService()) {
+  const tool = createSessionSearchTool({ ...CTX, ...ctx }, {
+    sessionSearch: fake.sessionSearch,
+  });
+  return { tool, fake };
+}
+
+/** The request the service was handed on the most recent call. */
+function lastRequest(fake: ReturnType<typeof fakeService>): SessionSearchRequest {
+  const call = fake.search.mock.calls.at(-1);
+  if (!call) throw new Error("service was never called");
+  return call[0];
+}
+
+describe("session_search tool definition", () => {
+  it("exposes the four calling shapes on its schema", () => {
+    const { tool } = build();
+    const props = tool.schema.properties as Record<string, unknown>;
+
+    expect(tool.name).toBe("session_search");
+    expect(Object.keys(props)).toEqual(
+      expect.arrayContaining([
+        "query",
+        "limit",
+        "sort",
+        "session_id",
+        "around_message_id",
+        "window",
+        "filters",
+      ]),
+    );
+    // No `required` — every shape, browse included, is a legal call.
+    expect(tool.schema.required).toBeUndefined();
+  });
+});
+
+describe("session_search shape inference", () => {
+  it("infers scroll when session_id and around_message_id are both set", async () => {
+    const { tool, fake } = build();
+
+    await tool.handler({
+      session_id: "sess_1",
+      around_message_id: "evt_5",
+      window: 10,
+      // A query alongside a scroll is ignored — scroll wins.
+      query: "ignored",
+    });
+
+    expect(lastRequest(fake)).toEqual({
+      kind: "scroll",
+      session_id: "sess_1",
+      around_message_id: "evt_5",
+      window: 10,
+    });
+  });
+
+  it("trims the ids it infers a scroll from", async () => {
+    const { tool, fake } = build();
+
+    await tool.handler({
+      session_id: "  sess_1  ",
+      around_message_id: "  evt_5  ",
+    });
+
+    expect(lastRequest(fake)).toMatchObject({
+      kind: "scroll",
+      session_id: "sess_1",
+      around_message_id: "evt_5",
+    });
+  });
+
+  it("leaves window undefined when it is absent or not a number", async () => {
+    const { tool, fake } = build();
+
+    await tool.handler({ session_id: "sess_1", around_message_id: "evt_5" });
+    expect(lastRequest(fake)).toMatchObject({ window: undefined });
+
+    await tool.handler({
+      session_id: "sess_1",
+      around_message_id: "evt_5",
+      window: "10",
+    });
+    expect(lastRequest(fake)).toMatchObject({ window: undefined });
+  });
+
+  it("infers read from a bare session_id", async () => {
+    const { tool, fake } = build();
+
+    await tool.handler({ session_id: "sess_1", limit: 5 });
+
+    expect(lastRequest(fake)).toEqual({ kind: "read", session_id: "sess_1" });
+  });
+
+  it("infers read when around_message_id is blank", async () => {
+    const { tool, fake } = build();
+
+    await tool.handler({ session_id: "sess_1", around_message_id: "   " });
+
+    expect(lastRequest(fake)).toEqual({ kind: "read", session_id: "sess_1" });
+  });
+
+  it("infers discover from a query, passing limit, sort and filters", async () => {
+    const { tool, fake } = build();
+
+    await tool.handler({
+      query: "  auth refactor  ",
+      limit: 3,
+      sort: "newest",
+      filters: { status: "failed" },
+    });
+
+    expect(lastRequest(fake)).toEqual({
+      kind: "discover",
+      query: "auth refactor",
+      limit: 3,
+      sort: "newest",
+      filters: { status: "failed" },
+    });
+  });
+
+  it("drops a sort that is not 'newest' or 'oldest'", async () => {
+    const { tool, fake } = build();
+
+    await tool.handler({ query: "x", sort: "relevance" });
+
+    expect(lastRequest(fake)).toMatchObject({ kind: "discover", sort: undefined });
+  });
+
+  it("infers browse when nothing identifying is passed", async () => {
+    const { tool, fake } = build();
+
+    await tool.handler({});
+
+    expect(lastRequest(fake)).toEqual({
+      kind: "browse",
+      limit: undefined,
+      filters: undefined,
+    });
+  });
+
+  it("infers browse when session_id and query are blank strings", async () => {
+    const { tool, fake } = build();
+
+    await tool.handler({ session_id: "  ", query: "  ", limit: 5 });
+
+    expect(lastRequest(fake)).toMatchObject({ kind: "browse", limit: 5 });
+  });
+
+  it("drops a filters value that is not an object", async () => {
+    const { tool, fake } = build();
+
+    await tool.handler({ filters: "status:failed" });
+    expect(lastRequest(fake)).toMatchObject({ filters: undefined });
+
+    await tool.handler({ filters: null });
+    expect(lastRequest(fake)).toMatchObject({ filters: undefined });
+  });
+});
+
+describe("session_search caller scope", () => {
+  it("forwards the caller's identity, tier and active session", async () => {
+    const { tool, fake } = build();
+
+    await tool.handler({ query: "x" });
+
+    expect(fake.search.mock.calls[0]?.[1]).toEqual({
+      callerAgentId: "agent_a",
+      hierarchyLevel: "team",
+      currentSessionId: "sess_current",
+    });
+  });
+});
+
+describe("session_search results and errors", () => {
+  it("returns the service result verbatim", async () => {
+    const payload = { kind: "read", session_id: "sess_1", messages: [{ id: "evt_1" }] };
+    const { tool } = build({}, fakeService(() => payload));
+
+    const result = await tool.handler({ session_id: "sess_1" });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual(payload);
+  });
+
+  it("maps a null result to not_found_or_forbidden", async () => {
+    const { tool } = build({}, fakeService(() => null));
+
+    const result = await tool.handler({ session_id: "sess_other" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "not_found_or_forbidden" });
+  });
+
+  it("surfaces a SessionSearchError's code", async () => {
+    const { tool } = build(
+      {},
+      fakeService(() => {
+        throw new SessionSearchError("forbidden_agent_filter", "out of scope");
+      }),
+    );
+
+    const result = await tool.handler({ query: "x", filters: { agent_id: "agent_z" } });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "forbidden_agent_filter",
+      message: "out of scope",
+    });
+  });
+
+  it("surfaces the code of a structurally identical error from another bundle", async () => {
+    // The api consumes core's dist/ while some scripts consume src/, so the
+    // handler matches on `name` too. Simulate the cross-bundle instance.
+    const foreign = new Error("query required");
+    foreign.name = "SessionSearchError";
+    (foreign as Error & { code: string }).code = "missing_query";
+
+    const { tool } = build(
+      {},
+      fakeService(() => {
+        throw foreign;
+      }),
+    );
+
+    const result = await tool.handler({});
+
+    expect(result.content).toEqual({
+      error: "missing_query",
+      message: "query required",
+    });
+  });
+
+  it("wraps an unrelated throw as internal_error", async () => {
+    const { tool } = build(
+      {},
+      fakeService(() => {
+        throw new Error("pg down");
+      }),
+    );
+
+    const result = await tool.handler({ query: "x" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "internal_error",
+      message: "pg down",
+    });
+  });
+
+  it("stringifies a non-Error throw", async () => {
+    const { tool } = build(
+      {},
+      fakeService(() => {
+        throw "boom";
+      }),
+    );
+
+    const result = await tool.handler({ query: "x" });
+
+    expect(result.content).toEqual({ error: "internal_error", message: "boom" });
+  });
+});

--- a/packages/api/src/tools/use-repo.test.ts
+++ b/packages/api/src/tools/use-repo.test.ts
@@ -1,0 +1,358 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  RepoRunRepository,
+  Task,
+  TaskRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import { createUseRepoTool } from "./use-repo.js";
+
+const AGENT = { id: "agent_a", name: "Ada" } as unknown as Agent;
+
+interface Fakes {
+  findById: ReturnType<typeof vi.fn>;
+  createTask: ReturnType<typeof vi.fn>;
+  createRepoRun: ReturnType<typeof vi.fn>;
+  dispatchTask: ReturnType<typeof vi.fn>;
+}
+
+function build(overrides: Partial<Fakes> = {}) {
+  const findById = overrides.findById ?? vi.fn(async () => AGENT);
+  const createTask =
+    overrides.createTask ??
+    vi.fn(async (row: Record<string, unknown>) => row as unknown as Task);
+  const createRepoRun = overrides.createRepoRun ?? vi.fn(async () => undefined);
+  const dispatchTask = overrides.dispatchTask ?? vi.fn(async () => ({}));
+
+  const tool = createUseRepoTool(
+    { agentId: "agent_a" },
+    {
+      agentRepo: { findById } as unknown as AgentRepository,
+      taskRepo: { create: createTask } as unknown as TaskRepository,
+      repoRunRepo: { create: createRepoRun } as unknown as RepoRunRepository,
+      dispatchService: { dispatchTask } as unknown as DispatchService,
+    },
+  );
+  return { tool, findById, createTask, createRepoRun, dispatchTask };
+}
+
+const OK_INPUT = {
+  goal: "Extract the tables from this PDF as JSON",
+  repo_url: "https://github.com/jsvine/pdfplumber",
+};
+
+describe("use_repo tool definition", () => {
+  it("requires goal and repo_url and forbids extra properties", () => {
+    const { tool } = build();
+
+    expect(tool.name).toBe("use_repo");
+    expect(tool.schema.required).toEqual(["goal", "repo_url"]);
+    expect(tool.schema.additionalProperties).toBe(false);
+  });
+});
+
+describe("use_repo input validation", () => {
+  it("rejects a missing, blank, or non-string goal", async () => {
+    const { tool, createTask } = build();
+
+    for (const goal of [undefined, "", "   ", 7]) {
+      const result = await tool.handler({ ...OK_INPUT, goal });
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({ error: "invalid_goal" });
+    }
+    expect(createTask).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["http://github.com/a/b", "not https"],
+    ["https://gitlab.com/a/b", "not github"],
+    ["https://notgithub.com/a/b", "github only as a suffix of another word"],
+    ["not a url at all", "unparseable"],
+    ["", "empty"],
+  ])("rejects repo_url %s (%s)", async (repoUrl) => {
+    const { tool, createTask } = build();
+
+    const result = await tool.handler({ ...OK_INPUT, repo_url: repoUrl });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "invalid_repo_url" });
+    expect(createTask).not.toHaveBeenCalled();
+  });
+
+  it("accepts a github.com subdomain", async () => {
+    const { tool } = build();
+
+    const result = await tool.handler({
+      ...OK_INPUT,
+      repo_url: "https://www.github.com/jsvine/pdfplumber",
+    });
+
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("rejects the call when the calling agent no longer exists", async () => {
+    const { tool, createTask } = build({ findById: vi.fn(async () => null) });
+
+    const result = await tool.handler(OK_INPUT);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "agent_not_found" });
+    expect(createTask).not.toHaveBeenCalled();
+  });
+});
+
+describe("use_repo happy path", () => {
+  it("creates the container task assigned to and created by the caller", async () => {
+    const { tool, createTask } = build();
+
+    await tool.handler(OK_INPUT);
+
+    expect(createTask).toHaveBeenCalledTimes(1);
+    expect(createTask.mock.calls[0]?.[0]).toMatchObject({
+      title: OK_INPUT.goal,
+      description: OK_INPUT.goal,
+      priority: "medium",
+      assignee_id: "agent_a",
+      creator_id: "agent_a",
+      creator_type: "agent",
+    });
+  });
+
+  it("collapses whitespace and truncates a long goal into the task title", async () => {
+    const { tool, createTask } = build();
+    const goal = `${"word ".repeat(40)}end`;
+
+    await tool.handler({ ...OK_INPUT, goal });
+
+    const title = createTask.mock.calls[0]?.[0].title as string;
+    expect(title).toHaveLength(78); // 77 chars + the ellipsis
+    expect(title.endsWith("…")).toBe(true);
+    expect(title).not.toMatch(/\s\s/);
+  });
+
+  it("keeps a short goal as the title untouched", async () => {
+    const { tool, createTask } = build();
+
+    await tool.handler({ ...OK_INPUT, goal: "  Extract   tables  " });
+
+    expect(createTask.mock.calls[0]?.[0].title).toBe("Extract tables");
+  });
+
+  it("dispatches under a pre-minted session id, then inserts the repo_run against it", async () => {
+    const { tool, dispatchTask, createRepoRun, createTask } = build();
+
+    const result = await tool.handler(OK_INPUT);
+
+    const dispatched = dispatchTask.mock.calls[0]?.[0];
+    const repoRun = createRepoRun.mock.calls[0]?.[0];
+    const task = createTask.mock.calls[0]?.[0];
+
+    expect(dispatched).toMatchObject({
+      agentId: "agent_a",
+      type: "run_repo",
+      intent: OK_INPUT.goal,
+      task,
+      reason: { kind: "fresh" },
+    });
+    // repo_run.session_id has an FK to session.id, so the dispatch that
+    // creates the session row must use the same id the repo_run points at.
+    expect(repoRun.session_id).toBe(dispatched.sessionIdOverride);
+    expect(repoRun).toMatchObject({
+      task_id: task.id,
+      agent_id: "agent_a",
+      goal: OK_INPUT.goal,
+      repo_url: OK_INPUT.repo_url,
+      status: "pending",
+    });
+    expect(result.content).toMatchObject({
+      repo_run_id: repoRun.id,
+      session_id: repoRun.session_id,
+      task_id: task.id,
+      status: "pending",
+      watch_url: `/capabilities/runs/${repoRun.id}`,
+    });
+  });
+
+  it("dispatches before inserting the repo_run", async () => {
+    const order: string[] = [];
+    const { tool } = build({
+      dispatchTask: vi.fn(async () => {
+        order.push("dispatch");
+        return {};
+      }),
+      createRepoRun: vi.fn(async () => {
+        order.push("repo_run");
+      }),
+    });
+
+    await tool.handler(OK_INPUT);
+
+    expect(order).toEqual(["dispatch", "repo_run"]);
+  });
+
+  it("trims goal and repo_url before persisting them", async () => {
+    const { tool, createRepoRun } = build();
+
+    await tool.handler({
+      goal: "  Extract tables  ",
+      repo_url: "  https://github.com/jsvine/pdfplumber  ",
+    });
+
+    expect(createRepoRun.mock.calls[0]?.[0]).toMatchObject({
+      goal: "Extract tables",
+      repo_url: "https://github.com/jsvine/pdfplumber",
+    });
+  });
+
+  it("echoes trimmed input_url and input_filename back to the agent", async () => {
+    const { tool } = build();
+
+    const result = await tool.handler({
+      ...OK_INPUT,
+      input_url: "  https://example.com/a.pdf  ",
+      input_filename: "  a.pdf  ",
+    });
+
+    expect(result.content).toMatchObject({
+      input_url: "https://example.com/a.pdf",
+      input_filename: "a.pdf",
+    });
+  });
+
+  it("leaves input_url and input_filename undefined when not strings", async () => {
+    const { tool } = build();
+
+    const result = await tool.handler({ ...OK_INPUT, input_url: 1, input_filename: {} });
+
+    expect(result.content).toMatchObject({
+      input_url: undefined,
+      input_filename: undefined,
+    });
+  });
+
+  it("mints a distinct repo_run, session and task id per call", async () => {
+    const { tool } = build();
+
+    const a = (await tool.handler(OK_INPUT)).content;
+    const b = (await tool.handler(OK_INPUT)).content;
+
+    expect(a.repo_run_id).not.toBe(b.repo_run_id);
+    expect(a.session_id).not.toBe(b.session_id);
+    expect(a.task_id).not.toBe(b.task_id);
+  });
+});
+
+describe("use_repo limit parsing", () => {
+  it("passes through in-range limits, flooring the integer ones", async () => {
+    const { tool } = build();
+
+    const result = await tool.handler({
+      ...OK_INPUT,
+      limits: { wall_clock_minutes: 15, max_install_attempts: 3.7, disk_mb: 1024.9 },
+    });
+
+    expect(result.content.limits).toEqual({
+      wall_clock_minutes: 15,
+      max_install_attempts: 3,
+      disk_mb: 1024,
+    });
+  });
+
+  it("clamps each limit to its ceiling", async () => {
+    const { tool } = build();
+
+    const result = await tool.handler({
+      ...OK_INPUT,
+      limits: { wall_clock_minutes: 999, max_install_attempts: 99, disk_mb: 999_999 },
+    });
+
+    expect(result.content.limits).toEqual({
+      wall_clock_minutes: 60,
+      max_install_attempts: 5,
+      disk_mb: 10_000,
+    });
+  });
+
+  it("drops non-positive and non-numeric limits", async () => {
+    const { tool } = build();
+
+    const result = await tool.handler({
+      ...OK_INPUT,
+      limits: {
+        wall_clock_minutes: 0,
+        max_install_attempts: -1,
+        disk_mb: "2048",
+      },
+    });
+
+    expect(result.content.limits).toEqual({});
+  });
+
+  it("returns empty limits when the field is absent or not an object", async () => {
+    const { tool } = build();
+
+    for (const limits of [undefined, null, "big", 5]) {
+      const result = await tool.handler({ ...OK_INPUT, limits });
+      expect(result.content.limits).toEqual({});
+    }
+  });
+});
+
+describe("use_repo failure paths", () => {
+  it("reports dispatch_failed without inserting a repo_run", async () => {
+    const { tool, createRepoRun } = build({
+      dispatchTask: vi.fn(async () => {
+        throw new Error("no runtime online");
+      }),
+    });
+
+    const result = await tool.handler(OK_INPUT);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "dispatch_failed",
+      message: "no runtime online",
+    });
+    expect(createRepoRun).not.toHaveBeenCalled();
+  });
+
+  it("reports repo_run_create_failed when the insert loses the race", async () => {
+    const { tool } = build({
+      createRepoRun: vi.fn(async () => {
+        throw new Error("duplicate key");
+      }),
+    });
+
+    const result = await tool.handler(OK_INPUT);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "repo_run_create_failed",
+      message: "duplicate key",
+    });
+  });
+
+  it("stringifies non-Error throws from either write", async () => {
+    const dispatchFail = build({
+      dispatchTask: vi.fn(async () => {
+        throw "boom";
+      }),
+    });
+    expect((await dispatchFail.tool.handler(OK_INPUT)).content).toMatchObject({
+      error: "dispatch_failed",
+      message: "boom",
+    });
+
+    const repoRunFail = build({
+      createRepoRun: vi.fn(async () => {
+        throw "bang";
+      }),
+    });
+    expect((await repoRunFail.tool.handler(OK_INPUT)).content).toMatchObject({
+      error: "repo_run_create_failed",
+      message: "bang",
+    });
+  });
+});

--- a/packages/api/src/tools/watch.test.ts
+++ b/packages/api/src/tools/watch.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  WatchAuthError,
+  WatchNotFoundError,
+  WatchValidationError,
+  type WatchService,
+} from "@beevibe/core/services/watch-service";
+import { buildWatchTools, type WatchToolContext } from "./watch.js";
+
+interface Fake {
+  watchService: WatchService;
+  watchTasks: ReturnType<typeof vi.fn>;
+  unwatch: ReturnType<typeof vi.fn>;
+}
+
+function fakeWatchService(overrides: Partial<Fake> = {}): Fake {
+  const watchTasks =
+    overrides.watchTasks ??
+    vi.fn(async () => ({ watchId: "watch_1", firedImmediately: false }));
+  const unwatch = overrides.unwatch ?? vi.fn(async () => undefined);
+  return {
+    watchTasks,
+    unwatch,
+    watchService: { watchTasks, unwatch } as unknown as WatchService,
+  };
+}
+
+function tools(ctx: Partial<WatchToolContext> = {}, fake = fakeWatchService()) {
+  const built = buildWatchTools(
+    { agentId: "agent_a", sessionId: "sess_1", ...ctx },
+    { watchService: fake.watchService },
+  );
+  const byName = (name: string) => {
+    const t = built.find((x) => x.name === name);
+    if (!t) throw new Error(`tool ${name} not built`);
+    return t;
+  };
+  return { built, fake, watchTasks: byName("watch_tasks"), unwatch: byName("unwatch") };
+}
+
+describe("buildWatchTools", () => {
+  it("builds watch_tasks and unwatch, in that order", () => {
+    const { built } = tools();
+    expect(built.map((t) => t.name)).toEqual(["watch_tasks", "unwatch"]);
+  });
+
+  it("advertises both modes on the watch_tasks schema", () => {
+    const { watchTasks } = tools();
+    const props = watchTasks.schema.properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(props.mode?.enum).toEqual(["all", "any"]);
+    expect(watchTasks.schema.required).toEqual(["task_ids"]);
+    expect(props.task_ids?.minItems).toBe(1);
+  });
+});
+
+describe("watch_tasks handler", () => {
+  it("passes caller identity, ids and mode through to the service", async () => {
+    const fake = fakeWatchService();
+    const { watchTasks } = tools({}, fake);
+
+    const result = await watchTasks.handler({
+      task_ids: ["task_1", "task_2"],
+      mode: "any",
+      reason: "  need the first signal  ",
+    });
+
+    expect(fake.watchTasks).toHaveBeenCalledWith({
+      callerAgentId: "agent_a",
+      callerSessionId: "sess_1",
+      taskIds: ["task_1", "task_2"],
+      mode: "any",
+      reason: "need the first signal",
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({
+      watch_id: "watch_1",
+      fired_immediately: false,
+    });
+  });
+
+  it("reports fired_immediately when the condition was already met", async () => {
+    const fake = fakeWatchService({
+      watchTasks: vi.fn(async () => ({
+        watchId: "watch_9",
+        firedImmediately: true,
+      })),
+    });
+    const { watchTasks } = tools({}, fake);
+
+    const result = await watchTasks.handler({ task_ids: ["task_1"] });
+
+    expect(result.content).toEqual({
+      watch_id: "watch_9",
+      fired_immediately: true,
+    });
+  });
+
+  it("defaults mode to 'all' when absent or not a known mode", async () => {
+    const fake = fakeWatchService();
+    const { watchTasks } = tools({}, fake);
+
+    await watchTasks.handler({ task_ids: ["task_1"] });
+    await watchTasks.handler({ task_ids: ["task_1"], mode: "sometimes" });
+    await watchTasks.handler({ task_ids: ["task_1"], mode: 7 });
+
+    for (const call of fake.watchTasks.mock.calls) {
+      expect(call[0]).toMatchObject({ mode: "all" });
+    }
+  });
+
+  it("drops non-string entries from task_ids", async () => {
+    const fake = fakeWatchService();
+    const { watchTasks } = tools({}, fake);
+
+    await watchTasks.handler({ task_ids: ["task_1", 42, null, "task_2"] });
+
+    expect(fake.watchTasks.mock.calls[0]?.[0]).toMatchObject({
+      taskIds: ["task_1", "task_2"],
+    });
+  });
+
+  it("omits a reason that is missing, blank, or not a string", async () => {
+    const fake = fakeWatchService();
+    const { watchTasks } = tools({}, fake);
+
+    await watchTasks.handler({ task_ids: ["task_1"] });
+    await watchTasks.handler({ task_ids: ["task_1"], reason: "   " });
+    await watchTasks.handler({ task_ids: ["task_1"], reason: 5 });
+
+    for (const call of fake.watchTasks.mock.calls) {
+      expect(call[0]).toMatchObject({ reason: undefined });
+    }
+  });
+
+  it("rejects a missing, empty, or non-array task_ids without calling the service", async () => {
+    const fake = fakeWatchService();
+    const { watchTasks } = tools({}, fake);
+
+    for (const input of [{}, { task_ids: [] }, { task_ids: "task_1" }, { task_ids: [1, 2] }]) {
+      const result = await watchTasks.handler(input);
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({ error: "watch_validation" });
+    }
+    expect(fake.watchTasks).not.toHaveBeenCalled();
+  });
+
+  it("rejects a call made outside a session context", async () => {
+    const fake = fakeWatchService();
+    const { watchTasks } = tools({ sessionId: undefined }, fake);
+
+    const result = await watchTasks.handler({ task_ids: ["task_1"] });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "watch_validation",
+      message: expect.stringContaining("session context"),
+    });
+    expect(fake.watchTasks).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [new WatchAuthError("not your task"), "watch_auth"],
+    [new WatchValidationError("bad ids"), "watch_validation"],
+    [new WatchNotFoundError("no such task"), "watch_not_found"],
+    [new Error("pg down"), "watch_error"],
+  ])("maps %s to a coded tool error", async (thrown, code) => {
+    const fake = fakeWatchService({
+      watchTasks: vi.fn(async () => {
+        throw thrown;
+      }),
+    });
+    const { watchTasks } = tools({}, fake);
+
+    const result = await watchTasks.handler({ task_ids: ["task_1"] });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: code,
+      message: (thrown as Error).message,
+    });
+  });
+
+  it("stringifies a non-Error throw", async () => {
+    const fake = fakeWatchService({
+      watchTasks: vi.fn(async () => {
+        throw "boom";
+      }),
+    });
+    const { watchTasks } = tools({}, fake);
+
+    const result = await watchTasks.handler({ task_ids: ["task_1"] });
+
+    expect(result.content).toMatchObject({
+      error: "watch_error",
+      message: "boom",
+    });
+  });
+});
+
+describe("unwatch handler", () => {
+  it("cancels the watch for the calling agent", async () => {
+    const fake = fakeWatchService();
+    const { unwatch } = tools({}, fake);
+
+    const result = await unwatch.handler({ watch_id: "watch_1" });
+
+    expect(fake.unwatch).toHaveBeenCalledWith({
+      callerAgentId: "agent_a",
+      watchId: "watch_1",
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({ ok: true });
+  });
+
+  it("rejects a missing or non-string watch_id without calling the service", async () => {
+    const fake = fakeWatchService();
+    const { unwatch } = tools({}, fake);
+
+    for (const input of [{}, { watch_id: "" }, { watch_id: 3 }]) {
+      const result = await unwatch.handler(input);
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({ error: "watch_validation" });
+    }
+    expect(fake.unwatch).not.toHaveBeenCalled();
+  });
+
+  it("maps a service throw through the same coded envelope", async () => {
+    const fake = fakeWatchService({
+      unwatch: vi.fn(async () => {
+        throw new WatchNotFoundError("watch_1");
+      }),
+    });
+    const { unwatch } = tools({}, fake);
+
+    const result = await unwatch.handler({ watch_id: "watch_1" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "watch_not_found",
+      message: "task_watch watch_1 not found",
+    });
+  });
+});


### PR DESCRIPTION
## What

A coverage sweep across every package put the worst concentrated gap in `packages/api/src/tools/` — the MCP tools agents actually call. Three modules had **no test file at all**; two more were only spot-checked.

### New test files

| File | Lines | Functions |
| --- | --- | --- |
| `watch.test.ts` | 46.26% → **100%** | 42.85% → **100%** |
| `session-search.test.ts` | 64.65% → **100%** | 33.33% → **100%** |
| `use-repo.test.ts` | 32.04% → **100%** | 20% → **100%** |

### Extended

| File | Lines | Branches |
| --- | --- | --- |
| `mesh.test.ts` | 45.93% → **100%** | — |
| `hierarchy.test.ts` | 71.25% → **95.17%** | 52.2% → **66.33%** |

`mesh.test.ts` was assembly-only (it asserted the tier inventory and deferred handler behavior to the m6/m7 e2e scripts); this adds handler tests for all six mesh tools. `hierarchy.test.ts` gains the three handlers that had no coverage at all: `revise_task`, `add_to_escalation`, and `create_subordinate_agent`.

**Package total: 52.16% → 59.91% lines, 72.6% → 79.53% functions.**

## Why here

The rest of the codebase is already in good shape. Excluding the DB- and key-gated suites that can't run without Postgres or provider keys, core's modules, `daemon` (80.41%) and `sandbox` (75.11%) sit at 90%+ per file; their remaining gaps are entrypoints (`main.ts`, `start.ts`) and the manual dev/ops scripts CLAUDE.md documents as deliberately untested. The tool surface was the one place where product-critical code had none.

## What the tests pin

Behavior that regresses silently and is expensive to debug through a live agent session:

- **`use_repo`** — the pre-minted session id that `repo_run.session_id`'s FK depends on, and dispatch-before-insert ordering (the comment in the source explains why the order matters; nothing enforced it).
- **`report_blocker`** — `markBlocked` completing before the parent's session is spawned, so the task reads as blocked when the parent looks at it.
- **`session_search`** — all four calling shapes and the precedence between them (scroll wins over a stray `query`; a blank `around_message_id` degrades to read).
- **`create_subordinate_agent`** — the per-parent daily spawn cap and its 24h window, runtime inheritance, and that a failed audit-row write still returns success (the agent and its memory are the user-visible artifacts).
- **`escalate_to_humans` / `add_to_escalation`** — create → unblock peer → `pg_notify` ordering, and that a failed create doesn't unblock the peer.
- Error envelopes throughout: `CodedMeshError` keeping its code and meta vs. the catch-all shape, and `session_search`'s cross-bundle `name`-matching fallback.

## Testing

All fakes, no DB — these run in the sandbox.

- `pnpm --filter @beevibe/api test` → the nine failures are the DB-gated integration suites that fail identically on `main` without Postgres; no new failures.
- `packages/api/src/tools/` alone: 198 tests, all passing.
- `typecheck` and `lint` are clean (lint's 4 warnings are pre-existing, in files this PR doesn't touch).

Coverage was measured with `@vitest/coverage-v8` installed ad hoc and **not committed**, per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ciw1MsmLrb32GXDsKJuKwb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ciw1MsmLrb32GXDsKJuKwb)_