### PR TITLE
test: cover the four untested MCP tool adapters (33-46% → 100%)

### DIFF
--- a/packages/api/src/tools/mesh.test.ts
+++ b/packages/api/src/tools/mesh.test.ts
@@ -1,14 +1,28 @@
 /**
- * Mesh tool assembly tests — IC vs team tier gating.
+ * Mesh tool tests — tier gating plus per-handler adapter behavior.
  *
- * Per-tool handler behavior is covered indirectly by the m6/m7 e2e scripts
- * (mesh flows require live Postgres + spawned CLI subprocesses). This file
- * locks the static tier inventory — the exact tool *names* each tier gets,
- * so future skill-loader work can rely on the surface being stable.
+ * The end-to-end mesh flows (real spawns, real blocking round-trips) are
+ * covered by the m6/m7 e2e scripts, which need live Postgres and spawned
+ * CLI subprocesses. What those scripts can't reach is the adapter layer
+ * in this module: the argument validation each handler does before it
+ * calls MeshServer, the projection of the server's reply down to the
+ * fields the agent sees, and the coded-error envelope. Those are unit
+ * tested here against a fake MeshServer, alongside the static tier
+ * inventory that future skill-loader work relies on.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { Agent, AgentRepository, TaskRepository } from "@beevibe/core";
 import type { ResolvedCaller } from "@beevibe/core/auth";
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import type { EscalationService } from "@beevibe/core/services/escalation-service";
+import type { TaskService } from "@beevibe/core/services/task-service";
 import { buildIcMeshTools, buildTeamMeshTools, type MeshToolServices } from "./mesh.js";
+import {
+  CannotNegotiateWithIcError,
+  MeshCapacityError,
+  MeshMaxRoundsError,
+} from "../mesh/types.js";
+import type { MeshServer } from "../mesh/server.js";
 
 // Fake services — the assembly itself doesn't invoke handlers, so the
 // dependencies just need to be the right shape.
@@ -45,5 +59,561 @@ describe("buildTeamMeshTools", () => {
       "respond_ask",
       "respond_negotiate",
     ]);
+  });
+});
+
+// ── Handler-level tests ──────────────────────────────────────────────────
+
+interface MeshHarness {
+  services: MeshToolServices;
+  mesh: {
+    sendAsk: ReturnType<typeof vi.fn>;
+    respondAsk: ReturnType<typeof vi.fn>;
+    sendNegotiate: ReturnType<typeof vi.fn>;
+    respondNegotiate: ReturnType<typeof vi.fn>;
+    unblockOnEscalate: ReturnType<typeof vi.fn>;
+    reportBlocker: ReturnType<typeof vi.fn>;
+  };
+  findParent: ReturnType<typeof vi.fn>;
+  markBlocked: ReturnType<typeof vi.fn>;
+  createEscalation: ReturnType<typeof vi.fn>;
+  query: ReturnType<typeof vi.fn>;
+}
+
+const PARENT: Agent = {
+  id: "agent_parent",
+  name: "Parent",
+  owner_id: "user_1",
+  hierarchy_level: "team",
+  runtime_config: {} as Agent["runtime_config"],
+  created_at: new Date("2025-01-01T00:00:00Z"),
+  updated_at: new Date("2025-01-01T00:00:00Z"),
+};
+
+function meshHarness(): MeshHarness {
+  const mesh = {
+    sendAsk: vi.fn(async (requestId: string, _from: string, to: string) => ({
+      request_id: requestId,
+      from_agent_id: to,
+      answer: "yes, feasible",
+    })),
+    respondAsk: vi.fn(),
+    sendNegotiate: vi.fn(async () => ({
+      negotiation_id: "neg_1",
+      from_agent_id: "agent_peer",
+      decision: "counter",
+      message: "how about this instead",
+      counter_proposal: "ship behind a flag",
+    })),
+    respondNegotiate: vi.fn(async () => null),
+    unblockOnEscalate: vi.fn(),
+    reportBlocker: vi.fn(),
+  };
+  const findParent = vi.fn(async () => PARENT as Agent | undefined);
+  const markBlocked = vi.fn(async () => undefined);
+  const createEscalation = vi.fn(async () => ({
+    id: "esc_1",
+    status: "open",
+    negotiation_id: "neg_1",
+  }));
+  const query = vi.fn(async () => ({ rows: [] }));
+
+  const services = {
+    mesh: mesh as unknown as MeshServer,
+    agentRepo: { findParent } as unknown as AgentRepository,
+    taskRepo: {} as unknown as TaskRepository,
+    taskService: { markBlocked } as unknown as TaskService,
+    escalationService: { create: createEscalation } as unknown as EscalationService,
+    pool: { query } as unknown as Pool,
+  } satisfies MeshToolServices;
+
+  return { services, mesh, findParent, markBlocked, createEscalation, query };
+}
+
+function toolNamed(h: MeshHarness, name: string) {
+  const tool = buildTeamMeshTools(fakeCtx, h.services).find((t) => t.name === name);
+  if (!tool) throw new Error(`no mesh tool named ${name}`);
+  return tool;
+}
+
+describe("ask", () => {
+  it("mints a request id and projects only the three agent-visible fields", async () => {
+    const h = meshHarness();
+    const result = await toolNamed(h, "ask").handler({
+      target_agent_id: "agent_peer",
+      question: "is X feasible?",
+    });
+
+    const [requestId, from, to, question] = h.mesh.sendAsk.mock.calls[0]!;
+    expect(requestId).toEqual(expect.any(String));
+    expect([from, to, question]).toEqual(["agent_x", "agent_peer", "is X feasible?"]);
+    expect(result.isError).toBeFalsy();
+    // The server's reply may carry more; the agent sees exactly these.
+    expect(result.content).toEqual({
+      request_id: requestId,
+      from_agent_id: "agent_peer",
+      answer: "yes, feasible",
+    });
+  });
+
+  it("mints a fresh request id per call", async () => {
+    const h = meshHarness();
+    const tool = toolNamed(h, "ask");
+    await tool.handler({ target_agent_id: "agent_peer", question: "q1" });
+    await tool.handler({ target_agent_id: "agent_peer", question: "q2" });
+
+    expect(h.mesh.sendAsk.mock.calls[0]![0]).not.toBe(
+      h.mesh.sendAsk.mock.calls[1]![0],
+    );
+  });
+
+  it.each([
+    ["target_agent_id", { question: "q" }],
+    ["question", { target_agent_id: "agent_peer" }],
+    ["both", {}],
+  ])("rejects a call missing %s without spawning the target", async (_l, input) => {
+    const h = meshHarness();
+    const result = await toolNamed(h, "ask").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "target_agent_id and question required",
+    });
+    expect(h.mesh.sendAsk).not.toHaveBeenCalled();
+  });
+
+  it("projects a capacity refusal as its coded envelope", async () => {
+    const h = meshHarness();
+    h.mesh.sendAsk.mockRejectedValueOnce(
+      new MeshCapacityError("at capacity", {
+        agentId: "agent_peer",
+        running: 3,
+        cap: 3,
+      }),
+    );
+    const result = await toolNamed(h, "ask").handler({
+      target_agent_id: "agent_peer",
+      question: "q",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "MESH_CAPACITY_EXCEEDED",
+      agentId: "agent_peer",
+      running: 3,
+      cap: 3,
+      message: "at capacity",
+    });
+  });
+
+  it("degrades an uncoded throw to the catch-all envelope", async () => {
+    const h = meshHarness();
+    h.mesh.sendAsk.mockRejectedValueOnce(new Error("target never responded"));
+    const result = await toolNamed(h, "ask").handler({
+      target_agent_id: "agent_peer",
+      question: "q",
+    });
+
+    expect(result.content).toEqual({ error: "target never responded" });
+  });
+});
+
+describe("respond_ask", () => {
+  it("unblocks the asker with the caller as from_agent_id", async () => {
+    const h = meshHarness();
+    const result = await toolNamed(h, "respond_ask").handler({
+      request_id: "req_1",
+      answer: "here you go",
+    });
+
+    expect(h.mesh.respondAsk).toHaveBeenCalledWith("req_1", {
+      request_id: "req_1",
+      from_agent_id: "agent_x",
+      answer: "here you go",
+    });
+    expect(result.content).toEqual({ responded: true, request_id: "req_1" });
+  });
+
+  it.each([
+    ["request_id", { answer: "a" }],
+    ["answer", { request_id: "req_1" }],
+  ])("rejects a call missing %s", async (_l, input) => {
+    const h = meshHarness();
+    const result = await toolNamed(h, "respond_ask").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "request_id and answer required",
+    });
+    expect(h.mesh.respondAsk).not.toHaveBeenCalled();
+  });
+
+  it("envelopes a synchronous throw from the server", async () => {
+    const h = meshHarness();
+    h.mesh.respondAsk.mockImplementationOnce(() => {
+      throw new Error("no waiter for req_1");
+    });
+    const result = await toolNamed(h, "respond_ask").handler({
+      request_id: "req_1",
+      answer: "a",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "no waiter for req_1" });
+  });
+});
+
+describe("negotiate", () => {
+  it("stamps the task and the initiator's session on the negotiation", async () => {
+    const h = meshHarness();
+    const result = await toolNamed(h, "negotiate").handler({
+      peer_id: "agent_peer",
+      proposal: "let's ship monday",
+      task_id: "task_7",
+    });
+
+    expect(h.mesh.sendNegotiate).toHaveBeenCalledWith(
+      "agent_x",
+      "agent_peer",
+      "let's ship monday",
+      { taskId: "task_7", initiatorSessionId: "ses_x" },
+    );
+    expect(result.content).toEqual({
+      negotiation_id: "neg_1",
+      from_agent_id: "agent_peer",
+      decision: "counter",
+      message: "how about this instead",
+      counter_proposal: "ship behind a flag",
+    });
+  });
+
+  it.each([
+    ["omitted", undefined],
+    ["empty", ""],
+    ["a non-string", 7],
+  ])("sends no taskId when task_id is %s", async (_l, taskId) => {
+    const h = meshHarness();
+    await toolNamed(h, "negotiate").handler({
+      peer_id: "agent_peer",
+      proposal: "p",
+      ...(taskId === undefined ? {} : { task_id: taskId }),
+    });
+
+    expect(h.mesh.sendNegotiate.mock.calls[0]![3]).toEqual({
+      taskId: undefined,
+      initiatorSessionId: "ses_x",
+    });
+  });
+
+  it.each([
+    ["peer_id", { proposal: "p" }],
+    ["proposal", { peer_id: "agent_peer" }],
+  ])("rejects a call missing %s", async (_l, input) => {
+    const h = meshHarness();
+    const result = await toolNamed(h, "negotiate").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "peer_id and proposal required" });
+    expect(h.mesh.sendNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("keeps the IC guardrail's code so the agent can branch to ask/create_task", async () => {
+    const h = meshHarness();
+    h.mesh.sendNegotiate.mockRejectedValueOnce(
+      new CannotNegotiateWithIcError({ agentId: "agent_ic" }),
+    );
+    const result = await toolNamed(h, "negotiate").handler({
+      peer_id: "agent_ic",
+      proposal: "p",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "CANNOT_NEGOTIATE_WITH_IC",
+      agentId: "agent_ic",
+    });
+  });
+
+  it("projects the escalated sentinel, not the ordinary response shape", async () => {
+    const h = meshHarness();
+    h.mesh.sendNegotiate.mockResolvedValueOnce({
+      decision: "escalated",
+      escalation_id: "esc_9",
+      negotiation_id: "neg_1",
+      message: "peer escalated to humans",
+    });
+    const result = await toolNamed(h, "negotiate").handler({
+      peer_id: "agent_peer",
+      proposal: "p",
+    });
+
+    expect(result.content).toEqual({
+      decision: "escalated",
+      escalation_id: "esc_9",
+      negotiation_id: "neg_1",
+      message: "peer escalated to humans",
+    });
+  });
+});
+
+describe("respond_negotiate", () => {
+  it("reports terminal when the server has nothing more to send back", async () => {
+    const h = meshHarness();
+    const result = await toolNamed(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "accept",
+      message: "agreed",
+    });
+
+    expect(h.mesh.respondNegotiate).toHaveBeenCalledWith(
+      "neg_1",
+      {
+        negotiation_id: "neg_1",
+        from_agent_id: "agent_x",
+        decision: "accept",
+        message: "agreed",
+        counter_proposal: undefined,
+      },
+      "ses_x",
+    );
+    expect(result.content).toEqual({
+      negotiation_id: "neg_1",
+      decision: "accept",
+      terminal: true,
+    });
+  });
+
+  it("projects the peer's reply when the exchange continues", async () => {
+    const h = meshHarness();
+    h.mesh.respondNegotiate.mockResolvedValueOnce({
+      negotiation_id: "neg_1",
+      from_agent_id: "agent_peer",
+      decision: "counter",
+      message: "not quite",
+      counter_proposal: "tuesday",
+    });
+    const result = await toolNamed(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "monday",
+      counter_proposal: "monday am",
+    });
+
+    expect(result.content).toMatchObject({
+      from_agent_id: "agent_peer",
+      counter_proposal: "tuesday",
+    });
+  });
+
+  it.each([
+    ["negotiation_id", { decision: "accept", message: "m" }],
+    ["message", { negotiation_id: "neg_1", decision: "accept" }],
+  ])("rejects a call missing %s", async (_l, input) => {
+    const h = meshHarness();
+    const result = await toolNamed(h, "respond_negotiate").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "negotiation_id and message required",
+    });
+    expect(h.mesh.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("rejects a decision outside counter|accept|reject", async () => {
+    const h = meshHarness();
+    const result = await toolNamed(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "maybe",
+      message: "m",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(String(result.content.error)).toContain("counter, accept, reject");
+    expect(h.mesh.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("requires counter_proposal when countering", async () => {
+    const h = meshHarness();
+    const result = await toolNamed(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "m",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "counter_proposal required when decision='counter'",
+    });
+    expect(h.mesh.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the max-rounds cap with its meta so the agent can escalate", async () => {
+    const h = meshHarness();
+    h.mesh.respondNegotiate.mockRejectedValueOnce(
+      new MeshMaxRoundsError({
+        negotiationId: "neg_1",
+        rounds_completed: 5,
+        max_rounds: 5,
+      }),
+    );
+    const result = await toolNamed(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "m",
+      counter_proposal: "c",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "MAX_ROUNDS_EXCEEDED",
+      negotiationId: "neg_1",
+      rounds_completed: 5,
+      max_rounds: 5,
+    });
+  });
+});
+
+describe("report_blocker", () => {
+  it("marks the task blocked, then spawns the derived parent", async () => {
+    const h = meshHarness();
+    const result = await toolNamed(h, "report_blocker").handler({
+      task_id: "task_7",
+      description: "the API key is missing",
+    });
+
+    // The parent is derived server-side from the caller's hierarchy —
+    // the agent never gets to name it.
+    expect(h.findParent).toHaveBeenCalledWith("agent_x");
+    expect(h.markBlocked).toHaveBeenCalledWith(
+      "task_7",
+      "agent_x",
+      "the API key is missing",
+    );
+    expect(h.mesh.reportBlocker).toHaveBeenCalledWith(
+      "agent_parent",
+      "agent_x",
+      "task_7",
+      "the API key is missing",
+    );
+    expect(result.content).toEqual({
+      reported: true,
+      parent_agent_id: "agent_parent",
+      task_id: "task_7",
+    });
+  });
+
+  it("refuses for a top-level agent and leaves the task alone", async () => {
+    const h = meshHarness();
+    h.findParent.mockResolvedValueOnce(undefined);
+    const result = await toolNamed(h, "report_blocker").handler({
+      task_id: "task_7",
+      description: "stuck",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "no_parent_to_block" });
+    expect(h.markBlocked).not.toHaveBeenCalled();
+    expect(h.mesh.reportBlocker).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["task_id", { description: "d" }],
+    ["description", { task_id: "task_7" }],
+  ])("rejects a call missing %s before any lookup", async (_l, input) => {
+    const h = meshHarness();
+    const result = await toolNamed(h, "report_blocker").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "task_id and description required" });
+    expect(h.findParent).not.toHaveBeenCalled();
+  });
+
+  it("does not claim the blocker was reported when marking it blocked fails", async () => {
+    const h = meshHarness();
+    h.markBlocked.mockRejectedValueOnce(new Error("task task_7 not found"));
+    const result = await toolNamed(h, "report_blocker").handler({
+      task_id: "task_7",
+      description: "stuck",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "task task_7 not found" });
+    expect(h.mesh.reportBlocker).not.toHaveBeenCalled();
+  });
+});
+
+describe("escalate_to_humans", () => {
+  it("creates the escalation, unblocks the peer, then notifies subscribers", async () => {
+    const h = meshHarness();
+    const result = await toolNamed(h, "escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "We disagree on the rollout order.",
+      proposals: [{ title: "A", description: "ship first" }],
+      open_questions: ["when is the customer demo?", 42],
+    });
+
+    expect(h.createEscalation).toHaveBeenCalledWith({
+      negotiationId: "neg_1",
+      callerAgentId: "agent_x",
+      summary: "We disagree on the rollout order.",
+      proposals: [{ title: "A", description: "ship first" }],
+      // Non-string open questions are filtered out.
+      openQuestions: ["when is the customer demo?"],
+    });
+    expect(h.mesh.unblockOnEscalate).toHaveBeenCalledWith("neg_1", "esc_1");
+    expect(h.query).toHaveBeenCalledWith(
+      expect.stringContaining("escalation_created"),
+      ["esc_1"],
+    );
+    expect(result.content).toEqual({
+      escalation_id: "esc_1",
+      status: "open",
+      negotiation_id: "neg_1",
+    });
+  });
+
+  it.each([
+    ["proposals", "proposals"],
+    ["open questions", "open_questions"],
+  ])("omits %s when the arg is not an array", async (_l, key) => {
+    const h = meshHarness();
+    await toolNamed(h, "escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "s",
+      [key]: "not an array",
+    });
+
+    const camel = key === "proposals" ? "proposals" : "openQuestions";
+    expect(h.createEscalation.mock.calls[0]![0]).toMatchObject({
+      [camel]: undefined,
+    });
+  });
+
+  it.each([
+    ["negotiation_id", { summary: "s" }],
+    ["summary", { negotiation_id: "neg_1" }],
+  ])("rejects a call missing %s", async (_l, input) => {
+    const h = meshHarness();
+    const result = await toolNamed(h, "escalate_to_humans").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "negotiation_id and summary required",
+    });
+    expect(h.createEscalation).not.toHaveBeenCalled();
+  });
+
+  it("does not unblock the peer when the escalation could not be created", async () => {
+    const h = meshHarness();
+    h.createEscalation.mockRejectedValueOnce(new Error("negotiation already resolved"));
+    const result = await toolNamed(h, "escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "s",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "negotiation already resolved" });
+    expect(h.mesh.unblockOnEscalate).not.toHaveBeenCalled();
+    expect(h.query).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/tools/session-search.test.ts
+++ b/packages/api/src/tools/session-search.test.ts
@@ -1,0 +1,301 @@
+/**
+ * session_search handler tests.
+ *
+ * The tool's real work is shape inference: four calling shapes are
+ * distinguished by which args are present, and the precedence between
+ * them (scroll beats read beats discover beats browse) is what decides
+ * whether an agent gets a message window or a whole transcript. The
+ * service behind it needs Postgres FTS; the inference and the error
+ * envelopes don't, so they're pinned here against a fake.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type {
+  HierarchyLevel,
+  SessionSearchRequest,
+  SessionSearchResult,
+} from "@beevibe/core";
+import {
+  SessionSearchError,
+  type SessionSearchService,
+} from "@beevibe/core/services/session-search";
+import { createSessionSearchTool } from "./session-search.js";
+
+const CTX = {
+  agentId: "agent_a",
+  hierarchyLevel: "team" as HierarchyLevel,
+  sessionId: "ses_current",
+};
+
+type SearchArgs = Parameters<SessionSearchService["search"]>;
+
+function harness(behavior: { result?: unknown; throws?: unknown } = {}) {
+  const search = vi.fn(async (..._args: SearchArgs) => {
+    if ("throws" in behavior) throw behavior.throws;
+    const fallback = { kind: "browse", sessions: [] };
+    return ("result" in behavior
+      ? behavior.result
+      : fallback) as SessionSearchResult | null;
+  });
+  const sessionSearch = { search } as unknown as SessionSearchService;
+  return { tool: createSessionSearchTool(CTX, { sessionSearch }), search };
+}
+
+/** The request the tool inferred from a given raw tool input. */
+async function inferred(
+  input: Record<string, unknown>,
+): Promise<SessionSearchRequest> {
+  const h = harness();
+  await h.tool.handler(input);
+  const req = h.search.mock.calls[0]?.[0];
+  if (!req) throw new Error("sessionSearch.search was never called");
+  return req;
+}
+
+describe("session_search — shape inference", () => {
+  it("browses when nothing is passed", async () => {
+    expect(await inferred({})).toEqual({
+      kind: "browse",
+      limit: undefined,
+      filters: undefined,
+    });
+  });
+
+  it("discovers when a query is passed", async () => {
+    expect(await inferred({ query: "auth refactor", limit: 5, sort: "newest" })).toEqual({
+      kind: "discover",
+      query: "auth refactor",
+      limit: 5,
+      sort: "newest",
+      filters: undefined,
+    });
+  });
+
+  it("reads when a bare session_id is passed", async () => {
+    expect(await inferred({ session_id: "ses_9" })).toEqual({
+      kind: "read",
+      session_id: "ses_9",
+    });
+  });
+
+  it("scrolls when session_id and around_message_id are both passed", async () => {
+    expect(
+      await inferred({
+        session_id: "ses_9",
+        around_message_id: "evt_3",
+        window: 10,
+      }),
+    ).toEqual({
+      kind: "scroll",
+      session_id: "ses_9",
+      around_message_id: "evt_3",
+      window: 10,
+    });
+  });
+
+  it("lets scroll win over discover when a query tags along", async () => {
+    // The tool description promises `query` is ignored once
+    // session_id + around_message_id are set.
+    expect(
+      await inferred({
+        query: "auth refactor",
+        session_id: "ses_9",
+        around_message_id: "evt_3",
+      }),
+    ).toMatchObject({ kind: "scroll" });
+  });
+
+  it("lets read win over discover when a query tags along", async () => {
+    expect(
+      await inferred({ query: "auth refactor", session_id: "ses_9" }),
+    ).toMatchObject({ kind: "read", session_id: "ses_9" });
+  });
+
+  it("accepts the synthetic user-turn anchor id format", async () => {
+    expect(
+      await inferred({ session_id: "ses_9", around_message_id: "intent:ses_9" }),
+    ).toMatchObject({ kind: "scroll", around_message_id: "intent:ses_9" });
+  });
+});
+
+describe("session_search — argument normalization", () => {
+  it("trims the string args", async () => {
+    expect(
+      await inferred({ session_id: "  ses_9  ", around_message_id: "  evt_3  " }),
+    ).toMatchObject({ session_id: "ses_9", around_message_id: "evt_3" });
+    expect(await inferred({ query: "  auth  " })).toMatchObject({
+      query: "auth",
+    });
+  });
+
+  it.each([
+    ["whitespace-only", "   "],
+    ["empty", ""],
+    ["a non-string", 42],
+  ])("treats a %s session_id as absent, falling back to browse", async (_l, sessionId) => {
+    expect(await inferred({ session_id: sessionId })).toMatchObject({
+      kind: "browse",
+    });
+  });
+
+  it("treats a whitespace-only anchor as absent, degrading scroll to read", async () => {
+    expect(
+      await inferred({ session_id: "ses_9", around_message_id: "   " }),
+    ).toMatchObject({ kind: "read" });
+  });
+
+  it("treats a whitespace-only query as absent, degrading discover to browse", async () => {
+    expect(await inferred({ query: "   " })).toMatchObject({ kind: "browse" });
+  });
+
+  it.each([
+    ["a numeric string", "10"],
+    ["null", null],
+  ])("drops a %s limit so the service default applies", async (_l, limit) => {
+    expect(await inferred({ query: "x", limit })).toMatchObject({
+      limit: undefined,
+    });
+  });
+
+  it("drops a non-numeric window so the service clamp default applies", async () => {
+    expect(
+      await inferred({ session_id: "s", around_message_id: "m", window: "10" }),
+    ).toMatchObject({ window: undefined });
+  });
+
+  it("drops a sort value outside newest|oldest", async () => {
+    expect(await inferred({ query: "x", sort: "relevance" })).toMatchObject({
+      sort: undefined,
+    });
+    expect(await inferred({ query: "x", sort: "oldest" })).toMatchObject({
+      sort: "oldest",
+    });
+  });
+
+  it("passes filters through on both the discover and browse shapes", async () => {
+    const filters = { status: "failed", session_type: "task" };
+    expect(await inferred({ query: "x", filters })).toMatchObject({ filters });
+    expect(await inferred({ filters })).toMatchObject({ filters });
+  });
+
+  it.each([
+    ["null", null],
+    ["a string", "status=failed"],
+  ])("drops %s filters", async (_l, filters) => {
+    expect(await inferred({ filters })).toMatchObject({ filters: undefined });
+  });
+});
+
+describe("session_search — caller context", () => {
+  it("passes the caller's tier and active session to the service", async () => {
+    const h = harness();
+    await h.tool.handler({ query: "x" });
+
+    expect(h.search.mock.calls[0]?.[1]).toEqual({
+      callerAgentId: "agent_a",
+      hierarchyLevel: "team",
+      currentSessionId: "ses_current",
+    });
+  });
+
+  it("returns the service result verbatim", async () => {
+    const payload = { kind: "read", session: { id: "ses_9" }, messages: [] };
+    const h = harness({ result: payload });
+    const result = await h.tool.handler({ session_id: "ses_9" });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toBe(payload);
+  });
+});
+
+describe("session_search — error envelopes", () => {
+  it("maps a null result to not_found_or_forbidden", async () => {
+    const h = harness({ result: null });
+    const result = await h.tool.handler({ session_id: "ses_other" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "not_found_or_forbidden" });
+  });
+
+  it("keeps a SessionSearchError's structured code", async () => {
+    const h = harness({
+      throws: new SessionSearchError(
+        "forbidden_agent_filter",
+        "agent_z is outside your scope",
+      ),
+    });
+    const result = await h.tool.handler({
+      query: "x",
+      filters: { agent_id: "agent_z" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "forbidden_agent_filter",
+      message: "agent_z is outside your scope",
+    });
+  });
+
+  it("matches a cross-bundle SessionSearchError by name, not just instanceof", async () => {
+    // src/ and dist/ copies of core produce distinct classes, so the
+    // handler falls back to the error name. Simulate the src-side twin.
+    const twin = Object.assign(new Error("query is required"), {
+      name: "SessionSearchError",
+      code: "missing_query",
+    });
+    const h = harness({ throws: twin });
+    const result = await h.tool.handler({ query: "x" });
+
+    expect(result.content).toEqual({
+      error: "missing_query",
+      message: "query is required",
+    });
+  });
+
+  it("wraps an unexpected Error as internal_error", async () => {
+    const h = harness({ throws: new Error("connection terminated") });
+    const result = await h.tool.handler({ query: "x" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "internal_error",
+      message: "connection terminated",
+    });
+  });
+
+  it("stringifies a non-Error throw", async () => {
+    const h = harness({ throws: { code: 42 } });
+    const result = await h.tool.handler({ query: "x" });
+
+    expect(result.content).toMatchObject({ error: "internal_error" });
+    expect(typeof result.content.message).toBe("string");
+  });
+});
+
+describe("session_search — tool surface", () => {
+  it("has no required args, since browse is the no-arg shape", () => {
+    const { tool } = harness();
+    expect(tool.name).toBe("session_search");
+    expect(tool.schema.required).toBeUndefined();
+  });
+
+  it("enumerates the session type and status filters from the domain constants", () => {
+    const { tool } = harness();
+    const filters = (
+      tool.schema.properties as {
+        filters: {
+          properties: {
+            session_type: { enum: string[] };
+            status: { enum: string[] };
+          };
+        };
+      }
+    ).filters.properties;
+
+    expect(filters.session_type.enum).toEqual(
+      expect.arrayContaining(["task", "chat", "run_repo"]),
+    );
+    expect(filters.status.enum).toEqual(
+      expect.arrayContaining(["failed", "succeeded"]),
+    );
+  });
+});

--- a/packages/api/src/tools/use-repo.test.ts
+++ b/packages/api/src/tools/use-repo.test.ts
@@ -1,0 +1,415 @@
+/**
+ * use_repo handler tests.
+ *
+ * The tool is the Capability Network's write path: it mints a container
+ * task, dispatches a `run_repo` session under a pre-minted session id,
+ * then inserts the repo_run row that the daemon's dispatch payload
+ * composer looks up by that session id. The ordering and the two
+ * partial-failure envelopes are the whole contract — everything the
+ * daemon sees depends on them, and neither is reachable from the e2e
+ * sandbox script, so they're pinned here with fakes.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  RepoRun,
+  RepoRunRepository,
+  Task,
+  TaskRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import { createUseRepoTool, type UseRepoServices } from "./use-repo.js";
+
+const AGENT: Agent = {
+  id: "agent_caller",
+  name: "Caller",
+  owner_id: "user_1",
+  hierarchy_level: "ic",
+  runtime_config: {} as Agent["runtime_config"],
+  created_at: new Date("2025-01-01T00:00:00Z"),
+  updated_at: new Date("2025-01-01T00:00:00Z"),
+};
+
+interface Harness {
+  services: UseRepoServices;
+  dispatchCalls: Array<Record<string, unknown>>;
+  taskCreateCalls: Array<Record<string, unknown>>;
+  repoRunCreateCalls: Array<Record<string, unknown>>;
+  /** Records the order tool-visible writes happened in. */
+  order: string[];
+}
+
+function harness(
+  overrides: {
+    agent?: Agent | undefined;
+    dispatchThrows?: unknown;
+    repoRunThrows?: unknown;
+  } = {},
+): Harness {
+  const dispatchCalls: Array<Record<string, unknown>> = [];
+  const taskCreateCalls: Array<Record<string, unknown>> = [];
+  const repoRunCreateCalls: Array<Record<string, unknown>> = [];
+  const order: string[] = [];
+
+  const agent = "agent" in overrides ? overrides.agent : AGENT;
+
+  const agentRepo = {
+    findById: vi.fn(async () => agent),
+  } as unknown as AgentRepository;
+
+  const taskRepo = {
+    create: vi.fn(async (row: Record<string, unknown>) => {
+      order.push("task.create");
+      taskCreateCalls.push(row);
+      return { ...row, status: "pending" } as unknown as Task;
+    }),
+  } as unknown as TaskRepository;
+
+  const repoRunRepo = {
+    create: vi.fn(async (row: Record<string, unknown>) => {
+      order.push("repoRun.create");
+      repoRunCreateCalls.push(row);
+      if ("repoRunThrows" in overrides) throw overrides.repoRunThrows;
+      return row as unknown as RepoRun;
+    }),
+  } as unknown as RepoRunRepository;
+
+  const dispatchService = {
+    dispatchTask: vi.fn(async (input: Record<string, unknown>) => {
+      order.push("dispatch");
+      dispatchCalls.push(input);
+      if ("dispatchThrows" in overrides) throw overrides.dispatchThrows;
+      return { sessionId: input.sessionIdOverride } as never;
+    }),
+  } as unknown as DispatchService;
+
+  return {
+    services: { agentRepo, taskRepo, repoRunRepo, dispatchService },
+    dispatchCalls,
+    taskCreateCalls,
+    repoRunCreateCalls,
+    order,
+  };
+}
+
+function tool(h: Harness) {
+  return createUseRepoTool({ agentId: "agent_caller" }, h.services);
+}
+
+describe("use_repo — input validation", () => {
+  it.each([
+    ["missing goal", { repo_url: "https://github.com/o/r" }],
+    ["blank goal", { goal: "   ", repo_url: "https://github.com/o/r" }],
+    ["non-string goal", { goal: 42, repo_url: "https://github.com/o/r" }],
+  ])("rejects %s before touching any repository", async (_label, input) => {
+    const h = harness();
+    const result = await tool(h).handler(input as Record<string, unknown>);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "invalid_goal" });
+    expect(h.services.agentRepo.findById).not.toHaveBeenCalled();
+    expect(h.order).toEqual([]);
+  });
+
+  it.each([
+    ["missing repo_url", undefined],
+    ["blank repo_url", "   "],
+    ["a non-GitHub host", "https://gitlab.com/o/r"],
+    // The hostname anchor is `(^|\.)github\.com$` — a lookalike domain
+    // that merely *contains* github.com must not slip through.
+    ["a lookalike host", "https://github.com.evil.test/o/r"],
+    ["plain http", "http://github.com/o/r"],
+    ["a git+ssh remote", "git@github.com:o/r.git"],
+    ["an unparseable url", "not a url at all"],
+  ])("rejects %s", async (_label, repoUrl) => {
+    const h = harness();
+    const result = await tool(h).handler({
+      goal: "extract the tables",
+      ...(repoUrl === undefined ? {} : { repo_url: repoUrl }),
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "invalid_repo_url" });
+    expect(h.order).toEqual([]);
+  });
+
+  it("accepts a github subdomain and trims surrounding whitespace", async () => {
+    const h = harness();
+    const result = await tool(h).handler({
+      goal: "  extract the tables  ",
+      repo_url: "  https://www.github.com/o/r  ",
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(h.repoRunCreateCalls[0]).toMatchObject({
+      goal: "extract the tables",
+      repo_url: "https://www.github.com/o/r",
+    });
+  });
+
+  it("returns agent_not_found when the bv_a_ token resolves to nothing", async () => {
+    const h = harness({ agent: undefined });
+    const result = await tool(h).handler({
+      goal: "extract the tables",
+      repo_url: "https://github.com/o/r",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "agent_not_found" });
+    expect(h.order).toEqual([]);
+  });
+});
+
+describe("use_repo — happy path", () => {
+  it("dispatches the session BEFORE inserting repo_run, under one session id", async () => {
+    const h = harness();
+    const result = await tool(h).handler({
+      goal: "Extract the tables from this PDF as JSON",
+      repo_url: "https://github.com/jsvine/pdfplumber",
+    });
+
+    // repo_run.session_id has an FK to session.id, so the dispatch that
+    // creates the session row has to land first.
+    expect(h.order).toEqual(["task.create", "dispatch", "repoRun.create"]);
+
+    const sessionIdValue = h.dispatchCalls[0]?.sessionIdOverride;
+    expect(sessionIdValue).toEqual(expect.any(String));
+    expect(h.repoRunCreateCalls[0]).toMatchObject({
+      session_id: sessionIdValue,
+      status: "pending",
+    });
+    expect(result.content).toMatchObject({
+      session_id: sessionIdValue,
+      status: "pending",
+    });
+  });
+
+  it("pins the container task to the resolved agent as both creator and assignee", async () => {
+    const h = harness();
+    await tool(h).handler({
+      goal: "Extract the tables",
+      repo_url: "https://github.com/o/r",
+    });
+
+    expect(h.taskCreateCalls[0]).toMatchObject({
+      assignee_id: "agent_caller",
+      creator_id: "agent_caller",
+      creator_type: "agent",
+      priority: "medium",
+      description: "Extract the tables",
+    });
+  });
+
+  it("dispatches as a run_repo fresh session with the goal as intent", async () => {
+    const h = harness();
+    await tool(h).handler({
+      goal: "Extract the tables",
+      repo_url: "https://github.com/o/r",
+    });
+
+    expect(h.dispatchCalls[0]).toMatchObject({
+      agentId: "agent_caller",
+      type: "run_repo",
+      intent: "Extract the tables",
+      reason: { kind: "fresh" },
+    });
+    expect(h.dispatchCalls[0]?.task).toMatchObject({
+      id: h.taskCreateCalls[0]?.id,
+    });
+  });
+
+  it("returns the ids, the watch url and the polling hint", async () => {
+    const h = harness();
+    const result = await tool(h).handler({
+      goal: "Extract the tables",
+      repo_url: "https://github.com/o/r",
+    });
+
+    const repoRunId = h.repoRunCreateCalls[0]?.id as string;
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toMatchObject({
+      repo_run_id: repoRunId,
+      task_id: h.taskCreateCalls[0]?.id,
+      status: "pending",
+      watch_url: `/capabilities/runs/${repoRunId}`,
+    });
+    expect(String(result.content.note)).toContain("repo_run.status");
+  });
+
+  it("passes trimmed input_url + input_filename back to the caller", async () => {
+    const h = harness();
+    const result = await tool(h).handler({
+      goal: "Extract the tables",
+      repo_url: "https://github.com/o/r",
+      input_url: "  https://example.test/a.pdf  ",
+      input_filename: "  a.pdf  ",
+    });
+
+    expect(result.content).toMatchObject({
+      input_url: "https://example.test/a.pdf",
+      input_filename: "a.pdf",
+    });
+  });
+});
+
+describe("use_repo — container task title", () => {
+  it("collapses runs of whitespace so the inbox row is scannable", async () => {
+    const h = harness();
+    await tool(h).handler({
+      goal: "  extract\n\ttables   from   the PDF  ",
+      repo_url: "https://github.com/o/r",
+    });
+
+    expect(h.taskCreateCalls[0]?.title).toBe("extract tables from the PDF");
+  });
+
+  it("truncates past 80 chars with an ellipsis but keeps the goal intact", async () => {
+    const h = harness();
+    const goal = "x".repeat(200);
+    await tool(h).handler({ goal, repo_url: "https://github.com/o/r" });
+
+    const title = h.taskCreateCalls[0]?.title as string;
+    expect(title).toHaveLength(78); // 77 chars + the ellipsis
+    expect(title.endsWith("…")).toBe(true);
+    expect(h.taskCreateCalls[0]?.description).toBe(goal);
+  });
+
+  it("leaves an exactly-80-char title alone", async () => {
+    const h = harness();
+    const goal = "y".repeat(80);
+    await tool(h).handler({ goal, repo_url: "https://github.com/o/r" });
+
+    expect(h.taskCreateCalls[0]?.title).toBe(goal);
+  });
+});
+
+describe("use_repo — limits parsing", () => {
+  async function limitsOf(raw: unknown): Promise<Record<string, unknown>> {
+    const h = harness();
+    const result = await tool(h).handler({
+      goal: "g",
+      repo_url: "https://github.com/o/r",
+      ...(raw === undefined ? {} : { limits: raw }),
+    });
+    return result.content.limits as Record<string, unknown>;
+  }
+
+  it.each([
+    ["omitted", undefined],
+    ["null", null],
+    ["a string", "20"],
+    ["a number", 20],
+  ])("defaults to {} when limits is %s", async (_label, raw) => {
+    expect(await limitsOf(raw)).toEqual({});
+  });
+
+  it("passes through in-range values untouched", async () => {
+    expect(
+      await limitsOf({
+        wall_clock_minutes: 30,
+        max_install_attempts: 3,
+        disk_mb: 4096,
+      }),
+    ).toEqual({
+      wall_clock_minutes: 30,
+      max_install_attempts: 3,
+      disk_mb: 4096,
+    });
+  });
+
+  it("clamps each field to its ceiling", async () => {
+    expect(
+      await limitsOf({
+        wall_clock_minutes: 999,
+        max_install_attempts: 50,
+        disk_mb: 1_000_000,
+      }),
+    ).toEqual({
+      wall_clock_minutes: 60,
+      max_install_attempts: 5,
+      disk_mb: 10_000,
+    });
+  });
+
+  it("floors the integer-only fields but not the wall clock", async () => {
+    expect(
+      await limitsOf({
+        wall_clock_minutes: 12.5,
+        max_install_attempts: 2.9,
+        disk_mb: 512.7,
+      }),
+    ).toEqual({
+      wall_clock_minutes: 12.5,
+      max_install_attempts: 2,
+      disk_mb: 512,
+    });
+  });
+
+  it.each([
+    ["zero", 0],
+    ["negative", -5],
+    ["a numeric string", "10"],
+  ])("drops %s values rather than clamping them", async (_label, value) => {
+    expect(
+      await limitsOf({
+        wall_clock_minutes: value,
+        max_install_attempts: value,
+        disk_mb: value,
+      }),
+    ).toEqual({});
+  });
+});
+
+describe("use_repo — partial failure", () => {
+  it("returns dispatch_failed and never inserts an orphan repo_run", async () => {
+    const h = harness({ dispatchThrows: new Error("no runtime online") });
+    const result = await tool(h).handler({
+      goal: "g",
+      repo_url: "https://github.com/o/r",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "dispatch_failed",
+      message: "no runtime online",
+    });
+    expect(h.order).toEqual(["task.create", "dispatch"]);
+  });
+
+  it("stringifies a non-Error dispatch throw", async () => {
+    const h = harness({ dispatchThrows: "boom" });
+    const result = await tool(h).handler({
+      goal: "g",
+      repo_url: "https://github.com/o/r",
+    });
+
+    expect(result.content).toMatchObject({
+      error: "dispatch_failed",
+      message: "boom",
+    });
+  });
+
+  it("surfaces repo_run_create_failed rather than silently leaving the agent to wait", async () => {
+    const h = harness({ repoRunThrows: new Error("duplicate key") });
+    const result = await tool(h).handler({
+      goal: "g",
+      repo_url: "https://github.com/o/r",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "repo_run_create_failed",
+      message: "duplicate key",
+    });
+  });
+});
+
+describe("use_repo — tool surface", () => {
+  it("declares goal + repo_url as the only required inputs", () => {
+    const t = tool(harness());
+    expect(t.name).toBe("use_repo");
+    expect(t.schema.required).toEqual(["goal", "repo_url"]);
+    expect(t.schema.additionalProperties).toBe(false);
+  });
+});

--- a/packages/api/src/tools/watch.test.ts
+++ b/packages/api/src/tools/watch.test.ts
@@ -1,0 +1,234 @@
+/**
+ * watch_tasks + unwatch handler tests.
+ *
+ * Both tools are thin adapters: the service does the auth check, the
+ * insert and the already-terminal race fire. What lives *here* is the
+ * input coercion (what counts as a task id, what a missing mode
+ * defaults to) and the error-class → error-code mapping the calling
+ * agent branches on. WatchService itself needs Postgres to test, so
+ * these run against a fake and pin the adapter half.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  WatchAuthError,
+  WatchNotFoundError,
+  WatchValidationError,
+  type WatchService,
+} from "@beevibe/core/services/watch-service";
+import { buildWatchTools, type WatchToolContext } from "./watch.js";
+
+interface Harness {
+  tools: ReturnType<typeof buildWatchTools>;
+  watchTasks: ReturnType<typeof vi.fn>;
+  unwatch: ReturnType<typeof vi.fn>;
+}
+
+function harness(
+  ctx: WatchToolContext = { agentId: "agent_a", sessionId: "ses_1" },
+  behavior: { watchThrows?: unknown; unwatchThrows?: unknown } = {},
+): Harness {
+  const watchTasks = vi.fn(async () => {
+    if ("watchThrows" in behavior) throw behavior.watchThrows;
+    return { watchId: "tw_minted", firedImmediately: false };
+  });
+  const unwatch = vi.fn(async () => {
+    if ("unwatchThrows" in behavior) throw behavior.unwatchThrows;
+  });
+  const watchService = { watchTasks, unwatch } as unknown as WatchService;
+  return {
+    tools: buildWatchTools(ctx, { watchService }),
+    watchTasks,
+    unwatch,
+  };
+}
+
+const watchTasksTool = (h: Harness) => h.tools[0]!;
+const unwatchTool = (h: Harness) => h.tools[1]!;
+
+describe("buildWatchTools", () => {
+  it("returns watch_tasks then unwatch", () => {
+    expect(harness().tools.map((t) => t.name)).toEqual([
+      "watch_tasks",
+      "unwatch",
+    ]);
+  });
+
+  it("advertises the three watch modes on watch_tasks", () => {
+    const schema = watchTasksTool(harness()).schema as {
+      properties: { mode: { enum: string[] } };
+      required: string[];
+    };
+    expect(schema.required).toEqual(["task_ids"]);
+    expect(schema.properties.mode.enum).toEqual(
+      expect.arrayContaining(["all", "any"]),
+    );
+  });
+});
+
+describe("watch_tasks — input coercion", () => {
+  it("forwards the caller's agent + session ids alongside the task ids", async () => {
+    const h = harness();
+    const result = await watchTasksTool(h).handler({
+      task_ids: ["task_1", "task_2"],
+      mode: "any",
+      reason: "  need both results  ",
+    });
+
+    expect(h.watchTasks).toHaveBeenCalledWith({
+      callerAgentId: "agent_a",
+      callerSessionId: "ses_1",
+      taskIds: ["task_1", "task_2"],
+      mode: "any",
+      reason: "need both results",
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({
+      watch_id: "tw_minted",
+      fired_immediately: false,
+    });
+  });
+
+  it("reports fired_immediately when the tasks were already terminal", async () => {
+    const h = harness();
+    h.watchTasks.mockResolvedValueOnce({
+      watchId: "tw_race",
+      firedImmediately: true,
+    });
+
+    const result = await watchTasksTool(h).handler({ task_ids: ["task_1"] });
+    expect(result.content).toEqual({
+      watch_id: "tw_race",
+      fired_immediately: true,
+    });
+  });
+
+  it("defaults mode to 'all'", async () => {
+    const h = harness();
+    await watchTasksTool(h).handler({ task_ids: ["task_1"] });
+    expect(h.watchTasks.mock.calls[0]?.[0]).toMatchObject({ mode: "all" });
+  });
+
+  it("falls back to 'all' for a mode outside the enum", async () => {
+    const h = harness();
+    await watchTasksTool(h).handler({ task_ids: ["task_1"], mode: "either" });
+    expect(h.watchTasks.mock.calls[0]?.[0]).toMatchObject({ mode: "all" });
+  });
+
+  it.each([
+    ["omitted", undefined],
+    ["blank", "   "],
+    ["a non-string", 7],
+  ])("sends no reason when it is %s", async (_label, reason) => {
+    const h = harness();
+    await watchTasksTool(h).handler({
+      task_ids: ["task_1"],
+      ...(reason === undefined ? {} : { reason }),
+    });
+    expect(h.watchTasks.mock.calls[0]?.[0]).toMatchObject({
+      reason: undefined,
+    });
+  });
+
+  it("drops non-string entries from task_ids", async () => {
+    const h = harness();
+    await watchTasksTool(h).handler({
+      task_ids: ["task_1", 42, null, "task_2"],
+    });
+    expect(h.watchTasks.mock.calls[0]?.[0]).toMatchObject({
+      taskIds: ["task_1", "task_2"],
+    });
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["an empty array", []],
+    ["a bare string", "task_1"],
+    ["all non-strings", [1, 2, 3]],
+  ])("rejects task_ids that are %s without calling the service", async (_label, taskIds) => {
+    const h = harness();
+    const result = await watchTasksTool(h).handler(
+      taskIds === undefined ? {} : { task_ids: taskIds },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "watch_validation" });
+    expect(h.watchTasks).not.toHaveBeenCalled();
+  });
+
+  it("refuses to register a watch outside a session context", async () => {
+    const h = harness({ agentId: "agent_a" });
+    const result = await watchTasksTool(h).handler({ task_ids: ["task_1"] });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "watch_validation",
+      message: expect.stringContaining("session context"),
+    });
+    expect(h.watchTasks).not.toHaveBeenCalled();
+  });
+});
+
+describe("unwatch", () => {
+  it("delegates with the caller's agent id and reports ok", async () => {
+    const h = harness();
+    const result = await unwatchTool(h).handler({ watch_id: "tw_1" });
+
+    expect(h.unwatch).toHaveBeenCalledWith({
+      callerAgentId: "agent_a",
+      watchId: "tw_1",
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({ ok: true });
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["empty", ""],
+    ["a non-string", 12],
+  ])("rejects a watch_id that is %s", async (_label, watchId) => {
+    const h = harness();
+    const result = await unwatchTool(h).handler(
+      watchId === undefined ? {} : { watch_id: watchId },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "watch_validation" });
+    expect(h.unwatch).not.toHaveBeenCalled();
+  });
+});
+
+describe("error-class → error-code mapping", () => {
+  // The agent branches on `error`, so each service failure has to keep
+  // its own code rather than collapsing into the generic one.
+  it.each([
+    [new WatchAuthError("not your task"), "watch_auth", "not your task"],
+    [
+      new WatchValidationError("mode must be all|any"),
+      "watch_validation",
+      "mode must be all|any",
+    ],
+    [new WatchNotFoundError("tw_9"), "watch_not_found", "task_watch tw_9 not found"],
+    [new Error("connection reset"), "watch_error", "connection reset"],
+    ["a bare string throw", "watch_error", "a bare string throw"],
+  ])("maps %o to %s", async (thrown, code, message) => {
+    const watched = harness(
+      { agentId: "agent_a", sessionId: "ses_1" },
+      { watchThrows: thrown },
+    );
+    const watchResult = await watchTasksTool(watched).handler({
+      task_ids: ["task_1"],
+    });
+    expect(watchResult.isError).toBe(true);
+    expect(watchResult.content).toEqual({ error: code, message });
+
+    // unwatch shares the same mapper, so it must agree.
+    const unwatched = harness(
+      { agentId: "agent_a", sessionId: "ses_1" },
+      { unwatchThrows: thrown },
+    );
+    const unwatchResult = await unwatchTool(unwatched).handler({
+      watch_id: "tw_1",
+    });
+    expect(unwatchResult.content).toEqual({ error: code, message });
+  });
+});


### PR DESCRIPTION
## What this is

A coverage sweep across every package, then tests for the biggest real gap it found.

## The sweep

v8 line coverage per package, `--coverage.all`, DB- and key-gated suites excluded per the CLAUDE.md recipe (no Docker daemon in this sandbox, so Postgres-backed suites can't run):

| Package | Lines | Functions |
| --- | --- | --- |
| `@beevibe/api` | **64.5%** | **83.6%** |
| `@beevibe/sandbox` | 75.1% | 88.1% |
| `@beevibe/daemon` | 80.4% | 92.4% |
| `@beevibe/core` | 53.4%\* | 77.3%\* |

\* Core's number is an artifact of the exclusions, not a real gap — everything under 90% there is either a suite I had to exclude (`watch-service`, the `postgres/*` repos, the codex/openai/anthropic adapters) or a types-only barrel that v8 counts as uncovered lines. Core is in good shape.

That left `@beevibe/api` as the genuine low. Four of its MCP tool modules were most of the gap — three had no test file at all, and `mesh.ts` had only an assembly test that checks tool *names*.

## What changed

| File | Before | After |
| --- | --- | --- |
| `packages/api/src/tools/use-repo.ts` | 32.0% | **100%** |
| `packages/api/src/tools/watch.ts` | 46.3% | **100%** |
| `packages/api/src/tools/session-search.ts` | 64.7% | **100%** |
| `packages/api/src/tools/mesh.ts` | 45.9% | **100%** |

Functions on all four: 20–50% → 100%.

These four are the agent-facing write path — reachable by any agent holding an MCP session. Each is a thin adapter over a service that needs live Postgres (and, for mesh, spawned CLI subprocesses) to exercise end to end, which is why they went untested: the m6/m7 e2e scripts cover the service half and nothing covered the adapter half. The adapter half is exactly what a fake can reach, so the new tests go after what the e2e scripts structurally can't see:

- **`use_repo`** — the dispatch-before-`repo_run` ordering the daemon's payload composer depends on (`repo_run.session_id` has an FK to `session.id`); both partial-failure envelopes; the GitHub URL check, including a `github.com.evil.test` lookalike that the hostname anchor has to reject; the limit clamps; container-task title truncation.
- **`watch_tasks` / `unwatch`** — task-id coercion, the mode default and enum fallback, and the error-class → error-code mapping the calling agent branches on, asserted identically across both tools since they share one mapper.
- **`session_search`** — the four calling shapes and their precedence (scroll > read > discover > browse), argument normalization, and the cross-bundle `SessionSearchError` match-by-name path that exists precisely because `instanceof` fails across a src/dist boundary.
- **mesh's six tools** — argument validation, response projections (including the escalated sentinel), the coded-error envelopes (`MESH_CAPACITY_EXCEEDED`, `CANNOT_NEGOTIATE_WITH_IC`, `MAX_ROUNDS_EXCEEDED`), and that a failure part-way through a multi-step handler never reports success anyway: a failed `markBlocked` must not spawn the parent, a failed escalation create must not unblock the peer.

Package totals: lines **64.5% → 69.7%**, functions **83.6% → 89.1%**. 126 new tests.

## Verification

- `pnpm --filter @beevibe/api test` — 46 files / 944 tests pass. The 9 failing files are the documented `DATABASE_URL_TEST` baseline, unchanged by this PR.
- `turbo run typecheck lint --filter=@beevibe/api` — clean (the 4 lint warnings are pre-existing `import/no-duplicates` in `negotiation.test.ts` and `ws-server.test.ts`).

Tests only — no production code touched. Per CLAUDE.md, `@vitest/coverage-v8` was installed for the sweep and is deliberately **not** committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DssZVFHFhhoEW7izprpiZ8

---
_Generated by [Claude Code](https://claude.ai/code/session_01DssZVFHFhhoEW7izprpiZ8)_