### PR TITLE
chore: remove dead CSS and an unused test binding found by a full sweep

### DIFF
--- a/packages/core/src/process-lifecycle.test.ts
+++ b/packages/core/src/process-lifecycle.test.ts
@@ -94,7 +94,7 @@ describe("installShutdownHandlers", () => {
   });
 
   it("handles SIGINT and SIGTERM alike", async () => {
-    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     const shutdown = vi.fn().mockResolvedValue(undefined);
 

--- a/packages/web/app/globals.css
+++ b/packages/web/app/globals.css
@@ -119,19 +119,6 @@
   }
 }
 
-.timeline-rail {
-  position: relative;
-}
-.timeline-rail::before {
-  content: "";
-  position: absolute;
-  left: 11px;
-  top: 8px;
-  bottom: 8px;
-  width: 1px;
-  background: hsl(var(--border));
-}
-
 /* Pearl button — sidebar New chat CTA. Adapted from Uiverse.io by
    marcelodolza, recolored to the app's honey primary. The .wrap
    pseudo-elements render the glossy top cap and rising under-glow. */
@@ -268,10 +255,10 @@
    material instead of solid blocks against shiny pearls.
 
    Use `.glass-surface` for popovers, composers, peek panels — anything
-   that hosts content. Use `.glass-bubble-agent` / `.glass-bubble-user`
-   for chat message bubbles. All three need a non-solid backdrop behind
-   them to read correctly; the chat surface's gradient + the sidebar's
-   `bg-card` both qualify. */
+   that hosts content. Use `.glass-bubble-user` for user chat message
+   bubbles; agent replies render unbubbled. Both need a non-solid
+   backdrop behind them to read correctly; the chat surface's gradient +
+   the sidebar's `bg-card` both qualify. */
 .glass-surface {
   background-color: hsl(var(--card) / 0.55);
   /* Apple Liquid Glass cues: heavy blur picks up backdrop variation, the
@@ -296,21 +283,6 @@
   .dark .glass-surface { background-color: hsl(var(--card) / 0.92); }
 }
 
-/* Agent message — neutral translucent bubble. Drops the solid
-   bg-secondary block in favor of a frosted variant that lets the
-   gradient backdrop bleed through. */
-.glass-bubble-agent {
-  background-color: hsl(var(--secondary) / 0.5);
-  backdrop-filter: blur(20px) saturate(180%);
-  -webkit-backdrop-filter: blur(20px) saturate(180%);
-  color: hsl(var(--foreground));
-  box-shadow: inset 0 1px 0 hsl(0 0% 100% / 0.06);
-}
-.dark .glass-bubble-agent {
-  background-color: hsl(var(--secondary) / 0.4);
-  box-shadow: inset 0 1px 0 hsl(0 0% 100% / 0.05);
-}
-
 /* User message — replaces the saturated bg-primary yellow with a low-
    opacity tint + brand-colored border. Brand reads as accent instead
    of dominating the column; short prompts stop looking like billboards. */
@@ -329,7 +301,6 @@
 }
 
 @supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
-  .glass-bubble-agent { background-color: hsl(var(--secondary) / 0.9); }
   .glass-bubble-user { background-color: hsl(var(--primary) / 0.22); }
 }
 
@@ -843,7 +814,6 @@
 
 @media (prefers-reduced-motion: reduce) {
   .animate-pulse-breathe,
-  .animate-spin-slow,
   .animate-row-flash {
     animation: none !important;
   }

--- a/packages/web/tailwind.config.ts
+++ b/packages/web/tailwind.config.ts
@@ -79,9 +79,6 @@ const config: Config = {
           "0%, 100%": { opacity: "1", transform: "scale(1)" },
           "50%": { opacity: "0.55", transform: "scale(0.92)" },
         },
-        "spin-slow": {
-          to: { transform: "rotate(360deg)" },
-        },
         "row-flash": {
           "0%": { backgroundColor: "hsl(48 96% 53% / 0.16)" },
           "100%": { backgroundColor: "transparent" },
@@ -96,7 +93,6 @@ const config: Config = {
       },
       animation: {
         "pulse-breathe": "pulse-breathe 2s ease-in-out infinite",
-        "spin-slow": "spin-slow 2.5s linear infinite",
         "row-flash": "row-flash 1200ms ease-out",
         "step-pop": "step-pop 260ms ease-out",
       },


### PR DESCRIPTION
## Summary

A static + dynamic dead-code sweep across all six packages. The TypeScript surface came back **already clean** — #285 swept it four commits ago and nothing has re-accumulated. The residue is in the one place those tools don't look, the stylesheet, plus one unused binding lint was already flagging.

Net: **-39 / +5 lines**, three dead CSS rules gone from the shipped bundle.

## What was removed, and why

| Removed | Why it's dead |
| --- | --- |
| `.timeline-rail` + `::before` (`globals.css`) | Added in #226 for the mesh timeline, never applied to an element since. No `.tsx` in the repo references it. |
| `.glass-bubble-agent` + its `.dark` and `@supports` fallback rules | The agent bubble design was dropped. `chat-client.tsx` renders agent replies unbubbled as a bare `<div className="py-1 text-sm leading-6 text-foreground/90">`. Its sibling `.glass-bubble-user` **is** still applied and is left in place. |
| `spin-slow` keyframe + animation entry (`tailwind.config.ts`), and the `.animate-spin-slow` line in the `prefers-reduced-motion` block | Nothing uses the generated `animate-spin-slow` utility — the consumer went away in #256 and left the definitions behind. |
| `const exit =` binding in `process-lifecycle.test.ts` | The test asserts on `shutdown`, not the spy. Only the binding goes — the `vi.spyOn(process, "exit")` call is load-bearing (it keeps the test from really exiting), matching the `console.error` spy on the next line. This was the only `no-unused-vars` warning in the monorepo. |

The block comment above `.glass-surface` documented both bubble halves, so it's updated to describe what actually ships. The three animations sharing those blocks — `pulse-breathe`, `row-flash`, `step-pop` — are all still in use and untouched.

## Verification

- `pnpm lint` — clean, and the one `no-unused-vars` warning is gone
- `pnpm typecheck` — clean, all 9 tasks
- `process-lifecycle.test.ts` — 11/11 pass
- `next build` — succeeds (run directly, bypassing the documented Turbo/proxy font issue)
- Diffed the **emitted stylesheet**: `glass-bubble-agent`, `timeline-rail`, `animate-spin-slow` are gone from the shipped CSS; `glass-bubble-user`, `animate-row-flash`, `animate-pulse-breathe` survive

## What the sweep checked and cleared

Everything else the tooling reported is a documented false positive:

- `tsc --noUnusedLocals --noUnusedParameters` and `--allowUnreachableCode false` — clean on all six packages
- **knip**: 7 unused files (migrations, sandbox scripts, shell-invoked scripts), unused deps (`node-pg-migrate`, `zod`, `postcss`, `autoprefixer`, `prettier`), and all 12 unused-export hits — each of the 12 is used inside its own declaring file, the "redundant export, not dead code" case
- **Name-based sweep** of all 597 exported values and 514 exported types across the monorepo (knip can't see past `@beevibe/core`'s subpath barrels): zero dead
- **Class methods**: all 399 swept. The 15 uncalled repository read methods are port-interface halves of live audit trails that CLAUDE.md marks as not ours to delete.
- **depcheck** and an independent unreferenced-file sweep: documented false positives only
- **Coverage** (v8, provider installed for the sweep and not committed): every 0% file was a Docker/key-gated suite excluded from the run, not dead code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oTdzmT4pfUrmGpLxMSCNi

---
_Generated by [Claude Code](https://claude.ai/code/session_013oTdzmT4pfUrmGpLxMSCNi)_