### PR TITLE
refactor: unify near-duplicate declarations across packages (fixes a silent `?lifecycle=` filter drop)

### DIFF
--- a/packages/api/src/routes/http-errors.test.ts
+++ b/packages/api/src/routes/http-errors.test.ts
@@ -3,6 +3,7 @@ import type { Request, Response } from "express";
 import {
   invalidBody,
   loadOwned,
+  requireEmail,
   requireNullableString,
   requireParam,
 } from "./http-errors.js";
@@ -217,5 +218,50 @@ describe("requireNullableString", () => {
     expect(res.body).toMatchObject({
       message: "expected { runtime_id: string | null }",
     });
+  });
+});
+
+describe("requireEmail", () => {
+  it("returns a well-formed address unchanged", () => {
+    const res = fakeRes();
+    expect(requireEmail(fakeBodyReq({ email: "dev@beevibe.ai" }), res)).toBe(
+      "dev@beevibe.ai",
+    );
+    expect(res.statusCode).toBeUndefined();
+  });
+
+  it("normalizes case and surrounding whitespace", () => {
+    // findByEmail is an exact match, so signup and signin must agree on
+    // the stored form or the account becomes unreachable.
+    const res = fakeRes();
+    expect(requireEmail(fakeBodyReq({ email: "  Dev@BeeVibe.AI  " }), res)).toBe(
+      "dev@beevibe.ai",
+    );
+  });
+
+  it.each([
+    ["absent", {}],
+    ["empty", { email: "" }],
+    ["whitespace only", { email: "   " }],
+    ["no @", { email: "devbeevibe.ai" }],
+    ["no domain dot", { email: "dev@beevibe" }],
+    ["no local part", { email: "@beevibe.ai" }],
+    ["inner whitespace", { email: "dev name@beevibe.ai" }],
+    ["wrong type", { email: 42 }],
+    ["null", { email: null }],
+  ])("400s invalid_email on %s", (_label, body) => {
+    const res = fakeRes();
+    expect(requireEmail(fakeBodyReq(body), res)).toBeUndefined();
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      error: "invalid_email",
+      message: "valid email required",
+    });
+  });
+
+  it("400s rather than throwing when there is no body at all", () => {
+    const res = fakeRes();
+    expect(requireEmail(fakeBodyReq(undefined), res)).toBeUndefined();
+    expect(res.statusCode).toBe(400);
   });
 });

--- a/packages/api/src/routes/http-errors.ts
+++ b/packages/api/src/routes/http-errors.ts
@@ -34,6 +34,42 @@ export function requireParam(
 }
 
 /**
+ * Shape check for an email address in a request body.
+ *
+ * `signin` and `signup` each carried a byte-identical copy of this
+ * regex. They are the two halves of one credential flow, so a drift
+ * between them is worse than the usual duplication: tightening one side
+ * alone would let a visitor create an account at an address they then
+ * can't sign in with (or vice versa). Deliberately permissive — it
+ * rejects obvious junk, and delivery is the real check.
+ */
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Read and normalize a body `email`, 400-ing when it's absent or
+ * malformed.
+ *
+ * Normalization (trim + lowercase) is part of the contract rather than
+ * the caller's job: `personRepo.findByEmail` does an exact match, so
+ * signup storing `Foo@Bar.com` while signin looks up `foo@bar.com` would
+ * be an account the owner can't reach. Both routes already lowercased —
+ * this makes it impossible for one of them to stop.
+ *
+ * Returns `undefined` after responding, so the caller's next line is
+ * `if (!email) return;` — the same guard convention as `requireParam`.
+ */
+export function requireEmail(req: Request, res: Response): string | undefined {
+  const body = req.body as Record<string, unknown> | undefined;
+  const raw = body?.email;
+  const email = typeof raw === "string" ? raw.trim().toLowerCase() : "";
+  if (!email || !EMAIL_RE.test(email)) {
+    res.status(400).json({ error: "invalid_email", message: "valid email required" });
+    return undefined;
+  }
+  return email;
+}
+
+/**
  * The 400 a handler returns when the request body doesn't typecheck.
  *
  * Six handlers across `view`, `learned-skills` and `me` wrote out the

--- a/packages/api/src/routes/signin.ts
+++ b/packages/api/src/routes/signin.ts
@@ -29,15 +29,13 @@
 import { Router } from "express";
 import type { PersonRepository } from "@beevibe/core";
 import { SIGNIN_NO_PASSWORD_SET, verifyPassword } from "@beevibe/core/auth";
-import { makeErrorHandler } from "./http-errors.js";
+import { makeErrorHandler, requireEmail } from "./http-errors.js";
 
 export interface SigninRoutesDeps {
   personRepo: PersonRepository;
   /** Default true. Set to false to 404 the route. */
   enabled?: boolean;
 }
-
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 const handleError = makeErrorHandler("signin route");
 
@@ -51,17 +49,11 @@ export function createSigninRouter(deps: SigninRoutesDeps): Router {
       return;
     }
     try {
-      const body = (req.body ?? {}) as Record<string, unknown>;
-      const email =
-        typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
-      const password = typeof body.password === "string" ? body.password : "";
+      const email = requireEmail(req, res);
+      if (!email) return;
 
-      if (!email || !EMAIL_RE.test(email)) {
-        res
-          .status(400)
-          .json({ error: "invalid_email", message: "valid email required" });
-        return;
-      }
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const password = typeof body.password === "string" ? body.password : "";
       if (!password) {
         res.status(400).json({
           error: "invalid_password",

--- a/packages/api/src/routes/signup.ts
+++ b/packages/api/src/routes/signup.ts
@@ -30,7 +30,7 @@ import {
   validatePasswordShape,
   verifyPassword,
 } from "@beevibe/core/auth";
-import { makeErrorHandler } from "./http-errors.js";
+import { makeErrorHandler, requireEmail } from "./http-errors.js";
 
 export interface SignupRoutesDeps {
   agentRepo: AgentRepository;
@@ -41,7 +41,6 @@ export interface SignupRoutesDeps {
 }
 
 const NAME_RE = /^[\p{L}\p{N} '\-_.]{1,80}$/u;
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 const handleError = makeErrorHandler("signup route");
 
@@ -57,8 +56,6 @@ export function createSignupRouter(deps: SignupRoutesDeps): Router {
     try {
       const body = (req.body ?? {}) as Record<string, unknown>;
       const name = typeof body.name === "string" ? body.name.trim() : "";
-      const email =
-        typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
       const password = typeof body.password === "string" ? body.password : "";
 
       if (!name || !NAME_RE.test(name)) {
@@ -69,10 +66,8 @@ export function createSignupRouter(deps: SignupRoutesDeps): Router {
         });
         return;
       }
-      if (!email || !EMAIL_RE.test(email)) {
-        res.status(400).json({ error: "invalid_email", message: "valid email required" });
-        return;
-      }
+      const email = requireEmail(req, res);
+      if (!email) return;
       const pwdCheck = validatePasswordShape(password);
       if (!pwdCheck.ok) {
         res.status(400).json({

--- a/packages/api/src/routes/task.ts
+++ b/packages/api/src/routes/task.ts
@@ -19,6 +19,7 @@
 import { Router, type RequestHandler, type Response } from "express";
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import {
+  CANCELLABLE_TASK_STATUSES,
   TASK_PRIORITIES,
   isInFlightSessionStatus,
   taskId,
@@ -44,16 +45,13 @@ import { requireHuman } from "../auth/middleware.js";
 import type { DaemonHub } from "../runtime/hub.js";
 import { requireParam } from "./http-errors.js";
 
-/** Statuses from which /cancel is legal. Anything non-terminal. */
-const CANCELLABLE_FROM: readonly TaskStatus[] = [
-  "pending",
-  "assigned",
-  "needs_revision",
-  "in_progress",
-  "revision",
-  "review",
-  "blocked",
-];
+/**
+ * Statuses from which /cancel is legal — anything non-terminal. Derived
+ * in `@beevibe/core` as the complement of `TERMINAL_TASK_STATUSES`, so
+ * this and the web's Cancel-button gate (`@/lib/task-status`) read one
+ * declaration instead of two hand-synced lists.
+ */
+const CANCELLABLE_FROM: readonly TaskStatus[] = CANCELLABLE_TASK_STATUSES;
 
 export interface TaskRoutesDeps {
   authMiddleware: RequestHandler;

--- a/packages/api/src/routes/view.test.ts
+++ b/packages/api/src/routes/view.test.ts
@@ -231,7 +231,7 @@ describe("GET /task", () => {
     expect(vi.mocked(listTasks).mock.calls[0]![1]).toEqual({ caller_person_id: PERSON });
   });
 
-  it.each(["pending", "in_progress", "in_review", "done"])(
+  it.each(["pending", "in_progress", "blocked", "in_review", "done", "archived"])(
     "passes through the %s lifecycle filter",
     async (lifecycle) => {
       await request(makeApp()).get(`/task?lifecycle=${lifecycle}`);

--- a/packages/api/src/routes/view.ts
+++ b/packages/api/src/routes/view.ts
@@ -23,6 +23,7 @@ import type { Pool } from "@beevibe/core/adapters/postgres";
 import {
   MEMORY_SCOPES,
   REVIEW_POLICIES,
+  TASK_LIFECYCLES,
   isKnownCli,
   type AgentRepository,
   type DaemonRepository,
@@ -32,6 +33,7 @@ import {
   type ReviewPolicy,
   type RuntimeConfig,
   type RuntimeRepository,
+  type TaskLifecycle,
 } from "@beevibe/core";
 import { requireHuman } from "../auth/middleware.js";
 import {
@@ -40,10 +42,6 @@ import {
   type CoreMemory,
 } from "@beevibe/core/services/memory";
 import { listTasks, getTask, type TaskListFilter } from "../views/tasks.js";
-import {
-  TASK_STATUSES_BY_LIFECYCLE,
-  type Lifecycle,
-} from "../views/tasks-grouping.js";
 import { listAgents, getAgent } from "../views/agents.js";
 import {
   getSessionByShortId,
@@ -85,9 +83,7 @@ export interface ViewRoutesDeps {
   memoryFactRepo: MemoryFactRepository;
 }
 
-const LIFECYCLES = new Set<Lifecycle>(
-  Object.keys(TASK_STATUSES_BY_LIFECYCLE) as Lifecycle[],
-);
+const LIFECYCLES = new Set<TaskLifecycle>(TASK_LIFECYCLES);
 const VIEWS = new Set<TaskListFilter["view"]>(["all", "mine", "sprint", "timeline"]);
 const SCOPES = new Set<MemoryScope>(MEMORY_SCOPES);
 
@@ -122,8 +118,8 @@ export function createViewRouter(deps: ViewRoutesDeps): Router {
     // owners (any logged-in person could see every task in the DB).
     const filter: TaskListFilter = { caller_person_id: req.caller.personId };
     const lifecycleParam = typeof req.query.lifecycle === "string" ? req.query.lifecycle : undefined;
-    if (lifecycleParam && LIFECYCLES.has(lifecycleParam as Lifecycle)) {
-      filter.lifecycle = lifecycleParam as Lifecycle;
+    if (lifecycleParam && LIFECYCLES.has(lifecycleParam as TaskLifecycle)) {
+      filter.lifecycle = lifecycleParam as TaskLifecycle;
     }
     const viewParam = typeof req.query.view === "string" ? req.query.view : undefined;
     if (viewParam && VIEWS.has(viewParam as TaskListFilter["view"])) {

--- a/packages/api/src/views/tasks-grouping.test.ts
+++ b/packages/api/src/views/tasks-grouping.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { TASK_STATUSES, TASK_STATUSES_BY_LIFECYCLE } from "@beevibe/core";
+import { TASK_STATUSES_BY_VIEW } from "./tasks-grouping.js";
+
+/**
+ * `sprint` and `timeline` are composed out of the lifecycle lanes, so a
+ * change to the lane split silently changes which rows these saved views
+ * return. These assertions pin the membership independently of how the
+ * lanes are carved up.
+ */
+
+describe("TASK_STATUSES_BY_VIEW", () => {
+  it("keeps sprint at every in-flight status", () => {
+    expect([...TASK_STATUSES_BY_VIEW.sprint!].sort()).toEqual(
+      [
+        "assigned",
+        "blocked",
+        "in_progress",
+        "needs_revision",
+        "pending",
+        "review",
+        "revision",
+      ].sort(),
+    );
+  });
+
+  it("excludes the settled statuses from sprint", () => {
+    for (const s of ["done", "failed", "cancelled"] as const) {
+      expect(TASK_STATUSES_BY_VIEW.sprint).not.toContain(s);
+    }
+  });
+
+  it("keeps timeline at every status there is", () => {
+    expect([...TASK_STATUSES_BY_VIEW.timeline!].sort()).toEqual([...TASK_STATUSES].sort());
+  });
+
+  it("lists sprint as a strict subset of timeline", () => {
+    for (const s of TASK_STATUSES_BY_VIEW.sprint!) {
+      expect(TASK_STATUSES_BY_VIEW.timeline).toContain(s);
+    }
+    expect(TASK_STATUSES_BY_VIEW.timeline!.length).toBeGreaterThan(
+      TASK_STATUSES_BY_VIEW.sprint!.length,
+    );
+  });
+
+  it("repeats no status within a view", () => {
+    for (const view of ["sprint", "timeline"] as const) {
+      const statuses = TASK_STATUSES_BY_VIEW[view]!;
+      expect(new Set(statuses).size).toBe(statuses.length);
+    }
+  });
+
+  it("leaves 'all' and 'mine' unmapped — they are not status filters", () => {
+    expect(TASK_STATUSES_BY_VIEW.all).toBeUndefined();
+    expect(TASK_STATUSES_BY_VIEW.mine).toBeUndefined();
+  });
+
+  it("covers timeline with exactly the union of every lane", () => {
+    const everyLane = Object.values(TASK_STATUSES_BY_LIFECYCLE).flatMap((s) => [...s]);
+    expect([...TASK_STATUSES_BY_VIEW.timeline!].sort()).toEqual(everyLane.sort());
+  });
+});

--- a/packages/api/src/views/tasks-grouping.ts
+++ b/packages/api/src/views/tasks-grouping.ts
@@ -1,35 +1,40 @@
 /**
- * Server-side mirror of `packages/web/lib/tasks-grouping.ts`. Keeps the
- * lifecycle → status mapping and the saved-view → status mapping next to
- * the SQL that filters on them, so the web can pass either `lifecycle` or
- * `view` and get the rows it expects.
+ * Saved-view → status mappings, kept next to the SQL that filters on them.
+ *
+ * The lifecycle taxonomy this builds on (`TaskLifecycle`,
+ * `TASK_STATUSES_BY_LIFECYCLE`) lives in `@beevibe/core`, which the web
+ * task board reads too. This module used to declare its own copy of it,
+ * and the two had drifted: the server folded `blocked` into `in_review`
+ * and `failed` / `cancelled` into `done`, and the lanes the board added
+ * since (`blocked`, `archived`) were missing entirely — so
+ * `?lifecycle=blocked` failed the route's key check and fell through to
+ * *no* status filter, silently returning every task instead of the
+ * blocked ones.
  */
 
-import type { TaskStatus } from "@beevibe/core";
-
-export type Lifecycle = "pending" | "in_progress" | "in_review" | "done";
-
-export const TASK_STATUSES_BY_LIFECYCLE: Record<Lifecycle, readonly TaskStatus[]> = {
-  pending: ["pending", "assigned"],
-  in_progress: ["in_progress", "revision", "needs_revision"],
-  in_review: ["review", "blocked"],
-  done: ["done", "failed", "cancelled"],
-};
+import { TASK_STATUSES_BY_LIFECYCLE, type TaskStatus } from "@beevibe/core";
 
 /**
  * Saved-view shortcut → status set. "all" and "mine" are intentionally
  * absent — "all" means no filter, "mine" routes to `assignee_id`.
+ *
+ * Both sets are spelled out over the lanes they cover so their membership
+ * is unchanged by the lane split described above: `sprint` is everything
+ * still in flight, `timeline` is every status there is.
  */
 export const TASK_STATUSES_BY_VIEW: Partial<Record<string, readonly TaskStatus[]>> = {
   sprint: [
     ...TASK_STATUSES_BY_LIFECYCLE.pending,
     ...TASK_STATUSES_BY_LIFECYCLE.in_progress,
+    ...TASK_STATUSES_BY_LIFECYCLE.blocked,
     ...TASK_STATUSES_BY_LIFECYCLE.in_review,
   ],
   timeline: [
     ...TASK_STATUSES_BY_LIFECYCLE.pending,
     ...TASK_STATUSES_BY_LIFECYCLE.in_progress,
+    ...TASK_STATUSES_BY_LIFECYCLE.blocked,
     ...TASK_STATUSES_BY_LIFECYCLE.in_review,
     ...TASK_STATUSES_BY_LIFECYCLE.done,
+    ...TASK_STATUSES_BY_LIFECYCLE.archived,
   ],
 };

--- a/packages/api/src/views/tasks.test.ts
+++ b/packages/api/src/views/tasks.test.ts
@@ -70,15 +70,27 @@ describe("listTasks", () => {
     expect(t.latest_session?.agent_label).toBe("alice");
   });
 
-  it("translates lifecycle filter into a status array param", async () => {
-    const pool = makeMockPool([[]]);
-    const queryMock = pool._spy;
-    await listTasks(pool, { lifecycle: "in_review", bypassOwnerScope: true });
-    expect(queryMock).toHaveBeenCalledWith(
-      expect.any(String),
-      [["review", "blocked"], null, null],
-    );
-  });
+  // The lanes below come from `TASK_LIFECYCLE_OF` in @beevibe/core, which
+  // the web task board groups on too. `in_review` deliberately excludes
+  // `blocked` and `done` excludes `failed`/`cancelled` — those have their
+  // own lanes, so a `?lifecycle=` link returns exactly the rows the
+  // requested lane paints.
+  it.each([
+    ["pending", ["pending", "assigned"]],
+    ["in_progress", ["in_progress", "needs_revision", "revision"]],
+    ["blocked", ["blocked"]],
+    ["in_review", ["review"]],
+    ["done", ["done"]],
+    ["archived", ["failed", "cancelled"]],
+  ] as const)(
+    "translates the %s lifecycle filter into its status array param",
+    async (lifecycle, statuses) => {
+      const pool = makeMockPool([[]]);
+      const queryMock = pool._spy;
+      await listTasks(pool, { lifecycle, bypassOwnerScope: true });
+      expect(queryMock).toHaveBeenCalledWith(expect.any(String), [statuses, null, null]);
+    },
+  );
 
   it("forwards assignee_id when set", async () => {
     const pool = makeMockPool([[]]);

--- a/packages/api/src/views/tasks.ts
+++ b/packages/api/src/views/tasks.ts
@@ -7,11 +7,7 @@
  */
 
 import type { Pool } from "@beevibe/core/adapters/postgres";
-import type { Lifecycle } from "./tasks-grouping.js";
-import {
-  TASK_STATUSES_BY_LIFECYCLE,
-  TASK_STATUSES_BY_VIEW,
-} from "./tasks-grouping.js";
+import { TASK_STATUSES_BY_VIEW } from "./tasks-grouping.js";
 import { deriveShortId, formatDurationLabel } from "./format.js";
 import type {
   TaskListItem,
@@ -19,10 +15,12 @@ import type {
   TaskDetailSessionRow,
   TaskLatestSessionSummary,
 } from "./types.js";
+import { TASK_STATUSES_BY_LIFECYCLE } from "@beevibe/core";
 import type {
   HierarchyLevel,
   SessionStatus,
   Task,
+  TaskLifecycle,
   TaskPriority,
   TaskStatus,
   WorkProduct,
@@ -30,7 +28,7 @@ import type {
 } from "@beevibe/core";
 
 export interface TaskListFilter {
-  lifecycle?: Lifecycle;
+  lifecycle?: TaskLifecycle;
   assignee_id?: string;
   /**
    * Saved-view shortcut. "mine" needs the caller's personId — the route

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,10 @@
       "types": "./dist/domain/format.d.ts",
       "default": "./dist/domain/format.js"
     },
+    "./domain/task": {
+      "types": "./dist/domain/task.d.ts",
+      "default": "./dist/domain/task.js"
+    },
     "./adapters/postgres": {
       "types": "./dist/adapters/postgres/index.d.ts",
       "default": "./dist/adapters/postgres/index.js"

--- a/packages/core/src/domain/task.test.ts
+++ b/packages/core/src/domain/task.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import {
+  CANCELLABLE_TASK_STATUSES,
+  RETRYABLE_TASK_STATUSES,
+  TASK_LIFECYCLES,
+  TASK_LIFECYCLE_OF,
+  TASK_STATUSES,
+  TASK_STATUSES_BY_LIFECYCLE,
+  TERMINAL_TASK_STATUSES,
+  isRetryableTaskStatus,
+  isTerminalTaskStatus,
+  taskLifecycleOf,
+  type TaskLifecycle,
+  type TaskStatus,
+} from "./task.js";
+
+/**
+ * These constants are the shared task taxonomy: the web board groups on
+ * them, `GET /task?lifecycle=` filters SQL on them, and the cancel route
+ * gates transitions on them. The invariants below are what previously
+ * drifted when each consumer carried its own copy.
+ */
+
+describe("task status sets", () => {
+  it("splits every status into exactly one of cancellable or terminal", () => {
+    const partitioned = [...CANCELLABLE_TASK_STATUSES, ...TERMINAL_TASK_STATUSES].sort();
+    expect(partitioned).toEqual([...TASK_STATUSES].sort());
+  });
+
+  it("keeps cancellable and terminal disjoint", () => {
+    const overlap = CANCELLABLE_TASK_STATUSES.filter((s) =>
+      TERMINAL_TASK_STATUSES.includes(s),
+    );
+    expect(overlap).toEqual([]);
+  });
+
+  it("treats every retryable status as terminal but not every terminal as retryable", () => {
+    for (const s of RETRYABLE_TASK_STATUSES) expect(isTerminalTaskStatus(s)).toBe(true);
+    expect(isRetryableTaskStatus("done")).toBe(false);
+  });
+
+  it("agrees between the predicates and the sets they read", () => {
+    for (const s of TASK_STATUSES) {
+      expect(isTerminalTaskStatus(s)).toBe(TERMINAL_TASK_STATUSES.includes(s));
+      expect(isRetryableTaskStatus(s)).toBe(RETRYABLE_TASK_STATUSES.includes(s));
+    }
+  });
+});
+
+describe("task lifecycle taxonomy", () => {
+  it("assigns every status to a declared lane", () => {
+    for (const s of TASK_STATUSES) {
+      expect(TASK_LIFECYCLES).toContain(TASK_LIFECYCLE_OF[s]);
+    }
+  });
+
+  it("inverts the forward map exactly — no status lost or duplicated", () => {
+    const flattened = TASK_LIFECYCLES.flatMap((l) => [...TASK_STATUSES_BY_LIFECYCLE[l]]);
+    expect(flattened.sort()).toEqual([...TASK_STATUSES].sort());
+  });
+
+  it("puts each status in the bucket its forward mapping names", () => {
+    for (const s of TASK_STATUSES) {
+      expect(TASK_STATUSES_BY_LIFECYCLE[TASK_LIFECYCLE_OF[s]]).toContain(s);
+    }
+  });
+
+  it("gives every lane a bucket, even if empty", () => {
+    for (const l of TASK_LIFECYCLES) {
+      expect(TASK_STATUSES_BY_LIFECYCLE[l]).toBeDefined();
+    }
+  });
+
+  it("keeps blocked and archived out of in_review and done", () => {
+    // The drift this taxonomy replaced: the server folded `blocked` into
+    // in_review and `failed`/`cancelled` into done, while the board
+    // painted them as their own lanes.
+    expect(TASK_STATUSES_BY_LIFECYCLE.in_review).toEqual(["review"]);
+    expect(TASK_STATUSES_BY_LIFECYCLE.done).toEqual(["done"]);
+    expect(TASK_STATUSES_BY_LIFECYCLE.blocked).toEqual(["blocked"]);
+    expect(TASK_STATUSES_BY_LIFECYCLE.archived).toEqual(["failed", "cancelled"]);
+  });
+
+  it("maps exactly the terminal statuses into the done + archived lanes", () => {
+    const settled: TaskStatus[] = [
+      ...TASK_STATUSES_BY_LIFECYCLE.done,
+      ...TASK_STATUSES_BY_LIFECYCLE.archived,
+    ];
+    expect(settled.sort()).toEqual([...TERMINAL_TASK_STATUSES].sort());
+  });
+
+  it("exposes the same lane through the helper as through the map", () => {
+    for (const s of TASK_STATUSES) {
+      expect(taskLifecycleOf(s)).toBe(TASK_LIFECYCLE_OF[s]);
+    }
+  });
+
+  it("lists lanes in workflow order", () => {
+    const expected: TaskLifecycle[] = [
+      "pending",
+      "in_progress",
+      "blocked",
+      "in_review",
+      "done",
+      "archived",
+    ];
+    expect([...TASK_LIFECYCLES]).toEqual(expected);
+  });
+});

--- a/packages/core/src/domain/task.ts
+++ b/packages/core/src/domain/task.ts
@@ -1,3 +1,20 @@
+/**
+ * Task domain types and the status / lifecycle taxonomy.
+ *
+ * The constants here are pure and dependency-free, so they are safe to
+ * pull into the browser bundle — the web task board groups on the same
+ * lifecycle map the api filters SQL on.
+ *
+ * IMPORT THE VALUES VIA `@beevibe/core/domain/task`, NOT the package
+ * root. The root barrel re-exports `./auth`, which reaches for
+ * `node:crypto` and `node:util`; a *value* import of the root from a
+ * client component drags those into webpack and fails `next build` with
+ * `UnhandledSchemeError: Reading from "node:crypto" is not handled by
+ * plugins`. Type-only root imports are fine — they erase — which is why
+ * `import type { TaskStatus } from "@beevibe/core"` is everywhere in the
+ * web app. Same rule and same reason as `./format.ts`; see its header.
+ */
+
 import type { ResolutionProposal } from "./escalation.js";
 
 export type TaskStatus =

--- a/packages/core/src/domain/task.ts
+++ b/packages/core/src/domain/task.ts
@@ -39,6 +39,103 @@ export const TERMINAL_TASK_STATUSES: readonly TaskStatus[] = [
   "cancelled",
 ] as const;
 
+/**
+ * Statuses a failed run can be retried out of. The complement pair to
+ * `CANCELLABLE_TASK_STATUSES` below: a task is either still cancellable
+ * (work in flight) or already terminal, and a terminal task is retryable
+ * only when it didn't succeed.
+ */
+export const RETRYABLE_TASK_STATUSES: readonly TaskStatus[] = [
+  "failed",
+  "cancelled",
+] as const;
+
+/**
+ * Statuses `POST /task/:id/cancel` accepts — every non-terminal status.
+ * Derived from {@link TERMINAL_TASK_STATUSES} rather than listed, so
+ * adding a `TaskStatus` can't leave the two sets disagreeing about
+ * whether a new status is cancellable.
+ */
+export const CANCELLABLE_TASK_STATUSES: readonly TaskStatus[] = TASK_STATUSES.filter(
+  (s) => !TERMINAL_TASK_STATUSES.includes(s),
+);
+
+export function isTerminalTaskStatus(status: TaskStatus): boolean {
+  return TERMINAL_TASK_STATUSES.includes(status);
+}
+
+export function isRetryableTaskStatus(status: TaskStatus): boolean {
+  return RETRYABLE_TASK_STATUSES.includes(status);
+}
+
+/**
+ * Board lane a task belongs to — the coarse grouping both the web task
+ * board and the server-side `?lifecycle=` filter speak in.
+ *
+ * Ten statuses collapse into six lanes. `blocked` and `archived` are
+ * deliberately their own lanes:
+ *
+ * - `blocked` = waiting on an external dependency, which asks something
+ *   different of the human reading the board than `in_review` (waiting on
+ *   a human verdict), so it gets its own column.
+ * - `archived` = `failed` / `cancelled`. Terminal but not success, so
+ *   they stay out of `done` — `Done` should read as "this shipped". The
+ *   web board hides this lane behind the archive toggle.
+ */
+export type TaskLifecycle =
+  | "pending"
+  | "in_progress"
+  | "blocked"
+  | "in_review"
+  | "done"
+  | "archived";
+
+/** Workflow order, left-to-right — the order the board paints its lanes. */
+export const TASK_LIFECYCLES: readonly TaskLifecycle[] = [
+  "pending",
+  "in_progress",
+  "blocked",
+  "in_review",
+  "done",
+  "archived",
+] as const;
+
+/**
+ * Status → lane. The single source of truth for the lifecycle taxonomy:
+ * `TASK_STATUSES_BY_LIFECYCLE` is derived from this map, so the forward
+ * and reverse directions cannot drift apart.
+ */
+export const TASK_LIFECYCLE_OF: Record<TaskStatus, TaskLifecycle> = {
+  pending: "pending",
+  assigned: "pending",
+  in_progress: "in_progress",
+  revision: "in_progress",
+  needs_revision: "in_progress",
+  blocked: "blocked",
+  review: "in_review",
+  done: "done",
+  failed: "archived",
+  cancelled: "archived",
+};
+
+/**
+ * Lane → statuses, inverted from {@link TASK_LIFECYCLE_OF} at module load.
+ * Backs the SQL status filter behind `GET /task?lifecycle=`, so the rows
+ * the server returns are exactly the ones the requested lane displays.
+ */
+export const TASK_STATUSES_BY_LIFECYCLE: Record<TaskLifecycle, readonly TaskStatus[]> =
+  TASK_LIFECYCLES.reduce(
+    (acc, lane) => {
+      acc[lane] = TASK_STATUSES.filter((s) => TASK_LIFECYCLE_OF[s] === lane);
+      return acc;
+    },
+    {} as Record<TaskLifecycle, TaskStatus[]>,
+  );
+
+export function taskLifecycleOf(status: TaskStatus): TaskLifecycle {
+  return TASK_LIFECYCLE_OF[status];
+}
+
 export type TaskPriority = "low" | "medium" | "high" | "critical";
 
 export const TASK_PRIORITIES: readonly TaskPriority[] = ["low", "medium", "high", "critical"] as const;

--- a/packages/web/components/rich-text.tsx
+++ b/packages/web/components/rich-text.tsx
@@ -1,7 +1,14 @@
 import { Fragment } from "react";
+import type { RichText } from "@beevibe/api/views/types";
 
-export type RichSegment = string | { mono: string };
-export type RichText = string | RichSegment[];
+/**
+ * The wire shape comes from `@beevibe/api`, which owns the contract and
+ * serializes these values — re-exported here so the existing
+ * `@/components/rich-text` import sites keep resolving. Both packages used
+ * to declare it; structural typing hid the duplication, but a `mono`
+ * rename on the api side would still have silently split the two.
+ */
+export type { RichSegment, RichText } from "@beevibe/api/views/types";
 
 export function RichTextRender({ value }: { value: RichText }) {
   if (typeof value === "string") return <>{value}</>;

--- a/packages/web/components/tasks/board-column.tsx
+++ b/packages/web/components/tasks/board-column.tsx
@@ -4,10 +4,10 @@ import { MoreHorizontal } from "lucide-react";
 import { TaskCard, type TaskSelectHandler } from "./task-card";
 import { cn } from "@/lib/utils";
 import type { TaskListItem } from "@/lib/types/tasks";
-import type { Lifecycle } from "@/lib/tasks-grouping";
+import type { TaskLifecycle } from "@beevibe/core";
 
 export type BoardLane = {
-  key: Lifecycle;
+  key: TaskLifecycle;
   label: string;
   dot: string;
   count: number;

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -12,6 +12,7 @@ import type {
   ReviewPolicy,
   SuggestedAction,
   Task,
+  TaskLifecycle,
 } from "@beevibe/core";
 export type { RepoRun, RepoRunStatus, LearnedSkill };
 /**
@@ -41,12 +42,11 @@ import type { PromotionEvent } from "@/lib/types/promotion-events";
 import type { InboxItem } from "@/lib/types/inbox";
 import type { EscalationReviewDetail } from "@/lib/types/escalations";
 import type { NegotiationReviewDetail } from "@/lib/types/negotiations";
-import type { Lifecycle } from "@/lib/tasks-grouping";
 
 export type TaskView = "all" | "mine";
 
 export interface TaskListFilter {
-  lifecycle?: Lifecycle;
+  lifecycle?: TaskLifecycle;
   assignee_id?: string;
   view?: TaskView;
 }

--- a/packages/web/lib/task-status.ts
+++ b/packages/web/lib/task-status.ts
@@ -18,4 +18,4 @@ export {
   TERMINAL_TASK_STATUSES,
   isRetryableTaskStatus,
   isTerminalTaskStatus,
-} from "@beevibe/core";
+} from "@beevibe/core/domain/task";

--- a/packages/web/lib/task-status.ts
+++ b/packages/web/lib/task-status.ts
@@ -1,30 +1,21 @@
-import type { TaskStatus } from "@beevibe/core";
-
 /**
- * Status sets the lifecycle-action UI gates on. Single source of truth
- * for "should we show Cancel?" / "should we show Retry?" — keep these
- * in lockstep with:
- *   - api/src/routes/task.ts `CANCELLABLE_FROM` (terminal complement)
- *   - core/src/services/task-service.ts `prepareRetry` (failed | cancelled)
+ * Status sets the lifecycle-action UI gates on — "should we show Cancel?"
+ * / "should we show Retry?".
  *
- * Typed as `readonly TaskStatus[]` so `.includes(task.status)` typechecks
- * without a cast.
+ * These now live in `@beevibe/core`'s domain layer and are re-exported
+ * here so existing `@/lib/task-status` imports keep working. They used to
+ * be a parallel copy of `TERMINAL_TASK_STATUSES` from
+ * `core/src/domain/task.ts`, kept in lockstep by comment with that
+ * declaration and with `CANCELLABLE_FROM` in `api/src/routes/task.ts`.
+ * The api route now derives its cancellable set from the same core
+ * constants, so the button the UI shows and the transition the server
+ * accepts can no longer disagree.
  */
-export const TERMINAL_TASK_STATUSES: readonly TaskStatus[] = [
-  "done",
-  "failed",
-  "cancelled",
-];
 
-export const RETRYABLE_TASK_STATUSES: readonly TaskStatus[] = [
-  "failed",
-  "cancelled",
-];
-
-export function isTerminalTaskStatus(status: TaskStatus): boolean {
-  return TERMINAL_TASK_STATUSES.includes(status);
-}
-
-export function isRetryableTaskStatus(status: TaskStatus): boolean {
-  return RETRYABLE_TASK_STATUSES.includes(status);
-}
+export {
+  CANCELLABLE_TASK_STATUSES,
+  RETRYABLE_TASK_STATUSES,
+  TERMINAL_TASK_STATUSES,
+  isRetryableTaskStatus,
+  isTerminalTaskStatus,
+} from "@beevibe/core";

--- a/packages/web/lib/tasks-grouping.test.ts
+++ b/packages/web/lib/tasks-grouping.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { TaskStatus } from "@beevibe/core";
-import { TASK_STATUSES } from "@beevibe/core";
-import {
-  countArchivedTasks,
-  groupTasks,
-  type Lifecycle,
-} from "./tasks-grouping";
+import { TASK_STATUSES, type TaskLifecycle, type TaskStatus } from "@beevibe/core";
+import { countArchivedTasks, groupTasks } from "./tasks-grouping";
 import type { TaskListItem } from "@/lib/types/tasks";
 
 function makeTask(id: string, status: TaskStatus): TaskListItem {
@@ -21,7 +16,7 @@ function makeTask(id: string, status: TaskStatus): TaskListItem {
   };
 }
 
-const EXPECTED_LIFECYCLE: Record<TaskStatus, Lifecycle> = {
+const EXPECTED_LIFECYCLE: Record<TaskStatus, TaskLifecycle> = {
   pending: "pending",
   assigned: "pending",
   in_progress: "in_progress",

--- a/packages/web/lib/tasks-grouping.test.ts
+++ b/packages/web/lib/tasks-grouping.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { TASK_STATUSES, type TaskLifecycle, type TaskStatus } from "@beevibe/core";
+import {
+  TASK_STATUSES,
+  type TaskLifecycle,
+  type TaskStatus,
+} from "@beevibe/core/domain/task";
 import { countArchivedTasks, groupTasks } from "./tasks-grouping";
 import type { TaskListItem } from "@/lib/types/tasks";
 

--- a/packages/web/lib/tasks-grouping.ts
+++ b/packages/web/lib/tasks-grouping.ts
@@ -11,7 +11,7 @@
  * (labels, dot colors, lane order on screen) is web-owned.
  */
 
-import { TASK_LIFECYCLE_OF, type TaskLifecycle } from "@beevibe/core";
+import { TASK_LIFECYCLE_OF, type TaskLifecycle } from "@beevibe/core/domain/task";
 import type { TaskListItem } from "@/lib/types/tasks";
 import type { BoardLane } from "@/components/tasks/board-column";
 

--- a/packages/web/lib/tasks-grouping.ts
+++ b/packages/web/lib/tasks-grouping.ts
@@ -1,42 +1,22 @@
-import type { TaskStatus } from "@beevibe/core";
+/**
+ * Board lane grouping for the task list.
+ *
+ * The taxonomy itself — which status belongs to which lane — lives in
+ * `@beevibe/core` (`TaskLifecycle` / `TASK_LIFECYCLE_OF`), because the
+ * server filters `GET /task?lifecycle=` on the same mapping. This module
+ * was previously a parallel declaration of it, and the two had drifted:
+ * the server still folded `blocked` into In review and `failed` /
+ * `cancelled` into Done, so a `?lifecycle=` deep link returned rows this
+ * board then painted into a different lane. Only the presentation below
+ * (labels, dot colors, lane order on screen) is web-owned.
+ */
+
+import { TASK_LIFECYCLE_OF, type TaskLifecycle } from "@beevibe/core";
 import type { TaskListItem } from "@/lib/types/tasks";
 import type { BoardLane } from "@/components/tasks/board-column";
 
-export type Lifecycle =
-  | "pending"
-  | "in_progress"
-  | "blocked"
-  | "in_review"
-  | "done"
-  | "archived";
-
-/**
- * Status → lifecycle lane.
- *
- * - `blocked` lives in its own lane (was previously folded into
- *   In review). Blocked = waiting on an external dependency, semantically
- *   different from "waiting on a human verdict." Different action by the
- *   human reading the board, so different column.
- * - `failed` and `cancelled` are terminal states that aren't success.
- *   They go into the `archived` lane, hidden by default — `Done` should
- *   read as "this shipped." Archive toggle exposes them when the user
- *   wants to see what didn't ship.
- */
-const LIFECYCLE_OF: Record<TaskStatus, Lifecycle> = {
-  pending: "pending",
-  assigned: "pending",
-  in_progress: "in_progress",
-  revision: "in_progress",
-  needs_revision: "in_progress",
-  review: "in_review",
-  blocked: "blocked",
-  done: "done",
-  failed: "archived",
-  cancelled: "archived",
-};
-
 interface LaneTemplate {
-  key: Lifecycle;
+  key: TaskLifecycle;
   label: string;
   dot: string;
 }
@@ -68,7 +48,7 @@ export function groupTasks(
   tasks: TaskListItem[],
   options: GroupOptions = {},
 ): BoardLane[] {
-  const buckets: Record<Lifecycle, TaskListItem[]> = {
+  const buckets: Record<TaskLifecycle, TaskListItem[]> = {
     pending: [],
     in_progress: [],
     blocked: [],
@@ -76,7 +56,7 @@ export function groupTasks(
     done: [],
     archived: [],
   };
-  for (const t of tasks) buckets[LIFECYCLE_OF[t.status]].push(t);
+  for (const t of tasks) buckets[TASK_LIFECYCLE_OF[t.status]].push(t);
   const template = options.showArchived
     ? [...VISIBLE_LANES, ARCHIVED_LANE]
     : VISIBLE_LANES;
@@ -87,11 +67,15 @@ export function groupTasks(
   }));
 }
 
-/** Count of failed+cancelled tasks — drives the "X archived" toggle. */
+/**
+ * Count of tasks in the archived lane (failed + cancelled) — drives the
+ * "X archived" toggle. Reads the lane off the shared taxonomy rather than
+ * naming the statuses, so it tracks `TASK_LIFECYCLE_OF` automatically.
+ */
 export function countArchivedTasks(tasks: TaskListItem[]): number {
   let n = 0;
   for (const t of tasks) {
-    if (t.status === "failed" || t.status === "cancelled") n += 1;
+    if (TASK_LIFECYCLE_OF[t.status] === "archived") n += 1;
   }
   return n;
 }


### PR DESCRIPTION
Found by a near-duplicate sweep of the monorepo. Most of the codebase is already well factored — `adapters/runtime-common.ts`, `adapters/postgres/pg-helpers.ts`, `core/domain/format.ts`, `views/agent-display.ts` and `routes/http-errors.ts` have all had passes, and their doc comments record what was merged. This PR takes the clusters those passes missed, which are the ones that span the **web ↔ api/core** boundary rather than living inside one package.

The headline finding is not cosmetic: one of the duplicate pairs had drifted, and the drift is a live bug.

## 1. Task status + lifecycle taxonomy → `core/domain/task.ts`

Four declarations of the same taxonomy, kept in lockstep by comment. Two had come apart.

**The drift.** `web/lib/tasks-grouping.ts` (the board's status → lane map) and `api/src/views/tasks-grouping.ts` (the `?lifecycle=` SQL filter) were parallel declarations. The web side had since given `blocked` its own lane and moved `failed`/`cancelled` into a new `archived` lane. The server copy never followed — it still folded `blocked` into `in_review` and `failed`/`cancelled` into `done`, and had no `blocked` or `archived` key at all:

| request | server returned | board paints those rows as |
| --- | --- | --- |
| `?lifecycle=blocked` | **every task the caller can see** | — |
| `?lifecycle=archived` | **every task the caller can see** | — |
| `?lifecycle=done` | `done` + `failed` + `cancelled` | `done` lane + `archived` lane, *hidden by default* |
| `?lifecycle=in_review` | `review` + `blocked` | `in_review` lane + separate `blocked` lane |

The first two rows are the real bug. `routes/view.ts` validates the param against the lane keys and, on a miss, simply doesn't set `filter.lifecycle` — so an unknown lane falls through to *no status filter* rather than an error. `web/lib/api/client.ts` typed `TaskListFilter.lifecycle` as the web's six-lane union, so `api.tasks.list({ lifecycle: "blocked" })` typechecked and quietly returned everything. The `done` row is user-visible too: `lib/dashboard-display.ts` links the Done KPI at `?lifecycle=done`, so that tile led to a board silently withholding part of what it had fetched.

**The fix.** `core/src/domain/task.ts` now owns `TaskLifecycle`, `TASK_LIFECYCLES`, `TASK_LIFECYCLE_OF`, `RETRYABLE_TASK_STATUSES` and the predicates. Crucially the two derived sets are *computed, not written down*:

- `TASK_STATUSES_BY_LIFECYCLE` is inverted from `TASK_LIFECYCLE_OF` at module load
- `CANCELLABLE_TASK_STATUSES` is the complement of `TERMINAL_TASK_STATUSES` over `TASK_STATUSES`

so neither pair can drift again, and adding a `TaskStatus` cannot leave one unassigned.

Also folded in, same taxonomy, no behavior change:

- `TERMINAL_TASK_STATUSES` was declared identically in `web/lib/task-status.ts` and `core/domain/task.ts` — whose own comment asks consumers to import rather than redeclare.
- `CANCELLABLE_FROM` in `api/routes/task.ts` spelled out the seven statuses that are exactly the complement of the terminal three, so the Cancel button's gate and the transition the server accepts were two hand-synced lists.

Each consumer keeps only what is genuinely its own: web keeps lane labels, dot colors and on-screen order; api keeps the `sprint`/`timeline` saved-view sets.

## 2. `RichSegment` / `RichText` → `@beevibe/api/views/types`

Declared identically in `api/src/views/types.ts` and `web/components/rich-text.tsx`. The api comment already claimed ownership ("defined here so the type lives in the package that owns the contract") but web declared its own anyway. Structural typing meant they never failed to line up — which is precisely why this could rot unnoticed: renaming `mono` on the api side would have split them silently, with web still compiling against its own copy. web now re-exports, the same pattern `web/lib/types/tasks.ts` already uses.

## 3. `EMAIL_RE` → `requireEmail` in `routes/http-errors.ts`

A byte-identical regex in `routes/signin.ts` and `routes/signup.ts`, each followed by the same body read, the same trim + lowercase, and the same `invalid_email` 400. These two are the halves of one credential flow, so drift here is worse than ordinary duplication: tightening one side alone would let someone sign up at an address they then can't sign in with, and since `findByEmail` is an exact match, normalizing on one side only would strand the account outright. Now one helper, alongside the route helpers already factored out in that file.

## Behavior change

Only in §1: **server-side `?lifecycle=` filtering now matches the lanes the board paints.** `blocked` and `archived` filter correctly instead of returning everything; `done` and `in_review` return their own lane only.

Everything else is unchanged, including the two subtle ones I checked explicitly:

- `sprint`/`timeline` are unchanged **as sets** — the lane split only moved `blocked` and `failed`/`cancelled` between lanes both views already covered. Verified numerically and pinned by a new test, since this is where a regression could have hidden.
- Cancel transition rules, and all validation order, error codes and messages in signin/signup.

## Third commit: the import path is load-bearing here

Worth a reviewer's eye, because it's a standing constraint on the new file rather than a one-off slip. The first push of §1 broke `next build`: `lib/tasks-grouping.ts` and `lib/task-status.ts` took the new constants as **value** imports off the `@beevibe/core` root barrel, and both are reachable from a client component. The root barrel re-exports `./auth` → `password.js` → `node:crypto` / `node:util`, so webpack tried to bundle Node builtins for the browser:

```
Module build failed: UnhandledSchemeError: Reading from "node:crypto" ...
Import trace: node:crypto → ../core/dist/auth/password.js
  → ../core/dist/auth/index.js → ../core/dist/index.js
  → ./lib/tasks-grouping.ts → ./app/(authed)/tasks/tasks-client.tsx
```

`core/domain/format.ts` already documents this trap: type-only root imports are fine because they erase — hence `import type { TaskStatus } from "@beevibe/core"` all over the web app — but a browser-reachable *value* import needs its own export subpath. So this adds a `./domain/task` subpath (the emitted `dist/domain/task.js` has no runtime imports at all) and points the three browser-reachable sites at it. `task.ts` now carries the same header warning as `format.ts`, so the next value added there doesn't repeat this. The api-side and test root-barrel imports are untouched — those run under Node, where the barrel is fine.

Two notes for whoever touches this next: any future *value* added to `domain/task.ts` and consumed by the web must go through the subpath, and `pnpm typecheck` does **not** catch a violation — only a real `next build` does, which is how it reached CI.

## Testing

New: `core/src/domain/task.test.ts` (12 tests — pins the forward/reverse map inversion, the cancellable/terminal partition, and the lane split itself), `api/src/views/tasks-grouping.test.ts` (7 tests on saved-view membership), plus `requireEmail` coverage in `http-errors.test.ts`. `api/src/views/tasks.test.ts` grew a case per lane, replacing the single assertion that had encoded the old `in_review → ["review","blocked"]` drift.

CI is green on `31dc403` (both `CI` and `DCO`). The build fix was verified by reproducing the failure first — reverting just the `tasks-grouping.ts` import reproduces the identical `UnhandledSchemeError` on the same module — then confirming `pnpm build` passes all 6 tasks with it in place.

`typecheck`, `lint` and `build` clean (0 errors; lint warning counts unchanged from baseline). Per-package `vitest` matches the documented bare-sandbox baseline in CLAUDE.md exactly — remaining local failures are all the Postgres- and provider-key-gated suites, unrelated to this change (and CI, which has a real Postgres, runs them green):

| package | result |
| --- | --- |
| `@beevibe/core` | 7 failed (all `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` missing), 621 passed |
| `@beevibe/api` | 0 tests failed, 846 passed; 9 files fail at DB setup (baseline: 9) |
| `@beevibe/web` | 203 passed |
| `@beevibe/daemon` | 156 passed |
| `@beevibe/scheduler` | 10 passed, 2 files fail at DB setup (baseline: 2 fail) |
| `@beevibe/sandbox` | 109 passed |

## Sweep findings not included here

Two clusters I found and deliberately left alone:

- **`web/app/**/loading.tsx` skeletons** (5 files) share a page-shell wrapper and duplicate blocks from `components/skeletons.tsx`; `escalations/[id]` and `negotiations/[id]` are near-identical. Left as-is: a skeleton's job is to match its own page's layout, so the variation is the point and extracting a shared shell would make each one harder to keep aligned. Only the outer wrapper is truly common, which isn't worth an abstraction.
- **`TaskListFilter`** exists in `core/ports/task-repo.ts`, `api/views/tasks.ts` and `web/lib/api/client.ts`. Checked and these are genuinely three different shapes for three layers (the api one carries `caller_person_id`/`bypassOwnerScope` for owner scoping), not copies. Only the `lifecycle` field type was shared, and that is now unified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiMHt8d1ddxdZCyZkEpYkg