### PR TITLE
refactor: unify two clusters of near-duplicate abstractions (runtime transcripts, web query hooks)

### DIFF
--- a/packages/core/src/adapters/claude-code/stream-json.ts
+++ b/packages/core/src/adapters/claude-code/stream-json.ts
@@ -1,5 +1,20 @@
 import type { RuntimeResult, RuntimeStep } from "../../ports/runtime.js";
-import { parseNdjsonLine } from "../runtime-common.js";
+import {
+  assistantLine,
+  bareCliExitMessage,
+  parseNdjsonLine,
+  toolCallLine,
+  toolResultLine,
+  transcriptDetail,
+} from "../runtime-common.js";
+
+/**
+ * `bareCliExitMessage` / `isBareCliExitMessage` moved to `runtime-common`
+ * once codex and opencode grew the same fallback. Re-exported here because
+ * `@beevibe/core/adapters/claude-code` is the public subpath the api's chat
+ * route imports them from.
+ */
+export { bareCliExitMessage, isBareCliExitMessage } from "../runtime-common.js";
 
 /**
  * Parser for Claude Code's `--output-format stream-json` output. Each line
@@ -214,36 +229,28 @@ export function parseClaudeMessages(
     if (msg.type === STREAM_TYPE.Assistant && msg.message) {
       const content = msg.message.content;
       if (typeof content === "string") {
-        transcriptParts.push(`[assistant] ${content}\n`);
+        transcriptParts.push(assistantLine(content));
         output = content;
       } else if (Array.isArray(content)) {
         const texts: string[] = [];
         for (const block of content) {
           if (block.type === BLOCK_TYPE.Text && typeof block.text === "string") {
-            transcriptParts.push(`[assistant] ${block.text}\n`);
+            transcriptParts.push(assistantLine(block.text));
             texts.push(block.text);
           } else if (block.type === BLOCK_TYPE.ToolUse) {
-            transcriptParts.push(`[tool_call] ${block.name ?? "unknown"}\n`);
+            transcriptParts.push(toolCallLine(block.name ?? "unknown"));
           }
           // Skip thinking blocks + signatures — they bloat the transcript.
         }
         if (texts.length > 0) output = texts.join("\n");
       }
     } else if (msg.type === STREAM_TYPE.ToolUse) {
-      transcriptParts.push(`[tool_call] ${msg.name ?? "unknown"}\n`);
+      transcriptParts.push(toolCallLine(msg.name ?? "unknown"));
     } else if (msg.type === STREAM_TYPE.ToolResult) {
       const toolName = msg.tool_use_id ? toolUseNames.get(msg.tool_use_id) : undefined;
       const resultContent =
-        typeof msg.content === "string" ? msg.content.slice(0, 200).replace(/\n/g, " ") : "";
-      if (toolName) {
-        transcriptParts.push(
-          resultContent
-            ? `[tool_result from ${toolName}] ${resultContent}\n`
-            : `[tool_result from ${toolName}]\n`,
-        );
-      } else {
-        transcriptParts.push("[tool_result]\n");
-      }
+        typeof msg.content === "string" ? transcriptDetail(msg.content) : "";
+      transcriptParts.push(toolResultLine(toolName, resultContent));
     } else if (msg.type === STREAM_TYPE.Result) {
       sessionId = msg.session_id;
       costUsd = msg.total_cost_usd ?? msg.cost_usd;
@@ -283,27 +290,6 @@ export function parseClaudeMessages(
     usage,
     cli_session_id: sessionId,
   };
-}
-
-/**
- * The placeholder message `parseClaudeMessages` returns when the CLI
- * exited non-zero with no final-result message to surface. Exported so
- * downstream consumers (e.g. the chat route's user-facing failure
- * mapping) can detect this exact string and replace it with something
- * more actionable instead of pattern-matching across package boundaries.
- */
-export function bareCliExitMessage(exitCode: number | null): string {
-  return `CLI exited with code ${exitCode}`;
-}
-
-/**
- * Matches strings produced by `bareCliExitMessage` — the only "useless"
- * stand-in this layer emits on failure. Consumers that want to swap a
- * bare exit for a friendlier diagnostic gate on this predicate so the
- * coupling stays in one place.
- */
-export function isBareCliExitMessage(s: string): boolean {
-  return /^CLI exited with code (-?\d+|null)$/.test(s);
 }
 
 /**

--- a/packages/core/src/adapters/codex/stream-json.ts
+++ b/packages/core/src/adapters/codex/stream-json.ts
@@ -1,6 +1,15 @@
 import type { RuntimeResult, RuntimeStep } from "../../ports/runtime.js";
-import { bareCliExitMessage } from "../claude-code/stream-json.js";
-import { describeToolInput, parseNdjsonLine } from "../runtime-common.js";
+import {
+  assistantLine,
+  describeToolInput,
+  errorLine,
+  parseNdjsonLine,
+  resolveCliOutput,
+  toolCallLine,
+  toolResultLine,
+  transcriptDetail,
+  TRANSCRIPT_DETAIL_CHARS,
+} from "../runtime-common.js";
 
 /**
  * Parser for `codex exec --json` output.
@@ -210,28 +219,28 @@ export function parseCodexEvents(
         break;
       case CODEX_EVENT_TYPE.Error:
         topLevelError = evt.message ?? topLevelError;
-        if (evt.message) transcriptParts.push(`[error] ${evt.message}\n`);
+        if (evt.message) transcriptParts.push(errorLine(evt.message));
         break;
       case CODEX_EVENT_TYPE.ItemCompleted: {
         const item = evt.item;
         if (!item || !item.type) break;
         if (item.type === CODEX_ITEM_TYPE.AgentMessage && item.text) {
           assistantText = item.text;
-          transcriptParts.push(`[assistant] ${item.text}\n`);
+          transcriptParts.push(assistantLine(item.text));
         } else if (item.type === CODEX_ITEM_TYPE.McpToolCall) {
           const tool = item.tool ?? "unknown";
-          transcriptParts.push(`[tool_call] ${tool}\n`);
+          transcriptParts.push(toolCallLine(tool));
           const resultSummary = summarizeMcpResult(item.result);
           if (resultSummary || item.error?.message) {
-            transcriptParts.push(
-              `[tool_result from ${tool}] ${item.error?.message ?? resultSummary}\n`,
-            );
+            transcriptParts.push(toolResultLine(tool, item.error?.message ?? resultSummary));
           }
         } else if (item.type === CODEX_ITEM_TYPE.CommandExecution) {
-          transcriptParts.push(`[tool_call] shell ${(item.command ?? "").slice(0, 200)}\n`);
+          transcriptParts.push(
+            toolCallLine("shell", (item.command ?? "").slice(0, TRANSCRIPT_DETAIL_CHARS)),
+          );
           if (item.aggregated_output) {
             transcriptParts.push(
-              `[tool_result from shell] ${item.aggregated_output.slice(0, 200).replace(/\n/g, " ")}\n`,
+              toolResultLine("shell", transcriptDetail(item.aggregated_output)),
             );
           }
         }
@@ -245,17 +254,16 @@ export function parseCodexEvents(
   }
 
   const failed = exitCode !== 0 || !!turnFailed || !!topLevelError;
-  const trimmedLast = lastMessage.trim();
-  const failureMessage = turnFailed ?? topLevelError;
-  // Success: prefer the file-backed last message (codex writes the canonical
-  // final assistant text there); fall back to the event-stream's last
-  // agent_message; final fallback bareCliExitMessage so the chat-route's
-  // failure-mapping helper can swap it for stderr/daemon-pointer. `||`
-  // not `??` — empty assistantText must fall through to the next branch,
-  // not short-circuit there.
-  const output = failed
-    ? failureMessage || assistantText || bareCliExitMessage(exitCode)
-    : trimmedLast || assistantText || "Session completed.";
+  // On success prefer the file-backed last message — codex writes the
+  // canonical final assistant text to `--output-last-message`, which is
+  // more reliable than reconstructing it from the event stream.
+  const output = resolveCliOutput({
+    failed,
+    exitCode,
+    assistantText,
+    failureMessage: turnFailed ?? topLevelError,
+    preferredOutput: lastMessage.trim(),
+  });
 
   return {
     status: failed ? "failed" : "completed",
@@ -280,8 +288,8 @@ function summarizeMcpResult(result: { content?: unknown[] } | null | undefined):
   for (const block of result.content) {
     if (block && typeof block === "object" && (block as { type?: unknown }).type === "text") {
       const text = (block as { text?: unknown }).text;
-      if (typeof text === "string") return text.slice(0, 200).replace(/\n/g, " ");
+      if (typeof text === "string") return transcriptDetail(text);
     }
   }
-  return JSON.stringify(result.content).slice(0, 200);
+  return JSON.stringify(result.content).slice(0, TRANSCRIPT_DETAIL_CHARS);
 }

--- a/packages/core/src/adapters/opencode/stream-json.ts
+++ b/packages/core/src/adapters/opencode/stream-json.ts
@@ -1,7 +1,15 @@
 import type { SessionUsage } from "../../domain/session.js";
 import type { RuntimeResult, RuntimeStep } from "../../ports/runtime.js";
-import { bareCliExitMessage } from "../claude-code/stream-json.js";
-import { describeToolInput, parseNdjsonLine } from "../runtime-common.js";
+import {
+  assistantLine,
+  describeToolInput,
+  errorLine,
+  parseNdjsonLine,
+  resolveCliOutput,
+  toolCallLine,
+  toolResultLine,
+  transcriptDetail,
+} from "../runtime-common.js";
 
 /**
  * Parser for `opencode run --format json` output.
@@ -172,7 +180,7 @@ export function parseOpenCodeEvents(
         const text = evt.part?.text;
         if (text) {
           assistantTexts.push(text);
-          transcriptParts.push(`[assistant] ${text}\n`);
+          transcriptParts.push(assistantLine(text));
         }
         break;
       }
@@ -182,20 +190,16 @@ export function parseOpenCodeEvents(
         const tool = part.tool ?? "unknown";
         const status = part.state?.status;
         if (status === OPENCODE_TOOL_STATUS.Completed || status === OPENCODE_TOOL_STATUS.Error) {
-          const detail = (part.state?.error ?? part.state?.output ?? "")
-            .slice(0, 200)
-            .replace(/\n/g, " ");
-          transcriptParts.push(
-            detail ? `[tool_result from ${tool}] ${detail}\n` : `[tool_result from ${tool}]\n`,
-          );
+          const detail = transcriptDetail(part.state?.error ?? part.state?.output ?? "");
+          transcriptParts.push(toolResultLine(tool, detail));
         } else {
-          transcriptParts.push(`[tool_call] ${tool}\n`);
+          transcriptParts.push(toolCallLine(tool));
         }
         break;
       }
       case OPENCODE_EVENT_TYPE.Error:
         errorMessage = evt.error?.message ?? evt.result?.error?.message ?? errorMessage;
-        if (errorMessage) transcriptParts.push(`[error] ${errorMessage}\n`);
+        if (errorMessage) transcriptParts.push(errorLine(errorMessage));
         break;
       default:
         break;
@@ -204,11 +208,15 @@ export function parseOpenCodeEvents(
 
   const assistantText = assistantTexts.join("\n").trim();
   const failed = exitCode !== 0 || !!errorMessage;
-  // `||` not `??` — empty assistantText must fall through to the next
-  // branch instead of short-circuiting at the empty string.
-  const output = failed
-    ? errorMessage || assistantText || bareCliExitMessage(exitCode)
-    : assistantText || "Session completed.";
+  // No `preferredOutput` — opencode has no canonical final-answer channel
+  // outside the event stream, so the accumulated assistant text is the best
+  // success output available.
+  const output = resolveCliOutput({
+    failed,
+    exitCode,
+    assistantText,
+    failureMessage: errorMessage,
+  });
 
   const usage: SessionUsage | undefined = sawUsage
     ? {

--- a/packages/core/src/adapters/runtime-common.test.ts
+++ b/packages/core/src/adapters/runtime-common.test.ts
@@ -2,10 +2,19 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CliProcessResult } from "./claude-code/spawn.js";
 import type { RuntimeResult } from "../ports/runtime.js";
 import {
+  assistantLine,
+  bareCliExitMessage,
   cancelledResult,
   createStdoutLineReader,
+  errorLine,
   finalizeCliResult,
+  isBareCliExitMessage,
+  resolveCliOutput,
+  toolCallLine,
+  toolResultLine,
+  transcriptDetail,
   warnIfTruncated,
+  TRANSCRIPT_DETAIL_CHARS,
 } from "./runtime-common.js";
 
 function cliResult(overrides: Partial<CliProcessResult> = {}): CliProcessResult {
@@ -145,5 +154,129 @@ describe("finalizeCliResult", () => {
   it("omits stderr on failure when the CLI wrote nothing", () => {
     const failed: RuntimeResult = { status: "failed", output: "" };
     expect(finalizeCliResult(failed, cliResult({ stderr: "", exitCode: 1 })).stderr).toBeUndefined();
+  });
+});
+
+describe("transcript line builders", () => {
+  it("tags an assistant message and terminates the line", () => {
+    expect(assistantLine("hello")).toBe("[assistant] hello\n");
+  });
+
+  it("tags a tool call by name, with no detail by default", () => {
+    expect(toolCallLine("Read")).toBe("[tool_call] Read\n");
+  });
+
+  it("appends a detail to a tool call when one is given", () => {
+    expect(toolCallLine("shell", "pnpm test")).toBe("[tool_call] shell pnpm test\n");
+  });
+
+  it("omits an empty detail rather than leaving a dangling separator", () => {
+    expect(toolCallLine("shell", "")).toBe("[tool_call] shell\n");
+  });
+
+  it("names the originating tool on a result line", () => {
+    expect(toolResultLine("Read", "ok")).toBe("[tool_result from Read] ok\n");
+  });
+
+  it("keeps the tool name when the result has no detail", () => {
+    expect(toolResultLine("Read", "")).toBe("[tool_result from Read]\n");
+  });
+
+  it("degrades to a bare tag when the tool name is unknown", () => {
+    // Claude Code tool_result messages carry only a tool_use_id; when
+    // correlating it back to a name fails, naming no tool beats naming
+    // the wrong one.
+    expect(toolResultLine(undefined, "ok")).toBe("[tool_result]\n");
+  });
+
+  it("tags an error message", () => {
+    expect(errorLine("boom")).toBe("[error] boom\n");
+  });
+});
+
+describe("transcriptDetail", () => {
+  it("passes short single-line text through untouched", () => {
+    expect(transcriptDetail("all good")).toBe("all good");
+  });
+
+  it("truncates to the shared cap", () => {
+    expect(transcriptDetail("x".repeat(500))).toHaveLength(TRANSCRIPT_DETAIL_CHARS);
+  });
+
+  it("flattens newlines so one payload cannot fake several tagged lines", () => {
+    expect(transcriptDetail("a\n[assistant] spoofed")).toBe("a [assistant] spoofed");
+  });
+
+  it("truncates before flattening, so the cap counts raw characters", () => {
+    expect(transcriptDetail("a\n".repeat(300))).toHaveLength(TRANSCRIPT_DETAIL_CHARS);
+  });
+});
+
+describe("resolveCliOutput", () => {
+  const exitCode = 1;
+
+  it("prefers the runtime's failure message on failure", () => {
+    expect(
+      resolveCliOutput({
+        failed: true,
+        exitCode,
+        assistantText: "partial",
+        failureMessage: "rate limited",
+      }),
+    ).toBe("rate limited");
+  });
+
+  it("falls back to the assistant text when a failure carried no message", () => {
+    expect(
+      resolveCliOutput({ failed: true, exitCode, assistantText: "partial" }),
+    ).toBe("partial");
+  });
+
+  it("falls back to the bare exit stand-in when a failure yielded nothing", () => {
+    expect(resolveCliOutput({ failed: true, exitCode, assistantText: "" })).toBe(
+      bareCliExitMessage(exitCode),
+    );
+  });
+
+  it("prefers the runtime's canonical final answer on success", () => {
+    expect(
+      resolveCliOutput({
+        failed: false,
+        exitCode: 0,
+        assistantText: "streamed",
+        preferredOutput: "canonical",
+      }),
+    ).toBe("canonical");
+  });
+
+  it("falls through an empty preferred output to the assistant text", () => {
+    // The `||`-not-`??` invariant: an empty string is absence, not a value.
+    expect(
+      resolveCliOutput({
+        failed: false,
+        exitCode: 0,
+        assistantText: "streamed",
+        preferredOutput: "",
+      }),
+    ).toBe("streamed");
+  });
+
+  it("confirms completion when a successful run said nothing at all", () => {
+    expect(resolveCliOutput({ failed: false, exitCode: 0, assistantText: "" })).toBe(
+      "Session completed.",
+    );
+  });
+});
+
+describe("bareCliExitMessage", () => {
+  it("round-trips through its own matcher for every exit code shape", () => {
+    for (const code of [0, 1, 137, -1, null]) {
+      expect(isBareCliExitMessage(bareCliExitMessage(code))).toBe(true);
+    }
+  });
+
+  it("rejects messages that merely contain the stand-in", () => {
+    expect(isBareCliExitMessage("CLI exited with code 1: OOM killed")).toBe(false);
+    expect(isBareCliExitMessage("Session completed.")).toBe(false);
   });
 });

--- a/packages/core/src/adapters/runtime-common.ts
+++ b/packages/core/src/adapters/runtime-common.ts
@@ -169,6 +169,117 @@ export function warnIfTruncated(runtimeTag: string, result: CliProcessResult): v
 }
 
 /**
+ * The persisted-transcript wire format, shared by every CLI runtime.
+ *
+ * A transcript is a newline-terminated sequence of tagged lines
+ * (`[assistant] …`, `[tool_call] …`, `[tool_result from X] …`,
+ * `[error] …`). The tags are a cross-provider contract: downstream LLM
+ * consumers — session summarizers, the chat route's history builder — read
+ * them to tell an agent's own words from a tool's output, and they must
+ * look the same whether the session ran under Claude Code, codex, or
+ * opencode.
+ *
+ * All three adapters previously spelled these templates out by hand, so a
+ * change to the format meant finding fourteen scattered template literals
+ * and getting every one of them right. These builders are the single
+ * definition; the adapters decide *which* lines to emit, not how they read.
+ */
+
+/**
+ * Max characters of tool payload kept on one transcript line. Tool output
+ * can be megabytes; the transcript exists to show the shape of a session,
+ * not to archive it.
+ */
+export const TRANSCRIPT_DETAIL_CHARS = 200;
+
+/**
+ * Squeeze arbitrary tool text onto a single transcript line: truncate to
+ * {@link TRANSCRIPT_DETAIL_CHARS} and flatten embedded newlines to spaces
+ * so one payload can't masquerade as several tagged lines.
+ */
+export function transcriptDetail(text: string): string {
+  return text.slice(0, TRANSCRIPT_DETAIL_CHARS).replace(/\n/g, " ");
+}
+
+/** An agent's own message. */
+export function assistantLine(text: string): string {
+  return `[assistant] ${text}\n`;
+}
+
+/**
+ * A tool invocation. `detail` is optional — most runtimes log the tool name
+ * alone, but codex appends the shell command it ran.
+ */
+export function toolCallLine(tool: string, detail?: string): string {
+  return detail ? `[tool_call] ${tool} ${detail}\n` : `[tool_call] ${tool}\n`;
+}
+
+/**
+ * A tool's result. `tool` is optional because Claude Code's `tool_result`
+ * messages carry only a `tool_use_id`; when correlating it back to a name
+ * fails, the line degrades to a bare `[tool_result]` rather than naming the
+ * wrong tool.
+ */
+export function toolResultLine(tool: string | undefined, detail?: string): string {
+  if (!tool) return "[tool_result]\n";
+  return detail ? `[tool_result from ${tool}] ${detail}\n` : `[tool_result from ${tool}]\n`;
+}
+
+/** A runtime-level error event. */
+export function errorLine(message: string): string {
+  return `[error] ${message}\n`;
+}
+
+/**
+ * The message a CLI runtime reports when it exited non-zero with nothing
+ * better to say.
+ *
+ * Lives here rather than in any one adapter because all three produce it
+ * and `routes/chat.ts` matches on it: {@link isBareCliExitMessage} is the
+ * gate the chat route uses to decide a runtime's `output` is a useless
+ * stand-in worth replacing with the stderr tail or a daemon pointer. Both
+ * halves stay adjacent so the producer and its matcher can't drift.
+ */
+export function bareCliExitMessage(exitCode: number | null): string {
+  return `CLI exited with code ${exitCode}`;
+}
+
+/** Matches exactly the strings {@link bareCliExitMessage} produces. */
+export function isBareCliExitMessage(s: string): boolean {
+  return /^CLI exited with code (-?\d+|null)$/.test(s);
+}
+
+/**
+ * Pick a session's user-facing `output` from the candidates a CLI event
+ * stream yields, in priority order.
+ *
+ * The ladder is the same for every runtime: on failure prefer the runtime's
+ * own error message, else whatever the agent last said, else the bare exit
+ * stand-in; on success prefer the runtime's canonical final answer when it
+ * has one (codex writes it to an `--output-last-message` file), else the
+ * agent's text, else a neutral confirmation.
+ *
+ * Note `||`, not `??`: an empty string must fall through to the next
+ * candidate rather than short-circuit as a "present" value. Both adapters
+ * carried this same warning as a comment above their own copy — the kind of
+ * subtlety that is worth stating once, in the one implementation.
+ */
+export function resolveCliOutput(opts: {
+  failed: boolean;
+  exitCode: number | null;
+  /** Last assistant text seen in the event stream. */
+  assistantText: string;
+  /** Runtime-reported failure message, when the stream carried one. */
+  failureMessage?: string;
+  /** Runtime's canonical final answer, preferred over `assistantText`. */
+  preferredOutput?: string;
+}): string {
+  return opts.failed
+    ? opts.failureMessage || opts.assistantText || bareCliExitMessage(opts.exitCode)
+    : opts.preferredOutput || opts.assistantText || "Session completed.";
+}
+
+/**
  * The `RuntimeResult` for a session the caller aborted via `abort_signal`.
  * Deliberately distinct from a failure so the executor marks the session
  * `cancelled` rather than surfacing it as an error to the user.

--- a/packages/web/app/(authed)/chat/chat-client.tsx
+++ b/packages/web/app/(authed)/chat/chat-client.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
   AlertTriangle,
@@ -17,7 +17,6 @@ import type { HierarchyLevel, KnownCli } from "@beevibe/core";
 import { isApiConfigured } from "@/lib/api/config";
 import {
   api,
-  type ChatConversationsResponse,
   type RepoCard,
   type SuggestedAction,
 } from "@/lib/api/client";
@@ -32,7 +31,7 @@ import { useConversation } from "@/lib/hooks/use-sessions";
 import type { TranscriptEntry } from "@/lib/types/sessions";
 import { useMe } from "@/lib/hooks/use-me";
 import { useAgents } from "@/lib/hooks/use-agents";
-import { queryKeys } from "@/lib/hooks/keys";
+import { useChatConversations } from "@/lib/hooks/use-chat-conversations";
 import { deriveShortId, formatRelativeTime } from "@/lib/format";
 import { defaultTryGoal, formatStars } from "@/lib/capabilities";
 import { cn } from "@/lib/utils";
@@ -374,12 +373,7 @@ function HeroEmptyChat({
   const teamAgent = agents.data?.find((a) => a.hierarchy !== "ic");
   const initial = (teamAgent?.display_name ?? teamAgent?.name ?? "?").charAt(0).toUpperCase();
 
-  const conversations = useQuery<ChatConversationsResponse>({
-    queryKey: queryKeys.chat.conversations(),
-    queryFn: ({ signal }) => api.chat.conversations({ signal }),
-    enabled: isApiConfigured,
-    staleTime: 30_000,
-  });
+  const conversations = useChatConversations();
   const recentChats = (conversations.data?.conversations ?? []).slice(0, 4);
   const suggestions = onboarding ? ONBOARDING_PROMPT_SUGGESTIONS : PROMPT_SUGGESTIONS;
 

--- a/packages/web/app/(authed)/rooms/[id]/room-detail-client.tsx
+++ b/packages/web/app/(authed)/rooms/[id]/room-detail-client.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   AlertTriangle,
   Bot,
@@ -16,6 +16,7 @@ import { useMe } from "@/lib/hooks/use-me";
 import { isApiConfigured } from "@/lib/api/config";
 import { api, type RoomDetail, type RoomMemberDetail, type RoomMessage } from "@/lib/api/client";
 import { ApiError, describeError } from "@/lib/api/http";
+import { useEntityQuery } from "@/lib/hooks/entity-query";
 import { queryKeys } from "@/lib/hooks/keys";
 import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
 import { ModalOverlay } from "@/components/modal-overlay";
@@ -33,10 +34,11 @@ export function RoomDetailClient({ roomId }: { roomId: string }) {
   const [draft, setDraft] = useState("");
   const transcriptRef = useRef<HTMLDivElement | null>(null);
 
-  const { data, isLoading, isError } = useQuery<RoomDetail>({
-    queryKey: queryKeys.rooms.detail(roomId),
-    queryFn: ({ signal }) => api.rooms.get(roomId, { signal }),
-    enabled: isApiConfigured && !!roomId,
+  const { data, isLoading, isError } = useEntityQuery<RoomDetail>({
+    id: roomId,
+    queryKey: queryKeys.rooms.detail,
+    disabledKey: queryKeys.rooms.all,
+    fetch: api.rooms.get,
     staleTime: 1_000,
     // Polling fallback — cloudflared trycloudflare quick tunnels
     // buffer SSE responses, so the bv_event channel often fails to

--- a/packages/web/app/(authed)/rooms/rooms-list-client.tsx
+++ b/packages/web/app/(authed)/rooms/rooms-list-client.tsx
@@ -3,10 +3,11 @@
 import Link from "next/link";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, Loader2, MessageCircleMore, Plus, Users } from "lucide-react";
 import { api, type Room } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
+import { useCollectionQuery } from "@/lib/hooks/entity-query";
 import { queryKeys } from "@/lib/hooks/keys";
 import { Skeleton } from "@/components/skeleton";
 import { EmptyState } from "@/components/empty-state";
@@ -18,10 +19,9 @@ export function RoomsListClient() {
   const [name, setName] = useState("");
   const [error, setError] = useState<string | null>(null);
 
-  const { data, isLoading, isError } = useQuery<{ ok: true; rooms: Room[] }>({
+  const { data, isLoading, isError } = useCollectionQuery<{ ok: true; rooms: Room[] }>({
     queryKey: queryKeys.rooms.list(),
-    queryFn: ({ signal }) => api.rooms.list({ signal }),
-    enabled: isApiConfigured,
+    fetch: api.rooms.list,
     staleTime: 10_000,
   });
 

--- a/packages/web/app/(authed)/runtimes/runtimes-client.tsx
+++ b/packages/web/app/(authed)/runtimes/runtimes-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   AlertTriangle,
   Cpu,
@@ -20,6 +20,7 @@ import {
 } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
 import { describeError } from "@/lib/api/http";
+import { useCollectionQuery } from "@/lib/hooks/entity-query";
 import { queryKeys } from "@/lib/hooks/keys";
 import { formatRelativeTime } from "@/lib/format";
 import { CommandBlock } from "@/components/command-block";
@@ -29,10 +30,9 @@ import { Skeleton } from "@/components/skeleton";
 import { cn } from "@/lib/utils";
 
 export function RuntimesClient() {
-  const query = useQuery<RuntimesListResponse>({
+  const query = useCollectionQuery<RuntimesListResponse>({
     queryKey: queryKeys.runtimes.list(),
-    queryFn: ({ signal }) => api.runtimes.list({ signal }),
-    enabled: isApiConfigured,
+    fetch: api.runtimes.list,
     // SSE invalidates this key on `runtime.updated`; keep cache otherwise
     // long so per-render polling doesn't fight the live updates.
     staleTime: 30_000,

--- a/packages/web/app/(authed)/settings/settings-client.tsx
+++ b/packages/web/app/(authed)/settings/settings-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { ArrowRight, Cpu, Sparkles } from "lucide-react";
 import {
   api,
@@ -9,16 +9,20 @@ import {
   type UserPreferences,
 } from "@/lib/api/client";
 import { isApiConfigured } from "@/lib/api/config";
+import { useCollectionQuery } from "@/lib/hooks/entity-query";
 import { queryKeys } from "@/lib/hooks/keys";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/skeleton";
 
 export function SettingsClient() {
   const qc = useQueryClient();
-  const { data, isLoading, isError } = useQuery<MeResponse>({
+  // NOTE: same cache slot as `useMe()`, but deliberately a longer
+  // staleTime — settings is a cold surface, not the onboarding path
+  // useMe() keeps fresh. Left as-is rather than folded into that hook,
+  // which would change refetch behavior on every other caller.
+  const { data, isLoading, isError } = useCollectionQuery<MeResponse>({
     queryKey: queryKeys.me.self(),
-    queryFn: ({ signal }) => api.me.self({ signal }),
-    enabled: isApiConfigured,
+    fetch: api.me.self,
     staleTime: 30_000,
   });
 

--- a/packages/web/app/(authed)/work-products/[id]/work-product-detail-client.tsx
+++ b/packages/web/app/(authed)/work-products/[id]/work-product-detail-client.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { useQuery } from "@tanstack/react-query";
 import {
   ArrowLeft,
   ChevronRight,
@@ -9,7 +8,7 @@ import {
   FileText,
 } from "lucide-react";
 import { api, type WorkProductDetail } from "@/lib/api/client";
-import { isApiConfigured } from "@/lib/api/config";
+import { useEntityQuery } from "@/lib/hooks/entity-query";
 import { queryKeys } from "@/lib/hooks/keys";
 import { DetailGate } from "@/components/detail/detail-gate";
 import { EmptyState } from "@/components/empty-state";
@@ -20,10 +19,11 @@ import { FooterField } from "@/components/detail/footer-field";
 import { formatRelativeTime, shortId } from "@/lib/format";
 
 export function WorkProductDetailClient({ workProductId }: { workProductId: string }) {
-  const query = useQuery<WorkProductDetail>({
-    queryKey: queryKeys.workProducts.detail(workProductId),
-    queryFn: ({ signal }) => api.workProducts.get(workProductId, { signal }),
-    enabled: isApiConfigured && !!workProductId,
+  const query = useEntityQuery<WorkProductDetail>({
+    id: workProductId,
+    queryKey: queryKeys.workProducts.detail,
+    disabledKey: queryKeys.workProducts.all,
+    fetch: api.workProducts.get,
     staleTime: 30_000,
   });
 

--- a/packages/web/components/chat/conversation-sidebar.tsx
+++ b/packages/web/components/chat/conversation-sidebar.tsx
@@ -3,14 +3,13 @@
 import Link from "next/link";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { MessageSquare, Trash2 } from "lucide-react";
 import {
   api,
-  type ChatConversationsResponse,
   type ChatConversationSummary,
 } from "@/lib/api/client";
-import { isApiConfigured } from "@/lib/api/config";
+import { useChatConversations } from "@/lib/hooks/use-chat-conversations";
 import { queryKeys } from "@/lib/hooks/keys";
 import { formatRelativeTime } from "@/lib/format";
 import { cn } from "@/lib/utils";
@@ -107,12 +106,7 @@ export function ConversationSidebar({
   activeConversationId: string | undefined;
   isFresh: boolean;
 }) {
-  const conversations = useQuery<ChatConversationsResponse>({
-    queryKey: queryKeys.chat.conversations(),
-    queryFn: ({ signal }) => api.chat.conversations({ signal }),
-    enabled: isApiConfigured,
-    staleTime: 30_000,
-  });
+  const conversations = useChatConversations();
 
   const list = conversations.data?.conversations ?? [];
   // The "no specific c, no new" state == latest conversation, which is

--- a/packages/web/components/mode-sidebars.tsx
+++ b/packages/web/components/mode-sidebars.tsx
@@ -2,7 +2,6 @@
 
 import Link from "next/link";
 import type { LucideIcon } from "lucide-react";
-import { useQuery } from "@tanstack/react-query";
 import {
   AlertCircle,
   Bot,
@@ -21,8 +20,8 @@ import {
   api,
   type Room,
 } from "@/lib/api/client";
-import { isApiConfigured } from "@/lib/api/config";
 import { useInbox } from "@/lib/hooks/use-inbox";
+import { useCollectionQuery } from "@/lib/hooks/entity-query";
 import { queryKeys } from "@/lib/hooks/keys";
 import { formatRelativeTime } from "@/lib/format";
 import { cn } from "@/lib/utils";
@@ -110,10 +109,9 @@ export function AgentsSidebar({ pathname }: { pathname: string }) {
 // ── Rooms list ───────────────────────────────────────────────────────
 
 export function RoomsSidebar({ activeRoomId }: { activeRoomId?: string }) {
-  const { data, isLoading } = useQuery<{ ok: true; rooms: Room[] }>({
+  const { data, isLoading } = useCollectionQuery<{ ok: true; rooms: Room[] }>({
     queryKey: queryKeys.rooms.list(),
-    queryFn: ({ signal }) => api.rooms.list({ signal }),
-    enabled: isApiConfigured,
+    fetch: api.rooms.list,
     staleTime: 30_000,
   });
 

--- a/packages/web/lib/hooks/entity-query.test.tsx
+++ b/packages/web/lib/hooks/entity-query.test.tsx
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+const apiState = {
+  isApiConfigured: true,
+};
+
+vi.mock("@/lib/api/config", () => ({
+  get isApiConfigured() {
+    return apiState.isApiConfigured;
+  },
+  apiBaseUrl: "https://api.example.com",
+}));
+
+import { useCollectionQuery, useEntityQuery } from "./entity-query";
+
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function TestQueryWrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+const detailKey = (id: string) => ["thing", "detail", id] as const;
+const allKey = ["thing"] as const;
+
+beforeEach(() => {
+  apiState.isApiConfigured = true;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useEntityQuery", () => {
+  it("fetches with the id once both id and config are present", async () => {
+    const fetch = vi.fn().mockResolvedValue({ id: "x1" });
+
+    const { result } = renderHook(
+      () => useEntityQuery({ id: "x1", queryKey: detailKey, disabledKey: allKey, fetch }),
+      { wrapper: wrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetch).toHaveBeenCalledWith("x1", expect.objectContaining({}));
+    expect(result.current.data).toEqual({ id: "x1" });
+  });
+
+  it("stays disabled while the id is undefined", () => {
+    const fetch = vi.fn().mockResolvedValue({ id: "x1" });
+
+    const { result } = renderHook(
+      () => useEntityQuery({ id: undefined, queryKey: detailKey, disabledKey: allKey, fetch }),
+      { wrapper: wrapper() },
+    );
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("treats an empty-string id as absent rather than fetching /''", () => {
+    const fetch = vi.fn().mockResolvedValue({ id: "" });
+
+    renderHook(
+      () => useEntityQuery({ id: "", queryKey: detailKey, disabledKey: allKey, fetch }),
+      { wrapper: wrapper() },
+    );
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("stays disabled when the api is unconfigured, even with an id", () => {
+    apiState.isApiConfigured = false;
+    const fetch = vi.fn().mockResolvedValue({ id: "x1" });
+
+    renderHook(
+      () => useEntityQuery({ id: "x1", queryKey: detailKey, disabledKey: allKey, fetch }),
+      { wrapper: wrapper() },
+    );
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("gives each id its own cache slot", async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ id: "a" })
+      .mockResolvedValueOnce({ id: "b" });
+    const wrap = wrapper();
+
+    const a = renderHook(
+      () => useEntityQuery({ id: "a", queryKey: detailKey, disabledKey: allKey, fetch }),
+      { wrapper: wrap },
+    );
+    await waitFor(() => expect(a.result.current.isSuccess).toBe(true));
+
+    const b = renderHook(
+      () => useEntityQuery({ id: "b", queryKey: detailKey, disabledKey: allKey, fetch }),
+      { wrapper: wrap },
+    );
+    await waitFor(() => expect(b.result.current.isSuccess).toBe(true));
+
+    expect(a.result.current.data).toEqual({ id: "a" });
+    expect(b.result.current.data).toEqual({ id: "b" });
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("passes extra useQuery options through", async () => {
+    const fetch = vi.fn().mockResolvedValue({ id: "x1", n: 2 });
+
+    const { result } = renderHook(
+      () =>
+        useEntityQuery({
+          id: "x1",
+          queryKey: detailKey,
+          disabledKey: allKey,
+          fetch,
+          select: (d: { id: string; n: number }) => d.n,
+        }),
+      { wrapper: wrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(2);
+  });
+
+  it("surfaces api errors", async () => {
+    const fetch = vi.fn().mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(
+      () => useEntityQuery({ id: "x1", queryKey: detailKey, disabledKey: allKey, fetch }),
+      { wrapper: wrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(new Error("boom"));
+  });
+});
+
+describe("useCollectionQuery", () => {
+  it("fetches when the api is configured", async () => {
+    const fetch = vi.fn().mockResolvedValue([1, 2]);
+
+    const { result } = renderHook(
+      () => useCollectionQuery({ queryKey: ["things", "list"], fetch }),
+      { wrapper: wrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([1, 2]);
+  });
+
+  it("does not fire when the api is unconfigured", () => {
+    apiState.isApiConfigured = false;
+    const fetch = vi.fn().mockResolvedValue([]);
+
+    const { result } = renderHook(
+      () => useCollectionQuery({ queryKey: ["things", "list"], fetch }),
+      { wrapper: wrapper() },
+    );
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("passes extra useQuery options through", async () => {
+    const fetch = vi.fn().mockResolvedValue([1, 2, 3]);
+
+    const { result } = renderHook(
+      () =>
+        useCollectionQuery({
+          queryKey: ["things", "list"],
+          fetch,
+          select: (d: number[]) => d.length,
+        }),
+      { wrapper: wrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(3);
+  });
+});

--- a/packages/web/lib/hooks/entity-query.ts
+++ b/packages/web/lib/hooks/entity-query.ts
@@ -1,0 +1,94 @@
+import { useQuery, type UseQueryOptions, type UseQueryResult } from "@tanstack/react-query";
+import type { ReadOptions } from "@/lib/api/client";
+import { isApiConfigured } from "@/lib/api/config";
+
+/**
+ * The "one entity, addressed by an id that may not be there yet" query.
+ *
+ * Eight call sites — `useTask`, `useAgent`, `useSession`, `useConversation`,
+ * `useEscalation`, `useNegotiation`, plus the room and work-product detail
+ * clients — had each written out the same four lines:
+ *
+ * ```ts
+ * useQuery({
+ *   queryKey: id ? queryKeys.x.detail(id) : queryKeys.x.all,
+ *   queryFn: ({ signal }) => api.x.get(id as string, { signal }),
+ *   enabled: isApiConfigured && !!id,
+ * })
+ * ```
+ *
+ * Three things are easy to get wrong when writing that by hand, and all
+ * three are invisible until runtime:
+ *
+ * - Dropping `isApiConfigured` from `enabled` fires a fetch at a null base
+ *   URL on a deployment that has no api configured.
+ * - Dropping `!!id` fires a fetch at `/undefined`.
+ * - The `id as string` cast in `queryFn` is only sound *because* `enabled`
+ *   gates it. The cast and the guard that justifies it sat in different
+ *   properties of the same object literal, repeated six times, with nothing
+ *   tying them together.
+ *
+ * Here the guard and the cast are adjacent, written once, and every caller
+ * inherits them. Callers pass the remaining useQuery options through —
+ * `staleTime`, `select`, `refetchInterval` — so the per-surface tuning that
+ * motivated several of these hooks survives verbatim.
+ */
+export function useEntityQuery<TData, TSelected = TData>({
+  id,
+  queryKey,
+  disabledKey,
+  fetch,
+  ...options
+}: {
+  /** The entity id. `undefined` while the route param is still resolving. */
+  id: string | undefined;
+  /** Cache key for a present id. */
+  queryKey: (id: string) => readonly unknown[];
+  /**
+   * Cache key used while `id` is absent. The query is disabled then, so
+   * this slot is never written; it exists because `queryKey` is required.
+   * Convention is the entity's `all` prefix.
+   */
+  disabledKey: readonly unknown[];
+  /** The api client read for this entity. */
+  fetch: (id: string, options: ReadOptions) => Promise<TData>;
+} & Omit<
+  UseQueryOptions<TData, Error, TSelected>,
+  "queryKey" | "queryFn" | "enabled"
+>): UseQueryResult<TSelected, Error> {
+  const hasId = id !== undefined && id !== "";
+  return useQuery<TData, Error, TSelected>({
+    queryKey: hasId ? queryKey(id) : disabledKey,
+    // Sound because `enabled` below is false whenever `hasId` is —
+    // react-query never invokes queryFn for a disabled query.
+    queryFn: ({ signal }) => fetch(id as string, { signal }),
+    enabled: isApiConfigured && hasId,
+    ...options,
+  });
+}
+
+/**
+ * The "whole collection" counterpart: no id to wait on, so the only shared
+ * concern is gating on a configured api. Seventeen call sites repeated
+ * `enabled: isApiConfigured`; the value of routing them through here is
+ * that adding a global read concern later (a signed-out guard, say) is one
+ * edit rather than seventeen.
+ */
+export function useCollectionQuery<TData, TSelected = TData>({
+  queryKey,
+  fetch,
+  ...options
+}: {
+  queryKey: readonly unknown[];
+  fetch: (options: ReadOptions) => Promise<TData>;
+} & Omit<
+  UseQueryOptions<TData, Error, TSelected>,
+  "queryKey" | "queryFn" | "enabled"
+>): UseQueryResult<TSelected, Error> {
+  return useQuery<TData, Error, TSelected>({
+    queryKey,
+    queryFn: ({ signal }) => fetch({ signal }),
+    enabled: isApiConfigured,
+    ...options,
+  });
+}

--- a/packages/web/lib/hooks/use-agent-network.ts
+++ b/packages/web/lib/hooks/use-agent-network.ts
@@ -1,9 +1,8 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
-import { isApiConfigured } from "@/lib/api/config";
 import type { AgentNetwork } from "@/lib/types/agent-network";
+import { useCollectionQuery } from "./entity-query";
 import { queryKeys } from "./keys";
 
 /**
@@ -12,10 +11,9 @@ import { queryKeys } from "./keys";
  * peer team orbits around it).
  */
 export function useAgentNetwork() {
-  return useQuery<AgentNetwork>({
+  return useCollectionQuery<AgentNetwork>({
     queryKey: queryKeys.agentNetwork.self(),
-    queryFn: ({ signal }) => api.agents.network({ signal }),
-    enabled: isApiConfigured,
+    fetch: api.agents.network,
     staleTime: 30_000,
   });
 }

--- a/packages/web/lib/hooks/use-agents.ts
+++ b/packages/web/lib/hooks/use-agents.ts
@@ -1,20 +1,19 @@
-import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
-import { isApiConfigured } from "@/lib/api/config";
+import { useCollectionQuery, useEntityQuery } from "./entity-query";
 import { queryKeys } from "./keys";
 
 export function useAgents() {
-  return useQuery({
+  return useCollectionQuery({
     queryKey: queryKeys.agents.list(),
-    queryFn: ({ signal }) => api.agents.list({ signal }),
-    enabled: isApiConfigured,
+    fetch: api.agents.list,
   });
 }
 
 export function useAgent(id: string | undefined) {
-  return useQuery({
-    queryKey: id ? queryKeys.agents.detail(id) : queryKeys.agents.all,
-    queryFn: ({ signal }) => api.agents.get(id as string, { signal }),
-    enabled: isApiConfigured && !!id,
+  return useEntityQuery({
+    id,
+    queryKey: queryKeys.agents.detail,
+    disabledKey: queryKeys.agents.all,
+    fetch: api.agents.get,
   });
 }

--- a/packages/web/lib/hooks/use-chat-conversations.ts
+++ b/packages/web/lib/hooks/use-chat-conversations.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { api, type ChatConversationsResponse } from "@/lib/api/client";
+import { useCollectionQuery } from "./entity-query";
+import { queryKeys } from "./keys";
+
+/**
+ * The caller's recent chat conversations, backing both the chat
+ * landing page's "recent" strip and the conversation sidebar. Those two
+ * had each declared the same query — same key, same fetch, same
+ * `staleTime` — so a change to one silently disagreed with the other
+ * while sharing a cache slot.
+ */
+export function useChatConversations() {
+  return useCollectionQuery<ChatConversationsResponse>({
+    queryKey: queryKeys.chat.conversations(),
+    fetch: api.chat.conversations,
+    staleTime: 30_000,
+  });
+}

--- a/packages/web/lib/hooks/use-dashboard.ts
+++ b/packages/web/lib/hooks/use-dashboard.ts
@@ -1,14 +1,12 @@
-import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
-import { isApiConfigured } from "@/lib/api/config";
 import { summaryToDisplay } from "@/lib/dashboard-display";
+import { useCollectionQuery } from "./entity-query";
 import { queryKeys } from "./keys";
 
 export function useDashboard() {
-  return useQuery({
+  return useCollectionQuery({
     queryKey: queryKeys.dashboard.summary(),
-    queryFn: ({ signal }) => api.dashboard.summary({ signal }),
+    fetch: api.dashboard.summary,
     select: summaryToDisplay,
-    enabled: isApiConfigured,
   });
 }

--- a/packages/web/lib/hooks/use-escalations.ts
+++ b/packages/web/lib/hooks/use-escalations.ts
@@ -1,12 +1,12 @@
-import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
-import { isApiConfigured } from "@/lib/api/config";
+import { useEntityQuery } from "./entity-query";
 import { queryKeys } from "./keys";
 
 export function useEscalation(id: string | undefined) {
-  return useQuery({
-    queryKey: id ? queryKeys.escalations.detail(id) : queryKeys.escalations.all,
-    queryFn: ({ signal }) => api.escalations.get(id as string, { signal }),
-    enabled: isApiConfigured && !!id,
+  return useEntityQuery({
+    id,
+    queryKey: queryKeys.escalations.detail,
+    disabledKey: queryKeys.escalations.all,
+    fetch: api.escalations.get,
   });
 }

--- a/packages/web/lib/hooks/use-inbox.ts
+++ b/packages/web/lib/hooks/use-inbox.ts
@@ -1,9 +1,8 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
-import { isApiConfigured } from "@/lib/api/config";
 import type { InboxItem } from "@/lib/types/inbox";
+import { useCollectionQuery } from "./entity-query";
 import { queryKeys } from "./keys";
 
 /**
@@ -12,10 +11,9 @@ import { queryKeys } from "./keys";
  * Backs the Home sidebar's primary list.
  */
 export function useInbox() {
-  return useQuery<InboxItem[]>({
+  return useCollectionQuery<InboxItem[]>({
     queryKey: queryKeys.inbox.list(),
-    queryFn: ({ signal }) => api.inbox.list({ signal }),
-    enabled: isApiConfigured,
+    fetch: api.inbox.list,
     staleTime: 10_000,
   });
 }

--- a/packages/web/lib/hooks/use-me.ts
+++ b/packages/web/lib/hooks/use-me.ts
@@ -1,8 +1,7 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
 import { api, type MeResponse } from "@/lib/api/client";
-import { isApiConfigured } from "@/lib/api/config";
+import { useCollectionQuery } from "./entity-query";
 import { queryKeys } from "./keys";
 
 /**
@@ -11,10 +10,9 @@ import { queryKeys } from "./keys";
  * (e.g. the chat route flipped the column after the first turn).
  */
 export function useMe() {
-  return useQuery<MeResponse>({
+  return useCollectionQuery<MeResponse>({
     queryKey: queryKeys.me.self(),
-    queryFn: ({ signal }) => api.me.self({ signal }),
-    enabled: isApiConfigured,
+    fetch: api.me.self,
     staleTime: 0,
   });
 }

--- a/packages/web/lib/hooks/use-memory-activity.ts
+++ b/packages/web/lib/hooks/use-memory-activity.ts
@@ -1,20 +1,10 @@
-import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
-import { isApiConfigured } from "@/lib/api/config";
+import { useCollectionQuery } from "./entity-query";
 import { queryKeys } from "./keys";
 
-export function useMemoryActivity(params: {
-  weeks?: number;
-  since?: string;
-}) {
-  return useQuery({
+export function useMemoryActivity(params: { weeks?: number; since?: string }) {
+  return useCollectionQuery({
     queryKey: queryKeys.memory.activity(params),
-    queryFn: ({ signal }) =>
-      api.memory.activity({
-        signal,
-        weeks: params.weeks,
-        since: params.since,
-      }),
-    enabled: isApiConfigured,
+    fetch: (opts) => api.memory.activity({ ...opts, weeks: params.weeks, since: params.since }),
   });
 }

--- a/packages/web/lib/hooks/use-memory.ts
+++ b/packages/web/lib/hooks/use-memory.ts
@@ -1,15 +1,13 @@
-import { useQuery } from "@tanstack/react-query";
 import type { MemoryScope } from "@beevibe/core";
 import { api } from "@/lib/api/client";
-import { isApiConfigured } from "@/lib/api/config";
 import type { FactCounts } from "@/lib/types/memory-facts";
+import { useCollectionQuery } from "./entity-query";
 import { queryKeys } from "./keys";
 
 export function useMemoryFacts(filter: { scope?: MemoryScope } = {}) {
-  return useQuery({
+  return useCollectionQuery({
     queryKey: queryKeys.memory.facts(filter),
-    queryFn: ({ signal }) => api.memory.listFacts(filter, { signal }),
-    enabled: isApiConfigured,
+    fetch: (opts) => api.memory.listFacts(filter, opts),
   });
 }
 
@@ -22,9 +20,8 @@ export function useMemoryFacts(filter: { scope?: MemoryScope } = {}) {
  * both at once.
  */
 export function useMemoryFactCounts() {
-  return useQuery<FactCounts>({
+  return useCollectionQuery<FactCounts>({
     queryKey: queryKeys.memory.counts(),
-    queryFn: ({ signal }) => api.memory.factCounts({ signal }),
-    enabled: isApiConfigured,
+    fetch: api.memory.factCounts,
   });
 }

--- a/packages/web/lib/hooks/use-mesh.ts
+++ b/packages/web/lib/hooks/use-mesh.ts
@@ -1,15 +1,13 @@
-import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
-import { isApiConfigured } from "@/lib/api/config";
 import { overviewToDisplay } from "@/lib/mesh-display";
 import type { MeshWindow } from "@/lib/types/mesh";
+import { useCollectionQuery } from "./entity-query";
 import { queryKeys } from "./keys";
 
 export function useMeshOverview(filter: { window?: MeshWindow } = {}) {
-  return useQuery({
+  return useCollectionQuery({
     queryKey: queryKeys.mesh.overview(filter),
-    queryFn: ({ signal }) => api.mesh.overview(filter, { signal }),
+    fetch: (opts) => api.mesh.overview(filter, opts),
     select: overviewToDisplay,
-    enabled: isApiConfigured,
   });
 }

--- a/packages/web/lib/hooks/use-negotiations.ts
+++ b/packages/web/lib/hooks/use-negotiations.ts
@@ -1,12 +1,12 @@
-import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
-import { isApiConfigured } from "@/lib/api/config";
+import { useEntityQuery } from "./entity-query";
 import { queryKeys } from "./keys";
 
 export function useNegotiation(id: string | undefined) {
-  return useQuery({
-    queryKey: id ? queryKeys.negotiations.detail(id) : queryKeys.negotiations.all,
-    queryFn: ({ signal }) => api.negotiations.get(id as string, { signal }),
-    enabled: isApiConfigured && !!id,
+  return useEntityQuery({
+    id,
+    queryKey: queryKeys.negotiations.detail,
+    disabledKey: queryKeys.negotiations.all,
+    fetch: api.negotiations.get,
   });
 }

--- a/packages/web/lib/hooks/use-promotions.ts
+++ b/packages/web/lib/hooks/use-promotions.ts
@@ -1,12 +1,10 @@
-import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
-import { isApiConfigured } from "@/lib/api/config";
+import { useCollectionQuery } from "./entity-query";
 import { queryKeys } from "./keys";
 
 export function usePromotions() {
-  return useQuery({
+  return useCollectionQuery({
     queryKey: queryKeys.promotions.list(),
-    queryFn: ({ signal }) => api.promotions.list({ signal }),
-    enabled: isApiConfigured,
+    fetch: api.promotions.list,
   });
 }

--- a/packages/web/lib/hooks/use-sessions.ts
+++ b/packages/web/lib/hooks/use-sessions.ts
@@ -1,13 +1,13 @@
-import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api/client";
-import { isApiConfigured } from "@/lib/api/config";
+import { useEntityQuery } from "./entity-query";
 import { queryKeys } from "./keys";
 
 export function useSession(shortId: string | undefined) {
-  return useQuery({
-    queryKey: shortId ? queryKeys.sessions.detail(shortId) : queryKeys.sessions.all,
-    queryFn: ({ signal }) => api.sessions.get(shortId as string, { signal }),
-    enabled: isApiConfigured && !!shortId,
+  return useEntityQuery({
+    id: shortId,
+    queryKey: queryKeys.sessions.detail,
+    disabledKey: queryKeys.sessions.all,
+    fetch: api.sessions.get,
   });
 }
 
@@ -18,12 +18,11 @@ export function useSession(shortId: string | undefined) {
  * renders them unchanged.
  */
 export function useConversation(shortId: string | undefined) {
-  return useQuery({
-    queryKey: shortId
-      ? queryKeys.sessions.conversation(shortId)
-      : queryKeys.sessions.all,
-    queryFn: ({ signal }) => api.sessions.conversation(shortId as string, { signal }),
-    enabled: isApiConfigured && !!shortId,
+  return useEntityQuery({
+    id: shortId,
+    queryKey: queryKeys.sessions.conversation,
+    disabledKey: queryKeys.sessions.all,
+    fetch: api.sessions.conversation,
     // A completed turn's transcript is immutable, so this potentially-large
     // fetch (every turn × up to 500 events) needn't refetch on focus/idle.
     // In-flight turns surface live via SSE, not this query. Cold loads still

--- a/packages/web/lib/hooks/use-tasks.ts
+++ b/packages/web/lib/hooks/use-tasks.ts
@@ -1,13 +1,11 @@
-import { useQuery } from "@tanstack/react-query";
 import { api, type TaskListFilter } from "@/lib/api/client";
-import { isApiConfigured } from "@/lib/api/config";
+import { useCollectionQuery, useEntityQuery } from "./entity-query";
 import { queryKeys } from "./keys";
 
 export function useTasks(filter: TaskListFilter = {}) {
-  return useQuery({
+  return useCollectionQuery({
     queryKey: queryKeys.tasks.list(filter),
-    queryFn: ({ signal }) => api.tasks.list(filter, { signal }),
-    enabled: isApiConfigured,
+    fetch: (opts) => api.tasks.list(filter, opts),
     // Always refetch when the user lands on /tasks. The default
     // staleTime: 30_000 (providers.tsx) combined with mount-with-cached-
     // data semantics means /chat → /tasks could render the previous
@@ -23,9 +21,10 @@ export function useTasks(filter: TaskListFilter = {}) {
 }
 
 export function useTask(id: string | undefined) {
-  return useQuery({
-    queryKey: id ? queryKeys.tasks.detail(id) : queryKeys.tasks.all,
-    queryFn: ({ signal }) => api.tasks.get(id as string, { signal }),
-    enabled: isApiConfigured && !!id,
+  return useEntityQuery({
+    id,
+    queryKey: queryKeys.tasks.detail,
+    disabledKey: queryKeys.tasks.all,
+    fetch: api.tasks.get,
   });
 }


### PR DESCRIPTION
Swept the monorepo for near-duplicate abstractions and unified the two clusters worth acting on. Two independent commits; each is reviewable on its own.

The codebase is already well-swept — `runtime-common.ts`, `pg-helpers.ts`, `http-errors.ts`, `views/format.ts` are all prior dedup passes. A token-level clone scan (jscpd, 12-line/70-token floor) puts duplication at **0.73%**, and only three of the 39 clones are outside test files. So what's left is *structural* duplication — same shape, different identifiers — which copy-paste detectors miss entirely. Both clusters below are that kind.

---

## 1. `refactor(core)`: the transcript wire format across CLI runtimes

The claude-code, codex and opencode parsers each spelled out the same persisted-transcript format by hand — `[assistant] …`, `[tool_call] …`, `[tool_result from X] …`, `[error] …` — across **fourteen template literals in three files**, plus four copies of the "truncate to 200, flatten newlines" idiom.

Those tags are a cross-provider contract: downstream LLM consumers read them to tell an agent's own words from a tool's output, and they must look identical whichever CLI ran the session. Three hand-maintained copies meant a format change had fourteen chances to go subtly wrong.

Adds the single definition to `runtime-common.ts` — `assistantLine` / `toolCallLine` / `toolResultLine` / `errorLine`, and `transcriptDetail` over a shared `TRANSCRIPT_DETAIL_CHARS`. Adapters now decide *which* lines to emit, not how they read.

Two more cross-runtime duplicates folded in:

- **`resolveCliOutput`** replaces the output-fallback ladder codex and opencode had each written out — down to a copy of the same comment warning that `||` (not `??`) is load-bearing because an empty string must fall through rather than short-circuit. When the same subtlety is worth a comment in two places, it's worth one implementation.
- **`bareCliExitMessage` / `isBareCliExitMessage`** move out of the claude-code adapter, an odd home for a stand-in all three runtimes produce and the api's chat route matches on. Re-exported from `claude-code/stream-json.ts`, so the public `@beevibe/core/adapters/claude-code` subpath is **unchanged**.

**One deliberate normalization:** a codex `command_execution` item with an empty command produced `[tool_call] shell \n` with a dangling space; `toolCallLine` now omits an empty detail. No test covered it.

## 2. `refactor(web)`: the api-backed query hooks

Twenty-two `useQuery` call sites across `lib/hooks` and the page clients had each written out the same read-query preamble, in two recurring shapes:

```ts
// eight "one entity by an id that may not be there yet" sites
useQuery({
  queryKey: id ? queryKeys.x.detail(id) : queryKeys.x.all,
  queryFn: ({ signal }) => api.x.get(id as string, { signal }),
  enabled: isApiConfigured && !!id,
})

// seventeen "whole collection" sites
useQuery({ queryKey, queryFn: ({ signal }) => …, enabled: isApiConfigured })
```

Three things in the first shape are easy to get wrong, and all three fail only at runtime:

- dropping `isApiConfigured` fetches against a null base URL,
- dropping `!!id` fetches `/undefined`,
- the `id as string` cast is sound **only because** `enabled` gates it — yet the cast and the guard justifying it sat in different properties of the same object literal, repeated six times, with nothing tying them together.

`useEntityQuery` / `useCollectionQuery` state each invariant once. The six call-site casts are gone; the one that remains lives inside the helper, adjacent to the guard that makes it sound. Callers still pass `staleTime`, `select`, `refetchOnMount` and `refetchInterval` through, so the per-surface tuning several of these hooks exist for survives verbatim.

Two duplicates surfaced while migrating:

- **`chat.conversations` was declared twice** — same key, same fetch, same `staleTime` — in `chat-client` and `conversation-sidebar`: two copies sharing one cache slot. Extracted as `useChatConversations`.
- **`settings-client` re-declares the `me.self` query** that `useMe` already owns, with a *different* `staleTime` on the same cache slot (30s vs 0), so whichever mounts first sets the refetch behavior. Left alone and commented rather than folded in — unifying them changes behavior for every other `useMe` caller, which is a product call, not a refactor. Flagged here for a maintainer.

---

## Verification

Behavior-preserving throughout. The strongest evidence is that the **existing** tests already pinned the invariants being centralized and pass untouched: `use-tasks.test.tsx` covers exactly "disabled with no id / disabled with no api config / fetches with both", and the 96 existing runtime parser tests cover the transcript output.

- `pnpm lint`, `pnpm typecheck` — clean across all 9 tasks
- `tsc --noEmit --noUnusedLocals` — clean (no imports orphaned by the migration)
- 213 web tests pass; 173 core adapter tests pass
- Real `next build` succeeds (via `pnpm --filter @beevibe/web exec next build`, per CLAUDE.md's note about Turbo stripping proxy env vars)
- **30 new tests** pin the new shared helpers directly — 20 for the runtime builders, 10 for the query hooks

Full-suite runs match the sandbox baseline in CLAUDE.md; every remaining failure is one of the four documented environmental causes (`DATABASE_URL_TEST`, `OPENAI_API_KEY`/`ANTHROPIC_API_KEY` missing, and the `reading 'end'` knock-on from the first). No new failure categories.

## Considered and deliberately not done

- **Postgres repos** — 21 sites of `rows[0] ? map(rows[0]) : undefined` and 3 of the `findManyByIds` guard. A helper would save ~2 lines each over SQL that genuinely differs per call (compound WHEREs, ORDER BYs, column lists). `pg-helpers.ts` already covers the cases that pay for themselves; the rest is noise, not duplication.
- **The three `runtime.ts` `execute()` bodies** — share a skeleton, but the provider-specific MCP wiring, arg construction and env handling between the shared steps mean a template method would need more parameters than it removes lines.
- **The codex/opencode `switch` bodies in `parse*Events`** — structurally parallel but over genuinely different event schemas. Merging them would couple two independent upstream wire formats; the existing file comments say as much, and I agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BYMU5phK4qRFcD78bu6fX

---
_Generated by [Claude Code](https://claude.ai/code/session_015BYMU5phK4qRFcD78bu6fX)_