### PR TITLE
test: cover the six modules that had no test file at all

### DIFF
--- a/packages/api/src/routes/chat.test.ts
+++ b/packages/api/src/routes/chat.test.ts
@@ -1,0 +1,806 @@
+/**
+ * The /chat router — the human chat surface.
+ *
+ * `chat-internals.test.ts` covers the exported pure helpers
+ * (`groupIntoConversations`, `chainToMessages`, `failureMessageFor`).
+ * This file covers the HTTP layer around them: the auth gate, the
+ * idempotent-replay ladder on POST, the rate-limit and daemon-offline
+ * refusals, the resolver timeout, the onboarding flip, and what GET
+ * puts on the wire.
+ *
+ * Every collaborator is injected, so the router mounts on a bare
+ * Express app with stub repos — no database, no daemon, no CLI.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import express, { json, type RequestHandler } from "express";
+import request from "supertest";
+import type {
+  AgentRepository,
+  PersonRepository,
+  RuntimeRepository,
+  Session,
+  SessionRepository,
+  SessionStatus,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import type { ChatResolver } from "../runtime/chat-resolver.js";
+import type { DaemonHub } from "../runtime/hub.js";
+import { ChatRateLimiter } from "./chat-rate-limit.js";
+import { createChatRouter } from "./chat.js";
+
+const PERSON = "per_alice";
+const AGENT = {
+  id: "agt_team",
+  name: "Team Lead",
+  hierarchy_level: "team",
+  runtime_config: { type: "claude" },
+};
+
+const humanCaller = { source: "human", personId: PERSON };
+const agentCaller = { source: "agent", personId: PERSON, agentId: "agt_1" };
+
+function callerAs(caller: unknown): RequestHandler {
+  return (req, _res, next) => {
+    if (caller !== null) (req as { caller?: unknown }).caller = caller;
+    next();
+  };
+}
+
+/** A chat session row as `listChatForAgent` would hand it back. */
+function chatSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "sess_aaaaaaaaaaaa",
+    type: "chat",
+    status: "succeeded",
+    agent_id: AGENT.id,
+    intent: "hello",
+    result_summary: "hi there",
+    created_at: new Date("2026-05-01T10:00:00Z"),
+    ...overrides,
+  } as Session;
+}
+
+interface Stubs {
+  findTopLevelForOwner: ReturnType<typeof vi.fn>;
+  personFindById: ReturnType<typeof vi.fn>;
+  personUpdate: ReturnType<typeof vi.fn>;
+  runtimeFindById: ReturnType<typeof vi.fn>;
+  listChatForAgent: ReturnType<typeof vi.fn>;
+  sessionFindById: ReturnType<typeof vi.fn>;
+  softDeleteChatChain: ReturnType<typeof vi.fn>;
+  dispatchTask: ReturnType<typeof vi.fn>;
+  register: ReturnType<typeof vi.fn>;
+  isOnline: ReturnType<typeof vi.fn>;
+}
+
+function makeApp(
+  opts: {
+    caller?: unknown;
+    agent?: unknown;
+    rateLimiter?: ChatRateLimiter;
+  } = {},
+): { app: express.Express } & Stubs {
+  const agent = "agent" in opts ? opts.agent : AGENT;
+
+  const stubs: Stubs = {
+    findTopLevelForOwner: vi.fn(async () => agent),
+    personFindById: vi.fn(async () => ({
+      id: PERSON,
+      onboarding_completed_at: new Date("2026-01-01"),
+    })),
+    personUpdate: vi.fn(async () => undefined),
+    runtimeFindById: vi.fn(async () => undefined),
+    listChatForAgent: vi.fn(async () => [] as Session[]),
+    sessionFindById: vi.fn(async () => undefined),
+    softDeleteChatChain: vi.fn(async () => 0),
+    dispatchTask: vi.fn(async () => ({
+      session: chatSession({ id: "sess_bbbbbbbbbbbb", status: "pending" }),
+      runtime_id: null,
+    })),
+    register: vi.fn(async () =>
+      chatSession({ id: "sess_bbbbbbbbbbbb", result_summary: "done" }),
+    ),
+    isOnline: vi.fn(() => true),
+  };
+
+  const router = createChatRouter({
+    authMiddleware: callerAs("caller" in opts ? opts.caller : humanCaller),
+    agentRepo: {
+      findTopLevelForOwner: stubs.findTopLevelForOwner,
+    } as unknown as AgentRepository,
+    personRepo: {
+      findById: stubs.personFindById,
+      update: stubs.personUpdate,
+    } as unknown as PersonRepository,
+    runtimeRepo: {
+      findById: stubs.runtimeFindById,
+    } as unknown as RuntimeRepository,
+    sessionRepo: {
+      listChatForAgent: stubs.listChatForAgent,
+      findById: stubs.sessionFindById,
+      softDeleteChatChain: stubs.softDeleteChatChain,
+    } as unknown as SessionRepository,
+    dispatchService: {
+      dispatchTask: stubs.dispatchTask,
+    } as unknown as DispatchService,
+    chatResolver: { register: stubs.register } as unknown as ChatResolver,
+    hub: { isOnline: stubs.isOnline } as unknown as DaemonHub,
+    rateLimiter: opts.rateLimiter,
+  });
+
+  const app = express();
+  app.use(json());
+  app.use("/chat", router);
+  return { app, ...stubs };
+}
+
+/** First argument of a mock's first call, as a readable bag of fields. */
+function firstArgOf(mock: {
+  mock: { calls: unknown[][] };
+}): Record<string, unknown> {
+  return mock.mock.calls[0]![0] as Record<string, unknown>;
+}
+
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  errorSpy.mockRestore();
+  vi.useRealTimers();
+});
+
+describe("chat routes — auth", () => {
+  it.each([
+    ["GET /chat", "get", "/chat"],
+    ["GET /chat/conversations", "get", "/chat/conversations"],
+    ["DELETE /chat/conversations/:headId", "delete", "/chat/conversations/sess_1"],
+    ["POST /chat", "post", "/chat"],
+  ])("%s refuses an agent caller", async (_label, method, path) => {
+    const { app, findTopLevelForOwner } = makeApp({ caller: agentCaller });
+    const send = (request(app) as unknown as Record<string, (p: string) => Promise<request.Response>>)[
+      method
+    ]!;
+    const res = await send(path);
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("human_required");
+    expect(findTopLevelForOwner).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /chat/conversations", () => {
+  it("returns an empty list when the caller has no primary agent", async () => {
+    const { app, listChatForAgent } = makeApp({ agent: undefined });
+    const res = await request(app).get("/chat/conversations");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, conversations: [] });
+    expect(listChatForAgent).not.toHaveBeenCalled();
+  });
+
+  it("summarizes each chain with a title, turn count and preview", async () => {
+    const head = chatSession({
+      id: "sess_head0000",
+      intent: "plan the migration",
+      result_summary: "sure",
+      created_at: new Date("2026-05-01T10:00:00Z"),
+    });
+    const tail = chatSession({
+      id: "sess_tail0000",
+      prior_session_id: head.id,
+      intent: "and then?",
+      result_summary: "then   we\nship it",
+      created_at: new Date("2026-05-01T11:00:00Z"),
+    });
+    const { app, listChatForAgent } = makeApp();
+    listChatForAgent.mockResolvedValue([head, tail]);
+
+    const res = await request(app).get("/chat/conversations");
+    expect(res.status).toBe(200);
+    expect(res.body.conversations).toEqual([
+      {
+        head_id: head.id,
+        // Title comes from the head turn; the preview from the tail.
+        title: "plan the migration",
+        turn_count: 2,
+        last_at: tail.created_at.toISOString(),
+        last_preview: "then we ship it",
+      },
+    ]);
+  });
+
+  it("truncates a long conversation title to 80 chars", async () => {
+    const { app, listChatForAgent } = makeApp();
+    listChatForAgent.mockResolvedValue([
+      chatSession({ intent: "z".repeat(200) }),
+    ]);
+    const res = await request(app).get("/chat/conversations");
+    const title = res.body.conversations[0].title as string;
+    expect(title).toHaveLength(80);
+    expect(title.endsWith("…")).toBe(true);
+  });
+
+  it("previews the error when a failed turn has no summary", async () => {
+    const { app, listChatForAgent } = makeApp();
+    listChatForAgent.mockResolvedValue([
+      chatSession({
+        status: "failed",
+        result_summary: undefined,
+        error: "spawn ENOENT",
+      }),
+    ]);
+    const res = await request(app).get("/chat/conversations");
+    expect(res.body.conversations[0].last_preview).toBe("spawn ENOENT");
+  });
+
+  it("clips a long preview to 140 chars", async () => {
+    const { app, listChatForAgent } = makeApp();
+    listChatForAgent.mockResolvedValue([
+      chatSession({ result_summary: "y".repeat(500) }),
+    ]);
+    const preview = (await request(app).get("/chat/conversations")).body
+      .conversations[0].last_preview as string;
+    expect(preview).toHaveLength(140);
+    expect(preview.endsWith("…")).toBe(true);
+  });
+});
+
+describe("DELETE /chat/conversations/:headId", () => {
+  it("soft-deletes the chain scoped to the caller's agent", async () => {
+    const { app, softDeleteChatChain } = makeApp();
+    softDeleteChatChain.mockResolvedValue(3);
+    const res = await request(app).delete("/chat/conversations/sess_head");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, deleted: 3 });
+    expect(softDeleteChatChain).toHaveBeenCalledWith("sess_head", AGENT.id);
+  });
+
+  it("is idempotent — a chain already gone deletes zero rows", async () => {
+    const { app, softDeleteChatChain } = makeApp();
+    softDeleteChatChain.mockResolvedValue(0);
+    const res = await request(app).delete("/chat/conversations/sess_head");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, deleted: 0 });
+  });
+
+  it("404s when the caller has no primary agent", async () => {
+    const { app, softDeleteChatChain } = makeApp({ agent: undefined });
+    const res = await request(app).delete("/chat/conversations/sess_head");
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("agent_not_found");
+    expect(softDeleteChatChain).not.toHaveBeenCalled();
+  });
+
+  it("500s with a request id when the delete throws", async () => {
+    const { app, softDeleteChatChain } = makeApp();
+    softDeleteChatChain.mockRejectedValue(new Error("deadlock detected"));
+    const res = await request(app).delete("/chat/conversations/sess_head");
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("internal_error");
+    expect(res.body.request_id).toMatch(/^req_/);
+    // The detail stays in the logs, not on the wire.
+    expect(JSON.stringify(res.body)).not.toContain("deadlock");
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});
+
+describe("GET /chat", () => {
+  it("returns a null agent when none is provisioned", async () => {
+    const { app } = makeApp({ agent: undefined });
+    const res = await request(app).get("/chat");
+    expect(res.body).toEqual({
+      ok: true,
+      agent: null,
+      messages: [],
+      prior_session_id: null,
+      conversation_id: null,
+    });
+  });
+
+  it("returns an empty conversation when the agent has no chats", async () => {
+    const { app } = makeApp();
+    const res = await request(app).get("/chat");
+    expect(res.body).toMatchObject({
+      ok: true,
+      agent: { id: AGENT.id, name: AGENT.name, hierarchy: "team" },
+      messages: [],
+      prior_session_id: null,
+      conversation_id: null,
+    });
+  });
+
+  it("rehydrates the most recent chain by default", async () => {
+    const { app, listChatForAgent } = makeApp();
+    const older = chatSession({
+      id: "sess_old000000",
+      intent: "old topic",
+      created_at: new Date("2026-05-01T09:00:00Z"),
+    });
+    const newer = chatSession({
+      id: "sess_new000000",
+      intent: "new topic",
+      created_at: new Date("2026-05-02T09:00:00Z"),
+    });
+    listChatForAgent.mockResolvedValue([older, newer]);
+
+    const res = await request(app).get("/chat");
+    expect(res.body.conversation_id).toBe(newer.id);
+    expect(res.body.prior_session_id).toBe(newer.id);
+    expect(res.body.messages.map((m: { content: string }) => m.content)).toEqual([
+      "new topic",
+      "hi there",
+    ]);
+  });
+
+  it("renders a failed turn in history as an agent bubble", async () => {
+    const { app, listChatForAgent } = makeApp();
+    listChatForAgent.mockResolvedValue([
+      chatSession({
+        status: "failed",
+        intent: "deploy it",
+        result_summary: undefined,
+        error: "beevibe runtime 'codex' not found on this daemon",
+      }),
+    ]);
+    const res = await request(app).get("/chat");
+    expect(res.body.messages).toHaveLength(2);
+    expect(res.body.messages[1]).toMatchObject({
+      role: "agent",
+      session_id: "sess_aaaaaaaaaaaa",
+    });
+    expect(res.body.messages[1].content).toContain("codex");
+  });
+
+  it("honors ?c= to select an older conversation", async () => {
+    const { app, listChatForAgent } = makeApp();
+    const older = chatSession({
+      id: "sess_old000000",
+      intent: "old topic",
+      created_at: new Date("2026-05-01T09:00:00Z"),
+    });
+    const newer = chatSession({
+      id: "sess_new000000",
+      intent: "new topic",
+      created_at: new Date("2026-05-02T09:00:00Z"),
+    });
+    listChatForAgent.mockResolvedValue([older, newer]);
+
+    const res = await request(app).get("/chat").query({ c: older.id });
+    expect(res.body.conversation_id).toBe(older.id);
+  });
+
+  it("renders the empty state rather than 404 for an unknown ?c=", async () => {
+    const { app, listChatForAgent } = makeApp();
+    listChatForAgent.mockResolvedValue([chatSession()]);
+    const res = await request(app).get("/chat").query({ c: "sess_nope" });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      messages: [],
+      prior_session_id: null,
+      conversation_id: null,
+    });
+  });
+
+  it("caps the rehydrated window at 25 sessions", async () => {
+    const { app, listChatForAgent } = makeApp();
+    // One long chain of 30 turns; HISTORY_LIMIT/2 = 25 survive.
+    const chain = Array.from({ length: 30 }, (_, i) =>
+      chatSession({
+        id: `sess_${String(i).padStart(12, "0")}`,
+        prior_session_id: i === 0 ? undefined : `sess_${String(i - 1).padStart(12, "0")}`,
+        intent: `turn ${i}`,
+        created_at: new Date(Date.UTC(2026, 4, 1, i)),
+      }),
+    );
+    listChatForAgent.mockResolvedValue(chain);
+
+    const res = await request(app).get("/chat");
+    // 25 sessions × (user + agent) messages.
+    expect(res.body.messages).toHaveLength(50);
+    expect(res.body.messages[0].content).toBe("turn 5");
+    expect(res.body.conversation_id).toBe(chain[0]!.id);
+  });
+
+  it.each([["pending"], ["running"]] as Array<[SessionStatus]>)(
+    "flags a %s tail session so the UI can resume its indicator",
+    async (status) => {
+      const { app, listChatForAgent } = makeApp();
+      listChatForAgent.mockResolvedValue([
+        chatSession({ status, result_summary: undefined }),
+      ]);
+      const res = await request(app).get("/chat");
+      expect(res.body.in_flight_session_id).toBe("sess_aaaaaaaaaaaa");
+    },
+  );
+
+  it("omits in_flight_session_id once the tail is terminal", async () => {
+    const { app, listChatForAgent } = makeApp();
+    listChatForAgent.mockResolvedValue([chatSession({ status: "succeeded" })]);
+    const res = await request(app).get("/chat");
+    expect(res.body.in_flight_session_id).toBeUndefined();
+  });
+
+  it("reports a runtime mismatch when the chain is pinned to another CLI", async () => {
+    const { app, listChatForAgent, runtimeFindById } = makeApp();
+    listChatForAgent.mockResolvedValue([chatSession({ runtime_id: "rt_1" })]);
+    runtimeFindById.mockResolvedValue({ id: "rt_1", cli: "codex" });
+
+    const res = await request(app).get("/chat");
+    expect(res.body.runtime_mismatch).toEqual({
+      pinned_cli: "codex",
+      current_cli: "claude",
+    });
+  });
+
+  it.each([
+    ["the chain has no runtime_id", undefined, undefined],
+    ["the runtime row is gone", "rt_1", undefined],
+    ["the pinned cli is unknown", "rt_1", { id: "rt_1", cli: "wat" }],
+    ["the pinned cli matches", "rt_1", { id: "rt_1", cli: "claude" }],
+  ])("omits runtime_mismatch when %s", async (_label, runtimeId, runtime) => {
+    const { app, listChatForAgent, runtimeFindById } = makeApp();
+    listChatForAgent.mockResolvedValue([chatSession({ runtime_id: runtimeId })]);
+    runtimeFindById.mockResolvedValue(runtime);
+
+    const res = await request(app).get("/chat");
+    expect(res.body.runtime_mismatch).toBeUndefined();
+  });
+});
+
+describe("POST /chat — validation", () => {
+  it.each([
+    ["omitted", {}],
+    ["empty", { message: "" }],
+    ["whitespace only", { message: "   " }],
+    ["not a string", { message: 42 }],
+  ])("400s when message is %s", async (_label, body) => {
+    const { app, dispatchTask } = makeApp();
+    const res = await request(app).post("/chat").send(body);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("message_required");
+    expect(dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("404s when the caller has no primary agent", async () => {
+    const { app, dispatchTask } = makeApp({ agent: undefined });
+    const res = await request(app).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("no_primary_agent");
+    expect(dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("trims the message before dispatching it", async () => {
+    const { app, dispatchTask } = makeApp();
+    await request(app).post("/chat").send({ message: "  hi there  " });
+    expect(firstArgOf(dispatchTask).intent).toBe("hi there");
+  });
+});
+
+describe("POST /chat — dispatch", () => {
+  it("dispatches a fresh chat turn", async () => {
+    const { app, dispatchTask } = makeApp();
+    const res = await request(app).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(200);
+    expect(dispatchTask).toHaveBeenCalledWith({
+      agentId: AGENT.id,
+      intent: "hi",
+      reason: { kind: "fresh" },
+      type: "chat",
+      sessionIdOverride: undefined,
+    });
+  });
+
+  it("sends a chat_continuation reason when prior_session_id is given", async () => {
+    const { app, dispatchTask } = makeApp();
+    await request(app)
+      .post("/chat")
+      .send({ message: "and then?", prior_session_id: "sess_prior" });
+    expect(firstArgOf(dispatchTask).reason).toEqual({
+      kind: "chat_continuation",
+      prior_session_id: "sess_prior",
+    });
+  });
+
+  it("passes a well-formed client session id through as the override", async () => {
+    const { app, dispatchTask } = makeApp();
+    await request(app)
+      .post("/chat")
+      .send({ message: "hi", session_id: "sess_abcdefghijkl" });
+    expect(firstArgOf(dispatchTask).sessionIdOverride).toBe(
+      "sess_abcdefghijkl",
+    );
+  });
+
+  it.each([
+    ["the wrong prefix", "chat_abcdefghijkl"],
+    ["the wrong length", "sess_abc"],
+    ["illegal characters", "sess_abcdefghij-l"],
+  ])("ignores a session_id with %s", async (_label, sessionId) => {
+    const { app, dispatchTask, sessionFindById } = makeApp();
+    await request(app).post("/chat").send({ message: "hi", session_id: sessionId });
+    expect(sessionFindById).not.toHaveBeenCalled();
+    expect(firstArgOf(dispatchTask).sessionIdOverride).toBeUndefined();
+  });
+
+  it("returns the resolved turn with the agent and parsed response", async () => {
+    const { app } = makeApp();
+    const res = await request(app).post("/chat").send({ message: "hi" });
+    expect(res.body).toMatchObject({
+      ok: true,
+      agent: { id: AGENT.id, name: AGENT.name, hierarchy: "team" },
+      session_id: "sess_bbbbbbbbbbbb",
+      response: "done",
+      status: "succeeded",
+      view_refs: [],
+    });
+    expect(res.body.replayed).toBeUndefined();
+  });
+
+  it("maps a failed turn to the friendly failure message", async () => {
+    const { app, register } = makeApp();
+    register.mockResolvedValue(
+      chatSession({
+        id: "sess_bbbbbbbbbbbb",
+        status: "failed",
+        result_summary: undefined,
+        error: "npm ERR! missing script",
+      }),
+    );
+    const res = await request(app).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("failed");
+    expect(res.body.response).toBe("npm ERR! missing script");
+  });
+
+  it("500s when dispatch throws, and frees the rate-limit slot", async () => {
+    const rateLimiter = new ChatRateLimiter({ maxConcurrent: 1 });
+    const { app, dispatchTask } = makeApp({ rateLimiter });
+    dispatchTask.mockRejectedValue(new Error("pool exhausted"));
+
+    const first = await request(app).post("/chat").send({ message: "hi" });
+    expect(first.status).toBe(500);
+    expect(first.body.error).toBe("internal_error");
+
+    // Slot released — a second attempt gets past the concurrency gate
+    // and fails on dispatch again rather than 429-ing.
+    const second = await request(app).post("/chat").send({ message: "hi" });
+    expect(second.status).toBe(500);
+  });
+});
+
+describe("POST /chat — daemon availability", () => {
+  it("503s when the pinned runtime's daemon is offline", async () => {
+    const { app, dispatchTask, isOnline, register } = makeApp();
+    dispatchTask.mockResolvedValue({
+      session: chatSession({ id: "sess_bbbbbbbbbbbb", status: "pending" }),
+      runtime_id: "rt_1",
+    });
+    isOnline.mockReturnValue(false);
+
+    const res = await request(app).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe("agent_offline");
+    expect(isOnline).toHaveBeenCalledWith("rt_1");
+    expect(register).not.toHaveBeenCalled();
+  });
+
+  it("proceeds for a null runtime_id — the in-process executor claims it", async () => {
+    const { app, isOnline, register } = makeApp();
+    const res = await request(app).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(200);
+    expect(isOnline).not.toHaveBeenCalled();
+    expect(register).toHaveBeenCalled();
+  });
+});
+
+describe("POST /chat — idempotent replay", () => {
+  const sessionId = "sess_abcdefghijkl";
+
+  it("replays a finished turn instead of spawning another", async () => {
+    const { app, sessionFindById, dispatchTask } = makeApp();
+    sessionFindById.mockResolvedValue(
+      chatSession({ id: sessionId, status: "succeeded", result_summary: "cached" }),
+    );
+
+    const res = await request(app).post("/chat").send({ message: "hi", session_id: sessionId });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      replayed: true,
+      session_id: sessionId,
+      response: "cached",
+      status: "succeeded",
+    });
+    expect(dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("replays a failed turn with its failure message", async () => {
+    const { app, sessionFindById } = makeApp();
+    sessionFindById.mockResolvedValue(
+      chatSession({
+        id: sessionId,
+        status: "failed",
+        result_summary: undefined,
+        error: "boom",
+      }),
+    );
+    const res = await request(app).post("/chat").send({ message: "hi", session_id: sessionId });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ replayed: true, response: "boom" });
+  });
+
+  it("409s while the same session is still running", async () => {
+    const { app, sessionFindById, dispatchTask } = makeApp();
+    sessionFindById.mockResolvedValue(
+      chatSession({ id: sessionId, status: "running" }),
+    );
+    const res = await request(app).post("/chat").send({ message: "hi", session_id: sessionId });
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe("session_in_flight");
+    expect(dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("403s when the session id belongs to another caller's agent", async () => {
+    const { app, sessionFindById, dispatchTask } = makeApp();
+    sessionFindById.mockResolvedValue(
+      chatSession({ id: sessionId, agent_id: "agt_someone_else" }),
+    );
+    const res = await request(app).post("/chat").send({ message: "hi", session_id: sessionId });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("session_belongs_to_other_caller");
+    expect(dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["the row does not exist", undefined],
+    ["the row is not a chat session", { ...chatSession(), type: "task" }],
+  ])("falls through to dispatch when %s", async (_label, existing) => {
+    const { app, sessionFindById, dispatchTask } = makeApp();
+    sessionFindById.mockResolvedValue(existing);
+    const res = await request(app).post("/chat").send({ message: "hi", session_id: sessionId });
+    expect(res.status).toBe(200);
+    expect(dispatchTask).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls through to dispatch for a pending row (never claimed)", async () => {
+    const { app, sessionFindById, dispatchTask } = makeApp();
+    sessionFindById.mockResolvedValue(
+      chatSession({ id: sessionId, status: "pending" }),
+    );
+    const res = await request(app).post("/chat").send({ message: "hi", session_id: sessionId });
+    expect(res.status).toBe(200);
+    expect(dispatchTask).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("POST /chat — rate limiting", () => {
+  it("429s with turn_in_flight when a turn is already running", async () => {
+    let now = 0;
+    const rateLimiter = new ChatRateLimiter({
+      maxConcurrent: 1,
+      now: () => now,
+    });
+    // Occupy the only slot and never release it.
+    const held = rateLimiter.acquire(PERSON);
+    expect(held.ok).toBe(true);
+
+    const { app, dispatchTask } = makeApp({ rateLimiter });
+    const res = await request(app).post("/chat").send({ message: "hi" });
+
+    expect(res.status).toBe(429);
+    expect(res.body.error).toBe("turn_in_flight");
+    expect(res.headers["retry-after"]).toBeDefined();
+    expect(dispatchTask).not.toHaveBeenCalled();
+    now += 1;
+  });
+
+  it("429s with rate_limited once the sliding window fills", async () => {
+    const rateLimiter = new ChatRateLimiter({
+      maxConcurrent: 5,
+      maxPerWindow: 2,
+      windowMs: 60_000,
+      now: () => 1_000,
+    });
+    const { app } = makeApp({ rateLimiter });
+
+    await request(app).post("/chat").send({ message: "one" });
+    await request(app).post("/chat").send({ message: "two" });
+    const third = await request(app).post("/chat").send({ message: "three" });
+
+    expect(third.status).toBe(429);
+    expect(third.body.error).toBe("rate_limited");
+    expect(third.body.retry_after_ms).toBe(60_000);
+    expect(third.headers["retry-after"]).toBe("60");
+  });
+
+  it("checks replay before the rate limiter, so a retry is never throttled", async () => {
+    const rateLimiter = new ChatRateLimiter({ maxConcurrent: 1 });
+    rateLimiter.acquire(PERSON); // slot held by the in-flight original
+    const { app, sessionFindById } = makeApp({ rateLimiter });
+    sessionFindById.mockResolvedValue(
+      chatSession({ id: "sess_abcdefghijkl", result_summary: "cached" }),
+    );
+
+    const res = await request(app)
+      .post("/chat")
+      .send({ message: "hi", session_id: "sess_abcdefghijkl" });
+    expect(res.status).toBe(200);
+    expect(res.body.replayed).toBe(true);
+  });
+});
+
+describe("POST /chat — turn timeout", () => {
+  it("504s when the resolver times out", async () => {
+    const { app, register } = makeApp();
+    register.mockRejectedValue(
+      new Error("chat resolver timeout (90000ms) for sess_b"),
+    );
+    const res = await request(app).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(504);
+    expect(res.body).toMatchObject({
+      error: "chat_turn_timeout",
+      timeout_ms: 90_000,
+    });
+    expect(res.body.message).toContain("90s");
+  });
+
+  it("500s on any other resolver failure", async () => {
+    const { app, register } = makeApp();
+    register.mockRejectedValue(new Error("resolver double-registered"));
+    const res = await request(app).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("internal_error");
+  });
+
+  it("releases the rate-limit slot after a timeout", async () => {
+    const rateLimiter = new ChatRateLimiter({ maxConcurrent: 1 });
+    const { app, register } = makeApp({ rateLimiter });
+    register.mockRejectedValueOnce(new Error("chat resolver timeout (90000ms)"));
+
+    expect((await request(app).post("/chat").send({ message: "hi" })).status).toBe(
+      504,
+    );
+    expect((await request(app).post("/chat").send({ message: "hi" })).status).toBe(
+      200,
+    );
+  });
+});
+
+describe("POST /chat — onboarding flip", () => {
+  it("stamps onboarding_completed_at on the first successful turn", async () => {
+    const { app, personFindById, personUpdate } = makeApp();
+    personFindById.mockResolvedValue({ id: PERSON, onboarding_completed_at: null });
+
+    await request(app).post("/chat").send({ message: "hi" });
+    expect(personUpdate).toHaveBeenCalledWith(PERSON, {
+      onboarding_completed_at: expect.any(Date),
+    });
+  });
+
+  it("leaves an already-onboarded person alone", async () => {
+    const { app, personUpdate } = makeApp();
+    await request(app).post("/chat").send({ message: "hi" });
+    expect(personUpdate).not.toHaveBeenCalled();
+  });
+
+  it("does not flip the flag on a failed first turn", async () => {
+    const { app, personFindById, personUpdate, register } = makeApp();
+    personFindById.mockResolvedValue({ id: PERSON, onboarding_completed_at: null });
+    register.mockResolvedValue(
+      chatSession({ id: "sess_bbbbbbbbbbbb", status: "failed", error: "nope" }),
+    );
+
+    await request(app).post("/chat").send({ message: "hi" });
+    expect(personUpdate).not.toHaveBeenCalled();
+  });
+
+  it("still answers the turn when the flag write fails", async () => {
+    const { app, personFindById, personUpdate } = makeApp();
+    personFindById.mockResolvedValue({ id: PERSON, onboarding_completed_at: null });
+    personUpdate.mockRejectedValue(new Error("write conflict"));
+
+    const res = await request(app).post("/chat").send({ message: "hi" });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+});

--- a/packages/api/src/routes/stream.test.ts
+++ b/packages/api/src/routes/stream.test.ts
@@ -1,0 +1,242 @@
+/**
+ * GET /api/stream — the browser SSE endpoint.
+ *
+ * The response never ends, so this drives the router with a fake
+ * req/res pair rather than supertest: the handler is synchronous, so
+ * everything it wires up (headers, priming event, subscription,
+ * heartbeat, teardown) is observable the moment the call returns.
+ *
+ * A real SseManager is used — it's a plain in-memory registry, and the
+ * point of most of these assertions is that a published event actually
+ * reaches the socket.
+ */
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RequestHandler } from "express";
+import { SseManager } from "../sse/manager.js";
+import { createStreamRouter } from "./stream.js";
+
+const PERSON = "per_alice";
+const OTHER = "per_bob";
+
+const humanCaller = { source: "human", personId: PERSON };
+const agentCaller = { source: "agent", personId: PERSON, agentId: "agt_1" };
+
+function callerAs(caller: unknown): RequestHandler {
+  return (req, _res, next) => {
+    if (caller !== null) (req as { caller?: unknown }).caller = caller;
+    next();
+  };
+}
+
+interface FakeRes extends EventEmitter {
+  writeHead: ReturnType<typeof vi.fn>;
+  write: ReturnType<typeof vi.fn>;
+  flushHeaders?: ReturnType<typeof vi.fn>;
+  status: ReturnType<typeof vi.fn>;
+  json: ReturnType<typeof vi.fn>;
+  statusCode?: number;
+  body?: unknown;
+}
+
+function makeRes(opts: { flushHeaders?: boolean } = {}): FakeRes {
+  const res = new EventEmitter() as FakeRes;
+  res.writeHead = vi.fn(() => res);
+  res.write = vi.fn(() => true);
+  if (opts.flushHeaders !== false) res.flushHeaders = vi.fn();
+  res.status = vi.fn((code: number) => {
+    res.statusCode = code;
+    return res;
+  });
+  res.json = vi.fn((body: unknown) => {
+    res.body = body;
+    return res;
+  });
+  return res;
+}
+
+interface Harness {
+  req: EventEmitter & { caller?: unknown };
+  res: FakeRes;
+  manager: SseManager;
+  /** Data lines the handler wrote, minus the SSE framing. */
+  dataLines: () => string[];
+}
+
+function open(
+  opts: { caller?: unknown; manager?: SseManager; flushHeaders?: boolean } = {},
+): Harness {
+  const manager = opts.manager ?? new SseManager();
+  const router = createStreamRouter({
+    authMiddleware: callerAs("caller" in opts ? opts.caller : humanCaller),
+    sseManager: manager,
+  });
+
+  const req = new EventEmitter() as EventEmitter & {
+    url: string;
+    method: string;
+    headers: Record<string, string>;
+  };
+  req.url = "/stream";
+  req.method = "GET";
+  req.headers = {};
+  const res = makeRes({ flushHeaders: opts.flushHeaders });
+
+  // Express routers are request handlers; the /stream handler runs
+  // synchronously and never calls next().
+  (router as unknown as (req: unknown, res: unknown, next: () => void) => void)(
+    req,
+    res,
+    () => undefined,
+  );
+
+  return {
+    req,
+    res,
+    manager,
+    dataLines: () =>
+      res.write.mock.calls
+        .map((c) => String(c[0]))
+        .filter((chunk) => chunk.startsWith("data: "))
+        .map((chunk) => chunk.slice("data: ".length).trimEnd()),
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("GET /stream — auth", () => {
+  it.each([
+    ["an agent caller", agentCaller],
+    ["no caller at all", null],
+  ])("rejects %s with 403 and never opens the stream", (_label, caller) => {
+    const { res, manager } = open({ caller });
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.body).toEqual({
+      error: "human_required",
+      message: "this endpoint requires a bv_u_ token",
+    });
+    expect(res.writeHead).not.toHaveBeenCalled();
+    expect(manager.size()).toBe(0);
+  });
+});
+
+describe("GET /stream — connection setup", () => {
+  it("writes the SSE headers proxies need to leave the stream alone", () => {
+    const { res } = open();
+    expect(res.writeHead).toHaveBeenCalledWith(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    });
+    expect(res.flushHeaders).toHaveBeenCalled();
+  });
+
+  it("survives a response object with no flushHeaders", () => {
+    const { res } = open({ flushHeaders: false });
+    expect(res.writeHead).toHaveBeenCalled();
+    expect(res.write).toHaveBeenCalledWith("data: {}\n\n");
+  });
+
+  it("primes the stream with an empty data event", () => {
+    // SSE comments don't fire onmessage in the browser, so the client's
+    // health probe needs a real data line before the first event.
+    const { res, dataLines } = open();
+    expect(res.write.mock.calls[0]![0]).toBe("data: {}\n\n");
+    expect(JSON.parse(dataLines()[0]!)).toEqual({});
+  });
+
+  it("registers exactly one subscriber", () => {
+    const { manager } = open();
+    expect(manager.size()).toBe(1);
+  });
+});
+
+describe("GET /stream — fanout", () => {
+  it("writes an event published to the caller's person id", () => {
+    const { manager, dataLines } = open();
+    const event = { event: "task.updated", id: "tsk_1" };
+    manager.publish(event, new Set([PERSON]));
+    expect(dataLines()).toEqual(["{}", JSON.stringify(event)]);
+  });
+
+  it("passes an inline payload through untouched", () => {
+    const { manager, dataLines } = open();
+    const event = {
+      event: "session.step",
+      id: "sess_1",
+      data: { kind: "tool_use", tool_name: "Bash" },
+    };
+    manager.publish(event, new Set([PERSON]));
+    expect(JSON.parse(dataLines()[1]!)).toEqual(event);
+  });
+
+  it("does not write an event owned by somebody else", () => {
+    const { manager, dataLines } = open();
+    manager.publish({ event: "task.updated", id: "tsk_1" }, new Set([OTHER]));
+    expect(dataLines()).toEqual(["{}"]);
+  });
+
+  it("keeps two subscribers on one manager independent", () => {
+    const manager = new SseManager();
+    const alice = open({ manager });
+    const bob = open({ manager, caller: { source: "human", personId: OTHER } });
+    expect(manager.size()).toBe(2);
+
+    manager.publish({ event: "task.updated", id: "tsk_1" }, new Set([OTHER]));
+    expect(alice.dataLines()).toEqual(["{}"]);
+    expect(bob.dataLines()).toHaveLength(2);
+  });
+});
+
+describe("GET /stream — heartbeat", () => {
+  it("writes a comment line every 25s", () => {
+    const { res } = open();
+    const heartbeats = () =>
+      res.write.mock.calls.filter((c) => c[0] === ": heartbeat\n\n").length;
+
+    expect(heartbeats()).toBe(0);
+    vi.advanceTimersByTime(24_999);
+    expect(heartbeats()).toBe(0);
+    vi.advanceTimersByTime(1);
+    expect(heartbeats()).toBe(1);
+    vi.advanceTimersByTime(50_000);
+    expect(heartbeats()).toBe(3);
+  });
+});
+
+describe("GET /stream — teardown", () => {
+  it.each([["req"], ["res"]])(
+    "unsubscribes and stops the heartbeat when %s closes",
+    (which) => {
+      const { req, res, manager } = open();
+      const emitter = which === "req" ? req : res;
+      emitter.emit("close");
+
+      expect(manager.size()).toBe(0);
+      const before = res.write.mock.calls.length;
+      vi.advanceTimersByTime(60_000);
+      expect(res.write.mock.calls).toHaveLength(before);
+    },
+  );
+
+  it("stops writing events after close", () => {
+    const { req, manager, dataLines } = open();
+    req.emit("close");
+    manager.publish({ event: "task.updated", id: "tsk_1" }, new Set([PERSON]));
+    expect(dataLines()).toEqual(["{}"]);
+  });
+
+  it("is idempotent when both req and res close", () => {
+    const { req, res, manager } = open();
+    req.emit("close");
+    res.emit("close");
+    expect(manager.size()).toBe(0);
+  });
+});

--- a/packages/api/src/tools/session-search.test.ts
+++ b/packages/api/src/tools/session-search.test.ts
@@ -1,0 +1,282 @@
+/**
+ * session_search tool — unit tests with a fake SessionSearchService.
+ *
+ * The service is tested on its own; what lives here is the adapter's
+ * shape inference (which of discover / scroll / read / browse a raw
+ * MCP input maps to), the caller-context passthrough, and the error
+ * envelopes — including the `name`-based fallback that keeps structured
+ * codes working when the error crosses a src/dist bundle boundary.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { HierarchyLevel, SessionSearchRequest } from "@beevibe/core";
+import {
+  SessionSearchError,
+  type SessionSearchService,
+} from "@beevibe/core/services/session-search";
+import { createSessionSearchTool } from "./session-search.js";
+import type { AgentToolResult } from "./types.js";
+
+const AGENT_ID = "agent_ic";
+const SESSION_ID = "sess_current";
+
+interface Harness {
+  handler: (input: Record<string, unknown>) => Promise<AgentToolResult>;
+  search: ReturnType<typeof vi.fn>;
+  /** The request the tool inferred from the last call. */
+  request: () => SessionSearchRequest;
+}
+
+function makeTool(
+  opts: {
+    hierarchyLevel?: HierarchyLevel;
+    search?: ReturnType<typeof vi.fn>;
+  } = {},
+): Harness {
+  const search = opts.search ?? vi.fn(async () => ({ results: [] }));
+  const tool = createSessionSearchTool(
+    {
+      agentId: AGENT_ID,
+      hierarchyLevel: opts.hierarchyLevel ?? "ic",
+      sessionId: SESSION_ID,
+    },
+    { sessionSearch: { search } as unknown as SessionSearchService },
+  );
+  return {
+    handler: tool.handler,
+    search,
+    request: () => search.mock.calls[0]![0] as SessionSearchRequest,
+  };
+}
+
+describe("session_search — tool shape", () => {
+  it("takes no required inputs, since browse is the no-arg shape", () => {
+    const tool = createSessionSearchTool(
+      { agentId: AGENT_ID, hierarchyLevel: "ic", sessionId: SESSION_ID },
+      { sessionSearch: {} as SessionSearchService },
+    );
+    expect(tool.name).toBe("session_search");
+    expect(tool.schema.required).toBeUndefined();
+    expect(tool.description).toContain("FOUR CALLING SHAPES");
+  });
+});
+
+describe("session_search — caller context", () => {
+  it.each([["ic"], ["team"], ["org"]] as Array<[HierarchyLevel]>)(
+    "passes the caller triple through for a %s caller",
+    async (hierarchyLevel) => {
+      const { handler, search } = makeTool({ hierarchyLevel });
+      await handler({});
+      expect(search.mock.calls[0]![1]).toEqual({
+        callerAgentId: AGENT_ID,
+        hierarchyLevel,
+        currentSessionId: SESSION_ID,
+      });
+    },
+  );
+
+  it("returns the service result verbatim", async () => {
+    const result = { kind: "browse", sessions: [{ id: "sess_1" }] };
+    const { handler } = makeTool({ search: vi.fn(async () => result) });
+    const res = await handler({});
+    expect(res.isError).toBeUndefined();
+    expect(res.content).toBe(result);
+  });
+});
+
+describe("session_search — shape inference", () => {
+  it("infers browse from no arguments", async () => {
+    const { handler, request } = makeTool();
+    await handler({});
+    expect(request()).toEqual({
+      kind: "browse",
+      limit: undefined,
+      filters: undefined,
+    });
+  });
+
+  it("carries limit and filters onto browse", async () => {
+    const { handler, request } = makeTool();
+    await handler({ limit: 7, filters: { status: "failed" } });
+    expect(request()).toEqual({
+      kind: "browse",
+      limit: 7,
+      filters: { status: "failed" },
+    });
+  });
+
+  it("infers discover from a query", async () => {
+    const { handler, request } = makeTool();
+    await handler({ query: "auth refactor", limit: 3, sort: "newest" });
+    expect(request()).toEqual({
+      kind: "discover",
+      query: "auth refactor",
+      limit: 3,
+      sort: "newest",
+      filters: undefined,
+    });
+  });
+
+  it.each([
+    ["an unknown value", "relevance"],
+    ["not a string", 1],
+    ["omitted", undefined],
+  ])("drops a sort that is %s", async (_label, sort) => {
+    const { handler, request } = makeTool();
+    await handler({ query: "auth", sort });
+    expect((request() as { sort?: string }).sort).toBeUndefined();
+  });
+
+  it("keeps 'oldest' as a valid sort", async () => {
+    const { handler, request } = makeTool();
+    await handler({ query: "auth", sort: "oldest" });
+    expect((request() as { sort?: string }).sort).toBe("oldest");
+  });
+
+  it("infers read from a bare session_id, ignoring query and limit", async () => {
+    const { handler, request } = makeTool();
+    await handler({ session_id: "sess_old", query: "auth", limit: 9 });
+    expect(request()).toEqual({ kind: "read", session_id: "sess_old" });
+  });
+
+  it("infers scroll when session_id and around_message_id are both set", async () => {
+    const { handler, request } = makeTool();
+    await handler({
+      session_id: "sess_old",
+      around_message_id: "evt_5",
+      window: 10,
+    });
+    expect(request()).toEqual({
+      kind: "scroll",
+      session_id: "sess_old",
+      around_message_id: "evt_5",
+      window: 10,
+    });
+  });
+
+  it("scroll beats discover when a query is also present", async () => {
+    const { handler, request } = makeTool();
+    await handler({
+      session_id: "sess_old",
+      around_message_id: "intent:sess_old",
+      query: "auth",
+    });
+    expect(request().kind).toBe("scroll");
+  });
+
+  it.each([
+    ["not a number", "10"],
+    ["omitted", undefined],
+  ])("leaves window undefined when it is %s", async (_label, window) => {
+    const { handler, request } = makeTool();
+    await handler({ session_id: "sess_old", around_message_id: "evt_5", window });
+    expect((request() as { window?: number }).window).toBeUndefined();
+  });
+
+  it("trims ids and query before inferring", async () => {
+    const { handler, request } = makeTool();
+    await handler({ session_id: "  sess_old  ", around_message_id: "  evt_5  " });
+    expect(request()).toMatchObject({
+      session_id: "sess_old",
+      around_message_id: "evt_5",
+    });
+  });
+
+  it.each([
+    ["blank strings", { session_id: "   ", around_message_id: "  ", query: "  " }],
+    ["wrong types", { session_id: 1, around_message_id: 2, query: 3 }],
+  ])("falls back to browse on %s", async (_label, input) => {
+    const { handler, request } = makeTool();
+    await handler(input);
+    expect(request().kind).toBe("browse");
+  });
+
+  it("treats a blank session_id with a real anchor as browse, not scroll", async () => {
+    const { handler, request } = makeTool();
+    await handler({ session_id: "  ", around_message_id: "evt_5" });
+    expect(request().kind).toBe("browse");
+  });
+
+  it.each([
+    ["null", null],
+    ["a string", "status=failed"],
+    ["omitted", undefined],
+  ])("drops filters that are %s", async (_label, filters) => {
+    const { handler, request } = makeTool();
+    await handler({ query: "auth", filters });
+    expect((request() as { filters?: unknown }).filters).toBeUndefined();
+  });
+});
+
+describe("session_search — error envelopes", () => {
+  it("maps a null result to not_found_or_forbidden", async () => {
+    const { handler } = makeTool({ search: vi.fn(async () => null) });
+    const res = await handler({ session_id: "sess_theirs" });
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("not_found_or_forbidden");
+    expect(res.content.message).toContain("not in your scope");
+  });
+
+  it.each([
+    ["forbidden_agent_filter"],
+    ["missing_query"],
+    ["missing_args"],
+  ] as Array<[SessionSearchError["code"]]>)(
+    "surfaces the %s code from a SessionSearchError",
+    async (code) => {
+      const { handler } = makeTool({
+        search: vi.fn(async () => {
+          throw new SessionSearchError(code, `bad request: ${code}`);
+        }),
+      });
+      const res = await handler({ query: "auth" });
+      expect(res.isError).toBe(true);
+      expect(res.content).toEqual({ error: code, message: `bad request: ${code}` });
+    },
+  );
+
+  it("recognizes a cross-bundle SessionSearchError by name", async () => {
+    // The api consumes @beevibe/core from dist/; a script consuming src/
+    // throws a structurally identical error that fails `instanceof`.
+    const impostor = Object.assign(new Error("out of scope"), {
+      name: "SessionSearchError",
+      code: "forbidden_agent_filter",
+    });
+    const { handler } = makeTool({
+      search: vi.fn(async () => {
+        throw impostor;
+      }),
+    });
+    const res = await handler({ query: "auth" });
+    expect(res.content).toEqual({
+      error: "forbidden_agent_filter",
+      message: "out of scope",
+    });
+  });
+
+  it("falls back to internal_error for an unrelated Error", async () => {
+    const { handler } = makeTool({
+      search: vi.fn(async () => {
+        throw new Error("connection terminated");
+      }),
+    });
+    const res = await handler({ query: "auth" });
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "internal_error",
+      message: "connection terminated",
+    });
+  });
+
+  it("stringifies a non-Error throw", async () => {
+    const { handler } = makeTool({
+      search: vi.fn(async () => {
+        throw "pool drained";
+      }),
+    });
+    const res = await handler({});
+    expect(res.content).toEqual({
+      error: "internal_error",
+      message: "pool drained",
+    });
+  });
+});

--- a/packages/api/src/tools/use-repo.test.ts
+++ b/packages/api/src/tools/use-repo.test.ts
@@ -1,0 +1,427 @@
+/**
+ * use_repo tool — unit tests with vitest fakes (no DB, no Docker).
+ *
+ * The handler is a plain closure over (ctx, services), so everything
+ * interesting is reachable without a sandbox: input validation, the
+ * `limits` clamp, the container-task title cut, and the two-step
+ * dispatch → repo_run insert whose ORDER is load-bearing (repo_run
+ * has an FK to session.id, which only exists once dispatch has run).
+ */
+import { describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  RepoRun,
+  RepoRunRepository,
+  Task,
+  TaskRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import { createUseRepoTool } from "./use-repo.js";
+import type { AgentToolResult } from "./types.js";
+
+const AGENT_ID = "agent_caller";
+const REPO_URL = "https://github.com/acme/pdfplumber";
+
+function fakeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: AGENT_ID,
+    name: "Caller",
+    owner_id: "person_1",
+    hierarchy_level: "ic",
+    runtime_config: { type: "claude" },
+    created_at: new Date("2026-04-01"),
+    updated_at: new Date("2026-04-01"),
+    ...overrides,
+  };
+}
+
+interface Harness {
+  handler: (input: Record<string, unknown>) => Promise<AgentToolResult>;
+  agentFindById: ReturnType<typeof vi.fn>;
+  taskCreate: ReturnType<typeof vi.fn>;
+  dispatchTask: ReturnType<typeof vi.fn>;
+  repoRunCreate: ReturnType<typeof vi.fn>;
+  /** Call order across the three writing collaborators. */
+  calls: string[];
+}
+
+/** First argument of a mock's first call, as a readable bag of fields. */
+function firstArg(mock: {
+  mock: { calls: unknown[][] };
+}): Record<string, unknown> {
+  return mock.mock.calls[0]![0] as Record<string, unknown>;
+}
+
+function makeTool(
+  overrides: {
+    agent?: Agent | undefined;
+    dispatchTask?: ReturnType<typeof vi.fn>;
+    repoRunCreate?: ReturnType<typeof vi.fn>;
+  } = {},
+): Harness {
+  const calls: string[] = [];
+  const agent = "agent" in overrides ? overrides.agent : fakeAgent();
+
+  const agentFindById = vi.fn(async () => agent);
+  const taskCreate = vi.fn(async (input: Partial<Task>) => {
+    calls.push("task.create");
+    return { ...input, status: "assigned" } as Task;
+  });
+  const dispatchTask =
+    overrides.dispatchTask ??
+    vi.fn(async () => {
+      calls.push("dispatch");
+      return { sessionId: "sess_x" };
+    });
+  const repoRunCreate =
+    overrides.repoRunCreate ??
+    vi.fn(async (input: Partial<RepoRun>) => {
+      calls.push("repoRun.create");
+      return input as RepoRun;
+    });
+
+  const tool = createUseRepoTool(
+    { agentId: AGENT_ID },
+    {
+      agentRepo: { findById: agentFindById } as unknown as AgentRepository,
+      taskRepo: { create: taskCreate } as unknown as TaskRepository,
+      repoRunRepo: { create: repoRunCreate } as unknown as RepoRunRepository,
+      dispatchService: {
+        dispatchTask,
+      } as unknown as DispatchService,
+    },
+  );
+
+  return {
+    handler: tool.handler,
+    agentFindById,
+    taskCreate,
+    dispatchTask,
+    repoRunCreate,
+    calls,
+  };
+}
+
+describe("use_repo — tool shape", () => {
+  it("declares goal + repo_url as the required inputs", () => {
+    const tool = createUseRepoTool({ agentId: AGENT_ID }, {
+      agentRepo: {} as AgentRepository,
+      taskRepo: {} as TaskRepository,
+      repoRunRepo: {} as RepoRunRepository,
+      dispatchService: {} as DispatchService,
+    });
+    expect(tool.name).toBe("use_repo");
+    expect(tool.schema.required).toEqual(["goal", "repo_url"]);
+  });
+});
+
+describe("use_repo — input validation", () => {
+  it.each([
+    ["omitted", undefined],
+    ["empty", ""],
+    ["whitespace only", "   "],
+    ["not a string", 42],
+  ])("rejects a goal that is %s", async (_label, goal) => {
+    const { handler, agentFindById } = makeTool();
+    const res = await handler({ goal, repo_url: REPO_URL });
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("invalid_goal");
+    // Validation short-circuits before any repo is touched.
+    expect(agentFindById).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["omitted", undefined],
+    ["empty", ""],
+    ["not a string", 7],
+    ["not a URL at all", "acme/pdfplumber"],
+    ["plain http", "http://github.com/acme/pdfplumber"],
+    ["a different host", "https://gitlab.com/acme/pdfplumber"],
+    ["a lookalike host", "https://evilgithub.com/acme/pdfplumber"],
+    ["ssh", "git@github.com:acme/pdfplumber.git"],
+  ])("rejects a repo_url that is %s", async (_label, repoUrl) => {
+    const { handler, agentFindById } = makeTool();
+    const res = await handler({ goal: "extract tables", repo_url: repoUrl });
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("invalid_repo_url");
+    expect(agentFindById).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["apex github.com", "https://github.com/acme/pdfplumber"],
+    ["a www subdomain", "https://www.github.com/acme/pdfplumber"],
+    ["mixed case host", "https://GitHub.com/acme/pdfplumber"],
+  ])("accepts %s", async (_label, repoUrl) => {
+    const { handler } = makeTool();
+    const res = await handler({ goal: "extract tables", repo_url: repoUrl });
+    expect(res.isError).toBeUndefined();
+  });
+
+  it("trims surrounding whitespace off goal and repo_url", async () => {
+    const { handler, taskCreate, repoRunCreate } = makeTool();
+    await handler({ goal: "  extract tables  ", repo_url: `  ${REPO_URL}  ` });
+    expect(firstArg(taskCreate).description).toBe("extract tables");
+    expect(firstArg(repoRunCreate).repo_url).toBe(REPO_URL);
+  });
+
+  it("404s when the calling agent no longer exists", async () => {
+    const { handler, taskCreate } = makeTool({ agent: undefined });
+    const res = await handler({ goal: "extract tables", repo_url: REPO_URL });
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("agent_not_found");
+    expect(taskCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe("use_repo — container task", () => {
+  it("pins creator and assignee to the calling agent", async () => {
+    const { handler, taskCreate } = makeTool();
+    await handler({ goal: "extract tables", repo_url: REPO_URL });
+    expect(taskCreate).toHaveBeenCalledTimes(1);
+    expect(firstArg(taskCreate)).toMatchObject({
+      title: "extract tables",
+      description: "extract tables",
+      priority: "medium",
+      assignee_id: AGENT_ID,
+      creator_id: AGENT_ID,
+      creator_type: "agent",
+    });
+  });
+
+  it("collapses runs of whitespace in the title", async () => {
+    const { handler, taskCreate } = makeTool();
+    const goal = "extract\n  tables\tfrom\nthe PDF";
+    await handler({ goal, repo_url: REPO_URL });
+    expect(firstArg(taskCreate).title).toBe("extract tables from the PDF");
+    // The full goal survives on description even when the title is reshaped.
+    expect(firstArg(taskCreate).description).toBe(goal);
+  });
+
+  it("keeps an exactly-80-char title intact", async () => {
+    const { handler, taskCreate } = makeTool();
+    const goal = "x".repeat(80);
+    await handler({ goal, repo_url: REPO_URL });
+    expect(firstArg(taskCreate).title).toBe(goal);
+  });
+
+  it("truncates a longer title to 77 chars plus an ellipsis", async () => {
+    const { handler, taskCreate } = makeTool();
+    await handler({ goal: "y".repeat(81), repo_url: REPO_URL });
+    const title = firstArg(taskCreate).title as string;
+    expect(title).toBe("y".repeat(77) + "…");
+    expect(title).toHaveLength(78);
+  });
+});
+
+describe("use_repo — dispatch then repo_run", () => {
+  it("dispatches a run_repo session under a pre-minted session id", async () => {
+    const { handler, dispatchTask, taskCreate } = makeTool();
+    await handler({ goal: "extract tables", repo_url: REPO_URL });
+
+    expect(dispatchTask).toHaveBeenCalledTimes(1);
+    const arg = firstArg(dispatchTask);
+    expect(arg).toMatchObject({
+      agentId: AGENT_ID,
+      type: "run_repo",
+      intent: "extract tables",
+      reason: { kind: "fresh" },
+    });
+    expect(arg.task).toBe(await taskCreate.mock.results[0]!.value);
+    expect(typeof arg.sessionIdOverride).toBe("string");
+  });
+
+  it("creates the repo_run only after dispatch, with the same session id", async () => {
+    const { handler, dispatchTask, repoRunCreate, calls } = makeTool();
+    const res = await handler({ goal: "extract tables", repo_url: REPO_URL });
+
+    // repo_run.session_id has an FK to session.id, which dispatch creates.
+    expect(calls).toEqual(["task.create", "dispatch", "repoRun.create"]);
+
+    const sessionId = firstArg(dispatchTask).sessionIdOverride;
+    expect(firstArg(repoRunCreate)).toMatchObject({
+      session_id: sessionId,
+      agent_id: AGENT_ID,
+      goal: "extract tables",
+      repo_url: REPO_URL,
+      status: "pending",
+    });
+    expect(res.content.session_id).toBe(sessionId);
+  });
+
+  it("returns the ids, a pending status and the watch url", async () => {
+    const { handler, repoRunCreate } = makeTool();
+    const res = await handler({ goal: "extract tables", repo_url: REPO_URL });
+
+    const created = firstArg(repoRunCreate);
+    const repoRunId = created.id as string;
+    const taskId = created.task_id as string;
+    expect(res.isError).toBeUndefined();
+    expect(res.content).toMatchObject({
+      repo_run_id: repoRunId,
+      task_id: taskId,
+      status: "pending",
+      watch_url: `/capabilities/runs/${repoRunId}`,
+    });
+    expect(res.content.note).toContain("Sandbox run started");
+  });
+
+  it("mints a fresh session and repo_run id per call", async () => {
+    const { handler } = makeTool();
+    const a = await handler({ goal: "one", repo_url: REPO_URL });
+    const b = await handler({ goal: "two", repo_url: REPO_URL });
+    expect(a.content.repo_run_id).not.toBe(b.content.repo_run_id);
+    expect(a.content.session_id).not.toBe(b.content.session_id);
+  });
+});
+
+describe("use_repo — failure envelopes", () => {
+  it("reports dispatch_failed and skips the repo_run insert", async () => {
+    const dispatchTask = vi.fn(async () => {
+      throw new Error("no daemon online");
+    });
+    const { handler, repoRunCreate } = makeTool({ dispatchTask });
+    const res = await handler({ goal: "extract tables", repo_url: REPO_URL });
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "dispatch_failed",
+      message: "no daemon online",
+    });
+    expect(repoRunCreate).not.toHaveBeenCalled();
+  });
+
+  it("stringifies a non-Error thrown out of dispatch", async () => {
+    const dispatchTask = vi.fn(async () => {
+      throw "boom";
+    });
+    const { handler } = makeTool({ dispatchTask });
+    const res = await handler({ goal: "extract tables", repo_url: REPO_URL });
+    expect(res.content.message).toBe("boom");
+  });
+
+  it("reports repo_run_create_failed when the insert loses the race", async () => {
+    const repoRunCreate = vi.fn(async () => {
+      throw new Error("duplicate key");
+    });
+    const { handler } = makeTool({ repoRunCreate });
+    const res = await handler({ goal: "extract tables", repo_url: REPO_URL });
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "repo_run_create_failed",
+      message: "duplicate key",
+    });
+  });
+
+  it("stringifies a non-Error thrown out of the repo_run insert", async () => {
+    const repoRunCreate = vi.fn(async () => {
+      throw { code: "23505" };
+    });
+    const { handler } = makeTool({ repoRunCreate });
+    const res = await handler({ goal: "extract tables", repo_url: REPO_URL });
+    expect(res.content.message).toBe("[object Object]");
+  });
+});
+
+describe("use_repo — optional input file", () => {
+  it("echoes a trimmed input_url and input_filename", async () => {
+    const { handler } = makeTool();
+    const res = await handler({
+      goal: "extract tables",
+      repo_url: REPO_URL,
+      input_url: "  https://example.com/a.pdf  ",
+      input_filename: "  a.pdf  ",
+    });
+    expect(res.content.input_url).toBe("https://example.com/a.pdf");
+    expect(res.content.input_filename).toBe("a.pdf");
+  });
+
+  it("leaves both undefined when they are absent or the wrong type", async () => {
+    const { handler } = makeTool();
+    const res = await handler({
+      goal: "extract tables",
+      repo_url: REPO_URL,
+      input_filename: 5,
+    });
+    expect(res.content.input_url).toBeUndefined();
+    expect(res.content.input_filename).toBeUndefined();
+  });
+});
+
+describe("use_repo — limits clamp", () => {
+  async function limitsFor(limits: unknown): Promise<Record<string, unknown>> {
+    const { handler } = makeTool();
+    const res = await handler({
+      goal: "extract tables",
+      repo_url: REPO_URL,
+      limits,
+    });
+    return res.content.limits as Record<string, unknown>;
+  }
+
+  it.each([
+    ["omitted", undefined],
+    ["null", null],
+    ["a string", "20"],
+    ["a number", 20],
+  ])("returns an empty object when limits is %s", async (_label, limits) => {
+    expect(await limitsFor(limits)).toEqual({});
+  });
+
+  it("passes through in-range values untouched", async () => {
+    expect(
+      await limitsFor({
+        wall_clock_minutes: 10,
+        max_install_attempts: 3,
+        disk_mb: 512,
+      }),
+    ).toEqual({
+      wall_clock_minutes: 10,
+      max_install_attempts: 3,
+      disk_mb: 512,
+    });
+  });
+
+  it("caps each value at its ceiling", async () => {
+    expect(
+      await limitsFor({
+        wall_clock_minutes: 999,
+        max_install_attempts: 50,
+        disk_mb: 1_000_000,
+      }),
+    ).toEqual({
+      wall_clock_minutes: 60,
+      max_install_attempts: 5,
+      disk_mb: 10_000,
+    });
+  });
+
+  it("floors the integer-valued limits but not the wall clock", async () => {
+    expect(
+      await limitsFor({
+        wall_clock_minutes: 1.5,
+        max_install_attempts: 2.9,
+        disk_mb: 100.7,
+      }),
+    ).toEqual({
+      wall_clock_minutes: 1.5,
+      max_install_attempts: 2,
+      disk_mb: 100,
+    });
+  });
+
+  it.each([
+    ["zero", 0],
+    ["negative", -5],
+    ["a string", "10"],
+  ])("drops a %s limit rather than clamping it", async (_label, value) => {
+    expect(
+      await limitsFor({
+        wall_clock_minutes: value,
+        max_install_attempts: value,
+        disk_mb: value,
+      }),
+    ).toEqual({});
+  });
+});

--- a/packages/api/src/tools/watch.test.ts
+++ b/packages/api/src/tools/watch.test.ts
@@ -1,0 +1,254 @@
+/**
+ * watch_tasks + unwatch — unit tests with vitest fakes (no DB).
+ *
+ * Both tools are thin adapters over WatchService, so what's worth
+ * pinning here is the adapter's own logic: the input coercion
+ * (task_ids filtering, mode fallback, reason trimming), the
+ * session-context guard, and the error-class → error-code mapping that
+ * decides what the calling agent can branch on.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  WatchAuthError,
+  WatchNotFoundError,
+  WatchValidationError,
+  type WatchService,
+} from "@beevibe/core/services/watch-service";
+import { buildWatchTools, type WatchToolContext } from "./watch.js";
+import type { AgentTool } from "./types.js";
+
+const AGENT_ID = "agent_lead";
+const SESSION_ID = "sess_now";
+
+interface Harness {
+  watchTasks: AgentTool;
+  unwatch: AgentTool;
+  watchTasksFn: ReturnType<typeof vi.fn>;
+  unwatchFn: ReturnType<typeof vi.fn>;
+}
+
+function makeTools(
+  ctx: Partial<WatchToolContext> = {},
+  service: Partial<Record<"watchTasks" | "unwatch", ReturnType<typeof vi.fn>>> = {},
+): Harness {
+  const watchTasksFn =
+    service.watchTasks ??
+    vi.fn(async () => ({ watchId: "twt_1", firedImmediately: false }));
+  const unwatchFn = service.unwatch ?? vi.fn(async () => undefined);
+
+  const tools = buildWatchTools(
+    { agentId: AGENT_ID, sessionId: SESSION_ID, ...ctx },
+    {
+      watchService: {
+        watchTasks: watchTasksFn,
+        unwatch: unwatchFn,
+      } as unknown as WatchService,
+    },
+  );
+
+  return {
+    watchTasks: tools[0]!,
+    unwatch: tools[1]!,
+    watchTasksFn,
+    unwatchFn,
+  };
+}
+
+describe("buildWatchTools", () => {
+  it("returns watch_tasks and unwatch, in that order", () => {
+    const { watchTasks, unwatch } = makeTools();
+    expect(watchTasks.name).toBe("watch_tasks");
+    expect(unwatch.name).toBe("unwatch");
+  });
+
+  it("advertises every task-watch mode on the watch_tasks schema", () => {
+    const { watchTasks } = makeTools();
+    const props = watchTasks.schema.properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(props.mode!.enum).toEqual(["all", "any"]);
+    expect(watchTasks.schema.required).toEqual(["task_ids"]);
+  });
+});
+
+describe("watch_tasks — input coercion", () => {
+  it("forwards the caller, session, ids, mode and reason", async () => {
+    const { watchTasks, watchTasksFn } = makeTools();
+    const res = await watchTasks.handler({
+      task_ids: ["tsk_1", "tsk_2"],
+      mode: "any",
+      reason: "  need the migration result  ",
+    });
+
+    expect(watchTasksFn).toHaveBeenCalledWith({
+      callerAgentId: AGENT_ID,
+      callerSessionId: SESSION_ID,
+      taskIds: ["tsk_1", "tsk_2"],
+      mode: "any",
+      reason: "need the migration result",
+    });
+    expect(res.isError).toBeUndefined();
+    expect(res.content).toEqual({ watch_id: "twt_1", fired_immediately: false });
+  });
+
+  it("surfaces an already-terminal race as fired_immediately", async () => {
+    const { watchTasks } = makeTools(
+      {},
+      {
+        watchTasks: vi.fn(async () => ({
+          watchId: "twt_9",
+          firedImmediately: true,
+        })),
+      },
+    );
+    const res = await watchTasks.handler({ task_ids: ["tsk_1"] });
+    expect(res.content).toEqual({ watch_id: "twt_9", fired_immediately: true });
+  });
+
+  it("drops non-string entries from task_ids", async () => {
+    const { watchTasks, watchTasksFn } = makeTools();
+    await watchTasks.handler({ task_ids: ["tsk_1", 42, null, "tsk_2"] });
+    expect(watchTasksFn.mock.calls[0]![0].taskIds).toEqual(["tsk_1", "tsk_2"]);
+  });
+
+  it.each([
+    ["omitted", undefined],
+    ["empty", []],
+    ["not an array", "tsk_1"],
+    ["all non-strings", [1, 2]],
+  ])("rejects task_ids that are %s", async (_label, taskIds) => {
+    const { watchTasks, watchTasksFn } = makeTools();
+    const res = await watchTasks.handler({ task_ids: taskIds });
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("watch_validation");
+    expect(watchTasksFn).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["omitted", undefined],
+    ["not a known mode", "eventually"],
+    ["not a string", 1],
+  ])("defaults mode to 'all' when it is %s", async (_label, mode) => {
+    const { watchTasks, watchTasksFn } = makeTools();
+    await watchTasks.handler({ task_ids: ["tsk_1"], mode });
+    expect(watchTasksFn.mock.calls[0]![0].mode).toBe("all");
+  });
+
+  it.each([
+    ["omitted", undefined],
+    ["blank", "   "],
+    ["not a string", 3],
+  ])("drops a reason that is %s", async (_label, reason) => {
+    const { watchTasks, watchTasksFn } = makeTools();
+    await watchTasks.handler({ task_ids: ["tsk_1"], reason });
+    expect(watchTasksFn.mock.calls[0]![0].reason).toBeUndefined();
+  });
+
+  it("refuses to register a watch outside a session context", async () => {
+    const { watchTasks, watchTasksFn } = makeTools({ sessionId: undefined });
+    const res = await watchTasks.handler({ task_ids: ["tsk_1"] });
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "watch_validation",
+      message: "watch_tasks must be called inside a session context",
+    });
+    expect(watchTasksFn).not.toHaveBeenCalled();
+  });
+
+  it("checks task_ids before the session context", async () => {
+    // Both are invalid; the id complaint is the more actionable one.
+    const { watchTasks } = makeTools({ sessionId: undefined });
+    const res = await watchTasks.handler({ task_ids: [] });
+    expect(res.content.message).toContain("task_ids must be a non-empty array");
+  });
+});
+
+describe("unwatch", () => {
+  it("cancels by id and reports ok", async () => {
+    const { unwatch, unwatchFn } = makeTools();
+    const res = await unwatch.handler({ watch_id: "twt_1" });
+    expect(unwatchFn).toHaveBeenCalledWith({
+      callerAgentId: AGENT_ID,
+      watchId: "twt_1",
+    });
+    expect(res.isError).toBeUndefined();
+    expect(res.content).toEqual({ ok: true });
+  });
+
+  it.each([
+    ["omitted", undefined],
+    ["empty", ""],
+    ["not a string", 12],
+  ])("rejects a watch_id that is %s", async (_label, watchId) => {
+    const { unwatch, unwatchFn } = makeTools();
+    const res = await unwatch.handler({ watch_id: watchId });
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("watch_validation");
+    expect(unwatchFn).not.toHaveBeenCalled();
+  });
+});
+
+describe("error mapping", () => {
+  const cases: Array<[string, unknown, string, string]> = [
+    [
+      "auth failures",
+      new WatchAuthError("not your task"),
+      "watch_auth",
+      "not your task",
+    ],
+    [
+      "validation failures",
+      new WatchValidationError("too many tasks"),
+      "watch_validation",
+      "too many tasks",
+    ],
+    [
+      "missing rows",
+      new WatchNotFoundError("twt_gone"),
+      "watch_not_found",
+      "task_watch twt_gone not found",
+    ],
+    [
+      "any other Error",
+      new Error("connection reset"),
+      "watch_error",
+      "connection reset",
+    ],
+    ["a non-Error throw", "kaboom", "watch_error", "kaboom"],
+  ];
+
+  it.each(cases)(
+    "watch_tasks maps %s to a coded envelope",
+    async (_label, thrown, code, message) => {
+      const { watchTasks } = makeTools(
+        {},
+        {
+          watchTasks: vi.fn(async () => {
+            throw thrown;
+          }),
+        },
+      );
+      const res = await watchTasks.handler({ task_ids: ["tsk_1"] });
+      expect(res.isError).toBe(true);
+      expect(res.content).toEqual({ error: code, message });
+    },
+  );
+
+  it.each(cases)(
+    "unwatch maps %s to a coded envelope",
+    async (_label, thrown, code, message) => {
+      const { unwatch } = makeTools(
+        {},
+        {
+          unwatch: vi.fn(async () => {
+            throw thrown;
+          }),
+        },
+      );
+      const res = await unwatch.handler({ watch_id: "twt_1" });
+      expect(res.isError).toBe(true);
+      expect(res.content).toEqual({ error: code, message });
+    },
+  );
+});

--- a/packages/daemon/src/start.test.ts
+++ b/packages/daemon/src/start.test.ts
@@ -1,0 +1,317 @@
+/**
+ * `beevibe-daemon start` — wiring tests.
+ *
+ * `runStart` never resolves by design (it parks on a forever-promise to
+ * hold the process open), so these tests fire it without awaiting and
+ * assert on what it wired up by the time the microtask queue drains.
+ * Every collaborator is mocked; nothing opens a socket or touches disk.
+ *
+ * The behaviour worth pinning is the part that isn't just construction:
+ * the missing-config guard, skills-sync being non-fatal, the
+ * WORKSPACE_ROOT precedence, and the signal / unhandledRejection
+ * handlers whose absence would either wedge or kill a live daemon.
+ */
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runStart } from "./start.js";
+
+const {
+  loadConfigMock,
+  getConfigRootMock,
+  syncSkillsCacheMock,
+  apiClientMock,
+  workspaceManagerMock,
+  supervisorMock,
+  claimerMock,
+  claimerStart,
+  claimerStop,
+  runtimeRegistryMock,
+  logMock,
+  warnMock,
+} = vi.hoisted(() => ({
+  loadConfigMock: vi.fn(),
+  getConfigRootMock: vi.fn(),
+  syncSkillsCacheMock: vi.fn(),
+  apiClientMock: vi.fn(),
+  workspaceManagerMock: vi.fn(),
+  supervisorMock: vi.fn(),
+  claimerMock: vi.fn(),
+  claimerStart: vi.fn(),
+  claimerStop: vi.fn(),
+  runtimeRegistryMock: vi.fn(),
+  logMock: vi.fn(),
+  warnMock: vi.fn(),
+}));
+
+vi.mock("./config.js", () => ({
+  loadConfig: loadConfigMock,
+  getConfigRoot: getConfigRootMock,
+}));
+vi.mock("./skills-cache.js", () => ({ syncSkillsCache: syncSkillsCacheMock }));
+vi.mock("./logger.js", () => ({ log: logMock, warn: warnMock }));
+vi.mock("./api-client.js", () => ({
+  ApiClient: class {
+    constructor(...args: unknown[]) {
+      apiClientMock(...args);
+    }
+  },
+}));
+vi.mock("./supervisor.js", () => ({
+  Supervisor: class {
+    constructor(...args: unknown[]) {
+      supervisorMock(...args);
+    }
+  },
+}));
+vi.mock("./claimer.js", () => ({
+  Claimer: class {
+    start = claimerStart;
+    stop = claimerStop;
+    constructor(...args: unknown[]) {
+      claimerMock(...args);
+    }
+  },
+}));
+vi.mock("@beevibe/core/adapters/local-workspace", () => ({
+  LocalWorkspaceManager: class {
+    constructor(...args: unknown[]) {
+      workspaceManagerMock(...args);
+    }
+  },
+}));
+vi.mock("@beevibe/core/adapters/runtime-registry", () => ({
+  createDefaultRuntimeRegistry: runtimeRegistryMock,
+}));
+
+const CONFIG = {
+  api_url: "http://api.test",
+  external_id: "ext_1",
+  daemon_id: "dmn_1",
+  daemon_token: "bv_d_secret",
+  runtimes: [
+    { id: "rt_claude", cli: "claude" },
+    { id: "rt_codex", cli: "codex" },
+  ],
+};
+
+const SIGNALS = ["SIGINT", "SIGTERM", "unhandledRejection"] as const;
+type Signal = (typeof SIGNALS)[number];
+type Listener = (arg?: unknown) => void;
+
+/**
+ * `process.listeners` is typed per-event; these two erase the overload
+ * so one loop can cover both the signals and `unhandledRejection`.
+ */
+const listenersOf = (signal: Signal): Listener[] =>
+  (process.listeners as unknown as (e: string) => Listener[])(signal);
+const removeListener = (signal: Signal, listener: Listener): void => {
+  (process.removeListener as unknown as (e: string, l: Listener) => void)(
+    signal,
+    listener,
+  );
+};
+
+/** Listeners already on the process, so tests only clean up their own. */
+let preexisting: Record<Signal, Listener[]>;
+
+/**
+ * Fire `runStart` without awaiting it (it never settles) and let the
+ * awaits inside it drain.
+ */
+async function start(options: { configRoot?: string } = {}): Promise<void> {
+  void runStart(options).catch(() => undefined);
+  await vi.waitFor(() => expect(claimerStart).toHaveBeenCalled());
+}
+
+/** The handler `runStart` registered for `signal`, if any. */
+function addedListener(signal: Signal): Listener | undefined {
+  return listenersOf(signal).find((l) => !preexisting[signal].includes(l));
+}
+
+/** First constructor/call argument of a mock, as a readable options bag. */
+function firstArg(mock: { mock: { calls: unknown[][] } }): Record<string, unknown> {
+  return (mock.mock.calls[0]?.[0] ?? {}) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  loadConfigMock.mockReturnValue(CONFIG);
+  getConfigRootMock.mockReturnValue("/home/tester/.beevibe");
+  syncSkillsCacheMock.mockResolvedValue("/home/tester/.beevibe/skills");
+  runtimeRegistryMock.mockReturnValue({ registry: true });
+  delete process.env.WORKSPACE_ROOT;
+
+  preexisting = {
+    SIGINT: listenersOf("SIGINT"),
+    SIGTERM: listenersOf("SIGTERM"),
+    unhandledRejection: listenersOf("unhandledRejection"),
+  };
+});
+
+afterEach(() => {
+  for (const signal of SIGNALS) {
+    for (const listener of listenersOf(signal)) {
+      if (!preexisting[signal].includes(listener)) {
+        removeListener(signal, listener);
+      }
+    }
+  }
+  delete process.env.WORKSPACE_ROOT;
+});
+
+describe("runStart — config guard", () => {
+  it("tells the operator to run setup when no config exists", async () => {
+    loadConfigMock.mockReturnValue(undefined);
+    await expect(runStart()).rejects.toThrow(/beevibe-daemon setup/);
+    expect(claimerStart).not.toHaveBeenCalled();
+  });
+
+  it("passes the config-root override through to loadConfig", async () => {
+    loadConfigMock.mockReturnValue(undefined);
+    await expect(runStart({ configRoot: "/tmp/alt" })).rejects.toThrow();
+    expect(loadConfigMock).toHaveBeenCalledWith("/tmp/alt");
+  });
+});
+
+describe("runStart — wiring", () => {
+  it("builds the api client from the persisted url and token", async () => {
+    await start();
+    expect(apiClientMock).toHaveBeenCalledWith({
+      apiUrl: "http://api.test",
+      daemonToken: "bv_d_secret",
+    });
+  });
+
+  it("points the workspace manager at the api's /mcp endpoint", async () => {
+    await start();
+    expect(firstArg(workspaceManagerMock)).toMatchObject({
+      mcpServerUrl: "http://api.test/mcp",
+      skillsSourceDir: "/home/tester/.beevibe/skills",
+      runtimeRegistry: { registry: true },
+    });
+  });
+
+  it("subscribes the claimer to every registered runtime id", async () => {
+    await start();
+    expect(firstArg(claimerMock)).toMatchObject({
+      runtimeIds: ["rt_claude", "rt_codex"],
+    });
+    expect(claimerStart).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs the daemon id, api url and runtime count once started", async () => {
+    await start();
+    expect(logMock).toHaveBeenCalledWith(
+      "[daemon] started (dmn_1 → http://api.test, 2 runtime(s))",
+    );
+  });
+});
+
+describe("runStart — workspace root precedence", () => {
+  it("defaults to <configRoot>/workspaces", async () => {
+    getConfigRootMock.mockReturnValue("/tmp/alt-root");
+    await start({ configRoot: "/tmp/alt-root" });
+    expect(getConfigRootMock).toHaveBeenCalledWith("/tmp/alt-root");
+    expect(firstArg(workspaceManagerMock).workspaceRoot).toBe(
+      join("/tmp/alt-root", "workspaces"),
+    );
+  });
+
+  it("lets WORKSPACE_ROOT win", async () => {
+    process.env.WORKSPACE_ROOT = "/ci/workspaces";
+    await start();
+    expect(firstArg(workspaceManagerMock).workspaceRoot).toBe(
+      "/ci/workspaces",
+    );
+  });
+
+  it("treats an empty WORKSPACE_ROOT as unset", async () => {
+    // Guards against a `WORKSPACE_ROOT=` line leaking out of a .env.
+    process.env.WORKSPACE_ROOT = "";
+    await start();
+    expect(firstArg(workspaceManagerMock).workspaceRoot).toBe(
+      join("/home/tester/.beevibe", "workspaces"),
+    );
+  });
+});
+
+describe("runStart — skills sync is best-effort", () => {
+  it("syncs against the same config root", async () => {
+    await start({ configRoot: "/tmp/alt-root" });
+    expect(syncSkillsCacheMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "/tmp/alt-root",
+    );
+  });
+
+  it("keeps starting when the sync fails, with a /dev/null skills dir", async () => {
+    syncSkillsCacheMock.mockRejectedValue(new Error("registry 503"));
+    await start();
+    expect(warnMock).toHaveBeenCalledWith(
+      "[daemon] skills sync failed; continuing without skills:",
+      "registry 503",
+    );
+    expect(firstArg(workspaceManagerMock).skillsSourceDir).toBe(
+      "/dev/null",
+    );
+    expect(claimerStart).toHaveBeenCalled();
+  });
+
+  it("stringifies a non-Error sync rejection", async () => {
+    syncSkillsCacheMock.mockRejectedValue("offline");
+    await start();
+    expect(warnMock).toHaveBeenCalledWith(
+      "[daemon] skills sync failed; continuing without skills:",
+      "offline",
+    );
+  });
+});
+
+describe("runStart — process handlers", () => {
+  it("stops the claimer and exits on SIGINT", async () => {
+    const exit = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as never);
+    await start();
+
+    addedListener("SIGINT")?.();
+    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(0));
+
+    expect(logMock).toHaveBeenCalledWith("[daemon] received SIGINT; stopping");
+    expect(claimerStop).toHaveBeenCalledTimes(1);
+    exit.mockRestore();
+  });
+
+  it("ignores a second signal while the first stop is in flight", async () => {
+    const exit = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as never);
+    await start();
+
+    const onTerm = addedListener("SIGTERM");
+    onTerm?.();
+    onTerm?.();
+    await vi.waitFor(() => expect(exit).toHaveBeenCalled());
+
+    expect(claimerStop).toHaveBeenCalledTimes(1);
+    exit.mockRestore();
+  });
+
+  it("logs and continues on an unhandled rejection rather than dying", async () => {
+    await start();
+    const onRejection = addedListener("unhandledRejection");
+    expect(onRejection).toBeDefined();
+
+    onRejection?.(new Error("fetch aborted"));
+    expect(warnMock).toHaveBeenCalledWith(
+      "[daemon] unhandledRejection (continuing):",
+      "fetch aborted",
+    );
+
+    onRejection?.("plain string");
+    expect(warnMock).toHaveBeenCalledWith(
+      "[daemon] unhandledRejection (continuing):",
+      "plain string",
+    );
+  });
+});


### PR DESCRIPTION
## What

A coverage sweep across `api`, `core`, `daemon`, `scheduler` and `sandbox`, then tests for what it found. No production code changed.

## How the targets were picked

Most low-coverage files read that way only because their suite is gated on Postgres or provider keys — `routes/mcp.ts`, `runtime/router.ts`, `routes/task.ts`, the postgres adapters. Those are covered in CI, where the DB exists, so chasing them locally would have been measuring the sandbox rather than the code.

What was genuinely untested *everywhere* was the handful of modules with **no sibling test file at all**. That's the scope here.

`core` needed nothing — every non-barrel module with real logic is already at or near 100% once the DB-gated suites are discounted.

## Coverage

| File | Before | After |
| --- | --- | --- |
| `packages/api/src/routes/chat.ts` | 26.9% | **100%** |
| `packages/api/src/tools/use-repo.ts` | 32.0% | **100%** |
| `packages/api/src/tools/watch.ts` | 46.3% | **100%** |
| `packages/api/src/tools/session-search.ts` | 64.7% | **100%** |
| `packages/api/src/routes/stream.ts` | 9.4% | **100%** |
| `packages/daemon/src/start.ts` | 0% | **98.4%** |

Package totals: `@beevibe/api` 64.9% → **71.8%** lines, `@beevibe/daemon` 80.4% → **86.1%**.

## What the tests actually pin

Beyond line execution, each file targets behaviour that would be a real bug if it regressed:

- **chat** (62 tests) — the auth gate, the idempotent-replay ladder (replay / 409 in-flight / 403 wrong owner / fall through), replay being checked *before* the rate limiter so a retry is never throttled, the daemon-offline 503, the resolver 504, rate-limit slot release on every failure path, and the onboarding flip firing only on a *successful* first turn. `chat-internals.test.ts` already covered the exported pure helpers; this covers the router around them — including the failed-turn branch of `chainToMessages` that neither file reached.
- **use_repo** (42) — the dispatch-then-`repo_run` ordering the session FK depends on, the GitHub-URL check (rejects `http`, gitlab, and the `evilgithub.com` lookalike that `(^|\.)github\.com$` is there to stop), and the `limits` clamp.
- **watch_tasks / unwatch** (31) — input coercion and the error-class → error-code mapping agents branch on.
- **session_search** (31) — shape inference across discover / scroll / read / browse, plus the name-based `SessionSearchError` match that keeps structured codes working across a src/dist bundle boundary.
- **stream** (15) — SSE headers, the priming `data: {}` line the browser health probe needs, per-person fanout isolation, the 25s heartbeat, and teardown on either `req` or `res` close.
- **daemon start** (15) — the missing-config guard, skills sync being non-fatal, `WORKSPACE_ROOT` precedence (empty string treated as unset), and the signal / `unhandledRejection` handlers whose absence would wedge or kill a live daemon.

## Test approach notes

- Everything is DI + vitest fakes — no Postgres, no Docker, no CLI, no sockets.
- `stream.ts` drives the router with a fake `req`/`res` pair rather than supertest, since an SSE response never ends; the handler is synchronous, so the wiring is observable the moment the call returns.
- `start.ts` parks on a forever-promise by design, so `runStart` is fired without awaiting and the test asserts once the claimer has started. Process listeners it registers are snapshotted and removed in `afterEach` so nothing leaks into sibling suites.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors (4 pre-existing warnings, none from these files)
- `@beevibe/api`: 1001 tests pass; the 9 failing files are byte-identical to the pre-change set (all DB/key-gated, per CLAUDE.md's baseline table)
- `@beevibe/daemon`: 171 pass, 0 fail

The coverage provider was installed for the sweep and removed again per CLAUDE.md — `package.json` and `pnpm-lock.yaml` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSrN5uMhLkBbnWiHGBsZb

---
_Generated by [Claude Code](https://claude.ai/code/session_019mSrN5uMhLkBbnWiHGBsZb)_