### PR TITLE
refactor: unify four near-duplicate abstractions

### DIFF
--- a/packages/api/src/routes/capabilities.ts
+++ b/packages/api/src/routes/capabilities.ts
@@ -29,6 +29,7 @@ import { getReferencedRepos } from "@beevibe/core/services/referenced-repos";
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
 import { requireHuman } from "../auth/middleware.js";
 import { createUseRepoTool } from "../tools/use-repo.js";
+import { codedFailure } from "./http-errors.js";
 
 export interface CapabilitiesRouterDeps {
   authMiddleware: RequestHandler;
@@ -86,8 +87,7 @@ export function createCapabilitiesRouter(deps: CapabilitiesRouterDeps): Router {
       });
       res.status(200).json({ repos });
     } catch (err) {
-      console.error("[capabilities/referenced-repos]", err);
-      res.status(500).json({ error: "scan_failed" });
+      codedFailure(res, "capabilities/referenced-repos", "scan_failed", err);
     }
   });
 
@@ -135,8 +135,7 @@ export function createCapabilitiesRouter(deps: CapabilitiesRouterDeps): Router {
       }
       res.status(202).json(result.content);
     } catch (err) {
-      console.error("[capabilities/use]", err);
-      res.status(500).json({ error: "use_failed" });
+      codedFailure(res, "capabilities/use", "use_failed", err);
     }
   });
 

--- a/packages/api/src/routes/find-repo.ts
+++ b/packages/api/src/routes/find-repo.ts
@@ -17,6 +17,7 @@ import type {
 } from "@beevibe/core";
 import { requireHuman } from "../auth/middleware.js";
 import { createFindRepoTool } from "../tools/find-repo.js";
+import { codedFailure } from "./http-errors.js";
 
 export interface FindRepoRouterDeps {
   authMiddleware: RequestHandler;
@@ -68,8 +69,7 @@ export function createFindRepoRouter(deps: FindRepoRouterDeps): Router {
       }
       res.status(200).json(result.content);
     } catch (err) {
-      console.error("[find-repo/search]", err);
-      res.status(500).json({ error: "search_failed" });
+      codedFailure(res, "find-repo/search", "search_failed", err);
     }
   });
 

--- a/packages/api/src/routes/http-errors.ts
+++ b/packages/api/src/routes/http-errors.ts
@@ -150,3 +150,34 @@ export function makeErrorHandler(
     });
   };
 }
+
+/**
+ * The *other* 500 shape in this codebase: a per-operation machine code and
+ * no message.
+ *
+ * `runtime/router`, `repo-runs`, `learned-skills`, `capabilities` and
+ * `find-repo` all answer failures with `{ error: "<operation>_failed" }`
+ * rather than the `internal_error` + `message` envelope above, and each of
+ * their 20 catch blocks spelled out the same pair of statements: log under a
+ * bracketed tag, then 500 with the code.
+ *
+ * This is deliberately NOT folded into `makeErrorHandler`. The two envelopes
+ * differ in what they put on the wire — these endpoints keep the error's
+ * message server-side and hand clients a code they can branch on — and the
+ * daemon does branch on those codes, so unifying the *envelopes* would be a
+ * wire-contract change. What is shared is only the log-then-respond shape.
+ *
+ * `error` stays a parameter because the codes are per-operation by design
+ * (`claim_failed` vs `events_failed` tells an operator which leg broke), and
+ * `tag` stays separate from it because the log tags are slash-namespaced
+ * (`runtime/claim`) while the codes are not.
+ */
+export function codedFailure(
+  res: Response,
+  tag: string,
+  error: string,
+  err: unknown,
+): void {
+  console.error(`[${tag}]`, err);
+  res.status(500).json({ error });
+}

--- a/packages/api/src/routes/learned-skills.ts
+++ b/packages/api/src/routes/learned-skills.ts
@@ -19,7 +19,7 @@ import {
 } from "@beevibe/core";
 import { requireHuman } from "../auth/middleware.js";
 import { readArtifactBody } from "../views/work-product.js";
-import { invalidBody, loadOwned, requireParam } from "./http-errors.js";
+import { codedFailure, invalidBody, loadOwned, requireParam } from "./http-errors.js";
 
 export interface LearnedSkillsRouterDeps {
   authMiddleware: RequestHandler;
@@ -63,8 +63,7 @@ export function createLearnedSkillsRouter(deps: LearnedSkillsRouterDeps): Router
       const skills = await deps.learnedSkillRepo.listByOwner(req.caller!.personId);
       res.status(200).json({ skills });
     } catch (err) {
-      console.error("[learned-skills/list]", err);
-      res.status(500).json({ error: "list_failed" });
+      codedFailure(res, "learned-skills/list", "list_failed", err);
     }
   });
 
@@ -141,8 +140,7 @@ export function createLearnedSkillsRouter(deps: LearnedSkillsRouterDeps): Router
 
       res.status(201).json({ skill });
     } catch (err) {
-      console.error("[learned-skills/create]", err);
-      res.status(500).json({ error: "create_failed" });
+      codedFailure(res, "learned-skills/create", "create_failed", err);
     }
   });
 
@@ -157,8 +155,7 @@ export function createLearnedSkillsRouter(deps: LearnedSkillsRouterDeps): Router
       await deps.learnedSkillRepo.delete(id);
       res.status(204).send();
     } catch (err) {
-      console.error("[learned-skills/delete]", err);
-      res.status(500).json({ error: "delete_failed" });
+      codedFailure(res, "learned-skills/delete", "delete_failed", err);
     }
   });
 

--- a/packages/api/src/routes/repo-runs.ts
+++ b/packages/api/src/routes/repo-runs.ts
@@ -19,7 +19,7 @@ import type {
   SessionEventRepository,
 } from "@beevibe/core";
 import { requireHuman } from "../auth/middleware.js";
-import { requireParam } from "./http-errors.js";
+import { codedFailure, requireParam } from "./http-errors.js";
 
 export interface RepoRunsRouterDeps {
   authMiddleware: RequestHandler;
@@ -67,8 +67,7 @@ export function createRepoRunsRouter(deps: RepoRunsRouterDeps): Router {
       const runs = await deps.repoRunRepo.listRecent({ limit: 50 });
       res.status(200).json({ runs });
     } catch (err) {
-      console.error("[repo-runs/list]", err);
-      res.status(500).json({ error: "list_failed" });
+      codedFailure(res, "repo-runs/list", "list_failed", err);
     }
   });
 
@@ -101,8 +100,7 @@ export function createRepoRunsRouter(deps: RepoRunsRouterDeps): Router {
       }
       res.status(200).json({ run: { ...run, transcript } });
     } catch (err) {
-      console.error("[repo-runs/get]", err);
-      res.status(500).json({ error: "get_failed" });
+      codedFailure(res, "repo-runs/get", "get_failed", err);
     }
   });
 
@@ -133,8 +131,7 @@ export function createRepoRunsRouter(deps: RepoRunsRouterDeps): Router {
       });
       res.status(200).json({ run: updated });
     } catch (err) {
-      console.error("[repo-runs/cancel]", err);
-      res.status(500).json({ error: "cancel_failed" });
+      codedFailure(res, "repo-runs/cancel", "cancel_failed", err);
     }
   });
 
@@ -187,8 +184,7 @@ export function createRepoRunsRouter(deps: RepoRunsRouterDeps): Router {
         task_id: run.task_id,
       });
     } catch (err) {
-      console.error("[repo-runs/artifact]", err);
-      res.status(500).json({ error: "artifact_failed" });
+      codedFailure(res, "repo-runs/artifact", "artifact_failed", err);
     }
   });
 

--- a/packages/api/src/runtime/router.ts
+++ b/packages/api/src/runtime/router.ts
@@ -44,6 +44,7 @@ import {
 } from "@beevibe/core/services/agent-session";
 import { transitionTaskOnClaim } from "@beevibe/core/services/dispatch-service";
 import { requireDaemon, requireHuman } from "../auth/middleware.js";
+import { codedFailure } from "../routes/http-errors.js";
 import type { DaemonHub } from "./hub.js";
 
 export interface RuntimeRouterDeps {
@@ -123,8 +124,7 @@ export function createRuntimeRouter(deps: RuntimeRouterDeps): Router {
       };
       res.status(isNew ? 201 : 200).json(response);
     } catch (err) {
-      console.error("[runtime/register]", err);
-      res.status(500).json({ error: "register_failed" });
+      codedFailure(res, "runtime/register", "register_failed", err);
     }
   });
 
@@ -147,8 +147,7 @@ export function createRuntimeRouter(deps: RuntimeRouterDeps): Router {
       };
       res.status(200).json(response);
     } catch (err) {
-      console.error("[runtime/sync]", err);
-      res.status(500).json({ error: "sync_failed" });
+      codedFailure(res, "runtime/sync", "sync_failed", err);
     }
   });
 
@@ -171,8 +170,7 @@ export function createRuntimeRouter(deps: RuntimeRouterDeps): Router {
       for (const id of runtimeIds) deps.hub.bumpLastSeen(id);
       res.status(204).send();
     } catch (err) {
-      console.error("[runtime/heartbeat]", err);
-      res.status(500).json({ error: "heartbeat_failed" });
+      codedFailure(res, "runtime/heartbeat", "heartbeat_failed", err);
     }
   });
 
@@ -220,8 +218,7 @@ export function createRuntimeRouter(deps: RuntimeRouterDeps): Router {
       await transitionTaskOnClaim(claimed, { taskRepo: deps.taskRepo });
       res.status(200).json(payload);
     } catch (err) {
-      console.error("[runtime/claim]", err);
-      res.status(500).json({ error: "claim_failed" });
+      codedFailure(res, "runtime/claim", "claim_failed", err);
     }
   });
 
@@ -261,8 +258,7 @@ export function createRuntimeRouter(deps: RuntimeRouterDeps): Router {
       );
       res.status(204).send();
     } catch (err) {
-      console.error("[runtime/events]", err);
-      res.status(500).json({ error: "events_failed" });
+      codedFailure(res, "runtime/events", "events_failed", err);
     }
   });
 
@@ -368,8 +364,7 @@ export function createRuntimeRouter(deps: RuntimeRouterDeps): Router {
       }
       res.status(204).send();
     } catch (err) {
-      console.error("[runtime/done]", err);
-      res.status(500).json({ error: "done_failed" });
+      codedFailure(res, "runtime/done", "done_failed", err);
     }
   });
 
@@ -379,8 +374,7 @@ export function createRuntimeRouter(deps: RuntimeRouterDeps): Router {
       const response = await readSkills(deps.skillsSourceDir);
       res.status(200).json(response);
     } catch (err) {
-      console.error("[runtime/skills]", err);
-      res.status(500).json({ error: "skills_read_failed" });
+      codedFailure(res, "runtime/skills", "skills_read_failed", err);
     }
   });
 

--- a/packages/web/app/(authed)/rooms/[id]/room-detail-client.tsx
+++ b/packages/web/app/(authed)/rooms/[id]/room-detail-client.tsx
@@ -17,7 +17,7 @@ import { isApiConfigured } from "@/lib/api/config";
 import { api, type RoomDetail, type RoomMemberDetail, type RoomMessage } from "@/lib/api/client";
 import { ApiError, describeError } from "@/lib/api/http";
 import { queryKeys } from "@/lib/hooks/keys";
-import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
+import { ShareLinkBox, signUpInviteLink } from "@/components/share-link-box";
 import { ModalOverlay } from "@/components/modal-overlay";
 import { ChatMarkdown } from "@/components/chat/markdown";
 import { ToolStepList } from "@/components/chat/tool-step-list";
@@ -275,7 +275,6 @@ function InviteDialog({ roomId, onClose }: { roomId: string; onClose: () => void
   const [error, setError] = useState<string | null>(null);
   /** When the invitee doesn't have an account yet, surface a share link they can use to sign up + auto-join. */
   const [shareLink, setShareLink] = useState<string | null>(null);
-  const { copied, copy } = useCopyToClipboard();
 
   const invite = useMutation({
     mutationFn: () => api.rooms.invite(roomId, { email: email.trim() }),
@@ -288,9 +287,7 @@ function InviteDialog({ roomId, onClose }: { roomId: string; onClose: () => void
       // yet. Show a copyable share link instead — they sign up via that
       // URL and land in this room as their first session.
       if (err instanceof ApiError && err.errorCode === "person_not_found") {
-        const origin = typeof window !== "undefined" ? window.location.origin : "";
-        const link = `${origin}/sign-up?room=${encodeURIComponent(roomId)}&email=${encodeURIComponent(email.trim())}`;
-        setShareLink(link);
+        setShareLink(signUpInviteLink(email.trim(), roomId));
         setError(null);
       } else {
         setShareLink(null);
@@ -333,27 +330,15 @@ function InviteDialog({ roomId, onClose }: { roomId: string; onClose: () => void
           </div>
         ) : null}
         {shareLink ? (
-          <div className="mt-3 rounded border border-border bg-muted/40 p-3">
-            <div className="text-[11px] text-muted-foreground mb-1.5">
-              No account for that email yet. Send them this link — they&apos;ll sign up and
-              land in this room.
-            </div>
-            <div className="flex items-center gap-1.5">
-              <input
-                readOnly
-                value={shareLink}
-                className="flex-1 rounded border border-border bg-background px-2 py-1.5 text-[11px] font-mono"
-                onFocus={(e) => e.currentTarget.select()}
-              />
-              <button
-                type="button"
-                onClick={() => void copy(shareLink ?? "")}
-                className="h-7 px-2.5 rounded text-[11px] font-medium border border-border hover:bg-secondary transition-colors cursor-pointer shrink-0"
-              >
-                {copied ? "Copied" : "Copy"}
-              </button>
-            </div>
-          </div>
+          <ShareLinkBox
+            link={shareLink}
+            description={
+              <>
+                No account for that email yet. Send them this link — they&apos;ll sign up and
+                land in this room.
+              </>
+            }
+          />
         ) : null}
         <div className="mt-4 flex items-center justify-end gap-2">
           <button

--- a/packages/web/app/(authed)/sessions/[sid]/chat-session-detail-client.tsx
+++ b/packages/web/app/(authed)/sessions/[sid]/chat-session-detail-client.tsx
@@ -5,13 +5,12 @@ import { ArrowLeft, ChevronRight, Terminal, Wrench } from "lucide-react";
 import { useConversation } from "@/lib/hooks/use-sessions";
 import { DetailGate } from "@/components/detail/detail-gate";
 import { EmptyState } from "@/components/empty-state";
-import { Skeleton } from "@/components/skeleton";
-import { SessionStatusPill } from "@/components/detail/status-pill";
-import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
-import { FooterField } from "@/components/detail/footer-field";
 import { ChatMarkdown } from "@/components/chat/markdown";
-import { HierChip } from "@/components/hier-chip";
-import { Avatar } from "@/components/avatar";
+import {
+  SessionDetailFooter,
+  SessionDetailHeader,
+  SessionDetailSkeleton,
+} from "@/components/sessions/session-detail-chrome";
 import { UsagePanel } from "@/components/sessions/usage-panel";
 import type {
   ConversationDisplay,
@@ -41,13 +40,7 @@ export function ChatSessionDetailClient({ sessionShortId }: { sessionShortId: st
       noun="session"
       id={sessionShortId}
       query={query}
-      skeleton={
-        <>
-          <Skeleton className="h-14 w-full mb-6" />
-          <Skeleton className="h-32 w-full mb-5 rounded-lg" />
-          <Skeleton className="h-64 w-full rounded-lg" />
-        </>
-      }
+      skeleton={<SessionDetailSkeleton />}
     >
       {(conversation) =>
         // Task-typed sessions belong on the task-scoped detail page; redirect
@@ -91,37 +84,23 @@ function ConversationBody({ conversation }: { conversation: ConversationDisplay 
 
   return (
     <>
-      <header className="mb-6">
-        <div className="flex items-start gap-3">
-          <Avatar
-            initial={conversation.agent_label.charAt(0).toUpperCase()}
-            kind={conversation.agent_hierarchy}
-            label={conversation.agent_label}
-            size={40}
-            presence={conversation.status === "running" ? "running" : "idle"}
-          />
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 mb-1">
-              <h1 className="text-base font-semibold tracking-tight leading-tight">
-                {multiTurn ? "Conversation" : "One turn"}
-              </h1>
-              <SessionStatusPill status={conversation.status} />
-            </div>
-            <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <span className="text-foreground/85">{conversation.agent_label}</span>
-              <HierChip hier={conversation.agent_hierarchy} />
-              {multiTurn ? (
-                <>
-                  <span className="text-muted-foreground/50">·</span>
-                  <span className="tabular-nums">{turns.length} turns</span>
-                </>
-              ) : null}
-              <span className="text-muted-foreground/50">·</span>
-              <span className="text-foreground/70">{conversation.type}</span>
-            </div>
-          </div>
-        </div>
-      </header>
+      <SessionDetailHeader
+        agentLabel={conversation.agent_label}
+        agentHierarchy={conversation.agent_hierarchy}
+        status={conversation.status}
+        title={multiTurn ? "Conversation" : "One turn"}
+        titleClassName="tracking-tight"
+        meta={[
+          multiTurn ? (
+            <span key="turns" className="tabular-nums">
+              {turns.length} turns
+            </span>
+          ) : null,
+          <span key="type" className="text-foreground/70">
+            {conversation.type}
+          </span>,
+        ]}
+      />
 
       <div className="space-y-6">
         {turns.map((turn) => (
@@ -131,22 +110,13 @@ function ConversationBody({ conversation }: { conversation: ConversationDisplay 
 
       {usage ? <UsagePanel usage={usage} /> : null}
 
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
-        <FooterField label="Conversation ID">
-          <ClickToCopyId id={conversation.conversation_id} />
-        </FooterField>
-        {lastTurn?.cli_session ? (
-          <FooterField label="CLI session" truncate>
-            <span className="font-mono">{lastTurn.cli_session}</span>
-          </FooterField>
-        ) : null}
-        {lastTurn?.worktree ? (
-          <FooterField label="Worktree" truncate>
-            <span className="font-mono">{lastTurn.worktree}</span>
-          </FooterField>
-        ) : null}
-        <FooterField label="Type">{conversation.type}</FooterField>
-      </footer>
+      <SessionDetailFooter
+        idLabel="Conversation ID"
+        id={conversation.conversation_id}
+        cliSession={lastTurn?.cli_session}
+        worktree={lastTurn?.worktree}
+        type={conversation.type}
+      />
     </>
   );
 }

--- a/packages/web/app/(authed)/tasks/[id]/sessions/[sid]/session-detail-client.tsx
+++ b/packages/web/app/(authed)/tasks/[id]/sessions/[sid]/session-detail-client.tsx
@@ -3,15 +3,14 @@
 import Link from "next/link";
 import { ChevronRight, Terminal } from "lucide-react";
 import { useSession } from "@/lib/hooks/use-sessions";
-import { Avatar } from "@/components/avatar";
-import { HierChip } from "@/components/hier-chip";
-import { SessionStatusPill } from "@/components/detail/status-pill";
-import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
 import { DetailGate } from "@/components/detail/detail-gate";
-import { FooterField } from "@/components/detail/footer-field";
 import { BriefingComposer } from "@/components/sessions/briefing-composer";
+import {
+  SessionDetailFooter,
+  SessionDetailHeader,
+  SessionDetailSkeleton,
+} from "@/components/sessions/session-detail-chrome";
 import { Transcript } from "@/components/sessions/transcript";
-import { Skeleton } from "@/components/skeleton";
 import { formatIntent, shortId } from "@/lib/format";
 import type { SessionDisplay } from "@/lib/types/sessions";
 
@@ -36,13 +35,7 @@ export function SessionDetailClient({ taskId, sessionShortId }: Props) {
       noun="session"
       id={sessionShortId}
       query={query}
-      skeleton={
-        <>
-          <Skeleton className="h-14 w-full mb-6" />
-          <Skeleton className="h-32 w-full mb-5 rounded-lg" />
-          <Skeleton className="h-64 w-full rounded-lg" />
-        </>
-      }
+      skeleton={<SessionDetailSkeleton />}
     >
       {(session) => <SessionDetailBody session={session} taskId={taskId} />}
     </DetailGate>
@@ -87,50 +80,26 @@ function SessionDetailBody({ session, taskId: _taskId }: { session: SessionDispl
   // running session orphaned in the daemon-spawn path.
   return (
     <>
-      <header className="mb-6">
-        <div className="flex items-start gap-3">
-          <Avatar
-            initial={session.agent_label.charAt(0).toUpperCase()}
-            kind={session.agent_hierarchy}
-            label={session.agent_label}
-            size={40}
-            presence={session.status === "running" ? "running" : "idle"}
-          />
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 mb-1">
-              <h1 className="text-base font-semibold leading-tight truncate">{formatIntent(session.intent)}</h1>
-              <SessionStatusPill status={session.status} />
-            </div>
-            <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <span className="text-foreground/85">{session.agent_label}</span>
-              <HierChip hier={session.agent_hierarchy} />
-              <span className="text-muted-foreground/50">·</span>
-              <span className="tabular-nums">{session.duration_label}</span>
-            </div>
-          </div>
-        </div>
-      </header>
+      <SessionDetailHeader
+        agentLabel={session.agent_label}
+        agentHierarchy={session.agent_hierarchy}
+        status={session.status}
+        title={formatIntent(session.intent)}
+        titleClassName="truncate"
+        meta={[<span key="duration" className="tabular-nums">{session.duration_label}</span>]}
+      />
 
       <BriefingComposer briefing={session.briefing} />
 
       <Transcript entries={session.transcript} ask_threads={session.ask_threads} />
 
-      <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
-        <FooterField label="Session ID">
-          <ClickToCopyId id={session.id} />
-        </FooterField>
-        {session.cli_session ? (
-          <FooterField label="CLI session" truncate>
-            <span className="font-mono">{session.cli_session}</span>
-          </FooterField>
-        ) : null}
-        {session.worktree ? (
-          <FooterField label="Worktree" truncate>
-            <span className="font-mono">{session.worktree}</span>
-          </FooterField>
-        ) : null}
-        <FooterField label="Type">{session.type}</FooterField>
-      </footer>
+      <SessionDetailFooter
+        idLabel="Session ID"
+        id={session.id}
+        cliSession={session.cli_session}
+        worktree={session.worktree}
+        type={session.type}
+      />
     </>
   );
 }

--- a/packages/web/app/sign-in/sign-in-client.tsx
+++ b/packages/web/app/sign-in/sign-in-client.tsx
@@ -3,16 +3,24 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { AlertTriangle, KeyRound, Loader2, LogIn } from "lucide-react";
+import { KeyRound, LogIn } from "lucide-react";
 import { SIGNIN_NO_PASSWORD_SET } from "@beevibe/core/auth/constants";
 import { api } from "@/lib/api/client";
 import { asApiError } from "@/lib/api/http";
 import {
+  API_NOT_CONFIGURED_MESSAGE,
   getUserKey,
   isApiConfigured,
   isWellFormedUserKey,
   setUserKey,
 } from "@/lib/api/config";
+import {
+  AuthCard,
+  AuthCardFooter,
+  AuthError,
+  AuthField,
+  AuthSubmitButton,
+} from "@/components/auth/auth-form";
 
 type Mode = "password" | "key";
 
@@ -52,7 +60,7 @@ export function SignInClient() {
   const submitPassword = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!isApiConfigured) {
-      setError("Web isn't configured to talk to an api server.");
+      setError(API_NOT_CONFIGURED_MESSAGE);
       return;
     }
     setError(null);
@@ -87,7 +95,7 @@ export function SignInClient() {
   const submitKey = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!isApiConfigured) {
-      setError("Web isn't configured to talk to an api server.");
+      setError(API_NOT_CONFIGURED_MESSAGE);
       return;
     }
     const key = keyDraft.trim();
@@ -114,133 +122,97 @@ export function SignInClient() {
   };
 
   return (
-    <main className="min-h-screen flex items-center justify-center px-6 bg-background">
-      <form
-        onSubmit={mode === "password" ? submitPassword : submitKey}
-        className="w-full max-w-sm bg-card border border-border rounded-lg p-6 shadow-sm"
-      >
-        <header className="mb-5">
-          <div className="inline-flex items-center justify-center h-10 w-10 rounded-md bg-primary text-primary-foreground mb-3">
-            {mode === "password" ? (
-              <LogIn className="h-5 w-5" />
-            ) : (
-              <KeyRound className="h-5 w-5" />
-            )}
-          </div>
-          <h1 className="text-lg font-semibold tracking-tight">Sign in to beevibe</h1>
-          <p className="mt-1 text-xs text-muted-foreground leading-relaxed">
-            {mode === "password" ? (
-              <>Email + password. Your <span className="font-mono">bv_u_</span> key is generated server-side and never leaves the browser after.</>
-            ) : (
-              <>Paste your <span className="font-mono">bv_u_</span> key — for legacy accounts or CLI-provisioned users.</>
-            )}
-          </p>
-        </header>
-
-        {mode === "password" ? (
-          <>
-            <label className="block text-xs font-medium text-foreground mb-1.5" htmlFor="email">
-              Email
-            </label>
-            <input
-              id="email"
-              type="email"
-              autoComplete="email"
-              inputMode="email"
-              autoFocus
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="alice@example.com"
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-              disabled={submitting}
-            />
-
-            <label className="block text-xs font-medium text-foreground mb-1.5 mt-3" htmlFor="password">
-              Password
-            </label>
-            <input
-              id="password"
-              type="password"
-              autoComplete="current-password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="••••••••"
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-              disabled={submitting}
-            />
-          </>
+    <AuthCard
+      icon={mode === "password" ? LogIn : KeyRound}
+      title="Sign in to beevibe"
+      description={
+        mode === "password" ? (
+          <>Email + password. Your <span className="font-mono">bv_u_</span> key is generated server-side and never leaves the browser after.</>
         ) : (
-          <>
-            <label className="block text-xs font-medium text-foreground mb-1.5" htmlFor="key">
-              User API key
-            </label>
-            <input
-              id="key"
-              type="password"
-              autoComplete="off"
-              autoFocus
-              spellCheck={false}
-              value={keyDraft}
-              onChange={(e) => setKeyDraft(e.target.value)}
-              placeholder="bv_u_..."
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-ring"
-              disabled={submitting}
-            />
-          </>
-        )}
+          <>Paste your <span className="font-mono">bv_u_</span> key — for legacy accounts or CLI-provisioned users.</>
+        )
+      }
+      onSubmit={mode === "password" ? submitPassword : submitKey}
+    >
+      {mode === "password" ? (
+        <>
+          <AuthField
+            id="email"
+            label="Email"
+            type="email"
+            autoComplete="email"
+            inputMode="email"
+            autoFocus
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="alice@example.com"
+            disabled={submitting}
+          />
 
-        {error ? (
-          <div className="mt-3 flex items-start gap-1.5 text-xs text-status-failed">
-            <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>{error}</span>
-          </div>
-        ) : null}
-
-        <button
-          type="submit"
-          disabled={
-            submitting ||
-            (mode === "password"
-              ? email.trim().length === 0 || password.length === 0
-              : keyDraft.trim().length === 0)
-          }
-          className="mt-5 w-full inline-flex items-center justify-center gap-1.5 h-9 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {submitting ? (
-            <>
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              {mode === "password" ? "Signing in…" : "Verifying…"}
-            </>
-          ) : (
-            <>
-              <LogIn className="h-3.5 w-3.5" />
-              Sign in
-            </>
-          )}
-        </button>
-
-        <button
-          type="button"
-          onClick={() => {
-            setMode((m) => (m === "password" ? "key" : "password"));
-            setError(null);
-          }}
+          <AuthField
+            id="password"
+            label="Password"
+            spaced
+            type="password"
+            autoComplete="current-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="••••••••"
+            disabled={submitting}
+          />
+        </>
+      ) : (
+        <AuthField
+          id="key"
+          label="User API key"
+          type="password"
+          autoComplete="off"
+          autoFocus
+          spellCheck={false}
+          value={keyDraft}
+          onChange={(e) => setKeyDraft(e.target.value)}
+          placeholder="bv_u_..."
+          className="font-mono"
           disabled={submitting}
-          className="mt-3 w-full text-[11px] text-muted-foreground hover:text-foreground transition-colors cursor-pointer disabled:opacity-50"
-        >
-          {mode === "password"
-            ? "Or sign in with your bv_u_ key"
-            : "Or sign in with email + password"}
-        </button>
+        />
+      )}
 
-        <footer className="mt-5 pt-4 border-t border-border/60 text-[11px] text-muted-foreground leading-relaxed">
-          New here?{" "}
-          <Link href="/sign-up" className="text-foreground/80 hover:underline">
-            Sign up
-          </Link>{" "}
-          — takes about 5 seconds.
-        </footer>
-      </form>
-    </main>
+      {error ? <AuthError message={error} /> : null}
+
+      <AuthSubmitButton
+        icon={LogIn}
+        label="Sign in"
+        pending={submitting}
+        pendingLabel={mode === "password" ? "Signing in…" : "Verifying…"}
+        disabled={
+          submitting ||
+          (mode === "password"
+            ? email.trim().length === 0 || password.length === 0
+            : keyDraft.trim().length === 0)
+        }
+      />
+
+      <button
+        type="button"
+        onClick={() => {
+          setMode((m) => (m === "password" ? "key" : "password"));
+          setError(null);
+        }}
+        disabled={submitting}
+        className="mt-3 w-full text-[11px] text-muted-foreground hover:text-foreground transition-colors cursor-pointer disabled:opacity-50"
+      >
+        {mode === "password"
+          ? "Or sign in with your bv_u_ key"
+          : "Or sign in with email + password"}
+      </button>
+
+      <AuthCardFooter>
+        New here?{" "}
+        <Link href="/sign-up" className="text-foreground/80 hover:underline">
+          Sign up
+        </Link>{" "}
+        — takes about 5 seconds.
+      </AuthCardFooter>
+    </AuthCard>
   );
 }

--- a/packages/web/app/sign-up/sign-up-client.tsx
+++ b/packages/web/app/sign-up/sign-up-client.tsx
@@ -3,11 +3,23 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { AlertTriangle, Loader2, Sparkles, UserPlus } from "lucide-react";
+import { Sparkles, UserPlus } from "lucide-react";
 import { PASSWORD_MIN_LENGTH } from "@beevibe/core/auth/constants";
 import { api } from "@/lib/api/client";
 import { asApiError } from "@/lib/api/http";
-import { getUserKey, isApiConfigured, setUserKey } from "@/lib/api/config";
+import {
+  API_NOT_CONFIGURED_MESSAGE,
+  getUserKey,
+  isApiConfigured,
+  setUserKey,
+} from "@/lib/api/config";
+import {
+  AuthCard,
+  AuthCardFooter,
+  AuthError,
+  AuthField,
+  AuthSubmitButton,
+} from "@/components/auth/auth-form";
 
 /**
  * Self-serve signup. Visitor enters name + email; the api mints them a
@@ -41,7 +53,7 @@ export function SignUpClient() {
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!isApiConfigured) {
-      setError("Web isn't configured to talk to an api server.");
+      setError(API_NOT_CONFIGURED_MESSAGE);
       return;
     }
     if (password.length < PASSWORD_MIN_LENGTH) {
@@ -88,105 +100,77 @@ export function SignUpClient() {
   };
 
   return (
-    <main className="min-h-screen flex items-center justify-center px-6 bg-background">
-      <form
-        onSubmit={submit}
-        className="w-full max-w-sm bg-card border border-border rounded-lg p-6 shadow-sm"
-      >
-        <header className="mb-5">
-          <div className="inline-flex items-center justify-center h-10 w-10 rounded-md bg-primary text-primary-foreground mb-3">
-            <UserPlus className="h-5 w-5" />
-          </div>
-          <h1 className="text-lg font-semibold tracking-tight">Sign up for beevibe</h1>
-          <p className="mt-1 text-xs text-muted-foreground leading-relaxed">
-            We&apos;ll mint you a personal team agent. Your key stays in your browser only — you
-            can come back and sign in with the same email later.
-          </p>
-        </header>
+    <AuthCard
+      icon={UserPlus}
+      title="Sign up for beevibe"
+      description={
+        <>
+          We&apos;ll mint you a personal team agent. Your key stays in your browser only — you
+          can come back and sign in with the same email later.
+        </>
+      }
+      onSubmit={submit}
+    >
+      <AuthField
+        id="name"
+        label="Name"
+        type="text"
+        autoComplete="name"
+        autoFocus
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Alice"
+        disabled={submitting}
+      />
 
-        <label className="block text-xs font-medium text-foreground mb-1.5" htmlFor="name">
-          Name
-        </label>
-        <input
-          id="name"
-          type="text"
-          autoComplete="name"
-          autoFocus
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Alice"
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-          disabled={submitting}
-        />
+      <AuthField
+        id="email"
+        label="Email"
+        spaced
+        type="email"
+        autoComplete="email"
+        inputMode="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="alice@example.com"
+        disabled={submitting}
+      />
 
-        <label className="block text-xs font-medium text-foreground mb-1.5 mt-3" htmlFor="email">
-          Email
-        </label>
-        <input
-          id="email"
-          type="email"
-          autoComplete="email"
-          inputMode="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          placeholder="alice@example.com"
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-          disabled={submitting}
-        />
+      <AuthField
+        id="password"
+        label="Password"
+        spaced
+        type="password"
+        autoComplete="new-password"
+        minLength={PASSWORD_MIN_LENGTH}
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder={`at least ${PASSWORD_MIN_LENGTH} characters`}
+        disabled={submitting}
+      />
 
-        <label className="block text-xs font-medium text-foreground mb-1.5 mt-3" htmlFor="password">
-          Password
-        </label>
-        <input
-          id="password"
-          type="password"
-          autoComplete="new-password"
-          minLength={PASSWORD_MIN_LENGTH}
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          placeholder={`at least ${PASSWORD_MIN_LENGTH} characters`}
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-          disabled={submitting}
-        />
+      {error ? <AuthError message={error} /> : null}
 
-        {error ? (
-          <div className="mt-3 flex items-start gap-1.5 text-xs text-status-failed">
-            <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>{error}</span>
-          </div>
-        ) : null}
+      <AuthSubmitButton
+        icon={Sparkles}
+        label="Create my team agent"
+        pending={submitting}
+        pendingLabel="Provisioning…"
+        disabled={
+          submitting ||
+          name.trim().length === 0 ||
+          email.trim().length === 0 ||
+          password.length < PASSWORD_MIN_LENGTH
+        }
+      />
 
-        <button
-          type="submit"
-          disabled={
-            submitting ||
-            name.trim().length === 0 ||
-            email.trim().length === 0 ||
-            password.length < PASSWORD_MIN_LENGTH
-          }
-          className="mt-5 w-full inline-flex items-center justify-center gap-1.5 h-9 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {submitting ? (
-            <>
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              Provisioning…
-            </>
-          ) : (
-            <>
-              <Sparkles className="h-3.5 w-3.5" />
-              Create my team agent
-            </>
-          )}
-        </button>
-
-        <footer className="mt-5 pt-4 border-t border-border/60 text-[11px] text-muted-foreground leading-relaxed">
-          Already have a key?{" "}
-          <Link href="/sign-in" className="text-foreground/80 hover:underline">
-            Sign in
-          </Link>{" "}
-          instead.
-        </footer>
-      </form>
-    </main>
+      <AuthCardFooter>
+        Already have a key?{" "}
+        <Link href="/sign-in" className="text-foreground/80 hover:underline">
+          Sign in
+        </Link>{" "}
+        instead.
+      </AuthCardFooter>
+    </AuthCard>
   );
 }

--- a/packages/web/components/auth/auth-form.test.tsx
+++ b/packages/web/components/auth/auth-form.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { KeyRound, LogIn } from "lucide-react";
+import {
+  AUTH_INPUT_CLASS,
+  AuthCard,
+  AuthError,
+  AuthField,
+  AuthSubmitButton,
+} from "./auth-form";
+
+describe("AuthCard", () => {
+  it("renders as a form so Enter submits", () => {
+    const { container } = render(
+      <AuthCard icon={LogIn} title="Sign in" description="blurb" onSubmit={() => {}}>
+        <span>body</span>
+      </AuthCard>,
+    );
+    expect(container.querySelector("form")).not.toBeNull();
+    expect(screen.getByRole("heading", { level: 1 }).textContent).toBe("Sign in");
+    expect(screen.getByText("blurb")).toBeTruthy();
+    expect(screen.getByText("body")).toBeTruthy();
+  });
+});
+
+describe("AuthField", () => {
+  it("ties the label to the input and keeps the shared input class", () => {
+    render(<AuthField id="email" label="Email" type="email" />);
+    const input = screen.getByLabelText("Email");
+    expect(input.getAttribute("id")).toBe("email");
+    expect(input.getAttribute("type")).toBe("email");
+    for (const cls of AUTH_INPUT_CLASS.split(" ")) {
+      expect(input.className).toContain(cls);
+    }
+  });
+
+  it("adds the stacking margin only when `spaced`", () => {
+    const { rerender, container } = render(<AuthField id="a" label="A" />);
+    expect(container.querySelector("label")?.className).not.toContain("mt-3");
+    rerender(<AuthField id="a" label="A" spaced />);
+    expect(container.querySelector("label")?.className).toContain("mt-3");
+  });
+
+  it("appends a caller class rather than replacing the shared one", () => {
+    render(<AuthField id="key" label="Key" className="font-mono" />);
+    const input = screen.getByLabelText("Key");
+    expect(input.className).toContain("font-mono");
+    expect(input.className).toContain("bg-background");
+  });
+});
+
+describe("AuthError", () => {
+  it("shows the message", () => {
+    render(<AuthError message="Email or password is incorrect." />);
+    expect(screen.getByText("Email or password is incorrect.")).toBeTruthy();
+  });
+});
+
+describe("AuthSubmitButton", () => {
+  it("swaps label for the pending label while in flight", () => {
+    const { rerender } = render(
+      <AuthSubmitButton icon={KeyRound} label="Sign in" pending={false} pendingLabel="Signing in…" />,
+    );
+    expect(screen.getByRole("button").textContent).toBe("Sign in");
+    rerender(
+      <AuthSubmitButton icon={KeyRound} label="Sign in" pending pendingLabel="Signing in…" />,
+    );
+    expect(screen.getByRole("button").textContent).toBe("Signing in…");
+  });
+
+  it("honours `disabled` independently of `pending`", () => {
+    render(
+      <AuthSubmitButton
+        icon={KeyRound}
+        label="Sign in"
+        pending={false}
+        pendingLabel="Signing in…"
+        disabled
+      />,
+    );
+    expect((screen.getByRole("button") as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/packages/web/components/auth/auth-form.tsx
+++ b/packages/web/components/auth/auth-form.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import type { FormEvent, InputHTMLAttributes, ReactNode } from "react";
+import { AlertTriangle, Loader2, type LucideIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * The chrome shared by `/sign-in` and `/sign-up`.
+ *
+ * The two pages are the same card — centered on an otherwise empty
+ * screen, an icon badge over a title and blurb, a stack of labelled
+ * inputs, an inline error, a spinner-on-submit button, and a footer
+ * pointing at the other page. They were built as two copies of that
+ * markup, which meant every Tailwind class in it existed twice: the
+ * input ring, the button's disabled states, the error row's icon size.
+ * Nudging the form's look meant finding and editing both, and a miss
+ * showed up as the two auth pages quietly drifting apart.
+ *
+ * What is *not* shared is the behavior: sign-in has two modes (password
+ * and paste-a-key) with their own validation, sign-up has the invite
+ * flow. Those stay in the page clients. This module is markup only —
+ * every piece here is a shape both pages already rendered identically.
+ */
+
+/**
+ * The input class both pages repeat on every field. Exported because
+ * the key field on `/sign-in` renders it plus `font-mono`, which it
+ * passes through `AuthField`'s `className`; nothing else should need
+ * it directly.
+ */
+export const AUTH_INPUT_CLASS =
+  "w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring";
+
+/**
+ * Full-screen centered card, rendered as the form itself so Enter
+ * submits. `icon` sits in the badge above `title`; `description` is the
+ * blurb under it, taken as a node because both pages put inline markup
+ * in theirs (a `<span className="font-mono">bv_u_</span>`, an escaped
+ * apostrophe).
+ */
+export function AuthCard({
+  icon: Icon,
+  title,
+  description,
+  onSubmit,
+  children,
+}: {
+  icon: LucideIcon;
+  title: string;
+  description: ReactNode;
+  onSubmit: (e: FormEvent) => void;
+  children: ReactNode;
+}) {
+  return (
+    <main className="min-h-screen flex items-center justify-center px-6 bg-background">
+      <form
+        onSubmit={onSubmit}
+        className="w-full max-w-sm bg-card border border-border rounded-lg p-6 shadow-sm"
+      >
+        <header className="mb-5">
+          <div className="inline-flex items-center justify-center h-10 w-10 rounded-md bg-primary text-primary-foreground mb-3">
+            <Icon className="h-5 w-5" />
+          </div>
+          <h1 className="text-lg font-semibold tracking-tight">{title}</h1>
+          <p className="mt-1 text-xs text-muted-foreground leading-relaxed">{description}</p>
+        </header>
+        {children}
+      </form>
+    </main>
+  );
+}
+
+/**
+ * A labelled input. Every other prop lands on the `<input>`, so callers
+ * keep their own `type`, `autoComplete`, `minLength`, `autoFocus` and
+ * handlers.
+ *
+ * `spaced` adds the `mt-3` that separates a field from the one above
+ * it. It is a flag rather than something inferred from position because
+ * the fields are written out one by one in the page clients (and on
+ * `/sign-in` which fields exist at all depends on the mode), so there
+ * is no list for a wrapper to walk.
+ */
+export function AuthField({
+  id,
+  label,
+  spaced,
+  className,
+  ...input
+}: {
+  id: string;
+  label: string;
+  /** Add the top margin that separates this field from the one above. */
+  spaced?: boolean;
+} & InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <>
+      <label
+        className={cn("block text-xs font-medium text-foreground mb-1.5", spaced && "mt-3")}
+        htmlFor={id}
+      >
+        {label}
+      </label>
+      <input id={id} {...input} className={cn(AUTH_INPUT_CLASS, className)} />
+    </>
+  );
+}
+
+/** Inline validation / request error, under the fields. */
+export function AuthError({ message }: { message: string }) {
+  return (
+    <div className="mt-3 flex items-start gap-1.5 text-xs text-status-failed">
+      <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+      <span>{message}</span>
+    </div>
+  );
+}
+
+/**
+ * The primary submit button, swapping its icon and label for a spinner
+ * while the request is in flight. `pendingLabel` is separate from
+ * `label` because the two pages say different things there ("Signing
+ * in…" / "Verifying…" / "Provisioning…") and it is the only feedback a
+ * user gets that the click registered.
+ */
+export function AuthSubmitButton({
+  icon: Icon,
+  label,
+  pending,
+  pendingLabel,
+  disabled,
+}: {
+  icon: LucideIcon;
+  label: string;
+  pending: boolean;
+  pendingLabel: string;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="submit"
+      disabled={disabled}
+      className="mt-5 w-full inline-flex items-center justify-center gap-1.5 h-9 rounded text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-opacity cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      {pending ? (
+        <>
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          {pendingLabel}
+        </>
+      ) : (
+        <>
+          <Icon className="h-3.5 w-3.5" />
+          {label}
+        </>
+      )}
+    </button>
+  );
+}
+
+/** Rule-and-fine-print block at the bottom of the card. */
+export function AuthCardFooter({ children }: { children: ReactNode }) {
+  return (
+    <footer className="mt-5 pt-4 border-t border-border/60 text-[11px] text-muted-foreground leading-relaxed">
+      {children}
+    </footer>
+  );
+}

--- a/packages/web/components/sessions/session-detail-chrome.test.tsx
+++ b/packages/web/components/sessions/session-detail-chrome.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SessionDetailFooter, SessionDetailHeader } from "./session-detail-chrome";
+
+const base = {
+  agentLabel: "Ada",
+  agentHierarchy: "team" as const,
+  status: "succeeded" as const,
+  title: "Conversation",
+};
+
+describe("SessionDetailHeader", () => {
+  it("renders the title, the agent, and no separator when there is no meta", () => {
+    const { container } = render(<SessionDetailHeader {...base} />);
+    expect(screen.getByRole("heading", { level: 1 }).textContent).toBe("Conversation");
+    expect(screen.getByText("Ada")).toBeTruthy();
+    expect(container.textContent).not.toContain("·");
+  });
+
+  it("puts a separator before each meta entry", () => {
+    const { container } = render(
+      <SessionDetailHeader
+        {...base}
+        meta={[<span key="a">2 turns</span>, <span key="b">chat</span>]}
+      />,
+    );
+    const dots = [...container.querySelectorAll("span")].filter((s) => s.textContent === "·");
+    expect(dots).toHaveLength(2);
+  });
+
+  it("drops a nullish meta entry along with its separator", () => {
+    const { container } = render(
+      <SessionDetailHeader {...base} meta={[null, <span key="b">chat</span>]} />,
+    );
+    const dots = [...container.querySelectorAll("span")].filter((s) => s.textContent === "·");
+    expect(dots).toHaveLength(1);
+    expect(container.textContent).toContain("chat");
+  });
+
+  it("applies the caller's title class on top of the shared one", () => {
+    const { container } = render(<SessionDetailHeader {...base} titleClassName="truncate" />);
+    const h1 = container.querySelector("h1");
+    expect(h1?.className).toContain("truncate");
+    expect(h1?.className).toContain("font-semibold");
+  });
+});
+
+describe("SessionDetailFooter", () => {
+  it("labels the id field per caller and shows the optional fields", () => {
+    render(
+      <SessionDetailFooter
+        idLabel="Conversation ID"
+        id="conv_1"
+        cliSession="cli-abc"
+        worktree="/tmp/wt"
+        type="chat"
+      />,
+    );
+    expect(screen.getByText("Conversation ID")).toBeTruthy();
+    expect(screen.getByText("cli-abc")).toBeTruthy();
+    expect(screen.getByText("/tmp/wt")).toBeTruthy();
+  });
+
+  it("hides CLI session and worktree when the runtime didn't report them", () => {
+    render(<SessionDetailFooter idLabel="Session ID" id="sess_1" type="task" />);
+    expect(screen.queryByText("CLI session")).toBeNull();
+    expect(screen.queryByText("Worktree")).toBeNull();
+    expect(screen.getByText("Type")).toBeTruthy();
+  });
+});

--- a/packages/web/components/sessions/session-detail-chrome.tsx
+++ b/packages/web/components/sessions/session-detail-chrome.tsx
@@ -1,0 +1,141 @@
+import { Fragment, type ReactNode } from "react";
+import { Avatar } from "@/components/avatar";
+import { ClickToCopyId } from "@/components/detail/click-to-copy-id";
+import { FooterField } from "@/components/detail/footer-field";
+import { SessionStatusPill } from "@/components/detail/status-pill";
+import { HierChip } from "@/components/hier-chip";
+import { Skeleton } from "@/components/skeleton";
+import type { SessionDisplay } from "@/lib/types/sessions";
+import { cn } from "@/lib/utils";
+
+/**
+ * The frame the two session detail pages share.
+ *
+ * `/sessions/[sid]` (a chat conversation, collapsed from its per-turn
+ * sessions) and `/tasks/[id]/sessions/[sid]` (one task-spawned session)
+ * show different bodies but the identical chrome around it: the same
+ * three-bar loading skeleton, the same avatar-and-status header, and
+ * the same four-column id/CLI-session/worktree/type footer. All three
+ * were written out twice, so a change to the header layout — or, worse,
+ * to the conditionals that hide an absent worktree — had to be made in
+ * both files to stick.
+ *
+ * The bodies stay where they are. Only the frame lives here.
+ */
+
+/** Header bar, footer row, then the body area. */
+export function SessionDetailSkeleton() {
+  return (
+    <>
+      <Skeleton className="h-14 w-full mb-6" />
+      <Skeleton className="h-32 w-full mb-5 rounded-lg" />
+      <Skeleton className="h-64 w-full rounded-lg" />
+    </>
+  );
+}
+
+/**
+ * Avatar, title, status pill, and a metadata line.
+ *
+ * `titleClassName` exists because the two pages want different overflow
+ * behavior from the same slot: the chat page's title is one of two fixed
+ * words so it takes `tracking-tight`, while the task page renders the
+ * session's intent and needs `truncate`.
+ *
+ * `meta` is a list rather than a single node so this component owns the
+ * `·` separators between the entries — that is the part the two copies
+ * were most likely to get out of step, since how many entries there are
+ * is itself conditional (the chat page hides its turn count on a
+ * single-turn conversation). Nullish entries are dropped, separator and
+ * all.
+ */
+export function SessionDetailHeader({
+  agentLabel,
+  agentHierarchy,
+  status,
+  title,
+  titleClassName,
+  meta = [],
+}: {
+  agentLabel: string;
+  agentHierarchy: SessionDisplay["agent_hierarchy"];
+  status: SessionDisplay["status"];
+  title: string;
+  titleClassName?: string;
+  meta?: ReactNode[];
+}) {
+  return (
+    <header className="mb-6">
+      <div className="flex items-start gap-3">
+        <Avatar
+          initial={agentLabel.charAt(0).toUpperCase()}
+          kind={agentHierarchy}
+          label={agentLabel}
+          size={40}
+          presence={status === "running" ? "running" : "idle"}
+        />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <h1 className={cn("text-base font-semibold leading-tight", titleClassName)}>
+              {title}
+            </h1>
+            <SessionStatusPill status={status} />
+          </div>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span className="text-foreground/85">{agentLabel}</span>
+            <HierChip hier={agentHierarchy} />
+            {meta.map((entry, i) =>
+              entry == null ? null : (
+                <Fragment key={i}>
+                  <span className="text-muted-foreground/50">·</span>
+                  {entry}
+                </Fragment>
+              ),
+            )}
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+/**
+ * The identifiers strip at the bottom of the page.
+ *
+ * `idLabel` is a parameter because the two pages copy different ids: the
+ * chat page the conversation's, the task page the session's. CLI session
+ * and worktree drop out entirely when the runtime didn't report them,
+ * which is the common case for a chat turn.
+ */
+export function SessionDetailFooter({
+  idLabel,
+  id,
+  cliSession,
+  worktree,
+  type,
+}: {
+  idLabel: string;
+  id: string;
+  cliSession?: string | null;
+  worktree?: string | null;
+  type: string;
+}) {
+  return (
+    <footer className="mt-10 pt-5 border-t border-border/60 grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-3 text-xs text-muted-foreground">
+      <FooterField label={idLabel}>
+        <ClickToCopyId id={id} />
+      </FooterField>
+      {cliSession ? (
+        <FooterField label="CLI session" truncate>
+          <span className="font-mono">{cliSession}</span>
+        </FooterField>
+      ) : null}
+      {worktree ? (
+        <FooterField label="Worktree" truncate>
+          <span className="font-mono">{worktree}</span>
+        </FooterField>
+      ) : null}
+      <FooterField label="Type">{type}</FooterField>
+    </footer>
+  );
+}

--- a/packages/web/components/share-link-box.test.tsx
+++ b/packages/web/components/share-link-box.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ShareLinkBox, signUpInviteLink } from "./share-link-box";
+
+describe("signUpInviteLink", () => {
+  it("carries just the email for a plain teammate invite", () => {
+    expect(signUpInviteLink("alice@example.com")).toBe(
+      `${window.location.origin}/sign-up?email=alice%40example.com`,
+    );
+  });
+
+  it("carries the room first when the invite auto-joins one", () => {
+    expect(signUpInviteLink("alice@example.com", "room_abc")).toBe(
+      `${window.location.origin}/sign-up?room=room_abc&email=alice%40example.com`,
+    );
+  });
+
+  it("escapes the characters an email is allowed to contain", () => {
+    const link = signUpInviteLink("a.b+c@ex-ample.co.uk");
+    expect(link).toContain("email=a.b%2Bc%40ex-ample.co.uk");
+    expect(new URL(link).searchParams.get("email")).toBe("a.b+c@ex-ample.co.uk");
+  });
+});
+
+describe("ShareLinkBox", () => {
+  it("shows the link read-only next to a copy button", () => {
+    render(<ShareLinkBox link="https://beevibe.test/sign-up?email=a%40b.c" description="Send this:" />);
+    const input = screen.getByDisplayValue("https://beevibe.test/sign-up?email=a%40b.c");
+    expect((input as HTMLInputElement).readOnly).toBe(true);
+    expect(screen.getByRole("button").textContent).toBe("Copy");
+    expect(screen.getByText("Send this:")).toBeTruthy();
+  });
+});

--- a/packages/web/components/share-link-box.tsx
+++ b/packages/web/components/share-link-box.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
+
+/**
+ * The copyable-link panel both invite dialogs show once they have a
+ * sign-up URL to hand over — "invite a teammate" in the user widget,
+ * "invite to room" on the room page.
+ *
+ * It was written out twice: the same read-only select-on-focus input
+ * next to the same Copy button, each dialog calling `useCopyToClipboard`
+ * itself. Owning the hook here means the "Copied" flash belongs to the
+ * box that was actually clicked, and a caller that grows a second link
+ * can't accidentally share one flash between them.
+ *
+ * `description` is a node because the two dialogs explain the link
+ * differently — the room one has to say the invitee will land in *this*
+ * room — and that sentence is the only thing telling the user what they
+ * are about to paste into a chat.
+ */
+export function ShareLinkBox({
+  link,
+  description,
+}: {
+  link: string;
+  description: ReactNode;
+}) {
+  const { copied, copy } = useCopyToClipboard();
+  return (
+    <div className="mt-3 rounded border border-border bg-muted/40 p-3">
+      <div className="text-[11px] text-muted-foreground mb-1.5">{description}</div>
+      <div className="flex items-center gap-1.5">
+        <input
+          readOnly
+          value={link}
+          className="flex-1 rounded border border-border bg-background px-2 py-1.5 text-[11px] font-mono"
+          onFocus={(e) => e.currentTarget.select()}
+        />
+        <button
+          type="button"
+          onClick={() => void copy(link)}
+          className="h-7 px-2.5 rounded text-[11px] font-medium border border-border hover:bg-secondary transition-colors cursor-pointer shrink-0"
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The sign-up URL an invite hands out.
+ *
+ * Both dialogs built this by hand off `window.location.origin`, and
+ * they had to agree on the query parameter names because `/sign-up`
+ * reads them: `email` pre-fills the field, `room` makes the new visitor
+ * auto-join that room and land there instead of `/welcome`. Three call
+ * sites for two names is enough for a typo to go unnoticed until an
+ * invite silently drops someone on the wrong page.
+ *
+ * Returns "" during pre-render, where there is no origin to build on —
+ * the dialogs are client-only, so this only shows up in tests.
+ */
+export function signUpInviteLink(email: string, roomId?: string): string {
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  const params = new URLSearchParams();
+  if (roomId) params.set("room", roomId);
+  params.set("email", email);
+  return `${origin}/sign-up?${params.toString()}`;
+}

--- a/packages/web/components/user-widget.tsx
+++ b/packages/web/components/user-widget.tsx
@@ -14,8 +14,8 @@ import {
 } from "lucide-react";
 import { useMe } from "@/lib/hooks/use-me";
 import { useDismissOnOutside } from "@/lib/hooks/use-dismiss";
-import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
 import { ModalOverlay } from "@/components/modal-overlay";
+import { ShareLinkBox, signUpInviteLink } from "@/components/share-link-box";
 import { clearUserKey } from "@/lib/api/config";
 import { cn } from "@/lib/utils";
 import { Avatar } from "@/components/avatar";
@@ -148,13 +148,9 @@ function MenuItem({
 
 function InviteTeammateDialog({ onClose }: { onClose: () => void }) {
   const [email, setEmail] = useState("");
-  const { copied, copy } = useCopyToClipboard();
   const trimmed = email.trim().toLowerCase();
   const valid = EMAIL_RE.test(trimmed);
-  const origin = typeof window !== "undefined" ? window.location.origin : "";
-  const shareLink = valid
-    ? `${origin}/sign-up?email=${encodeURIComponent(trimmed)}`
-    : "";
+  const shareLink = valid ? signUpInviteLink(trimmed) : "";
 
   return (
     <ModalOverlay onClose={onClose}>
@@ -173,26 +169,7 @@ function InviteTeammateDialog({ onClose }: { onClose: () => void }) {
           className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
         />
         {shareLink ? (
-          <div className="mt-3 rounded border border-border bg-muted/40 p-3">
-            <div className="text-[11px] text-muted-foreground mb-1.5">
-              Send them this link:
-            </div>
-            <div className="flex items-center gap-1.5">
-              <input
-                readOnly
-                value={shareLink}
-                className="flex-1 rounded border border-border bg-background px-2 py-1.5 text-[11px] font-mono"
-                onFocus={(e) => e.currentTarget.select()}
-              />
-              <button
-                type="button"
-                onClick={() => void copy(shareLink)}
-                className="h-7 px-2.5 rounded text-[11px] font-medium border border-border hover:bg-secondary transition-colors cursor-pointer shrink-0"
-              >
-                {copied ? "Copied" : "Copy"}
-              </button>
-            </div>
-          </div>
+          <ShareLinkBox link={shareLink} description="Send them this link:" />
         ) : null}
         <div className="mt-4 flex items-center justify-end gap-2">
           <button

--- a/packages/web/lib/api/config.ts
+++ b/packages/web/lib/api/config.ts
@@ -65,6 +65,15 @@ export function subscribeToUserKey(cb: Listener): () => void {
 
 export const isApiConfigured: boolean = apiBaseUrl !== null;
 
+/**
+ * What the auth forms show when `isApiConfigured` is false — a
+ * misconfigured deploy, not anything the visitor did wrong. Lives next
+ * to the flag it explains so the three guards that check it (both
+ * `/sign-in` submit paths and `/sign-up`) can't drift on the wording.
+ */
+export const API_NOT_CONFIGURED_MESSAGE =
+  "Web isn't configured to talk to an api server.";
+
 /** Format check only — server-side `lookupApiKey` does the real validation. */
 export function isWellFormedUserKey(key: string): boolean {
   return /^bv_u_[A-Za-z0-9]{16,}$/.test(key.trim());


### PR DESCRIPTION
Swept the monorepo for near-duplicate abstractions and unified the four clusters worth unifying. One commit per cluster; each is behavior-preserving, and the two that touch rendered markup were verified by diffing the emitted HTML before and after.

## What the sweep found

The **backend is already swept.** `runtime-common.ts` (the three CLI runtimes), `pg-helpers.ts` (the repositories), `routes/http-errors.ts` and `tools/types.ts` are all prior unifications, and a token-level clone detector over `packages/**` finds **zero** exact clones in `.ts` — the `rowTo*` mappers and the per-provider `stream-json.ts` parsers that look alike are genuinely per-entity and per-schema.

Everything left is in `packages/web`, which has no shared form or chrome layer, plus one uniform shape in the api.

## The four clusters

### 1. `packages/api` — the coded-500 catch block (17 sites, 5 files)

`runtime/router`, `repo-runs`, `learned-skills`, `capabilities` and `find-repo` each spelled out `console.error("[<tag>]", err)` then `res.status(500).json({ error: "<operation>_failed" })`.

`routes/http-errors.ts` already owned the *other* 500 shape (`makeErrorHandler`, which reflects `err.message` back under `internal_error`). `codedFailure` joins it for the code-only shape.

Deliberately **not** merged with `makeErrorHandler`: these endpoints keep the message server-side and hand clients a per-operation code the daemon branches on, so unifying the envelopes would be a wire-contract change. Only the log-then-respond shape is shared — every response and log line is byte-identical.

### 2. `packages/web` — `/sign-in` and `/sign-up` are the same card

Two copies of the same markup meant every Tailwind class in it existed twice: the input's focus ring (verbatim on all five fields across the two files), the button's disabled states, the error row's icon sizing. Nudging the form's look meant editing both, and a miss showed up as the two auth pages drifting apart.

New `components/auth/auth-form.tsx` — `AuthCard`, `AuthField`, `AuthError`, `AuthSubmitButton`, `AuthCardFooter` — plus the "web isn't configured" copy moving next to the `isApiConfigured` flag it explains. Markup only; sign-in's two modes and sign-up's invite flow stay in the page clients.

### 3. `packages/web` — the two session detail pages share a frame

`/sessions/[sid]` and `/tasks/[id]/sessions/[sid]` render different bodies inside identical chrome: same loading skeleton, same avatar/title/status header, same four-column id / CLI-session / worktree / type footer, all written out twice.

The footer is the part worth having once — both copies hide CLI session and worktree when the runtime didn't report them (the common case for a chat turn), so that's two conditionals in two files that had to agree.

New `components/sessions/session-detail-chrome.tsx`. The knobs are where the pages genuinely differ: the title's overflow behavior, the footer's id label, and the metadata entries — passed as a list so the component owns the `·` separators, including dropping one along with an entry a page hides.

### 4. `packages/web` — the two invite dialogs' share-link box

Both invite flows end at the same read-only select-on-focus input next to a Copy button, written out twice, each calling `useCopyToClipboard` itself. The sign-up URL was hand-built in both places too, off `window.location.origin` with the query names `/sign-up` reads (`email` pre-fills, `room` auto-joins) — two hand-rolled copies of a contract with a third file.

New `components/share-link-box.tsx` with `ShareLinkBox` and `signUpInviteLink`. `ModalOverlay` already unified these two dialogs' shell; this is the same seam one layer in.

## Verification

- `pnpm typecheck` and `pnpm lint` clean across all 9 tasks (the two `import/no-duplicates` warnings are pre-existing, in an untouched file).
- `packages/web`: 220 tests pass, including 17 new ones covering the extracted components.
- `packages/api`: 820 tests pass; 9 failing files are the documented Postgres-gated suites.
- `packages/core`: untouched; its 7 failures are the documented `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` suites.
- Clusters 2 and 3 additionally verified by rendering the affected pages before and after and diffing the emitted HTML. Cluster 2 is byte-identical. Cluster 3 is identical apart from the order of two class tokens on one `<h1>`, which Tailwind does not read.

## Considered and left alone

`components/cli-mcp-instructions.tsx` and `components/daemon-install.tsx` are the same shape — `SegmentedTabs` over a bundle of `CommandBlock` steps — but they diverge on enough axes (an epilogue, conditional step numbering, default-channel detection) that a shared component would need three knobs to save ~19 lines. Reported rather than done; happy to take it if you'd rather have it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHKhgXynBsoLcQieJULXaK

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHKhgXynBsoLcQieJULXaK)_