### PR TITLE
test(api): cover five under-tested modules (27–65% → 100% lines)

### DIFF
--- a/packages/api/src/routes/chat.test.ts
+++ b/packages/api/src/routes/chat.test.ts
@@ -1,0 +1,840 @@
+/**
+ * `createChatRouter` — unit tests with vitest fakes (no DB).
+ *
+ * `chat-internals.test.ts` already covers the exported pure helpers
+ * (`groupIntoConversations`, `chainToMessages`, `failureMessageFor`).
+ * This file covers the four handlers those helpers feed, which is where
+ * the route's real risk lives: the idempotent-replay ladder (403/409/
+ * 200-replayed) that stops a double-submit from paying for a second CLI
+ * turn, the rate limiter and offline-daemon short-circuits, and the
+ * error mapping that turns a resolver timeout into a 504 rather than a
+ * 500.
+ */
+import express, { json } from "express";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  PersonRepository,
+  RuntimeRepository,
+  Session,
+  SessionRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import type { ChatResolver } from "../runtime/chat-resolver.js";
+import type { DaemonHub } from "../runtime/hub.js";
+import { ChatRateLimiter } from "./chat-rate-limit.js";
+import { createChatRouter, type ChatRoutesDeps } from "./chat.js";
+
+const PERSON = "person_1";
+const AGENT = "agent_a";
+
+function fakeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: AGENT,
+    name: "Ada's team",
+    owner_id: PERSON,
+    hierarchy_level: "team",
+    runtime_config: { type: "claude" },
+    created_at: new Date("2026-04-01"),
+    updated_at: new Date("2026-04-01"),
+    ...overrides,
+  } as Agent;
+}
+
+function fakeSession(overrides: Partial<Session> & Pick<Session, "id">): Session {
+  return {
+    agent_id: AGENT,
+    type: "chat",
+    status: "succeeded",
+    intent: "hello",
+    created_at: new Date("2026-04-01T10:00:00Z"),
+    updated_at: new Date("2026-04-01T10:00:00Z"),
+    ...overrides,
+  } as Session;
+}
+
+function makeAgentRepo(agent: Agent = fakeAgent()): AgentRepository {
+  return {
+    findById: vi.fn(async () => agent),
+    findTopLevelForOwner: vi.fn(async () => agent),
+  } as unknown as AgentRepository;
+}
+
+/** The un-provisioned caller: every handler branches on this. */
+function makeNoAgentRepo(): AgentRepository {
+  return {
+    findById: vi.fn(async () => undefined),
+    findTopLevelForOwner: vi.fn(async () => undefined),
+  } as unknown as AgentRepository;
+}
+
+function makePersonRepo(onboardedAt?: Date): PersonRepository {
+  return {
+    findById: vi.fn(async (id: string) => ({
+      id,
+      name: "Ada",
+      email: "ada@example.com",
+      ...(onboardedAt ? { onboarding_completed_at: onboardedAt } : {}),
+    })),
+    update: vi.fn(async () => undefined),
+  } as unknown as PersonRepository;
+}
+
+function makeSessionRepo(chats: Session[] = []): SessionRepository {
+  return {
+    findById: vi.fn(async () => undefined),
+    listChatForAgent: vi.fn(async () => chats),
+    softDeleteChatChain: vi.fn(async () => chats.length),
+  } as unknown as SessionRepository;
+}
+
+function makeRuntimeRepo(cli?: string): RuntimeRepository {
+  return {
+    findById: vi.fn(async () => (cli ? { id: "rt_1", cli } : undefined)),
+  } as unknown as RuntimeRepository;
+}
+
+function makeDispatchService(result?: unknown): DispatchService {
+  return {
+    dispatchTask: vi.fn(async () => result),
+  } as unknown as DispatchService;
+}
+
+function makeResolver(impl?: () => Promise<Session>): ChatResolver {
+  return {
+    register: vi.fn(impl ?? (async () => fakeSession({ id: "sess_new" }))),
+  } as unknown as ChatResolver;
+}
+
+function makeHub(online = true): DaemonHub {
+  return { isOnline: vi.fn(() => online) } as unknown as DaemonHub;
+}
+
+/**
+ * Stand-in for `createAuthMiddleware`. The real one resolves a bv_ token
+ * against Postgres; these handlers only gate on `requireHuman`, so the
+ * caller source is set per-app.
+ */
+function stubAuth(source: "human" | "agent") {
+  return (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    req.caller =
+      source === "human"
+        ? { source: "human", agentId: AGENT, hierarchyLevel: "team", personId: PERSON }
+        : { source: "agent", agentId: AGENT, hierarchyLevel: "ic" };
+    next();
+  };
+}
+
+function makeApp(overrides: Partial<ChatRoutesDeps> = {}, source: "human" | "agent" = "human") {
+  const deps: ChatRoutesDeps = {
+    authMiddleware: stubAuth(source),
+    agentRepo: makeAgentRepo(),
+    personRepo: makePersonRepo(),
+    runtimeRepo: makeRuntimeRepo(),
+    sessionRepo: makeSessionRepo(),
+    dispatchService: makeDispatchService({
+      session: fakeSession({ id: "sess_new", status: "pending" }),
+      runtime_id: null,
+    }),
+    chatResolver: makeResolver(),
+    hub: makeHub(),
+    ...overrides,
+  };
+  const app = express();
+  app.use(json());
+  app.use("/", createChatRouter(deps));
+  return { app, deps };
+}
+
+// `handleError` logs the stack behind a request_id; the expected-error
+// tests below would otherwise spray it across the run output.
+let errorSpy: ReturnType<typeof vi.spyOn>;
+beforeEach(() => {
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+afterEach(() => {
+  errorSpy.mockRestore();
+  vi.useRealTimers();
+});
+
+// ── auth gate ────────────────────────────────────────────────────────────
+
+describe("human-only gate", () => {
+  it.each([
+    ["get", "/conversations"],
+    ["get", "/"],
+    ["post", "/"],
+    ["delete", "/conversations/sess_head"],
+  ] as const)("rejects an agent caller on %s %s", async (method, path) => {
+    const { app } = makeApp({}, "agent");
+    const res = await request(app)[method](path).send({ message: "hi" });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("human_required");
+  });
+});
+
+// ── GET /conversations ───────────────────────────────────────────────────
+
+describe("GET /conversations", () => {
+  it("returns an empty list when the caller has no primary agent", async () => {
+    const { app, deps } = makeApp({ agentRepo: makeNoAgentRepo() });
+    const res = await request(app).get("/conversations");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, conversations: [] });
+    // No agent means no reason to touch the session table at all.
+    expect(deps.sessionRepo.listChatForAgent).not.toHaveBeenCalled();
+  });
+
+  it("summarizes each chain with title, turn count and last activity", async () => {
+    const head = fakeSession({
+      id: "sess_head",
+      intent: "how do I deploy?",
+      result_summary: "run pnpm deploy",
+      created_at: new Date("2026-04-01T10:00:00Z"),
+    });
+    const tail = fakeSession({
+      id: "sess_tail",
+      prior_session_id: "sess_head",
+      intent: "and roll back?",
+      result_summary: "run pnpm rollback",
+      created_at: new Date("2026-04-01T10:05:00Z"),
+    });
+    const { app } = makeApp({ sessionRepo: makeSessionRepo([head, tail]) });
+    const res = await request(app).get("/conversations");
+
+    expect(res.status).toBe(200);
+    expect(res.body.conversations).toEqual([
+      {
+        head_id: "sess_head",
+        title: "how do I deploy?",
+        turn_count: 2,
+        last_at: "2026-04-01T10:05:00.000Z",
+        last_preview: "run pnpm rollback",
+      },
+    ]);
+  });
+
+  it("truncates a long title at CHAT_THREAD_TITLE_MAX", async () => {
+    const long = "x".repeat(200);
+    const { app } = makeApp({
+      sessionRepo: makeSessionRepo([fakeSession({ id: "sess_head", intent: long })]),
+    });
+    const res = await request(app).get("/conversations");
+
+    expect(res.body.conversations[0].title).toBe("x".repeat(79) + "…");
+  });
+
+  it("previews the error, then the intent, when there is no result_summary", async () => {
+    const failed = fakeSession({
+      id: "sess_a",
+      status: "failed",
+      intent: "deploy",
+      error: "boom",
+      created_at: new Date("2026-04-01T11:00:00Z"),
+    });
+    const pending = fakeSession({
+      id: "sess_b",
+      status: "pending",
+      intent: "still\n  thinking",
+      created_at: new Date("2026-04-01T10:00:00Z"),
+    });
+    const { app } = makeApp({ sessionRepo: makeSessionRepo([failed, pending]) });
+    const res = await request(app).get("/conversations");
+
+    const previews = Object.fromEntries(
+      res.body.conversations.map((c: { head_id: string; last_preview: string }) => [
+        c.head_id,
+        c.last_preview,
+      ]),
+    );
+    expect(previews.sess_a).toBe("boom");
+    // Whitespace is collapsed so a multi-line intent stays one line.
+    expect(previews.sess_b).toBe("still thinking");
+  });
+
+  it("truncates a preview past 140 chars with an ellipsis", async () => {
+    const { app } = makeApp({
+      sessionRepo: makeSessionRepo([
+        fakeSession({ id: "sess_a", result_summary: "y".repeat(300) }),
+      ]),
+    });
+    const res = await request(app).get("/conversations");
+
+    const preview: string = res.body.conversations[0].last_preview;
+    expect(preview).toHaveLength(140);
+    expect(preview.endsWith("…")).toBe(true);
+  });
+
+  it("caps the list at 50 conversations, newest first", async () => {
+    // 60 unrelated single-turn chains, oldest first on the way in.
+    const sessions = Array.from({ length: 60 }, (_, i) =>
+      fakeSession({
+        id: `sess_${i}`,
+        intent: `turn ${i}`,
+        created_at: new Date(Date.UTC(2026, 3, 1, 0, i)),
+      }),
+    );
+    const { app } = makeApp({ sessionRepo: makeSessionRepo(sessions) });
+    const res = await request(app).get("/conversations");
+
+    expect(res.body.conversations).toHaveLength(50);
+    expect(res.body.conversations[0].head_id).toBe("sess_59");
+  });
+});
+
+// ── DELETE /conversations/:headId ────────────────────────────────────────
+
+describe("DELETE /conversations/:headId", () => {
+  it("soft-deletes the chain scoped to the caller's agent", async () => {
+    const sessionRepo = makeSessionRepo();
+    vi.mocked(sessionRepo.softDeleteChatChain).mockResolvedValue(3);
+    const { app } = makeApp({ sessionRepo });
+    const res = await request(app).delete("/conversations/sess_head");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, deleted: 3 });
+    expect(sessionRepo.softDeleteChatChain).toHaveBeenCalledWith("sess_head", AGENT);
+  });
+
+  it("is idempotent — a chain already deleted returns 200 with deleted: 0", async () => {
+    const sessionRepo = makeSessionRepo();
+    vi.mocked(sessionRepo.softDeleteChatChain).mockResolvedValue(0);
+    const { app } = makeApp({ sessionRepo });
+    const res = await request(app).delete("/conversations/sess_head");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, deleted: 0 });
+  });
+
+  it("404s when the caller has no primary agent", async () => {
+    const sessionRepo = makeSessionRepo();
+    const { app } = makeApp({ agentRepo: makeNoAgentRepo(), sessionRepo });
+    const res = await request(app).delete("/conversations/sess_head");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("agent_not_found");
+    expect(sessionRepo.softDeleteChatChain).not.toHaveBeenCalled();
+  });
+
+  it("maps a repo failure to a 500 carrying a request_id", async () => {
+    const sessionRepo = makeSessionRepo();
+    vi.mocked(sessionRepo.softDeleteChatChain).mockRejectedValue(new Error("pg down"));
+    const { app } = makeApp({ sessionRepo });
+    const res = await request(app).delete("/conversations/sess_head");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("internal_error");
+    expect(res.body.request_id).toMatch(/^req_/);
+    // The internal detail stays in the log, not the response body.
+    expect(JSON.stringify(res.body)).not.toContain("pg down");
+  });
+});
+
+// ── GET / ────────────────────────────────────────────────────────────────
+
+describe("GET /", () => {
+  it("returns a null agent and empty history when none is provisioned", async () => {
+    const { app } = makeApp({ agentRepo: makeNoAgentRepo() });
+    const res = await request(app).get("/");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      agent: null,
+      messages: [],
+      prior_session_id: null,
+      conversation_id: null,
+    });
+  });
+
+  it("returns the most recent chain when no conversation is requested", async () => {
+    const older = fakeSession({
+      id: "sess_old",
+      intent: "old question",
+      result_summary: "old answer",
+      created_at: new Date("2026-04-01T09:00:00Z"),
+    });
+    const newer = fakeSession({
+      id: "sess_new",
+      intent: "new question",
+      result_summary: "new answer",
+      created_at: new Date("2026-04-01T10:00:00Z"),
+    });
+    const { app } = makeApp({ sessionRepo: makeSessionRepo([older, newer]) });
+    const res = await request(app).get("/");
+
+    expect(res.status).toBe(200);
+    expect(res.body.conversation_id).toBe("sess_new");
+    expect(res.body.prior_session_id).toBe("sess_new");
+    expect(res.body.agent).toEqual({ id: AGENT, name: "Ada's team", hierarchy: "team" });
+    expect(res.body.messages).toEqual([
+      { id: "u_sess_new", role: "user", content: "new question" },
+      { id: "a_sess_new", role: "agent", content: "new answer", session_id: "sess_new" },
+    ]);
+  });
+
+  it("renders a failed turn in history with the friendlier message", async () => {
+    // The bare "CLI exited with code 1" tells the user nothing, so the
+    // stderr tail on `error` wins over it.
+    const { app } = makeApp({
+      sessionRepo: makeSessionRepo([
+        fakeSession({
+          id: "sess_a",
+          intent: "deploy it",
+          status: "failed",
+          result_summary: "CLI exited with code 1",
+          error: "claude: command not found",
+        }),
+      ]),
+    });
+    const res = await request(app).get("/");
+
+    expect(res.body.messages).toEqual([
+      { id: "u_sess_a", role: "user", content: "deploy it" },
+      {
+        id: "a_sess_a",
+        role: "agent",
+        content: "claude: command not found",
+        session_id: "sess_a",
+      },
+    ]);
+  });
+
+  it("selects the chain named by ?c=", async () => {
+    const a = fakeSession({
+      id: "sess_a",
+      intent: "first thread",
+      created_at: new Date("2026-04-01T09:00:00Z"),
+    });
+    const b = fakeSession({
+      id: "sess_b",
+      intent: "second thread",
+      created_at: new Date("2026-04-01T10:00:00Z"),
+    });
+    const { app } = makeApp({ sessionRepo: makeSessionRepo([a, b]) });
+    const res = await request(app).get("/").query({ c: "sess_a" });
+
+    expect(res.body.conversation_id).toBe("sess_a");
+    expect(res.body.messages[0].content).toBe("first thread");
+  });
+
+  it("returns an empty history (not a 404) for an unknown ?c=", async () => {
+    const { app } = makeApp({
+      sessionRepo: makeSessionRepo([fakeSession({ id: "sess_a" })]),
+    });
+    const res = await request(app).get("/").query({ c: "sess_missing" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      agent: { id: AGENT, name: "Ada's team", hierarchy: "team" },
+      messages: [],
+      prior_session_id: null,
+      conversation_id: null,
+    });
+  });
+
+  it("keeps only the newest 25 sessions of a long chain", async () => {
+    // HISTORY_LIMIT is 50 messages; each session is up to 2 messages.
+    const chain = Array.from({ length: 40 }, (_, i) =>
+      fakeSession({
+        id: `sess_${i}`,
+        ...(i > 0 ? { prior_session_id: `sess_${i - 1}` } : {}),
+        intent: `turn ${i}`,
+        created_at: new Date(Date.UTC(2026, 3, 1, 0, i)),
+      }),
+    );
+    const { app } = makeApp({ sessionRepo: makeSessionRepo(chain) });
+    const res = await request(app).get("/");
+
+    // 25 sessions × 1 message each (no result_summary on these).
+    expect(res.body.messages).toHaveLength(25);
+    expect(res.body.messages[0].content).toBe("turn 15");
+    // The chain id still points at the true head, not the truncation point.
+    expect(res.body.conversation_id).toBe("sess_0");
+  });
+
+  it.each(["pending", "running"])("surfaces a %s tail as in_flight_session_id", async (status) => {
+    const { app } = makeApp({
+      sessionRepo: makeSessionRepo([fakeSession({ id: "sess_a", status: status as never })]),
+    });
+    const res = await request(app).get("/");
+
+    expect(res.body.in_flight_session_id).toBe("sess_a");
+  });
+
+  it("omits in_flight_session_id once the tail is terminal", async () => {
+    const { app } = makeApp({
+      sessionRepo: makeSessionRepo([fakeSession({ id: "sess_a", status: "succeeded" })]),
+    });
+    const res = await request(app).get("/");
+
+    expect(res.body.in_flight_session_id).toBeUndefined();
+  });
+
+  it("flags a chain pinned to a CLI the agent no longer uses", async () => {
+    const { app } = makeApp({
+      sessionRepo: makeSessionRepo([fakeSession({ id: "sess_a", runtime_id: "rt_1" })]),
+      runtimeRepo: makeRuntimeRepo("codex"),
+    });
+    const res = await request(app).get("/");
+
+    expect(res.body.runtime_mismatch).toEqual({ pinned_cli: "codex", current_cli: "claude" });
+  });
+
+  it.each([
+    ["the pinned CLI matches the agent's", "claude"],
+    ["the runtime row is gone", undefined],
+    ["the pinned cli is unrecognized", "some-fork"],
+  ])("omits runtime_mismatch when %s", async (_label, cli) => {
+    const { app } = makeApp({
+      sessionRepo: makeSessionRepo([fakeSession({ id: "sess_a", runtime_id: "rt_1" })]),
+      runtimeRepo: makeRuntimeRepo(cli),
+    });
+    const res = await request(app).get("/");
+
+    expect(res.body.runtime_mismatch).toBeUndefined();
+  });
+
+  it("skips the runtime lookup entirely when the tail has no runtime_id", async () => {
+    const runtimeRepo = makeRuntimeRepo("codex");
+    const { app } = makeApp({
+      sessionRepo: makeSessionRepo([fakeSession({ id: "sess_a" })]),
+      runtimeRepo,
+    });
+    const res = await request(app).get("/");
+
+    expect(res.body.runtime_mismatch).toBeUndefined();
+    expect(runtimeRepo.findById).not.toHaveBeenCalled();
+  });
+});
+
+// ── POST / ───────────────────────────────────────────────────────────────
+
+describe("POST /", () => {
+  it.each([
+    ["an absent body field", {}],
+    ["a blank string", { message: "   " }],
+    ["a non-string", { message: 42 }],
+  ])("400s on %s", async (_label, body) => {
+    const { app, deps } = makeApp();
+    const res = await request(app).post("/").send(body);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("message_required");
+    expect(deps.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("404s when the caller has no primary agent", async () => {
+    const { app, deps } = makeApp({ agentRepo: makeNoAgentRepo() });
+    const res = await request(app).post("/").send({ message: "hi" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("no_primary_agent");
+    expect(deps.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("dispatches a fresh turn and returns the resolved response", async () => {
+    const { app, deps } = makeApp({
+      chatResolver: makeResolver(async () =>
+        fakeSession({ id: "sess_new", status: "succeeded", result_summary: "done!" }),
+      ),
+    });
+    const res = await request(app).post("/").send({ message: "  hi  " });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      agent: { id: AGENT, name: "Ada's team", hierarchy: "team" },
+      session_id: "sess_new",
+      response: "done!",
+      status: "succeeded",
+      view_refs: [],
+    });
+    expect(res.body.replayed).toBeUndefined();
+    // The message is trimmed before dispatch, and a first turn is "fresh".
+    expect(deps.dispatchService.dispatchTask).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: AGENT, intent: "hi", type: "chat", reason: { kind: "fresh" } }),
+    );
+  });
+
+  it("passes prior_session_id through as a chat_continuation resume", async () => {
+    const { app, deps } = makeApp();
+    await request(app).post("/").send({ message: "and then?", prior_session_id: "sess_prev" });
+
+    expect(deps.dispatchService.dispatchTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: { kind: "chat_continuation", prior_session_id: "sess_prev" },
+      }),
+    );
+  });
+
+  it("forwards a well-formed client session id as the override", async () => {
+    const sessionRepo = makeSessionRepo();
+    const { app, deps } = makeApp({ sessionRepo });
+    await request(app).post("/").send({ message: "hi", session_id: "sess_abcdef123456" });
+
+    expect(sessionRepo.findById).toHaveBeenCalledWith("sess_abcdef123456");
+    expect(deps.dispatchService.dispatchTask).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionIdOverride: "sess_abcdef123456" }),
+    );
+  });
+
+  it("ignores a malformed client session id rather than replaying on it", async () => {
+    const sessionRepo = makeSessionRepo();
+    const { app, deps } = makeApp({ sessionRepo });
+    await request(app).post("/").send({ message: "hi", session_id: "not-a-session-id" });
+
+    expect(sessionRepo.findById).not.toHaveBeenCalled();
+    expect(deps.dispatchService.dispatchTask).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionIdOverride: undefined }),
+    );
+  });
+
+  describe("idempotent replay", () => {
+    const RETRY_ID = "sess_abcdef123456";
+
+    function appWithExisting(existing: Session | undefined) {
+      const sessionRepo = makeSessionRepo();
+      vi.mocked(sessionRepo.findById).mockResolvedValue(existing);
+      return makeApp({ sessionRepo });
+    }
+
+    it("replays a finished turn without paying for a second dispatch", async () => {
+      const { app, deps } = appWithExisting(
+        fakeSession({ id: RETRY_ID, status: "succeeded", result_summary: "cached answer" }),
+      );
+      const res = await request(app).post("/").send({ message: "hi", session_id: RETRY_ID });
+
+      expect(res.status).toBe(200);
+      expect(res.body.replayed).toBe(true);
+      expect(res.body.response).toBe("cached answer");
+      expect(res.body.session_id).toBe(RETRY_ID);
+      expect(deps.dispatchService.dispatchTask).not.toHaveBeenCalled();
+    });
+
+    it("replays a failed turn with the friendlier failure message", async () => {
+      const { app } = appWithExisting(
+        fakeSession({ id: RETRY_ID, status: "failed", error: "disk full" }),
+      );
+      const res = await request(app).post("/").send({ message: "hi", session_id: RETRY_ID });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ replayed: true, status: "failed", response: "disk full" });
+    });
+
+    it("409s while the prior turn is still running", async () => {
+      const { app, deps } = appWithExisting(fakeSession({ id: RETRY_ID, status: "running" }));
+      const res = await request(app).post("/").send({ message: "hi", session_id: RETRY_ID });
+
+      expect(res.status).toBe(409);
+      expect(res.body.error).toBe("session_in_flight");
+      expect(deps.dispatchService.dispatchTask).not.toHaveBeenCalled();
+    });
+
+    it("403s when the id collides with another caller's session", async () => {
+      const { app, deps } = appWithExisting(
+        fakeSession({ id: RETRY_ID, agent_id: "agent_other", status: "succeeded" }),
+      );
+      const res = await request(app).post("/").send({ message: "hi", session_id: RETRY_ID });
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe("session_belongs_to_other_caller");
+      expect(deps.dispatchService.dispatchTask).not.toHaveBeenCalled();
+    });
+
+    it("falls through to a real dispatch for a non-chat session id", async () => {
+      const { app, deps } = appWithExisting(
+        fakeSession({ id: RETRY_ID, type: "task", status: "succeeded" }),
+      );
+      const res = await request(app).post("/").send({ message: "hi", session_id: RETRY_ID });
+
+      expect(res.status).toBe(200);
+      expect(res.body.replayed).toBeUndefined();
+      expect(deps.dispatchService.dispatchTask).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls through to a real dispatch for a pending row (nothing to replay)", async () => {
+      const { app, deps } = appWithExisting(fakeSession({ id: RETRY_ID, status: "pending" }));
+      const res = await request(app).post("/").send({ message: "hi", session_id: RETRY_ID });
+
+      expect(res.status).toBe(200);
+      expect(deps.dispatchService.dispatchTask).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("rate limiting", () => {
+    it("429s a concurrent second turn from the same person", async () => {
+      const rateLimiter = new ChatRateLimiter({ maxConcurrent: 1 });
+      // Hold the only slot so the request below is the second in flight.
+      const held = rateLimiter.acquire(PERSON);
+      expect(held.ok).toBe(true);
+
+      const { app, deps } = makeApp({ rateLimiter });
+      const res = await request(app).post("/").send({ message: "hi" });
+
+      expect(res.status).toBe(429);
+      expect(res.body.error).toBe("turn_in_flight");
+      expect(res.headers["retry-after"]).toBeDefined();
+      expect(deps.dispatchService.dispatchTask).not.toHaveBeenCalled();
+    });
+
+    it("429s once the sliding window is full", async () => {
+      const rateLimiter = new ChatRateLimiter({ maxConcurrent: 5, maxPerWindow: 1 });
+      const first = rateLimiter.acquire(PERSON);
+      if (first.ok) first.release();
+
+      const { app } = makeApp({ rateLimiter });
+      const res = await request(app).post("/").send({ message: "hi" });
+
+      expect(res.status).toBe(429);
+      expect(res.body.error).toBe("rate_limited");
+      expect(res.body.retry_after_ms).toBeGreaterThan(0);
+    });
+
+    it("releases the slot after a turn finishes so the next one is admitted", async () => {
+      const rateLimiter = new ChatRateLimiter({ maxConcurrent: 1 });
+      const { app } = makeApp({ rateLimiter });
+
+      expect((await request(app).post("/").send({ message: "one" })).status).toBe(200);
+      expect((await request(app).post("/").send({ message: "two" })).status).toBe(200);
+    });
+
+    it("releases the slot when dispatch throws", async () => {
+      const rateLimiter = new ChatRateLimiter({ maxConcurrent: 1 });
+      const dispatchService = makeDispatchService({
+        session: fakeSession({ id: "sess_new", status: "pending" }),
+        runtime_id: null,
+      });
+      vi.mocked(dispatchService.dispatchTask).mockRejectedValueOnce(new Error("no agent"));
+      const { app } = makeApp({ rateLimiter, dispatchService });
+
+      expect((await request(app).post("/").send({ message: "one" })).status).toBe(500);
+      // Slot must be free again, or one failed turn wedges the person out.
+      expect((await request(app).post("/").send({ message: "two" })).status).toBe(200);
+    });
+
+    it("releases the slot when the daemon is offline", async () => {
+      const rateLimiter = new ChatRateLimiter({ maxConcurrent: 1 });
+      const dispatchService = makeDispatchService({
+        session: fakeSession({ id: "sess_new", status: "pending" }),
+        runtime_id: "rt_1",
+      });
+      const hub = makeHub(false);
+      const { app } = makeApp({ rateLimiter, dispatchService, hub });
+
+      expect((await request(app).post("/").send({ message: "one" })).status).toBe(503);
+      expect((await request(app).post("/").send({ message: "two" })).status).toBe(503);
+    });
+  });
+
+  it("503s when the session is bound to a daemon that is offline", async () => {
+    const dispatchService = makeDispatchService({
+      session: fakeSession({ id: "sess_new", status: "pending" }),
+      runtime_id: "rt_1",
+    });
+    const { app, deps } = makeApp({ dispatchService, hub: makeHub(false) });
+    const res = await request(app).post("/").send({ message: "hi" });
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe("agent_offline");
+    expect(deps.chatResolver.register).not.toHaveBeenCalled();
+  });
+
+  it("proceeds for a null-runtime session even with no daemon online", async () => {
+    // runtime_id null routes to the in-process executor, so hub state is
+    // irrelevant — checking it would 503 every legacy agent.
+    const hub = makeHub(false);
+    const { app, deps } = makeApp({ hub });
+    const res = await request(app).post("/").send({ message: "hi" });
+
+    expect(res.status).toBe(200);
+    expect(hub.isOnline).not.toHaveBeenCalled();
+    expect(deps.chatResolver.register).toHaveBeenCalledWith("sess_new", 90_000);
+  });
+
+  it("500s when dispatch throws", async () => {
+    const dispatchService = makeDispatchService();
+    vi.mocked(dispatchService.dispatchTask).mockRejectedValue(new Error("agent not found"));
+    const { app, deps } = makeApp({ dispatchService });
+    const res = await request(app).post("/").send({ message: "hi" });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("internal_error");
+    expect(deps.chatResolver.register).not.toHaveBeenCalled();
+  });
+
+  it("504s when the resolver times out", async () => {
+    const { app } = makeApp({
+      chatResolver: makeResolver(async () => {
+        throw new Error("chat resolver timeout (90000ms) for sess_new");
+      }),
+    });
+    const res = await request(app).post("/").send({ message: "hi" });
+
+    expect(res.status).toBe(504);
+    expect(res.body).toMatchObject({ error: "chat_turn_timeout", timeout_ms: 90_000 });
+  });
+
+  it("500s on a non-timeout resolver failure", async () => {
+    const { app } = makeApp({
+      chatResolver: makeResolver(async () => {
+        throw new Error("chat resolver already registered for sess_new");
+      }),
+    });
+    const res = await request(app).post("/").send({ message: "hi" });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("internal_error");
+  });
+
+  describe("onboarding flip", () => {
+    it("stamps onboarding_completed_at on the first successful turn", async () => {
+      const personRepo = makePersonRepo(); // no onboarding_completed_at
+      const { app } = makeApp({ personRepo });
+      const res = await request(app).post("/").send({ message: "hi" });
+
+      expect(res.status).toBe(200);
+      expect(personRepo.update).toHaveBeenCalledWith(PERSON, {
+        onboarding_completed_at: expect.any(Date),
+      });
+    });
+
+    it("leaves an already-onboarded person alone", async () => {
+      const personRepo = makePersonRepo(new Date("2026-01-01"));
+      const { app } = makeApp({ personRepo });
+      await request(app).post("/").send({ message: "hi" });
+
+      expect(personRepo.update).not.toHaveBeenCalled();
+    });
+
+    it("does not flip onboarding on a failed turn", async () => {
+      const personRepo = makePersonRepo();
+      const { app } = makeApp({
+        personRepo,
+        chatResolver: makeResolver(async () =>
+          fakeSession({ id: "sess_new", status: "failed", error: "boom" }),
+        ),
+      });
+      const res = await request(app).post("/").send({ message: "hi" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe("failed");
+      expect(personRepo.update).not.toHaveBeenCalled();
+    });
+
+    it("still answers the turn when the onboarding write rejects", async () => {
+      // Fire-and-forget by design — a flaky write must not fail the turn.
+      const personRepo = makePersonRepo();
+      vi.mocked(personRepo.update).mockRejectedValue(new Error("pg down"));
+      const { app } = makeApp({ personRepo });
+      const res = await request(app).post("/").send({ message: "hi" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+    });
+  });
+});

--- a/packages/api/src/routes/stream.test.ts
+++ b/packages/api/src/routes/stream.test.ts
@@ -1,0 +1,200 @@
+/**
+ * GET /stream (SSE) — driven over a real socket, since the whole route
+ * is streaming side effects rather than a returned body.
+ *
+ * The two things that actually break here are the two tested hardest:
+ * the response has to be unbuffered and un-cached end to end (a proxy
+ * that buffers turns live updates into nothing), and disconnect has to
+ * clear BOTH the heartbeat interval and the SseManager subscription —
+ * leaking either one means a reconnecting browser accumulates writers
+ * against a dead socket for the life of the process.
+ *
+ * Only the interval timers are faked; the socket I/O stays real, so a
+ * 25s heartbeat is assertable without a 25s test.
+ */
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import express from "express";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SseManager, type BvEvent } from "../sse/manager.js";
+import { createStreamRouter } from "./stream.js";
+
+const PERSON = "person_1";
+
+function stubAuth(source: "human" | "agent") {
+  return (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    req.caller =
+      source === "human"
+        ? { source: "human", agentId: "agent_a", hierarchyLevel: "team", personId: PERSON }
+        : { source: "agent", agentId: "agent_a", hierarchyLevel: "ic" };
+    next();
+  };
+}
+
+interface Live {
+  res: http.IncomingMessage;
+  /** Everything received so far. */
+  body: () => string;
+  /** Resolves once the received body satisfies `pred`. */
+  until: (pred: (body: string) => boolean) => Promise<void>;
+  /**
+   * Resolves when the server ends the response. Attached inside
+   * `connect`, because a non-streaming reply (the 403) can complete
+   * before the awaiting test body gets a turn to add its own listener.
+   */
+  ended: Promise<void>;
+  close: () => void;
+}
+
+const servers: http.Server[] = [];
+
+function start(sseManager: SseManager, source: "human" | "agent" = "human") {
+  const app = express();
+  app.use("/", createStreamRouter({ authMiddleware: stubAuth(source), sseManager }));
+  const server = app.listen(0);
+  servers.push(server);
+  return server;
+}
+
+function connect(server: http.Server): Promise<Live> {
+  const { port } = server.address() as AddressInfo;
+  return new Promise((resolve) => {
+    // `agent: false` matters twice over: a fresh socket per request means
+    // no pooled connection survives into the next test, and none of the
+    // global agent's keep-alive timers land in the faked timer set.
+    const req = http.get({ port, path: "/stream", agent: false }, (res) => {
+      let body = "";
+      const waiters: Array<{ pred: (b: string) => boolean; go: () => void }> = [];
+      res.setEncoding("utf8");
+      const ended = new Promise<void>((done) => res.on("end", () => done()));
+      res.on("data", (chunk: string) => {
+        body += chunk;
+        for (let i = waiters.length - 1; i >= 0; i--) {
+          if (waiters[i]!.pred(body)) waiters.splice(i, 1)[0]!.go();
+        }
+      });
+      resolve({
+        res,
+        body: () => body,
+        until: (pred) =>
+          new Promise<void>((go) => {
+            if (pred(body)) return go();
+            waiters.push({ pred, go });
+          }),
+        ended,
+        close: () => req.destroy(),
+      });
+    });
+  });
+}
+
+/** Give the server's own 'close' handlers a turn to run. */
+function settle(): Promise<void> {
+  return new Promise((r) => setImmediate(() => setImmediate(r)));
+}
+
+/**
+ * Poll `pred` across macrotask turns. Used instead of a fixed number of
+ * ticks because the server-side 'close' handler runs an indeterminate
+ * few turns after the client destroys its socket. `setImmediate` is not
+ * in the faked timer set, so this works under fake timers too.
+ */
+async function waitFor(pred: () => boolean, turns = 200): Promise<void> {
+  for (let i = 0; i < turns; i++) {
+    if (pred()) return;
+    await settle();
+  }
+  throw new Error("condition not met before the turn budget ran out");
+}
+
+afterEach(async () => {
+  vi.useRealTimers();
+  await Promise.all(servers.splice(0).map((s) => new Promise((r) => s.close(r))));
+});
+
+describe("GET /stream", () => {
+  it("opens an unbuffered event-stream and sends a priming data event", async () => {
+    const live = await connect(start(new SseManager()));
+    await live.until((b) => b.includes("data: {}"));
+
+    expect(live.res.statusCode).toBe(200);
+    expect(live.res.headers["content-type"]).toBe("text/event-stream");
+    // These three are what keep nginx / cloudflared from buffering the
+    // stream into a single delivery at the end.
+    expect(live.res.headers["cache-control"]).toBe("no-cache, no-transform");
+    expect(live.res.headers["x-accel-buffering"]).toBe("no");
+    // A comment line would not fire the browser's onmessage, so the
+    // primer has to be a data line.
+    expect(live.body()).toBe("data: {}\n\n");
+
+    live.close();
+  });
+
+  it("writes each event the manager fans out to this person", async () => {
+    const sseManager = new SseManager();
+    const live = await connect(start(sseManager));
+    await live.until((b) => b.includes("data: {}"));
+
+    const event: BvEvent = { event: "task.updated", id: "task_1" };
+    sseManager.publish(event, new Set([PERSON]));
+    await live.until((b) => b.includes("task.updated"));
+
+    expect(live.body()).toBe(`data: {}\n\ndata: ${JSON.stringify(event)}\n\n`);
+
+    live.close();
+  });
+
+  it("does not write events owned by a different person", async () => {
+    const sseManager = new SseManager();
+    const live = await connect(start(sseManager));
+    await live.until((b) => b.includes("data: {}"));
+
+    sseManager.publish({ event: "task.updated", id: "task_1" }, new Set(["person_other"]));
+    await settle();
+
+    expect(live.body()).toBe("data: {}\n\n");
+
+    live.close();
+  });
+
+  it("emits a heartbeat comment every 25s", async () => {
+    // Fake only the interval timers; the socket keeps real I/O.
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    const live = await connect(start(new SseManager()));
+    await live.until((b) => b.includes("data: {}"));
+
+    vi.advanceTimersByTime(25_000);
+    await live.until((b) => b.includes(": heartbeat"));
+    vi.advanceTimersByTime(25_000);
+    await live.until((b) => b.split(": heartbeat").length === 3);
+
+    live.close();
+  });
+
+  it("unsubscribes and stops the heartbeat when the client disconnects", async () => {
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    const sseManager = new SseManager();
+    const live = await connect(start(sseManager));
+    await live.until((b) => b.includes("data: {}"));
+    expect(sseManager.size()).toBe(1);
+
+    live.close();
+    await waitFor(() => sseManager.size() === 0);
+
+    // The subscription is gone, so a later publish has no one to write
+    // to a socket that no longer exists.
+    expect(sseManager.size()).toBe(0);
+    // And the interval is cleared, so nothing is left firing forever.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("rejects a non-human caller before opening a stream", async () => {
+    const sseManager = new SseManager();
+    const live = await connect(start(sseManager, "agent"));
+    await live.ended;
+
+    expect(live.res.statusCode).toBe(403);
+    expect(JSON.parse(live.body()).error).toBe("human_required");
+    expect(sseManager.size()).toBe(0);
+  });
+});

--- a/packages/api/src/tools/session-search.test.ts
+++ b/packages/api/src/tools/session-search.test.ts
@@ -1,0 +1,230 @@
+/**
+ * session_search tool — vitest fakes, no DB.
+ *
+ * `SessionSearchService` does the scoping and the SQL; it is tested
+ * against Postgres in core. The adapter's own job is shape inference —
+ * deciding from a loose `Record<string, unknown>` whether the agent
+ * meant scroll, read, discover or browse — plus passing the caller's
+ * tier through and mapping errors. Shape inference is the part with
+ * teeth: the precedence between `session_id`, `around_message_id` and
+ * `query` decides which query runs at all, and a whitespace-only field
+ * has to read as absent or a bare " " flips a browse into a read.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { SessionSearchRequest } from "@beevibe/core";
+import {
+  SessionSearchError,
+  type SessionSearchService,
+} from "@beevibe/core/services/session-search";
+import {
+  createSessionSearchTool,
+  type SessionSearchToolContext,
+} from "./session-search.js";
+
+const CTX: SessionSearchToolContext = {
+  agentId: "agent_a",
+  hierarchyLevel: "team",
+  sessionId: "sess_current",
+};
+
+function build(ctx: SessionSearchToolContext = CTX) {
+  const sessionSearch = {
+    search: vi.fn(async () => ({ results: [] })),
+  } as unknown as SessionSearchService;
+  return { tool: createSessionSearchTool(ctx, { sessionSearch }), sessionSearch };
+}
+
+/** The request the handler inferred from one call's raw input. */
+async function inferred(input: Record<string, unknown>): Promise<SessionSearchRequest> {
+  const { tool, sessionSearch } = build();
+  await tool.handler(input);
+  return vi.mocked(sessionSearch.search).mock.calls[0]![0];
+}
+
+describe("shape inference", () => {
+  it("browses when given no arguments", async () => {
+    expect(await inferred({})).toEqual({ kind: "browse", limit: undefined, filters: undefined });
+  });
+
+  it("discovers when given a query", async () => {
+    expect(await inferred({ query: "  auth refactor  ", limit: 7, sort: "newest" })).toEqual({
+      kind: "discover",
+      query: "auth refactor",
+      limit: 7,
+      sort: "newest",
+      filters: undefined,
+    });
+  });
+
+  it("reads when given a bare session_id", async () => {
+    expect(await inferred({ session_id: "  sess_x  " })).toEqual({
+      kind: "read",
+      session_id: "sess_x",
+    });
+  });
+
+  it("scrolls when given session_id and around_message_id", async () => {
+    expect(
+      await inferred({ session_id: "sess_x", around_message_id: " evt_1 ", window: 10 }),
+    ).toEqual({
+      kind: "scroll",
+      session_id: "sess_x",
+      around_message_id: "evt_1",
+      window: 10,
+    });
+  });
+
+  it("prefers scroll over discovery when a query is also present", async () => {
+    // Documented precedence: the anchored slice wins, the query is ignored.
+    const req = await inferred({
+      session_id: "sess_x",
+      around_message_id: "evt_1",
+      query: "auth",
+    });
+    expect(req.kind).toBe("scroll");
+  });
+
+  it("prefers read over discovery when a query is also present", async () => {
+    const req = await inferred({ session_id: "sess_x", query: "auth" });
+    expect(req).toEqual({ kind: "read", session_id: "sess_x" });
+  });
+
+  it("ignores a dangling around_message_id with no session_id", async () => {
+    const req = await inferred({ around_message_id: "evt_1" });
+    expect(req.kind).toBe("browse");
+  });
+
+  it.each([
+    ["blank", "   "],
+    ["a non-string", 42],
+  ])("treats %s session_id as absent", async (_label, session_id) => {
+    expect((await inferred({ session_id })).kind).toBe("browse");
+  });
+
+  it.each([
+    ["blank", "   "],
+    ["a non-string", 42],
+  ])("treats %s query as absent", async (_label, query) => {
+    expect((await inferred({ query })).kind).toBe("browse");
+  });
+
+  it("treats a blank around_message_id as a read, not a scroll", async () => {
+    expect((await inferred({ session_id: "sess_x", around_message_id: "  " })).kind).toBe("read");
+  });
+
+  it.each([
+    ["a non-number limit", { limit: "3" }, "limit"],
+    ["a non-number window", { session_id: "s", around_message_id: "e", window: "5" }, "window"],
+  ])("drops %s so the service default applies", async (_label, extra, field) => {
+    const req = (await inferred(extra)) as unknown as Record<string, unknown>;
+    expect(req[field]).toBeUndefined();
+  });
+
+  it("drops an unrecognized sort rather than forwarding it", async () => {
+    const req = (await inferred({ query: "x", sort: "relevance" })) as { sort?: string };
+    expect(req.sort).toBeUndefined();
+  });
+
+  it("forwards filters on discovery and browse", async () => {
+    const filters = { status: "failed", session_type: "task" };
+    expect((await inferred({ query: "x", filters })) as unknown).toMatchObject({ filters });
+    expect((await inferred({ filters })) as unknown).toMatchObject({ filters });
+  });
+
+  it.each([
+    ["null", null],
+    ["a non-object", "status=failed"],
+  ])("drops %s filters", async (_label, filters) => {
+    expect((await inferred({ filters })) as unknown).toMatchObject({ filters: undefined });
+  });
+});
+
+describe("caller scope", () => {
+  it("passes the caller's agent, tier and active session to the service", async () => {
+    const { tool, sessionSearch } = build({
+      agentId: "agent_b",
+      hierarchyLevel: "org",
+      sessionId: "sess_live",
+    });
+    await tool.handler({ query: "x" });
+
+    expect(sessionSearch.search).toHaveBeenCalledWith(expect.anything(), {
+      callerAgentId: "agent_b",
+      hierarchyLevel: "org",
+      currentSessionId: "sess_live",
+    });
+  });
+
+  it("returns the service payload verbatim on success", async () => {
+    const { tool, sessionSearch } = build();
+    const payload = { results: [{ session: { id: "sess_1" }, snippet: "…auth…" }] };
+    vi.mocked(sessionSearch.search).mockResolvedValue(payload as never);
+
+    const res = await tool.handler({ query: "auth" });
+
+    expect(res.isError).toBeUndefined();
+    expect(res.content).toEqual(payload);
+  });
+});
+
+describe("error mapping", () => {
+  it("maps a null result to not_found_or_forbidden", async () => {
+    // One code for three causes on purpose — telling an out-of-scope
+    // caller which of them applied would leak that the session exists.
+    const { tool, sessionSearch } = build();
+    vi.mocked(sessionSearch.search).mockResolvedValue(null as never);
+
+    const res = await tool.handler({ session_id: "sess_someone_else" });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("not_found_or_forbidden");
+  });
+
+  it.each(["forbidden_agent_filter", "missing_query", "missing_args"] as const)(
+    "surfaces the %s service error code",
+    async (code) => {
+      const { tool, sessionSearch } = build();
+      vi.mocked(sessionSearch.search).mockRejectedValue(
+        new SessionSearchError(code, `bad: ${code}`),
+      );
+
+      const res = await tool.handler({ query: "x" });
+
+      expect(res.isError).toBe(true);
+      expect(res.content).toEqual({ error: code, message: `bad: ${code}` });
+    },
+  );
+
+  it("recognizes a SessionSearchError from another bundle by name", async () => {
+    // src/ and dist/ copies of core fail `instanceof`; the name check is
+    // what keeps the structured code from degrading to internal_error.
+    const foreign = new Error("out of scope");
+    foreign.name = "SessionSearchError";
+    (foreign as Error & { code: string }).code = "forbidden_agent_filter";
+    const { tool, sessionSearch } = build();
+    vi.mocked(sessionSearch.search).mockRejectedValue(foreign);
+
+    const res = await tool.handler({ query: "x" });
+
+    expect(res.content).toEqual({ error: "forbidden_agent_filter", message: "out of scope" });
+  });
+
+  it("maps an unexpected throw to internal_error", async () => {
+    const { tool, sessionSearch } = build();
+    vi.mocked(sessionSearch.search).mockRejectedValue(new Error("pg down"));
+
+    const res = await tool.handler({ query: "x" });
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({ error: "internal_error", message: "pg down" });
+  });
+
+  it("stringifies a non-Error throw", async () => {
+    const { tool, sessionSearch } = build();
+    vi.mocked(sessionSearch.search).mockRejectedValue("socket hang up");
+
+    const res = await tool.handler({ query: "x" });
+
+    expect(res.content).toEqual({ error: "internal_error", message: "socket hang up" });
+  });
+});

--- a/packages/api/src/tools/use-repo.test.ts
+++ b/packages/api/src/tools/use-repo.test.ts
@@ -1,0 +1,329 @@
+/**
+ * use_repo tool — vitest fakes, no DB and no Docker.
+ *
+ * Three things here are worth pinning down. First, `repo_url` is a
+ * trust boundary: this tool hands the URL to a sandbox that clones and
+ * executes it, so the GitHub-host check has to reject look-alikes
+ * (`evilgithub.com`, `github.com.evil.com`) and plain http, not just
+ * obvious junk. Second, `limits` are clamped server-side — an agent
+ * asking for a 10-hour run or a 500 GB disk must come back capped, not
+ * honored. Third, the write order (task → session → repo_run) is load-
+ * bearing because `repo_run.session_id` carries an FK, and each of the
+ * two failure points has its own error code so the agent can tell a
+ * retryable dispatch failure from an orphaned session.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type {
+  AgentRepository,
+  RepoRunRepository,
+  Task,
+  TaskRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import { createUseRepoTool, type UseRepoServices } from "./use-repo.js";
+
+const AGENT = "agent_a";
+const GOAL = "Extract the tables from this PDF as JSON";
+const REPO = "https://github.com/jsvine/pdfplumber";
+
+function makeServices(overrides: Partial<UseRepoServices> = {}): UseRepoServices {
+  return {
+    agentRepo: {
+      findById: vi.fn(async (id: string) => ({ id, name: "Ada", hierarchy_level: "ic" })),
+    } as unknown as AgentRepository,
+    taskRepo: {
+      create: vi.fn(async (input: { id: string; title: string }) => input as unknown as Task),
+    } as unknown as TaskRepository,
+    repoRunRepo: {
+      create: vi.fn(async (input: unknown) => input),
+    } as unknown as RepoRunRepository,
+    dispatchService: {
+      dispatchTask: vi.fn(async () => ({ session: { id: "sess_x" }, runtime_id: null })),
+    } as unknown as DispatchService,
+    ...overrides,
+  };
+}
+
+function build(overrides: Partial<UseRepoServices> = {}) {
+  const services = makeServices(overrides);
+  return { tool: createUseRepoTool({ agentId: AGENT }, services), services };
+}
+
+describe("use_repo happy path", () => {
+  it("creates the container task, dispatches, then records the repo run", async () => {
+    const { tool, services } = build();
+    const res = await tool.handler({ goal: `  ${GOAL}  `, repo_url: `  ${REPO}  ` });
+
+    expect(res.isError).toBeUndefined();
+    expect(res.content).toMatchObject({
+      status: "pending",
+      task_id: expect.stringMatching(/^task_/),
+      session_id: expect.stringMatching(/^sess_/),
+      repo_run_id: expect.stringMatching(/^repo_/),
+    });
+    expect(res.content.watch_url).toBe(`/capabilities/runs/${res.content.repo_run_id}`);
+
+    // Container task is owned by the calling agent on both sides.
+    expect(services.taskRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: GOAL,
+        description: GOAL,
+        assignee_id: AGENT,
+        creator_id: AGENT,
+        creator_type: "agent",
+      }),
+    );
+    // The session id the tool reports is the one it pre-minted and
+    // forced onto the dispatch, so the repo_run FK resolves.
+    expect(services.dispatchService.dispatchTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: AGENT,
+        type: "run_repo",
+        intent: GOAL,
+        reason: { kind: "fresh" },
+        sessionIdOverride: res.content.session_id,
+      }),
+    );
+    expect(services.repoRunRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: res.content.repo_run_id,
+        session_id: res.content.session_id,
+        task_id: res.content.task_id,
+        agent_id: AGENT,
+        goal: GOAL,
+        repo_url: REPO,
+        status: "pending",
+      }),
+    );
+  });
+
+  it("inserts the session before the repo_run (FK ordering)", async () => {
+    const order: string[] = [];
+    const services = makeServices();
+    vi.mocked(services.dispatchService.dispatchTask).mockImplementation(async () => {
+      order.push("dispatch");
+      return { session: { id: "sess_x" }, runtime_id: null } as never;
+    });
+    vi.mocked(services.repoRunRepo.create).mockImplementation(async (input) => {
+      order.push("repo_run");
+      return input as never;
+    });
+    const tool = createUseRepoTool({ agentId: AGENT }, services);
+
+    await tool.handler({ goal: GOAL, repo_url: REPO });
+
+    expect(order).toEqual(["dispatch", "repo_run"]);
+  });
+
+  it("passes the input download through to the agent-visible result", async () => {
+    const { tool } = build();
+    const res = await tool.handler({
+      goal: GOAL,
+      repo_url: REPO,
+      input_url: "  https://example.com/report.pdf  ",
+      input_filename: "  report.pdf  ",
+    });
+
+    expect(res.content).toMatchObject({
+      input_url: "https://example.com/report.pdf",
+      input_filename: "report.pdf",
+    });
+  });
+
+  it("mints a distinct run and session per call", async () => {
+    const { tool } = build();
+    const a = await tool.handler({ goal: GOAL, repo_url: REPO });
+    const b = await tool.handler({ goal: GOAL, repo_url: REPO });
+
+    expect(a.content.repo_run_id).not.toBe(b.content.repo_run_id);
+    expect(a.content.session_id).not.toBe(b.content.session_id);
+    expect(a.content.task_id).not.toBe(b.content.task_id);
+  });
+
+  it("truncates a long goal into a scannable task title", async () => {
+    const { tool, services } = build();
+    await tool.handler({ goal: "g".repeat(200), repo_url: REPO });
+
+    const title = vi.mocked(services.taskRepo.create).mock.calls[0]![0].title as string;
+    expect(title).toHaveLength(78); // 77 chars + ellipsis
+    expect(title.endsWith("…")).toBe(true);
+  });
+
+  it("collapses whitespace in the task title but keeps the full description", async () => {
+    const { tool, services } = build();
+    await tool.handler({ goal: "extract\n\n  the   tables", repo_url: REPO });
+
+    expect(services.taskRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "extract the tables",
+        description: "extract\n\n  the   tables",
+      }),
+    );
+  });
+});
+
+describe("use_repo input validation", () => {
+  it.each([
+    ["absent", undefined],
+    ["blank", "   "],
+    ["a non-string", 42],
+  ])("rejects a %s goal", async (_label, goal) => {
+    const { tool, services } = build();
+    const res = await tool.handler({ ...(goal === undefined ? {} : { goal }), repo_url: REPO });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("invalid_goal");
+    expect(services.taskRepo.create).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["a look-alike host", "https://evilgithub.com/a/b"],
+    ["a suffixed host", "https://github.com.evil.com/a/b"],
+    ["plain http", "http://github.com/a/b"],
+    ["a non-GitHub host", "https://gitlab.com/a/b"],
+    ["a git+ssh remote", "git@github.com:a/b.git"],
+    ["an unparseable string", "not a url"],
+    ["a blank string", "   "],
+    ["a non-string", 42],
+  ])("rejects %s as repo_url", async (_label, repo_url) => {
+    const { tool, services } = build();
+    const res = await tool.handler({ goal: GOAL, repo_url });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("invalid_repo_url");
+    // Nothing is written for a rejected URL.
+    expect(services.taskRepo.create).not.toHaveBeenCalled();
+    expect(services.dispatchService.dispatchTask).not.toHaveBeenCalled();
+    expect(services.repoRunRepo.create).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["the bare host", "https://github.com/owner/repo"],
+    ["a www subdomain", "https://www.github.com/owner/repo"],
+    ["an uppercased host", "https://GitHub.com/owner/repo"],
+  ])("accepts %s", async (_label, repo_url) => {
+    const { tool } = build();
+    const res = await tool.handler({ goal: GOAL, repo_url });
+
+    expect(res.isError).toBeUndefined();
+  });
+});
+
+describe("use_repo limits", () => {
+  it("passes sane limits through untouched", async () => {
+    const { tool } = build();
+    const res = await tool.handler({
+      goal: GOAL,
+      repo_url: REPO,
+      limits: { wall_clock_minutes: 10, max_install_attempts: 3, disk_mb: 512 },
+    });
+
+    expect(res.content.limits).toEqual({
+      wall_clock_minutes: 10,
+      max_install_attempts: 3,
+      disk_mb: 512,
+    });
+  });
+
+  it("clamps limits to their server-side ceilings", async () => {
+    const { tool } = build();
+    const res = await tool.handler({
+      goal: GOAL,
+      repo_url: REPO,
+      limits: { wall_clock_minutes: 600, max_install_attempts: 99, disk_mb: 500_000 },
+    });
+
+    expect(res.content.limits).toEqual({
+      wall_clock_minutes: 60,
+      max_install_attempts: 5,
+      disk_mb: 10_000,
+    });
+  });
+
+  it("floors fractional attempt and disk counts", async () => {
+    const { tool } = build();
+    const res = await tool.handler({
+      goal: GOAL,
+      repo_url: REPO,
+      limits: { max_install_attempts: 2.9, disk_mb: 100.7 },
+    });
+
+    expect(res.content.limits).toEqual({ max_install_attempts: 2, disk_mb: 100 });
+  });
+
+  it.each([
+    ["absent", undefined],
+    ["null", null],
+    ["a non-object", "20"],
+    ["an object of non-numbers", { wall_clock_minutes: "20", disk_mb: null }],
+    ["zero and negative values", { wall_clock_minutes: 0, max_install_attempts: -1, disk_mb: -5 }],
+  ])("drops %s limits to the defaults", async (_label, limits) => {
+    const { tool } = build();
+    const res = await tool.handler({
+      goal: GOAL,
+      repo_url: REPO,
+      ...(limits === undefined ? {} : { limits }),
+    });
+
+    expect(res.content.limits).toEqual({});
+  });
+});
+
+describe("use_repo failure paths", () => {
+  it("reports agent_not_found without writing anything", async () => {
+    const services = makeServices();
+    vi.mocked(services.agentRepo.findById).mockResolvedValue(undefined);
+    const tool = createUseRepoTool({ agentId: AGENT }, services);
+
+    const res = await tool.handler({ goal: GOAL, repo_url: REPO });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("agent_not_found");
+    expect(services.taskRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("reports dispatch_failed and never inserts an unreferenced repo_run", async () => {
+    const services = makeServices();
+    vi.mocked(services.dispatchService.dispatchTask).mockRejectedValue(
+      new Error("no runtime bound"),
+    );
+    const tool = createUseRepoTool({ agentId: AGENT }, services);
+
+    const res = await tool.handler({ goal: GOAL, repo_url: REPO });
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({ error: "dispatch_failed", message: "no runtime bound" });
+    expect(services.repoRunRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("surfaces repo_run_create_failed rather than letting the agent wait on an orphan", async () => {
+    const services = makeServices();
+    vi.mocked(services.repoRunRepo.create).mockRejectedValue(new Error("unique violation"));
+    const tool = createUseRepoTool({ agentId: AGENT }, services);
+
+    const res = await tool.handler({ goal: GOAL, repo_url: REPO });
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({
+      error: "repo_run_create_failed",
+      message: "unique violation",
+    });
+  });
+
+  it.each([
+    ["dispatchService", "dispatchTask", "dispatch_failed"],
+    ["repoRunRepo", "create", "repo_run_create_failed"],
+  ] as const)("stringifies a non-Error thrown by %s", async (dep, method, code) => {
+    const services = makeServices();
+    const target = services[dep as "dispatchService" | "repoRunRepo"] as unknown as Record<
+      string,
+      ReturnType<typeof vi.fn>
+    >;
+    target[method]!.mockRejectedValue("socket hang up");
+    const tool = createUseRepoTool({ agentId: AGENT }, services);
+
+    const res = await tool.handler({ goal: GOAL, repo_url: REPO });
+
+    expect(res.content).toEqual({ error: code, message: "socket hang up" });
+  });
+});

--- a/packages/api/src/tools/watch.test.ts
+++ b/packages/api/src/tools/watch.test.ts
@@ -1,0 +1,204 @@
+/**
+ * watch_tasks + unwatch tool adapters — vitest fakes, no DB.
+ *
+ * `WatchService` owns the real state machine and is tested against
+ * Postgres in core. What lives *here* is the adapter layer, and its
+ * whole job is input coercion and error mapping: silently dropping a
+ * non-string out of `task_ids`, defaulting an unknown `mode` to "all"
+ * rather than passing it through, and translating each typed service
+ * error into the `error` code an agent branches on. Those are the paths
+ * covered below.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  WatchAuthError,
+  WatchNotFoundError,
+  WatchValidationError,
+  type WatchService,
+} from "@beevibe/core/services/watch-service";
+import { buildWatchTools, type WatchToolContext } from "./watch.js";
+import type { AgentTool } from "./types.js";
+
+const CTX: WatchToolContext = { agentId: "agent_a", sessionId: "sess_1" };
+
+function makeService(): WatchService {
+  return {
+    watchTasks: vi.fn(async () => ({ watchId: "watch_1", firedImmediately: false })),
+    unwatch: vi.fn(async () => undefined),
+  } as unknown as WatchService;
+}
+
+function build(ctx: WatchToolContext = CTX, watchService: WatchService = makeService()) {
+  const tools = buildWatchTools(ctx, { watchService });
+  const byName = (name: string): AgentTool => {
+    const tool = tools.find((t) => t.name === name);
+    if (!tool) throw new Error(`tool ${name} not built`);
+    return tool;
+  };
+  return { tools, watchService, watchTasks: byName("watch_tasks"), unwatch: byName("unwatch") };
+}
+
+describe("buildWatchTools", () => {
+  it("builds both tools with input schemas that require their key field", () => {
+    const { tools, watchTasks, unwatch } = build();
+
+    expect(tools.map((t) => t.name)).toEqual(["watch_tasks", "unwatch"]);
+    expect(watchTasks.schema).toMatchObject({ required: ["task_ids"] });
+    expect(unwatch.schema).toMatchObject({ required: ["watch_id"] });
+    // The mode enum is the agent-facing contract; it must track the domain.
+    expect((watchTasks.schema.properties as Record<string, { enum?: string[] }>).mode?.enum).toEqual(
+      ["all", "any"],
+    );
+  });
+});
+
+describe("watch_tasks", () => {
+  it("registers a watch and returns the id plus the fired flag", async () => {
+    const { watchTasks, watchService } = build();
+    vi.mocked(watchService.watchTasks).mockResolvedValue({
+      watchId: "watch_9",
+      firedImmediately: true,
+    });
+
+    const res = await watchTasks.handler({
+      task_ids: ["task_1", "task_2"],
+      mode: "any",
+      reason: "  need the first result  ",
+    });
+
+    expect(res.isError).toBeUndefined();
+    expect(res.content).toEqual({ watch_id: "watch_9", fired_immediately: true });
+    expect(watchService.watchTasks).toHaveBeenCalledWith({
+      callerAgentId: "agent_a",
+      callerSessionId: "sess_1",
+      taskIds: ["task_1", "task_2"],
+      mode: "any",
+      // Trimmed — it lands in the wake intent the agent reads back.
+      reason: "need the first result",
+    });
+  });
+
+  it("defaults mode to 'all'", async () => {
+    const { watchTasks, watchService } = build();
+    await watchTasks.handler({ task_ids: ["task_1"] });
+
+    expect(watchService.watchTasks).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "all" }),
+    );
+  });
+
+  it("falls back to 'all' rather than forwarding an unknown mode", async () => {
+    const { watchTasks, watchService } = build();
+    await watchTasks.handler({ task_ids: ["task_1"], mode: "either" });
+
+    expect(watchService.watchTasks).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "all" }),
+    );
+  });
+
+  it.each([
+    ["absent", undefined],
+    ["blank", "   "],
+    ["a non-string", 7],
+  ])("omits reason when it is %s", async (_label, reason) => {
+    const { watchTasks, watchService } = build();
+    await watchTasks.handler({ task_ids: ["task_1"], ...(reason === undefined ? {} : { reason }) });
+
+    expect(watchService.watchTasks).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: undefined }),
+    );
+  });
+
+  it("drops non-string entries from task_ids", async () => {
+    const { watchTasks, watchService } = build();
+    await watchTasks.handler({ task_ids: ["task_1", 42, null, "task_2"] });
+
+    expect(watchService.watchTasks).toHaveBeenCalledWith(
+      expect.objectContaining({ taskIds: ["task_1", "task_2"] }),
+    );
+  });
+
+  it.each([
+    ["an empty array", []],
+    ["a non-array", "task_1"],
+    ["an array with no strings left after filtering", [1, 2]],
+    ["an absent field", undefined],
+  ])("rejects %s without calling the service", async (_label, task_ids) => {
+    const { watchTasks, watchService } = build();
+    const res = await watchTasks.handler(task_ids === undefined ? {} : { task_ids });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("watch_validation");
+    expect(watchService.watchTasks).not.toHaveBeenCalled();
+  });
+
+  it("rejects a call made outside a session context", async () => {
+    // No sessionId means no waiter to resume — the service could not
+    // identify who to wake.
+    const { watchTasks, watchService } = build({ agentId: "agent_a" });
+    const res = await watchTasks.handler({ task_ids: ["task_1"] });
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toMatchObject({ error: "watch_validation" });
+    expect(res.content.message).toContain("session context");
+    expect(watchService.watchTasks).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [new WatchAuthError("not your task"), "watch_auth", "not your task"],
+    [new WatchValidationError("task_ids must be non-empty"), "watch_validation", "task_ids must be non-empty"],
+    [new WatchNotFoundError("watch_x"), "watch_not_found", "task_watch watch_x not found"],
+    [new Error("pg down"), "watch_error", "pg down"],
+    ["a bare string throw", "watch_error", "a bare string throw"],
+  ])("maps a thrown %s to its tool error code", async (thrown, code, message) => {
+    const { watchTasks, watchService } = build();
+    vi.mocked(watchService.watchTasks).mockRejectedValue(thrown);
+
+    const res = await watchTasks.handler({ task_ids: ["task_1"] });
+
+    expect(res.isError).toBe(true);
+    expect(res.content).toEqual({ error: code, message });
+  });
+});
+
+describe("unwatch", () => {
+  it("cancels the watch scoped to the calling agent", async () => {
+    const { unwatch, watchService } = build();
+    const res = await unwatch.handler({ watch_id: "watch_1" });
+
+    expect(res.isError).toBeUndefined();
+    expect(res.content).toEqual({ ok: true });
+    expect(watchService.unwatch).toHaveBeenCalledWith({
+      callerAgentId: "agent_a",
+      watchId: "watch_1",
+    });
+  });
+
+  it.each([
+    ["an absent watch_id", {}],
+    ["an empty watch_id", { watch_id: "" }],
+    ["a non-string watch_id", { watch_id: 12 }],
+  ])("rejects %s without calling the service", async (_label, input) => {
+    const { unwatch, watchService } = build();
+    const res = await unwatch.handler(input);
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe("watch_validation");
+    expect(watchService.unwatch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [new WatchAuthError("watch does not belong to caller"), "watch_auth"],
+    [new WatchNotFoundError("watch_x"), "watch_not_found"],
+    [new WatchValidationError("cannot unwatch a watch that already fired"), "watch_validation"],
+    [new Error("pg down"), "watch_error"],
+  ])("maps a thrown %s to its tool error code", async (thrown, code) => {
+    const { unwatch, watchService } = build();
+    vi.mocked(watchService.unwatch).mockRejectedValue(thrown);
+
+    const res = await unwatch.handler({ watch_id: "watch_1" });
+
+    expect(res.isError).toBe(true);
+    expect(res.content.error).toBe(code);
+  });
+});


### PR DESCRIPTION
## What

A coverage sweep across the monorepo turned up five `@beevibe/api` modules well under a reasonable line threshold. This PR adds focused tests for each. **No production code changes.**

| Module | Lines | Functions | Notes |
| --- | --- | --- | --- |
| `routes/chat.ts` | 26.94% → **100%** | 50% → 100% | 722 loc, 5 commits in the last year |
| `tools/use-repo.ts` | 32.04% → **100%** | 20% → 100% | no test file existed |
| `tools/watch.ts` | 46.26% → **100%** | 42.85% → 100% | no test file existed |
| `tools/session-search.ts` | 64.65% → **100%** | 33.33% → 100% | no test file existed |
| `routes/stream.ts` | 0% → **100%** | 0% → 100% | no test file existed |

Package total: **64.53% → 71.53% lines**, **83.63% → 89.15% functions**.

## How the targets were picked

Coverage was measured with `@vitest/coverage-v8` and `--coverage.all` (installed for the sweep, **not** committed — per CLAUDE.md). The DB- and key-gated suites were excluded, since this sandbox has neither Docker nor provider keys and an unhandled `afterAll` error in those files aborts report generation entirely.

That exclusion makes some files *read* as 0% when they are in fact covered by a gated suite (the postgres adapters, `runtime/router.ts`, `routes/task.ts`, …). Those were discounted rather than targeted. The five above were chosen from what remained, ranked by uncovered lines and cross-referenced against `git log` churn.

## What the tests actually assert

These target behavior, not line numbers:

- **`chat.ts`** — the exported pure helpers were already covered by `chat-internals.test.ts`; `createChatRouter` was not. Covered: the idempotent-replay ladder (403 on a colliding session id, 409 while in flight, 200 replayed) that stops a double-submit from paying for a second CLI turn; rate-limiter release on *every* exit path, including dispatch failure and the offline short-circuit, since a leaked slot wedges the person out; the offline-daemon 503; and a resolver timeout mapping to 504 rather than 500.
- **`use-repo.ts`** — `repo_url` is a trust boundary: the URL is handed to a sandbox that clones and executes it. The GitHub host check is tested against look-alikes (`evilgithub.com`, `github.com.evil.com`, plain `http`), not just obvious junk. Also server-side limit clamping (an agent asking for a 10-hour run comes back capped) and the load-bearing `task → session → repo_run` write order behind `repo_run.session_id`'s FK, with a distinct error code at each of the two failure points.
- **`watch.ts` / `session-search.ts`** — input coercion (dropping non-strings, defaulting an unknown `mode` to `all` rather than forwarding it, shape-inference precedence between `session_id` / `around_message_id` / `query`) and the typed-error → tool-error-code mapping agents branch on.
- **`stream.ts`** — driven over a real socket, faking only the interval timers so a 25s heartbeat is assertable without a 25s test. Asserts the no-buffering headers and that disconnect clears **both** the heartbeat interval and the `SseManager` subscription — leaking either accumulates writers against a dead socket for the life of the process.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean (the 4 remaining api warnings are pre-existing, in `negotiation.test.ts` and `ws-server.test.ts`)
- `@beevibe/api` suite: 968 tests pass across 48 files. The 9 failing files are exactly the DB-gated ones that failed before this branch — no new failures.
- `stream.test.ts` uses real sockets, so it was run 5× consecutively to check for flakiness: 6/6 passing each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018A2878e674SZtbLyK7JyRG

---
_Generated by [Claude Code](https://claude.ai/code/session_018A2878e674SZtbLyK7JyRG)_