### PR TITLE
refactor: unify two clusters of near-duplicate abstractions (CLI runtime scaffolding, web form controls)

### DIFF
--- a/packages/core/src/adapters/claude-code/runtime.ts
+++ b/packages/core/src/adapters/claude-code/runtime.ts
@@ -9,11 +9,9 @@ import type {
 import {
   cancelledResult,
   cliVersionHealthCheck,
-  createStdoutLineReader,
   finalizeCliResult,
-  warnIfTruncated,
+  runCliRuntime,
 } from "../runtime-common.js";
-import { runCliProcess } from "./spawn.js";
 import {
   extractStepEvents,
   parseClaudeMessages,
@@ -103,39 +101,17 @@ export class ClaudeCodeRuntime implements AgentRuntime {
     for (const key of ANTHROPIC_AUTH_VARS) delete env[key];
     if (context.env) Object.assign(env, context.env);
 
-    // Parse messages incrementally during streaming so we don't re-parse
-    // the entire stdout after close. A line buffer handles chunk boundaries
-    // (a single JSON message can arrive split across multiple chunks).
-    const messages: StreamJsonMessage[] = [];
-    const handleLine = (line: string): void => {
-      const msg = parseStreamJsonLine(line);
-      if (!msg) return;
-      messages.push(msg);
-      if (context.onStep) {
-        for (const step of extractStepEvents(msg)) {
-          context.onStep(step);
-        }
-      }
-    };
-    const stdout = createStdoutLineReader(handleLine);
-
-    const result = await runCliProcess({
+    const { events: messages, result } = await runCliRuntime<StreamJsonMessage>({
+      runtimeTag: "ClaudeCodeRuntime",
       command: this.config.command ?? "claude",
       args,
       cwd,
       env,
       stdin: context.intent,
-      abortSignal: context.abort_signal,
-      onSpawn: ({ pid, process_group_id }) => {
-        context.onSpawn?.({ process_pid: pid, process_group_id });
-      },
-      onLog: stdout.onLog,
+      context,
+      parseLine: parseStreamJsonLine,
+      extractSteps: extractStepEvents,
     });
-
-    // Flush any final partial line (stream without trailing \n)
-    stdout.flush();
-
-    warnIfTruncated("ClaudeCodeRuntime", result);
 
     if (result.aborted) return cancelledResult(result);
 

--- a/packages/core/src/adapters/codex/runtime.ts
+++ b/packages/core/src/adapters/codex/runtime.ts
@@ -8,15 +8,13 @@ import type {
   RuntimeWorkspaceContext,
   Workspace,
 } from "../../ports/runtime.js";
-import { runCliProcess } from "../claude-code/spawn.js";
 import { MCP_TOOL_TIMEOUT_MS } from "../local-workspace/manager.js";
 import {
   cancelledResult,
   cliVersionHealthCheck,
   composePrompt,
-  createStdoutLineReader,
   finalizeCliResult,
-  warnIfTruncated,
+  runCliRuntime,
 } from "../runtime-common.js";
 import {
   extractCodexStepEvents,
@@ -120,32 +118,16 @@ export class CodexRuntime implements AgentRuntime {
     if (context.env) Object.assign(env, context.env);
     if (prepared) env.BEEVIBE_AGENT_API_KEY = prepared.agentApiKey;
 
-    const events: CodexEvent[] = [];
-    const handleLine = (line: string): void => {
-      const evt = parseCodexEventLine(line);
-      if (!evt) return;
-      events.push(evt);
-      if (!context.onStep) return;
-      for (const step of extractCodexStepEvents(evt)) {
-        context.onStep(step);
-      }
-    };
-    const stdout = createStdoutLineReader(handleLine);
-
-    const result = await runCliProcess({
+    const { events, result } = await runCliRuntime<CodexEvent>({
+      runtimeTag: "CodexRuntime",
       command: this.config.command ?? "codex",
       args,
       cwd: context.workspace.path,
       env,
-      abortSignal: context.abort_signal,
-      onSpawn: ({ pid, process_group_id }) => {
-        context.onSpawn?.({ process_pid: pid, process_group_id });
-      },
-      onLog: stdout.onLog,
+      context,
+      parseLine: parseCodexEventLine,
+      extractSteps: extractCodexStepEvents,
     });
-    stdout.flush();
-
-    warnIfTruncated("CodexRuntime", result);
 
     if (result.aborted) {
       removeIfExists(lastMessagePath);

--- a/packages/core/src/adapters/opencode/runtime.ts
+++ b/packages/core/src/adapters/opencode/runtime.ts
@@ -8,14 +8,12 @@ import type {
   RuntimeWorkspaceContext,
   Workspace,
 } from "../../ports/runtime.js";
-import { runCliProcess } from "../claude-code/spawn.js";
 import {
   cancelledResult,
   cliVersionHealthCheck,
   composePrompt,
-  createStdoutLineReader,
   finalizeCliResult,
-  warnIfTruncated,
+  runCliRuntime,
 } from "../runtime-common.js";
 import {
   extractOpenCodeStepEvents,
@@ -76,32 +74,16 @@ export class OpenCodeRuntime implements AgentRuntime {
     const env: Record<string, string | undefined> = { ...process.env };
     if (context.env) Object.assign(env, context.env);
 
-    const events: OpenCodeEvent[] = [];
-    const handleLine = (line: string): void => {
-      const evt = parseOpenCodeEventLine(line);
-      if (!evt) return;
-      events.push(evt);
-      if (!context.onStep) return;
-      for (const step of extractOpenCodeStepEvents(evt)) {
-        context.onStep(step);
-      }
-    };
-    const stdout = createStdoutLineReader(handleLine);
-
-    const result = await runCliProcess({
+    const { events, result } = await runCliRuntime<OpenCodeEvent>({
+      runtimeTag: "OpenCodeRuntime",
       command: this.config.command ?? "opencode",
       args,
       cwd: context.workspace.path,
       env,
-      abortSignal: context.abort_signal,
-      onSpawn: ({ pid, process_group_id }) => {
-        context.onSpawn?.({ process_pid: pid, process_group_id });
-      },
-      onLog: stdout.onLog,
+      context,
+      parseLine: parseOpenCodeEventLine,
+      extractSteps: extractOpenCodeStepEvents,
     });
-    stdout.flush();
-
-    warnIfTruncated("OpenCodeRuntime", result);
 
     if (result.aborted) return cancelledResult(result);
 

--- a/packages/core/src/adapters/runtime-common.ts
+++ b/packages/core/src/adapters/runtime-common.ts
@@ -1,5 +1,10 @@
 import { tmpdir } from "node:os";
-import type { RuntimeContext, RuntimeHealth, RuntimeResult } from "../ports/runtime.js";
+import type {
+  RuntimeContext,
+  RuntimeHealth,
+  RuntimeResult,
+  RuntimeStep,
+} from "../ports/runtime.js";
 import { type CliProcessResult, runCliProcess } from "./claude-code/spawn.js";
 
 /**
@@ -166,6 +171,89 @@ export function createStdoutLineReader(handleLine: (line: string) => void): {
 export function warnIfTruncated(runtimeTag: string, result: CliProcessResult): void {
   if (!result.truncated) return;
   console.warn(`[${runtimeTag}] stdout truncated at 4MB — result parsing may be incomplete`);
+}
+
+export interface CliRuntimeRunOptions<TEvent> {
+  /** Log tag for the truncation warning, e.g. `"CodexRuntime"`. */
+  runtimeTag: string;
+  command: string;
+  args: string[];
+  cwd: string;
+  env: Record<string, string | undefined>;
+  /**
+   * Fed to the CLI's stdin. Only claude-code uses this (it pipes the intent
+   * rather than passing it on argv); `undefined` is what the other adapters
+   * already produced by omitting the field, and `runCliProcess` guards the
+   * write on `!== undefined`, so passing it through unconditionally is
+   * behaviour-preserving for them.
+   */
+  stdin?: string;
+  context: RuntimeContext;
+  /** Provider-specific NDJSON line parser, e.g. `parseCodexEventLine`. */
+  parseLine: (line: string) => TEvent | null;
+  /** Provider-specific step extractor, e.g. `extractCodexStepEvents`. */
+  extractSteps: (event: TEvent) => readonly RuntimeStep[];
+}
+
+export interface CliRuntimeRun<TEvent> {
+  /** Every event the parser accepted, in stream order. */
+  events: TEvent[];
+  result: CliProcessResult;
+}
+
+/**
+ * Spawn a CLI runtime, stream-parse its NDJSON stdout, and collect the events.
+ *
+ * All three CLI adapters run the identical scaffolding around their own
+ * `parseLine` / `extractSteps` pair: accumulate every parsed event into an
+ * array for the post-hoc `parse*Events` call, forward each one's steps to
+ * `context.onStep` as they arrive, wire `onSpawn` through to the pid/pgid
+ * shape the executor persists, flush the trailing partial line, and warn on
+ * truncation. Only the two provider-specific functions and the argv actually
+ * differed, so the scaffolding lives here and the adapters pass those in.
+ *
+ * Deliberately stops short of the final `parse*Events` call: each adapter
+ * feeds that different extra arguments (codex passes its
+ * `--output-last-message` file) and codex has cleanup to do on the aborted
+ * path, so the caller keeps ownership of turning events into a
+ * `RuntimeResult` via {@link cancelledResult} / {@link finalizeCliResult}.
+ */
+export async function runCliRuntime<TEvent>(
+  opts: CliRuntimeRunOptions<TEvent>,
+): Promise<CliRuntimeRun<TEvent>> {
+  // Parse incrementally during streaming rather than re-parsing the whole of
+  // stdout after close. The line reader handles chunk boundaries — a single
+  // JSON event can arrive split across chunks.
+  const events: TEvent[] = [];
+  const stdout = createStdoutLineReader((line: string): void => {
+    const event = opts.parseLine(line);
+    if (!event) return;
+    events.push(event);
+    if (!opts.context.onStep) return;
+    for (const step of opts.extractSteps(event)) {
+      opts.context.onStep(step);
+    }
+  });
+
+  const result = await runCliProcess({
+    command: opts.command,
+    args: opts.args,
+    cwd: opts.cwd,
+    env: opts.env,
+    stdin: opts.stdin,
+    abortSignal: opts.context.abort_signal,
+    onSpawn: ({ pid, process_group_id }) => {
+      opts.context.onSpawn?.({ process_pid: pid, process_group_id });
+    },
+    onLog: stdout.onLog,
+  });
+
+  // Flush any final partial line (a stream that ends without a trailing \n).
+  stdout.flush();
+
+  warnIfTruncated(opts.runtimeTag, result);
+
+  return { events, result };
 }
 
 /**

--- a/packages/web/app/(authed)/rooms/[id]/room-detail-client.tsx
+++ b/packages/web/app/(authed)/rooms/[id]/room-detail-client.tsx
@@ -17,8 +17,8 @@ import { isApiConfigured } from "@/lib/api/config";
 import { api, type RoomDetail, type RoomMemberDetail, type RoomMessage } from "@/lib/api/client";
 import { ApiError, describeError } from "@/lib/api/http";
 import { queryKeys } from "@/lib/hooks/keys";
-import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
 import { ModalOverlay } from "@/components/modal-overlay";
+import { InlineFormError, ShareLinkBox, TextField } from "@/components/form-controls";
 import { ChatMarkdown } from "@/components/chat/markdown";
 import { ToolStepList } from "@/components/chat/tool-step-list";
 import { useChatStream, type ChatStreamStep } from "@/lib/chat-stream";
@@ -275,7 +275,6 @@ function InviteDialog({ roomId, onClose }: { roomId: string; onClose: () => void
   const [error, setError] = useState<string | null>(null);
   /** When the invitee doesn't have an account yet, surface a share link they can use to sign up + auto-join. */
   const [shareLink, setShareLink] = useState<string | null>(null);
-  const { copied, copy } = useCopyToClipboard();
 
   const invite = useMutation({
     mutationFn: () => api.rooms.invite(roomId, { email: email.trim() }),
@@ -317,43 +316,25 @@ function InviteDialog({ roomId, onClose }: { roomId: string; onClose: () => void
           Enter the invitee&apos;s email. If they already have a beevibe account they&apos;re
           added immediately. If not, you&apos;ll get a sign-up link to share.
         </p>
-        <input
+        <TextField
           type="email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           autoFocus
           placeholder="alice@example.com"
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
           disabled={invite.isPending}
         />
-        {error ? (
-          <div className="mt-2 text-xs text-status-failed flex items-start gap-1.5">
-            <AlertTriangle className="h-3 w-3 mt-0.5 shrink-0" />
-            <span>{error}</span>
-          </div>
-        ) : null}
+        {error ? <InlineFormError className="mt-2">{error}</InlineFormError> : null}
         {shareLink ? (
-          <div className="mt-3 rounded border border-border bg-muted/40 p-3">
-            <div className="text-[11px] text-muted-foreground mb-1.5">
-              No account for that email yet. Send them this link — they&apos;ll sign up and
-              land in this room.
-            </div>
-            <div className="flex items-center gap-1.5">
-              <input
-                readOnly
-                value={shareLink}
-                className="flex-1 rounded border border-border bg-background px-2 py-1.5 text-[11px] font-mono"
-                onFocus={(e) => e.currentTarget.select()}
-              />
-              <button
-                type="button"
-                onClick={() => void copy(shareLink ?? "")}
-                className="h-7 px-2.5 rounded text-[11px] font-medium border border-border hover:bg-secondary transition-colors cursor-pointer shrink-0"
-              >
-                {copied ? "Copied" : "Copy"}
-              </button>
-            </div>
-          </div>
+          <ShareLinkBox
+            blurb={
+              <>
+                No account for that email yet. Send them this link — they&apos;ll sign up and
+                land in this room.
+              </>
+            }
+            link={shareLink}
+          />
         ) : null}
         <div className="mt-4 flex items-center justify-end gap-2">
           <button

--- a/packages/web/app/(authed)/rooms/rooms-list-client.tsx
+++ b/packages/web/app/(authed)/rooms/rooms-list-client.tsx
@@ -10,6 +10,7 @@ import { isApiConfigured } from "@/lib/api/config";
 import { queryKeys } from "@/lib/hooks/keys";
 import { Skeleton } from "@/components/skeleton";
 import { EmptyState } from "@/components/empty-state";
+import { InlineFormError, TextField } from "@/components/form-controls";
 import { formatRelativeTime, shortId } from "@/lib/format";
 
 export function RoomsListClient() {
@@ -70,16 +71,13 @@ export function RoomsListClient() {
           className="mb-6 flex items-end gap-2 bg-card border border-border rounded-lg p-3"
         >
           <div className="flex-1">
-            <label htmlFor="room-name" className="block text-xs font-medium text-foreground mb-1.5">
-              Create a new room
-            </label>
-            <input
+            <TextField
               id="room-name"
+              label="Create a new room"
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="e.g. Plan the M9 launch"
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
               disabled={create.isPending}
             />
           </div>
@@ -92,12 +90,7 @@ export function RoomsListClient() {
             Create
           </button>
         </form>
-        {error ? (
-          <div className="mb-4 flex items-start gap-1.5 text-xs text-status-failed">
-            <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>{error}</span>
-          </div>
-        ) : null}
+        {error ? <InlineFormError className="mb-4">{error}</InlineFormError> : null}
 
         <h2 className="text-[11px] uppercase tracking-wider text-muted-foreground mb-2 font-medium">
           Your rooms

--- a/packages/web/app/sign-in/sign-in-client.tsx
+++ b/packages/web/app/sign-in/sign-in-client.tsx
@@ -3,7 +3,8 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { AlertTriangle, KeyRound, Loader2, LogIn } from "lucide-react";
+import { KeyRound, Loader2, LogIn } from "lucide-react";
+import { InlineFormError, TextField } from "@/components/form-controls";
 import { SIGNIN_NO_PASSWORD_SET } from "@beevibe/core/auth/constants";
 import { api } from "@/lib/api/client";
 import { asApiError } from "@/lib/api/http";
@@ -139,11 +140,9 @@ export function SignInClient() {
 
         {mode === "password" ? (
           <>
-            <label className="block text-xs font-medium text-foreground mb-1.5" htmlFor="email">
-              Email
-            </label>
-            <input
+            <TextField
               id="email"
+              label="Email"
               type="email"
               autoComplete="email"
               inputMode="email"
@@ -151,50 +150,38 @@ export function SignInClient() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="alice@example.com"
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
               disabled={submitting}
             />
 
-            <label className="block text-xs font-medium text-foreground mb-1.5 mt-3" htmlFor="password">
-              Password
-            </label>
-            <input
+            <TextField
               id="password"
+              label="Password"
+              labelClassName="mt-3"
               type="password"
               autoComplete="current-password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               placeholder="••••••••"
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
               disabled={submitting}
             />
           </>
         ) : (
-          <>
-            <label className="block text-xs font-medium text-foreground mb-1.5" htmlFor="key">
-              User API key
-            </label>
-            <input
-              id="key"
-              type="password"
-              autoComplete="off"
-              autoFocus
-              spellCheck={false}
-              value={keyDraft}
-              onChange={(e) => setKeyDraft(e.target.value)}
-              placeholder="bv_u_..."
-              className="w-full rounded border border-border bg-background px-3 py-2 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-ring"
-              disabled={submitting}
-            />
-          </>
+          <TextField
+            id="key"
+            label="User API key"
+            type="password"
+            autoComplete="off"
+            autoFocus
+            spellCheck={false}
+            value={keyDraft}
+            onChange={(e) => setKeyDraft(e.target.value)}
+            placeholder="bv_u_..."
+            className="font-mono"
+            disabled={submitting}
+          />
         )}
 
-        {error ? (
-          <div className="mt-3 flex items-start gap-1.5 text-xs text-status-failed">
-            <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>{error}</span>
-          </div>
-        ) : null}
+        {error ? <InlineFormError className="mt-3">{error}</InlineFormError> : null}
 
         <button
           type="submit"

--- a/packages/web/app/sign-up/sign-up-client.tsx
+++ b/packages/web/app/sign-up/sign-up-client.tsx
@@ -3,11 +3,12 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { AlertTriangle, Loader2, Sparkles, UserPlus } from "lucide-react";
+import { Loader2, Sparkles, UserPlus } from "lucide-react";
 import { PASSWORD_MIN_LENGTH } from "@beevibe/core/auth/constants";
 import { api } from "@/lib/api/client";
 import { asApiError } from "@/lib/api/http";
 import { getUserKey, isApiConfigured, setUserKey } from "@/lib/api/config";
+import { InlineFormError, TextField } from "@/components/form-controls";
 
 /**
  * Self-serve signup. Visitor enters name + email; the api mints them a
@@ -104,57 +105,45 @@ export function SignUpClient() {
           </p>
         </header>
 
-        <label className="block text-xs font-medium text-foreground mb-1.5" htmlFor="name">
-          Name
-        </label>
-        <input
+        <TextField
           id="name"
+          label="Name"
           type="text"
           autoComplete="name"
           autoFocus
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="Alice"
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
           disabled={submitting}
         />
 
-        <label className="block text-xs font-medium text-foreground mb-1.5 mt-3" htmlFor="email">
-          Email
-        </label>
-        <input
+        <TextField
           id="email"
+          label="Email"
+          labelClassName="mt-3"
           type="email"
           autoComplete="email"
           inputMode="email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           placeholder="alice@example.com"
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
           disabled={submitting}
         />
 
-        <label className="block text-xs font-medium text-foreground mb-1.5 mt-3" htmlFor="password">
-          Password
-        </label>
-        <input
+        <TextField
           id="password"
+          label="Password"
+          labelClassName="mt-3"
           type="password"
           autoComplete="new-password"
           minLength={PASSWORD_MIN_LENGTH}
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           placeholder={`at least ${PASSWORD_MIN_LENGTH} characters`}
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
           disabled={submitting}
         />
 
-        {error ? (
-          <div className="mt-3 flex items-start gap-1.5 text-xs text-status-failed">
-            <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>{error}</span>
-          </div>
-        ) : null}
+        {error ? <InlineFormError className="mt-3">{error}</InlineFormError> : null}
 
         <button
           type="submit"

--- a/packages/web/components/form-controls.tsx
+++ b/packages/web/components/form-controls.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+import type { InputHTMLAttributes, ReactNode } from "react";
+import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
+import { cn } from "@/lib/utils";
+
+/**
+ * The hand-written form controls, in one place.
+ *
+ * The app has no component library — controls are Tailwind class strings
+ * written inline at each call site. That is fine until the same string is
+ * written ten times: the sign-in / sign-up forms, the two invite dialogs and
+ * the room-create form all spelled out the identical input chrome, and the
+ * three inline error rows were byte-identical bar their margin. Restyling a
+ * field then meant finding every copy, and a missed one drifted silently.
+ *
+ * These are deliberately thin — a class constant and the two or three
+ * elements that always travel together — not a general design system. The
+ * richer controls that already have a home (`chip.tsx`, the pickers'
+ * `PICKER_SELECT_CLASS`, `ModalOverlay`, `MutationError`) stay where they
+ * are; this covers the plain form primitives that had none.
+ */
+
+/**
+ * Text-input chrome shared by every plain form field. Pass extra classes
+ * through `TextField`'s `className` — it merges via `cn`, so a caller can
+ * add `font-mono` or override a single property without restating the rest.
+ */
+export const FIELD_INPUT_CLASS =
+  "w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring";
+
+/** Label chrome for a {@link TextField}. */
+export const FIELD_LABEL_CLASS = "block text-xs font-medium text-foreground mb-1.5";
+
+/**
+ * A labelled text input, rendered as a bare `<label>` + `<input>` pair (no
+ * wrapper element) so it drops into the existing forms without changing
+ * their layout — the forms space their fields with `mt-3` on the *label*,
+ * which `labelClassName` carries.
+ *
+ * `label` is optional: the invite dialogs have a single self-evident field
+ * and render the input alone.
+ */
+export function TextField({
+  label,
+  labelClassName,
+  className,
+  id,
+  ...input
+}: {
+  label?: ReactNode;
+  /** Extra classes for the label — in practice the `mt-3` field spacing. */
+  labelClassName?: string;
+} & InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <>
+      {label ? (
+        <label className={cn(FIELD_LABEL_CLASS, labelClassName)} htmlFor={id}>
+          {label}
+        </label>
+      ) : null}
+      <input id={id} className={cn(FIELD_INPUT_CLASS, className)} {...input} />
+    </>
+  );
+}
+
+/**
+ * The warning-triangle error row a form shows under its fields.
+ *
+ * Callers own the margin (`mt-3` under a field, `mb-4` under a form) and
+ * pass it via `className`, because it depends on what the row sits between.
+ */
+export function InlineFormError({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className={cn("flex items-start gap-1.5 text-xs text-status-failed", className)}>
+      <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+      <span>{children}</span>
+    </div>
+  );
+}
+
+/**
+ * The "here's a link to send them" panel both invite dialogs show once the
+ * invitee turns out not to have an account: a read-only, select-on-focus
+ * input holding the URL, and a Copy button that flashes "Copied".
+ *
+ * Owns its own {@link useCopyToClipboard} — both call sites used the hook
+ * for this and nothing else, so the flash state belongs with the button
+ * rather than with the dialog.
+ *
+ * `blurb` differs between the two (the room dialog explains they'll land in
+ * the room), so it stays a prop.
+ */
+export function ShareLinkBox({ blurb, link }: { blurb: ReactNode; link: string }) {
+  const { copied, copy } = useCopyToClipboard();
+  return (
+    <div className="mt-3 rounded border border-border bg-muted/40 p-3">
+      <div className="text-[11px] text-muted-foreground mb-1.5">{blurb}</div>
+      <div className="flex items-center gap-1.5">
+        <input
+          readOnly
+          value={link}
+          className="flex-1 rounded border border-border bg-background px-2 py-1.5 text-[11px] font-mono"
+          onFocus={(e) => e.currentTarget.select()}
+        />
+        <button
+          type="button"
+          onClick={() => void copy(link)}
+          className="h-7 px-2.5 rounded text-[11px] font-medium border border-border hover:bg-secondary transition-colors cursor-pointer shrink-0"
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/components/user-widget.tsx
+++ b/packages/web/components/user-widget.tsx
@@ -14,8 +14,8 @@ import {
 } from "lucide-react";
 import { useMe } from "@/lib/hooks/use-me";
 import { useDismissOnOutside } from "@/lib/hooks/use-dismiss";
-import { useCopyToClipboard } from "@/lib/hooks/use-copy-to-clipboard";
 import { ModalOverlay } from "@/components/modal-overlay";
+import { ShareLinkBox, TextField } from "@/components/form-controls";
 import { clearUserKey } from "@/lib/api/config";
 import { cn } from "@/lib/utils";
 import { Avatar } from "@/components/avatar";
@@ -148,7 +148,6 @@ function MenuItem({
 
 function InviteTeammateDialog({ onClose }: { onClose: () => void }) {
   const [email, setEmail] = useState("");
-  const { copied, copy } = useCopyToClipboard();
   const trimmed = email.trim().toLowerCase();
   const valid = EMAIL_RE.test(trimmed);
   const origin = typeof window !== "undefined" ? window.location.origin : "";
@@ -164,35 +163,15 @@ function InviteTeammateDialog({ onClose }: { onClose: () => void }) {
           Share a sign-up link. When they sign up, they get their own team
           agent — then you can pull them into rooms with you.
         </p>
-        <input
+        <TextField
           type="email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           autoFocus
           placeholder="alice@example.com"
-          className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
         />
         {shareLink ? (
-          <div className="mt-3 rounded border border-border bg-muted/40 p-3">
-            <div className="text-[11px] text-muted-foreground mb-1.5">
-              Send them this link:
-            </div>
-            <div className="flex items-center gap-1.5">
-              <input
-                readOnly
-                value={shareLink}
-                className="flex-1 rounded border border-border bg-background px-2 py-1.5 text-[11px] font-mono"
-                onFocus={(e) => e.currentTarget.select()}
-              />
-              <button
-                type="button"
-                onClick={() => void copy(shareLink)}
-                className="h-7 px-2.5 rounded text-[11px] font-medium border border-border hover:bg-secondary transition-colors cursor-pointer shrink-0"
-              >
-                {copied ? "Copied" : "Copy"}
-              </button>
-            </div>
-          </div>
+          <ShareLinkBox blurb="Send them this link:" link={shareLink} />
         ) : null}
         <div className="mt-4 flex items-center justify-end gap-2">
           <button


### PR DESCRIPTION
Swept the monorepo for near-duplicate abstractions and unified the two clusters that were still worth merging. Both commits are behaviour-preserving and reviewable independently.

## 1. `refactor(core)`: unify the CLI runtimes' spawn + stream-parse scaffolding

`runtime-common.ts` already exists to hold what's identical across the three CLI adapters, but it stopped at the leaf helpers. The whole *sequence* those helpers get called in was still copied three times in `execute()`:

- accumulate parsed events for the post-hoc `parse*Events` call
- forward each event's steps to `context.onStep` as they arrive
- adapt `onSpawn` to the `pid`/`pgid` shape the executor persists
- flush the trailing partial line, then warn on truncation

Only the provider-specific `parseLine`/`extractSteps` pair and the argv actually differed. That's now `runCliRuntime()`, which the adapters call with their own two functions.

It deliberately stops short of the final `parse*Events` call — codex feeds that its `--output-last-message` file and has cleanup to do on the aborted path — so each adapter keeps ownership of turning events into a `RuntimeResult`.

`stdin` is passed through unconditionally; `runCliProcess` already guards the write on `!== undefined`, so that matches what codex and opencode produced by omitting the field.

**Net: −59 lines across the three adapters.** The 70 existing adapter tests pass unchanged.

## 2. `refactor(web)`: unify the hand-written form controls

The app has no component library, so form controls are Tailwind class strings written inline. Three had accumulated copies:

| Duplicated | Copies | Where |
| --- | --- | --- |
| Text-input chrome | 10, across 5 files | both auth forms, both invite dialogs, room-create form |
| Warning-triangle error row | 3, byte-identical bar the margin | `sign-in`, `sign-up`, `rooms-list` |
| Share-link panel (read-only select-on-focus input + Copy button) | 2, identical bar the blurb | `user-widget`, `room-detail` |

New `components/form-controls.tsx` provides `TextField`, `InlineFormError` and `ShareLinkBox`, adopted at all ten call sites. `ShareLinkBox` owns its own `useCopyToClipboard` — both dialogs used the hook for this and nothing else, so the flash state moves next to the button it drives.

These are deliberately thin, not a design system. Controls that already have a home (`chip.tsx`, the pickers' `PICKER_SELECT_CLASS`, `ModalOverlay`, `MutationError`) are untouched.

**One intentional visual change:** the room invite dialog's error icon was `h-3` where the other three were `h-3.5`; it now matches. Otherwise the rendered markup is unchanged — `TextField` emits a bare `label`+`input` pair (no wrapper), so the forms' `mt-3` field spacing survives verbatim.

## Not changed, and why

The codebase has been swept before, and most of what a duplicate-detector flags is already unified or is a documented false positive:

- **Runtime `stream-json.ts` parsers** — genuinely different event schemas; `runtime-common.ts` already says these must stay separate.
- **Agent pickers** (`chip-popover.tsx`, `picker-card.tsx`), **route error handling** (`http-errors.ts`), **view formatters** (`format.ts`, `agent-display.ts`), **skeletons** — already extracted, with good adoption.
- **`welcome-client`'s error banner** — looks similar but is a bordered card, a different visual; left alone rather than forced into `InlineFormError`.
- **Detail-page `loading.tsx` files** — 5 files share a skeleton shell, but each differs enough below the header that parameterising it would cost more than it saves.
- **`api`/`scheduler` `bootstrap.ts` + `main.ts`** — overlap is the wiring order of shared services, not logic. Merging them would couple two deployables that are deliberately separate.

## Validation

- `pnpm typecheck` — clean (9/9)
- `pnpm lint` — 0 errors (remaining warnings are pre-existing `import/no-duplicates` in untouched files)
- `pnpm --filter @beevibe/web exec next build` — succeeds
- 203 web tests pass; 70 runtime-adapter tests pass
- Remaining core test failures are the documented sandbox baseline (no Postgres, no provider keys) and are in `openai`/`anthropic`/`postgres` files only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RD77S3j5f9iiwA8BSrAJi8

---
_Generated by [Claude Code](https://claude.ai/code/session_01RD77S3j5f9iiwA8BSrAJi8)_