### PR TITLE
test: drop a zero-signal test, repair a tautological one

### DIFF
--- a/packages/api/src/views/agent-network.test.ts
+++ b/packages/api/src/views/agent-network.test.ts
@@ -101,7 +101,10 @@ describe("getAgentNetwork", () => {
     });
   });
 
-  it("groups peer rows by owner_id into AgentPeerOwner[]", async () => {
+  // Peer rows arrive sorted (team first, then ICs). Grouping must not
+  // shuffle; the UI relies on team-at-index-0 for orbit centers — hence
+  // the ordered `agents.map(...)` assertion rather than a bare length.
+  it("groups peer rows by owner_id into AgentPeerOwner[], preserving SQL row order", async () => {
     const pool = makeMockPool([
       [],
       [peerTeamDaniel, peerIcDaniel, peerTeamBob],
@@ -113,19 +116,8 @@ describe("getAgentNetwork", () => {
     expect(daniel?.owner_label).toBe("Daniel");
     expect(daniel?.agents).toHaveLength(2);
     expect(daniel?.agents.map((a) => a.id)).toEqual(["agt_d_team", "agt_d_ic"]);
+    expect(daniel?.agents.map((a) => a.hierarchy)).toEqual(["team", "ic"]);
     expect(bob?.owner_label).toBe("bob");
     expect(bob?.agents).toHaveLength(1);
-  });
-
-  it("preserves SQL row order within each peer-owner bucket", async () => {
-    // Peer rows arrive sorted (team first, then ICs). Grouping must
-    // not shuffle; the UI relies on team-at-index-0 for orbit centers.
-    const pool = makeMockPool([
-      [],
-      [peerTeamDaniel, peerIcDaniel],
-    ]);
-    const { peers } = await getAgentNetwork(pool, "per_w");
-    expect(peers[0]?.agents[0]?.hierarchy).toBe("team");
-    expect(peers[0]?.agents[1]?.hierarchy).toBe("ic");
   });
 });

--- a/packages/api/src/views/dashboard.test.ts
+++ b/packages/api/src/views/dashboard.test.ts
@@ -254,27 +254,33 @@ describe("getDashboardSummary", () => {
     });
   });
 
-  it("fires all 7 queries in parallel (single Promise.all)", async () => {
-    const calls: number[] = [];
-    let next = 0;
+  it("issues every query before awaiting any of them (single Promise.all)", async () => {
+    // Hold every query open on one gate. Under `Promise.all` the whole
+    // fan-out is issued before the first result lands, so the call count
+    // at gate time equals the final count. Awaiting the queries one at a
+    // time would stall on the first and leave the rest unissued.
+    let openGate: () => void = () => undefined;
+    const gate = new Promise<void>((resolve) => {
+      openGate = resolve;
+    });
     const query = vi.fn(async (sql: unknown) => {
-      const i = next++;
-      calls.push(i);
-      // First-issued query resolves last to prove they were issued together,
-      // not awaited sequentially.
-      await new Promise((r) => setTimeout(r, i === 0 ? 10 : 0));
       const sqlText = String(sql);
+      await gate;
       if (sqlText.includes("FROM days") && sqlText.includes("active_sessions")) return { rows: makeKpiTrendRows() };
       if (sqlText.includes("FROM days")) return { rows: makeTrendRows() };
-      if (sqlText.includes("FROM agent")) return { rows: [] };
-      if (sqlText.includes("blocked', 'failed'")) return { rows: [] };
-      if (sqlText.includes("usage IS NOT NULL")) return { rows: [] };
       return { rows: [] };
     });
     const pool = { query } as unknown as Pool;
-    await getDashboardSummary(pool);
-    expect(calls).toEqual([0, 1, 2, 3, 4, 5, 6]);
-    expect(query).toHaveBeenCalledTimes(7);
+
+    const pending = getDashboardSummary(pool);
+    // Let the synchronous fan-out run without resolving a single query.
+    await Promise.resolve();
+    const issuedBeforeAnyResolved = query.mock.calls.length;
+    openGate();
+    await pending;
+
+    expect(issuedBeforeAnyResolved).toBeGreaterThan(1);
+    expect(issuedBeforeAnyResolved).toBe(query.mock.calls.length);
   });
 });
 

--- a/packages/scheduler/src/worker.test.ts
+++ b/packages/scheduler/src/worker.test.ts
@@ -36,7 +36,6 @@ import {
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { DEFAULT_TASK_CAP } from "@beevibe/core";
 import { createTestPool, truncateAll } from "@beevibe/core/test-helpers";
 import {
   DEFAULT_POLL_MS,
@@ -481,9 +480,5 @@ describe("TaskExecutionWorker (Phase 4 — session-based claim)", () => {
     } finally {
       vi.useRealTimers();
     }
-  });
-
-  it("DEFAULT_TASK_CAP is 1", () => {
-    expect(DEFAULT_TASK_CAP).toBe(1);
   });
 });


### PR DESCRIPTION
Sweep of the whole test suite for tests that no longer earn their keep — skipped/disabled without reason, targeting removed code, assertion-free, or asserting implementation detail rather than behavior. Three changes came out of it; everything else came back clean.

## Candidates removed / repaired

| File | Test | Why |
| --- | --- | --- |
| `packages/api/src/views/dashboard.test.ts` | `fires all 7 queries in parallel (single Promise.all)` | **Asserted nothing about parallelism.** It recorded call order into an array, but `calls.push(i)` runs synchronously at call time, so the sequence is `[0..6]` whether the queries are issued together or awaited one at a time. `toHaveBeenCalledTimes(7)` was a query-count change-detector. Verified by mutation: rewriting `getDashboardSummary` to `await` each query in turn left the test green. **Rewritten**, not deleted — the new version holds every query on one gate and asserts the whole fan-out is issued before any result lands. It fails on that same sequential rewrite (`expected 1 to be greater than 1`) and no longer hard-codes the query count. |
| `packages/api/src/views/agent-network.test.ts` | `preserves SQL row order within each peer-owner bucket` | **Strictly subsumed** by the grouping test directly above it, which already asserts `daniel?.agents.map(a => a.id)` in order. Mutating the grouping to `unshift` failed both tests. Folded the hierarchy-order assertion and the comment explaining why order matters into the grouping test; dropped the duplicate. |
| `packages/scheduler/src/worker.test.ts` | `DEFAULT_TASK_CAP is 1` | **Restates a constant** the scheduler doesn't consume — its only production use is `session-repo.ts`. The behavior is already covered by `session-repo.test.ts` (`defaults to cap=1 when max_task_sessions is NULL`) and by the per-agent cap test in this same file. Dropped along with its now-unused import. |

## What came back clean

- **Skipped / disabled tests** — every one is env- or platform-gated with a documented opt-in, none are dormant: `RUN_CLAUDE_SMOKE` (referenced in `ci.yml` + `CONTRIBUTING.md`), `BEEVIBE_E2E_DOCKER`, `BEEVIBE_E2E_MULTI_INSTANCE`, live provider keys for `/mcp`, and `skipIf(win32)` on the workspace/spawn suites. No `.skip`, `.todo`, `.only`, or `xit` anywhere.
- **Tests for removed code** — `turbo run typecheck` passes across all nine tasks, so nothing references a deleted symbol. The seven test files whose name doesn't match a sibling module (`chat-internals`, `watch-fire.db`, `shell-quote`, …) are naming convention only; each subject exists.
- **Assertion-free tests** — a balanced-delimiter scan over every `it`/`test` body found zero.
- Scanned for weak-assertion-only tests, duplicate test names within a file, and test-only exported symbols. The hits were all legitimate: negative assertions (`not.toHaveBeenCalled`), same-named tests under different `describe` subjects, and deliberate test seams.

## Verification

- `turbo run typecheck lint` — clean (15/15 tasks).
- `packages/api` view suites: 164 pass, only the two `.db.test.ts` files fail on the documented no-Postgres sandbox baseline.
- Both edits mutation-checked: the rewritten dashboard test and the surviving agent-network test each fail against a deliberately broken implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bWqCQPmWauUhqFArfPWKr

---
_Generated by [Claude Code](https://claude.ai/code/session_014bWqCQPmWauUhqFArfPWKr)_