### PR TITLE
test(api): cover the five thinnest-tested modules on the agent surface (0-65% → 100% lines)

### DIFF
--- a/packages/api/src/routes/stream.test.ts
+++ b/packages/api/src/routes/stream.test.ts
@@ -1,0 +1,248 @@
+/**
+ * GET /api/stream — the browser SSE endpoint, driven over a real socket.
+ *
+ * supertest buffers until the response ends, and an SSE response never
+ * ends, so these tests bind an ephemeral port and read the wire directly.
+ * That is also the only way to check the parts that matter here: the
+ * priming `data: {}` frame (the client's health probe never trips
+ * without it), the per-person fanout filter, and the cleanup that
+ * unsubscribes and clears the heartbeat when a browser goes away — a
+ * leak there accumulates one live interval per reconnect.
+ */
+import { once } from "node:events";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import express, { type RequestHandler } from "express";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedCaller } from "@beevibe/core/auth";
+import { SseManager } from "../sse/manager.js";
+import { createStreamRouter } from "./stream.js";
+
+const PERSON = "person_1";
+const OTHER = "person_2";
+
+const HUMAN: ResolvedCaller = {
+  source: "human",
+  agentId: "agent_a",
+  hierarchyLevel: "ic",
+  personId: PERSON,
+};
+
+const AGENT: ResolvedCaller = {
+  source: "agent",
+  agentId: "agent_a",
+  hierarchyLevel: "ic",
+};
+
+function fakeAuth(caller: ResolvedCaller | undefined): RequestHandler {
+  return (req, _res, next) => {
+    req.caller = caller;
+    next();
+  };
+}
+
+interface Harness {
+  port: number;
+  sseManager: SseManager;
+  close: () => Promise<void>;
+}
+
+const servers: http.Server[] = [];
+
+async function startHarness(caller: ResolvedCaller | undefined): Promise<Harness> {
+  const sseManager = new SseManager();
+  const app = express();
+  app.use("/api", createStreamRouter({ authMiddleware: fakeAuth(caller), sseManager }));
+  const server = app.listen(0);
+  servers.push(server);
+  await once(server, "listening");
+  return {
+    port: (server.address() as AddressInfo).port,
+    sseManager,
+    close: async () => {
+      server.closeAllConnections();
+      server.close();
+    },
+  };
+}
+
+interface Connection {
+  status: number;
+  headers: http.IncomingHttpHeaders;
+  /** Everything received so far. */
+  body: () => string;
+  waitFor: (needle: string) => Promise<void>;
+  disconnect: () => void;
+}
+
+function connect(port: number): Promise<Connection> {
+  return new Promise((resolve, reject) => {
+    const req = http.get(
+      { host: "127.0.0.1", port, path: "/api/stream" },
+      (res) => {
+        let buf = "";
+        const waiters: Array<{ needle: string; resolve: () => void }> = [];
+        res.setEncoding("utf8");
+        res.on("data", (chunk: string) => {
+          buf += chunk;
+          for (let i = waiters.length - 1; i >= 0; i--) {
+            if (buf.includes(waiters[i]!.needle)) {
+              waiters[i]!.resolve();
+              waiters.splice(i, 1);
+            }
+          }
+        });
+        resolve({
+          status: res.statusCode ?? 0,
+          headers: res.headers,
+          body: () => buf,
+          waitFor: (needle) =>
+            new Promise<void>((ok) => {
+              if (buf.includes(needle)) return ok();
+              waiters.push({ needle, resolve: ok });
+            }),
+          disconnect: () => req.destroy(),
+        });
+      },
+    );
+    req.on("error", reject);
+  });
+}
+
+/** Let the event loop drain queued socket writes. */
+const tick = () => new Promise((r) => setImmediate(r));
+
+afterEach(() => {
+  vi.useRealTimers();
+  for (const server of servers.splice(0)) {
+    server.closeAllConnections();
+    server.close();
+  }
+});
+
+describe("GET /api/stream auth", () => {
+  it("rejects an agent caller with 403 and never subscribes it", async () => {
+    const h = await startHarness(AGENT);
+
+    const res = await fetch(`http://127.0.0.1:${h.port}/api/stream`);
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ error: "human_required" });
+    expect(h.sseManager.size()).toBe(0);
+  });
+
+  it("rejects an unauthenticated request with 403", async () => {
+    const h = await startHarness(undefined);
+
+    const res = await fetch(`http://127.0.0.1:${h.port}/api/stream`);
+
+    expect(res.status).toBe(403);
+    expect(h.sseManager.size()).toBe(0);
+  });
+});
+
+describe("GET /api/stream fanout", () => {
+  it("opens an un-buffered event-stream and primes it with an empty data frame", async () => {
+    const h = await startHarness(HUMAN);
+
+    const conn = await connect(h.port);
+    await conn.waitFor("data: {}");
+
+    expect(conn.status).toBe(200);
+    expect(conn.headers["content-type"]).toBe("text/event-stream");
+    expect(conn.headers["cache-control"]).toBe("no-cache, no-transform");
+    expect(conn.headers["x-accel-buffering"]).toBe("no");
+    // A comment line would not fire the browser's onmessage.
+    expect(conn.body()).toBe("data: {}\n\n");
+
+    conn.disconnect();
+    await h.close();
+  });
+
+  it("writes events owned by the connected person as SSE data frames", async () => {
+    const h = await startHarness(HUMAN);
+    const conn = await connect(h.port);
+    await conn.waitFor("data: {}");
+
+    const event = { event: "task.updated", id: "task_1", data: { status: "done" } };
+    h.sseManager.publish(event, new Set([PERSON]));
+    await conn.waitFor("task.updated");
+
+    expect(conn.body()).toBe(`data: {}\n\ndata: ${JSON.stringify(event)}\n\n`);
+
+    conn.disconnect();
+    await h.close();
+  });
+
+  it("does not write events owned by a different person", async () => {
+    const h = await startHarness(HUMAN);
+    const conn = await connect(h.port);
+    await conn.waitFor("data: {}");
+
+    h.sseManager.publish({ event: "task.updated", id: "task_9" }, new Set([OTHER]));
+    await tick();
+
+    expect(conn.body()).toBe("data: {}\n\n");
+
+    conn.disconnect();
+    await h.close();
+  });
+
+  it("registers exactly one subscriber per connection", async () => {
+    const h = await startHarness(HUMAN);
+
+    const a = await connect(h.port);
+    await a.waitFor("data: {}");
+    const b = await connect(h.port);
+    await b.waitFor("data: {}");
+
+    expect(h.sseManager.size()).toBe(2);
+
+    a.disconnect();
+    b.disconnect();
+    await h.close();
+  });
+});
+
+describe("GET /api/stream lifecycle", () => {
+  it("unsubscribes when the browser disconnects", async () => {
+    const h = await startHarness(HUMAN);
+    const conn = await connect(h.port);
+    await conn.waitFor("data: {}");
+    expect(h.sseManager.size()).toBe(1);
+
+    conn.disconnect();
+    for (let i = 0; i < 50 && h.sseManager.size() > 0; i++) await tick();
+
+    expect(h.sseManager.size()).toBe(0);
+    await h.close();
+  });
+
+  it("sends a heartbeat comment every 25s and clears the timer on disconnect", async () => {
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    const clearSpy = vi.spyOn(globalThis, "clearInterval");
+    const h = await startHarness(HUMAN);
+    const conn = await connect(h.port);
+    await conn.waitFor("data: {}");
+
+    await vi.advanceTimersByTimeAsync(25_000);
+    await tick();
+    expect(conn.body()).toBe("data: {}\n\n: heartbeat\n\n");
+
+    await vi.advanceTimersByTimeAsync(25_000);
+    await tick();
+    expect(conn.body()).toBe("data: {}\n\n: heartbeat\n\n: heartbeat\n\n");
+
+    conn.disconnect();
+    for (let i = 0; i < 50 && h.sseManager.size() > 0; i++) await tick();
+    expect(clearSpy).toHaveBeenCalled();
+
+    // No further heartbeats once the connection is gone.
+    const settled = conn.body();
+    await vi.advanceTimersByTimeAsync(50_000);
+    await tick();
+    expect(conn.body()).toBe(settled);
+
+    await h.close();
+  });
+});

--- a/packages/api/src/tools/mesh.test.ts
+++ b/packages/api/src/tools/mesh.test.ts
@@ -1,14 +1,30 @@
 /**
- * Mesh tool assembly tests — IC vs team tier gating.
+ * Mesh tools — tier gating plus per-handler behavior, with vitest fakes
+ * (no DB, no spawned CLI).
  *
- * Per-tool handler behavior is covered indirectly by the m6/m7 e2e scripts
- * (mesh flows require live Postgres + spawned CLI subprocesses). This file
- * locks the static tier inventory — the exact tool *names* each tier gets,
- * so future skill-loader work can rely on the surface being stable.
+ * The tier inventory locks the exact tool *names* each tier gets, so
+ * future skill-loader work can rely on the surface being stable. The
+ * handler tests below cover what the m6/m7 e2e scripts can't cheaply
+ * reach: the argument coercion each handler does before it touches the
+ * MeshServer, the ordering the escalation path depends on (create →
+ * sentinel-unblock → pg_notify), and the coded-error envelope agents
+ * branch on — a MAX_ROUNDS_EXCEEDED that degrades to the generic shape
+ * sends the agent back into a negotiation the server will refuse.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentRepository, TaskRepository } from "@beevibe/core";
 import type { ResolvedCaller } from "@beevibe/core/auth";
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import type { EscalationService } from "@beevibe/core/services/escalation-service";
+import type { TaskService } from "@beevibe/core/services/task-service";
+import type { MeshServer } from "../mesh/server.js";
+import {
+  CannotNegotiateWithIcError,
+  MeshCapacityError,
+  MeshMaxRoundsError,
+} from "../mesh/types.js";
 import { buildIcMeshTools, buildTeamMeshTools, type MeshToolServices } from "./mesh.js";
+import type { AgentTool } from "./types.js";
 
 // Fake services — the assembly itself doesn't invoke handlers, so the
 // dependencies just need to be the right shape.
@@ -45,5 +61,606 @@ describe("buildTeamMeshTools", () => {
       "respond_ask",
       "respond_negotiate",
     ]);
+  });
+});
+
+// ── Handler fakes ────────────────────────────────────────────────────────
+
+interface Overrides {
+  mesh?: Partial<MeshServer>;
+  agentRepo?: Partial<AgentRepository>;
+  taskService?: Partial<TaskService>;
+  escalationService?: Partial<EscalationService>;
+  pool?: Partial<Pool>;
+}
+
+function buildServices(overrides: Overrides = {}) {
+  const mesh = {
+    sendAsk: vi.fn(async (requestId: string, _from: string, to: string) => ({
+      request_id: requestId,
+      from_agent_id: to,
+      answer: "yes, feasible",
+    })),
+    respondAsk: vi.fn(),
+    sendNegotiate: vi.fn(async () => ({
+      negotiation_id: "neg_1",
+      from_agent_id: "agent_peer",
+      decision: "counter" as const,
+      message: "how about this",
+      counter_proposal: "do it next sprint",
+    })),
+    respondNegotiate: vi.fn(async () => null),
+    unblockOnEscalate: vi.fn(),
+    reportBlocker: vi.fn(),
+    ...overrides.mesh,
+  } as unknown as MeshServer;
+
+  const agentRepo = {
+    findParent: vi.fn(async () => ({ id: "agent_parent" })),
+    ...overrides.agentRepo,
+  } as unknown as AgentRepository;
+
+  const taskService = {
+    markBlocked: vi.fn(async () => undefined),
+    ...overrides.taskService,
+  } as unknown as TaskService;
+
+  const escalationService = {
+    create: vi.fn(async () => ({
+      id: "esc_1",
+      status: "pending",
+      negotiation_id: "neg_1",
+    })),
+    ...overrides.escalationService,
+  } as unknown as EscalationService;
+
+  const pool = {
+    query: vi.fn(async () => ({ rows: [] })),
+    ...overrides.pool,
+  } as unknown as Pool;
+
+  return {
+    mesh,
+    agentRepo,
+    taskRepo: {} as unknown as TaskRepository,
+    taskService,
+    escalationService,
+    pool,
+  } satisfies MeshToolServices;
+}
+
+function build(overrides: Overrides = {}) {
+  const services = buildServices(overrides);
+  const tools = buildTeamMeshTools(fakeCtx, services);
+  const tool = (name: string): AgentTool => {
+    const found = tools.find((t) => t.name === name);
+    if (!found) throw new Error(`no tool named ${name}`);
+    return found;
+  };
+  return { services, tool };
+}
+
+// ── ask / respond_ask ────────────────────────────────────────────────────
+
+describe("ask", () => {
+  it("mints a request id, forwards the question and projects the answer", async () => {
+    const { services, tool } = build();
+
+    const result = await tool("ask").handler({
+      target_agent_id: "agent_peer",
+      question: "is X feasible?",
+    });
+
+    const [requestId, from, to, question] = vi.mocked(services.mesh.sendAsk).mock
+      .calls[0]!;
+    expect(requestId).toMatch(/^[0-9a-f-]{36}$/);
+    expect([from, to, question]).toEqual(["agent_x", "agent_peer", "is X feasible?"]);
+    expect(result.isError).toBeFalsy();
+    // Only the three wire fields — no internal state leaks to the agent.
+    expect(result.content).toEqual({
+      request_id: requestId,
+      from_agent_id: "agent_peer",
+      answer: "yes, feasible",
+    });
+  });
+
+  it.each([
+    ["a missing target", { question: "q" }],
+    ["a missing question", { target_agent_id: "agent_peer" }],
+    ["an empty target", { target_agent_id: "", question: "q" }],
+  ])("rejects %s without spawning the peer", async (_label, input) => {
+    const { services, tool } = build();
+
+    const result = await tool("ask").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "target_agent_id and question required",
+    });
+    expect(services.mesh.sendAsk).not.toHaveBeenCalled();
+  });
+
+  it("projects a MeshCapacityError with its code and meta", async () => {
+    const { tool } = build({
+      mesh: {
+        sendAsk: vi.fn(async () => {
+          throw new MeshCapacityError("at capacity", {
+            agentId: "agent_peer",
+            running: 3,
+            cap: 3,
+          });
+        }),
+      },
+    });
+
+    const result = await tool("ask").handler({
+      target_agent_id: "agent_peer",
+      question: "q",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "MESH_CAPACITY_EXCEEDED",
+      agentId: "agent_peer",
+      running: 3,
+      cap: 3,
+      message: "at capacity",
+    });
+  });
+});
+
+describe("respond_ask", () => {
+  it("unblocks the asker with the caller as the responder", async () => {
+    const { services, tool } = build();
+
+    const result = await tool("respond_ask").handler({
+      request_id: "req_1",
+      answer: "yes",
+    });
+
+    expect(services.mesh.respondAsk).toHaveBeenCalledWith("req_1", {
+      request_id: "req_1",
+      from_agent_id: "agent_x",
+      answer: "yes",
+    });
+    expect(result.content).toEqual({ responded: true, request_id: "req_1" });
+  });
+
+  it.each([
+    ["a missing request_id", { answer: "yes" }],
+    ["a missing answer", { request_id: "req_1" }],
+  ])("rejects %s", async (_label, input) => {
+    const { services, tool } = build();
+
+    const result = await tool("respond_ask").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(services.mesh.respondAsk).not.toHaveBeenCalled();
+  });
+
+  it("wraps a throw from the server in the generic error envelope", async () => {
+    const { tool } = build({
+      mesh: {
+        respondAsk: vi.fn(() => {
+          throw new Error("no waiter for req_1");
+        }),
+      },
+    });
+
+    const result = await tool("respond_ask").handler({
+      request_id: "req_1",
+      answer: "yes",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "no waiter for req_1" });
+  });
+});
+
+// ── negotiate / respond_negotiate ────────────────────────────────────────
+
+describe("negotiate", () => {
+  it("passes the optional task_id and the caller's session as originator metadata", async () => {
+    const { services, tool } = build();
+
+    const result = await tool("negotiate").handler({
+      peer_id: "agent_peer",
+      proposal: "ship friday",
+      task_id: "task_1",
+    });
+
+    expect(services.mesh.sendNegotiate).toHaveBeenCalledWith(
+      "agent_x",
+      "agent_peer",
+      "ship friday",
+      { taskId: "task_1", initiatorSessionId: "ses_x" },
+    );
+    expect(result.content).toEqual({
+      negotiation_id: "neg_1",
+      from_agent_id: "agent_peer",
+      decision: "counter",
+      message: "how about this",
+      counter_proposal: "do it next sprint",
+    });
+  });
+
+  it("omits an empty or non-string task_id rather than passing it through", async () => {
+    const { services, tool } = build();
+
+    await tool("negotiate").handler({ peer_id: "p", proposal: "x", task_id: "" });
+    await tool("negotiate").handler({ peer_id: "p", proposal: "x", task_id: 7 });
+
+    for (const call of vi.mocked(services.mesh.sendNegotiate).mock.calls) {
+      expect(call[3]).toEqual({ taskId: undefined, initiatorSessionId: "ses_x" });
+    }
+  });
+
+  it.each([
+    ["a missing peer", { proposal: "x" }],
+    ["a missing proposal", { peer_id: "agent_peer" }],
+  ])("rejects %s without spawning the peer", async (_label, input) => {
+    const { services, tool } = build();
+
+    const result = await tool("negotiate").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "peer_id and proposal required" });
+    expect(services.mesh.sendNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("projects the escalated sentinel shape when the peer escalated first", async () => {
+    const { tool } = build({
+      mesh: {
+        sendNegotiate: vi.fn(async () => ({
+          decision: "escalated" as const,
+          escalation_id: "esc_7",
+          negotiation_id: "neg_1",
+          message: "handed to humans",
+        })),
+      },
+    });
+
+    const result = await tool("negotiate").handler({ peer_id: "p", proposal: "x" });
+
+    expect(result.content).toEqual({
+      decision: "escalated",
+      escalation_id: "esc_7",
+      negotiation_id: "neg_1",
+      message: "handed to humans",
+    });
+  });
+
+  it("projects CannotNegotiateWithIcError with its code", async () => {
+    const { tool } = build({
+      mesh: {
+        sendNegotiate: vi.fn(async () => {
+          throw new CannotNegotiateWithIcError({ agentId: "agent_ic" });
+        }),
+      },
+    });
+
+    const result = await tool("negotiate").handler({ peer_id: "agent_ic", proposal: "x" });
+
+    expect(result.content).toMatchObject({
+      error: "CANNOT_NEGOTIATE_WITH_IC",
+      agentId: "agent_ic",
+    });
+  });
+});
+
+describe("respond_negotiate", () => {
+  it("reports terminal when the server has nothing further to return", async () => {
+    const { services, tool } = build();
+
+    const result = await tool("respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "accept",
+      message: "agreed",
+    });
+
+    expect(services.mesh.respondNegotiate).toHaveBeenCalledWith(
+      "neg_1",
+      {
+        negotiation_id: "neg_1",
+        from_agent_id: "agent_x",
+        decision: "accept",
+        message: "agreed",
+        counter_proposal: undefined,
+      },
+      "ses_x",
+    );
+    expect(result.content).toEqual({
+      negotiation_id: "neg_1",
+      decision: "accept",
+      terminal: true,
+    });
+  });
+
+  it("projects the peer's reply when the round continues", async () => {
+    const { tool } = build({
+      mesh: {
+        respondNegotiate: vi.fn(async () => ({
+          negotiation_id: "neg_1",
+          from_agent_id: "agent_peer",
+          decision: "counter" as const,
+          message: "not yet",
+          counter_proposal: "next sprint",
+        })),
+      },
+    });
+
+    const result = await tool("respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "ship friday",
+      counter_proposal: "or monday",
+    });
+
+    expect(result.content).toMatchObject({
+      from_agent_id: "agent_peer",
+      decision: "counter",
+      counter_proposal: "next sprint",
+    });
+  });
+
+  it.each([
+    ["a missing negotiation_id", { decision: "accept", message: "ok" }],
+    ["a missing message", { negotiation_id: "neg_1", decision: "accept" }],
+  ])("rejects %s", async (_label, input) => {
+    const { services, tool } = build();
+
+    const result = await tool("respond_negotiate").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "negotiation_id and message required",
+    });
+    expect(services.mesh.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("rejects a decision outside counter/accept/reject", async () => {
+    const { services, tool } = build();
+
+    const result = await tool("respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "maybe",
+      message: "hmm",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "decision must be one of: counter, accept, reject",
+    });
+    expect(services.mesh.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("requires a counter_proposal when countering", async () => {
+    const { services, tool } = build();
+
+    const result = await tool("respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "not this",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "counter_proposal required when decision='counter'",
+    });
+    expect(services.mesh.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("surfaces MAX_ROUNDS_EXCEEDED with the round counts so the agent escalates", async () => {
+    const { tool } = build({
+      mesh: {
+        respondNegotiate: vi.fn(async () => {
+          throw new MeshMaxRoundsError({
+            negotiationId: "neg_1",
+            rounds_completed: 5,
+            max_rounds: 5,
+          });
+        }),
+      },
+    });
+
+    const result = await tool("respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "again",
+      counter_proposal: "or this",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "MAX_ROUNDS_EXCEEDED",
+      rounds_completed: 5,
+      max_rounds: 5,
+    });
+  });
+});
+
+// ── report_blocker ───────────────────────────────────────────────────────
+
+describe("report_blocker", () => {
+  it("marks the task blocked, then spawns the parent", async () => {
+    const { services, tool } = build();
+    const order: string[] = [];
+    vi.mocked(services.taskService.markBlocked).mockImplementation(async () => {
+      order.push("markBlocked");
+      return undefined as never;
+    });
+    vi.mocked(services.mesh.reportBlocker).mockImplementation(() => {
+      order.push("reportBlocker");
+    });
+
+    const result = await tool("report_blocker").handler({
+      task_id: "task_1",
+      description: "creds missing",
+    });
+
+    expect(services.agentRepo.findParent).toHaveBeenCalledWith("agent_x");
+    expect(services.taskService.markBlocked).toHaveBeenCalledWith(
+      "task_1",
+      "agent_x",
+      "creds missing",
+    );
+    expect(services.mesh.reportBlocker).toHaveBeenCalledWith(
+      "agent_parent",
+      "agent_x",
+      "task_1",
+      "creds missing",
+    );
+    // The task has to be blocked before the parent's session can read it.
+    expect(order).toEqual(["markBlocked", "reportBlocker"]);
+    expect(result.content).toEqual({
+      reported: true,
+      parent_agent_id: "agent_parent",
+      task_id: "task_1",
+    });
+  });
+
+  it.each([
+    ["a missing task_id", { description: "creds missing" }],
+    ["a missing description", { task_id: "task_1" }],
+  ])("rejects %s before looking up the parent", async (_label, input) => {
+    const { services, tool } = build();
+
+    const result = await tool("report_blocker").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "task_id and description required" });
+    expect(services.agentRepo.findParent).not.toHaveBeenCalled();
+  });
+
+  it("refuses for a top-level agent and leaves the task alone", async () => {
+    const { services, tool } = build({
+      agentRepo: { findParent: vi.fn(async () => undefined) },
+    });
+
+    const result = await tool("report_blocker").handler({
+      task_id: "task_1",
+      description: "creds missing",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "no_parent_to_block" });
+    expect(services.taskService.markBlocked).not.toHaveBeenCalled();
+    expect(services.mesh.reportBlocker).not.toHaveBeenCalled();
+  });
+
+  it("wraps a markBlocked failure rather than reporting success", async () => {
+    const { services, tool } = build({
+      taskService: {
+        markBlocked: vi.fn(async () => {
+          throw new Error("task task_1 not found");
+        }),
+      },
+    });
+
+    const result = await tool("report_blocker").handler({
+      task_id: "task_1",
+      description: "creds missing",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "task task_1 not found" });
+    expect(services.mesh.reportBlocker).not.toHaveBeenCalled();
+  });
+});
+
+// ── escalate_to_humans ───────────────────────────────────────────────────
+
+describe("escalate_to_humans", () => {
+  it("creates the escalation, unblocks the peer, then notifies listeners", async () => {
+    const { services, tool } = build();
+    const order: string[] = [];
+    vi.mocked(services.escalationService.create).mockImplementation(async () => {
+      order.push("create");
+      return { id: "esc_1", status: "pending", negotiation_id: "neg_1" } as never;
+    });
+    vi.mocked(services.mesh.unblockOnEscalate).mockImplementation(() => {
+      order.push("unblock");
+    });
+    vi.mocked(services.pool.query).mockImplementation((async () => {
+      order.push("notify");
+      return { rows: [] };
+    }) as never);
+
+    const result = await tool("escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "stuck on X",
+      proposals: [{ title: "A", description: "do A" }],
+      open_questions: ["who owns X?", 7],
+    });
+
+    expect(services.escalationService.create).toHaveBeenCalledWith({
+      negotiationId: "neg_1",
+      callerAgentId: "agent_x",
+      summary: "stuck on X",
+      proposals: [{ title: "A", description: "do A" }],
+      // Non-string questions are dropped, not forwarded.
+      openQuestions: ["who owns X?"],
+    });
+    expect(services.mesh.unblockOnEscalate).toHaveBeenCalledWith("neg_1", "esc_1");
+    expect(services.pool.query).toHaveBeenCalledWith(
+      expect.stringContaining("pg_notify('escalation_created'"),
+      ["esc_1"],
+    );
+    expect(order).toEqual(["create", "unblock", "notify"]);
+    expect(result.content).toEqual({
+      escalation_id: "esc_1",
+      status: "pending",
+      negotiation_id: "neg_1",
+    });
+  });
+
+  it("omits proposals and open_questions when they are not arrays", async () => {
+    const { services, tool } = build();
+
+    await tool("escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "stuck",
+      proposals: "A or B",
+      open_questions: "who owns X?",
+    });
+
+    expect(services.escalationService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ proposals: undefined, openQuestions: undefined }),
+    );
+  });
+
+  it.each([
+    ["a missing negotiation_id", { summary: "stuck" }],
+    ["a missing summary", { negotiation_id: "neg_1" }],
+  ])("rejects %s without creating an escalation", async (_label, input) => {
+    const { services, tool } = build();
+
+    const result = await tool("escalate_to_humans").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "negotiation_id and summary required",
+    });
+    expect(services.escalationService.create).not.toHaveBeenCalled();
+  });
+
+  it("wraps a create failure and leaves the peer blocked for the server to time out", async () => {
+    const { services, tool } = build({
+      escalationService: {
+        create: vi.fn(async () => {
+          throw new Error("negotiation already escalated");
+        }),
+      },
+    });
+
+    const result = await tool("escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "stuck",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "negotiation already escalated" });
+    expect(services.mesh.unblockOnEscalate).not.toHaveBeenCalled();
+    expect(services.pool.query).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/tools/session-search.test.ts
+++ b/packages/api/src/tools/session-search.test.ts
@@ -1,0 +1,266 @@
+/**
+ * session_search MCP tool — unit tests with vitest fakes (no DB).
+ *
+ * The service does the scoping and the SQL; the tool owns `inferRequest`,
+ * which turns loosely-typed MCP input into one of four request shapes.
+ * Shape inference is priority-ordered (scroll > read > discover > browse)
+ * and silently mis-routing a call is invisible at runtime — a scroll that
+ * degrades to a read dumps a whole transcript into the agent's context
+ * instead of a ±5 window. Hence a case per shape, plus the error mapping.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { HierarchyLevel, SessionSearchRequest } from "@beevibe/core";
+import {
+  SessionSearchError,
+  type SessionSearchContext,
+  type SessionSearchService,
+} from "@beevibe/core/services/session-search";
+import { createSessionSearchTool } from "./session-search.js";
+
+const CTX = {
+  agentId: "agent_a",
+  hierarchyLevel: "team" as HierarchyLevel,
+  sessionId: "sess_current",
+};
+
+const BROWSE_RESULT = { kind: "browse", sessions: [] };
+
+/** A `search` double whose recorded calls keep their argument types. */
+function fakeSearch(
+  impl: (
+    req: SessionSearchRequest,
+    ctx: SessionSearchContext,
+  ) => Promise<unknown> = async () => BROWSE_RESULT,
+) {
+  return vi.fn(
+    async (req: SessionSearchRequest, ctx: SessionSearchContext) =>
+      (await impl(req, ctx)) as never,
+  );
+}
+
+function build(search = fakeSearch(), ctx = CTX) {
+  const sessionSearch = { search } as unknown as SessionSearchService;
+  return { tool: createSessionSearchTool(ctx, { sessionSearch }), sessionSearch };
+}
+
+/** The request the tool inferred from one raw MCP input. */
+async function inferred(
+  input: Record<string, unknown>,
+): Promise<SessionSearchRequest> {
+  const search = fakeSearch();
+  const { tool } = build(search);
+  await tool.handler(input);
+  return search.mock.calls[0]![0];
+}
+
+describe("session_search tool descriptor", () => {
+  it("exposes the four calling shapes and the filter enums agents pick from", () => {
+    const { tool } = build();
+    const props = tool.schema.properties as Record<string, Record<string, unknown>>;
+    const filters = props.filters?.properties as Record<string, { enum?: string[] }>;
+
+    expect(tool.name).toBe("session_search");
+    expect(tool.description).toContain("FOUR CALLING SHAPES");
+    expect(Object.keys(props)).toEqual([
+      "query",
+      "limit",
+      "sort",
+      "session_id",
+      "around_message_id",
+      "window",
+      "filters",
+    ]);
+    expect(filters.session_type?.enum).toContain("run_repo");
+    expect(filters.status?.enum).toContain("failed");
+    // No `required` — a bare call is the browse shape.
+    expect(tool.schema.required).toBeUndefined();
+  });
+});
+
+describe("session_search shape inference", () => {
+  it("browses when called with no arguments", async () => {
+    expect(await inferred({})).toEqual({
+      kind: "browse",
+      limit: undefined,
+      filters: undefined,
+    });
+  });
+
+  it("discovers when given a query", async () => {
+    expect(await inferred({ query: "  auth refactor  ", limit: 7, sort: "newest" })).toEqual({
+      kind: "discover",
+      query: "auth refactor",
+      limit: 7,
+      sort: "newest",
+      filters: undefined,
+    });
+  });
+
+  it("reads when given a bare session_id", async () => {
+    expect(await inferred({ session_id: "  sess_7  ", query: "ignored" })).toEqual({
+      kind: "read",
+      session_id: "sess_7",
+    });
+  });
+
+  it("scrolls when given session_id + around_message_id, outranking query", async () => {
+    expect(
+      await inferred({
+        session_id: "sess_7",
+        around_message_id: "  evt_3  ",
+        window: 12,
+        query: "ignored",
+      }),
+    ).toEqual({
+      kind: "scroll",
+      session_id: "sess_7",
+      around_message_id: "evt_3",
+      window: 12,
+    });
+  });
+
+  it("falls back to browse when every string argument is blank", async () => {
+    const req = await inferred({
+      query: "   ",
+      session_id: "  ",
+      around_message_id: "  ",
+    });
+
+    expect(req.kind).toBe("browse");
+  });
+
+  it("treats an anchor without a session_id as discovery, not scroll", async () => {
+    const req = await inferred({ around_message_id: "evt_3", query: "auth" });
+
+    expect(req.kind).toBe("discover");
+  });
+
+  it("drops non-numeric window / limit and unknown sort values", async () => {
+    expect(await inferred({ session_id: "sess_7", around_message_id: "evt_3", window: "10" }))
+      .toMatchObject({ window: undefined });
+    expect(await inferred({ query: "x", limit: "3", sort: "relevance" })).toMatchObject({
+      limit: undefined,
+      sort: undefined,
+    });
+    expect(await inferred({ limit: null })).toMatchObject({ limit: undefined });
+  });
+
+  it("forwards filters on the discover and browse shapes", async () => {
+    const filters = { status: "failed", session_type: "task" };
+
+    expect(await inferred({ query: "x", filters })).toMatchObject({ filters });
+    expect(await inferred({ filters })).toMatchObject({ filters });
+  });
+
+  it("ignores a non-object filters value", async () => {
+    expect(await inferred({ filters: "status:failed" })).toMatchObject({
+      filters: undefined,
+    });
+    expect(await inferred({ filters: null })).toMatchObject({ filters: undefined });
+  });
+});
+
+describe("session_search delegation", () => {
+  it("passes the caller's tier and current session as the search context", async () => {
+    const search = fakeSearch();
+    const { tool } = build(search);
+
+    await tool.handler({ query: "auth" });
+
+    expect(search.mock.calls[0]?.[1]).toEqual({
+      callerAgentId: "agent_a",
+      hierarchyLevel: "team",
+      currentSessionId: "sess_current",
+    });
+  });
+
+  it("returns the service result verbatim", async () => {
+    const result = { kind: "read", session: { id: "sess_7" }, messages: [] };
+    const { tool } = build(fakeSearch(async () => result));
+
+    const out = await tool.handler({ session_id: "sess_7" });
+
+    expect(out.isError).toBeFalsy();
+    expect(out.content).toBe(result);
+  });
+
+  it("turns a null result into not_found_or_forbidden", async () => {
+    const { tool } = build(fakeSearch(async () => null));
+
+    const out = await tool.handler({ session_id: "sess_other" });
+
+    expect(out.isError).toBe(true);
+    expect(out.content).toMatchObject({ error: "not_found_or_forbidden" });
+  });
+});
+
+describe("session_search error mapping", () => {
+  it("surfaces a SessionSearchError's code", async () => {
+    const { tool } = build(
+      fakeSearch(async () => {
+        throw new SessionSearchError(
+          "forbidden_agent_filter",
+          "agent_id outside your scope",
+        );
+      }),
+    );
+
+    const out = await tool.handler({ query: "x", filters: { agent_id: "agent_z" } });
+
+    expect(out.isError).toBe(true);
+    expect(out.content).toEqual({
+      error: "forbidden_agent_filter",
+      message: "agent_id outside your scope",
+    });
+  });
+
+  it("matches by error name too, for a cross-bundle SessionSearchError", async () => {
+    // src/ and dist/ copies of core are different classes, so instanceof
+    // fails across the bundle boundary; the name check is the fallback.
+    const foreign = new Error("query is required for discovery") as Error & {
+      code: string;
+    };
+    foreign.name = "SessionSearchError";
+    foreign.code = "missing_query";
+    const { tool } = build(
+      fakeSearch(async () => {
+        throw foreign;
+      }),
+    );
+
+    const out = await tool.handler({ query: "x" });
+
+    expect(out.content).toEqual({
+      error: "missing_query",
+      message: "query is required for discovery",
+    });
+  });
+
+  it("wraps anything else as internal_error", async () => {
+    const { tool } = build(
+      fakeSearch(async () => {
+        throw new Error("connection reset");
+      }),
+    );
+
+    const out = await tool.handler({ query: "x" });
+
+    expect(out.isError).toBe(true);
+    expect(out.content).toEqual({
+      error: "internal_error",
+      message: "connection reset",
+    });
+  });
+
+  it("stringifies a non-Error throw", async () => {
+    const { tool } = build(
+      fakeSearch(async () => {
+        throw "kaput";
+      }),
+    );
+
+    const out = await tool.handler({});
+
+    expect(out.content).toEqual({ error: "internal_error", message: "kaput" });
+  });
+});

--- a/packages/api/src/tools/use-repo.test.ts
+++ b/packages/api/src/tools/use-repo.test.ts
@@ -1,0 +1,409 @@
+/**
+ * use_repo MCP tool — unit tests with vitest fakes (no DB).
+ *
+ * The handler is the Capability Network's write path: it validates the
+ * agent-supplied goal + repo URL, mints a container task, dispatches a
+ * `run_repo` session under a pre-minted session id, then inserts the
+ * repo_run row that the daemon joins on. Three things are worth pinning:
+ *
+ *   - the URL guard (only https GitHub hosts get through),
+ *   - the dispatch-before-repo_run ordering and the shared session id
+ *     (repo_run.session_id has an FK to the session dispatch created),
+ *   - the two failure envelopes, since a swallowed error here leaves the
+ *     agent polling a run that will never start.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  RepoRun,
+  RepoRunRepository,
+  Session,
+  Task,
+  TaskRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import { createUseRepoTool } from "./use-repo.js";
+
+const AGENT = "agent_a";
+const REPO = "https://github.com/acme/pdf-tools";
+
+function fakeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: AGENT,
+    name: "A",
+    owner_id: "person_1",
+    hierarchy_level: "ic",
+    runtime_config: { type: "claude" },
+    created_at: new Date("2026-04-01"),
+    updated_at: new Date("2026-04-01"),
+    ...overrides,
+  };
+}
+
+function fakeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "task_1",
+    title: "Extract tables",
+    status: "pending",
+    priority: "medium",
+    creator_id: AGENT,
+    creator_type: "agent",
+    created_at: new Date("2026-04-01"),
+    updated_at: new Date("2026-04-01"),
+    ...overrides,
+  };
+}
+
+function buildServices(
+  overrides: {
+    agentRepo?: Partial<AgentRepository>;
+    taskRepo?: Partial<TaskRepository>;
+    repoRunRepo?: Partial<RepoRunRepository>;
+    dispatchService?: Partial<DispatchService>;
+  } = {},
+) {
+  const agentRepo = {
+    findById: vi.fn(async () => fakeAgent()),
+    ...overrides.agentRepo,
+  } as unknown as AgentRepository;
+
+  const taskRepo = {
+    create: vi.fn(async (input: Parameters<TaskRepository["create"]>[0]) =>
+      fakeTask(input as Partial<Task>),
+    ),
+    ...overrides.taskRepo,
+  } as unknown as TaskRepository;
+
+  const repoRunRepo = {
+    create: vi.fn(
+      async (input: Parameters<RepoRunRepository["create"]>[0]) =>
+        input as unknown as RepoRun,
+    ),
+    ...overrides.repoRunRepo,
+  } as unknown as RepoRunRepository;
+
+  const dispatchService = {
+    dispatchTask: vi.fn(async (input: { agentId: string }) => ({
+      session: {
+        id: "sess_dispatched",
+        agent_id: input.agentId,
+        type: "run_repo",
+        status: "pending",
+        intent: "x",
+        created_at: new Date("2026-04-01"),
+      } as Session,
+      runtime_id: null,
+    })),
+    ...overrides.dispatchService,
+  } as unknown as DispatchService;
+
+  return { agentRepo, taskRepo, repoRunRepo, dispatchService };
+}
+
+function build(
+  overrides: Parameters<typeof buildServices>[0] = {},
+  ctx: { agentId: string } = { agentId: AGENT },
+) {
+  const services = buildServices(overrides);
+  return { tool: createUseRepoTool(ctx, services), services };
+}
+
+describe("use_repo tool descriptor", () => {
+  it("advertises goal + repo_url as the required inputs", () => {
+    const { tool } = build();
+
+    expect(tool.name).toBe("use_repo");
+    expect(tool.schema.required).toEqual(["goal", "repo_url"]);
+    expect(tool.description).toContain("Docker sandbox");
+  });
+});
+
+describe("use_repo input validation", () => {
+  it("rejects a blank goal without touching any repo", async () => {
+    const { tool, services } = build();
+
+    const result = await tool.handler({ goal: "   ", repo_url: REPO });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "invalid_goal" });
+    expect(services.agentRepo.findById).not.toHaveBeenCalled();
+    expect(services.taskRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing goal (non-string input)", async () => {
+    const { tool } = build();
+
+    const result = await tool.handler({ repo_url: REPO });
+
+    expect(result.content).toMatchObject({ error: "invalid_goal" });
+  });
+
+  it.each([
+    ["a non-GitHub host", "https://gitlab.com/acme/tool"],
+    ["plain http", "http://github.com/acme/tool"],
+    ["a lookalike host", "https://notgithub.com/acme/tool"],
+    ["an unparseable url", "github.com/acme/tool"],
+    ["an empty string", "   "],
+  ])("rejects %s as repo_url", async (_label, repoUrl) => {
+    const { tool, services } = build();
+
+    const result = await tool.handler({ goal: "extract tables", repo_url: repoUrl });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "invalid_repo_url" });
+    expect(services.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("accepts a github subdomain over https", async () => {
+    const { tool } = build();
+
+    const result = await tool.handler({
+      goal: "extract tables",
+      repo_url: "https://www.github.com/acme/tool",
+    });
+
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("returns agent_not_found when the caller does not resolve", async () => {
+    const { tool, services } = build({
+      agentRepo: { findById: vi.fn(async () => undefined) },
+    });
+
+    const result = await tool.handler({ goal: "extract tables", repo_url: REPO });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "agent_not_found" });
+    expect(services.taskRepo.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("use_repo happy path", () => {
+  it("creates the container task, dispatches, then inserts the repo_run", async () => {
+    const { tool, services } = build();
+
+    const result = await tool.handler({ goal: "extract tables", repo_url: REPO });
+
+    expect(result.isError).toBeFalsy();
+    const content = result.content as Record<string, string>;
+
+    // Container task carries the goal verbatim and is both created by and
+    // assigned to the calling agent.
+    expect(services.taskRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "extract tables",
+        description: "extract tables",
+        assignee_id: AGENT,
+        creator_id: AGENT,
+        creator_type: "agent",
+      }),
+    );
+
+    // Dispatch runs before the repo_run insert and pins the session id.
+    expect(services.dispatchService.dispatchTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: AGENT,
+        type: "run_repo",
+        intent: "extract tables",
+        reason: { kind: "fresh" },
+        sessionIdOverride: content.session_id,
+      }),
+    );
+
+    // repo_run joins the dispatched session and the container task.
+    expect(services.repoRunRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: content.repo_run_id,
+        session_id: content.session_id,
+        task_id: content.task_id,
+        agent_id: AGENT,
+        goal: "extract tables",
+        repo_url: REPO,
+        status: "pending",
+      }),
+    );
+  });
+
+  it("returns the ids, pending status and the watch url the UI polls", async () => {
+    const { tool } = build();
+
+    const result = await tool.handler({ goal: "extract tables", repo_url: REPO });
+    const content = result.content as Record<string, unknown>;
+
+    expect(content.status).toBe("pending");
+    expect(content.watch_url).toBe(`/capabilities/runs/${String(content.repo_run_id)}`);
+    expect(typeof content.session_id).toBe("string");
+    expect(typeof content.task_id).toBe("string");
+    expect(content.note).toContain("Sandbox run started");
+  });
+
+  it("passes input_url + input_filename back trimmed, and omits them when absent", async () => {
+    const { tool } = build();
+
+    const withInput = await tool.handler({
+      goal: "extract tables",
+      repo_url: REPO,
+      input_url: "  https://example.com/a.pdf  ",
+      input_filename: "  a.pdf  ",
+    });
+    expect(withInput.content).toMatchObject({
+      input_url: "https://example.com/a.pdf",
+      input_filename: "a.pdf",
+    });
+
+    const withoutInput = await tool.handler({ goal: "extract tables", repo_url: REPO });
+    expect(withoutInput.content.input_url).toBeUndefined();
+    expect(withoutInput.content.input_filename).toBeUndefined();
+  });
+
+  it("collapses whitespace and truncates the container task title at 80 chars", async () => {
+    const { tool, services } = build();
+    const goal = `${"extract  tables\nfrom  the  pdf ".repeat(6)}end`;
+
+    await tool.handler({ goal, repo_url: REPO });
+
+    const created = vi.mocked(services.taskRepo.create).mock.calls[0]?.[0];
+    expect(created?.title).toHaveLength(78); // 77 chars + the ellipsis
+    expect(created?.title.endsWith("…")).toBe(true);
+    // The full goal still reaches the description and the dispatch intent.
+    expect(created?.description).toBe(goal);
+  });
+
+  it("keeps a short title untouched", async () => {
+    const { tool, services } = build();
+
+    await tool.handler({ goal: "  extract   tables  ", repo_url: REPO });
+
+    const created = vi.mocked(services.taskRepo.create).mock.calls[0]?.[0];
+    expect(created?.title).toBe("extract tables");
+  });
+});
+
+describe("use_repo limit parsing", () => {
+  it("clamps each limit to its ceiling and floors the integer ones", async () => {
+    const { tool } = build();
+
+    const result = await tool.handler({
+      goal: "extract tables",
+      repo_url: REPO,
+      limits: { wall_clock_minutes: 999, max_install_attempts: 9.7, disk_mb: 99_999 },
+    });
+
+    expect(result.content.limits).toEqual({
+      wall_clock_minutes: 60,
+      max_install_attempts: 5,
+      disk_mb: 10_000,
+    });
+  });
+
+  it("passes in-range limits through, flooring the integer ones", async () => {
+    const { tool } = build();
+
+    const result = await tool.handler({
+      goal: "extract tables",
+      repo_url: REPO,
+      limits: { wall_clock_minutes: 5, max_install_attempts: 3.9, disk_mb: 512.5 },
+    });
+
+    expect(result.content.limits).toEqual({
+      wall_clock_minutes: 5,
+      max_install_attempts: 3,
+      disk_mb: 512,
+    });
+  });
+
+  it.each([
+    ["a non-object", "20"],
+    ["null", null],
+    ["nothing", undefined],
+  ])("returns empty limits for %s", async (_label, limits) => {
+    const { tool } = build();
+
+    const result = await tool.handler({ goal: "g", repo_url: REPO, limits });
+
+    expect(result.content.limits).toEqual({});
+  });
+
+  it("drops non-positive and non-numeric limit values", async () => {
+    const { tool } = build();
+
+    const result = await tool.handler({
+      goal: "g",
+      repo_url: REPO,
+      limits: { wall_clock_minutes: 0, max_install_attempts: -1, disk_mb: "2048" },
+    });
+
+    expect(result.content.limits).toEqual({});
+  });
+});
+
+describe("use_repo failure envelopes", () => {
+  it("surfaces a dispatch failure and never inserts the repo_run", async () => {
+    const { tool, services } = build({
+      dispatchService: {
+        dispatchTask: vi.fn(async () => {
+          throw new Error("no daemon online");
+        }),
+      },
+    });
+
+    const result = await tool.handler({ goal: "g", repo_url: REPO });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "dispatch_failed",
+      message: "no daemon online",
+    });
+    expect(services.repoRunRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("stringifies a non-Error dispatch throw", async () => {
+    const { tool } = build({
+      dispatchService: {
+        dispatchTask: vi.fn(async () => {
+          throw "boom";
+        }),
+      },
+    });
+
+    const result = await tool.handler({ goal: "g", repo_url: REPO });
+
+    expect(result.content).toMatchObject({ error: "dispatch_failed", message: "boom" });
+  });
+
+  it("surfaces a repo_run insert failure rather than leaving the agent waiting", async () => {
+    const { tool } = build({
+      repoRunRepo: {
+        create: vi.fn(async () => {
+          throw new Error("fk violation");
+        }),
+      },
+    });
+
+    const result = await tool.handler({ goal: "g", repo_url: REPO });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "repo_run_create_failed",
+      message: "fk violation",
+    });
+  });
+
+  it("stringifies a non-Error repo_run throw", async () => {
+    const { tool } = build({
+      repoRunRepo: {
+        create: vi.fn(async () => {
+          throw "kaput";
+        }),
+      },
+    });
+
+    const result = await tool.handler({ goal: "g", repo_url: REPO });
+
+    expect(result.content).toMatchObject({
+      error: "repo_run_create_failed",
+      message: "kaput",
+    });
+  });
+});

--- a/packages/api/src/tools/watch.test.ts
+++ b/packages/api/src/tools/watch.test.ts
@@ -1,0 +1,241 @@
+/**
+ * watch_tasks + unwatch MCP tools — unit tests with vitest fakes (no DB).
+ *
+ * Both are thin adapters over WatchService, so the logic that lives here
+ * (and can therefore regress here) is exactly: input coercion, the
+ * missing-session guard, mode defaulting, and the error-class → error-code
+ * mapping. A miscoded error is the expensive one — the agent branches on
+ * `error`, so a `watch_auth` that degrades to `watch_error` silently turns
+ * a permission bug into a retry loop.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  WatchAuthError,
+  WatchNotFoundError,
+  WatchValidationError,
+  type WatchService,
+} from "@beevibe/core/services/watch-service";
+import { buildWatchTools } from "./watch.js";
+import type { AgentTool } from "./types.js";
+
+const AGENT = "agent_a";
+const SESSION = "sess_1";
+
+function buildTools(
+  overrides: Partial<WatchService> = {},
+  ctx: { agentId: string; sessionId?: string } = {
+    agentId: AGENT,
+    sessionId: SESSION,
+  },
+) {
+  const watchService = {
+    watchTasks: vi.fn(async () => ({ watchId: "tw_1", firedImmediately: false })),
+    unwatch: vi.fn(async () => {}),
+    ...overrides,
+  } as unknown as WatchService;
+
+  const tools = buildWatchTools(ctx, { watchService });
+  const byName = (name: string): AgentTool => {
+    const tool = tools.find((t) => t.name === name);
+    if (!tool) throw new Error(`no tool named ${name}`);
+    return tool;
+  };
+  return { tools, watchService, watchTasks: byName("watch_tasks"), unwatch: byName("unwatch") };
+}
+
+describe("buildWatchTools", () => {
+  it("returns watch_tasks and unwatch, in that order", () => {
+    const { tools } = buildTools();
+
+    expect(tools.map((t) => t.name)).toEqual(["watch_tasks", "unwatch"]);
+  });
+
+  it("advertises the fire modes on the schema so the agent can pick one", () => {
+    const { watchTasks, unwatch } = buildTools();
+    const props = watchTasks.schema.properties as Record<string, { enum?: string[] }>;
+
+    expect(watchTasks.schema.required).toEqual(["task_ids"]);
+    expect(props.mode?.enum).toEqual(["all", "any"]);
+    expect(unwatch.schema.required).toEqual(["watch_id"]);
+  });
+});
+
+describe("watch_tasks", () => {
+  it("forwards caller identity, ids, mode and reason to the service", async () => {
+    const { watchTasks, watchService } = buildTools();
+
+    const result = await watchTasks.handler({
+      task_ids: ["task_1", "task_2"],
+      mode: "any",
+      reason: "  need the first result  ",
+    });
+
+    expect(watchService.watchTasks).toHaveBeenCalledWith({
+      callerAgentId: AGENT,
+      callerSessionId: SESSION,
+      taskIds: ["task_1", "task_2"],
+      mode: "any",
+      reason: "need the first result",
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({ watch_id: "tw_1", fired_immediately: false });
+  });
+
+  it("reports fired_immediately when the tasks were already terminal", async () => {
+    const { watchTasks } = buildTools({
+      watchTasks: vi.fn(async () => ({ watchId: "tw_9", firedImmediately: true })),
+    });
+
+    const result = await watchTasks.handler({ task_ids: ["task_1"] });
+
+    expect(result.content).toEqual({ watch_id: "tw_9", fired_immediately: true });
+  });
+
+  it("defaults mode to 'all' when omitted or not a known mode", async () => {
+    const { watchTasks, watchService } = buildTools();
+
+    await watchTasks.handler({ task_ids: ["task_1"] });
+    await watchTasks.handler({ task_ids: ["task_1"], mode: "either" });
+    await watchTasks.handler({ task_ids: ["task_1"], mode: 7 });
+
+    const modes = vi
+      .mocked(watchService.watchTasks)
+      .mock.calls.map(([input]) => input.mode);
+    expect(modes).toEqual(["all", "all", "all"]);
+  });
+
+  it("drops a blank reason rather than passing an empty string through", async () => {
+    const { watchTasks, watchService } = buildTools();
+
+    await watchTasks.handler({ task_ids: ["task_1"], reason: "   " });
+    await watchTasks.handler({ task_ids: ["task_1"], reason: 42 });
+
+    for (const [input] of vi.mocked(watchService.watchTasks).mock.calls) {
+      expect(input.reason).toBeUndefined();
+    }
+  });
+
+  it("keeps only the string entries of task_ids", async () => {
+    const { watchTasks, watchService } = buildTools();
+
+    await watchTasks.handler({ task_ids: ["task_1", 2, null, "task_3"] });
+
+    expect(vi.mocked(watchService.watchTasks).mock.calls[0]?.[0].taskIds).toEqual([
+      "task_1",
+      "task_3",
+    ]);
+  });
+
+  it.each([
+    ["an empty array", []],
+    ["a non-array", "task_1"],
+    ["an array with no strings", [1, 2]],
+    ["nothing", undefined],
+  ])("rejects %s for task_ids without calling the service", async (_label, taskIds) => {
+    const { watchTasks, watchService } = buildTools();
+
+    const result = await watchTasks.handler({ task_ids: taskIds });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "watch_validation" });
+    expect(watchService.watchTasks).not.toHaveBeenCalled();
+  });
+
+  it("refuses to register a watch outside a session context", async () => {
+    const { watchTasks, watchService } = buildTools({}, { agentId: AGENT });
+
+    const result = await watchTasks.handler({ task_ids: ["task_1"] });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "watch_validation",
+      message: "watch_tasks must be called inside a session context",
+    });
+    expect(watchService.watchTasks).not.toHaveBeenCalled();
+  });
+});
+
+describe("unwatch", () => {
+  it("cancels the watch for the calling agent", async () => {
+    const { unwatch, watchService } = buildTools();
+
+    const result = await unwatch.handler({ watch_id: "tw_1" });
+
+    expect(watchService.unwatch).toHaveBeenCalledWith({
+      callerAgentId: AGENT,
+      watchId: "tw_1",
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({ ok: true });
+  });
+
+  it.each([
+    ["an empty string", ""],
+    ["a non-string", 7],
+    ["nothing", undefined],
+  ])("rejects %s for watch_id without calling the service", async (_label, watchId) => {
+    const { unwatch, watchService } = buildTools();
+
+    const result = await unwatch.handler({ watch_id: watchId });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "watch_validation" });
+    expect(watchService.unwatch).not.toHaveBeenCalled();
+  });
+});
+
+describe("service error mapping", () => {
+  const cases: Array<[string, () => unknown, string, string]> = [
+    [
+      "WatchAuthError",
+      () => new WatchAuthError("task task_1 is not yours"),
+      "watch_auth",
+      "task task_1 is not yours",
+    ],
+    [
+      "WatchValidationError",
+      () => new WatchValidationError("task_ids must be non-empty"),
+      "watch_validation",
+      "task_ids must be non-empty",
+    ],
+    [
+      "WatchNotFoundError",
+      () => new WatchNotFoundError("tw_missing"),
+      "watch_not_found",
+      "task_watch tw_missing not found",
+    ],
+    [
+      "a plain Error",
+      () => new Error("connection reset"),
+      "watch_error",
+      "connection reset",
+    ],
+    ["a thrown string", () => "kaput", "watch_error", "kaput"],
+  ];
+
+  it.each(cases)("maps %s thrown by watchTasks", async (_label, make, code, message) => {
+    const { watchTasks } = buildTools({
+      watchTasks: vi.fn(async () => {
+        throw make();
+      }),
+    });
+
+    const result = await watchTasks.handler({ task_ids: ["task_1"] });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: code, message });
+  });
+
+  it.each(cases)("maps %s thrown by unwatch", async (_label, make, code, message) => {
+    const { unwatch } = buildTools({
+      unwatch: vi.fn(async () => {
+        throw make();
+      }),
+    });
+
+    const result = await unwatch.handler({ watch_id: "tw_1" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: code, message });
+  });
+});


### PR DESCRIPTION
## What

A coverage sweep across every package, then tests for the five modules that came back thinnest. No production code changed.

## The sweep

Measured with `@vitest/coverage-v8` (installed for the sweep, **not committed**, per CLAUDE.md), `--coverage.all` on, and the DB- and key-gated suites excluded — this sandbox has no Docker and no provider keys, so those suites can't run. Everything they cover (the `postgres/*` adapters, `routes/{task,mcp,escalation,negotiation,runtimes}`, `runtime/{router,ws-server}`, `auth/middleware`, `scheduler/worker`) shows as 0% here and was discounted rather than re-tested.

What that leaves, per package:

| Package | Lines | Read |
| --- | --- | --- |
| `@beevibe/core` | 53% overall, but **90% services / 95% memory / 98% claude-code adapter** | healthy; the 0%s are gated adapters and type-only barrels |
| `@beevibe/daemon` | 80% | healthy; the gaps are `main.ts` / `start.ts` entrypoints |
| `@beevibe/sandbox` | 75% | healthy after #275; the gaps are `src/scripts/*` dev utilities |
| `@beevibe/scheduler` | 24% | almost entirely the DB-gated `worker.ts` + `cancel-listener.ts` |
| `@beevibe/api` | **64.5%** | the real gap — five agent-facing modules with no test file, or one that only checked assembly |

## The five modules

| File | Before | After |
| --- | --- | --- |
| `src/routes/stream.ts` | 0.00% | 100% |
| `src/tools/use-repo.ts` | 32.04% | 100% |
| `src/tools/mesh.ts` | 45.93% | 100% |
| `src/tools/watch.ts` | 46.26% | 100% |
| `src/tools/session-search.ts` | 64.65% | 100% |

Package lines **64.53% → 70.04%**; 820 → 928 tests. All five are on the path an agent actually takes at runtime, which is why they were picked over the wiring files that also read low.

## What each test file pins

- **`use_repo`** — the GitHub-URL guard, the dispatch-before-`repo_run` ordering and the shared pre-minted session id its FK depends on, limit clamping, and both failure envelopes. A swallowed error on that path leaves the calling agent polling a run that will never start.
- **`mesh` (6 tools)** — per-handler behavior the m6/m7 e2e scripts can't reach cheaply: argument coercion, the `create → sentinel-unblock → pg_notify` ordering on escalation, and the coded-error envelope agents branch on (a `MAX_ROUNDS_EXCEEDED` that degrades to the generic shape sends the agent back into a negotiation the server will refuse). The existing tier-inventory tests are kept unchanged.
- **`watch_tasks` / `unwatch`** — input coercion, the missing-session guard, mode defaulting, and the `WatchAuthError | WatchValidationError | WatchNotFoundError` → error-code mapping.
- **`session_search`** — `inferRequest`'s four-shape priority order (scroll > read > discover > browse). A mis-route is silent at runtime: a scroll that degrades to a read dumps a whole transcript into the agent's context instead of a ±5 window.
- **`GET /api/stream`** — driven over a real socket on an ephemeral port, because supertest buffers until a response ends and an SSE response never does. Covers the priming `data: {}` frame (the client's health probe never trips without it), the per-person fanout filter, and the cleanup that unsubscribes and clears the heartbeat on disconnect — a leak there accumulates one live interval per browser reconnect.

## Verification

- `pnpm typecheck` — clean, all 9 tasks.
- `pnpm lint` — clean; the 4 remaining warnings are pre-existing `import/no-duplicates` in files this PR doesn't touch.
- `@beevibe/api` suite (DB-gated suites excluded): **47 files, 928 tests, all passing.**
- `src/routes/stream.test.ts` run 3× to confirm the socket-driven test isn't flaky.

Not verified here: the DB- and key-gated suites, which need Postgres and provider keys this sandbox doesn't have. No files they cover were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZxSkd5wcf1g64uPxrCqGV

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZxSkd5wcf1g64uPxrCqGV)_