### PR TITLE
test: cover four untested MCP tool modules and three daemon/core gaps

### DIFF
--- a/packages/api/src/tools/mesh.test.ts
+++ b/packages/api/src/tools/mesh.test.ts
@@ -1,17 +1,32 @@
 /**
- * Mesh tool assembly tests — IC vs team tier gating.
+ * Mesh tool tests — tier gating plus per-handler behavior.
  *
- * Per-tool handler behavior is covered indirectly by the m6/m7 e2e scripts
- * (mesh flows require live Postgres + spawned CLI subprocesses). This file
- * locks the static tier inventory — the exact tool *names* each tier gets,
- * so future skill-loader work can rely on the surface being stable.
+ * The end-to-end mesh flows (a real spawn, a real block, a real
+ * round-trip) need live Postgres and CLI subprocesses, and stay in the
+ * m6/m7 e2e scripts. What lives here is everything that runs *before*
+ * the server call and everything that shapes the result afterwards:
+ * the tier inventory, argument validation, the parent lookup that gates
+ * report_blocker, and the error/result projections the calling agent
+ * branches on. All of that was uncovered.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentRepository, TaskRepository } from "@beevibe/core";
 import type { ResolvedCaller } from "@beevibe/core/auth";
-import { buildIcMeshTools, buildTeamMeshTools, type MeshToolServices } from "./mesh.js";
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import type { EscalationService } from "@beevibe/core/services/escalation-service";
+import type { TaskService } from "@beevibe/core/services/task-service";
+import { CannotNegotiateWithIcError, MeshMaxRoundsError } from "../mesh/types.js";
+import type { MeshServer } from "../mesh/server.js";
+import {
+  buildIcMeshTools,
+  buildTeamMeshTools,
+  type MeshToolContext,
+  type MeshToolServices,
+} from "./mesh.js";
 
-// Fake services — the assembly itself doesn't invoke handlers, so the
-// dependencies just need to be the right shape.
+// Empty stand-in for the inventory tests below: assembly never invokes a
+// handler, so it doesn't touch any of these. The handler tests build a
+// wired harness (`meshHarness`) instead.
 const fakeServices = {} as unknown as MeshToolServices;
 
 const fakeCaller: ResolvedCaller = {
@@ -19,7 +34,7 @@ const fakeCaller: ResolvedCaller = {
   source: "agent",
   hierarchyLevel: "team",
 };
-const fakeCtx = { caller: fakeCaller, beevibeSid: "ses_x" };
+const fakeCtx: MeshToolContext = { caller: fakeCaller, beevibeSid: "ses_x" };
 
 describe("buildIcMeshTools (M9.1)", () => {
   // Exact set, not a superset: ICs are responders, not initiators, so the
@@ -45,5 +60,567 @@ describe("buildTeamMeshTools", () => {
       "respond_ask",
       "respond_negotiate",
     ]);
+  });
+});
+
+// ── Handler behavior ──────────────────────────────────────────────────
+
+interface MeshHarness {
+  services: MeshToolServices;
+  mesh: {
+    sendAsk: ReturnType<typeof vi.fn>;
+    respondAsk: ReturnType<typeof vi.fn>;
+    sendNegotiate: ReturnType<typeof vi.fn>;
+    respondNegotiate: ReturnType<typeof vi.fn>;
+    reportBlocker: ReturnType<typeof vi.fn>;
+    unblockOnEscalate: ReturnType<typeof vi.fn>;
+  };
+  findParent: ReturnType<typeof vi.fn>;
+  markBlocked: ReturnType<typeof vi.fn>;
+  createEscalation: ReturnType<typeof vi.fn>;
+  query: ReturnType<typeof vi.fn>;
+}
+
+function meshHarness(
+  overrides: {
+    parent?: { id: string } | null;
+    sendAsk?: () => unknown;
+    sendNegotiate?: () => unknown;
+    respondNegotiate?: () => unknown;
+    markBlocked?: () => unknown;
+    createEscalation?: () => unknown;
+  } = {},
+): MeshHarness {
+  const mesh = {
+    sendAsk: vi.fn(async () =>
+      overrides.sendAsk
+        ? overrides.sendAsk()
+        : { request_id: "req_1", from_agent_id: "agent_b", answer: "yes, feasible" },
+    ),
+    respondAsk: vi.fn(() => undefined),
+    sendNegotiate: vi.fn(async () =>
+      overrides.sendNegotiate
+        ? overrides.sendNegotiate()
+        : {
+            negotiation_id: "neg_1",
+            from_agent_id: "agent_b",
+            decision: "counter",
+            message: "how about Tuesday",
+            counter_proposal: "Tuesday",
+          },
+    ),
+    respondNegotiate: vi.fn(async () =>
+      overrides.respondNegotiate ? overrides.respondNegotiate() : null,
+    ),
+    reportBlocker: vi.fn(() => undefined),
+    unblockOnEscalate: vi.fn(() => undefined),
+  };
+  const findParent = vi.fn(async () =>
+    "parent" in overrides ? overrides.parent : { id: "agent_parent" },
+  );
+  const markBlocked = vi.fn(async () =>
+    overrides.markBlocked ? overrides.markBlocked() : undefined,
+  );
+  const createEscalation = vi.fn(async () =>
+    overrides.createEscalation
+      ? overrides.createEscalation()
+      : { id: "esc_1", status: "open", negotiation_id: "neg_1" },
+  );
+  const query = vi.fn(async () => ({ rows: [] }));
+
+  const services = {
+    mesh: mesh as unknown as MeshServer,
+    agentRepo: { findParent } as unknown as AgentRepository,
+    taskRepo: {} as unknown as TaskRepository,
+    taskService: { markBlocked } as unknown as TaskService,
+    escalationService: { create: createEscalation } as unknown as EscalationService,
+    pool: { query } as unknown as Pool,
+  } satisfies MeshToolServices;
+
+  return { services, mesh, findParent, markBlocked, createEscalation, query };
+}
+
+function meshTool(h: MeshHarness, name: string, ctx: MeshToolContext = fakeCtx) {
+  const tool = buildTeamMeshTools(ctx, h.services).find((t) => t.name === name);
+  if (!tool) throw new Error(`no such mesh tool: ${name}`);
+  return tool;
+}
+
+describe("ask", () => {
+  it("mints a request id, forwards the caller as the asker, and projects the response", async () => {
+    const h = meshHarness();
+    const result = await meshTool(h, "ask").handler({
+      target_agent_id: "agent_b",
+      question: "is X feasible?",
+    });
+
+    expect(h.mesh.sendAsk).toHaveBeenCalledTimes(1);
+    const [requestId, from, to, question] = h.mesh.sendAsk.mock.calls[0] ?? [];
+    // A UUID minted per call — the asker never supplies it, so two asks
+    // can't collide on the mesh server's pending-request map.
+    expect(requestId).toMatch(/^[0-9a-f-]{36}$/);
+    expect([from, to, question]).toEqual(["agent_x", "agent_b", "is X feasible?"]);
+
+    // Projection, not passthrough: the agent sees only these three keys.
+    expect(result.content).toEqual({
+      request_id: "req_1",
+      from_agent_id: "agent_b",
+      answer: "yes, feasible",
+    });
+  });
+
+  it("uses a fresh request id on every call", async () => {
+    const h = meshHarness();
+    const tool = meshTool(h, "ask");
+    await tool.handler({ target_agent_id: "agent_b", question: "q1" });
+    await tool.handler({ target_agent_id: "agent_b", question: "q2" });
+    expect(h.mesh.sendAsk.mock.calls[0]?.[0]).not.toBe(h.mesh.sendAsk.mock.calls[1]?.[0]);
+  });
+
+  it("rejects a missing target or question without spawning the peer", async () => {
+    const h = meshHarness();
+    for (const input of [
+      {},
+      { target_agent_id: "agent_b" },
+      { question: "q" },
+      { target_agent_id: "", question: "q" },
+      { target_agent_id: "agent_b", question: "" },
+    ]) {
+      const result = await meshTool(h, "ask").handler(input);
+      expect(result.isError, JSON.stringify(input)).toBe(true);
+      expect(result.content).toEqual({
+        error: "target_agent_id and question required",
+      });
+    }
+    expect(h.mesh.sendAsk).not.toHaveBeenCalled();
+  });
+
+  // A capacity or max-rounds refusal has to keep its code: the agent's
+  // documented next step differs per code.
+  it("preserves a CodedMeshError's code and meta", async () => {
+    const err = new MeshMaxRoundsError({
+      negotiationId: "neg_1",
+      rounds_completed: 5,
+      max_rounds: 5,
+    });
+    const h = meshHarness({
+      sendAsk: () => {
+        throw err;
+      },
+    });
+    const result = await meshTool(h, "ask").handler({
+      target_agent_id: "agent_b",
+      question: "q",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "MAX_ROUNDS_EXCEEDED",
+      negotiationId: "neg_1",
+      max_rounds: 5,
+    });
+  });
+
+  it("degrades an uncoded throw to the catch-all envelope", async () => {
+    const h = meshHarness({
+      sendAsk: () => {
+        throw new Error("peer offline");
+      },
+    });
+    const result = await meshTool(h, "ask").handler({
+      target_agent_id: "agent_b",
+      question: "q",
+    });
+    expect(result.content).toEqual({ error: "peer offline" });
+  });
+});
+
+describe("respond_ask", () => {
+  it("unblocks the asker with the caller stamped as the responder", async () => {
+    const h = meshHarness();
+    const result = await meshTool(h, "respond_ask").handler({
+      request_id: "req_9",
+      answer: "yes",
+    });
+    expect(h.mesh.respondAsk).toHaveBeenCalledWith("req_9", {
+      request_id: "req_9",
+      from_agent_id: "agent_x",
+      answer: "yes",
+    });
+    expect(result.content).toEqual({ responded: true, request_id: "req_9" });
+  });
+
+  it("rejects a missing request_id or answer", async () => {
+    const h = meshHarness();
+    for (const input of [{}, { request_id: "req_9" }, { answer: "yes" }]) {
+      const result = await meshTool(h, "respond_ask").handler(input);
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual({ error: "request_id and answer required" });
+    }
+    expect(h.mesh.respondAsk).not.toHaveBeenCalled();
+  });
+
+  // respondAsk is synchronous — an unknown request id throws straight
+  // out of the mesh server rather than rejecting a promise.
+  it("envelopes a throw from the mesh server", async () => {
+    const h = meshHarness();
+    h.mesh.respondAsk.mockImplementation(() => {
+      throw new Error("no pending ask req_9");
+    });
+    const result = await meshTool(h, "respond_ask").handler({
+      request_id: "req_9",
+      answer: "yes",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "no pending ask req_9" });
+  });
+});
+
+describe("negotiate", () => {
+  it("forwards the proposal with the initiator's session id and optional task", async () => {
+    const h = meshHarness();
+    const result = await meshTool(h, "negotiate").handler({
+      peer_id: "agent_b",
+      proposal: "ship Monday",
+      task_id: "task_7",
+    });
+    expect(h.mesh.sendNegotiate).toHaveBeenCalledWith(
+      "agent_x",
+      "agent_b",
+      "ship Monday",
+      { taskId: "task_7", initiatorSessionId: "ses_x" },
+    );
+    expect(result.content).toEqual({
+      negotiation_id: "neg_1",
+      from_agent_id: "agent_b",
+      decision: "counter",
+      message: "how about Tuesday",
+      counter_proposal: "Tuesday",
+    });
+  });
+
+  it("omits task_id when absent or blank", async () => {
+    for (const task_id of [undefined, "", 7]) {
+      const h = meshHarness();
+      await meshTool(h, "negotiate").handler({
+        peer_id: "agent_b",
+        proposal: "p",
+        task_id,
+      });
+      expect(h.mesh.sendNegotiate.mock.calls[0]?.[3]).toMatchObject({
+        taskId: undefined,
+      });
+    }
+  });
+
+  it("rejects a missing peer_id or proposal", async () => {
+    const h = meshHarness();
+    for (const input of [{}, { peer_id: "agent_b" }, { proposal: "p" }]) {
+      const result = await meshTool(h, "negotiate").handler(input);
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual({ error: "peer_id and proposal required" });
+    }
+    expect(h.mesh.sendNegotiate).not.toHaveBeenCalled();
+  });
+
+  // The escalated sentinel is a different shape entirely — the peer
+  // escalated while we were blocked, and we must surface the escalation
+  // id rather than a decision the agent would read as a real answer.
+  it("projects the escalated sentinel instead of a decision", async () => {
+    const h = meshHarness({
+      sendNegotiate: () => ({
+        decision: "escalated",
+        escalation_id: "esc_3",
+        negotiation_id: "neg_1",
+        message: "peer escalated",
+      }),
+    });
+    const result = await meshTool(h, "negotiate").handler({
+      peer_id: "agent_b",
+      proposal: "p",
+    });
+    expect(result.content).toEqual({
+      decision: "escalated",
+      escalation_id: "esc_3",
+      negotiation_id: "neg_1",
+      message: "peer escalated",
+    });
+    expect(result.content.from_agent_id).toBeUndefined();
+  });
+
+  it("surfaces CANNOT_NEGOTIATE_WITH_IC with the offending agent id", async () => {
+    const h = meshHarness({
+      sendNegotiate: () => {
+        throw new CannotNegotiateWithIcError({ agentId: "agent_ic" });
+      },
+    });
+    const result = await meshTool(h, "negotiate").handler({
+      peer_id: "agent_ic",
+      proposal: "p",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "CANNOT_NEGOTIATE_WITH_IC",
+      agentId: "agent_ic",
+    });
+  });
+});
+
+describe("respond_negotiate", () => {
+  it("sends the round and reports terminal when the server returns null", async () => {
+    const h = meshHarness({ respondNegotiate: () => null });
+    const result = await meshTool(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "accept",
+      message: "agreed",
+    });
+    expect(h.mesh.respondNegotiate).toHaveBeenCalledWith(
+      "neg_1",
+      {
+        negotiation_id: "neg_1",
+        from_agent_id: "agent_x",
+        decision: "accept",
+        message: "agreed",
+        counter_proposal: undefined,
+      },
+      "ses_x",
+    );
+    expect(result.content).toEqual({
+      negotiation_id: "neg_1",
+      decision: "accept",
+      terminal: true,
+    });
+  });
+
+  it("projects the peer's next round when the negotiation continues", async () => {
+    const h = meshHarness({
+      respondNegotiate: () => ({
+        negotiation_id: "neg_1",
+        from_agent_id: "agent_b",
+        decision: "counter",
+        message: "Wednesday?",
+        counter_proposal: "Wednesday",
+      }),
+    });
+    const result = await meshTool(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "Tuesday?",
+      counter_proposal: "Tuesday",
+    });
+    expect(result.content).toMatchObject({ decision: "counter", from_agent_id: "agent_b" });
+  });
+
+  it("rejects a missing negotiation_id or message", async () => {
+    const h = meshHarness();
+    for (const input of [
+      { decision: "accept", message: "m" },
+      { negotiation_id: "neg_1", decision: "accept" },
+    ]) {
+      const result = await meshTool(h, "respond_negotiate").handler(input);
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual({ error: "negotiation_id and message required" });
+    }
+    expect(h.mesh.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("rejects a decision outside counter/accept/reject", async () => {
+    const h = meshHarness();
+    for (const decision of [undefined, "", "maybe", "COUNTER"]) {
+      const result = await meshTool(h, "respond_negotiate").handler({
+        negotiation_id: "neg_1",
+        decision,
+        message: "m",
+      });
+      expect(result.isError, String(decision)).toBe(true);
+      expect(String(result.content.error)).toContain("decision must be one of");
+    }
+    expect(h.mesh.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  // A counter with no alternative is a dead end: the peer is unblocked
+  // with nothing to respond to, and the round is spent.
+  it("requires counter_proposal when the decision is 'counter'", async () => {
+    const h = meshHarness();
+    const result = await meshTool(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "not this",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "counter_proposal required when decision='counter'",
+    });
+    expect(h.mesh.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("surfaces MAX_ROUNDS_EXCEEDED with its round counts", async () => {
+    const h = meshHarness({
+      respondNegotiate: () => {
+        throw new MeshMaxRoundsError({
+          negotiationId: "neg_1",
+          rounds_completed: 5,
+          max_rounds: 5,
+        });
+      },
+    });
+    const result = await meshTool(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "m",
+      counter_proposal: "c",
+    });
+    expect(result.content).toMatchObject({
+      error: "MAX_ROUNDS_EXCEEDED",
+      rounds_completed: 5,
+      max_rounds: 5,
+    });
+  });
+});
+
+describe("report_blocker", () => {
+  it("marks the task blocked, then spawns the parent", async () => {
+    const h = meshHarness();
+    const result = await meshTool(h, "report_blocker").handler({
+      task_id: "task_7",
+      description: "no credentials for the staging DB",
+    });
+
+    expect(h.findParent).toHaveBeenCalledWith("agent_x");
+    expect(h.markBlocked).toHaveBeenCalledWith(
+      "task_7",
+      "agent_x",
+      "no credentials for the staging DB",
+    );
+    expect(h.mesh.reportBlocker).toHaveBeenCalledWith(
+      "agent_parent",
+      "agent_x",
+      "task_7",
+      "no credentials for the staging DB",
+    );
+    expect(result.content).toEqual({
+      reported: true,
+      parent_agent_id: "agent_parent",
+      task_id: "task_7",
+    });
+  });
+
+  // A top-level agent has nobody to report to; spawning nothing and
+  // silently succeeding would strand the task in blocked forever.
+  it("refuses for a top-level agent and leaves the task untouched", async () => {
+    const h = meshHarness({ parent: null });
+    const result = await meshTool(h, "report_blocker").handler({
+      task_id: "task_7",
+      description: "stuck",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "no_parent_to_block" });
+    expect(h.markBlocked).not.toHaveBeenCalled();
+    expect(h.mesh.reportBlocker).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing task_id or description before the parent lookup", async () => {
+    const h = meshHarness();
+    for (const input of [{}, { task_id: "task_7" }, { description: "stuck" }]) {
+      const result = await meshTool(h, "report_blocker").handler(input);
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual({ error: "task_id and description required" });
+    }
+    expect(h.findParent).not.toHaveBeenCalled();
+  });
+
+  // The spawn is fire-and-forget, so if markBlocked fails the parent
+  // must not be woken about a task that was never actually blocked.
+  it("does not spawn the parent when markBlocked throws", async () => {
+    const h = meshHarness({
+      markBlocked: () => {
+        throw new Error("task not found");
+      },
+    });
+    const result = await meshTool(h, "report_blocker").handler({
+      task_id: "task_missing",
+      description: "stuck",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "task not found" });
+    expect(h.mesh.reportBlocker).not.toHaveBeenCalled();
+  });
+
+  it("is available to IC agents too", async () => {
+    const h = meshHarness();
+    const ic = buildIcMeshTools(fakeCtx, h.services).find(
+      (t) => t.name === "report_blocker",
+    );
+    const result = await ic?.handler({ task_id: "task_7", description: "stuck" });
+    expect(result?.content).toMatchObject({ reported: true });
+  });
+});
+
+describe("escalate_to_humans", () => {
+  it("creates the escalation, unblocks the peer, then notifies listeners", async () => {
+    const h = meshHarness();
+    const result = await meshTool(h, "escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "We're stuck on the deploy window.",
+      proposals: [{ title: "Monday", description: "ship Monday" }],
+      open_questions: ["Is there a customer commitment?", 42],
+    });
+
+    expect(h.createEscalation).toHaveBeenCalledWith({
+      negotiationId: "neg_1",
+      callerAgentId: "agent_x",
+      summary: "We're stuck on the deploy window.",
+      proposals: [{ title: "Monday", description: "ship Monday" }],
+      // Non-string entries are filtered out rather than reaching the DB.
+      openQuestions: ["Is there a customer commitment?"],
+    });
+    expect(h.mesh.unblockOnEscalate).toHaveBeenCalledWith("neg_1", "esc_1");
+    expect(h.query).toHaveBeenCalledWith(expect.stringContaining("pg_notify"), ["esc_1"]);
+    expect(result.content).toEqual({
+      escalation_id: "esc_1",
+      status: "open",
+      negotiation_id: "neg_1",
+    });
+  });
+
+  it("omits proposals and open_questions when they are not arrays", async () => {
+    const h = meshHarness();
+    await meshTool(h, "escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "stuck",
+      proposals: "Monday",
+      open_questions: "anything?",
+    });
+    expect(h.createEscalation.mock.calls[0]?.[0]).toMatchObject({
+      proposals: undefined,
+      openQuestions: undefined,
+    });
+  });
+
+  it("rejects a missing negotiation_id or summary", async () => {
+    const h = meshHarness();
+    for (const input of [{}, { negotiation_id: "neg_1" }, { summary: "stuck" }]) {
+      const result = await meshTool(h, "escalate_to_humans").handler(input);
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual({ error: "negotiation_id and summary required" });
+    }
+    expect(h.createEscalation).not.toHaveBeenCalled();
+  });
+
+  // If the escalation row never landed there is nothing to unblock the
+  // peer with — sending the sentinel anyway would point at a dead id.
+  it("does not unblock the peer when the escalation insert fails", async () => {
+    const h = meshHarness({
+      createEscalation: () => {
+        throw new Error("negotiation already escalated");
+      },
+    });
+    const result = await meshTool(h, "escalate_to_humans").handler({
+      negotiation_id: "neg_1",
+      summary: "stuck",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "negotiation already escalated" });
+    expect(h.mesh.unblockOnEscalate).not.toHaveBeenCalled();
+    expect(h.query).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/tools/session-search.test.ts
+++ b/packages/api/src/tools/session-search.test.ts
@@ -1,0 +1,281 @@
+/**
+ * session_search unit tests.
+ *
+ * The tool's real work is `inferRequest` — a four-way shape inference
+ * (scroll / read / discover / browse) driven purely by which arguments
+ * the agent happened to pass. Pick the wrong shape and the agent gets a
+ * whole transcript when it asked for a five-message window, or an FTS
+ * query when it asked to scroll. That inference had no test file; the
+ * SessionSearchService behind it is integration-tested separately, so
+ * it's faked here.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { SessionSearchRequest } from "@beevibe/core";
+import {
+  SessionSearchError,
+  type SessionSearchService,
+} from "@beevibe/core/services/session-search";
+import {
+  createSessionSearchTool,
+  type SessionSearchToolContext,
+} from "./session-search.js";
+
+const CTX: SessionSearchToolContext = {
+  agentId: "agent_a",
+  hierarchyLevel: "team",
+  sessionId: "ses_current",
+};
+
+function fakeService(impl?: () => unknown) {
+  // Parameters are declared (rather than `async () => …`) so `mock.calls`
+  // stays a two-element tuple and the assertions below type-check.
+  const search = vi.fn(
+    async (_req: SessionSearchRequest, _ctx: SessionSearchToolContext) =>
+      impl ? impl() : { kind: "ok" },
+  );
+  return { sessionSearch: { search } as unknown as SessionSearchService, search };
+}
+
+/** Run the tool and hand back the request the service was called with. */
+async function requestFor(input: Record<string, unknown>): Promise<SessionSearchRequest> {
+  const f = fakeService();
+  await createSessionSearchTool(CTX, { sessionSearch: f.sessionSearch }).handler(input);
+  return f.search.mock.calls[0]?.[0] as unknown as SessionSearchRequest;
+}
+
+describe("session_search — shape inference", () => {
+  it("infers browse from no arguments", async () => {
+    expect(await requestFor({})).toEqual({
+      kind: "browse",
+      limit: undefined,
+      filters: undefined,
+    });
+  });
+
+  it("carries limit and filters into a browse", async () => {
+    const filters = { status: "failed" };
+    expect(await requestFor({ limit: 10, filters })).toEqual({
+      kind: "browse",
+      limit: 10,
+      filters,
+    });
+  });
+
+  it("infers discover from a query", async () => {
+    expect(await requestFor({ query: "auth refactor", limit: 5, sort: "newest" })).toEqual({
+      kind: "discover",
+      query: "auth refactor",
+      limit: 5,
+      sort: "newest",
+      filters: undefined,
+    });
+  });
+
+  it("infers read from a bare session_id", async () => {
+    expect(await requestFor({ session_id: "ses_7" })).toEqual({
+      kind: "read",
+      session_id: "ses_7",
+    });
+  });
+
+  it("infers scroll from session_id + around_message_id", async () => {
+    expect(
+      await requestFor({ session_id: "ses_7", around_message_id: "evt_3", window: 10 }),
+    ).toEqual({
+      kind: "scroll",
+      session_id: "ses_7",
+      around_message_id: "evt_3",
+      window: 10,
+    });
+  });
+
+  // Scroll is the most specific shape, so it wins: an agent that pastes
+  // back a whole discovery hit (query included) still gets its window.
+  it("prefers scroll over read and discover when all three are present", async () => {
+    const req = await requestFor({
+      query: "auth refactor",
+      session_id: "ses_7",
+      around_message_id: "evt_3",
+    });
+    expect(req.kind).toBe("scroll");
+  });
+
+  it("prefers read over discover when session_id and query are both present", async () => {
+    const req = await requestFor({ query: "auth refactor", session_id: "ses_7" });
+    expect(req).toEqual({ kind: "read", session_id: "ses_7" });
+  });
+
+  it("trims whitespace off session_id, around_message_id and query", async () => {
+    expect(await requestFor({ session_id: "  ses_7  ", around_message_id: " evt_3 " })).toEqual(
+      { kind: "scroll", session_id: "ses_7", around_message_id: "evt_3", window: undefined },
+    );
+    expect(await requestFor({ query: "  auth  " })).toMatchObject({ query: "auth" });
+  });
+
+  // A blank string is what an agent sends when it templated an empty
+  // variable; treating it as "present" would infer read on a nonexistent
+  // session instead of browsing.
+  it("treats blank and non-string arguments as absent", async () => {
+    expect((await requestFor({ session_id: "   ", query: "   " })).kind).toBe("browse");
+    expect((await requestFor({ session_id: 7, query: null })).kind).toBe("browse");
+    // A blank anchor demotes scroll to read rather than scrolling nowhere.
+    expect(await requestFor({ session_id: "ses_7", around_message_id: "  " })).toEqual({
+      kind: "read",
+      session_id: "ses_7",
+    });
+  });
+
+  it("drops a non-numeric limit or window rather than forwarding it", async () => {
+    expect(await requestFor({ query: "x", limit: "5" })).toMatchObject({ limit: undefined });
+    expect(
+      await requestFor({ session_id: "s", around_message_id: "m", window: "10" }),
+    ).toMatchObject({ window: undefined });
+  });
+
+  it("only accepts 'newest' and 'oldest' for sort", async () => {
+    expect(await requestFor({ query: "x", sort: "oldest" })).toMatchObject({ sort: "oldest" });
+    for (const sort of ["relevance", "", 1, undefined]) {
+      expect(await requestFor({ query: "x", sort })).toMatchObject({ sort: undefined });
+    }
+  });
+
+  it("passes filters through on discover and browse", async () => {
+    const filters = { session_type: "task", status: "failed" };
+    expect(await requestFor({ query: "x", filters })).toMatchObject({ filters });
+    expect(await requestFor({ filters })).toMatchObject({ filters });
+  });
+
+  it("ignores a null or non-object filters value", async () => {
+    expect(await requestFor({ query: "x", filters: null })).toMatchObject({
+      filters: undefined,
+    });
+    expect(await requestFor({ query: "x", filters: "task" })).toMatchObject({
+      filters: undefined,
+    });
+  });
+});
+
+describe("session_search — context threading", () => {
+  it("passes the caller's agent id, tier and current session to the service", async () => {
+    const f = fakeService();
+    await createSessionSearchTool(CTX, { sessionSearch: f.sessionSearch }).handler({});
+    expect(f.search.mock.calls[0]?.[1]).toEqual({
+      callerAgentId: "agent_a",
+      hierarchyLevel: "team",
+      currentSessionId: "ses_current",
+    });
+  });
+
+  it("forwards the tier verbatim — scope resolution is the service's job", async () => {
+    for (const hierarchyLevel of ["ic", "team", "org"] as const) {
+      const f = fakeService();
+      await createSessionSearchTool(
+        { ...CTX, hierarchyLevel },
+        { sessionSearch: f.sessionSearch },
+      ).handler({ query: "x" });
+      expect(f.search.mock.calls[0]?.[1]).toMatchObject({ hierarchyLevel });
+    }
+  });
+
+  it("returns the service result verbatim on success", async () => {
+    const payload = { results: [{ session: { id: "ses_1" } }] };
+    const f = fakeService(() => payload);
+    const result = await createSessionSearchTool(CTX, {
+      sessionSearch: f.sessionSearch,
+    }).handler({ query: "x" });
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toBe(payload);
+  });
+});
+
+describe("session_search — error envelopes", () => {
+  // null is the service's "out of scope / no such anchor" signal. It has
+  // to become an isError result, not an empty success the agent reads as
+  // "there was nothing there".
+  it("turns a null result into not_found_or_forbidden", async () => {
+    const f = fakeService(() => null);
+    const result = await createSessionSearchTool(CTX, {
+      sessionSearch: f.sessionSearch,
+    }).handler({ session_id: "ses_other" });
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "not_found_or_forbidden" });
+  });
+
+  it("surfaces a SessionSearchError's code", async () => {
+    const f = fakeService(() => {
+      throw new SessionSearchError("forbidden_agent_filter", "agent_b is out of your scope");
+    });
+    const result = await createSessionSearchTool(CTX, {
+      sessionSearch: f.sessionSearch,
+    }).handler({ query: "x", filters: { agent_id: "agent_b" } });
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "forbidden_agent_filter",
+      message: "agent_b is out of your scope",
+    });
+  });
+
+  // The handler matches on `err.name` as well as instanceof, so that a
+  // cross-bundle throw (src/ vs dist/ copies of the class) still yields
+  // the structured code instead of collapsing to internal_error.
+  it("matches a same-named error from another bundle by name", async () => {
+    const f = fakeService(() => {
+      const err = new Error("missing query") as Error & { code: string };
+      err.name = "SessionSearchError";
+      err.code = "missing_query";
+      throw err;
+    });
+    const result = await createSessionSearchTool(CTX, {
+      sessionSearch: f.sessionSearch,
+    }).handler({ query: "x" });
+    expect(result.content).toEqual({ error: "missing_query", message: "missing query" });
+  });
+
+  it("wraps anything else as internal_error", async () => {
+    const f = fakeService(() => {
+      throw new Error("pg connection lost");
+    });
+    const result = await createSessionSearchTool(CTX, {
+      sessionSearch: f.sessionSearch,
+    }).handler({});
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "internal_error",
+      message: "pg connection lost",
+    });
+  });
+
+  it("stringifies a non-Error throw", async () => {
+    const f = fakeService(() => {
+      throw "kaboom";
+    });
+    const result = await createSessionSearchTool(CTX, {
+      sessionSearch: f.sessionSearch,
+    }).handler({});
+    expect(result.content).toEqual({ error: "internal_error", message: "kaboom" });
+  });
+});
+
+describe("session_search — advertised schema", () => {
+  it("names the tool session_search and offers all four shapes' arguments", () => {
+    const tool = createSessionSearchTool(CTX, fakeService().sessionSearch as never);
+    expect(tool.name).toBe("session_search");
+    expect(Object.keys(tool.schema.properties as object).sort()).toEqual([
+      "around_message_id",
+      "filters",
+      "limit",
+      "query",
+      "session_id",
+      "sort",
+      "window",
+    ]);
+  });
+
+  // Browse is the no-argument shape, so nothing may be required — a
+  // `required` list here would make `session_search()` uncallable.
+  it("requires no arguments, so the browse shape stays reachable", () => {
+    const tool = createSessionSearchTool(CTX, fakeService().sessionSearch as never);
+    expect(tool.schema.required).toBeUndefined();
+  });
+});

--- a/packages/api/src/tools/use-repo.test.ts
+++ b/packages/api/src/tools/use-repo.test.ts
@@ -1,0 +1,360 @@
+/**
+ * use_repo unit tests.
+ *
+ * The tool is the Agent App Store's only verb, and it had no test file —
+ * the whole surface (URL gating, limit clamping, and the ordering
+ * contract between dispatch and the repo_run insert) was only exercised
+ * by the Postgres-backed e2e path.
+ *
+ * Two things here are load-bearing beyond "does it return the right
+ * shape":
+ *   - `repo_url` gating is a security boundary: whatever passes it gets
+ *     cloned and executed inside the sandbox.
+ *   - the session row must exist before the repo_run insert, because
+ *     repo_run.session_id carries an FK to session.id. The source
+ *     comment spells this out; these tests pin it.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  RepoRun,
+  RepoRunRepository,
+  Task,
+  TaskRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import { createUseRepoTool, type UseRepoServices } from "./use-repo.js";
+
+const AGENT: Agent = { id: "agent_a", name: "Ada" } as unknown as Agent;
+
+interface Harness {
+  services: UseRepoServices;
+  calls: string[];
+  taskCreate: ReturnType<typeof vi.fn>;
+  dispatchTask: ReturnType<typeof vi.fn>;
+  repoRunCreate: ReturnType<typeof vi.fn>;
+}
+
+function harness(
+  overrides: {
+    agent?: Agent | undefined;
+    dispatchImpl?: () => Promise<unknown>;
+    repoRunImpl?: () => Promise<unknown>;
+  } = {},
+): Harness {
+  // Shared ordered log — the dispatch-before-insert contract is only
+  // observable as a sequence across two different fakes.
+  const calls: string[] = [];
+
+  const taskCreate = vi.fn(async (input: Record<string, unknown>) => {
+    calls.push("task.create");
+    return { ...input, status: "pending" } as unknown as Task;
+  });
+  const dispatchTask = vi.fn(async () => {
+    calls.push("dispatch");
+    return overrides.dispatchImpl ? await overrides.dispatchImpl() : {};
+  });
+  const repoRunCreate = vi.fn(async (input: Record<string, unknown>) => {
+    calls.push("repoRun.create");
+    if (overrides.repoRunImpl) await overrides.repoRunImpl();
+    return input as unknown as RepoRun;
+  });
+
+  const services: UseRepoServices = {
+    agentRepo: {
+      findById: vi.fn(async () =>
+        "agent" in overrides ? overrides.agent : AGENT,
+      ),
+    } as unknown as AgentRepository,
+    taskRepo: { create: taskCreate } as unknown as TaskRepository,
+    repoRunRepo: { create: repoRunCreate } as unknown as RepoRunRepository,
+    dispatchService: { dispatchTask } as unknown as DispatchService,
+  };
+
+  return { services, calls, taskCreate, dispatchTask, repoRunCreate };
+}
+
+function tool(h: Harness) {
+  return createUseRepoTool({ agentId: "agent_a" }, h.services);
+}
+
+const OK_INPUT = {
+  goal: "Extract the tables from this PDF as JSON",
+  repo_url: "https://github.com/jsvine/pdfplumber",
+};
+
+describe("use_repo — input validation", () => {
+  it("rejects a missing or blank goal before touching any service", async () => {
+    const h = harness();
+    for (const goal of [undefined, "", "   ", 42]) {
+      const result = await tool(h).handler({ ...OK_INPUT, goal });
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatchObject({ error: "invalid_goal" });
+    }
+    expect(h.taskCreate).not.toHaveBeenCalled();
+    expect(h.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  // Anything that passes this gate is cloned and run inside the sandbox,
+  // so the accept list stays narrow: HTTPS, github.com or a subdomain.
+  it("accepts github.com and its subdomains over HTTPS", async () => {
+    for (const repo_url of [
+      "https://github.com/jsvine/pdfplumber",
+      "https://www.github.com/jsvine/pdfplumber",
+      "https://GitHub.com/jsvine/pdfplumber",
+      "  https://github.com/jsvine/pdfplumber  ",
+    ]) {
+      const result = await tool(harness()).handler({ ...OK_INPUT, repo_url });
+      expect(result.isError, repo_url).toBeFalsy();
+    }
+  });
+
+  it("rejects non-HTTPS, non-github, lookalike and malformed repo_urls", async () => {
+    const h = harness();
+    for (const repo_url of [
+      undefined,
+      "",
+      "   ",
+      "http://github.com/a/b", // plaintext
+      "git@github.com:a/b.git", // ssh
+      "https://gitlab.com/a/b",
+      "https://notgithub.com/a/b",
+      "https://github.com.evil.example/a/b", // suffix lookalike
+      "https://evilgithub.com/a/b",
+      "not a url at all",
+    ]) {
+      const result = await tool(h).handler({ ...OK_INPUT, repo_url });
+      expect(result.isError, String(repo_url)).toBe(true);
+      expect(result.content).toMatchObject({ error: "invalid_repo_url" });
+    }
+    expect(h.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("returns agent_not_found when the caller's agent row is gone", async () => {
+    const h = harness({ agent: undefined });
+    const result = await tool(h).handler(OK_INPUT);
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "agent_not_found" });
+    expect(h.taskCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe("use_repo — happy path", () => {
+  it("creates the container task, dispatches, then inserts the repo_run", async () => {
+    const h = harness();
+    const result = await tool(h).handler(OK_INPUT);
+
+    expect(result.isError).toBeFalsy();
+    // The FK on repo_run.session_id makes this order mandatory, not
+    // incidental: dispatchTask is what writes the session row.
+    expect(h.calls).toEqual(["task.create", "dispatch", "repoRun.create"]);
+
+    const task = h.taskCreate.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(task).toMatchObject({
+      title: OK_INPUT.goal,
+      description: OK_INPUT.goal,
+      priority: "medium",
+      assignee_id: "agent_a",
+      creator_id: "agent_a",
+      creator_type: "agent",
+    });
+
+    const dispatch = h.dispatchTask.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(dispatch).toMatchObject({
+      agentId: "agent_a",
+      type: "run_repo",
+      intent: OK_INPUT.goal,
+      reason: { kind: "fresh" },
+    });
+
+    const run = h.repoRunCreate.mock.calls[0]?.[0] as Record<string, unknown>;
+    // The pre-minted session id has to be the same one dispatch was told
+    // to use, or the daemon's composeDispatchPayload finds no repo_run.
+    expect(run.session_id).toBe(dispatch.sessionIdOverride);
+    expect(run).toMatchObject({
+      task_id: task.id,
+      agent_id: "agent_a",
+      goal: OK_INPUT.goal,
+      repo_url: OK_INPUT.repo_url,
+      status: "pending",
+    });
+
+    expect(result.content).toMatchObject({
+      repo_run_id: run.id,
+      session_id: run.session_id,
+      task_id: task.id,
+      status: "pending",
+      watch_url: `/capabilities/runs/${String(run.id)}`,
+    });
+  });
+
+  it("trims the goal and repo_url before storing them", async () => {
+    const h = harness();
+    await tool(h).handler({
+      goal: "  extract tables  ",
+      repo_url: "  https://github.com/a/b  ",
+    });
+    expect(h.repoRunCreate.mock.calls[0]?.[0]).toMatchObject({
+      goal: "extract tables",
+      repo_url: "https://github.com/a/b",
+    });
+  });
+
+  // The title is what shows up as an inbox row, so it has to stay
+  // scannable no matter how long the goal is.
+  it("collapses whitespace and truncates the container task title at 80 chars", async () => {
+    const h = harness();
+    const goal = `${"a".repeat(200)}\n\n  b`;
+    await tool(h).handler({ ...OK_INPUT, goal });
+    const title = (h.taskCreate.mock.calls[0]?.[0] as { title: string }).title;
+    // 77 kept chars + the ellipsis; comfortably under the 80-char cap.
+    expect(title).toHaveLength(78);
+    expect(title.length).toBeLessThanOrEqual(80);
+    expect(title.endsWith("…")).toBe(true);
+    // Only the title is squeezed — the description and the dispatch
+    // intent keep the goal verbatim, newlines and all, because that's
+    // what the child agent reads.
+    expect(h.taskCreate.mock.calls[0]?.[0]).toMatchObject({ description: goal });
+    expect(h.dispatchTask.mock.calls[0]?.[0]).toMatchObject({ intent: goal });
+  });
+
+  it("leaves a short title unmarked", async () => {
+    const h = harness();
+    await tool(h).handler({ ...OK_INPUT, goal: "short   goal" });
+    expect(h.taskCreate.mock.calls[0]?.[0]).toMatchObject({ title: "short goal" });
+  });
+
+  it("echoes trimmed input_url / input_filename back to the caller", async () => {
+    const h = harness();
+    const result = await tool(h).handler({
+      ...OK_INPUT,
+      input_url: "  https://example.com/report.pdf  ",
+      input_filename: "  report.pdf  ",
+    });
+    expect(result.content).toMatchObject({
+      input_url: "https://example.com/report.pdf",
+      input_filename: "report.pdf",
+    });
+  });
+
+  it("omits input_url / input_filename when not supplied", async () => {
+    const result = await tool(harness()).handler(OK_INPUT);
+    expect(result.content.input_url).toBeUndefined();
+    expect(result.content.input_filename).toBeUndefined();
+  });
+
+  it("mints a fresh repo_run / session / task id per call", async () => {
+    const h = harness();
+    const a = await tool(h).handler(OK_INPUT);
+    const b = await tool(h).handler(OK_INPUT);
+    expect(a.content.repo_run_id).not.toBe(b.content.repo_run_id);
+    expect(a.content.session_id).not.toBe(b.content.session_id);
+  });
+});
+
+describe("use_repo — limits clamping", () => {
+  it("clamps each limit to its documented ceiling", async () => {
+    const result = await tool(harness()).handler({
+      ...OK_INPUT,
+      limits: { wall_clock_minutes: 999, max_install_attempts: 50, disk_mb: 999_999 },
+    });
+    expect(result.content.limits).toEqual({
+      wall_clock_minutes: 60,
+      max_install_attempts: 5,
+      disk_mb: 10_000,
+    });
+  });
+
+  it("passes through in-range values and floors the integer limits", async () => {
+    const result = await tool(harness()).handler({
+      ...OK_INPUT,
+      limits: { wall_clock_minutes: 12.5, max_install_attempts: 3.9, disk_mb: 512.7 },
+    });
+    expect(result.content.limits).toEqual({
+      wall_clock_minutes: 12.5,
+      max_install_attempts: 3,
+      disk_mb: 512,
+    });
+  });
+
+  // Silently dropping a bad limit is the intended behavior: the sandbox
+  // applies its own defaults, so a junk value must not become 0 or NaN.
+  it("drops non-positive, non-numeric and unknown limit entries", async () => {
+    const result = await tool(harness()).handler({
+      ...OK_INPUT,
+      limits: {
+        wall_clock_minutes: 0,
+        max_install_attempts: -1,
+        disk_mb: "2048",
+        cpu_shares: 512,
+      },
+    });
+    expect(result.content.limits).toEqual({});
+  });
+
+  it("treats a missing or non-object limits value as no limits", async () => {
+    for (const limits of [undefined, null, "20", 20, []]) {
+      const result = await tool(harness()).handler({ ...OK_INPUT, limits });
+      expect(result.content.limits, JSON.stringify(limits)).toEqual({});
+    }
+  });
+});
+
+describe("use_repo — failure paths", () => {
+  it("returns dispatch_failed and skips the repo_run insert when dispatch throws", async () => {
+    const h = harness({
+      dispatchImpl: async () => {
+        throw new Error("no runtime online");
+      },
+    });
+    const result = await tool(h).handler(OK_INPUT);
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "dispatch_failed",
+      message: "no runtime online",
+    });
+    expect(h.repoRunCreate).not.toHaveBeenCalled();
+  });
+
+  // The orphan-session case the source comment describes: the session
+  // row landed, the repo_run didn't. It self-heals, but the agent has to
+  // be told rather than left polling a run that will never exist.
+  it("surfaces repo_run_create_failed rather than returning ids for an orphan session", async () => {
+    const h = harness({
+      repoRunImpl: async () => {
+        throw new Error("duplicate key");
+      },
+    });
+    const result = await tool(h).handler(OK_INPUT);
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "repo_run_create_failed",
+      message: "duplicate key",
+    });
+    expect(result.content.repo_run_id).toBeUndefined();
+  });
+
+  it("stringifies non-Error throws from either write", async () => {
+    const dispatchFail = harness({
+      dispatchImpl: async () => {
+        throw "dispatch exploded";
+      },
+    });
+    expect((await tool(dispatchFail).handler(OK_INPUT)).content).toMatchObject({
+      error: "dispatch_failed",
+      message: "dispatch exploded",
+    });
+
+    const insertFail = harness({
+      repoRunImpl: async () => {
+        throw "insert exploded";
+      },
+    });
+    expect((await tool(insertFail).handler(OK_INPUT)).content).toMatchObject({
+      error: "repo_run_create_failed",
+      message: "insert exploded",
+    });
+  });
+});

--- a/packages/api/src/tools/watch.test.ts
+++ b/packages/api/src/tools/watch.test.ts
@@ -1,0 +1,254 @@
+/**
+ * watch_tasks / unwatch unit tests.
+ *
+ * These two tools back the task-completion wake-up: without a watch, an
+ * agent that dispatched work is simply never re-invoked. The adapter
+ * layer here is thin, but everything it does is load-bearing —
+ * defaulting the mode, refusing a call made outside a session context,
+ * and mapping each WatchService error class onto the stable code the
+ * calling agent branches on. None of it had a test file.
+ *
+ * WatchService itself is integration-tested against Postgres
+ * (core/src/services/watch-service.test.ts); this file fakes it so the
+ * adapter's own branches run without a database.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  WatchAuthError,
+  WatchNotFoundError,
+  WatchValidationError,
+  type WatchService,
+} from "@beevibe/core/services/watch-service";
+import { buildWatchTools, type WatchToolContext } from "./watch.js";
+
+function fakeService(
+  overrides: Partial<{
+    watchTasks: WatchService["watchTasks"];
+    unwatch: WatchService["unwatch"];
+  }> = {},
+) {
+  const watchTasks = vi.fn(
+    overrides.watchTasks ??
+      (async () => ({ watchId: "tw_1", firedImmediately: false })),
+  );
+  const unwatch = vi.fn(overrides.unwatch ?? (async () => undefined));
+  return {
+    watchService: { watchTasks, unwatch } as unknown as WatchService,
+    watchTasks,
+    unwatch,
+  };
+}
+
+const CTX: WatchToolContext = { agentId: "agent_a", sessionId: "ses_1" };
+
+function tools(ctx: WatchToolContext, watchService: WatchService) {
+  const built = buildWatchTools(ctx, { watchService });
+  const byName = new Map(built.map((t) => [t.name, t]));
+  const watchTool = byName.get("watch_tasks");
+  const unwatchTool = byName.get("unwatch");
+  if (!watchTool || !unwatchTool) throw new Error("missing watch tools");
+  return { watchTool, unwatchTool };
+}
+
+describe("buildWatchTools", () => {
+  it("returns watch_tasks and unwatch, in that order", () => {
+    const { watchService } = fakeService();
+    expect(buildWatchTools(CTX, { watchService }).map((t) => t.name)).toEqual([
+      "watch_tasks",
+      "unwatch",
+    ]);
+  });
+
+  it("advertises both watch modes on the schema enum", () => {
+    const { watchService } = fakeService();
+    const { watchTool } = tools(CTX, watchService);
+    const props = watchTool.schema.properties as Record<
+      string,
+      { enum?: string[] }
+    >;
+    expect(props.mode?.enum).toEqual(["all", "any"]);
+    expect(watchTool.schema.required).toEqual(["task_ids"]);
+  });
+});
+
+describe("watch_tasks", () => {
+  it("forwards caller identity, task ids, mode and reason to the service", async () => {
+    const f = fakeService();
+    const { watchTool } = tools(CTX, f.watchService);
+
+    const result = await watchTool.handler({
+      task_ids: ["task_1", "task_2"],
+      mode: "any",
+      reason: "  need the first result  ",
+    });
+
+    expect(f.watchTasks).toHaveBeenCalledWith({
+      callerAgentId: "agent_a",
+      callerSessionId: "ses_1",
+      taskIds: ["task_1", "task_2"],
+      mode: "any",
+      reason: "need the first result",
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({ watch_id: "tw_1", fired_immediately: false });
+  });
+
+  // "all" is the documented default; an agent that omits `mode` must not
+  // silently get "any" and wake on the first of five tasks.
+  it("defaults mode to 'all' when omitted or not a valid mode", async () => {
+    for (const mode of [undefined, "", "eventually", 1, null]) {
+      const f = fakeService();
+      const { watchTool } = tools(CTX, f.watchService);
+      await watchTool.handler({ task_ids: ["task_1"], mode });
+      expect(f.watchTasks.mock.calls[0]?.[0]).toMatchObject({ mode: "all" });
+    }
+  });
+
+  it("omits a blank or non-string reason instead of passing it through", async () => {
+    for (const reason of [undefined, "", "   ", 7]) {
+      const f = fakeService();
+      const { watchTool } = tools(CTX, f.watchService);
+      await watchTool.handler({ task_ids: ["task_1"], reason });
+      expect(f.watchTasks.mock.calls[0]?.[0]?.reason).toBeUndefined();
+    }
+  });
+
+  it("filters non-string entries out of task_ids", async () => {
+    const f = fakeService();
+    const { watchTool } = tools(CTX, f.watchService);
+    await watchTool.handler({ task_ids: ["task_1", 42, null, "task_2"] });
+    expect(f.watchTasks.mock.calls[0]?.[0]?.taskIds).toEqual(["task_1", "task_2"]);
+  });
+
+  it("rejects an empty, absent or all-junk task_ids without calling the service", async () => {
+    for (const task_ids of [undefined, [], "task_1", [42, null]]) {
+      const f = fakeService();
+      const { watchTool } = tools(CTX, f.watchService);
+      const result = await watchTool.handler({ task_ids });
+      expect(result.isError, JSON.stringify(task_ids)).toBe(true);
+      expect(result.content).toMatchObject({ error: "watch_validation" });
+      expect(f.watchTasks).not.toHaveBeenCalled();
+    }
+  });
+
+  // Without a session id the service cannot identify the waiter, so the
+  // watch would be unroutable — refuse rather than insert a dead row.
+  it("refuses when the tool call has no session context", async () => {
+    const f = fakeService();
+    const { watchTool } = tools({ agentId: "agent_a" }, f.watchService);
+    const result = await watchTool.handler({ task_ids: ["task_1"] });
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "watch_validation",
+      message: "watch_tasks must be called inside a session context",
+    });
+    expect(f.watchTasks).not.toHaveBeenCalled();
+  });
+
+  it("reports fired_immediately when the condition was already met", async () => {
+    const f = fakeService({
+      watchTasks: (async () => ({
+        watchId: "tw_hot",
+        firedImmediately: true,
+      })) as unknown as WatchService["watchTasks"],
+    });
+    const { watchTool } = tools(CTX, f.watchService);
+    const result = await watchTool.handler({ task_ids: ["task_done"] });
+    expect(result.content).toEqual({ watch_id: "tw_hot", fired_immediately: true });
+  });
+});
+
+describe("unwatch", () => {
+  it("delegates to the service with the caller's agent id", async () => {
+    const f = fakeService();
+    const { unwatchTool } = tools(CTX, f.watchService);
+    const result = await unwatchTool.handler({ watch_id: "tw_1" });
+    expect(f.unwatch).toHaveBeenCalledWith({
+      callerAgentId: "agent_a",
+      watchId: "tw_1",
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({ ok: true });
+  });
+
+  it("rejects a missing or non-string watch_id without calling the service", async () => {
+    for (const watch_id of [undefined, "", 42, null]) {
+      const f = fakeService();
+      const { unwatchTool } = tools(CTX, f.watchService);
+      const result = await unwatchTool.handler({ watch_id });
+      expect(result.isError, String(watch_id)).toBe(true);
+      expect(result.content).toMatchObject({
+        error: "watch_validation",
+        message: "watch_id must be a non-empty string",
+      });
+      expect(f.unwatch).not.toHaveBeenCalled();
+    }
+  });
+
+  // The description promises idempotence; unwatch is allowed to work
+  // without a session context (unlike watch_tasks).
+  it("works without a session context", async () => {
+    const f = fakeService();
+    const { unwatchTool } = tools({ agentId: "agent_a" }, f.watchService);
+    expect((await unwatchTool.handler({ watch_id: "tw_1" })).content).toEqual({
+      ok: true,
+    });
+  });
+});
+
+/**
+ * The error mapping is the part agents actually branch on: an auth
+ * failure ("that task isn't in your chain") means stop, a validation
+ * failure means fix the arguments, and a not-found on unwatch is benign.
+ * Collapsing them all to one code would make that undecidable.
+ */
+describe("error mapping — shared by both tools", () => {
+  const cases: Array<[string, unknown, string]> = [
+    ["WatchAuthError", new WatchAuthError("not your chain"), "watch_auth"],
+    ["WatchValidationError", new WatchValidationError("bad mode"), "watch_validation"],
+    ["WatchNotFoundError", new WatchNotFoundError("no such watch"), "watch_not_found"],
+    ["a plain Error", new Error("pg down"), "watch_error"],
+    ["a non-Error throw", "kaboom", "watch_error"],
+  ];
+
+  for (const [label, thrown, code] of cases) {
+    it(`maps ${label} to ${code} on watch_tasks`, async () => {
+      const f = fakeService({
+        watchTasks: (async () => {
+          throw thrown;
+        }) as unknown as WatchService["watchTasks"],
+      });
+      const { watchTool } = tools(CTX, f.watchService);
+      const result = await watchTool.handler({ task_ids: ["task_1"] });
+      expect(result.isError).toBe(true);
+      expect(result.content.error).toBe(code);
+      expect(typeof result.content.message).toBe("string");
+    });
+
+    it(`maps ${label} to ${code} on unwatch`, async () => {
+      const f = fakeService({
+        unwatch: (async () => {
+          throw thrown;
+        }) as unknown as WatchService["unwatch"],
+      });
+      const { unwatchTool } = tools(CTX, f.watchService);
+      const result = await unwatchTool.handler({ watch_id: "tw_1" });
+      expect(result.isError).toBe(true);
+      expect(result.content.error).toBe(code);
+    });
+  }
+
+  it("preserves the thrown message for the human reading the transcript", async () => {
+    const f = fakeService({
+      watchTasks: (async () => {
+        throw new WatchAuthError("task(s) not dispatched in your conversation chain: t1");
+      }) as unknown as WatchService["watchTasks"],
+    });
+    const { watchTool } = tools(CTX, f.watchService);
+    const result = await watchTool.handler({ task_ids: ["t1"] });
+    expect(result.content.message).toBe(
+      "task(s) not dispatched in your conversation chain: t1",
+    );
+  });
+});

--- a/packages/core/src/env.test.ts
+++ b/packages/core/src/env.test.ts
@@ -1,0 +1,87 @@
+/**
+ * `env.ts` is the composition-root's only env-parsing surface — both the
+ * api and the scheduler binaries route through it before they bind a
+ * port or hand agents an MCP URL. It had no test file at all, so the
+ * Railway fallback and the `Number("")` guard the doc comments call out
+ * were unverified.
+ */
+
+import { describe, expect, it } from "vitest";
+import { readPositiveInt, resolveMcpServerUrl } from "./env.js";
+
+describe("resolveMcpServerUrl", () => {
+  it("prefers an explicit BEEVIBE_MCP_SERVER_URL", () => {
+    expect(
+      resolveMcpServerUrl({ BEEVIBE_MCP_SERVER_URL: "https://api.example.com/mcp" }),
+    ).toBe("https://api.example.com/mcp");
+  });
+
+  // The explicit var wins even when a PaaS domain is also present —
+  // otherwise an operator override would be silently ignored on Railway.
+  it("prefers the explicit var over RAILWAY_PUBLIC_DOMAIN", () => {
+    expect(
+      resolveMcpServerUrl({
+        BEEVIBE_MCP_SERVER_URL: "https://explicit.example.com/mcp",
+        RAILWAY_PUBLIC_DOMAIN: "beevibe.up.railway.app",
+      }),
+    ).toBe("https://explicit.example.com/mcp");
+  });
+
+  it("falls back to https://${RAILWAY_PUBLIC_DOMAIN}/mcp so a one-click deploy works", () => {
+    expect(resolveMcpServerUrl({ RAILWAY_PUBLIC_DOMAIN: "beevibe.up.railway.app" })).toBe(
+      "https://beevibe.up.railway.app/mcp",
+    );
+  });
+
+  it("returns undefined when neither var is set", () => {
+    expect(resolveMcpServerUrl({})).toBeUndefined();
+  });
+
+  // An empty string is falsy, so it must behave like "unset" rather than
+  // producing "https:///mcp" or an empty URL.
+  it("treats empty strings as unset", () => {
+    expect(resolveMcpServerUrl({ BEEVIBE_MCP_SERVER_URL: "" })).toBeUndefined();
+    expect(
+      resolveMcpServerUrl({ BEEVIBE_MCP_SERVER_URL: "", RAILWAY_PUBLIC_DOMAIN: "" }),
+    ).toBeUndefined();
+    expect(
+      resolveMcpServerUrl({ BEEVIBE_MCP_SERVER_URL: "", RAILWAY_PUBLIC_DOMAIN: "d.example" }),
+    ).toBe("https://d.example/mcp");
+  });
+});
+
+describe("readPositiveInt", () => {
+  it("parses a positive integer", () => {
+    expect(readPositiveInt("8080", 3000)).toBe(8080);
+  });
+
+  it("falls back when undefined", () => {
+    expect(readPositiveInt(undefined, 3000)).toBe(3000);
+  });
+
+  // The whole reason this helper exists: Number("") is 0, which would
+  // bind an HTTP server to a random port instead of the intended one.
+  it("falls back on the empty string rather than yielding 0", () => {
+    expect(readPositiveInt("", 3000)).toBe(3000);
+  });
+
+  it("falls back on non-numeric input", () => {
+    expect(readPositiveInt("not-a-port", 3000)).toBe(3000);
+    expect(readPositiveInt("   ", 3000)).toBe(3000);
+  });
+
+  it("falls back on zero and negatives", () => {
+    expect(readPositiveInt("0", 3000)).toBe(3000);
+    expect(readPositiveInt("-1", 3000)).toBe(3000);
+  });
+
+  // parseInt stops at the first non-digit, which is the documented
+  // behavior here — "8080abc" is a typo'd port, not a fallback case.
+  it("takes parseInt's leading-digits reading of a trailing-garbage value", () => {
+    expect(readPositiveInt("8080abc", 3000)).toBe(8080);
+  });
+
+  it("truncates a float to its integer part", () => {
+    expect(readPositiveInt("8080.9", 3000)).toBe(8080);
+  });
+});

--- a/packages/daemon/src/logger.test.ts
+++ b/packages/daemon/src/logger.test.ts
@@ -1,0 +1,71 @@
+/**
+ * The daemon's only logging surface. Every `[daemon] …` line an operator
+ * reads out of /tmp/beevibe-daemon.log goes through here, and the
+ * ISO-timestamp prefix is what makes those lines greppable by time —
+ * so the prefix is a contract, not decoration.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { error, log, warn } from "./logger.js";
+
+const ISO_8601 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("logger", () => {
+  it("log() writes to console.log with an ISO timestamp first", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    log("[daemon] started");
+    expect(spy).toHaveBeenCalledTimes(1);
+    const args = spy.mock.calls[0] ?? [];
+    expect(String(args[0])).toMatch(ISO_8601);
+    expect(args[1]).toBe("[daemon] started");
+  });
+
+  // warn/error must not collapse onto console.log: operators separate
+  // the daemon's stdout from its stderr when running it under a
+  // supervisor, so the stream a line lands on is observable behavior.
+  it("warn() writes to console.warn, not console.log", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    warn("[daemon] skills sync failed;", "continuing");
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const args = warnSpy.mock.calls[0] ?? [];
+    expect(String(args[0])).toMatch(ISO_8601);
+    expect(args.slice(1)).toEqual(["[daemon] skills sync failed;", "continuing"]);
+  });
+
+  it("error() writes to console.error, not console.log", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    error("[daemon] claim failed");
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    expect(String((errSpy.mock.calls[0] ?? [])[0])).toMatch(ISO_8601);
+  });
+
+  it("forwards every variadic argument after the timestamp", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const err = new Error("boom");
+    log("a", 1, { b: 2 }, err);
+    expect((spy.mock.calls[0] ?? []).slice(1)).toEqual(["a", 1, { b: 2 }, err]);
+  });
+
+  it("stamps the time of the call, not of module load", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+      log("first");
+      vi.setSystemTime(new Date("2024-01-01T00:05:00.000Z"));
+      log("second");
+    } finally {
+      vi.useRealTimers();
+    }
+    expect((spy.mock.calls[0] ?? [])[0]).toBe("2024-01-01T00:00:00.000Z");
+    expect((spy.mock.calls[1] ?? [])[0]).toBe("2024-01-01T00:05:00.000Z");
+  });
+});

--- a/packages/daemon/src/supervisor.test.ts
+++ b/packages/daemon/src/supervisor.test.ts
@@ -1,5 +1,18 @@
-import { describe, expect, it } from "vitest";
-import { Supervisor } from "./supervisor.js";
+import { afterEach, describe, expect, it } from "vitest";
+import { DEFAULT_MAX_CONCURRENT, Supervisor } from "./supervisor.js";
+
+const ENV_KEY = "BEEVIBE_DAEMON_MAX_CONCURRENT";
+
+/** Fill the supervisor and report the cap it actually enforced. */
+function observedCap(s: Supervisor): number {
+  let n = 0;
+  while (s.hasCapacity()) {
+    s.start(`sess_${n}`);
+    n++;
+    if (n > 1000) throw new Error("supervisor never reported full");
+  }
+  return n;
+}
 
 describe("Supervisor", () => {
   it("respects maxConcurrent: hasCapacity flips to false at the cap", () => {
@@ -46,5 +59,61 @@ describe("Supervisor", () => {
     s.cancelAll();
     expect(abortCount).toBe(3);
     expect(s.inFlight()).toBe(0);
+  });
+});
+
+/**
+ * The no-argument constructor reads BEEVIBE_DAEMON_MAX_CONCURRENT — that
+ * is the path `runStart` actually takes, and it was the one part of this
+ * module with no coverage. A bad parse here either uncaps the daemon or
+ * pins it at zero concurrency, and both fail silently at runtime.
+ */
+describe("Supervisor — cap from BEEVIBE_DAEMON_MAX_CONCURRENT", () => {
+  const original = process.env[ENV_KEY];
+
+  afterEach(() => {
+    if (original === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = original;
+  });
+
+  it("defaults to DEFAULT_MAX_CONCURRENT when the var is unset", () => {
+    delete process.env[ENV_KEY];
+    expect(observedCap(new Supervisor())).toBe(DEFAULT_MAX_CONCURRENT);
+  });
+
+  it("honors a valid override", () => {
+    process.env[ENV_KEY] = "3";
+    expect(observedCap(new Supervisor())).toBe(3);
+  });
+
+  it("treats an empty string as unset", () => {
+    process.env[ENV_KEY] = "";
+    expect(observedCap(new Supervisor())).toBe(DEFAULT_MAX_CONCURRENT);
+  });
+
+  it("falls back on non-numeric input", () => {
+    process.env[ENV_KEY] = "lots";
+    expect(observedCap(new Supervisor())).toBe(DEFAULT_MAX_CONCURRENT);
+  });
+
+  // "0" would wedge the daemon — hasCapacity() false forever, so it
+  // claims nothing and no operator error is ever printed.
+  it("falls back on values below 1 rather than wedging the claimer", () => {
+    process.env[ENV_KEY] = "0";
+    expect(observedCap(new Supervisor())).toBe(DEFAULT_MAX_CONCURRENT);
+    process.env[ENV_KEY] = "-4";
+    expect(observedCap(new Supervisor())).toBe(DEFAULT_MAX_CONCURRENT);
+  });
+
+  it("takes the integer part of a float override", () => {
+    process.env[ENV_KEY] = "2.9";
+    expect(observedCap(new Supervisor())).toBe(2);
+  });
+
+  // An explicit constructor argument is what the tests above rely on;
+  // it must not be overridden by a stray env var in the operator's shell.
+  it("lets an explicit constructor argument win over the env var", () => {
+    process.env[ENV_KEY] = "7";
+    expect(observedCap(new Supervisor(1))).toBe(1);
   });
 });


### PR DESCRIPTION
## What

A coverage sweep across every package found the modules that still had **no test file at all**. Four of them are MCP tool surfaces — the verbs agents actually call — and three are small pieces of composition-root plumbing whose failure modes are silent at runtime.

No source changes; tests only.

| File | Lines before | After |
| --- | --- | --- |
| `api/src/tools/use-repo.ts` | 32.0% | **100%** |
| `api/src/tools/mesh.ts` | 45.9% | **100%** |
| `api/src/tools/watch.ts` | 46.3% | **100%** |
| `api/src/tools/session-search.ts` | 64.7% | **100%** |
| `core/src/env.ts` | 0% | **100%** |
| `daemon/src/logger.ts` | 0% | **100%** |
| `daemon/src/supervisor.ts` | 82.0% | **100%** |

New files: `use-repo.test.ts`, `watch.test.ts`, `session-search.test.ts`, `core/src/env.test.ts`, `daemon/src/logger.test.ts`. Extended: `tools/mesh.test.ts` (it previously locked only the tier inventory and deferred handler behavior to the e2e scripts), `daemon/src/supervisor.test.ts`.

## How the sweep was done

Per package, v8 provider, `--coverage.all` (without it, files with no test file are simply absent from the report and read as covered). DB- and key-gated suites were excluded from the measuring run only — an unhandled error in `afterAll` otherwise aborts report generation entirely. Both traps are the ones `CLAUDE.md` documents.

The remaining sub-90% files after this change are all either barrel/type-only modules, or modules whose tests are the excluded DB-gated ones (`routes/task.ts`, `routes/mcp.ts`, `runtime/router.ts`, `scheduler/src/worker.ts`, …) — they are covered when Postgres is available, not genuinely untested.

## What the tests pin, beyond line count

- **`use_repo`** — the `repo_url` gate is a security boundary: whatever passes it gets cloned and executed inside the sandbox. Lookalike hosts (`github.com.evil.example`, `evilgithub.com`), plaintext HTTP and SSH URLs are asserted rejected. The dispatch-before-`repo_run`-insert ordering the source comment calls out (`repo_run.session_id` carries an FK to `session.id`) is asserted as a call sequence, and both failure branches are checked for not handing the caller ids for a run that doesn't exist. Limit clamping covers the ceilings, the floors, and the drop-junk-silently path.
- **`session_search`** — the four-way shape inference (scroll ▸ read ▸ discover ▸ browse). Pick the wrong shape and the agent gets a whole transcript when it asked for a five-message window. A blank string counts as absent rather than inferring a read on a nonexistent session.
- **`watch_tasks` / `unwatch`** — `mode` defaults to `all` (waking on the first of five tasks instead of all five is a silent behavior change), a call with no session context is refused rather than inserting an unroutable row, and each `WatchService` error class maps to its own stable code — the codes agents branch on to decide stop vs. retry.
- **mesh tools** — `report_blocker` refuses for a top-level agent and does not spawn the parent when `markBlocked` throws; `escalate_to_humans` does not send the peer a sentinel pointing at an escalation row that failed to insert; `CodedMeshError` codes and meta survive the tool envelope.
- **`Supervisor`'s env cap** — `BEEVIBE_DAEMON_MAX_CONCURRENT=0` would wedge the claimer into claiming nothing, with no operator-visible error.

## Verification

`pnpm typecheck`, `pnpm lint` and `pnpm build` are clean.

Test suites were run before and after; the failing set is identical and consists only of the documented environmental failures (`DATABASE_URL_TEST env var is required` and its `pool.end` knock-on; missing provider keys) in a sandbox with no Docker and no API keys. `@beevibe/daemon` is fully green: 168 passed, 2 skipped.

`@vitest/coverage-v8` was installed for the sweep and is deliberately **not** committed, per `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDpmsR3xhtzunf9j1Beiw8

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDpmsR3xhtzunf9j1Beiw8)_