### PR TITLE
test(sandbox): drop the zero-signal ensureArtifactDir test and its dead subject

### DIFF
--- a/packages/sandbox/src/docker.test.ts
+++ b/packages/sandbox/src/docker.test.ts
@@ -24,7 +24,6 @@ const {
   createSandbox,
   DEFAULT_IMAGE,
   destroySandbox,
-  ensureArtifactDir,
   exec,
   exportArtifact,
   listDir,
@@ -506,19 +505,5 @@ describe("teardown", () => {
     const sbx = await fakeSandbox();
     await cleanupArtifactDir(sbx);
     await expect(cleanupArtifactDir(sbx)).resolves.toBeUndefined();
-  });
-});
-
-describe("ensureArtifactDir", () => {
-  it("creates the directory recursively and tolerates re-runs", async () => {
-    const base = await mkdtemp(join(tmpdir(), "bv-test-ensure-"));
-    tempDirs.push(base);
-    const nested = join(base, "a", "b", "c");
-
-    await ensureArtifactDir(nested);
-    await ensureArtifactDir(nested);
-
-    await writeFile(join(nested, "probe.txt"), "ok", "utf8");
-    expect(await readFile(join(nested, "probe.txt"), "utf8")).toBe("ok");
   });
 });

--- a/packages/sandbox/src/docker.ts
+++ b/packages/sandbox/src/docker.ts
@@ -14,7 +14,7 @@
  */
 import { spawn } from "node:child_process";
 import { randomBytes } from "node:crypto";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -417,13 +417,4 @@ function generateId(label: string): string {
  */
 export function shellQuote(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`;
-}
-
-/**
- * Ensure the artifact dir exists on the host before bind-mounting.
- * Exposed only because tests want to construct synthetic sandboxes
- * without going through the full `createSandbox` path.
- */
-export async function ensureArtifactDir(path: string): Promise<void> {
-  await mkdir(path, { recursive: true });
 }

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -10,7 +10,6 @@ export {
   createSandbox,
   DEFAULT_IMAGE,
   destroySandbox,
-  ensureArtifactDir,
   exec,
   exportArtifact,
   listDir,


### PR DESCRIPTION
## What

A sweep of the whole test suite for obsolete tests — skipped/disabled without a clear reason, tests for removed or refactored features, and tests with no assertions or that only pin implementation details. It turned up exactly **one** candidate, removed here.

## The one finding

| File | Test | Reason |
| --- | --- | --- |
| `packages/sandbox/src/docker.test.ts:512` | `ensureArtifactDir > creates the directory recursively and tolerates re-runs` | Asserts Node's own `fs.mkdir({recursive:true})` behavior, on a function nothing in the repo calls. |

`ensureArtifactDir` is a one-line wrapper over `mkdir(path, { recursive: true })` with **no caller anywhere in the monorepo** — not `orchestrator.ts`, not the daemon, not `scripts/`, not the e2e suite:

```
packages/sandbox/src/docker.ts:427   <- declaration
packages/sandbox/src/index.ts:13     <- barrel re-export
packages/sandbox/src/docker.test.ts  <- the test, and nothing else
```

Its docstring claims it is *"exposed only because tests want to construct synthetic sandboxes without going through the full `createSandbox` path"* — but that justification is stale. `fakeSandbox()` in `docker.test.ts` does not use it, and no other test does either. The only reference was the `describe` block added to take `docker.ts` to 100% lines in #275.

So the test could not fail for any reason attributable to this repo. It's removed along with the export it existed to reach, plus the now-unused `mkdir` import. `@beevibe/sandbox` is `private: true`, so the barrel export has no external consumer.

## Everything else came back clean

- **Skipped tests** — every `skip` is environment-gated and self-explanatory: `it.skipIf(process.platform === "win32")` (18×), Docker-gated `describe.skip` in the two e2e suites, and `describe.skipIf(!HAS_LIVE_API_KEYS)` / `!RUN` for the live-provider suites. None are stale or unexplained; no `.only`, no `it.todo`, no `it.failing`.
- **Tests for removed features** — `pnpm typecheck` is clean across all 9 packages, so no test references a removed symbol. Every test file still has a live subject module (the seven whose filename doesn't map to a module — `shell-quote`, `chat-internals`, `client-mutations`, `auth.integration`, `watch-fire.db`, the two e2e — are concept-named suites over live modules).
- **Assertion-free tests** — scripted every `it`/`test` block in all 138 test files; zero have no assertion.
- **Duplicates** — zero duplicate test bodies after normalization. Repeated test *names* (`"500s when the composer throws"` ×14, etc.) are parallel coverage of different routers, not copies.
- **Implementation-detail tests** — the interaction-only (`toHaveBeenCalledWith`) cases are almost all assertions at a real boundary (the SQL a view emits, the argv handed to `docker`, the URL a client builds), which is behavior, not internals. No test mocks its own subject module.
- **Test-only code** — the only exported symbols reachable solely from tests are the deliberate fixtures in `auth/test-fakes.ts` and `test-helpers.ts`, plus `ensureArtifactDir` above.

Prior sweeps (#261, #265, #270, #284, #291) had already taken the rest, which matches the thinness of this result.

## Verification

- `pnpm typecheck` — clean, 9/9 packages
- `pnpm lint` — clean (two pre-existing `import/no-duplicates` warnings in `packages/web/lib/types/dashboard.ts`, untouched by this change)
- `npx tsc -p packages/sandbox/tsconfig.json --noEmit --noUnusedLocals --noUnusedParameters` — clean
- `@beevibe/sandbox` — 108 tests pass (was 109)
- `@beevibe/daemon` (the consumer of `@beevibe/sandbox`) — 156 tests pass

DB- and provider-key-gated suites were not run; this change touches none of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2p883pJcgcpdMNPqc59iY

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2p883pJcgcpdMNPqc59iY)_