### PR TITLE
refactor: one declaration for the task lifecycle vocabulary

### DIFF
--- a/packages/api/src/routes/task.ts
+++ b/packages/api/src/routes/task.ts
@@ -19,6 +19,7 @@
 import { Router, type RequestHandler, type Response } from "express";
 import type { Pool } from "@beevibe/core/adapters/postgres";
 import {
+  CANCELLABLE_TASK_STATUSES,
   TASK_PRIORITIES,
   isInFlightSessionStatus,
   taskId,
@@ -29,7 +30,6 @@ import {
   type SkillOutcomeValue,
   type TaskRepository,
   type TaskPriority,
-  type TaskStatus,
   type WorkProductRepository,
 } from "@beevibe/core";
 import { newSkillOutcomeId } from "@beevibe/core/adapters/postgres";
@@ -44,16 +44,13 @@ import { requireHuman } from "../auth/middleware.js";
 import type { DaemonHub } from "../runtime/hub.js";
 import { requireParam } from "./http-errors.js";
 
-/** Statuses from which /cancel is legal. Anything non-terminal. */
-const CANCELLABLE_FROM: readonly TaskStatus[] = [
-  "pending",
-  "assigned",
-  "needs_revision",
-  "in_progress",
-  "revision",
-  "review",
-  "blocked",
-];
+/**
+ * Statuses from which /cancel is legal. Anything non-terminal — derived
+ * in core as the complement of `TERMINAL_TASK_STATUSES` rather than
+ * listed here, so a newly added non-terminal status is cancellable by
+ * default instead of silently rejected.
+ */
+const CANCELLABLE_FROM = CANCELLABLE_TASK_STATUSES;
 
 export interface TaskRoutesDeps {
   authMiddleware: RequestHandler;

--- a/packages/api/src/routes/view.test.ts
+++ b/packages/api/src/routes/view.test.ts
@@ -231,7 +231,7 @@ describe("GET /task", () => {
     expect(vi.mocked(listTasks).mock.calls[0]![1]).toEqual({ caller_person_id: PERSON });
   });
 
-  it.each(["pending", "in_progress", "in_review", "done"])(
+  it.each(["pending", "in_progress", "blocked", "in_review", "done", "archived"])(
     "passes through the %s lifecycle filter",
     async (lifecycle) => {
       await request(makeApp()).get(`/task?lifecycle=${lifecycle}`);

--- a/packages/api/src/views/tasks-grouping.ts
+++ b/packages/api/src/views/tasks-grouping.ts
@@ -1,35 +1,39 @@
 /**
- * Server-side mirror of `packages/web/lib/tasks-grouping.ts`. Keeps the
- * lifecycle → status mapping and the saved-view → status mapping next to
- * the SQL that filters on them, so the web can pass either `lifecycle` or
- * `view` and get the rows it expects.
+ * Task lifecycle filtering for the views layer.
+ *
+ * The lifecycle vocabulary itself — the lanes and the status → lane
+ * mapping — now lives in `@beevibe/core`'s domain layer, where the web
+ * app reads the same declaration. This file used to carry a parallel
+ * four-lane copy of `packages/web/lib/tasks-grouping.ts`'s six, and the
+ * two had drifted apart while still feeding the same wire parameter; see
+ * `TaskLifecycle` in `core/src/domain/task.ts` for what that broke.
+ *
+ * What stays here is the saved-view → status mapping, which is an api
+ * concern (`?view=sprint` has no client-side counterpart).
  */
 
-import type { TaskStatus } from "@beevibe/core";
+import {
+  CANCELLABLE_TASK_STATUSES,
+  TASK_STATUSES,
+  type TaskLifecycle,
+  type TaskStatus,
+} from "@beevibe/core";
 
-export type Lifecycle = "pending" | "in_progress" | "in_review" | "done";
+export { TASK_STATUSES_BY_LIFECYCLE } from "@beevibe/core";
 
-export const TASK_STATUSES_BY_LIFECYCLE: Record<Lifecycle, readonly TaskStatus[]> = {
-  pending: ["pending", "assigned"],
-  in_progress: ["in_progress", "revision", "needs_revision"],
-  in_review: ["review", "blocked"],
-  done: ["done", "failed", "cancelled"],
-};
+/** The api's historical name for core's `TaskLifecycle`. */
+export type Lifecycle = TaskLifecycle;
 
 /**
  * Saved-view shortcut → status set. "all" and "mine" are intentionally
  * absent — "all" means no filter, "mine" routes to `assignee_id`.
+ *
+ * Both sets are expressed in terms of the terminal/non-terminal split
+ * rather than by listing lanes, which is what they already meant:
+ * "sprint" is the work still in flight, "timeline" is everything that
+ * has a timeline to plot.
  */
 export const TASK_STATUSES_BY_VIEW: Partial<Record<string, readonly TaskStatus[]>> = {
-  sprint: [
-    ...TASK_STATUSES_BY_LIFECYCLE.pending,
-    ...TASK_STATUSES_BY_LIFECYCLE.in_progress,
-    ...TASK_STATUSES_BY_LIFECYCLE.in_review,
-  ],
-  timeline: [
-    ...TASK_STATUSES_BY_LIFECYCLE.pending,
-    ...TASK_STATUSES_BY_LIFECYCLE.in_progress,
-    ...TASK_STATUSES_BY_LIFECYCLE.in_review,
-    ...TASK_STATUSES_BY_LIFECYCLE.done,
-  ],
+  sprint: CANCELLABLE_TASK_STATUSES,
+  timeline: TASK_STATUSES,
 };

--- a/packages/api/src/views/tasks.test.ts
+++ b/packages/api/src/views/tasks.test.ts
@@ -74,10 +74,29 @@ describe("listTasks", () => {
     const pool = makeMockPool([[]]);
     const queryMock = pool._spy;
     await listTasks(pool, { lifecycle: "in_review", bypassOwnerScope: true });
-    expect(queryMock).toHaveBeenCalledWith(
+    // `in_review` is 'review' alone: 'blocked' is its own lane in the
+    // lifecycle vocabulary core now shares with the board, where it used
+    // to be folded in here.
+    expect(queryMock).toHaveBeenCalledWith(expect.any(String), [["review"], null, null]);
+  });
+
+  it("filters the blocked lane on its own, separately from in_review", async () => {
+    const pool = makeMockPool([[]]);
+    await listTasks(pool, { lifecycle: "blocked", bypassOwnerScope: true });
+    expect(pool._spy).toHaveBeenCalledWith(expect.any(String), [["blocked"], null, null]);
+  });
+
+  it("filters the archived lane on failed + cancelled, keeping them out of done", async () => {
+    const archived = makeMockPool([[]]);
+    await listTasks(archived, { lifecycle: "archived", bypassOwnerScope: true });
+    expect(archived._spy).toHaveBeenCalledWith(
       expect.any(String),
-      [["review", "blocked"], null, null],
+      [["failed", "cancelled"], null, null],
     );
+
+    const done = makeMockPool([[]]);
+    await listTasks(done, { lifecycle: "done", bypassOwnerScope: true });
+    expect(done._spy).toHaveBeenCalledWith(expect.any(String), [["done"], null, null]);
   });
 
   it("forwards assignee_id when set", async () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,10 @@
       "types": "./dist/domain/format.d.ts",
       "default": "./dist/domain/format.js"
     },
+    "./domain/task": {
+      "types": "./dist/domain/task.d.ts",
+      "default": "./dist/domain/task.js"
+    },
     "./adapters/postgres": {
       "types": "./dist/adapters/postgres/index.d.ts",
       "default": "./dist/adapters/postgres/index.js"

--- a/packages/core/src/domain/task.test.ts
+++ b/packages/core/src/domain/task.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  CANCELLABLE_TASK_STATUSES,
+  RETRYABLE_TASK_STATUSES,
+  TASK_LIFECYCLES,
+  TASK_LIFECYCLE_OF_STATUS,
+  TASK_STATUSES,
+  TASK_STATUSES_BY_LIFECYCLE,
+  TERMINAL_TASK_STATUSES,
+} from "./task.js";
+
+/**
+ * These sets are the shared lifecycle vocabulary the api's `?lifecycle=`
+ * filter, its `/cancel` and `/retry` gates, and the web board all read.
+ * They are derived from `TASK_LIFECYCLE_OF_STATUS`, so what's worth
+ * testing is the derivation — that no status goes missing or lands in two
+ * lanes, and that the two gates stay exact complements.
+ */
+describe("task lifecycle vocabulary", () => {
+  it("assigns every TaskStatus to exactly one lane", () => {
+    const seen = Object.values(TASK_STATUSES_BY_LIFECYCLE).flat();
+    expect([...seen].sort()).toEqual([...TASK_STATUSES].sort());
+    expect(new Set(seen).size).toBe(TASK_STATUSES.length);
+  });
+
+  it("inverts TASK_LIFECYCLE_OF_STATUS consistently", () => {
+    for (const status of TASK_STATUSES) {
+      const lane = TASK_LIFECYCLE_OF_STATUS[status];
+      expect(TASK_STATUSES_BY_LIFECYCLE[lane], `status=${status}`).toContain(status);
+    }
+  });
+
+  it("has a bucket for every lane, even an empty one", () => {
+    for (const lane of TASK_LIFECYCLES) {
+      expect(TASK_STATUSES_BY_LIFECYCLE[lane]).toBeInstanceOf(Array);
+    }
+  });
+
+  it("keeps blocked out of in_review and failed/cancelled out of done", () => {
+    expect(TASK_STATUSES_BY_LIFECYCLE.in_review).toEqual(["review"]);
+    expect(TASK_STATUSES_BY_LIFECYCLE.blocked).toEqual(["blocked"]);
+    expect(TASK_STATUSES_BY_LIFECYCLE.done).toEqual(["done"]);
+    expect(TASK_STATUSES_BY_LIFECYCLE.archived).toEqual(["failed", "cancelled"]);
+  });
+
+  it("derives the retry gate as the archived lane", () => {
+    expect([...RETRYABLE_TASK_STATUSES]).toEqual(["failed", "cancelled"]);
+  });
+
+  it("derives the cancel gate as the exact complement of the terminal set", () => {
+    const terminal = new Set<string>(TERMINAL_TASK_STATUSES);
+    for (const status of CANCELLABLE_TASK_STATUSES) {
+      expect(terminal.has(status), `cancellable=${status}`).toBe(false);
+    }
+    expect(CANCELLABLE_TASK_STATUSES.length + TERMINAL_TASK_STATUSES.length).toBe(
+      TASK_STATUSES.length,
+    );
+  });
+
+  it("treats every non-terminal status as cancellable", () => {
+    const cancellable = new Set<string>(CANCELLABLE_TASK_STATUSES);
+    for (const status of TASK_STATUSES) {
+      if (TERMINAL_TASK_STATUSES.includes(status)) continue;
+      expect(cancellable.has(status), `status=${status}`).toBe(true);
+    }
+  });
+});

--- a/packages/core/src/domain/task.ts
+++ b/packages/core/src/domain/task.ts
@@ -39,6 +39,99 @@ export const TERMINAL_TASK_STATUSES: readonly TaskStatus[] = [
   "cancelled",
 ] as const;
 
+/**
+ * Workflow lane a task's status belongs to — the coarse grouping the
+ * board renders as columns and `GET /task?lifecycle=` filters on.
+ *
+ * This used to be declared twice, and the two had drifted:
+ * `packages/api/src/views/tasks-grouping.ts` had four lanes (folding
+ * `blocked` into `in_review` and `failed`/`cancelled` into `done`) while
+ * `packages/web/lib/tasks-grouping.ts` had these six. Both fed the same
+ * wire parameter — the web client typed `TaskListFilter.lifecycle` with
+ * its own six-value union while the api validated against its own four —
+ * so `?lifecycle=blocked` typechecked on the client, failed the server's
+ * allow-list, and silently returned *unfiltered* tasks. The six-lane
+ * shape below is the one the UI actually renders, so it wins.
+ *
+ * Lane semantics:
+ * - `blocked` is its own lane, not part of `in_review`: blocked means
+ *   waiting on an external dependency, which asks a different action of
+ *   the human than waiting on their verdict does.
+ * - `archived` holds the terminal-but-not-successful statuses (`failed`,
+ *   `cancelled`), so `done` reads as "this shipped."
+ */
+export type TaskLifecycle =
+  | "pending"
+  | "in_progress"
+  | "blocked"
+  | "in_review"
+  | "done"
+  | "archived";
+
+/** Workflow order, left-to-right — the order the board lays lanes out. */
+export const TASK_LIFECYCLES: readonly TaskLifecycle[] = [
+  "pending",
+  "in_progress",
+  "blocked",
+  "in_review",
+  "done",
+  "archived",
+] as const;
+
+/**
+ * Status → lane. The single source of truth for the grouping: everything
+ * below is derived from it, so adding a `TaskStatus` is a compile error
+ * here (exhaustive `Record`) and needs no other edit.
+ */
+export const TASK_LIFECYCLE_OF_STATUS: Record<TaskStatus, TaskLifecycle> = {
+  pending: "pending",
+  assigned: "pending",
+  in_progress: "in_progress",
+  needs_revision: "in_progress",
+  revision: "in_progress",
+  review: "in_review",
+  blocked: "blocked",
+  done: "done",
+  failed: "archived",
+  cancelled: "archived",
+};
+
+function groupStatusesByLifecycle(): Record<TaskLifecycle, readonly TaskStatus[]> {
+  const buckets = Object.fromEntries(
+    TASK_LIFECYCLES.map((lifecycle) => [lifecycle, [] as TaskStatus[]]),
+  ) as Record<TaskLifecycle, TaskStatus[]>;
+  for (const status of TASK_STATUSES) {
+    buckets[TASK_LIFECYCLE_OF_STATUS[status]].push(status);
+  }
+  return buckets;
+}
+
+/**
+ * Lane → the statuses in it, inverted from {@link TASK_LIFECYCLE_OF_STATUS}
+ * rather than hand-listed so the two can't disagree. Statuses appear in
+ * `TASK_STATUSES` order.
+ */
+export const TASK_STATUSES_BY_LIFECYCLE: Record<TaskLifecycle, readonly TaskStatus[]> =
+  groupStatusesByLifecycle();
+
+/**
+ * Statuses `/task/:id/retry` accepts — the `archived` lane, i.e. terminal
+ * but unsuccessful. Kept in step with `TaskService.prepareRetry`, which
+ * gates on this set.
+ */
+export const RETRYABLE_TASK_STATUSES: readonly TaskStatus[] =
+  TASK_STATUSES_BY_LIFECYCLE.archived;
+
+/**
+ * Statuses `/task/:id/cancel` accepts — the exact complement of
+ * {@link TERMINAL_TASK_STATUSES}. Derived rather than listed: the api
+ * spelled all seven out by hand, which meant a new non-terminal status
+ * would have been silently un-cancellable.
+ */
+export const CANCELLABLE_TASK_STATUSES: readonly TaskStatus[] = TASK_STATUSES.filter(
+  (status) => !TERMINAL_TASK_STATUSES.includes(status),
+);
+
 export type TaskPriority = "low" | "medium" | "high" | "critical";
 
 export const TASK_PRIORITIES: readonly TaskPriority[] = ["low", "medium", "high", "critical"] as const;

--- a/packages/core/src/services/task-service.ts
+++ b/packages/core/src/services/task-service.ts
@@ -1,4 +1,5 @@
 import {
+  RETRYABLE_TASK_STATUSES,
   TERMINAL_TASK_STATUSES,
   type NextDispatchContext,
   type Task,
@@ -287,7 +288,7 @@ export class TaskService {
     priorSessionId: string | undefined;
   }> {
     const task = await this.requireTask(taskId);
-    if (task.status !== "failed" && task.status !== "cancelled") {
+    if (!RETRYABLE_TASK_STATUSES.includes(task.status)) {
       throw new InvalidTaskTransitionError(
         `Task ${taskId} is in status '${task.status}'; retry is only allowed from 'failed' or 'cancelled'`,
       );

--- a/packages/web/lib/dashboard-display.test.ts
+++ b/packages/web/lib/dashboard-display.test.ts
@@ -61,6 +61,9 @@ describe("summaryToDisplay — KPIs", () => {
     expect(byKpi("Awaiting review").trend_kind).toBe("bar");
     expect(byKpi("Completed today").trend_color).toBe("done");
     expect(byKpi("Blocked").trend_color).toBe("primary");
+    // Blocked is its own lifecycle lane, so the KPI deep-links to it
+    // rather than to in_review.
+    expect(byKpi("Blocked").href).toBe("/tasks?lifecycle=blocked");
   });
 
   it("preserves raw trend arrays (web's sparkline owns geometry)", () => {

--- a/packages/web/lib/dashboard-display.ts
+++ b/packages/web/lib/dashboard-display.ts
@@ -74,7 +74,10 @@ const KPI_CONFIG: Record<KpiKind, KpiConfig> = {
   },
   blocked: {
     label: "Blocked",
-    href: "/tasks?lifecycle=in_review",
+    // `blocked` is a lane in its own right now that the api and the board
+    // share one lifecycle vocabulary. This pointed at `in_review` because
+    // the api's older four-lane mapping had no `blocked` value to accept.
+    href: "/tasks?lifecycle=blocked",
     trend_color: "primary",
     trend_kind: "bar",
   },

--- a/packages/web/lib/task-status.ts
+++ b/packages/web/lib/task-status.ts
@@ -1,25 +1,28 @@
-import type { TaskStatus } from "@beevibe/core";
-
 /**
- * Status sets the lifecycle-action UI gates on. Single source of truth
- * for "should we show Cancel?" / "should we show Retry?" — keep these
- * in lockstep with:
- *   - api/src/routes/task.ts `CANCELLABLE_FROM` (terminal complement)
- *   - core/src/services/task-service.ts `prepareRetry` (failed | cancelled)
+ * Status sets the lifecycle-action UI gates on — "should we show Cancel?"
+ * / "should we show Retry?"
  *
- * Typed as `readonly TaskStatus[]` so `.includes(task.status)` typechecks
- * without a cast.
+ * Both sets are now re-exports from `@beevibe/core/domain/task`, which is
+ * also what the api's `/cancel` gate and `TaskService.prepareRetry` read.
+ * They used to be declared here as literals, with a comment asking that
+ * they be kept "in lockstep" with those two — including a second,
+ * byte-identical `TERMINAL_TASK_STATUSES` that shadowed core's own export
+ * (whose doc-comment asks callers not to redeclare it). A UI that
+ * disagrees with the server about which statuses are terminal offers a
+ * Cancel button the api answers with 409.
+ *
+ * Imported from the `domain/task` subpath, not the package root — the
+ * root barrel pulls in `node:crypto` via `./auth` and these are used from
+ * client components.
  */
-export const TERMINAL_TASK_STATUSES: readonly TaskStatus[] = [
-  "done",
-  "failed",
-  "cancelled",
-];
 
-export const RETRYABLE_TASK_STATUSES: readonly TaskStatus[] = [
-  "failed",
-  "cancelled",
-];
+import {
+  RETRYABLE_TASK_STATUSES,
+  TERMINAL_TASK_STATUSES,
+  type TaskStatus,
+} from "@beevibe/core/domain/task";
+
+export { RETRYABLE_TASK_STATUSES, TERMINAL_TASK_STATUSES };
 
 export function isTerminalTaskStatus(status: TaskStatus): boolean {
   return TERMINAL_TASK_STATUSES.includes(status);

--- a/packages/web/lib/tasks-grouping.test.ts
+++ b/packages/web/lib/tasks-grouping.test.ts
@@ -21,6 +21,12 @@ function makeTask(id: string, status: TaskStatus): TaskListItem {
   };
 }
 
+/**
+ * Spelled out here rather than imported from core so this stays a real
+ * assertion about the lane each status lands in — importing the mapping
+ * `groupTasks` uses would make the exhaustiveness test below tautological.
+ * This copy is the *expectation*; core's is the implementation.
+ */
 const EXPECTED_LIFECYCLE: Record<TaskStatus, Lifecycle> = {
   pending: "pending",
   assigned: "pending",

--- a/packages/web/lib/tasks-grouping.ts
+++ b/packages/web/lib/tasks-grouping.ts
@@ -1,39 +1,29 @@
-import type { TaskStatus } from "@beevibe/core";
+/**
+ * Board grouping. The lifecycle vocabulary — the lanes and the status →
+ * lane mapping — comes from `@beevibe/core/domain/task`, which the api
+ * reads too; this file owns only the presentation (order, labels, dot
+ * colors) and the bucketing.
+ *
+ * The mapping used to be declared here *and*, differently, in
+ * `packages/api/src/views/tasks-grouping.ts`, with both feeding the same
+ * `?lifecycle=` wire parameter. See `TaskLifecycle` in core for what the
+ * drift broke.
+ *
+ * Imported from the `domain/task` subpath, not the package root: the root
+ * barrel re-exports `./auth`, which reaches for `node:crypto`, and this
+ * module is pulled into a client component. Same reason
+ * `@beevibe/core/domain/format` has its own subpath.
+ */
+
+import {
+  TASK_LIFECYCLE_OF_STATUS,
+  type TaskLifecycle,
+} from "@beevibe/core/domain/task";
 import type { TaskListItem } from "@/lib/types/tasks";
 import type { BoardLane } from "@/components/tasks/board-column";
 
-export type Lifecycle =
-  | "pending"
-  | "in_progress"
-  | "blocked"
-  | "in_review"
-  | "done"
-  | "archived";
-
-/**
- * Status → lifecycle lane.
- *
- * - `blocked` lives in its own lane (was previously folded into
- *   In review). Blocked = waiting on an external dependency, semantically
- *   different from "waiting on a human verdict." Different action by the
- *   human reading the board, so different column.
- * - `failed` and `cancelled` are terminal states that aren't success.
- *   They go into the `archived` lane, hidden by default — `Done` should
- *   read as "this shipped." Archive toggle exposes them when the user
- *   wants to see what didn't ship.
- */
-const LIFECYCLE_OF: Record<TaskStatus, Lifecycle> = {
-  pending: "pending",
-  assigned: "pending",
-  in_progress: "in_progress",
-  revision: "in_progress",
-  needs_revision: "in_progress",
-  review: "in_review",
-  blocked: "blocked",
-  done: "done",
-  failed: "archived",
-  cancelled: "archived",
-};
+/** The web's historical name for core's `TaskLifecycle`. */
+export type Lifecycle = TaskLifecycle;
 
 interface LaneTemplate {
   key: Lifecycle;
@@ -76,7 +66,7 @@ export function groupTasks(
     done: [],
     archived: [],
   };
-  for (const t of tasks) buckets[LIFECYCLE_OF[t.status]].push(t);
+  for (const t of tasks) buckets[TASK_LIFECYCLE_OF_STATUS[t.status]].push(t);
   const template = options.showArchived
     ? [...VISIBLE_LANES, ARCHIVED_LANE]
     : VISIBLE_LANES;
@@ -87,11 +77,15 @@ export function groupTasks(
   }));
 }
 
-/** Count of failed+cancelled tasks — drives the "X archived" toggle. */
+/**
+ * Count of tasks in the archived lane (failed + cancelled) — drives the
+ * "X archived" toggle. Keyed off the shared mapping rather than a status
+ * literal so it can't disagree with which lane `groupTasks` hides.
+ */
 export function countArchivedTasks(tasks: TaskListItem[]): number {
   let n = 0;
   for (const t of tasks) {
-    if (t.status === "failed" || t.status === "cancelled") n += 1;
+    if (TASK_LIFECYCLE_OF_STATUS[t.status] === "archived") n += 1;
   }
   return n;
 }


### PR DESCRIPTION
Found while sweeping the tree for near-duplicate abstractions. This is the highest-impact cluster: the only duplicate found that is actively wrong rather than merely repetitive.

## The duplicate

`Lifecycle` was declared twice, and the two copies disagreed:

| | `api/src/views/tasks-grouping.ts` | `web/lib/tasks-grouping.ts` |
| --- | --- | --- |
| lanes | 4 | 6 |
| `blocked` | folded into `in_review` | its own lane |
| `failed` / `cancelled` | folded into `done` | own `archived` lane |

Both fed the same wire parameter. `web/lib/api/client.ts` typed `TaskListFilter.lifecycle` with the web's six-value union, while `routes/view.ts` validated against the api's four:

- `?lifecycle=blocked` and `?lifecycle=archived` typechecked on the client, failed the server's allow-list, and the api answered with **unfiltered** tasks rather than an error.
- `?lifecycle=done` returned `failed` + `cancelled` rows that the board's Done lane doesn't show — so the dashboard's "Completed today" deep link counted work that didn't ship.

The original file header called itself a "server-side mirror" of the web module. It had stopped being one.

## The unification

One `TaskLifecycle` type plus one `TASK_LIFECYCLE_OF_STATUS` map in `core/src/domain/task.ts`, with everything else derived from it so the pieces can't drift again:

- `TASK_STATUSES_BY_LIFECYCLE` inverts the map instead of being hand-listed.
- `RETRYABLE_TASK_STATUSES` is the `archived` lane. `TaskService.prepareRetry` gates on it instead of on two inline status literals.
- `CANCELLABLE_TASK_STATUSES` is the exact complement of `TERMINAL_TASK_STATUSES`, replacing the seven statuses `/cancel` spelled out by hand — which meant a newly added non-terminal status would have been silently un-cancellable.

The six-lane shape won because it's the one the UI actually renders.

Two smaller duplicates in the same cluster, folded in:

- `web/lib/task-status.ts` declared its own byte-identical `TERMINAL_TASK_STATUSES`, shadowing core's export — whose doc-comment explicitly asks callers not to redeclare it. Now a re-export. Its "keep these in lockstep with…" comment is no longer a comment; it's the type system.
- The dashboard's Blocked KPI pointed at `?lifecycle=in_review` because the api had no `blocked` value to accept. It now points at `?lifecycle=blocked`.

Both packages keep their local `Lifecycle` name as an alias, so no import site moved — the same shim approach `views/format.ts` uses.

## Behavior changes

Deliberate, and both align the api with the board the user is looking at:

- `?lifecycle=in_review` is `review` alone (was `review` + `blocked`).
- `?lifecycle=done` is `done` alone (was `done` + `failed` + `cancelled`).
- `blocked` and `archived` are newly accepted values.

`?view=sprint` and `?view=timeline` resolve to exactly the same status sets as before — re-expressed as "non-terminal" and "everything", which is what they already meant.

Worth a reviewer's eye: `?lifecycle=` is currently reachable only via the raw `GET /task` API. `tasks-client.tsx` never reads the URL param — it fetches unfiltered and groups client-side — so the dashboard KPI deep links don't filter today either way. The fix is to a latent contract, not to something a user can see right now.

## Verification

- `pnpm typecheck` — 9/9 tasks clean.
- `pnpm lint` — 0 errors, and back to the pre-existing warning baseline (I removed the one new warning my first pass introduced).
- `pnpm build` for every package, plus `pnpm --filter @beevibe/web exec next build` directly. The web build matters here: it's what proves the new client-side value import of core doesn't drag `node:crypto` into the bundle. Hence the dedicated `@beevibe/core/domain/task` subpath export, mirroring `domain/format`.
- Tests: **no assertion failure anywhere in the tree.** api 824 pass / 9 files fail, core 616 pass / 7 fail, web 203/203, scheduler 10 pass / 2 files fail — every failure is a documented Postgres- or provider-key-gated suite in a sandbox with neither.
- New `core/src/domain/task.test.ts` covers the derivation itself: every status lands in exactly one lane, the inversion round-trips, and the cancel/retry gates stay exact complements.

Test updates: `api/src/views/tasks.test.ts` asserted the old `in_review → ["review", "blocked"]` mapping (now updated, plus new cases for the `blocked` and `archived` lanes); `routes/view.test.ts` gained the two new accepted values. `web/lib/tasks-grouping.test.ts` keeps its own copy of the expected mapping on purpose — importing core's would make the exhaustiveness test tautological.

## Other clusters found, not in this PR

Reported for follow-up; none is a live bug the way this one was:

1. **Room message wire contract** — `api/src/routes/room.ts`'s private `MessageReply` (line 133) is field-for-field `web/lib/api/client.ts`'s `RoomMessage` (line 148). Exactly the drift #283 eliminated for the chat contract, still standing for rooms. Same fix: one declaration in core.
2. **CLI runtime session skeleton** — the ~25-line spawn → line-read → parse → finalize block is near-identical across all three of `adapters/{claude-code,codex,opencode}/runtime.ts` (jscpd flags codex ↔ opencode directly). `runtime-common.ts` already holds the shared pieces and is the natural home for a `runNdjsonCliSession<TEvent>()`. The `{...process.env}`-minus-auth-vars preamble repeats three times too.
3. **`rowToWorkProduct`** — `api/src/views/tasks.ts:305` re-implements the mapper `core/src/adapters/postgres/work-product-repo.ts:107` already owns, with weaker typing (`Record<string, unknown>` + `String()` casts). A new column means editing both.
4. **Gated-detail query hooks** — five copies of the same subtle idiom in `web/lib/hooks/` (`queryKey: id ? detail(id) : all`, `enabled: … && !!id`, `id as string`). A typed factory would delete the cast.
5. **Test fixture builders** — `makeApp` ×9, `makeAgent` ×8, `makeSession` ×8, `fakeAgent` ×6, `stubAuth` ×5, despite three existing `test-helpers` / `test-fakes` modules.
6. Minor: `clamp` ×3, and the `err instanceof Error ? err.message : String(err)` idiom inline in 54 places.

For context on why the list is short: jscpd puts the whole tree at 0.31% duplication. The obvious copies were already extracted (`domain/format.ts`, `runtime-common.ts`, `pg-helpers.ts`, `routes/http-errors.ts`), each with a doc-comment explaining what it replaced. What's left is mostly semantic near-duplicates that token-level detectors can't see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKUsQegMqa762EQi3VebN9

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKUsQegMqa762EQi3VebN9)_