### PR TITLE
test: cover the mesh A2A broker, the session-tree view and the opencode workspace prep

### DIFF
--- a/packages/api/src/mesh/server.test.ts
+++ b/packages/api/src/mesh/server.test.ts
@@ -1,15 +1,24 @@
 /**
- * MeshServer unit tests. Focused on the failure-propagation path —
- * when a callee session terminates non-success, the caller's pending
- * `ask`/`negotiate` promise must reject within a tick instead of sitting
- * through the 5-minute resolver timeout (which surfaces to the MCP layer
- * as a generic "transport dropped" error).
+ * MeshServer unit tests.
+ *
+ * Two halves:
+ *   1. Failure propagation — when a callee session terminates non-success,
+ *      the caller's pending `ask`/`negotiate` promise must reject within a
+ *      tick instead of sitting through the 5-minute resolver timeout (which
+ *      surfaces to the MCP layer as a generic "transport dropped" error).
+ *   2. The ask / negotiate / blocker protocol itself: capacity gating, the
+ *      round bookkeeping `respondNegotiate` does against `negotiation` +
+ *      `negotiation_round`, the resolver hand-off that alternates which
+ *      side is blocked each round, and the escalation sentinel.
  */
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
+  Agent,
   AgentRepository,
+  Negotiation,
   NegotiationRepository,
+  NegotiationRound,
   NegotiationRoundRepository,
   RuntimeRegistry,
   SessionEventRepository,
@@ -18,44 +27,165 @@ import type {
 } from "@beevibe/core";
 import type { DispatchService } from "@beevibe/core/services/dispatch-service";
 import { MeshServer } from "./server.js";
+import {
+  CannotNegotiateWithIcError,
+  MeshCapacityError,
+  MeshMaxRoundsError,
+  type NegotiateResponse,
+} from "./types.js";
 
-function makeMesh() {
-  const dispatchCalls: Array<{ agentId: string; sessionIdOverride?: string }> = [];
+const ASK_TIMEOUT_MS = 5 * 60_000;
+const NEGOTIATE_TIMEOUT_MS = 5 * 60_000;
+
+type DispatchCall = {
+  agentId: string;
+  intent: string;
+  type: string;
+  sessionIdOverride?: string;
+  callerAgentId?: string;
+};
+
+interface MeshFixtureOptions {
+  /** Per-agent overrides keyed by agent id, merged over the default agent. */
+  agents?: Record<string, Partial<Agent> | null>;
+  /** Running mesh sessions reported by `countRunningByAgent`. */
+  running?: number;
+  /** Make every `dispatchTask` reject with this error. */
+  dispatchError?: Error;
+}
+
+const DEFAULT_AGENT: Agent = {
+  id: "agent_default",
+  name: "Default",
+  owner_id: "per_1",
+  hierarchy_level: "team",
+  max_mesh_sessions: 5,
+  max_negotiation_rounds: 5,
+  runtime_config: { type: "claude" },
+} as unknown as Agent;
+
+function makeMesh(options: MeshFixtureOptions = {}) {
+  const dispatchCalls: DispatchCall[] = [];
   const dispatchService = {
-    dispatchTask: vi.fn(async (opts: { agentId: string; sessionIdOverride?: string }) => {
+    dispatchTask: vi.fn(async (opts: DispatchCall) => {
       dispatchCalls.push(opts);
-      // Return a minimal shape that satisfies the type — MeshServer
-      // discards the return via `void`, so values don't matter.
+      if (options.dispatchError) throw options.dispatchError;
+      // MeshServer discards the return via `void`, so the value is inert.
       return {} as Awaited<ReturnType<DispatchService["dispatchTask"]>>;
     }),
   } as unknown as DispatchService;
 
+  const agentRepo = {
+    findById: vi.fn(async (id: string): Promise<Agent | undefined> => {
+      const override = options.agents?.[id];
+      if (override === null) return undefined;
+      return { ...DEFAULT_AGENT, id, name: id, ...override };
+    }),
+  } as unknown as AgentRepository;
+
+  // In-memory negotiation store: `update` mutates in place so a later
+  // `findById` observes rounds_completed / status / counterparty_session_id
+  // exactly as the Postgres adapter would.
+  const negotiations = new Map<string, Negotiation>();
+  const rounds: NegotiationRound[] = [];
+  let negSeq = 0;
+
+  const negotiationRepo = {
+    findById: vi.fn(async (id: string) => negotiations.get(id)),
+    create: vi.fn(async (input: Partial<Negotiation>) => {
+      const row = {
+        rounds_completed: 0,
+        status: "active",
+        created_at: new Date(0),
+        updated_at: new Date(0),
+        ...input,
+        id: input.id ?? `neg_${++negSeq}`,
+      } as Negotiation;
+      negotiations.set(row.id, row);
+      return row;
+    }),
+    update: vi.fn(async (id: string, patch: Partial<Negotiation>) => {
+      const row = negotiations.get(id);
+      if (!row) throw new Error(`no negotiation ${id}`);
+      Object.assign(row, patch);
+      return row;
+    }),
+  } as unknown as NegotiationRepository;
+
+  const negotiationRoundRepo = {
+    create: vi.fn(async (input: Omit<NegotiationRound, "sent_at">) => {
+      const row = { ...input, sent_at: new Date(0) } as NegotiationRound;
+      rounds.push(row);
+      return row;
+    }),
+  } as unknown as NegotiationRoundRepository;
+
   const mesh = new MeshServer({
-    agentRepo: {
-      findById: vi.fn(async (id: string) => ({
-        id,
-        name: id,
-        owner_id: "per_1",
-        hierarchy_level: "team" as const,
-        max_mesh_sessions: 5,
-        max_negotiation_rounds: 5,
-        runtime_config: { type: "claude" as const },
-      })),
-    } as unknown as AgentRepository,
+    agentRepo,
     sessionRepo: {
-      countRunningByAgent: vi.fn(async () => 0),
+      countRunningByAgent: vi.fn(async () => options.running ?? 0),
     } as unknown as SessionRepository,
     sessionEventRepo: {} as SessionEventRepository,
-    negotiationRepo: {} as NegotiationRepository,
-    negotiationRoundRepo: {} as NegotiationRoundRepository,
+    negotiationRepo,
+    negotiationRoundRepo,
     workspaceManager: {} as WorkspaceManager,
     runtimeRegistry: {} as RuntimeRegistry,
     dispatchService,
     makeMemoryAgent: () => ({}) as never,
   });
 
-  return { mesh, dispatchCalls };
+  return {
+    mesh,
+    dispatchCalls,
+    dispatchService,
+    agentRepo,
+    negotiationRepo,
+    negotiationRoundRepo,
+    negotiations,
+    rounds,
+    /** Seed an active negotiation without going through `sendNegotiate`. */
+    seedNegotiation(row: Partial<Negotiation>): Negotiation {
+      const seeded = {
+        id: "neg_seed",
+        initiator_agent_id: "agent_a",
+        initiator_session_id: "sess_a",
+        counterparty_agent_id: "agent_b",
+        max_rounds: 5,
+        rounds_completed: 1,
+        status: "active",
+        created_at: new Date(0),
+        updated_at: new Date(0),
+        ...row,
+      } as Negotiation;
+      negotiations.set(seeded.id, seeded);
+      return seeded;
+    },
+  };
 }
+
+/** Let the awaits inside sendAsk/sendNegotiate settle and the spawn fire. */
+async function tick(): Promise<void> {
+  await new Promise((r) => setImmediate(r));
+}
+
+function counter(
+  negotiationId: string,
+  fromAgentId: string,
+  message = "how about this instead",
+): NegotiateResponse {
+  return {
+    negotiation_id: negotiationId,
+    from_agent_id: fromAgentId,
+    decision: "counter",
+    message,
+    counter_proposal: message,
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
 
 describe("MeshServer.failResolverForCalleeSession", () => {
   it("rejects an ask waiter as soon as the callee session is marked failed", async () => {
@@ -64,7 +194,7 @@ describe("MeshServer.failResolverForCalleeSession", () => {
 
     // sendAsk awaits capacity checks before kicking off the spawn — wait
     // a full event-loop tick so the pre-minted sessionId reaches the spy.
-    await new Promise((r) => setImmediate(r));
+    await tick();
     const calleeSid = dispatchCalls[0]?.sessionIdOverride;
     expect(calleeSid).toBeDefined();
 
@@ -84,7 +214,7 @@ describe("MeshServer.failResolverForCalleeSession", () => {
     expect(mesh.hasPendingCalleeSession("sess_unknown")).toBe(false);
 
     const ask = mesh.sendAsk("req_3", "agent_caller", "agent_callee", "yo?");
-    await new Promise((r) => setImmediate(r));
+    await tick();
     const calleeSid = dispatchCalls[0]?.sessionIdOverride;
     expect(calleeSid).toBeDefined();
     expect(mesh.hasPendingCalleeSession(calleeSid!)).toBe(true);
@@ -99,7 +229,7 @@ describe("MeshServer.failResolverForCalleeSession", () => {
     const { mesh, dispatchCalls } = makeMesh();
     const ask = mesh.sendAsk("req_2", "agent_caller", "agent_callee", "ping?");
 
-    await new Promise((r) => setImmediate(r));
+    await tick();
     const calleeSid = dispatchCalls[0]?.sessionIdOverride;
     expect(calleeSid).toBeDefined();
 
@@ -118,5 +248,498 @@ describe("MeshServer.failResolverForCalleeSession", () => {
     // After the success path drains the reverse index, a stale failure
     // signal for the same session is a no-op (idempotency).
     expect(() => mesh.failResolverForCalleeSession(calleeSid!, "late")).not.toThrow();
+  });
+
+  it("rejects a blocked respond_negotiate when the B-resident session dies", async () => {
+    const f = makeMesh();
+    const neg = f.seedNegotiation({ counterparty_session_id: "sess_bbb" });
+
+    const blocked = f.mesh.respondNegotiate(neg.id, counter(neg.id, "agent_b"), "sess_bbb");
+    await tick();
+    expect(f.mesh.hasPendingCalleeSession("sess_bbb")).toBe(true);
+
+    f.mesh.failResolverForCalleeSession("sess_bbb", "runtime_offline");
+    await expect(blocked).rejects.toThrow(/mesh callee session failed: runtime_offline/);
+  });
+});
+
+describe("MeshServer.sendAsk", () => {
+  it("dispatches a mesh_ask carrying the caller id and the respond_ask contract", async () => {
+    const { mesh, dispatchCalls } = makeMesh();
+    void mesh.sendAsk("req_x", "agent_a", "agent_b", "what is the deploy story?");
+    await tick();
+
+    const call = dispatchCalls[0]!;
+    expect(call.agentId).toBe("agent_b");
+    expect(call.type).toBe("mesh_ask");
+    expect(call.callerAgentId).toBe("agent_a");
+    expect(call.sessionIdOverride).toMatch(/^sess_/);
+    expect(call.intent).toContain('<mesh-ask request_id="req_x" from="agent_a">');
+    expect(call.intent).toContain("what is the deploy story?");
+    expect(call.intent).toContain('respond_ask(request_id="req_x"');
+  });
+
+  it("escapes XML metacharacters in the request id and caller id", async () => {
+    const { mesh, dispatchCalls } = makeMesh();
+    void mesh.sendAsk('req"1&<', "a<gent>", "agent_b", "q");
+    await tick();
+
+    expect(dispatchCalls[0]!.intent).toContain(
+      '<mesh-ask request_id="req&quot;1&amp;&lt;" from="a&lt;gent&gt;">',
+    );
+  });
+
+  it("throws MeshCapacityError without dispatching when the target is at cap", async () => {
+    const { mesh, dispatchCalls } = makeMesh({
+      running: 5,
+      agents: { agent_b: { max_mesh_sessions: 5 } },
+    });
+
+    await expect(mesh.sendAsk("req_c", "agent_a", "agent_b", "q")).rejects.toBeInstanceOf(
+      MeshCapacityError,
+    );
+    expect(dispatchCalls).toHaveLength(0);
+  });
+
+  it("falls back to a cap of 3 when the target has no max_mesh_sessions", async () => {
+    const atDefaultCap = makeMesh({
+      running: 3,
+      agents: { agent_b: { max_mesh_sessions: undefined } },
+    });
+    await expect(
+      atDefaultCap.mesh.sendAsk("req_d", "agent_a", "agent_b", "q"),
+    ).rejects.toMatchObject({ meta: { agentId: "agent_b", running: 3, cap: 3 } });
+
+    const underDefaultCap = makeMesh({
+      running: 2,
+      agents: { agent_b: { max_mesh_sessions: undefined } },
+    });
+    void underDefaultCap.mesh.sendAsk("req_e", "agent_a", "agent_b", "q");
+    await tick();
+    expect(underDefaultCap.dispatchCalls).toHaveLength(1);
+  });
+
+  it("throws when the target agent does not exist", async () => {
+    const { mesh } = makeMesh({ agents: { agent_gone: null } });
+    await expect(mesh.sendAsk("req_f", "agent_a", "agent_gone", "q")).rejects.toThrow(
+      "target agent not found: agent_gone",
+    );
+  });
+
+  it("logs and swallows a dispatch failure — the resolver stays armed", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { mesh } = makeMesh({ dispatchError: new Error("daemon offline") });
+
+    const ask = mesh.sendAsk("req_g", "agent_a", "agent_b", "q");
+    await tick();
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "[mesh] dispatch for agent_b (mesh_ask) failed:",
+      "daemon offline",
+    );
+    // The ask itself did not reject — it is still waiting on respond_ask.
+    mesh.respondAsk("req_g", {
+      request_id: "req_g",
+      from_agent_id: "agent_b",
+      answer: "late but fine",
+    });
+    await expect(ask).resolves.toMatchObject({ answer: "late but fine" });
+  });
+
+  it("rejects with a resolver timeout when respond_ask never arrives", async () => {
+    vi.useFakeTimers();
+    const { mesh } = makeMesh();
+    const ask = mesh.sendAsk("req_h", "agent_a", "agent_b", "q");
+    const assertion = expect(ask).rejects.toThrow(
+      `mesh resolver timeout (${ASK_TIMEOUT_MS}ms) for req_h:asker`,
+    );
+
+    await vi.advanceTimersByTimeAsync(0); // arm the resolver
+    await vi.advanceTimersByTimeAsync(ASK_TIMEOUT_MS);
+    await assertion;
+  });
+});
+
+describe("MeshServer.respondAsk", () => {
+  it("is a no-op when no asker is blocked (B responded twice, or after a timeout)", () => {
+    const { mesh } = makeMesh();
+    expect(() =>
+      mesh.respondAsk("req_unknown", {
+        request_id: "req_unknown",
+        from_agent_id: "agent_b",
+        answer: "nobody home",
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("MeshServer.sendNegotiate", () => {
+  it("creates the negotiation, records round 1 and dispatches B", async () => {
+    const f = makeMesh();
+    void f.mesh.sendNegotiate("agent_a", "agent_b", "ship on Friday", {
+      initiatorSessionId: "sess_initiator",
+      taskId: "task_9",
+    });
+    await tick();
+
+    const neg = [...f.negotiations.values()][0]!;
+    expect(neg).toMatchObject({
+      initiator_agent_id: "agent_a",
+      initiator_session_id: "sess_initiator",
+      counterparty_agent_id: "agent_b",
+      task_id: "task_9",
+      max_rounds: 5,
+      // sendNegotiate bumps rounds_completed so B's first respond_negotiate
+      // computes round_number=2 and doesn't collide on the UNIQUE index.
+      rounds_completed: 1,
+    });
+
+    expect(f.rounds).toHaveLength(1);
+    expect(f.rounds[0]).toMatchObject({
+      negotiation_id: neg.id,
+      round_number: 1,
+      from_agent_id: "agent_a",
+      decision: "propose",
+      message: "ship on Friday",
+    });
+
+    const call = f.dispatchCalls[0]!;
+    expect(call).toMatchObject({
+      agentId: "agent_b",
+      type: "mesh_negotiate",
+      callerAgentId: "agent_a",
+    });
+    expect(call.sessionIdOverride).toMatch(/^sess_/);
+    expect(call.intent).toContain(
+      `<mesh-negotiate negotiation_id="${neg.id}" from="agent_a" round="1">`,
+    );
+    expect(call.intent).toContain("ship on Friday");
+  });
+
+  it("stamps max_rounds from the initiator, defaulting to 5", async () => {
+    const custom = makeMesh({ agents: { agent_a: { max_negotiation_rounds: 2 } } });
+    void custom.mesh.sendNegotiate("agent_a", "agent_b", "p", {
+      initiatorSessionId: "s",
+    });
+    await tick();
+    expect([...custom.negotiations.values()][0]!.max_rounds).toBe(2);
+
+    const fallback = makeMesh({
+      agents: { agent_a: { max_negotiation_rounds: undefined } },
+    });
+    void fallback.mesh.sendNegotiate("agent_a", "agent_b", "p", {
+      initiatorSessionId: "s",
+    });
+    await tick();
+    expect([...fallback.negotiations.values()][0]!.max_rounds).toBe(5);
+  });
+
+  it("rejects an IC target before touching capacity or the negotiation table", async () => {
+    const f = makeMesh({ agents: { agent_ic: { hierarchy_level: "ic" } } });
+
+    await expect(
+      f.mesh.sendNegotiate("agent_a", "agent_ic", "p", { initiatorSessionId: "s" }),
+    ).rejects.toBeInstanceOf(CannotNegotiateWithIcError);
+    expect(f.negotiations.size).toBe(0);
+    expect(f.dispatchCalls).toHaveLength(0);
+  });
+
+  it("throws when the target or the initiator does not exist", async () => {
+    const noTarget = makeMesh({ agents: { agent_gone: null } });
+    await expect(
+      noTarget.mesh.sendNegotiate("agent_a", "agent_gone", "p", {
+        initiatorSessionId: "s",
+      }),
+    ).rejects.toThrow("target agent not found: agent_gone");
+
+    const noInitiator = makeMesh({ agents: { agent_gone: null } });
+    await expect(
+      noInitiator.mesh.sendNegotiate("agent_gone", "agent_b", "p", {
+        initiatorSessionId: "s",
+      }),
+    ).rejects.toThrow("initiator agent not found: agent_gone");
+    expect(noInitiator.negotiations.size).toBe(0);
+  });
+
+  it("capacity-gates the target before creating the negotiation row", async () => {
+    const f = makeMesh({ running: 9, agents: { agent_b: { max_mesh_sessions: 1 } } });
+    await expect(
+      f.mesh.sendNegotiate("agent_a", "agent_b", "p", { initiatorSessionId: "s" }),
+    ).rejects.toBeInstanceOf(MeshCapacityError);
+    expect(f.negotiations.size).toBe(0);
+  });
+
+  it("rejects with a resolver timeout when B never responds", async () => {
+    vi.useFakeTimers();
+    const f = makeMesh();
+    const neg = f.mesh.sendNegotiate("agent_a", "agent_b", "p", {
+      initiatorSessionId: "s",
+    });
+    const assertion = expect(neg).rejects.toThrow(
+      new RegExp(`mesh resolver timeout \\(${NEGOTIATE_TIMEOUT_MS}ms\\) for neg_\\w+:initiator`),
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(NEGOTIATE_TIMEOUT_MS);
+    await assertion;
+  });
+});
+
+describe("MeshServer.respondNegotiate", () => {
+  it("runs a full counter → accept exchange, alternating which side is blocked", async () => {
+    const f = makeMesh();
+    const initiatorPromise = f.mesh.sendNegotiate("agent_a", "agent_b", "ship Friday", {
+      initiatorSessionId: "sess_a",
+    });
+    await tick();
+    const negId = [...f.negotiations.keys()][0]!;
+    const counterpartySid = f.dispatchCalls[0]!.sessionIdOverride!;
+
+    // Round 2: B counters. A's sendNegotiate resolves with B's response and
+    // B is now the blocked side.
+    const bBlocked = f.mesh.respondNegotiate(
+      negId,
+      counter(negId, "agent_b", "ship Monday"),
+      counterpartySid,
+    );
+    await expect(initiatorPromise).resolves.toMatchObject({
+      from_agent_id: "agent_b",
+      decision: "counter",
+      message: "ship Monday",
+    });
+    await tick();
+
+    // First response from the counterparty stamps its session id.
+    expect(f.negotiations.get(negId)!.counterparty_session_id).toBe(counterpartySid);
+    expect(f.negotiations.get(negId)!.rounds_completed).toBe(2);
+
+    // Round 3: A accepts. B's blocked call resolves with A's response and
+    // A's own call returns null (terminal).
+    const aTerminal = await f.mesh.respondNegotiate(
+      negId,
+      {
+        negotiation_id: negId,
+        from_agent_id: "agent_a",
+        decision: "accept",
+        message: "Monday works",
+      },
+      "sess_a",
+    );
+
+    expect(aTerminal).toBeNull();
+    await expect(bBlocked).resolves.toMatchObject({
+      from_agent_id: "agent_a",
+      decision: "accept",
+    });
+    expect(f.negotiations.get(negId)!.status).toBe("accepted");
+    expect(f.negotiations.get(negId)!.rounds_completed).toBe(3);
+    expect(f.rounds.map((r) => [r.round_number, r.from_agent_id, r.decision])).toEqual([
+      [1, "agent_a", "propose"],
+      [2, "agent_b", "counter"],
+      [3, "agent_a", "accept"],
+    ]);
+  });
+
+  it("closes the negotiation as rejected on a reject decision", async () => {
+    const f = makeMesh();
+    const neg = f.seedNegotiation({ id: "neg_rej" });
+
+    const result = await f.mesh.respondNegotiate(
+      neg.id,
+      {
+        negotiation_id: neg.id,
+        from_agent_id: "agent_b",
+        decision: "reject",
+        message: "no",
+      },
+      "sess_b",
+    );
+
+    expect(result).toBeNull();
+    expect(f.negotiations.get(neg.id)!.status).toBe("rejected");
+  });
+
+  it("stamps counterparty_session_id only on the counterparty's first response", async () => {
+    const f = makeMesh();
+    const neg = f.seedNegotiation({ id: "neg_stamp" });
+
+    // The initiator responding first must NOT claim the counterparty slot.
+    void f.mesh.respondNegotiate(neg.id, counter(neg.id, "agent_a"), "sess_a");
+    await tick();
+    expect(f.negotiations.get(neg.id)!.counterparty_session_id).toBeUndefined();
+
+    void f.mesh.respondNegotiate(neg.id, counter(neg.id, "agent_b"), "sess_b_first");
+    await tick();
+    expect(f.negotiations.get(neg.id)!.counterparty_session_id).toBe("sess_b_first");
+
+    // A later response from B is a no-op — the column is immutable.
+    void f.mesh.respondNegotiate(neg.id, counter(neg.id, "agent_b"), "sess_b_second");
+    await tick();
+    expect(f.negotiations.get(neg.id)!.counterparty_session_id).toBe("sess_b_first");
+  });
+
+  it("throws when the negotiation is unknown or already terminal", async () => {
+    const f = makeMesh();
+    await expect(
+      f.mesh.respondNegotiate("neg_nope", counter("neg_nope", "agent_b"), "s"),
+    ).rejects.toThrow("negotiation neg_nope not found");
+
+    const closed = f.seedNegotiation({ id: "neg_closed", status: "accepted" });
+    await expect(
+      f.mesh.respondNegotiate(closed.id, counter(closed.id, "agent_b"), "s"),
+    ).rejects.toThrow("negotiation neg_closed is not active (status='accepted')");
+  });
+
+  it("caps on EXCHANGES, not rows — B completing exchange 1 is allowed at max_rounds=1", async () => {
+    const f = makeMesh();
+    const neg = f.seedNegotiation({
+      id: "neg_cap",
+      max_rounds: 1,
+      rounds_completed: 1,
+    });
+
+    // Row 2 completes exchange 1 → still under the cap.
+    void f.mesh.respondNegotiate(neg.id, counter(neg.id, "agent_b"), "sess_b");
+    await tick();
+    expect(f.negotiations.get(neg.id)!.rounds_completed).toBe(2);
+
+    // Row 3 would open exchange 2 → over the cap.
+    await expect(
+      f.mesh.respondNegotiate(neg.id, counter(neg.id, "agent_a"), "sess_a"),
+    ).rejects.toBeInstanceOf(MeshMaxRoundsError);
+    expect(f.rounds).toHaveLength(1);
+    expect(f.negotiations.get(neg.id)!.rounds_completed).toBe(2);
+  });
+
+  it("carries the round numbers into MeshMaxRoundsError so the tool can prompt an escalation", async () => {
+    const f = makeMesh();
+    const neg = f.seedNegotiation({
+      id: "neg_over",
+      max_rounds: 2,
+      rounds_completed: 4,
+    });
+
+    await expect(
+      f.mesh.respondNegotiate(neg.id, counter(neg.id, "agent_a"), "sess_a"),
+    ).rejects.toMatchObject({
+      code: "MAX_ROUNDS_EXCEEDED",
+      meta: { negotiationId: "neg_over", rounds_completed: 4, max_rounds: 2 },
+    });
+  });
+
+  it("blocks the initiator key when neither side is waiting (B's reply to round 1)", async () => {
+    const f = makeMesh();
+    const neg = f.seedNegotiation({ id: "neg_first", counterparty_session_id: "sess_b" });
+
+    // No sendNegotiate ran, so no resolver is registered — the counter must
+    // still park the responder on the initiator key rather than dropping it.
+    const blocked = f.mesh.respondNegotiate(neg.id, counter(neg.id, "agent_b"), "sess_b");
+    await tick();
+
+    f.mesh.unblockOnEscalate(neg.id, "esc_1");
+    await expect(blocked).resolves.toMatchObject({ decision: "escalated" });
+  });
+});
+
+describe("MeshServer.unblockOnEscalate", () => {
+  it("releases the blocked peer with an add_to_escalation sentinel", async () => {
+    const f = makeMesh();
+    const initiatorPromise = f.mesh.sendNegotiate("agent_a", "agent_b", "p", {
+      initiatorSessionId: "sess_a",
+    });
+    await tick();
+    const negId = [...f.negotiations.keys()][0]!;
+
+    f.mesh.unblockOnEscalate(negId, "esc_42");
+
+    await expect(initiatorPromise).resolves.toEqual({
+      decision: "escalated",
+      message:
+        "Peer initiated escalation. Submit your perspective via " +
+        'add_to_escalation(escalation_id="esc_42", proposals, open_questions), then exit.',
+      escalation_id: "esc_42",
+      negotiation_id: negId,
+    });
+  });
+
+  it("releases the responder side once the rounds have flipped", async () => {
+    const f = makeMesh();
+    const initiatorPromise = f.mesh.sendNegotiate("agent_a", "agent_b", "p", {
+      initiatorSessionId: "sess_a",
+    });
+    await tick();
+    const negId = [...f.negotiations.keys()][0]!;
+    const counterpartySid = f.dispatchCalls[0]!.sessionIdOverride!;
+
+    // B's counter resolves the initiator and parks B on the responder key.
+    const bBlocked = f.mesh.respondNegotiate(negId, counter(negId, "agent_b"), counterpartySid);
+    await expect(initiatorPromise).resolves.toMatchObject({ decision: "counter" });
+    await tick();
+
+    f.mesh.unblockOnEscalate(negId, "esc_43");
+    await expect(bBlocked).resolves.toMatchObject({
+      decision: "escalated",
+      escalation_id: "esc_43",
+    });
+  });
+
+  it("is a no-op when both sides already exited", () => {
+    const { mesh } = makeMesh();
+    expect(() => mesh.unblockOnEscalate("neg_gone", "esc_1")).not.toThrow();
+  });
+});
+
+describe("MeshServer.reportBlocker", () => {
+  it("dispatches a fire-and-forget blocker session to the parent", async () => {
+    const f = makeMesh();
+    f.mesh.reportBlocker("agent_parent", "agent_child", "task_7", "creds missing");
+    await tick();
+
+    const call = f.dispatchCalls[0]!;
+    expect(call).toMatchObject({
+      agentId: "agent_parent",
+      type: "blocker",
+      callerAgentId: "agent_child",
+    });
+    // Fire-and-forget: no pre-minted session id, nothing to wait on.
+    expect(call.sessionIdOverride).toBeUndefined();
+    expect(call.intent).toContain('<mesh-blocker from="agent_child" task_id="task_7">');
+    expect(call.intent).toContain("creds missing");
+    expect(call.intent).toContain('revise_task(task_id="task_7"');
+  });
+
+  it("does not capacity-gate the parent — a blocker report must always land", async () => {
+    const f = makeMesh({ running: 99, agents: { agent_parent: { max_mesh_sessions: 1 } } });
+    f.mesh.reportBlocker("agent_parent", "agent_child", "task_7", "stuck");
+    await tick();
+    expect(f.dispatchCalls).toHaveLength(1);
+  });
+
+  it("logs a dispatch failure instead of raising an unhandled rejection", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const f = makeMesh({ dispatchError: new Error("no runtime") });
+
+    expect(() =>
+      f.mesh.reportBlocker("agent_parent", "agent_child", "task_7", "stuck"),
+    ).not.toThrow();
+    await tick();
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "[mesh] dispatch for agent_parent (blocker) failed:",
+      "no runtime",
+    );
+  });
+
+  it("reports a non-Error dispatch rejection verbatim", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const f = makeMesh({ dispatchError: "boom" as unknown as Error });
+
+    f.mesh.reportBlocker("agent_parent", "agent_child", "task_7", "stuck");
+    await tick();
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "[mesh] dispatch for agent_parent (blocker) failed:",
+      "boom",
+    );
   });
 });

--- a/packages/api/src/views/sessions.test.ts
+++ b/packages/api/src/views/sessions.test.ts
@@ -3,6 +3,7 @@ import {
   AmbiguousShortIdError,
   getConversationByShortId,
   getSessionByShortId,
+  getSessionTree,
   toSessionUsageDisplay,
 } from "./sessions.js";
 import { makeMockPool } from "./test-helpers.js";
@@ -38,6 +39,71 @@ describe("getSessionByShortId", () => {
     expect(session?.briefing.block_count).toBe(0);
     expect(session?.transcript).toEqual([]);
     expect(session?.ask_threads).toEqual([]);
+  });
+
+  it("fills the display defaults for a task-less, unclaimed session (a chat turn)", async () => {
+    const row = {
+      ...sampleRow("sess_chat00aaa"),
+      type: "chat",
+      task_id: null,
+      task_title: null,
+      workspace_path: null,
+      cli_session_id: null,
+      started_at: null,
+      spawn_mode: null,
+      runtime_id: null,
+      runtime_cli: null,
+      runtime_cli_version: null,
+      daemon_device_name: null,
+    };
+    const session = await getSessionByShortId(makeMockPool([row]), "chat00");
+    expect(session).toMatchObject({
+      task_id: "",
+      task_short_id: "",
+      task_title: "(untitled task)",
+      // Epoch stands in for "never started" so the UI can sort without
+      // special-casing null.
+      started_at: new Date(0),
+    });
+    expect(session?.worktree).toBeUndefined();
+    expect(session?.cli_session).toBeUndefined();
+    expect(session?.spawn_mode).toBeUndefined();
+    expect(session?.runtime_id).toBeUndefined();
+    expect(session?.runtime_cli).toBeUndefined();
+    expect(session?.runtime_cli_version).toBeUndefined();
+    expect(session?.daemon_device_name).toBeUndefined();
+  });
+
+  it("maps aggregated session_event rows into transcript entries", async () => {
+    const row = {
+      ...sampleRow("sess_script001"),
+      transcript: [
+        {
+          kind: "assistant",
+          timestamp: "2026-04-30T11:00:01Z",
+          content: "on it",
+          tool_name: null,
+        },
+        {
+          kind: "tool_use",
+          timestamp: "2026-04-30T11:00:02Z",
+          content: '{"file":"a.ts"}',
+          tool_name: "Read",
+        },
+      ],
+    };
+    const session = await getSessionByShortId(makeMockPool([row]), "script");
+    expect(session?.transcript).toEqual([
+      // `tool_name` is omitted entirely (not set to null) when the event
+      // carries none — the wire shape marks it optional.
+      { kind: "assistant", timestamp: "2026-04-30T11:00:01Z", content: "on it" },
+      {
+        kind: "tool_use",
+        timestamp: "2026-04-30T11:00:02Z",
+        content: '{"file":"a.ts"}',
+        tool_name: "Read",
+      },
+    ]);
   });
 
   it("returns the persisted briefing JSONB when present (#45 item 3a)", async () => {
@@ -282,6 +348,121 @@ describe("getConversationByShortId", () => {
     expect(conv?.usage).toBeUndefined();
   });
 });
+
+describe("getSessionTree", () => {
+  it("returns undefined when the root session does not exist", async () => {
+    const pool = makeMockPool([]);
+    expect(await getSessionTree(pool, "sess_missing0")).toBeUndefined();
+  });
+
+  it("returns the root plus every descendant, depth-ordered", async () => {
+    const pool = makeMockPool([
+      treeRow("sess_root00aaaa", null, 0),
+      treeRow("sess_child01bbb", "sess_root00aaaa", 1),
+      treeRow("sess_child02ccc", "sess_root00aaaa", 1),
+      treeRow("sess_grand03ddd", "sess_child01bbb", 2),
+    ]);
+
+    const tree = await getSessionTree(pool, "sess_root00aaaa");
+    expect(tree?.root.id).toBe("sess_root00aaaa");
+    expect(tree?.root.short_id).toBe("root00");
+    expect(tree?.descendants.map((n) => n.id)).toEqual([
+      "sess_child01bbb",
+      "sess_child02ccc",
+      "sess_grand03ddd",
+    ]);
+    expect(tree?.descendants.map((n) => n.parent_session_id)).toEqual([
+      "sess_root00aaaa",
+      "sess_root00aaaa",
+      "sess_child01bbb",
+    ]);
+    expect(pool._spy).toHaveBeenCalledWith(expect.any(String), ["sess_root00aaaa"]);
+  });
+
+  it("maps every node field, deriving short ids and ISO timestamps", async () => {
+    const pool = makeMockPool([
+      {
+        ...treeRow("sess_node00aaaa", null, 0),
+        task_id: "task_abcdef01",
+        task_title: "Bill rewrite",
+        type: "task",
+        status: "succeeded",
+        intent: "do the work",
+        started_at: new Date("2026-04-30T11:00:00Z"),
+        completed_at: new Date("2026-04-30T11:02:30Z"),
+      },
+    ]);
+
+    const tree = await getSessionTree(pool, "sess_node00aaaa");
+    expect(tree?.root).toEqual({
+      id: "sess_node00aaaa",
+      short_id: "node00",
+      parent_session_id: null,
+      agent_id: "agt_team",
+      agent_label: "Beta",
+      agent_hierarchy: "team",
+      task_id: "task_abcdef01",
+      task_short_id: "abcdef",
+      task_title: "Bill rewrite",
+      type: "task",
+      status: "succeeded",
+      intent: "do the work",
+      started_at: "2026-04-30T11:00:00.000Z",
+      completed_at: "2026-04-30T11:02:30.000Z",
+    });
+    expect(tree?.descendants).toEqual([]);
+  });
+
+  it("leaves task and timestamp fields null for an unclaimed, task-less session", async () => {
+    const pool = makeMockPool([
+      {
+        ...treeRow("sess_pend00aaaa", null, 0),
+        task_id: null,
+        task_title: null,
+        status: "pending",
+        started_at: null,
+        completed_at: null,
+      },
+    ]);
+
+    const tree = await getSessionTree(pool, "sess_pend00aaaa");
+    expect(tree?.root.task_id).toBeNull();
+    expect(tree?.root.task_short_id).toBeNull();
+    expect(tree?.root.task_title).toBeNull();
+    expect(tree?.root.started_at).toBeNull();
+    expect(tree?.root.completed_at).toBeNull();
+  });
+
+  it("returns undefined when the first row is not the requested root", async () => {
+    // The recursive CTE anchors on `id = $1`, so a first row with a
+    // different id means the caller passed a non-root session id (or the
+    // ordering broke). Serving a partial subtree as if it were the whole
+    // thing would silently hide the caller's real parent chain.
+    const pool = makeMockPool([
+      treeRow("sess_child01bbb", "sess_root00aaaa", 0),
+      treeRow("sess_grand03ddd", "sess_child01bbb", 1),
+    ]);
+    expect(await getSessionTree(pool, "sess_root00aaaa")).toBeUndefined();
+  });
+});
+
+function treeRow(id: string, parent_session_id: string | null, depth: number) {
+  return {
+    id,
+    parent_session_id,
+    agent_id: "agt_team",
+    agent_label: "Beta",
+    agent_hier: "team",
+    task_id: "task_001",
+    task_title: "Bill rewrite",
+    type: "task",
+    status: "running",
+    intent: "do the work",
+    started_at: new Date("2026-04-30T11:00:00Z"),
+    completed_at: null,
+    depth,
+  };
+}
 
 function resolveRow(
   id: string,

--- a/packages/core/src/adapters/opencode/runtime.test.ts
+++ b/packages/core/src/adapters/opencode/runtime.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeContext, RuntimeStep } from "../../ports/runtime.js";
 import { OpenCodeRuntime, buildOpenCodeConfig } from "./runtime.js";
@@ -246,5 +249,60 @@ describe("buildOpenCodeConfig", () => {
     expect(parsed.mcp.beevibe.headers["X-Beevibe-Session"]).toBe(
       "{env:BEEVIBE_SESSION_ID}",
     );
+  });
+});
+
+describe("OpenCodeRuntime.prepareWorkspace", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "beevibe-opencode-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes opencode.json with the Beevibe MCP server, owner-only", () => {
+    new OpenCodeRuntime().prepareWorkspace({
+      workspace: { path: dir },
+      agentApiKey: "bv_a_test",
+      mcpServerUrl: "http://api.test/mcp",
+    });
+
+    const configPath = join(dir, "opencode.json");
+    expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual(
+      JSON.parse(buildOpenCodeConfig("bv_a_test", "http://api.test/mcp")),
+    );
+    // The file carries the agent's API key, so it must not be world- or
+    // group-readable.
+    expect(statSync(configPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("leaves an existing opencode.json alone — the agent may have edited it", () => {
+    const configPath = join(dir, "opencode.json");
+    writeFileSync(configPath, '{"mine":true}\n');
+
+    new OpenCodeRuntime().prepareWorkspace({
+      workspace: { path: dir },
+      agentApiKey: "bv_a_test",
+      mcpServerUrl: "http://api.test/mcp",
+    });
+
+    expect(readFileSync(configPath, "utf8")).toBe('{"mine":true}\n');
+  });
+});
+
+describe("OpenCodeRuntime.skillsDir", () => {
+  it("points at opencode's per-workspace skills directory", () => {
+    expect(new OpenCodeRuntime().skillsDir({ path: "/ws/agt_1" })).toBe(
+      "/ws/agt_1/.opencode/skills",
+    );
+  });
+});
+
+describe("OpenCodeRuntime.shutdown", () => {
+  it("resolves — the runtime is stateless, each session is its own process", async () => {
+    await expect(new OpenCodeRuntime().shutdown()).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
## What

Coverage sweep across `api` / `core` / `daemon` / `scheduler` (v8, `--coverage.all`, with the Postgres- and provider-key-gated suites excluded so they don't abort report generation). Three modules came out well under the rest of the tree while being reachable with plain unit tests — no Docker, no CLI, no provider keys.

| File | Lines before | Lines after |
| --- | --- | --- |
| `packages/api/src/mesh/server.ts` | 43.6% | **100%** |
| `packages/api/src/views/sessions.ts` | 78.7% | **100%** |
| `packages/core/src/adapters/opencode/runtime.ts` | 89.3% | **100%** |

Tests only — **no source changes**.

## `mesh/server.ts` — the A2A broker

Existing tests covered only the `ask` fast-fail path. The negotiate protocol — where all the interesting bookkeeping lives — had none. Added:

- **Round-1 entry point.** `sendNegotiate` creates the `negotiation` row, inserts round 1 as `propose`, and bumps `rounds_completed` to 1 so B's first `respond_negotiate` computes `round_number=2` instead of colliding on the UNIQUE index.
- **The exchange cap.** `max_rounds` caps A↔B *exchanges*, not `negotiation_round` rows. Pinned both sides of that boundary: at `max_rounds=1`, B completing exchange 1 is legal, while A opening exchange 2 raises `MeshMaxRoundsError` — and does so *before* inserting a round or bumping the counter.
- **The resolver hand-off.** A full `propose → counter → accept` exchange, asserting which side is blocked at each step: B's counter resolves the initiator and parks B; A's accept resolves B, returns `null`, and flips the row to `accepted`.
- **`counterparty_session_id` is one-shot.** Stamped on the counterparty's *first* response only — not by the initiator responding first, and not overwritten by B's later rounds.
- **The escalation sentinel** releases whichever side is parked (initiator key and responder key both), and is a no-op once both sides have exited.
- **Capacity gating**, including the cap-of-3 default when the target has no `max_mesh_sessions`, and that a rejected `ask`/`negotiate` never dispatches or creates a row.
- **The IC guard** rejects before touching capacity or the negotiation table.
- **Fire-and-forget robustness**: `reportBlocker` is not capacity-gated (a blocker report must always land), and a rejected `dispatchTask` is logged rather than raising an unhandled rejection — with the resolver left armed.
- **The 5-minute resolver timeouts** for both `ask` and `negotiate`, under fake timers.
- **Callee-session failure** now also covered for a blocked `respond_negotiate`, not just `ask`.

## `views/sessions.ts`

`getSessionTree` — the hydration fallback `useChatStreamTree` calls on cold mount — and its row mapper were entirely untested. Added the depth-ordered root+descendants shape, full field mapping (derived short ids, ISO timestamps), the task-less/unclaimed null case, and the guard that returns `undefined` when the first row isn't the requested root rather than serving a partial subtree as if it were the whole thing. Also covered the transcript mapping (`tool_name` omitted, not nulled) and the display defaults a chat turn hits.

## `adapters/opencode/runtime.ts`

`prepareWorkspace` writes the agent's API key into `opencode.json`. Its `0600` mode and its don't-clobber-an-existing-file guard now have tests, alongside `skillsDir` and `shutdown`.

## Verification

- `pnpm typecheck` — clean (9/9)
- `pnpm lint` — clean on the changed files; the 4 pre-existing warnings elsewhere are unchanged
- `@beevibe/api`: 820 → 856 passing
- `@beevibe/core`: 595 → 613 passing
- Failing suites are unchanged from `main` and all environmental (no Postgres, no provider keys): 9 DB-gated files in `api`, 20 DB-gated files + 7 key-gated tests in `core`

The coverage provider was installed for the sweep and removed before committing, per CLAUDE.md — `pnpm-lock.yaml` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrF7EQALrvoiNzrHrGFNdD

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrF7EQALrvoiNzrHrGFNdD)_