### PR TITLE
chore(api): drop the dead `AgentDisplay.merge_events` field

### DIFF
--- a/packages/api/src/views/types.ts
+++ b/packages/api/src/views/types.ts
@@ -93,8 +93,6 @@ export interface AgentDisplay
   hierarchy: HierarchyLevel;
   sessions_count?: number;
   facts_learned?: number;
-  /** Reserved for future memory-merge telemetry. */
-  merge_events?: number;
   specialization?: string;
   themes?: string[];
   /** CLI tool the agent uses — derived from `runtime_config.type`. */


### PR DESCRIPTION
## What

Removes `merge_events?: number` from `AgentDisplay` in `packages/api/src/views/types.ts` — a two-line deletion.

## Why it's dead

`merge_events` had **one reference in the entire monorepo: its own declaration.** Its comment ("Reserved for future memory-merge telemetry") is accurate — it was speculative surface that never grew a producer or a consumer.

- **Nothing populates it.** `toAgentDisplay` in `views/agent-display.ts` is the single `agent` row → `AgentDisplay` mapper and never sets it; `AgentDisplayRow` has no matching column; no migration defines a `merge_events` column, so no `SELECT *` spread can supply it either.
- **Nothing reads it.** The web side never projects it.
- **Not a wire-contract break.** The field is optional and was never present in any response body, so no client can be reading it.

## What the rest of the sweep found (nothing else to remove)

| Check | Result |
| --- | --- |
| `tsc --noUnusedLocals --noUnusedParameters` (6 packages) | clean |
| `tsc --allowUnreachableCode false` (6 packages) | clean — no TS7027 |
| knip (files, dependencies, unlisted) | all 7 "unused files" plus `node-pg-migrate` and `prettier` are the load-bearing false positives already documented in CLAUDE.md |
| Name-based export sweep (914 `export function\|class\|const\|interface\|type` symbols) | no dead exports |
| Method sweep over ports + adapters | no unclaimed dead methods |
| Module-reachability sweep past the core subpath barrels (knip's documented blind spot) | no unimported modules |
| Type-field sweep (2158 fields) | this field only |
| Union-literal-member sweep (197 members) | no dead members |
| Coverage run on `@beevibe/core` | only the documented environmental failures (no Postgres, no provider keys) |

Every other candidate resolved to same-file use, a deliberate test seam (`clearCache`, marked `@internal Tests only`), a keeper documented in CLAUDE.md, or a symbol already claimed by an open sibling PR. In particular #343 removes `themes` and `promotion_origin_scope` from this same interface but leaves `merge_events` in place, so there's no overlap.

## Verification

- `pnpm typecheck` — 9/9 tasks green
- `pnpm lint` — 9/9 tasks green (the two `import/no-duplicates` warnings in `web/lib/types/dashboard.ts` are pre-existing and unrelated)
- `agent-display` / `agents` / `agent-network` view suites — 18 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdVgJPd8kwLfvypsy6GvPd

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdVgJPd8kwLfvypsy6GvPd)_