### PR TITLE
test: drop a constant-mirroring test, unflake the parallel-claim test, correct two stale fixtures

### DIFF
--- a/packages/core/src/adapters/openai/embeddings.test.ts
+++ b/packages/core/src/adapters/openai/embeddings.test.ts
@@ -44,11 +44,6 @@ describe("OpenAIEmbeddingService", () => {
     }
   });
 
-  it("reports its identity via the `type` field", () => {
-    const svc = new OpenAIEmbeddingService();
-    expect(svc.type).toBe("openai:text-embedding-3-small");
-  });
-
   it("embedBatch([]) returns [] without hitting the API", async () => {
     // Deliberately break the key so we'd get a 401 if we actually called out.
     const svc = new OpenAIEmbeddingService({ apiKey: "sk-broken" });

--- a/packages/core/src/adapters/postgres/session-repo.test.ts
+++ b/packages/core/src/adapters/postgres/session-repo.test.ts
@@ -450,8 +450,27 @@ describe("PostgresSessionRepository", () => {
         sessions.claimNextForRuntime(runtime),
         sessions.claimNextForRuntime(runtime),
       ]);
-      const claimedIds = [a?.id, b?.id].filter((x): x is string => Boolean(x)).sort();
-      expect(claimedIds).toEqual(ids.slice().sort());
+      const claimedIds = [a?.id, b?.id].filter((x): x is string => Boolean(x));
+
+      // "distinct sessions OR undefined" — not "both succeed". The claim
+      // takes `FOR UPDATE OF s, a SKIP LOCKED`, and both candidates join
+      // the SAME agent row, so a claim that overlaps the other's agent
+      // lock skips every candidate and correctly returns undefined.
+      // Asserting both succeed made this a coin flip on scheduling.
+      expect(new Set(claimedIds).size).toBe(claimedIds.length);
+      expect(claimedIds.length).toBeGreaterThan(0);
+      for (const id of claimedIds) expect(ids).toContain(id);
+
+      // A skip is only a skip: whatever the race passed over is still
+      // pending, not lost or consumed. Draining serially afterwards must
+      // yield exactly the two seeded sessions — this is what would break
+      // if SKIP LOCKED ever handed the same row out twice or dropped one.
+      for (let i = 0; i < ids.length && claimedIds.length < ids.length; i++) {
+        const next = await sessions.claimNextForRuntime(runtime);
+        if (!next) break;
+        claimedIds.push(next.id);
+      }
+      expect(claimedIds.slice().sort()).toEqual(ids.slice().sort());
     });
 
     it("respects per-agent max_task_sessions cap (the exact case from #127)", async () => {

--- a/packages/core/src/services/dispatch-service.test.ts
+++ b/packages/core/src/services/dispatch-service.test.ts
@@ -189,7 +189,7 @@ describe("DispatchService.dispatchTask", () => {
     const reason: ResumeReason = {
       kind: "post_escalation",
       role: "initiator",
-      resolution: { title: "T", description: "D", proposals: [], notes: "" },
+      resolution: { title: "T", description: "D", source: "human" },
       prior_session_id: "sess_neg",
     };
 

--- a/packages/core/src/services/task-service.test.ts
+++ b/packages/core/src/services/task-service.test.ts
@@ -49,7 +49,6 @@ function makeSession(overrides: Partial<Session> = {}): Session {
     intent: "test",
     cli_session_id: "cli_abc",
     created_at: new Date(),
-    updated_at: new Date(),
     ...overrides,
   };
 }


### PR DESCRIPTION
Fourth sweep of the suite (135 test files, ~38k lines) for dead weight — skipped/disabled tests, tests for removed features, tests with no assertions, and tests that pin implementation details rather than behavior. The suite is in good shape; three things came out of it (the third surfaced when CI ran this PR).

No production code is touched in any commit.

## Removed (1 test)

| File | Test | Why |
| --- | --- | --- |
| `packages/core/src/adapters/openai/embeddings.test.ts` | `reports its identity via the \`type\` field` | Mirrors a source constant; needs a live API key to read it |

#261 removed exactly this test from `anthropic/llm-provider.test.ts` and `openai/llm-provider.test.ts`; the third copy, on the embedding adapter, was missed. Same reasoning verbatim:

- It asserts `svc.type === "openai:text-embedding-3-small"` on a `readonly type: string` that the `EmbeddingService` port already pins at compile time.
- `git grep -n -w -- "type"` over the monorepo finds **zero** consumers of `.type` outside this assertion — nothing branches on it at runtime. So it can only fail if someone edits the literal and its own test in opposite directions.
- It constructed a live `OpenAIEmbeddingService()` purely to read that string, so CI must spend a real `OPENAI_API_KEY` to assert a constant. It is one of the keyless-sandbox failures CLAUDE.md documents as the baseline.

The offline `throws when no API key is configured` and `embedBatch([]) returns [] without hitting the API` cases in the same file are untouched.

## Unflaked (1 test)

CI failed this PR on `session-repo.test.ts > two parallel claims race-safely return distinct sessions or undefined`:

```
expected [ 'sess_kvZmyULeWc0v' ] to deeply equal [ 'sess_jyCAXxEvTNzZ', …(1) ]
```

One claim landed; the assertion demanded two. Nothing in this PR touches `session-repo.ts` or its test, and main is green on the same test — a latent flake that fires under CI load, not a regression.

**Root cause, confirmed against a real Postgres rather than inferred.** `claimNextWhere` selects its candidate with `FOR UPDATE OF s, a SKIP LOCKED`. Both seeded sessions belong to the *same* agent, so both candidates join the same `agent` row. A claim that overlaps the other's agent-row lock skips it — and since every candidate hangs off that one row, skipping it empties the candidate set and the claim returns `undefined`. Probe: with two pending sessions, cap 2, and a second connection holding `SELECT … FROM agent … FOR UPDATE`, the claim returns `undefined`; release the lock and the same call returns a session. So "both claims succeed" was never a guarantee — it held only when the two queries happened not to overlap.

The test's own name already said the right thing ("distinct sessions **or undefined**"), as does the doc comment on `claimNextWhere` ("the second has to wait on (or skip past) the agent row lock"). Only the assertion was out of step, so the name stays and the assertion now pins what the code actually provides:

- the two racing claims never return the same session;
- every id returned is one of the seeded ones;
- at least one claim wins (the lock manager grants the agent row to one of them, so the race cannot starve both);
- draining serially afterwards yields exactly the two seeded sessions — a skip is only a skip, never a lost or double-handed-out row.

That last step is **new** coverage: it pins that SKIP LOCKED passed the row over rather than consuming it, which the old assertion never checked because it required the race to claim everything up front.

## Corrected (2 fixtures)

`packages/core/tsconfig.json` excludes `**/*.test.ts`, so core's test files are the one place in the monorepo where a fixture can drift from its domain type without `pnpm typecheck` noticing. Re-running `tsc` over `src/**/*` with that exclusion lifted surfaced these:

- **`services/dispatch-service.test.ts`** built a `ResolutionProposal` as `{ title, description, proposals: [], notes: "" }`. Neither `proposals` nor `notes` is a field on it — `notes` is a sibling of `resolution` on `PostEscalationContext` — and the required `source` discriminant was missing. Now `{ title, description, source: "human" }`, matching the real shape and the fixtures in `agent-session.test.ts`.
- **`services/task-service.test.ts`** stamped `updated_at` on its `makeSession` fixture; `Session` has no such field. Dropped.

Both are runtime no-ops — the extra keys were carried through untouched, which is why the tests passed — but a fixture that invents fields misleads the next reader about the domain.

## Checked and found healthy, no action taken

- **No abandoned skips.** No `.only`, no unconditional `.skip`, no `it.todo`, no xfail anywhere. Every skip in the tree is an environment or platform gate with a live guard: `RUN_CLAUDE_SMOKE`, `BEEVIBE_E2E_DOCKER`, `BEEVIBE_E2E_MULTI_INSTANCE`, `HAS_LIVE_API_KEYS`, `process.platform === "win32"`.
- **No assertion-free tests.** A scan of all 1,452 test blocks found none.
- **No test references a removed API.** `pnpm typecheck` is clean across all nine packages, and the two packages that exclude tests from their tsconfig (core, scheduler) were checked separately with the exclusion lifted — scheduler came back clean.
- **Two type-only mismatches in core tests, deliberately left alone.** The `{ type: "thinking", thinking, signature }` block in `stream-json.test.ts` mirrors the real Anthropic wire shape while the internal `ContentBlock` models only the subset the parser reads — reconciling it means widening a production type, not editing a test. The `out?.hierarchyLevel` in `api-key.test.ts` is union narrowing: `ResolvedCaller`'s daemon variant has no such field, but the assertion is correct at runtime.
- **Tests for surfaces CLAUDE.md flags as deliberately kept.** `views/activity.test.ts` (documented public endpoint with no in-repo caller), `views/promotions.test.ts` and the promotion-repo tests (unfinished wiring, not dead code).
- **Pass-through delegation.** The classes #270 cleaned up did not recur. The remaining `delegates to` / `passes through` tests each assert something typecheck doesn't: an allowlist gate on a query param, a URL path string, or a derived value.

## Verification

A local Postgres 16 + pgvector was stood up for this, so the DB-gated suites actually ran rather than being skipped:

- The unflaked test passes **15/15** consecutive runs, and the forced-skip branch (agent row held by a third connection, so the parallel claims return nothing) drains to exactly both seeded sessions — the path CI hit is now covered rather than fatal.
- `@beevibe/core`: **876 pass**; 6 fail, all of them the provider-key suites failing on this sandbox's placeholder keys. Every DB-gated suite passes, `session-repo` 44/44.
- `@beevibe/api`: **929 pass**; the single failure is `mcp.test.ts`, which is live-key gated.
- `@beevibe/web`: 203/203 pass.
- `pnpm typecheck` and `pnpm lint`: clean, 9/9 packages.

On mutation strength: dropping `FOR UPDATE … SKIP LOCKED` from the source survives **both** the old and the new assertion on an idle single-CPU box, so the rewrite loses nothing — the double-claim that guard prevents simply needs real contention to surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKxtf7Gcby546i5kyeYr6K