### PR TITLE
test(api): cover the six lowest-coverage modules in the api package

### DIFF
--- a/packages/api/src/routes/chat.test.ts
+++ b/packages/api/src/routes/chat.test.ts
@@ -1,0 +1,936 @@
+/**
+ * /chat route handlers — unit tests with vitest fakes (no DB, no daemon).
+ *
+ * `chat-internals.test.ts` already covers the exported pure helpers
+ * (groupIntoConversations, chainToMessages, failureMessageFor). This
+ * file covers the four handlers wrapped around them, where the
+ * product-visible behaviour actually lives:
+ *
+ *   - GET  /chat/conversations   sidebar list (titles, previews, counts)
+ *   - DEL  /chat/conversations/:headId  soft-delete, scoped to the caller
+ *   - GET  /chat                 history + the runtime-pin mismatch banner
+ *   - POST /chat                 the money path: idempotent replay, rate
+ *                                limiting, offline-daemon 503, resolver
+ *                                timeout 504, onboarding flip
+ *
+ * POST in particular has five distinct ways to refuse a turn before it
+ * ever spawns a CLI subprocess, each with its own status code the web
+ * client branches on — and each one costs real money when it regresses
+ * open.
+ */
+
+import express, { json } from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  Person,
+  PersonRepository,
+  RuntimeRepository,
+  Session,
+  SessionRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import type { ChatResolver } from "../runtime/chat-resolver.js";
+import type { DaemonHub } from "../runtime/hub.js";
+import { ChatRateLimiter } from "./chat-rate-limit.js";
+import { createChatRouter, type ChatRoutesDeps } from "./chat.js";
+
+const PERSON = "person_1";
+const AGENT = "agent_team";
+
+function fakeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: AGENT,
+    name: "Hive",
+    owner_id: PERSON,
+    hierarchy_level: "team",
+    runtime_config: { type: "claude" },
+    created_at: new Date("2026-04-01"),
+    updated_at: new Date("2026-04-01"),
+    ...overrides,
+  };
+}
+
+function fakePerson(overrides: Partial<Person> = {}): Person {
+  return {
+    id: PERSON,
+    name: "Ada",
+    email: "ada@example.com",
+    created_at: new Date("2026-04-01"),
+    updated_at: new Date("2026-04-01"),
+    ...overrides,
+  } as Person;
+}
+
+function fakeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "sess_aaaaaaaaaaaa",
+    agent_id: AGENT,
+    type: "chat",
+    status: "succeeded",
+    intent: "hello",
+    created_at: new Date("2026-04-01T10:00:00Z"),
+    updated_at: new Date("2026-04-01T10:00:00Z"),
+    ...overrides,
+  } as Session;
+}
+
+interface Harness {
+  app: express.Express;
+  agentRepo: { findTopLevelForOwner: ReturnType<typeof vi.fn> };
+  personRepo: {
+    findById: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+  runtimeRepo: { findById: ReturnType<typeof vi.fn> };
+  sessionRepo: {
+    listChatForAgent: ReturnType<typeof vi.fn>;
+    softDeleteChatChain: ReturnType<typeof vi.fn>;
+    findById: ReturnType<typeof vi.fn>;
+  };
+  dispatchService: { dispatchTask: ReturnType<typeof vi.fn> };
+  chatResolver: { register: ReturnType<typeof vi.fn> };
+  hub: { isOnline: ReturnType<typeof vi.fn> };
+}
+
+function harness(
+  opts: {
+    caller?: unknown;
+    agent?: Agent | null;
+    person?: Person | undefined;
+    rateLimiter?: ChatRateLimiter;
+  } = {},
+): Harness {
+  const agentRepo = {
+    findTopLevelForOwner: vi.fn(async () =>
+      opts.agent === undefined ? fakeAgent() : (opts.agent ?? undefined),
+    ),
+  };
+  const personRepo = {
+    findById: vi.fn(async () =>
+      "person" in opts ? opts.person : fakePerson(),
+    ),
+    update: vi.fn(async () => fakePerson()),
+  };
+  const runtimeRepo = { findById: vi.fn(async () => undefined) };
+  const sessionRepo = {
+    listChatForAgent: vi.fn(async () => [] as Session[]),
+    softDeleteChatChain: vi.fn(async () => 0),
+    findById: vi.fn(async () => undefined),
+  };
+  const dispatchService = {
+    dispatchTask: vi.fn(async () => ({
+      session: fakeSession({ status: "pending" }),
+      runtime_id: undefined,
+    })),
+  };
+  const chatResolver = {
+    register: vi.fn(async () =>
+      fakeSession({ status: "succeeded", result_summary: "hi there" }),
+    ),
+  };
+  const hub = { isOnline: vi.fn(() => true) };
+
+  const deps: ChatRoutesDeps = {
+    authMiddleware: (req, _res, next) => {
+      (req as unknown as { caller: unknown }).caller =
+        "caller" in opts ? opts.caller : { source: "human", personId: PERSON };
+      next();
+    },
+    agentRepo: agentRepo as unknown as AgentRepository,
+    personRepo: personRepo as unknown as PersonRepository,
+    runtimeRepo: runtimeRepo as unknown as RuntimeRepository,
+    sessionRepo: sessionRepo as unknown as SessionRepository,
+    dispatchService: dispatchService as unknown as DispatchService,
+    chatResolver: chatResolver as unknown as ChatResolver,
+    hub: hub as unknown as DaemonHub,
+    rateLimiter: opts.rateLimiter,
+  };
+
+  const app = express();
+  app.use(json());
+  app.use("/chat", createChatRouter(deps));
+  return {
+    app,
+    agentRepo,
+    personRepo,
+    runtimeRepo,
+    sessionRepo,
+    dispatchService,
+    chatResolver,
+    hub,
+  };
+}
+
+const AGENT_CALLER = { source: "agent", agentId: "agent_x" };
+
+describe("GET /chat/conversations", () => {
+  it("rejects a non-human caller", async () => {
+    const h = harness({ caller: AGENT_CALLER });
+    const res = await request(h.app).get("/chat/conversations");
+
+    expect(res.status).toBe(403);
+    expect(h.sessionRepo.listChatForAgent).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty list when the caller has no primary agent", async () => {
+    const h = harness({ agent: null });
+    const res = await request(h.app).get("/chat/conversations");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, conversations: [] });
+  });
+
+  it("summarises each chain with its title, turn count and last activity", async () => {
+    const h = harness();
+    h.sessionRepo.listChatForAgent.mockResolvedValueOnce([
+      fakeSession({
+        id: "sess_head00000001",
+        intent: "Ship the release",
+        result_summary: "first",
+        created_at: new Date("2026-04-01T10:00:00Z"),
+      }),
+      fakeSession({
+        id: "sess_tail00000001",
+        prior_session_id: "sess_head00000001",
+        intent: "and now the changelog",
+        result_summary: "done: changelog written",
+        created_at: new Date("2026-04-01T11:00:00Z"),
+      }),
+    ]);
+
+    const res = await request(h.app).get("/chat/conversations");
+
+    expect(res.body.conversations).toEqual([
+      {
+        head_id: "sess_head00000001",
+        title: "Ship the release",
+        turn_count: 2,
+        last_at: "2026-04-01T11:00:00.000Z",
+        last_preview: "done: changelog written",
+      },
+    ]);
+  });
+
+  it("previews the intent when a turn produced neither summary nor error", async () => {
+    const h = harness();
+    h.sessionRepo.listChatForAgent.mockResolvedValueOnce([
+      fakeSession({ id: "sess_pending00001", intent: "what's up", status: "running" }),
+    ]);
+
+    const res = await request(h.app).get("/chat/conversations");
+
+    expect(res.body.conversations[0].last_preview).toBe("what's up");
+  });
+
+  it("previews the error when a turn failed without a summary", async () => {
+    const h = harness();
+    h.sessionRepo.listChatForAgent.mockResolvedValueOnce([
+      fakeSession({
+        id: "sess_failed000001",
+        status: "failed",
+        result_summary: undefined,
+        error: "the daemon went away",
+      }),
+    ]);
+
+    const res = await request(h.app).get("/chat/conversations");
+
+    expect(res.body.conversations[0].last_preview).toBe("the daemon went away");
+  });
+
+  it("collapses whitespace and ellipsises a long preview", async () => {
+    const h = harness();
+    h.sessionRepo.listChatForAgent.mockResolvedValueOnce([
+      fakeSession({ result_summary: `a  b\n\nc ${"x".repeat(200)}` }),
+    ]);
+
+    const res = await request(h.app).get("/chat/conversations");
+    const preview = res.body.conversations[0].last_preview as string;
+
+    expect(preview).toHaveLength(140);
+    expect(preview.startsWith("a b c ")).toBe(true);
+    expect(preview.endsWith("…")).toBe(true);
+  });
+
+  it("caps the list at 50 conversations", async () => {
+    const h = harness();
+    h.sessionRepo.listChatForAgent.mockResolvedValueOnce(
+      Array.from({ length: 60 }, (_, i) =>
+        fakeSession({
+          id: `sess_${String(i).padStart(12, "0")}`,
+          created_at: new Date(2026, 3, 1, i),
+        }),
+      ),
+    );
+
+    const res = await request(h.app).get("/chat/conversations");
+
+    expect(res.body.conversations).toHaveLength(50);
+  });
+});
+
+describe("DELETE /chat/conversations/:headId", () => {
+  it("rejects a non-human caller", async () => {
+    const h = harness({ caller: AGENT_CALLER });
+    const res = await request(h.app).delete("/chat/conversations/sess_head00000001");
+
+    expect(res.status).toBe(403);
+    expect(h.sessionRepo.softDeleteChatChain).not.toHaveBeenCalled();
+  });
+
+  it("404s when the caller has no primary agent", async () => {
+    const h = harness({ agent: null });
+    const res = await request(h.app).delete("/chat/conversations/sess_head00000001");
+
+    expect(res.status).toBe(404);
+    expect(res.body).toMatchObject({ error: "agent_not_found" });
+  });
+
+  it("soft-deletes the chain scoped to the caller's own agent", async () => {
+    const h = harness();
+    h.sessionRepo.softDeleteChatChain.mockResolvedValueOnce(3);
+
+    const res = await request(h.app).delete("/chat/conversations/sess_head00000001");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, deleted: 3 });
+    expect(h.sessionRepo.softDeleteChatChain).toHaveBeenCalledWith(
+      "sess_head00000001",
+      AGENT,
+    );
+  });
+
+  it("is idempotent — a chain already deleted reports zero rows, not an error", async () => {
+    const h = harness();
+    h.sessionRepo.softDeleteChatChain.mockResolvedValueOnce(0);
+
+    const res = await request(h.app).delete("/chat/conversations/sess_head00000001");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, deleted: 0 });
+  });
+
+  it("returns a 500 with a request id when the repo throws", async () => {
+    const h = harness();
+    h.sessionRepo.softDeleteChatChain.mockRejectedValueOnce(new Error("boom"));
+    const logged = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const res = await request(h.app).delete("/chat/conversations/sess_head00000001");
+
+    expect(res.status).toBe(500);
+    expect(res.body).toMatchObject({ error: "internal_error" });
+    // The detail stays server-side; the client gets a paste-able id.
+    expect(res.body.request_id).toMatch(/^req_/);
+    expect(res.body.message).not.toContain("boom");
+    logged.mockRestore();
+  });
+});
+
+describe("GET /chat", () => {
+  it("rejects a non-human caller", async () => {
+    const h = harness({ caller: AGENT_CALLER });
+    const res = await request(h.app).get("/chat");
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns a null agent and empty history when none is provisioned", async () => {
+    const h = harness({ agent: null });
+    const res = await request(h.app).get("/chat");
+
+    expect(res.body).toEqual({
+      ok: true,
+      agent: null,
+      messages: [],
+      prior_session_id: null,
+      conversation_id: null,
+    });
+  });
+
+  it("returns the most recent chain by default", async () => {
+    const h = harness();
+    h.sessionRepo.listChatForAgent.mockResolvedValueOnce([
+      fakeSession({
+        id: "sess_old000000001",
+        intent: "older",
+        result_summary: "older reply",
+        created_at: new Date("2026-04-01T09:00:00Z"),
+      }),
+      fakeSession({
+        id: "sess_new000000001",
+        intent: "newer",
+        result_summary: "newer reply",
+        created_at: new Date("2026-04-02T09:00:00Z"),
+      }),
+    ]);
+
+    const res = await request(h.app).get("/chat");
+
+    expect(res.body.conversation_id).toBe("sess_new000000001");
+    expect(res.body.prior_session_id).toBe("sess_new000000001");
+    expect(res.body.agent).toEqual({ id: AGENT, name: "Hive", hierarchy: "team" });
+    expect(res.body.messages).toMatchObject([
+      { role: "user", content: "newer" },
+      { role: "agent", content: "newer reply", session_id: "sess_new000000001" },
+    ]);
+  });
+
+  it("selects the chain named by ?c=", async () => {
+    const h = harness();
+    h.sessionRepo.listChatForAgent.mockResolvedValueOnce([
+      fakeSession({
+        id: "sess_old000000001",
+        intent: "older",
+        result_summary: "older reply",
+        created_at: new Date("2026-04-01T09:00:00Z"),
+      }),
+      fakeSession({
+        id: "sess_new000000001",
+        intent: "newer",
+        created_at: new Date("2026-04-02T09:00:00Z"),
+      }),
+    ]);
+
+    const res = await request(h.app).get("/chat?c=sess_old000000001");
+
+    expect(res.body.conversation_id).toBe("sess_old000000001");
+  });
+
+  it("renders the empty state rather than 404 for an unknown ?c=", async () => {
+    const h = harness();
+    h.sessionRepo.listChatForAgent.mockResolvedValueOnce([fakeSession()]);
+
+    const res = await request(h.app).get("/chat?c=sess_nonexistent1");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      agent: { id: AGENT, name: "Hive", hierarchy: "team" },
+      messages: [],
+      prior_session_id: null,
+      conversation_id: null,
+    });
+  });
+
+  it("truncates history to the last 25 sessions", async () => {
+    const h = harness();
+    const chain = Array.from({ length: 40 }, (_, i) =>
+      fakeSession({
+        id: `sess_${String(i).padStart(12, "0")}`,
+        prior_session_id:
+          i === 0 ? undefined : `sess_${String(i - 1).padStart(12, "0")}`,
+        intent: `turn ${i}`,
+        result_summary: `reply ${i}`,
+        created_at: new Date(2026, 3, 1, i),
+      }),
+    );
+    h.sessionRepo.listChatForAgent.mockResolvedValueOnce(chain);
+
+    const res = await request(h.app).get("/chat");
+
+    // 25 sessions × (user + agent) bubbles.
+    expect(res.body.messages).toHaveLength(50);
+    expect(res.body.messages[0]).toMatchObject({
+      role: "user",
+      content: "turn 15",
+    });
+  });
+
+  it("surfaces the tail session id while a turn is still in flight", async () => {
+    const h = harness();
+    h.sessionRepo.listChatForAgent.mockResolvedValueOnce([
+      fakeSession({ id: "sess_running00001", status: "running" }),
+    ]);
+
+    const res = await request(h.app).get("/chat");
+
+    expect(res.body.in_flight_session_id).toBe("sess_running00001");
+  });
+
+  it("omits in_flight_session_id once the tail session is terminal", async () => {
+    const h = harness();
+    h.sessionRepo.listChatForAgent.mockResolvedValueOnce([
+      fakeSession({ status: "succeeded", result_summary: "done" }),
+    ]);
+
+    const res = await request(h.app).get("/chat");
+
+    expect(res.body.in_flight_session_id).toBeUndefined();
+  });
+
+  it("flags a runtime mismatch when the chain is pinned to another CLI", async () => {
+    const h = harness();
+    h.sessionRepo.listChatForAgent.mockResolvedValueOnce([
+      fakeSession({ runtime_id: "rt_1", result_summary: "hi" }),
+    ]);
+    h.runtimeRepo.findById.mockResolvedValueOnce({ id: "rt_1", cli: "codex" });
+
+    const res = await request(h.app).get("/chat");
+
+    expect(res.body.runtime_mismatch).toEqual({
+      pinned_cli: "codex",
+      current_cli: "claude",
+    });
+  });
+
+  it("omits the mismatch when the pinned CLI matches the agent's", async () => {
+    const h = harness();
+    h.sessionRepo.listChatForAgent.mockResolvedValueOnce([
+      fakeSession({ runtime_id: "rt_1", result_summary: "hi" }),
+    ]);
+    h.runtimeRepo.findById.mockResolvedValueOnce({ id: "rt_1", cli: "claude" });
+
+    const res = await request(h.app).get("/chat");
+
+    expect(res.body.runtime_mismatch).toBeUndefined();
+  });
+
+  it.each([
+    ["the runtime row is gone", undefined],
+    ["the runtime's cli is unrecognised", { id: "rt_1", cli: "wingman" }],
+  ])("omits the mismatch when %s", async (_label, runtime) => {
+    const h = harness();
+    h.sessionRepo.listChatForAgent.mockResolvedValueOnce([
+      fakeSession({ runtime_id: "rt_1", result_summary: "hi" }),
+    ]);
+    h.runtimeRepo.findById.mockResolvedValueOnce(runtime);
+
+    const res = await request(h.app).get("/chat");
+
+    expect(res.body.runtime_mismatch).toBeUndefined();
+  });
+
+  it("skips the runtime lookup entirely for an unpinned chain", async () => {
+    const h = harness();
+    h.sessionRepo.listChatForAgent.mockResolvedValueOnce([
+      fakeSession({ runtime_id: undefined, result_summary: "hi" }),
+    ]);
+
+    await request(h.app).get("/chat");
+
+    expect(h.runtimeRepo.findById).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /chat validation and dispatch", () => {
+  it("rejects a non-human caller", async () => {
+    const h = harness({ caller: AGENT_CALLER });
+    const res = await request(h.app).post("/chat").send({ message: "hi" });
+
+    expect(res.status).toBe(403);
+    expect(h.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["missing", {}],
+    ["blank", { message: "   " }],
+    ["non-string", { message: 42 }],
+  ])("400s on a %s message", async (_label, body) => {
+    const h = harness();
+    const res = await request(h.app).post("/chat").send(body);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: "message_required" });
+    expect(h.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("404s when the caller has no primary agent", async () => {
+    const h = harness({ agent: null });
+    const res = await request(h.app).post("/chat").send({ message: "hi" });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toMatchObject({ error: "no_primary_agent" });
+  });
+
+  it("dispatches a fresh chat turn with the trimmed message", async () => {
+    const h = harness();
+    const res = await request(h.app).post("/chat").send({ message: "  hello  " });
+
+    expect(res.status).toBe(200);
+    expect(h.dispatchService.dispatchTask).toHaveBeenCalledWith({
+      agentId: AGENT,
+      intent: "hello",
+      reason: { kind: "fresh" },
+      type: "chat",
+      sessionIdOverride: undefined,
+    });
+  });
+
+  it("dispatches a continuation when prior_session_id is given", async () => {
+    const h = harness();
+    await request(h.app)
+      .post("/chat")
+      .send({ message: "and then?", prior_session_id: "sess_prior000001" });
+
+    expect(h.dispatchService.dispatchTask.mock.calls[0]![0].reason).toEqual({
+      kind: "chat_continuation",
+      prior_session_id: "sess_prior000001",
+    });
+  });
+
+  it("honours a well-formed client session id as the override", async () => {
+    const h = harness();
+    await request(h.app)
+      .post("/chat")
+      .send({ message: "hi", session_id: "sess_ABCdef123456" });
+
+    expect(h.dispatchService.dispatchTask.mock.calls[0]![0].sessionIdOverride).toBe(
+      "sess_ABCdef123456",
+    );
+  });
+
+  it.each([
+    ["the wrong prefix", "chat_ABCdef123456"],
+    ["the wrong length", "sess_short"],
+    ["illegal characters", "sess_ABCdef-23456"],
+  ])("ignores a session_id with %s", async (_label, sessionId) => {
+    const h = harness();
+    await request(h.app).post("/chat").send({ message: "hi", session_id: sessionId });
+
+    expect(h.sessionRepo.findById).not.toHaveBeenCalled();
+    expect(h.dispatchService.dispatchTask.mock.calls[0]![0].sessionIdOverride).toBe(
+      undefined,
+    );
+  });
+
+  it("returns the resolved turn with the processed response text", async () => {
+    const h = harness();
+    h.chatResolver.register.mockResolvedValueOnce(
+      fakeSession({ id: "sess_done00000001", result_summary: "all done" }),
+    );
+
+    const res = await request(h.app).post("/chat").send({ message: "hi" });
+
+    expect(res.body).toMatchObject({
+      ok: true,
+      agent: { id: AGENT, name: "Hive", hierarchy: "team" },
+      session_id: "sess_done00000001",
+      response: "all done",
+      status: "succeeded",
+    });
+    expect(res.body.replayed).toBeUndefined();
+  });
+
+  it("renders a failed turn with the friendly failure message", async () => {
+    const h = harness();
+    h.chatResolver.register.mockResolvedValueOnce(
+      fakeSession({ status: "failed", result_summary: undefined, error: "disk full" }),
+    );
+
+    const res = await request(h.app).post("/chat").send({ message: "hi" });
+
+    expect(res.body).toMatchObject({ status: "failed", response: "disk full" });
+  });
+
+  it("500s with a request id when dispatch throws", async () => {
+    const h = harness();
+    h.dispatchService.dispatchTask.mockRejectedValueOnce(new Error("no runtime"));
+    const logged = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const res = await request(h.app).post("/chat").send({ message: "hi" });
+
+    expect(res.status).toBe(500);
+    expect(res.body).toMatchObject({ error: "internal_error" });
+    logged.mockRestore();
+  });
+});
+
+describe("POST /chat idempotent replay", () => {
+  const SID = "sess_ABCdef123456";
+
+  it("replays a succeeded session instead of spawning another turn", async () => {
+    const h = harness();
+    h.sessionRepo.findById.mockResolvedValueOnce(
+      fakeSession({ id: SID, status: "succeeded", result_summary: "cached reply" }),
+    );
+
+    const res = await request(h.app)
+      .post("/chat")
+      .send({ message: "hi", session_id: SID });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      session_id: SID,
+      response: "cached reply",
+      replayed: true,
+    });
+    expect(h.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("replays a failed session with its failure message", async () => {
+    const h = harness();
+    h.sessionRepo.findById.mockResolvedValueOnce(
+      fakeSession({
+        id: SID,
+        status: "failed",
+        result_summary: undefined,
+        error: "disk full",
+      }),
+    );
+
+    const res = await request(h.app)
+      .post("/chat")
+      .send({ message: "hi", session_id: SID });
+
+    expect(res.body).toMatchObject({ replayed: true, response: "disk full" });
+    expect(h.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("409s while the session is still running", async () => {
+    const h = harness();
+    h.sessionRepo.findById.mockResolvedValueOnce(
+      fakeSession({ id: SID, status: "running" }),
+    );
+
+    const res = await request(h.app)
+      .post("/chat")
+      .send({ message: "hi", session_id: SID });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({ error: "session_in_flight" });
+    expect(h.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("403s when the session id collides with another caller's session", async () => {
+    const h = harness();
+    h.sessionRepo.findById.mockResolvedValueOnce(
+      fakeSession({ id: SID, agent_id: "agent_someone_else" }),
+    );
+
+    const res = await request(h.app)
+      .post("/chat")
+      .send({ message: "hi", session_id: SID });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ error: "session_belongs_to_other_caller" });
+    expect(h.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("falls through to dispatch when the id is unknown", async () => {
+    const h = harness();
+    h.sessionRepo.findById.mockResolvedValueOnce(undefined);
+
+    await request(h.app).post("/chat").send({ message: "hi", session_id: SID });
+
+    expect(h.dispatchService.dispatchTask).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls through to dispatch when the id belongs to a non-chat session", async () => {
+    const h = harness();
+    h.sessionRepo.findById.mockResolvedValueOnce(
+      fakeSession({ id: SID, type: "task" }),
+    );
+
+    await request(h.app).post("/chat").send({ message: "hi", session_id: SID });
+
+    expect(h.dispatchService.dispatchTask).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls through to dispatch when a pending row was pre-created", async () => {
+    const h = harness();
+    h.sessionRepo.findById.mockResolvedValueOnce(
+      fakeSession({ id: SID, status: "pending" }),
+    );
+
+    await request(h.app).post("/chat").send({ message: "hi", session_id: SID });
+
+    expect(h.dispatchService.dispatchTask).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("POST /chat rate limiting", () => {
+  it("429s with turn_in_flight when a turn is already running for the person", async () => {
+    const limiter = new ChatRateLimiter({ maxConcurrent: 1, now: () => 1000 });
+    limiter.acquire(PERSON); // occupy the only slot
+    const h = harness({ rateLimiter: limiter });
+
+    const res = await request(h.app).post("/chat").send({ message: "hi" });
+
+    expect(res.status).toBe(429);
+    expect(res.body).toMatchObject({ error: "turn_in_flight" });
+    expect(res.headers["retry-after"]).toBeDefined();
+    expect(h.dispatchService.dispatchTask).not.toHaveBeenCalled();
+  });
+
+  it("429s with rate_limited once the sliding window is full", async () => {
+    const limiter = new ChatRateLimiter({
+      maxConcurrent: 5,
+      maxPerWindow: 2,
+      windowMs: 60_000,
+      now: () => 1000,
+    });
+    const first = limiter.acquire(PERSON);
+    first.ok && first.release();
+    const second = limiter.acquire(PERSON);
+    second.ok && second.release();
+    const h = harness({ rateLimiter: limiter });
+
+    const res = await request(h.app).post("/chat").send({ message: "hi" });
+
+    expect(res.status).toBe(429);
+    expect(res.body).toMatchObject({ error: "rate_limited" });
+    expect(res.body.retry_after_ms).toBe(60_000);
+  });
+
+  it("releases the slot after a successful turn, so the next one is admitted", async () => {
+    const limiter = new ChatRateLimiter({ maxConcurrent: 1 });
+    const h = harness({ rateLimiter: limiter });
+
+    await request(h.app).post("/chat").send({ message: "one" });
+    const second = await request(h.app).post("/chat").send({ message: "two" });
+
+    expect(second.status).toBe(200);
+    expect(h.dispatchService.dispatchTask).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases the slot when dispatch throws", async () => {
+    const limiter = new ChatRateLimiter({ maxConcurrent: 1 });
+    const h = harness({ rateLimiter: limiter });
+    h.dispatchService.dispatchTask.mockRejectedValueOnce(new Error("nope"));
+    const logged = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await request(h.app).post("/chat").send({ message: "one" });
+    const second = await request(h.app).post("/chat").send({ message: "two" });
+
+    expect(second.status).toBe(200);
+    logged.mockRestore();
+  });
+
+  it("releases the slot when the daemon turns out to be offline", async () => {
+    const limiter = new ChatRateLimiter({ maxConcurrent: 1 });
+    const h = harness({ rateLimiter: limiter });
+    h.dispatchService.dispatchTask.mockResolvedValueOnce({
+      session: fakeSession({ status: "pending" }),
+      runtime_id: "rt_1",
+    });
+    h.hub.isOnline.mockReturnValueOnce(false);
+
+    const first = await request(h.app).post("/chat").send({ message: "one" });
+    const second = await request(h.app).post("/chat").send({ message: "two" });
+
+    expect(first.status).toBe(503);
+    expect(second.status).toBe(200);
+  });
+});
+
+describe("POST /chat daemon availability and timeouts", () => {
+  it("503s when the session is bound to an offline daemon", async () => {
+    const h = harness();
+    h.dispatchService.dispatchTask.mockResolvedValueOnce({
+      session: fakeSession({ status: "pending" }),
+      runtime_id: "rt_offline",
+    });
+    h.hub.isOnline.mockReturnValueOnce(false);
+
+    const res = await request(h.app).post("/chat").send({ message: "hi" });
+
+    expect(res.status).toBe(503);
+    expect(res.body).toMatchObject({ error: "agent_offline" });
+    expect(h.chatResolver.register).not.toHaveBeenCalled();
+  });
+
+  it("proceeds for a null-runtime session without consulting the hub", async () => {
+    const h = harness();
+
+    const res = await request(h.app).post("/chat").send({ message: "hi" });
+
+    expect(res.status).toBe(200);
+    expect(h.hub.isOnline).not.toHaveBeenCalled();
+  });
+
+  it("504s when the resolver times out", async () => {
+    const h = harness();
+    h.chatResolver.register.mockRejectedValueOnce(
+      new Error("chat resolver timeout (90000ms) for sess_x"),
+    );
+
+    const res = await request(h.app).post("/chat").send({ message: "hi" });
+
+    expect(res.status).toBe(504);
+    expect(res.body).toMatchObject({
+      error: "chat_turn_timeout",
+      timeout_ms: 90_000,
+    });
+  });
+
+  it("500s on any other resolver rejection", async () => {
+    const h = harness();
+    h.chatResolver.register.mockRejectedValueOnce(new Error("resolver exploded"));
+    const logged = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const res = await request(h.app).post("/chat").send({ message: "hi" });
+
+    expect(res.status).toBe(500);
+    expect(res.body).toMatchObject({ error: "internal_error" });
+    logged.mockRestore();
+  });
+
+  it("registers the resolver against the dispatched session with the 90s cap", async () => {
+    const h = harness();
+    h.dispatchService.dispatchTask.mockResolvedValueOnce({
+      session: fakeSession({ id: "sess_dispatched01" }),
+      runtime_id: undefined,
+    });
+
+    await request(h.app).post("/chat").send({ message: "hi" });
+
+    expect(h.chatResolver.register).toHaveBeenCalledWith("sess_dispatched01", 90_000);
+  });
+});
+
+describe("POST /chat onboarding flip", () => {
+  it("stamps onboarding_completed_at on the first successful turn", async () => {
+    const h = harness({ person: fakePerson({ onboarding_completed_at: undefined }) });
+
+    await request(h.app).post("/chat").send({ message: "hi" });
+
+    expect(h.personRepo.update).toHaveBeenCalledWith(
+      PERSON,
+      expect.objectContaining({ onboarding_completed_at: expect.any(Date) }),
+    );
+  });
+
+  it("does not re-stamp a person who already completed onboarding", async () => {
+    const h = harness({
+      person: fakePerson({ onboarding_completed_at: new Date("2026-01-01") }),
+    });
+
+    await request(h.app).post("/chat").send({ message: "hi" });
+
+    expect(h.personRepo.update).not.toHaveBeenCalled();
+  });
+
+  it("does not stamp when the first turn failed", async () => {
+    const h = harness({ person: fakePerson({ onboarding_completed_at: undefined }) });
+    h.chatResolver.register.mockResolvedValueOnce(
+      fakeSession({ status: "failed", error: "nope" }),
+    );
+
+    await request(h.app).post("/chat").send({ message: "hi" });
+
+    expect(h.personRepo.update).not.toHaveBeenCalled();
+  });
+
+  it("still answers the turn when the onboarding write rejects", async () => {
+    const h = harness({ person: fakePerson({ onboarding_completed_at: undefined }) });
+    h.personRepo.update.mockRejectedValueOnce(new Error("write failed"));
+    const logged = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const res = await request(h.app).post("/chat").send({ message: "hi" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    logged.mockRestore();
+  });
+
+  it("treats a missing person row as still onboarding", async () => {
+    const h = harness({ person: undefined });
+
+    await request(h.app).post("/chat").send({ message: "hi" });
+
+    expect(h.personRepo.update).toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/routes/stream.test.ts
+++ b/packages/api/src/routes/stream.test.ts
@@ -1,0 +1,261 @@
+/**
+ * GET /stream — the SSE fanout route, exercised over a real socket.
+ *
+ * Everything this route does is invisible to a normal JSON assertion:
+ * the headers that stop proxies from buffering, the priming `data: {}`
+ * line that trips the browser's health probe, the 25s heartbeat that
+ * keeps nginx/cloudflared from idling the connection out, and the
+ * unsubscribe-on-disconnect that stops the subscriber set from leaking
+ * a closed response. So the tests drive a real http server and read the
+ * raw bytes off the wire.
+ *
+ * Intervals are faked (and only intervals) so the heartbeat is
+ * assertable without a 25-second test.
+ */
+
+import { createServer, get as httpGet, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import express, { type RequestHandler } from "express";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BvEvent, SseManager } from "../sse/manager.js";
+import { createStreamRouter } from "./stream.js";
+
+const PERSON = "person_1";
+
+interface CapturedSubscriber {
+  personId: string;
+  send: (event: BvEvent) => void;
+  active: boolean;
+}
+
+function fakeSseManager(): {
+  manager: SseManager;
+  subs: CapturedSubscriber[];
+} {
+  const subs: CapturedSubscriber[] = [];
+  const manager = {
+    subscribe(personId: string, cb: (event: BvEvent) => void) {
+      const entry: CapturedSubscriber = { personId, send: cb, active: true };
+      subs.push(entry);
+      return () => {
+        entry.active = false;
+      };
+    },
+  } as unknown as SseManager;
+  return { manager, subs };
+}
+
+/** Auth middleware stand-in: stamps whatever caller the test wants. */
+function authAs(caller: unknown): RequestHandler {
+  return (req, _res, next) => {
+    (req as unknown as { caller: unknown }).caller = caller;
+    next();
+  };
+}
+
+const HUMAN = { source: "human", personId: PERSON };
+
+interface Harness {
+  server: Server;
+  port: number;
+  subs: CapturedSubscriber[];
+}
+
+async function startServer(caller: unknown): Promise<Harness> {
+  const { manager, subs } = fakeSseManager();
+  const app = express();
+  app.use(createStreamRouter({ authMiddleware: authAs(caller), sseManager: manager }));
+  const server = createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  return { server, port: (server.address() as AddressInfo).port, subs };
+}
+
+/**
+ * Open the SSE connection and hand back a reader that resolves the next
+ * chunk of the stream — the only way to assert on a response that never
+ * ends.
+ */
+interface Stream {
+  status: number;
+  headers: Record<string, string | string[] | undefined>;
+  /** Resolves with the next chunk written by the server. */
+  next(): Promise<string>;
+  close(): void;
+  closed: Promise<void>;
+}
+
+function open(port: number): Promise<Stream> {
+  return new Promise((resolve, reject) => {
+    const req = httpGet(
+      { host: "127.0.0.1", port, path: "/stream" },
+      (res) => {
+        const queued: string[] = [];
+        let pending: ((chunk: string) => void) | undefined;
+        res.setEncoding("utf8");
+        res.on("data", (chunk: string) => {
+          if (pending) {
+            const resolveNext = pending;
+            pending = undefined;
+            resolveNext(chunk);
+          } else {
+            queued.push(chunk);
+          }
+        });
+        let markClosed = (): void => undefined;
+        const closed = new Promise<void>((r) => {
+          markClosed = r;
+        });
+        res.on("close", () => markClosed());
+        resolve({
+          status: res.statusCode ?? 0,
+          headers: res.headers,
+          next: () =>
+            new Promise<string>((r) => {
+              const queuedChunk = queued.shift();
+              if (queuedChunk !== undefined) r(queuedChunk);
+              else pending = r;
+            }),
+          close: () => req.destroy(),
+          closed,
+        });
+      },
+    );
+    req.on("error", reject);
+  });
+}
+
+/** Poll until `predicate` holds — the server-side close is asynchronous. */
+async function until(predicate: () => boolean): Promise<void> {
+  for (let i = 0; i < 200; i++) {
+    if (predicate()) return;
+    await new Promise((r) => setImmediate(r));
+  }
+  throw new Error("condition never became true");
+}
+
+describe("GET /stream", () => {
+  let harness: Harness | undefined;
+  const opened: Stream[] = [];
+
+  /** Open a stream the teardown will always tear down. */
+  async function connect(port: number): Promise<Stream> {
+    const stream = await open(port);
+    opened.push(stream);
+    return stream;
+  }
+
+  beforeEach(() => {
+    // Only intervals: real socket I/O and setImmediate must keep working.
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    // An SSE response never ends on its own, so server.close() would hang
+    // forever if a connection were left open.
+    for (const stream of opened.splice(0)) stream.close();
+    if (harness) {
+      harness.server.closeAllConnections();
+      await new Promise<void>((resolve) => harness!.server.close(() => resolve()));
+      harness = undefined;
+    }
+  });
+
+  it("sends the SSE headers that keep proxies from buffering", async () => {
+    harness = await startServer(HUMAN);
+    const stream = await connect(harness.port);
+
+    expect(stream.status).toBe(200);
+    expect(stream.headers["content-type"]).toBe("text/event-stream");
+    expect(stream.headers["cache-control"]).toBe("no-cache, no-transform");
+    expect(stream.headers["x-accel-buffering"]).toBe("no");
+
+    stream.close();
+  });
+
+  it("primes the stream with an empty data event", async () => {
+    harness = await startServer(HUMAN);
+    const stream = await connect(harness.port);
+
+    // A comment line would not fire the browser's onmessage, so the
+    // health probe needs a real data line first.
+    await expect(stream.next()).resolves.toBe("data: {}\n\n");
+
+    stream.close();
+  });
+
+  it("subscribes the caller's own personId", async () => {
+    harness = await startServer(HUMAN);
+    const stream = await connect(harness.port);
+    await stream.next();
+
+    expect(harness.subs).toHaveLength(1);
+    expect(harness.subs[0]!.personId).toBe(PERSON);
+
+    stream.close();
+  });
+
+  it("writes a published event as a JSON data line", async () => {
+    harness = await startServer(HUMAN);
+    const stream = await connect(harness.port);
+    await stream.next();
+
+    const event: BvEvent = {
+      event: "task.updated",
+      id: "task_1",
+      data: { status: "done" },
+    };
+    harness.subs[0]!.send(event);
+
+    await expect(stream.next()).resolves.toBe(
+      `data: ${JSON.stringify(event)}\n\n`,
+    );
+
+    stream.close();
+  });
+
+  it("writes a heartbeat comment every 25 seconds", async () => {
+    harness = await startServer(HUMAN);
+    const stream = await connect(harness.port);
+    await stream.next();
+
+    vi.advanceTimersByTime(25_000);
+    await expect(stream.next()).resolves.toBe(": heartbeat\n\n");
+
+    vi.advanceTimersByTime(25_000);
+    await expect(stream.next()).resolves.toBe(": heartbeat\n\n");
+
+    stream.close();
+  });
+
+  it("unsubscribes and clears the heartbeat when the client disconnects", async () => {
+    harness = await startServer(HUMAN);
+    const stream = await connect(harness.port);
+    await stream.next();
+
+    stream.close();
+    await until(() => harness!.subs[0]!.active === false);
+
+    // The interval is gone too: nothing is left to write to a dead socket.
+    expect(() => vi.advanceTimersByTime(60_000)).not.toThrow();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("rejects a non-human caller with 403 and never subscribes", async () => {
+    harness = await startServer({ source: "agent", agentId: "agent_a" });
+    const stream = await connect(harness.port);
+
+    expect(stream.status).toBe(403);
+    expect(harness.subs).toHaveLength(0);
+    await stream.closed;
+  });
+
+  it("rejects a caller the auth middleware left unresolved", async () => {
+    harness = await startServer(null);
+    const stream = await connect(harness.port);
+
+    expect(stream.status).toBe(403);
+    expect(harness.subs).toHaveLength(0);
+    await stream.closed;
+  });
+});

--- a/packages/api/src/tools/mesh-handlers.test.ts
+++ b/packages/api/src/tools/mesh-handlers.test.ts
@@ -1,0 +1,684 @@
+/**
+ * Mesh tool *handlers* — unit tests with vitest fakes.
+ *
+ * `mesh.test.ts` locks the per-tier tool inventory; this file covers
+ * what each handler does when an agent calls it. The handlers were
+ * previously exercised only by the m6/m7 e2e scripts, which need live
+ * Postgres and real spawned CLI subprocesses — so in a normal test run
+ * nothing checked the argument coercion, the required-field refusals,
+ * or the response projections, all of which are pure functions over
+ * injected services.
+ *
+ * The projections matter because they are the agent-facing wire
+ * contract: `respond_negotiate` returning `terminal: true` versus a
+ * peer's counter is how a negotiating agent decides whether to keep
+ * talking or exit.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { AgentRepository, TaskRepository } from "@beevibe/core";
+import type { ResolvedCaller } from "@beevibe/core/auth";
+import type { TaskService } from "@beevibe/core/services/task-service";
+import type { EscalationService } from "@beevibe/core/services/escalation-service";
+import type { Pool } from "@beevibe/core/adapters/postgres";
+import { MeshCapacityError, MeshMaxRoundsError } from "../mesh/types.js";
+import type { MeshServer } from "../mesh/server.js";
+import {
+  buildIcMeshTools,
+  buildTeamMeshTools,
+  type MeshToolContext,
+  type MeshToolServices,
+} from "./mesh.js";
+import type { AgentTool } from "./types.js";
+
+const CALLER: ResolvedCaller = {
+  agentId: "agent_caller",
+  source: "agent",
+  hierarchyLevel: "team",
+};
+const CTX: MeshToolContext = { caller: CALLER, beevibeSid: "sess_caller0001" };
+
+interface Harness {
+  tools: Map<string, AgentTool>;
+  mesh: {
+    sendAsk: ReturnType<typeof vi.fn>;
+    respondAsk: ReturnType<typeof vi.fn>;
+    sendNegotiate: ReturnType<typeof vi.fn>;
+    respondNegotiate: ReturnType<typeof vi.fn>;
+    reportBlocker: ReturnType<typeof vi.fn>;
+    unblockOnEscalate: ReturnType<typeof vi.fn>;
+  };
+  agentRepo: { findParent: ReturnType<typeof vi.fn> };
+  taskService: { markBlocked: ReturnType<typeof vi.fn> };
+  escalationService: { create: ReturnType<typeof vi.fn> };
+  pool: { query: ReturnType<typeof vi.fn> };
+}
+
+function harness(): Harness {
+  const mesh = {
+    sendAsk: vi.fn(async () => ({
+      request_id: "req_1",
+      from_agent_id: "agent_peer",
+      answer: "yes, feasible",
+    })),
+    respondAsk: vi.fn(() => undefined),
+    sendNegotiate: vi.fn(async () => ({
+      negotiation_id: "neg_1",
+      from_agent_id: "agent_peer",
+      decision: "counter" as const,
+      message: "how about this",
+      counter_proposal: "do it in two phases",
+    })),
+    respondNegotiate: vi.fn(async () => null),
+    reportBlocker: vi.fn(() => undefined),
+    unblockOnEscalate: vi.fn(() => undefined),
+  };
+  const agentRepo = {
+    findParent: vi.fn(async () => ({ id: "agent_parent" })),
+  };
+  const taskService = { markBlocked: vi.fn(async () => undefined) };
+  const escalationService = {
+    create: vi.fn(async () => ({
+      id: "esc_1",
+      status: "open",
+      negotiation_id: "neg_1",
+    })),
+  };
+  const pool = { query: vi.fn(async () => ({ rows: [] })) };
+
+  const services = {
+    mesh: mesh as unknown as MeshServer,
+    agentRepo: agentRepo as unknown as AgentRepository,
+    taskRepo: {} as TaskRepository,
+    taskService: taskService as unknown as TaskService,
+    escalationService: escalationService as unknown as EscalationService,
+    pool: pool as unknown as Pool,
+  } satisfies MeshToolServices;
+
+  const tools = new Map(
+    buildTeamMeshTools(CTX, services).map((t) => [t.name, t]),
+  );
+  return { tools, mesh, agentRepo, taskService, escalationService, pool };
+}
+
+function tool(h: Harness, name: string): AgentTool {
+  return h.tools.get(name)!;
+}
+
+describe("ask", () => {
+  it("forwards the caller, target and question with a minted request id", async () => {
+    const h = harness();
+    const result = await tool(h, "ask").handler({
+      target_agent_id: "agent_peer",
+      question: "is X feasible?",
+    });
+
+    expect(h.mesh.sendAsk).toHaveBeenCalledTimes(1);
+    const [requestId, from, target, question] = h.mesh.sendAsk.mock.calls[0]!;
+    expect(requestId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    expect(from).toBe("agent_caller");
+    expect(target).toBe("agent_peer");
+    expect(question).toBe("is X feasible?");
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("mints a fresh request id per call", async () => {
+    const h = harness();
+    await tool(h, "ask").handler({ target_agent_id: "p", question: "q" });
+    await tool(h, "ask").handler({ target_agent_id: "p", question: "q" });
+
+    expect(h.mesh.sendAsk.mock.calls[0]![0]).not.toBe(
+      h.mesh.sendAsk.mock.calls[1]![0],
+    );
+  });
+
+  it("projects only the three wire fields of the answer", async () => {
+    const h = harness();
+    h.mesh.sendAsk.mockResolvedValueOnce({
+      request_id: "req_9",
+      from_agent_id: "agent_peer",
+      answer: "no",
+      // Anything else the server happens to carry stays server-side.
+      internal_note: "leak me",
+    });
+
+    const result = await tool(h, "ask").handler({
+      target_agent_id: "agent_peer",
+      question: "q",
+    });
+
+    expect(result.content).toEqual({
+      request_id: "req_9",
+      from_agent_id: "agent_peer",
+      answer: "no",
+    });
+  });
+
+  it.each([
+    ["target_agent_id", { question: "q" }],
+    ["question", { target_agent_id: "agent_peer" }],
+    ["both", {}],
+  ])("refuses when %s is missing", async (_label, input) => {
+    const h = harness();
+    const result = await tool(h, "ask").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "target_agent_id and question required",
+    });
+    expect(h.mesh.sendAsk).not.toHaveBeenCalled();
+  });
+
+  it("projects a capacity error with its code and meta", async () => {
+    const h = harness();
+    h.mesh.sendAsk.mockRejectedValueOnce(
+      new MeshCapacityError("peer is at capacity", {
+        agentId: "agent_peer",
+        running: 5,
+        cap: 5,
+      }),
+    );
+
+    const result = await tool(h, "ask").handler({
+      target_agent_id: "agent_peer",
+      question: "q",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "MESH_CAPACITY_EXCEEDED",
+      agentId: "agent_peer",
+      running: 5,
+      cap: 5,
+      message: "peer is at capacity",
+    });
+  });
+
+  it("degrades an uncoded throw to the catch-all envelope", async () => {
+    const h = harness();
+    h.mesh.sendAsk.mockRejectedValueOnce(new Error("transport dropped"));
+
+    const result = await tool(h, "ask").handler({
+      target_agent_id: "agent_peer",
+      question: "q",
+    });
+
+    expect(result.content).toEqual({ error: "transport dropped" });
+  });
+});
+
+describe("respond_ask", () => {
+  it("resolves the asker's pending request with the caller as responder", async () => {
+    const h = harness();
+    const result = await tool(h, "respond_ask").handler({
+      request_id: "req_1",
+      answer: "here you go",
+    });
+
+    expect(h.mesh.respondAsk).toHaveBeenCalledWith("req_1", {
+      request_id: "req_1",
+      from_agent_id: "agent_caller",
+      answer: "here you go",
+    });
+    expect(result.content).toEqual({ responded: true, request_id: "req_1" });
+  });
+
+  it.each([
+    ["request_id", { answer: "a" }],
+    ["answer", { request_id: "req_1" }],
+  ])("refuses when %s is missing", async (_label, input) => {
+    const h = harness();
+    const result = await tool(h, "respond_ask").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "request_id and answer required" });
+    expect(h.mesh.respondAsk).not.toHaveBeenCalled();
+  });
+
+  it("envelopes a throw from the resolver", async () => {
+    const h = harness();
+    h.mesh.respondAsk.mockImplementationOnce(() => {
+      throw new Error("no resolver waiting");
+    });
+
+    const result = await tool(h, "respond_ask").handler({
+      request_id: "req_1",
+      answer: "a",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "no resolver waiting" });
+  });
+
+  it("is available to IC agents", () => {
+    const names = buildIcMeshTools(CTX, {} as MeshToolServices).map((t) => t.name);
+    expect(names).toContain("respond_ask");
+  });
+});
+
+describe("negotiate", () => {
+  it("opens round one with the caller's session as the initiator", async () => {
+    const h = harness();
+    await tool(h, "negotiate").handler({
+      peer_id: "agent_peer",
+      proposal: "split the work",
+      task_id: "task_1",
+    });
+
+    expect(h.mesh.sendNegotiate).toHaveBeenCalledWith(
+      "agent_caller",
+      "agent_peer",
+      "split the work",
+      { taskId: "task_1", initiatorSessionId: "sess_caller0001" },
+    );
+  });
+
+  it.each([
+    ["absent", undefined],
+    ["an empty string", ""],
+    ["a non-string", 7],
+  ])("omits a task_id that is %s", async (_label, taskId) => {
+    const h = harness();
+    await tool(h, "negotiate").handler({
+      peer_id: "agent_peer",
+      proposal: "p",
+      task_id: taskId,
+    });
+
+    expect(h.mesh.sendNegotiate.mock.calls[0]![3].taskId).toBeUndefined();
+  });
+
+  it("projects the peer's counter, counter_proposal included", async () => {
+    const h = harness();
+    const result = await tool(h, "negotiate").handler({
+      peer_id: "agent_peer",
+      proposal: "p",
+    });
+
+    expect(result.content).toEqual({
+      negotiation_id: "neg_1",
+      from_agent_id: "agent_peer",
+      decision: "counter",
+      message: "how about this",
+      counter_proposal: "do it in two phases",
+    });
+  });
+
+  it("projects the escalated sentinel into its own shape", async () => {
+    const h = harness();
+    h.mesh.sendNegotiate.mockResolvedValueOnce({
+      decision: "escalated",
+      message: "handed to humans",
+      escalation_id: "esc_7",
+      negotiation_id: "neg_1",
+    });
+
+    const result = await tool(h, "negotiate").handler({
+      peer_id: "agent_peer",
+      proposal: "p",
+    });
+
+    // No from_agent_id / counter_proposal on this branch — the peer isn't
+    // the author of an escalation sentinel.
+    expect(result.content).toEqual({
+      decision: "escalated",
+      escalation_id: "esc_7",
+      negotiation_id: "neg_1",
+      message: "handed to humans",
+    });
+  });
+
+  it.each([
+    ["peer_id", { proposal: "p" }],
+    ["proposal", { peer_id: "agent_peer" }],
+  ])("refuses when %s is missing", async (_label, input) => {
+    const h = harness();
+    const result = await tool(h, "negotiate").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "peer_id and proposal required" });
+    expect(h.mesh.sendNegotiate).not.toHaveBeenCalled();
+  });
+});
+
+describe("respond_negotiate", () => {
+  it("reports terminal when the server has nothing further to return", async () => {
+    const h = harness();
+    const result = await tool(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "accept",
+      message: "deal",
+    });
+
+    expect(h.mesh.respondNegotiate).toHaveBeenCalledWith(
+      "neg_1",
+      {
+        negotiation_id: "neg_1",
+        from_agent_id: "agent_caller",
+        decision: "accept",
+        message: "deal",
+        counter_proposal: undefined,
+      },
+      "sess_caller0001",
+    );
+    expect(result.content).toEqual({
+      negotiation_id: "neg_1",
+      decision: "accept",
+      terminal: true,
+    });
+  });
+
+  it("projects the peer's reply when the negotiation continues", async () => {
+    const h = harness();
+    h.mesh.respondNegotiate.mockResolvedValueOnce({
+      negotiation_id: "neg_1",
+      from_agent_id: "agent_peer",
+      decision: "counter",
+      message: "not quite",
+      counter_proposal: "try this",
+    });
+
+    const result = await tool(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "my turn",
+      counter_proposal: "mine",
+    });
+
+    expect(result.content).toMatchObject({
+      from_agent_id: "agent_peer",
+      decision: "counter",
+      counter_proposal: "try this",
+    });
+  });
+
+  it("projects an escalated sentinel arriving mid-negotiation", async () => {
+    const h = harness();
+    h.mesh.respondNegotiate.mockResolvedValueOnce({
+      decision: "escalated",
+      message: "peer escalated",
+      escalation_id: "esc_3",
+      negotiation_id: "neg_1",
+    });
+
+    const result = await tool(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "m",
+      counter_proposal: "c",
+    });
+
+    expect(result.content).toEqual({
+      decision: "escalated",
+      escalation_id: "esc_3",
+      negotiation_id: "neg_1",
+      message: "peer escalated",
+    });
+  });
+
+  it.each([
+    ["negotiation_id", { decision: "accept", message: "m" }],
+    ["message", { negotiation_id: "neg_1", decision: "accept" }],
+  ])("refuses when %s is missing", async (_label, input) => {
+    const h = harness();
+    const result = await tool(h, "respond_negotiate").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "negotiation_id and message required",
+    });
+    expect(h.mesh.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it.each([["approve"], [""], [undefined]])(
+    "refuses the unknown decision %s",
+    async (decision) => {
+      const h = harness();
+      const result = await tool(h, "respond_negotiate").handler({
+        negotiation_id: "neg_1",
+        decision,
+        message: "m",
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual({
+        error: "decision must be one of: counter, accept, reject",
+      });
+      expect(h.mesh.respondNegotiate).not.toHaveBeenCalled();
+    },
+  );
+
+  it("refuses a counter with no counter_proposal", async () => {
+    const h = harness();
+    const result = await tool(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "m",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "counter_proposal required when decision='counter'",
+    });
+    expect(h.mesh.respondNegotiate).not.toHaveBeenCalled();
+  });
+
+  it("allows accept and reject without a counter_proposal", async () => {
+    const h = harness();
+    for (const decision of ["accept", "reject"]) {
+      const result = await tool(h, "respond_negotiate").handler({
+        negotiation_id: "neg_1",
+        decision,
+        message: "m",
+      });
+      expect(result.isError).toBeFalsy();
+    }
+    expect(h.mesh.respondNegotiate).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces the max-rounds error with its structured meta", async () => {
+    const h = harness();
+    h.mesh.respondNegotiate.mockRejectedValueOnce(
+      new MeshMaxRoundsError({
+        negotiationId: "neg_1",
+        rounds_completed: 5,
+        max_rounds: 5,
+      }),
+    );
+
+    const result = await tool(h, "respond_negotiate").handler({
+      negotiation_id: "neg_1",
+      decision: "counter",
+      message: "m",
+      counter_proposal: "c",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "MAX_ROUNDS_EXCEEDED",
+      negotiationId: "neg_1",
+      rounds_completed: 5,
+      max_rounds: 5,
+    });
+    // The message is what tells the agent to escalate instead of retrying.
+    expect(result.content.message).toContain("escalate_to_humans");
+  });
+});
+
+describe("report_blocker", () => {
+  it("marks the task blocked and spawns the direct parent", async () => {
+    const h = harness();
+    const result = await tool(h, "report_blocker").handler({
+      task_id: "task_1",
+      description: "the API key is missing",
+    });
+
+    expect(h.agentRepo.findParent).toHaveBeenCalledWith("agent_caller");
+    expect(h.taskService.markBlocked).toHaveBeenCalledWith(
+      "task_1",
+      "agent_caller",
+      "the API key is missing",
+    );
+    expect(h.mesh.reportBlocker).toHaveBeenCalledWith(
+      "agent_parent",
+      "agent_caller",
+      "task_1",
+      "the API key is missing",
+    );
+    expect(result.content).toEqual({
+      reported: true,
+      parent_agent_id: "agent_parent",
+      task_id: "task_1",
+    });
+  });
+
+  it("refuses for a top-level agent with no parent", async () => {
+    const h = harness();
+    h.agentRepo.findParent.mockResolvedValueOnce(undefined);
+
+    const result = await tool(h, "report_blocker").handler({
+      task_id: "task_1",
+      description: "stuck",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "no_parent_to_block" });
+    // Nothing is mutated on the refusal path.
+    expect(h.taskService.markBlocked).not.toHaveBeenCalled();
+    expect(h.mesh.reportBlocker).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["task_id", { description: "d" }],
+    ["description", { task_id: "task_1" }],
+  ])("refuses when %s is missing", async (_label, input) => {
+    const h = harness();
+    const result = await tool(h, "report_blocker").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "task_id and description required" });
+    expect(h.agentRepo.findParent).not.toHaveBeenCalled();
+  });
+
+  it("does not spawn the parent when marking the task blocked fails", async () => {
+    const h = harness();
+    h.taskService.markBlocked.mockRejectedValueOnce(new Error("task not found"));
+
+    const result = await tool(h, "report_blocker").handler({
+      task_id: "task_1",
+      description: "stuck",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "task not found" });
+    expect(h.mesh.reportBlocker).not.toHaveBeenCalled();
+  });
+});
+
+describe("escalate_to_humans", () => {
+  const INPUT = {
+    negotiation_id: "neg_1",
+    summary: "we disagree on the rollout order",
+  };
+
+  it("creates the escalation, unblocks the peer, then notifies", async () => {
+    const h = harness();
+    const result = await tool(h, "escalate_to_humans").handler(INPUT);
+
+    expect(h.escalationService.create).toHaveBeenCalledWith({
+      negotiationId: "neg_1",
+      callerAgentId: "agent_caller",
+      summary: "we disagree on the rollout order",
+      proposals: undefined,
+      openQuestions: undefined,
+    });
+    expect(h.mesh.unblockOnEscalate).toHaveBeenCalledWith("neg_1", "esc_1");
+    expect(h.pool.query).toHaveBeenCalledWith(
+      expect.stringContaining("pg_notify('escalation_created'"),
+      ["esc_1"],
+    );
+    expect(result.content).toEqual({
+      escalation_id: "esc_1",
+      status: "open",
+      negotiation_id: "neg_1",
+    });
+  });
+
+  it("passes proposals and open questions through", async () => {
+    const h = harness();
+    await tool(h, "escalate_to_humans").handler({
+      ...INPUT,
+      proposals: [{ title: "A", description: "do A" }],
+      open_questions: ["who owns the rollout?"],
+    });
+
+    expect(h.escalationService.create.mock.calls[0]![0]).toMatchObject({
+      proposals: [{ title: "A", description: "do A" }],
+      openQuestions: ["who owns the rollout?"],
+    });
+  });
+
+  it("drops non-string entries from open_questions", async () => {
+    const h = harness();
+    await tool(h, "escalate_to_humans").handler({
+      ...INPUT,
+      open_questions: ["real question", 42, null],
+    });
+
+    expect(h.escalationService.create.mock.calls[0]![0].openQuestions).toEqual([
+      "real question",
+    ]);
+  });
+
+  it.each([
+    ["proposals", "not an array"],
+    ["open_questions", { a: 1 }],
+  ])("ignores a non-array %s", async (field, value) => {
+    const h = harness();
+    await tool(h, "escalate_to_humans").handler({ ...INPUT, [field]: value });
+
+    const arg = h.escalationService.create.mock.calls[0]![0];
+    expect(arg.proposals).toBeUndefined();
+    expect(arg.openQuestions).toBeUndefined();
+  });
+
+  it.each([
+    ["negotiation_id", { summary: "s" }],
+    ["summary", { negotiation_id: "neg_1" }],
+  ])("refuses when %s is missing", async (_label, input) => {
+    const h = harness();
+    const result = await tool(h, "escalate_to_humans").handler(input);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "negotiation_id and summary required",
+    });
+    expect(h.escalationService.create).not.toHaveBeenCalled();
+  });
+
+  it("does not unblock the peer when creating the escalation fails", async () => {
+    const h = harness();
+    h.escalationService.create.mockRejectedValueOnce(
+      new Error("negotiation already escalated"),
+    );
+
+    const result = await tool(h, "escalate_to_humans").handler(INPUT);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "negotiation already escalated" });
+    expect(h.mesh.unblockOnEscalate).not.toHaveBeenCalled();
+    expect(h.pool.query).not.toHaveBeenCalled();
+  });
+
+  it("envelopes a pg_notify failure rather than throwing out of the tool", async () => {
+    const h = harness();
+    h.pool.query.mockRejectedValueOnce(new Error("connection terminated"));
+
+    const result = await tool(h, "escalate_to_humans").handler(INPUT);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: "connection terminated" });
+  });
+});

--- a/packages/api/src/tools/mesh.test.ts
+++ b/packages/api/src/tools/mesh.test.ts
@@ -1,10 +1,11 @@
 /**
  * Mesh tool assembly tests — IC vs team tier gating.
  *
- * Per-tool handler behavior is covered indirectly by the m6/m7 e2e scripts
- * (mesh flows require live Postgres + spawned CLI subprocesses). This file
- * locks the static tier inventory — the exact tool *names* each tier gets,
- * so future skill-loader work can rely on the surface being stable.
+ * This file locks the static tier inventory — the exact tool *names* each
+ * tier gets, so future skill-loader work can rely on the surface being
+ * stable. Per-tool handler behavior lives in `mesh-handlers.test.ts`
+ * (fakes for the mesh server + services); the m6/m7 e2e scripts cover the
+ * live end-to-end flow, which needs Postgres + spawned CLI subprocesses.
  */
 import { describe, expect, it } from "vitest";
 import type { ResolvedCaller } from "@beevibe/core/auth";

--- a/packages/api/src/tools/session-search.test.ts
+++ b/packages/api/src/tools/session-search.test.ts
@@ -1,0 +1,333 @@
+/**
+ * session_search MCP tool — unit tests with a fake SessionSearchService.
+ *
+ * The tool's own logic is `inferRequest`: four calling shapes the agent
+ * selects implicitly by which arguments it sets, with a documented
+ * precedence (scroll > read > discover > browse). Getting that wrong
+ * silently answers a different question than the agent asked, so every
+ * branch and every "blank counts as absent" coercion is pinned here.
+ *
+ * The other half is the error surface: a `null` result means
+ * not-found-or-forbidden, a SessionSearchError carries its own code
+ * through, and anything else degrades to `internal_error`. The service
+ * is also matched by `name` rather than `instanceof` alone (src/ vs
+ * dist/ dual-loading), which has its own test.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { SessionSearchRequest } from "@beevibe/core";
+import {
+  SessionSearchError,
+  type SessionSearchService,
+} from "@beevibe/core/services/session-search";
+import { createSessionSearchTool } from "./session-search.js";
+
+const CTX = {
+  agentId: "agent_a",
+  hierarchyLevel: "team" as const,
+  sessionId: "sess_current",
+};
+
+function harness(
+  opts: { result?: unknown; throws?: unknown } = {},
+): {
+  search: ReturnType<typeof vi.fn>;
+  tool: ReturnType<typeof createSessionSearchTool>;
+} {
+  const search = vi.fn(async () => {
+    if (opts.throws) throw opts.throws;
+    return "result" in opts ? opts.result : { kind: "browse", sessions: [] };
+  });
+  const sessionSearch = { search } as unknown as SessionSearchService;
+  return { search, tool: createSessionSearchTool(CTX, { sessionSearch }) };
+}
+
+/** The request the tool inferred from the agent's raw arguments. */
+async function inferred(
+  input: Record<string, unknown>,
+): Promise<SessionSearchRequest> {
+  const h = harness();
+  await h.tool.handler(input);
+  return h.search.mock.calls[0]![0] as SessionSearchRequest;
+}
+
+describe("session_search descriptor", () => {
+  it("exposes the tool name and a schema with no required fields", () => {
+    const { tool } = harness();
+    expect(tool.name).toBe("session_search");
+    // Every shape is optional — bare `session_search()` is the browse shape.
+    expect(tool.schema.required).toBeUndefined();
+    expect(Object.keys(tool.schema.properties as object)).toEqual([
+      "query",
+      "limit",
+      "sort",
+      "session_id",
+      "around_message_id",
+      "window",
+      "filters",
+    ]);
+  });
+
+  it("documents the four calling shapes in the agent-facing description", () => {
+    const { tool } = harness();
+    for (const shape of ["DISCOVERY", "SCROLL", "READ", "BROWSE"]) {
+      expect(tool.description).toContain(shape);
+    }
+  });
+});
+
+describe("session_search caller context", () => {
+  it("passes the caller's agent id, tier and active session to the service", async () => {
+    const h = harness();
+    await h.tool.handler({});
+
+    expect(h.search.mock.calls[0]![1]).toEqual({
+      callerAgentId: "agent_a",
+      hierarchyLevel: "team",
+      currentSessionId: "sess_current",
+    });
+  });
+});
+
+describe("session_search shape inference", () => {
+  it("browses when no arguments are given", async () => {
+    expect(await inferred({})).toEqual({
+      kind: "browse",
+      limit: undefined,
+      filters: undefined,
+    });
+  });
+
+  it("browses with a limit and filters", async () => {
+    expect(
+      await inferred({ limit: 8, filters: { status: "failed" } }),
+    ).toEqual({
+      kind: "browse",
+      limit: 8,
+      filters: { status: "failed" },
+    });
+  });
+
+  it("discovers when a query is given", async () => {
+    expect(await inferred({ query: "auth refactor", limit: 3 })).toEqual({
+      kind: "discover",
+      query: "auth refactor",
+      limit: 3,
+      sort: undefined,
+      filters: undefined,
+    });
+  });
+
+  it("trims the query", async () => {
+    const req = await inferred({ query: "  auth refactor  " });
+    expect(req).toMatchObject({ kind: "discover", query: "auth refactor" });
+  });
+
+  it.each([["newest"], ["oldest"]])("passes sort=%s through", async (sort) => {
+    expect(await inferred({ query: "x", sort })).toMatchObject({ sort });
+  });
+
+  it("drops an unrecognised sort rather than forwarding it", async () => {
+    expect(await inferred({ query: "x", sort: "relevance" })).toMatchObject({
+      sort: undefined,
+    });
+  });
+
+  it("reads when only session_id is given", async () => {
+    expect(await inferred({ session_id: "sess_1" })).toEqual({
+      kind: "read",
+      session_id: "sess_1",
+    });
+  });
+
+  it("scrolls when session_id and around_message_id are both given", async () => {
+    expect(
+      await inferred({
+        session_id: "sess_1",
+        around_message_id: "evt_9",
+        window: 10,
+      }),
+    ).toEqual({
+      kind: "scroll",
+      session_id: "sess_1",
+      around_message_id: "evt_9",
+      window: 10,
+    });
+  });
+
+  it("leaves window undefined for the service to default", async () => {
+    expect(
+      await inferred({ session_id: "sess_1", around_message_id: "evt_9" }),
+    ).toMatchObject({ window: undefined });
+  });
+
+  it("ignores a non-numeric window", async () => {
+    expect(
+      await inferred({
+        session_id: "sess_1",
+        around_message_id: "evt_9",
+        window: "10",
+      }),
+    ).toMatchObject({ window: undefined });
+  });
+
+  it("supports the documented user-turn anchor id format", async () => {
+    expect(
+      await inferred({
+        session_id: "sess_1",
+        around_message_id: "intent:sess_1",
+      }),
+    ).toMatchObject({ kind: "scroll", around_message_id: "intent:sess_1" });
+  });
+
+  it("scroll wins over discover when a query is also present", async () => {
+    expect(
+      await inferred({
+        query: "auth",
+        session_id: "sess_1",
+        around_message_id: "evt_9",
+      }),
+    ).toMatchObject({ kind: "scroll" });
+  });
+
+  it("read wins over discover when a query is also present", async () => {
+    expect(
+      await inferred({ query: "auth", session_id: "sess_1" }),
+    ).toMatchObject({ kind: "read" });
+  });
+
+  it("an anchor without a session_id falls back to discover", async () => {
+    expect(
+      await inferred({ query: "auth", around_message_id: "evt_9" }),
+    ).toMatchObject({ kind: "discover" });
+  });
+
+  it("an anchor alone falls back to browse", async () => {
+    expect(await inferred({ around_message_id: "evt_9" })).toMatchObject({
+      kind: "browse",
+    });
+  });
+
+  it.each([
+    ["blank", "   "],
+    ["empty", ""],
+    ["non-string", 42],
+  ])("treats a %s session_id as absent", async (_label, sessionId) => {
+    expect(
+      await inferred({ session_id: sessionId, query: "auth" }),
+    ).toMatchObject({ kind: "discover" });
+  });
+
+  it.each([
+    ["blank", "   "],
+    ["non-string", 42],
+  ])("treats a %s anchor as absent, degrading scroll to read", async (
+    _label,
+    anchor,
+  ) => {
+    expect(
+      await inferred({ session_id: "sess_1", around_message_id: anchor }),
+    ).toMatchObject({ kind: "read" });
+  });
+
+  it.each([
+    ["blank", "   "],
+    ["non-string", 42],
+  ])("treats a %s query as absent, degrading discover to browse", async (
+    _label,
+    query,
+  ) => {
+    expect(await inferred({ query })).toMatchObject({ kind: "browse" });
+  });
+
+  it("drops a non-object filters value", async () => {
+    expect(await inferred({ query: "auth", filters: "status:failed" })).toMatchObject(
+      { filters: undefined },
+    );
+  });
+
+  it("drops a null filters value rather than forwarding it", async () => {
+    // `typeof null === "object"`, so this is the branch a naive check misses.
+    expect(await inferred({ filters: null })).toMatchObject({
+      filters: undefined,
+    });
+  });
+});
+
+describe("session_search results and errors", () => {
+  it("returns the service result verbatim on success", async () => {
+    const payload = { kind: "read", session: { id: "sess_1" }, messages: [] };
+    const h = harness({ result: payload });
+
+    const result = await h.tool.handler({ session_id: "sess_1" });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toBe(payload);
+  });
+
+  it("maps a null result to not_found_or_forbidden", async () => {
+    const h = harness({ result: null });
+
+    const result = await h.tool.handler({ session_id: "sess_other" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "not_found_or_forbidden",
+    });
+  });
+
+  it.each([
+    ["forbidden_agent_filter"],
+    ["missing_query"],
+    ["missing_args"],
+  ] as const)("passes the %s SessionSearchError code through", async (code) => {
+    const h = harness({ throws: new SessionSearchError(code, "nope") });
+
+    const result = await h.tool.handler({ query: "x" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({ error: code, message: "nope" });
+  });
+
+  it("recognises a SessionSearchError from another module instance by name", async () => {
+    // src/ and dist/ copies of core fail `instanceof`; the name check is
+    // what keeps the structured code from degrading to internal_error.
+    const foreign = new Error("scope refused");
+    foreign.name = "SessionSearchError";
+    (foreign as unknown as { code: string }).code = "forbidden_agent_filter";
+    const h = harness({ throws: foreign });
+
+    const result = await h.tool.handler({
+      query: "x",
+      filters: { agent_id: "agent_z" },
+    });
+
+    expect(result.content).toEqual({
+      error: "forbidden_agent_filter",
+      message: "scope refused",
+    });
+  });
+
+  it("degrades an unexpected Error to internal_error", async () => {
+    const h = harness({ throws: new Error("pool exhausted") });
+
+    const result = await h.tool.handler({ query: "x" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual({
+      error: "internal_error",
+      message: "pool exhausted",
+    });
+  });
+
+  it("stringifies a non-Error throw", async () => {
+    const h = harness({ throws: "kaboom" });
+
+    const result = await h.tool.handler({});
+
+    expect(result.content).toEqual({
+      error: "internal_error",
+      message: "kaboom",
+    });
+  });
+});

--- a/packages/api/src/tools/use-repo.test.ts
+++ b/packages/api/src/tools/use-repo.test.ts
@@ -1,0 +1,435 @@
+/**
+ * use_repo MCP tool — unit tests with vitest fakes (no DB, no daemon).
+ *
+ * The handler is small but load-bearing: it validates agent-supplied
+ * input, mints three ids, and writes two rows in a FK-ordered sequence
+ * (dispatch creates `session`, then `repo_run` references it). Each of
+ * those steps has its own failure envelope the calling agent branches
+ * on, and the ordering comment in the source is a correctness claim —
+ * so the tests pin both the envelopes and the call order.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type {
+  Agent,
+  AgentRepository,
+  RepoRunRepository,
+  Task,
+  TaskRepository,
+} from "@beevibe/core";
+import type { DispatchService } from "@beevibe/core/services/dispatch-service";
+import { createUseRepoTool, type UseRepoServices } from "./use-repo.js";
+
+const AGENT = "agent_a";
+
+function fakeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: AGENT,
+    name: "A",
+    owner_id: "person_1",
+    hierarchy_level: "ic",
+    runtime_config: { type: "claude" },
+    created_at: new Date("2026-04-01"),
+    updated_at: new Date("2026-04-01"),
+    ...overrides,
+  };
+}
+
+function fakeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "task_container",
+    title: "Extract tables",
+    status: "pending",
+    priority: "medium",
+    creator_id: AGENT,
+    creator_type: "agent",
+    created_at: new Date("2026-04-01"),
+    updated_at: new Date("2026-04-01"),
+    ...overrides,
+  };
+}
+
+interface Harness {
+  services: UseRepoServices;
+  /** Ordered record of the writes, so FK ordering is assertable. */
+  order: string[];
+  agentRepo: { findById: ReturnType<typeof vi.fn> };
+  taskRepo: { create: ReturnType<typeof vi.fn> };
+  repoRunRepo: { create: ReturnType<typeof vi.fn> };
+  dispatchService: { dispatchTask: ReturnType<typeof vi.fn> };
+}
+
+function harness(
+  opts: {
+    agent?: Agent | undefined;
+    dispatchError?: unknown;
+    repoRunError?: unknown;
+  } = {},
+): Harness {
+  const order: string[] = [];
+  const agentRepo = {
+    findById: vi.fn(async () =>
+      "agent" in opts ? opts.agent : fakeAgent(),
+    ),
+  };
+  const taskRepo = {
+    create: vi.fn(async (input: { id: string; title: string }) => {
+      order.push("task.create");
+      return fakeTask({ id: input.id, title: input.title });
+    }),
+  };
+  const dispatchService = {
+    dispatchTask: vi.fn(async () => {
+      order.push("dispatch");
+      if (opts.dispatchError) throw opts.dispatchError;
+      return {};
+    }),
+  };
+  const repoRunRepo = {
+    create: vi.fn(async (input: Record<string, unknown>) => {
+      order.push("repoRun.create");
+      if (opts.repoRunError) throw opts.repoRunError;
+      return input;
+    }),
+  };
+  return {
+    order,
+    agentRepo,
+    taskRepo,
+    repoRunRepo,
+    dispatchService,
+    services: {
+      agentRepo: agentRepo as unknown as AgentRepository,
+      taskRepo: taskRepo as unknown as TaskRepository,
+      repoRunRepo: repoRunRepo as unknown as RepoRunRepository,
+      dispatchService: dispatchService as unknown as DispatchService,
+    },
+  };
+}
+
+function tool(h: Harness) {
+  return createUseRepoTool({ agentId: AGENT }, h.services);
+}
+
+const GOAL = "Extract the tables from this PDF as JSON";
+const REPO = "https://github.com/acme/pdf-tables";
+
+describe("use_repo tool descriptor", () => {
+  it("exposes the tool name and required schema fields", () => {
+    const t = tool(harness());
+    expect(t.name).toBe("use_repo");
+    expect(t.schema.required).toEqual(["goal", "repo_url"]);
+    expect(t.schema.additionalProperties).toBe(false);
+  });
+});
+
+describe("use_repo input validation", () => {
+  it("rejects a missing goal before touching any repo", async () => {
+    const h = harness();
+    const result = await tool(h).handler({ repo_url: REPO });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "invalid_goal" });
+    expect(h.agentRepo.findById).not.toHaveBeenCalled();
+    expect(h.order).toEqual([]);
+  });
+
+  it("rejects a whitespace-only goal", async () => {
+    const h = harness();
+    const result = await tool(h).handler({ goal: "   ", repo_url: REPO });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "invalid_goal" });
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["non-GitHub host", "https://gitlab.com/acme/tool"],
+    ["plain http", "http://github.com/acme/tool"],
+    ["unparseable", "not-a-url"],
+    ["lookalike host", "https://github.com.evil.example/acme/tool"],
+  ])("rejects repo_url: %s", async (_label, repoUrl) => {
+    const h = harness();
+    const result = await tool(h).handler({ goal: GOAL, repo_url: repoUrl });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "invalid_repo_url" });
+    expect(h.order).toEqual([]);
+  });
+
+  it("accepts a github.com subdomain host", async () => {
+    const h = harness();
+    const result = await tool(h).handler({
+      goal: GOAL,
+      repo_url: "https://www.github.com/acme/tool",
+    });
+
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("returns agent_not_found when the caller does not resolve", async () => {
+    const h = harness({ agent: undefined });
+    const result = await tool(h).handler({ goal: GOAL, repo_url: REPO });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "agent_not_found" });
+    expect(h.order).toEqual([]);
+  });
+});
+
+describe("use_repo happy path", () => {
+  it("creates the container task, dispatches, then inserts repo_run in FK order", async () => {
+    const h = harness();
+    const result = await tool(h).handler({ goal: GOAL, repo_url: REPO });
+
+    expect(result.isError).toBeFalsy();
+    // repo_run.session_id has an FK to session.id, and dispatchTask is
+    // what creates the session row — so the insert must come after.
+    expect(h.order).toEqual(["task.create", "dispatch", "repoRun.create"]);
+  });
+
+  it("pins the dispatch to the resolved agent and the pre-minted session id", async () => {
+    const h = harness();
+    const result = await tool(h).handler({ goal: GOAL, repo_url: REPO });
+
+    const sessionId = (result.content as { session_id: string }).session_id;
+    expect(h.dispatchService.dispatchTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: AGENT,
+        type: "run_repo",
+        intent: GOAL,
+        reason: { kind: "fresh" },
+        sessionIdOverride: sessionId,
+      }),
+    );
+  });
+
+  it("writes the repo_run row against the same session and task", async () => {
+    const h = harness();
+    const result = await tool(h).handler({ goal: GOAL, repo_url: REPO });
+    const content = result.content as {
+      repo_run_id: string;
+      session_id: string;
+      task_id: string;
+    };
+
+    expect(h.repoRunRepo.create).toHaveBeenCalledWith({
+      id: content.repo_run_id,
+      session_id: content.session_id,
+      task_id: content.task_id,
+      agent_id: AGENT,
+      goal: GOAL,
+      repo_url: REPO,
+      status: "pending",
+    });
+  });
+
+  it("returns the ids, pending status and the UI watch url", async () => {
+    const h = harness();
+    const result = await tool(h).handler({ goal: GOAL, repo_url: REPO });
+    const content = result.content as Record<string, unknown>;
+
+    expect(content.status).toBe("pending");
+    expect(content.watch_url).toBe(`/capabilities/runs/${content.repo_run_id}`);
+    expect(content.task_id).toBe(h.taskRepo.create.mock.calls[0]![0].id);
+    expect(typeof content.note).toBe("string");
+  });
+
+  it("assigns the container task to the calling agent as both creator and assignee", async () => {
+    const h = harness();
+    await tool(h).handler({ goal: GOAL, repo_url: REPO });
+
+    expect(h.taskRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assignee_id: AGENT,
+        creator_id: AGENT,
+        creator_type: "agent",
+        priority: "medium",
+        description: GOAL,
+      }),
+    );
+  });
+
+  it("trims the goal and repo_url before use", async () => {
+    const h = harness();
+    const result = await tool(h).handler({
+      goal: `  ${GOAL}  `,
+      repo_url: `  ${REPO}  `,
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(h.repoRunRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ goal: GOAL, repo_url: REPO }),
+    );
+  });
+
+  it("passes optional input_url / input_filename straight back to the caller", async () => {
+    const h = harness();
+    const result = await tool(h).handler({
+      goal: GOAL,
+      repo_url: REPO,
+      input_url: "  https://example.com/doc.pdf  ",
+      input_filename: "  doc.pdf  ",
+    });
+
+    expect(result.content).toMatchObject({
+      input_url: "https://example.com/doc.pdf",
+      input_filename: "doc.pdf",
+    });
+  });
+
+  it("leaves input fields undefined when not supplied", async () => {
+    const h = harness();
+    const result = await tool(h).handler({ goal: GOAL, repo_url: REPO });
+
+    expect(result.content.input_url).toBeUndefined();
+    expect(result.content.input_filename).toBeUndefined();
+  });
+});
+
+describe("use_repo container task title", () => {
+  it("collapses whitespace in the title while keeping the full goal as description", async () => {
+    const h = harness();
+    await tool(h).handler({
+      goal: "Extract\n  tables\tfrom  the PDF",
+      repo_url: REPO,
+    });
+
+    const arg = h.taskRepo.create.mock.calls[0]![0];
+    expect(arg.title).toBe("Extract tables from the PDF");
+    expect(arg.description).toBe("Extract\n  tables\tfrom  the PDF");
+  });
+
+  it("truncates a long goal to 80 chars with an ellipsis", async () => {
+    const h = harness();
+    const longGoal = "x".repeat(200);
+    await tool(h).handler({ goal: longGoal, repo_url: REPO });
+
+    const title = h.taskRepo.create.mock.calls[0]![0].title as string;
+    expect(title).toHaveLength(78); // 77 chars + the single-char ellipsis
+    expect(title.endsWith("…")).toBe(true);
+  });
+
+  it("leaves an exactly-80-char goal untouched", async () => {
+    const h = harness();
+    const goal = "y".repeat(80);
+    await tool(h).handler({ goal, repo_url: REPO });
+
+    expect(h.taskRepo.create.mock.calls[0]![0].title).toBe(goal);
+  });
+});
+
+describe("use_repo limits parsing", () => {
+  async function limitsFor(limits: unknown): Promise<Record<string, unknown>> {
+    const h = harness();
+    const result = await tool(h).handler({
+      goal: GOAL,
+      repo_url: REPO,
+      limits,
+    });
+    return (result.content as { limits: Record<string, unknown> }).limits;
+  }
+
+  it("returns an empty object when limits is absent or not an object", async () => {
+    expect(await limitsFor(undefined)).toEqual({});
+    expect(await limitsFor("20")).toEqual({});
+    expect(await limitsFor(null)).toEqual({});
+  });
+
+  it("passes through in-range values unchanged", async () => {
+    expect(
+      await limitsFor({
+        wall_clock_minutes: 15,
+        max_install_attempts: 3,
+        disk_mb: 4096,
+      }),
+    ).toEqual({
+      wall_clock_minutes: 15,
+      max_install_attempts: 3,
+      disk_mb: 4096,
+    });
+  });
+
+  it("clamps each limit to its ceiling", async () => {
+    expect(
+      await limitsFor({
+        wall_clock_minutes: 999,
+        max_install_attempts: 99,
+        disk_mb: 999_999,
+      }),
+    ).toEqual({
+      wall_clock_minutes: 60,
+      max_install_attempts: 5,
+      disk_mb: 10_000,
+    });
+  });
+
+  it("floors the integer limits but not the wall clock", async () => {
+    expect(
+      await limitsFor({
+        wall_clock_minutes: 2.5,
+        max_install_attempts: 2.9,
+        disk_mb: 1024.7,
+      }),
+    ).toEqual({
+      wall_clock_minutes: 2.5,
+      max_install_attempts: 2,
+      disk_mb: 1024,
+    });
+  });
+
+  it("drops non-positive and non-numeric limits rather than clamping them", async () => {
+    expect(
+      await limitsFor({
+        wall_clock_minutes: 0,
+        max_install_attempts: -1,
+        disk_mb: "2048",
+      }),
+    ).toEqual({});
+  });
+});
+
+describe("use_repo failure envelopes", () => {
+  it("returns dispatch_failed and skips the repo_run insert when dispatch throws", async () => {
+    const h = harness({ dispatchError: new Error("no daemon online") });
+    const result = await tool(h).handler({ goal: GOAL, repo_url: REPO });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "dispatch_failed",
+      message: "no daemon online",
+    });
+    expect(h.repoRunRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("stringifies a non-Error dispatch throw", async () => {
+    const h = harness({ dispatchError: "boom" });
+    const result = await tool(h).handler({ goal: GOAL, repo_url: REPO });
+
+    expect(result.content).toMatchObject({
+      error: "dispatch_failed",
+      message: "boom",
+    });
+  });
+
+  it("returns repo_run_create_failed when the repo_run insert throws", async () => {
+    const h = harness({ repoRunError: new Error("fk violation") });
+    const result = await tool(h).handler({ goal: GOAL, repo_url: REPO });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "repo_run_create_failed",
+      message: "fk violation",
+    });
+    // The session row already landed — the orphan is surfaced, not hidden.
+    expect(h.order).toEqual(["task.create", "dispatch", "repoRun.create"]);
+  });
+
+  it("stringifies a non-Error repo_run throw", async () => {
+    const h = harness({ repoRunError: { code: "23503" } });
+    const result = await tool(h).handler({ goal: GOAL, repo_url: REPO });
+
+    expect(result.content).toMatchObject({ error: "repo_run_create_failed" });
+    expect(typeof (result.content as { message: string }).message).toBe("string");
+  });
+});

--- a/packages/api/src/tools/watch.test.ts
+++ b/packages/api/src/tools/watch.test.ts
@@ -1,0 +1,271 @@
+/**
+ * watch_tasks + unwatch MCP tools — unit tests with a fake WatchService.
+ *
+ * The tools are thin adapters, so the risk is concentrated in the two
+ * things they do own: coercing agent-supplied input into a valid
+ * `WatchTasksInput` (mode defaulting, task_ids filtering, session
+ * context), and mapping the four WatchService error classes onto stable
+ * `error` codes the calling agent branches on. Both are pinned here.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { TASK_WATCH_MODES } from "@beevibe/core";
+import {
+  WatchAuthError,
+  WatchNotFoundError,
+  WatchValidationError,
+  type WatchService,
+} from "@beevibe/core/services/watch-service";
+import { buildWatchTools, type WatchToolContext } from "./watch.js";
+import type { AgentTool } from "./types.js";
+
+const AGENT = "agent_a";
+const SESSION = "sess_1";
+
+interface Harness {
+  watchTasks: ReturnType<typeof vi.fn>;
+  unwatch: ReturnType<typeof vi.fn>;
+  tools: AgentTool[];
+  watch: AgentTool;
+  unwatchTool: AgentTool;
+}
+
+function harness(
+  opts: { ctx?: Partial<WatchToolContext>; throws?: unknown } = {},
+): Harness {
+  const reject = async (): Promise<never> => {
+    throw opts.throws;
+  };
+  const watchTasks = vi.fn(
+    opts.throws
+      ? reject
+      : async () => ({ watchId: "tw_1", firedImmediately: false }),
+  );
+  const unwatch = vi.fn(opts.throws ? reject : async () => undefined);
+  const watchService = { watchTasks, unwatch } as unknown as WatchService;
+
+  const tools = buildWatchTools(
+    { agentId: AGENT, sessionId: SESSION, ...opts.ctx },
+    { watchService },
+  );
+  return {
+    watchTasks,
+    unwatch,
+    tools,
+    watch: tools.find((t) => t.name === "watch_tasks")!,
+    unwatchTool: tools.find((t) => t.name === "unwatch")!,
+  };
+}
+
+describe("buildWatchTools descriptors", () => {
+  it("returns watch_tasks and unwatch, in that order", () => {
+    const h = harness();
+    expect(h.tools.map((t) => t.name)).toEqual(["watch_tasks", "unwatch"]);
+  });
+
+  it("advertises the domain's watch modes in the watch_tasks schema", () => {
+    const h = harness();
+    const props = h.watch.schema.properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(props.mode!.enum).toEqual([...TASK_WATCH_MODES]);
+    expect(h.watch.schema.required).toEqual(["task_ids"]);
+  });
+
+  it("requires watch_id on unwatch", () => {
+    const h = harness();
+    expect(h.unwatchTool.schema.required).toEqual(["watch_id"]);
+  });
+});
+
+describe("watch_tasks input handling", () => {
+  it("forwards task_ids with the caller's agent and session ids", async () => {
+    const h = harness();
+    const result = await h.watch.handler({ task_ids: ["task_1", "task_2"] });
+
+    expect(h.watchTasks).toHaveBeenCalledWith({
+      callerAgentId: AGENT,
+      callerSessionId: SESSION,
+      taskIds: ["task_1", "task_2"],
+      mode: "all",
+      reason: undefined,
+    });
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("defaults mode to 'all' when the value is not a known mode", async () => {
+    const h = harness();
+    await h.watch.handler({ task_ids: ["task_1"], mode: "first" });
+
+    expect(h.watchTasks.mock.calls[0]![0].mode).toBe("all");
+  });
+
+  it("honours an explicit 'any' mode", async () => {
+    const h = harness();
+    await h.watch.handler({ task_ids: ["task_1"], mode: "any" });
+
+    expect(h.watchTasks.mock.calls[0]![0].mode).toBe("any");
+  });
+
+  it("drops non-string entries from task_ids", async () => {
+    const h = harness();
+    await h.watch.handler({ task_ids: ["task_1", 42, null, "task_2"] });
+
+    expect(h.watchTasks.mock.calls[0]![0].taskIds).toEqual([
+      "task_1",
+      "task_2",
+    ]);
+  });
+
+  it.each([
+    ["an empty array", []],
+    ["a non-array", "task_1"],
+    ["an array with no strings left after filtering", [1, 2]],
+  ])("rejects task_ids that is %s", async (_label, taskIds) => {
+    const h = harness();
+    const result = await h.watch.handler({ task_ids: taskIds });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: "watch_validation" });
+    expect(h.watchTasks).not.toHaveBeenCalled();
+  });
+
+  it("trims a reason and passes it through", async () => {
+    const h = harness();
+    await h.watch.handler({ task_ids: ["task_1"], reason: "  check CI  " });
+
+    expect(h.watchTasks.mock.calls[0]![0].reason).toBe("check CI");
+  });
+
+  it.each([
+    ["blank", "   "],
+    ["non-string", 7],
+  ])("omits a %s reason", async (_label, reason) => {
+    const h = harness();
+    await h.watch.handler({ task_ids: ["task_1"], reason });
+
+    expect(h.watchTasks.mock.calls[0]![0].reason).toBeUndefined();
+  });
+
+  it("refuses to register a watch outside a session context", async () => {
+    const h = harness({ ctx: { sessionId: undefined } });
+    const result = await h.watch.handler({ task_ids: ["task_1"] });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "watch_validation",
+      message: "watch_tasks must be called inside a session context",
+    });
+    expect(h.watchTasks).not.toHaveBeenCalled();
+  });
+
+  it("validates task_ids before the session context", async () => {
+    // Ordering matters only in that the agent sees the most actionable
+    // problem first; pin it so a refactor can't silently swap them.
+    const h = harness({ ctx: { sessionId: undefined } });
+    const result = await h.watch.handler({ task_ids: [] });
+
+    expect(result.content).toMatchObject({
+      message: "task_ids must be a non-empty array of strings",
+    });
+  });
+
+  it("returns the watch id and the fired_immediately flag", async () => {
+    const h = harness();
+    h.watchTasks.mockResolvedValueOnce({
+      watchId: "tw_now",
+      firedImmediately: true,
+    });
+    const result = await h.watch.handler({ task_ids: ["task_1"] });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual({
+      watch_id: "tw_now",
+      fired_immediately: true,
+    });
+  });
+});
+
+describe("unwatch input handling", () => {
+  it("forwards the watch id with the caller's agent id", async () => {
+    const h = harness();
+    const result = await h.unwatchTool.handler({ watch_id: "tw_1" });
+
+    expect(h.unwatch).toHaveBeenCalledWith({
+      callerAgentId: AGENT,
+      watchId: "tw_1",
+    });
+    expect(result.content).toEqual({ ok: true });
+    expect(result.isError).toBeFalsy();
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["empty", ""],
+    ["non-string", 5],
+  ])("rejects a %s watch_id", async (_label, watchId) => {
+    const h = harness();
+    const result = await h.unwatchTool.handler({ watch_id: watchId });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({
+      error: "watch_validation",
+      message: "watch_id must be a non-empty string",
+    });
+    expect(h.unwatch).not.toHaveBeenCalled();
+  });
+});
+
+describe("WatchService error mapping", () => {
+  const cases: Array<[string, unknown, string]> = [
+    ["WatchAuthError", new WatchAuthError("not your session"), "watch_auth"],
+    [
+      "WatchValidationError",
+      new WatchValidationError("task_ids must be non-empty"),
+      "watch_validation",
+    ],
+    ["WatchNotFoundError", new WatchNotFoundError("tw_9"), "watch_not_found"],
+    ["a plain Error", new Error("pool exhausted"), "watch_error"],
+    ["a non-Error throw", "kaboom", "watch_error"],
+  ];
+
+  it.each(cases)("watch_tasks maps %s to %s", async (_label, thrown, code) => {
+    const h = harness({ throws: thrown });
+    const result = await h.watch.handler({ task_ids: ["task_1"] });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: code });
+    expect(typeof (result.content as { message: string }).message).toBe(
+      "string",
+    );
+  });
+
+  it.each(cases)("unwatch maps %s to %s", async (_label, thrown, code) => {
+    const h = harness({ throws: thrown });
+    const result = await h.unwatchTool.handler({ watch_id: "tw_1" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatchObject({ error: code });
+  });
+
+  it("keeps the service's message on a mapped error", async () => {
+    const h = harness({ throws: new WatchAuthError("not your session") });
+    const result = await h.watch.handler({ task_ids: ["task_1"] });
+
+    expect(result.content).toMatchObject({
+      error: "watch_auth",
+      message: "not your session",
+    });
+  });
+
+  it("formats WatchNotFoundError's generated message", async () => {
+    const h = harness({ throws: new WatchNotFoundError("tw_9") });
+    const result = await h.unwatchTool.handler({ watch_id: "tw_9" });
+
+    expect(result.content).toMatchObject({
+      error: "watch_not_found",
+      message: "task_watch tw_9 not found",
+    });
+  });
+});


### PR DESCRIPTION
## What

A v8 coverage sweep put `@beevibe/api` at **64.5% lines** — the weakest package once `core` (#284, #286) and `daemon` were brought up. This adds focused unit tests for the six worst files that aren't wiring entrypoints or Postgres-gated.

| File | lines before | after |
| --- | --- | --- |
| `routes/chat.ts` | 26.9% | 98.2% |
| `routes/stream.ts` | 0% | 100% |
| `tools/use-repo.ts` | 32.0% | 100% |
| `tools/watch.ts` | 46.3% | 100% |
| `tools/session-search.ts` | 64.7% | 100% |
| `tools/mesh.ts` | 45.9% | 99.4% |

**Package total: 64.53% → 73.49% lines, 83.63% → 91.56% functions.** 214 new tests, all fakes — no new dependencies, and the suites run clean without Postgres, Docker, or provider keys.

## How the targets were picked

```
npx vitest run --coverage --coverage.provider=v8 --coverage.all \
  --coverage.include='src/**/*.ts' --coverage.exclude='src/**/*.test.ts'
```

per CLAUDE.md, with the DB- and key-gated suites excluded (an unhandled `afterAll` error in those aborts report generation entirely). Ranked by uncovered lines, then filtered to what a unit test can actually reach: `bootstrap.ts`, `server.ts`, `main.ts` and `runtime/router.ts` are wiring or already covered by the Postgres-gated integration suites, so they're left alone.

## What the tests pin, beyond line count

- **`routes/chat.ts`** — the four handlers wrapped around the pure helpers `chat-internals.test.ts` already covers. `POST /chat` has five ways to refuse a turn *before* it spawns a CLI subprocess (idempotent replay, 409 in-flight, 403 session-id collision, 429 rate limit, 503 offline daemon); each one costs real money when it regresses open, and each has a status code the web client branches on. Also covers the rate-limiter slot being released on every exit path (success, dispatch throw, 503), the 504 resolver timeout, the onboarding-flag flip, and the runtime-pin mismatch banner on `GET /chat`.
- **`routes/stream.ts`** — SSE, driven over a real socket, because none of its behaviour is visible to a JSON assertion: the headers that stop proxies buffering, the priming `data: {}` line (a comment wouldn't fire the browser's `onmessage`), the 25s heartbeat, and unsubscribe-on-disconnect. Only `setInterval`/`clearInterval` are faked, so socket I/O stays real and the heartbeat is assertable without a 25-second test.
- **`tools/use-repo.ts`** — the FK-ordered write sequence the source comments claim (container task → dispatch's session row → `repo_run`), both failure envelopes including the orphan-session path, GitHub URL validation, and the limits clamping/flooring.
- **`tools/watch.ts`** — mode defaulting, `task_ids` coercion, the session-context guard, and the mapping from the four `WatchService` error classes onto the stable codes agents branch on.
- **`tools/session-search.ts`** — `inferRequest`'s four calling shapes and their documented precedence (scroll > read > discover > browse), every "blank counts as absent" coercion, and the by-name `SessionSearchError` match that survives src/dist dual-loading.
- **`tools/mesh.ts`** — the six handlers, in a new `mesh-handlers.test.ts`. These were previously reachable only through the m6/m7 e2e scripts (live Postgres + spawned CLI subprocesses), so in a normal run nothing checked the argument coercion, the required-field refusals, or the response projections — and those projections are the agent-facing wire contract: `respond_negotiate` returning `terminal: true` versus a peer's counter is how a negotiating agent decides whether to keep talking or exit. `mesh.test.ts` keeps its tier-inventory scope; its header now points at the new file.

## Testing

- `pnpm typecheck` — clean (9/9 tasks).
- `pnpm lint` — 0 errors. The 4 `import/no-duplicates` warnings are pre-existing, in files this PR doesn't touch.
- `packages/api` full suite: **1033 passing**, 9 failing files — all of them the documented DB-gated integration suites (`DATABASE_URL_TEST env var is required`), matching the bare-sandbox baseline in CLAUDE.md exactly. No package outside `packages/api` is modified.

The `@vitest/coverage-v8` install used for the sweep is deliberately **not** committed, per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Nxi4e9gy9vofgejMHHpxn

---
_Generated by [Claude Code](https://claude.ai/code/session_019Nxi4e9gy9vofgejMHHpxn)_